### PR TITLE
ci(release-pieces): self-contained piece bundles — stop publishing shared libs & strip build-only deps

### DIFF
--- a/.github/workflows/release-pieces.yml
+++ b/.github/workflows/release-pieces.yml
@@ -46,20 +46,8 @@ jobs:
       - name: copy project .npmrc to user level
         run: cp .npmrc $HOME/.npmrc
 
-      - name: publish shared package
-        run: npx turbo run build --filter=@activepieces/shared --force && npx ts-node -r tsconfig-paths/register -P packages/server/engine/tsconfig.lib.json tools/scripts/utils/publish-npm-package.ts packages/core/shared 
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-
-      - name: publish pieces-common package
-        run: npx turbo run build --filter=@activepieces/pieces-common --force && npx ts-node -r tsconfig-paths/register -P packages/server/engine/tsconfig.lib.json tools/scripts/utils/publish-npm-package.ts packages/pieces/common
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-
-      - name: publish pieces-framework package
-        run: npx turbo run build --filter=@activepieces/pieces-framework --force && npx ts-node -r tsconfig-paths/register -P packages/server/engine/tsconfig.lib.json tools/scripts/utils/publish-npm-package.ts packages/pieces/framework
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      # @activepieces/shared, pieces-common and pieces-framework are no longer published to npm:
+      # pieces are now self-contained bundles that inline these dependencies at build time.
 
       - name: Find changed pieces
         id: changed

--- a/docs/build-pieces/misc/bundling-pieces.mdx
+++ b/docs/build-pieces/misc/bundling-pieces.mdx
@@ -1,0 +1,56 @@
+---
+title: 'Bundling Pieces'
+icon: 'cube'
+---
+
+Activepieces builds every piece into a **self-contained bundle**. Instead of shipping a piece that depends on `@activepieces/shared`, `@activepieces/pieces-framework`, `@activepieces/pieces-common`, and the `@activepieces/core-*` packages at install time, the build inlines all of that code into a single artifact.
+
+This is what lets the engine provision a piece by downloading **one artifact** — no `bun install` / `npm install` of a dependency tree at runtime.
+
+### What gets bundled
+
+When a piece is built for publishing, the bundler:
+
+- **Inlines all `@activepieces/*` workspace libraries** (`shared`, `pieces-framework`, `pieces-common`, `core-utils`, `core-piece-types`, …) directly into the bundle. These libraries are **never published to npm** — they only exist as part of each piece's bundle.
+- **Inlines third-party dependencies** (e.g. an SDK the piece imports) into the same bundle.
+- **Keeps a small allow-list of deps external** only when they genuinely cannot be inlined — native addons or packages that use dynamic `require`. These remain in the published `dependencies` so the runtime installer resolves them.
+
+The result is typically **~2–3× smaller** than the raw inputs, and the published `package.json` lists only the few unavoidable external deps (e.g. `tslib`).
+
+### The published manifest
+
+After bundling, the piece's `dist/package.json` is rewritten:
+
+```jsonc
+{
+  "name": "@activepieces/piece-json",
+  "version": "0.1.7",
+  "main": "./src/index.js",      // the self-contained bundle
+  "dependencies": {
+    "tslib": "2.6.2"             // only genuinely-external deps remain
+  },
+  "files": ["src/index.js", "package.json", "src/i18n"]
+}
+```
+
+No `@activepieces/*` dependency appears — installing the piece never requires those packages to exist on the registry.
+
+### Forcing a dependency to stay external
+
+If a dependency must not be inlined (for example a native module), add it to a `bundleDeps` array in the piece's `package.json`. The bundler will keep it external and preserve it in the published `dependencies`.
+
+```jsonc
+{
+  "name": "@activepieces/piece-example",
+  "bundleDeps": ["some-native-addon"]
+}
+```
+
+### Building and publishing
+
+Bundling happens automatically when you build or publish a piece:
+
+- `npm run build-piece <name>` — builds and packs the bundle into a `.tgz` (see [Build Custom Pieces](./build-piece)).
+- `npm run publish-piece-to-api` — bundles and uploads the piece to a platform (see [Publish Custom Pieces](./publish-piece)).
+
+You don't need to configure anything for bundling — it is the default behavior.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -299,6 +299,7 @@
                   "group": "Misc",
                   "pages": [
                      "build-pieces/misc/build-piece",
+                     "build-pieces/misc/bundling-pieces",
                      "build-pieces/misc/publish-piece",
                      "build-pieces/misc/pieces-ci-cd",
                      "build-pieces/misc/migrate-nx-to-turbo",

--- a/packages/cli/src/lib/commands/create-piece.ts
+++ b/packages/cli/src/lib/commands/create-piece.ts
@@ -70,6 +70,8 @@ const scaffoldPiece = async (
       '@activepieces/pieces-common': 'workspace:*',
       '@activepieces/pieces-framework': 'workspace:*',
       '@activepieces/shared': 'workspace:*',
+    },
+    devDependencies: {
       tslib: '2.6.2',
     },
     scripts: {

--- a/packages/cli/src/lib/utils/bundle-piece-utils.ts
+++ b/packages/cli/src/lib/utils/bundle-piece-utils.ts
@@ -45,7 +45,7 @@ async function bundlePiece({ piecePath, distPath, repoRoot }: BundlePieceParams)
 
     const bundleBytes = statSync(outfile).size
     const rawBytes = totalInputBytes(pass.result.metafile)
-    const external = directDepsOf(manifest).filter((dep) => !pass.inlined.has(dep) && !dep.startsWith('@activepieces/'))
+    const external = directDepsOf(manifest).filter((dep) => !pass.inlined.has(dep) && !dep.startsWith('@activepieces/') && !BUNDLE_HELPER_DEPS.has(dep))
 
     enforceSizeGate({ piecePath, bundleBytes })
 
@@ -253,6 +253,11 @@ function enforceSizeGate({ piecePath, bundleBytes }: SizeGateParams): void {
 // "main"). Emitting a single self-contained src/index.js keeps bundled pieces installable
 // on every engine version while still inlining all @activepieces/* workspace code.
 const BUNDLE_FILENAME = 'src/index.js'
+// tslib only exists to back tsc's `importHelpers` down-levelling. esbuild emits its own inline
+// helpers, so the published bundle never requires it. Drop it from every manifest rather than
+// telling the runtime installer to fetch a package the bundle does not use. (Deps loaded
+// out-of-band — e.g. a forked child requiring oracledb — are NOT declared-dead and stay.)
+const BUNDLE_HELPER_DEPS = new Set<string>(['tslib'])
 const WARN_BYTES = 3 * 1024 * 1024
 const FAIL_BYTES = 5 * 1024 * 1024
 const NODE_BUILTINS = new Set(builtinModules)

--- a/packages/cli/src/lib/utils/prepare-piece-utils.ts
+++ b/packages/cli/src/lib/utils/prepare-piece-utils.ts
@@ -1,5 +1,5 @@
-import { readFileSync, writeFileSync, existsSync, copyFileSync, readdirSync, mkdirSync } from 'node:fs'
-import { join } from 'node:path'
+import { readFileSync, writeFileSync, existsSync, copyFileSync, readdirSync, mkdirSync, statSync, rmSync } from 'node:fs'
+import { join, relative } from 'node:path'
 import { buildWorkspaceVersionMap, findRepoRoot, resolveWorkspaceDependencies, stripSemverRanges } from './workspace-utils'
 import { bundlePieceUtils } from './bundle-piece-utils'
 
@@ -41,6 +41,7 @@ async function preparePieceDistForPublish(piecePath: string): Promise<void> {
     const { bundleBytes, rawBytes, external } = await bundlePieceUtils.bundlePiece({ ...paths, repoRoot })
 
     rewriteManifestForBundle({ distPath, external, repoRoot })
+    pruneDistToPublishedFiles({ distPath })
 
     const ratio = rawBytes > 0 ? (rawBytes / bundleBytes).toFixed(1) : '—'
     const extNote = external.length ? ` external=[${external.join(', ')}]` : ''
@@ -75,6 +76,56 @@ function rewriteManifestForBundle({ distPath, external, repoRoot }: { distPath: 
     json.files = [bundlePieceUtils.BUNDLE_FILENAME, 'package.json', 'src/i18n']
 
     writeFileSync(distPackageJsonPath, JSON.stringify(json, null, 2) + '\n')
+}
+
+// After bundling, dist/ still holds the full tsc output (compiled lib/*, .d.ts, .map). Prune it
+// down to EXACTLY what npm would publish — the manifest's `files` allow-list (the self-contained
+// bundle + i18n) plus package.json — so `dist/` mirrors the published artifact 1:1.
+function pruneDistToPublishedFiles({ distPath }: { distPath: string }): void {
+    const json = JSON.parse(readFileSync(join(distPath, 'package.json'), 'utf-8'))
+    const entries: string[] = json.files ?? []
+
+    const keepFiles = new Set<string>(['package.json'])
+    const keepDirs: string[] = []
+    for (const entry of entries) {
+        const normalized = entry.replace(/\/$/, '')
+        const abs = join(distPath, normalized)
+        if (existsSync(abs) && statSync(abs).isDirectory()) {
+            keepDirs.push(normalized)
+        }
+        else {
+            keepFiles.add(normalized)
+        }
+    }
+
+    const toPosix = (p: string): string => p.split('\\').join('/')
+    const isKept = (rel: string): boolean =>
+        keepFiles.has(rel) || keepDirs.some((dir) => rel === dir || rel.startsWith(`${dir}/`))
+
+    const removeUnpublished = (dir: string): boolean => {
+        let empty = true
+        for (const name of readdirSync(dir)) {
+            const full = join(dir, name)
+            if (statSync(full).isDirectory()) {
+                const childEmpty = removeUnpublished(full)
+                if (childEmpty) {
+                    rmSync(full, { recursive: true, force: true })
+                }
+                else {
+                    empty = false
+                }
+            }
+            else if (isKept(toPosix(relative(distPath, full)))) {
+                empty = false
+            }
+            else {
+                rmSync(full, { force: true })
+            }
+        }
+        return empty
+    }
+
+    removeUnpublished(distPath)
 }
 
 export { preparePieceDistForPublish }

--- a/packages/pieces/common/package.json
+++ b/packages/pieces/common/package.json
@@ -13,8 +13,9 @@
     "@activepieces/pieces-framework": "workspace:*",
     "@activepieces/core-utils": "workspace:*",
     "form-data": "4.0.4",
-    "tslib": "2.6.2",
     "zod": "4.3.6"
   },
-  "devDependencies": {}
+  "devDependencies": {
+    "tslib": "2.6.2"
+  }
 }

--- a/packages/pieces/community/activecampaign/package.json
+++ b/packages/pieces/community/activecampaign/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/activepieces/package.json
+++ b/packages/pieces/community/activepieces/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/actualbudget/package.json
+++ b/packages/pieces/community/actualbudget/package.json
@@ -7,12 +7,12 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "@actual-app/api": "26.5.2",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
   },
   "devDependencies": {
-    "@types/node": "^24"
+    "@types/node": "^24",
+    "tslib": "2.6.2"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/acuity-scheduling/package.json
+++ b/packages/pieces/community/acuity-scheduling/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/acumbamail/package.json
+++ b/packages/pieces/community/acumbamail/package.json
@@ -12,8 +12,10 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "form-data": "4.0.4",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/add-event/package.json
+++ b/packages/pieces/community/add-event/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/afforai/package.json
+++ b/packages/pieces/community/afforai/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/agentx/package.json
+++ b/packages/pieces/community/agentx/package.json
@@ -8,9 +8,11 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "dayjs": "1.11.9",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/ai/package.json
+++ b/packages/pieces/community/ai/package.json
@@ -21,7 +21,6 @@
     "ai-gateway-provider": "3.1.1",
     "ajv": "8.18.0",
     "mime-types": "2.1.35",
-    "tslib": "2.6.2",
     "zod": "4.3.6",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
@@ -32,6 +31,7 @@
     "lint": "eslint 'src/**/*.ts'"
   },
   "devDependencies": {
-    "@types/mime-types": "2.1.1"
+    "@types/mime-types": "2.1.1",
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/aianswer/package.json
+++ b/packages/pieces/community/aianswer/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/aidbase/package.json
+++ b/packages/pieces/community/aidbase/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/aiprise/package.json
+++ b/packages/pieces/community/aiprise/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/air-ops/package.json
+++ b/packages/pieces/community/air-ops/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/aircall/package.json
+++ b/packages/pieces/community/aircall/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/airparser/package.json
+++ b/packages/pieces/community/airparser/package.json
@@ -12,8 +12,10 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "form-data": "4.0.4",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/airtable/package.json
+++ b/packages/pieces/community/airtable/package.json
@@ -8,9 +8,11 @@
     "@activepieces/pieces-framework": "workspace:*",
     "airtable": "0.11.6",
     "dayjs": "1.11.9",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/airtop/package.json
+++ b/packages/pieces/community/airtop/package.json
@@ -7,10 +7,12 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "zod": "4.3.6",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/alai/package.json
+++ b/packages/pieces/community/alai/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/algolia/package.json
+++ b/packages/pieces/community/algolia/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/alt-text-ai/package.json
+++ b/packages/pieces/community/alt-text-ai/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/alttextify/package.json
+++ b/packages/pieces/community/alttextify/package.json
@@ -8,7 +8,6 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "mime-types": "2.1.35",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
   },
@@ -18,6 +17,7 @@
     "lint": "eslint 'src/**/*.ts'"
   },
   "devDependencies": {
-    "@types/mime-types": "2.1.1"
+    "@types/mime-types": "2.1.1",
+    "tslib": "^2.3.0"
   }
 }

--- a/packages/pieces/community/amazon-bedrock/package.json
+++ b/packages/pieces/community/amazon-bedrock/package.json
@@ -12,9 +12,11 @@
     "@aws-sdk/client-bedrock-runtime": "^3.987.0",
     "@smithy/protocol-http": "5.3.8",
     "@smithy/signature-v4": "5.3.8",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/amazon-s3/package.json
+++ b/packages/pieces/community/amazon-s3/package.json
@@ -13,7 +13,6 @@
     "dayjs": "1.11.9",
     "mime-types": "2.1.35",
     "openpgp": "^6.3.0",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
   },
@@ -23,6 +22,7 @@
     "lint": "eslint 'src/**/*.ts'"
   },
   "devDependencies": {
-    "@types/mime-types": "2.1.1"
+    "@types/mime-types": "2.1.1",
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/amazon-secrets-manager/package.json
+++ b/packages/pieces/community/amazon-secrets-manager/package.json
@@ -8,9 +8,11 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "@aws-sdk/client-secrets-manager": "3.989.0",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/amazon-ses/package.json
+++ b/packages/pieces/community/amazon-ses/package.json
@@ -7,9 +7,11 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "@aws-sdk/client-ses": "3.864.0",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/amazon-sns/package.json
+++ b/packages/pieces/community/amazon-sns/package.json
@@ -7,9 +7,11 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "@aws-sdk/client-sns": "3.726.1",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/amazon-sqs/package.json
+++ b/packages/pieces/community/amazon-sqs/package.json
@@ -7,9 +7,11 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "@aws-sdk/client-sqs": "^3.806.0",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/amazon-textract/package.json
+++ b/packages/pieces/community/amazon-textract/package.json
@@ -8,9 +8,11 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "@aws-sdk/client-textract": "^3.0.0",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/aminos/package.json
+++ b/packages/pieces/community/aminos/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/ampeco/package.json
+++ b/packages/pieces/community/ampeco/package.json
@@ -12,8 +12,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/anyhook-graphql/package.json
+++ b/packages/pieces/community/anyhook-graphql/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/anyhook-websocket/package.json
+++ b/packages/pieces/community/anyhook-websocket/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/apify/package.json
+++ b/packages/pieces/community/apify/package.json
@@ -11,9 +11,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "apify-client": "2.22.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/apitable/package.json
+++ b/packages/pieces/community/apitable/package.json
@@ -12,8 +12,10 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "dayjs": "1.11.9",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/apitemplate-io/package.json
+++ b/packages/pieces/community/apitemplate-io/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/apollo/package.json
+++ b/packages/pieces/community/apollo/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/appfollow/package.json
+++ b/packages/pieces/community/appfollow/package.json
@@ -8,9 +8,11 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "dayjs": "1.11.9",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/asana/package.json
+++ b/packages/pieces/community/asana/package.json
@@ -12,8 +12,10 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "dayjs": "1.11.9",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/ashby/package.json
+++ b/packages/pieces/community/ashby/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/ask-handle/package.json
+++ b/packages/pieces/community/ask-handle/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/asknews/package.json
+++ b/packages/pieces/community/asknews/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/assembled/package.json
+++ b/packages/pieces/community/assembled/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/assemblyai/package.json
+++ b/packages/pieces/community/assemblyai/package.json
@@ -16,13 +16,13 @@
     "mergician": "^2.0.2",
     "title-case": "^4.3.1",
     "tsx": "^4.19.0",
-    "typescript": "^5.6.2"
+    "typescript": "^5.6.2",
+    "tslib": "2.6.2"
   },
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "assemblyai": "4.7.0",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
   }

--- a/packages/pieces/community/attio/package.json
+++ b/packages/pieces/community/attio/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/autocalls/package.json
+++ b/packages/pieces/community/autocalls/package.json
@@ -12,8 +12,10 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "dayjs": "1.11.9",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/avian/package.json
+++ b/packages/pieces/community/avian/package.json
@@ -8,9 +8,11 @@
     "@activepieces/pieces-framework": "workspace:*",
     "openai": "4.67.1",
     "zod": "4.3.6",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/avoma/package.json
+++ b/packages/pieces/community/avoma/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/azure-ad/package.json
+++ b/packages/pieces/community/azure-ad/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/azure-blob-storage/package.json
+++ b/packages/pieces/community/azure-blob-storage/package.json
@@ -9,9 +9,11 @@
     "@activepieces/pieces-framework": "workspace:*",
     "@azure/identity": "4.13.0",
     "@azure/storage-blob": "12.29.1",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/azure-communication-services/package.json
+++ b/packages/pieces/community/azure-communication-services/package.json
@@ -7,9 +7,11 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "@azure/communication-email": "1.0.0",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/azure-devops/package.json
+++ b/packages/pieces/community/azure-devops/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/azure-openai/package.json
+++ b/packages/pieces/community/azure-openai/package.json
@@ -9,9 +9,11 @@
     "@azure/openai": "1.0.0-beta.11",
     "tiktoken": "1.0.11",
     "zod": "4.3.6",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/backblaze/package.json
+++ b/packages/pieces/community/backblaze/package.json
@@ -12,8 +12,10 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "@aws-sdk/client-s3": "3.974.0",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/bamboohr/package.json
+++ b/packages/pieces/community/bamboohr/package.json
@@ -12,8 +12,10 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "dayjs": "1.11.9",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/bannerbear/package.json
+++ b/packages/pieces/community/bannerbear/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/barcode-lookup/package.json
+++ b/packages/pieces/community/barcode-lookup/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/baremetrics/package.json
+++ b/packages/pieces/community/baremetrics/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/base44/package.json
+++ b/packages/pieces/community/base44/package.json
@@ -8,9 +8,11 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "@base44/sdk": "^0.8.4",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/baserow/package.json
+++ b/packages/pieces/community/baserow/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/beamer/package.json
+++ b/packages/pieces/community/beamer/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/beebole/package.json
+++ b/packages/pieces/community/beebole/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/beehiiv/package.json
+++ b/packages/pieces/community/beehiiv/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/bettermode/package.json
+++ b/packages/pieces/community/bettermode/package.json
@@ -12,8 +12,10 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "zod": "4.3.6",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/bexio/package.json
+++ b/packages/pieces/community/bexio/package.json
@@ -9,9 +9,11 @@
     "@activepieces/pieces-framework": "workspace:*",
     "dayjs": "1.11.9",
     "form-data": "4.0.4",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/bigcommerce/package.json
+++ b/packages/pieces/community/bigcommerce/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/bigin-by-zoho/package.json
+++ b/packages/pieces/community/bigin-by-zoho/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/bika/package.json
+++ b/packages/pieces/community/bika/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/billplz/package.json
+++ b/packages/pieces/community/billplz/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/binance/package.json
+++ b/packages/pieces/community/binance/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/bitly/package.json
+++ b/packages/pieces/community/bitly/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/bland-ai/package.json
+++ b/packages/pieces/community/bland-ai/package.json
@@ -6,9 +6,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/blockscout/package.json
+++ b/packages/pieces/community/blockscout/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/bluesky/package.json
+++ b/packages/pieces/community/bluesky/package.json
@@ -9,9 +9,11 @@
     "@activepieces/pieces-framework": "workspace:*",
     "@atproto/api": "0.16.0",
     "dayjs": "1.11.9",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/bocha-search/package.json
+++ b/packages/pieces/community/bocha-search/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/bokio/package.json
+++ b/packages/pieces/community/bokio/package.json
@@ -8,9 +8,11 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "i18next": "23.13.0",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/bolna/package.json
+++ b/packages/pieces/community/bolna/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/bonjoro/package.json
+++ b/packages/pieces/community/bonjoro/package.json
@@ -12,8 +12,10 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "zod": "4.3.6",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/bookedin/package.json
+++ b/packages/pieces/community/bookedin/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/box/package.json
+++ b/packages/pieces/community/box/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/brave-search/package.json
+++ b/packages/pieces/community/brave-search/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/brilliant-directories/package.json
+++ b/packages/pieces/community/brilliant-directories/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/browse-ai/package.json
+++ b/packages/pieces/community/browse-ai/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/browserless/package.json
+++ b/packages/pieces/community/browserless/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/bubble/package.json
+++ b/packages/pieces/community/bubble/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/buffer/package.json
+++ b/packages/pieces/community/buffer/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/bumpups/package.json
+++ b/packages/pieces/community/bumpups/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/bursty-ai/package.json
+++ b/packages/pieces/community/bursty-ai/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/buttondown/package.json
+++ b/packages/pieces/community/buttondown/package.json
@@ -6,9 +6,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/cal-com/package.json
+++ b/packages/pieces/community/cal-com/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/calendly/package.json
+++ b/packages/pieces/community/calendly/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/call-rounded/package.json
+++ b/packages/pieces/community/call-rounded/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/camb-ai/package.json
+++ b/packages/pieces/community/camb-ai/package.json
@@ -8,9 +8,11 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "form-data": "^4.0.4",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/campaign-monitor/package.json
+++ b/packages/pieces/community/campaign-monitor/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/canny/package.json
+++ b/packages/pieces/community/canny/package.json
@@ -6,9 +6,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/canva/package.json
+++ b/packages/pieces/community/canva/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/capsule-crm/package.json
+++ b/packages/pieces/community/capsule-crm/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/captain-data/package.json
+++ b/packages/pieces/community/captain-data/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/carbone/package.json
+++ b/packages/pieces/community/carbone/package.json
@@ -8,9 +8,11 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "form-data": "4.0.4",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/cartloom/package.json
+++ b/packages/pieces/community/cartloom/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/cashfree-payments/package.json
+++ b/packages/pieces/community/cashfree-payments/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/certopus/package.json
+++ b/packages/pieces/community/certopus/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/chain-aware/package.json
+++ b/packages/pieces/community/chain-aware/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/chainalysis-api/package.json
+++ b/packages/pieces/community/chainalysis-api/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/chaindesk/package.json
+++ b/packages/pieces/community/chaindesk/package.json
@@ -8,9 +8,11 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "form-data": "4.0.4",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/chargebee/package.json
+++ b/packages/pieces/community/chargebee/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/chargekeep/package.json
+++ b/packages/pieces/community/chargekeep/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/chartly/package.json
+++ b/packages/pieces/community/chartly/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/chat-aid/package.json
+++ b/packages/pieces/community/chat-aid/package.json
@@ -8,9 +8,11 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "form-data": "4.0.4",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/chat-data/package.json
+++ b/packages/pieces/community/chat-data/package.json
@@ -8,10 +8,12 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "form-data": "4.0.4",
-    "tslib": "^2.3.0",
     "zod": "4.3.6",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/chatbase/package.json
+++ b/packages/pieces/community/chatbase/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/chatfly/package.json
+++ b/packages/pieces/community/chatfly/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/chatling/package.json
+++ b/packages/pieces/community/chatling/package.json
@@ -8,9 +8,11 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "dayjs": "1.11.9",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/chatnode/package.json
+++ b/packages/pieces/community/chatnode/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/chatsistant/package.json
+++ b/packages/pieces/community/chatsistant/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/chatwoot/package.json
+++ b/packages/pieces/community/chatwoot/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/checkout/package.json
+++ b/packages/pieces/community/checkout/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/chess-com/package.json
+++ b/packages/pieces/community/chess-com/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/circle/package.json
+++ b/packages/pieces/community/circle/package.json
@@ -12,8 +12,10 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "dayjs": "1.11.9",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/clarifai/package.json
+++ b/packages/pieces/community/clarifai/package.json
@@ -7,9 +7,11 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "clarifai-nodejs-grpc": "11.3.3",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/claude/package.json
+++ b/packages/pieces/community/claude/package.json
@@ -10,7 +10,6 @@
     "ajv": "8.18.0",
     "mime-types": "2.1.35",
     "zod": "4.3.6",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
   },
@@ -20,6 +19,7 @@
     "lint": "eslint 'src/**/*.ts'"
   },
   "devDependencies": {
-    "@types/mime-types": "2.1.1"
+    "@types/mime-types": "2.1.1",
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/clearout/package.json
+++ b/packages/pieces/community/clearout/package.json
@@ -12,8 +12,10 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "zod": "4.3.6",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/clearoutphone/package.json
+++ b/packages/pieces/community/clearoutphone/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/clicdata/package.json
+++ b/packages/pieces/community/clicdata/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/clickfunnels/package.json
+++ b/packages/pieces/community/clickfunnels/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/clicksend/package.json
+++ b/packages/pieces/community/clicksend/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/clickup/package.json
+++ b/packages/pieces/community/clickup/package.json
@@ -14,11 +14,11 @@
     "dayjs": "1.11.9",
     "qs": "6.14.2",
     "zod": "4.3.6",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
   },
   "devDependencies": {
-    "@types/qs": "6.14.0"
+    "@types/qs": "6.14.0",
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/clockify/package.json
+++ b/packages/pieces/community/clockify/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/clockodo/package.json
+++ b/packages/pieces/community/clockodo/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/close/package.json
+++ b/packages/pieces/community/close/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/cloudconvert/package.json
+++ b/packages/pieces/community/cloudconvert/package.json
@@ -7,10 +7,12 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "zod": "4.3.6",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/cloudinary/package.json
+++ b/packages/pieces/community/cloudinary/package.json
@@ -13,8 +13,10 @@
     "@activepieces/pieces-framework": "workspace:*",
     "dayjs": "1.11.9",
     "form-data": "4.0.4",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/cloutly/package.json
+++ b/packages/pieces/community/cloutly/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/coda/package.json
+++ b/packages/pieces/community/coda/package.json
@@ -12,8 +12,10 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "dayjs": "1.11.9",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/cody/package.json
+++ b/packages/pieces/community/cody/package.json
@@ -8,7 +8,6 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "mime-types": "2.1.35",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
   },
@@ -18,6 +17,7 @@
     "lint": "eslint 'src/**/*.ts'"
   },
   "devDependencies": {
-    "@types/mime-types": "2.1.1"
+    "@types/mime-types": "2.1.1",
+    "tslib": "^2.3.0"
   }
 }

--- a/packages/pieces/community/cognito-forms/package.json
+++ b/packages/pieces/community/cognito-forms/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/cohere/package.json
+++ b/packages/pieces/community/cohere/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/cometapi/package.json
+++ b/packages/pieces/community/cometapi/package.json
@@ -7,10 +7,12 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "zod": "4.3.6",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/comfyicu/package.json
+++ b/packages/pieces/community/comfyicu/package.json
@@ -12,8 +12,10 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "dayjs": "1.11.9",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/confluence/package.json
+++ b/packages/pieces/community/confluence/package.json
@@ -7,7 +7,6 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "xml2js": "0.6.2",
-    "tslib": "2.6.2",
     "form-data": "4.0.4",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
@@ -18,6 +17,7 @@
     "lint": "eslint 'src/**/*.ts'"
   },
   "devDependencies": {
-    "@types/xml2js": "0.4.14"
+    "@types/xml2js": "0.4.14",
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/connectuc/package.json
+++ b/packages/pieces/community/connectuc/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/constant-contact/package.json
+++ b/packages/pieces/community/constant-contact/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/contentful/package.json
+++ b/packages/pieces/community/contentful/package.json
@@ -8,9 +8,11 @@
     "@activepieces/pieces-framework": "workspace:*",
     "contentful-management": "11.48.1",
     "zod": "4.3.6",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/contextual-ai/package.json
+++ b/packages/pieces/community/contextual-ai/package.json
@@ -8,9 +8,11 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "contextual-client": "^0.10.0",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/contiguity/package.json
+++ b/packages/pieces/community/contiguity/package.json
@@ -12,8 +12,10 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "zod": "4.3.6",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/convertkit/package.json
+++ b/packages/pieces/community/convertkit/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/copper/package.json
+++ b/packages/pieces/community/copper/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/copy-ai/package.json
+++ b/packages/pieces/community/copy-ai/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/coralogix/package.json
+++ b/packages/pieces/community/coralogix/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/couchbase/package.json
+++ b/packages/pieces/community/couchbase/package.json
@@ -8,9 +8,11 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "couchbase": "^4.6.0",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/coupa/package.json
+++ b/packages/pieces/community/coupa/package.json
@@ -9,7 +9,6 @@
     "@activepieces/pieces-framework": "workspace:*",
     "dayjs": "1.11.9",
     "form-data": "4.0.4",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
   },
@@ -20,6 +19,7 @@
     "test": "vitest run"
   },
   "devDependencies": {
-    "vitest": "3.0.8"
+    "vitest": "3.0.8",
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/crisp/package.json
+++ b/packages/pieces/community/crisp/package.json
@@ -8,9 +8,11 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "dayjs": "1.11.9",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/cryptolens/package.json
+++ b/packages/pieces/community/cryptolens/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/cursor/package.json
+++ b/packages/pieces/community/cursor/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/customer-io/package.json
+++ b/packages/pieces/community/customer-io/package.json
@@ -7,9 +7,11 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "buffer": "6.0.3",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/customgpt/package.json
+++ b/packages/pieces/community/customgpt/package.json
@@ -8,10 +8,12 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "dayjs": "1.11.9",
-    "tslib": "^2.3.0",
     "zod": "4.3.6",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/cyberark/package.json
+++ b/packages/pieces/community/cyberark/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/dappier/package.json
+++ b/packages/pieces/community/dappier/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/dashworks/package.json
+++ b/packages/pieces/community/dashworks/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/datadog/package.json
+++ b/packages/pieces/community/datadog/package.json
@@ -8,10 +8,12 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "@datadog/datadog-api-client": "^1.43.0",
-    "tslib": "^2.3.0",
     "zod": "4.3.6",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/dataforb2b/package.json
+++ b/packages/pieces/community/dataforb2b/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/datafuel/package.json
+++ b/packages/pieces/community/datafuel/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/datocms/package.json
+++ b/packages/pieces/community/datocms/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/deepgram/package.json
+++ b/packages/pieces/community/deepgram/package.json
@@ -12,11 +12,11 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "mime-types": "2.1.35",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
   },
   "devDependencies": {
-    "@types/mime-types": "2.1.1"
+    "@types/mime-types": "2.1.1",
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/deepl/package.json
+++ b/packages/pieces/community/deepl/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/deepseek/package.json
+++ b/packages/pieces/community/deepseek/package.json
@@ -8,9 +8,11 @@
     "@activepieces/pieces-framework": "workspace:*",
     "openai": "4.67.1",
     "zod": "4.3.6",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/deftform/package.json
+++ b/packages/pieces/community/deftform/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/denser-ai/package.json
+++ b/packages/pieces/community/denser-ai/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/descript/package.json
+++ b/packages/pieces/community/descript/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/detecting-ai/package.json
+++ b/packages/pieces/community/detecting-ai/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/devin/package.json
+++ b/packages/pieces/community/devin/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/digital-ocean/package.json
+++ b/packages/pieces/community/digital-ocean/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/digital-pilot/package.json
+++ b/packages/pieces/community/digital-pilot/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/dimo/package.json
+++ b/packages/pieces/community/dimo/package.json
@@ -7,9 +7,11 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "ethers": "6.15.0",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/discord/package.json
+++ b/packages/pieces/community/discord/package.json
@@ -13,8 +13,10 @@
     "@activepieces/pieces-framework": "workspace:*",
     "dayjs": "1.11.9",
     "form-data": "4.0.4",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/discourse/package.json
+++ b/packages/pieces/community/discourse/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/dittofeed/package.json
+++ b/packages/pieces/community/dittofeed/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/docsbot/package.json
+++ b/packages/pieces/community/docsbot/package.json
@@ -7,10 +7,12 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "zod": "4.3.6",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/doctly/package.json
+++ b/packages/pieces/community/doctly/package.json
@@ -8,9 +8,11 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "form-data": "4.0.4",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/documentpro/package.json
+++ b/packages/pieces/community/documentpro/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/documerge/package.json
+++ b/packages/pieces/community/documerge/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/docusign/package.json
+++ b/packages/pieces/community/docusign/package.json
@@ -8,7 +8,6 @@
     "@activepieces/pieces-framework": "workspace:*",
     "axios": "1.15.2",
     "docusign-esign": "8.1.0",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
   },
@@ -18,6 +17,7 @@
     "lint": "eslint 'src/**/*.ts'"
   },
   "devDependencies": {
-    "@types/docusign-esign": "5.19.9"
+    "@types/docusign-esign": "5.19.9",
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/drip/package.json
+++ b/packages/pieces/community/drip/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/dropbox/package.json
+++ b/packages/pieces/community/dropbox/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/drupal/package.json
+++ b/packages/pieces/community/drupal/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/dub/package.json
+++ b/packages/pieces/community/dub/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/duckdb/package.json
+++ b/packages/pieces/community/duckdb/package.json
@@ -8,9 +8,11 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "@duckdb/node-api": "1.4.3-r.2",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/dumpling-ai/package.json
+++ b/packages/pieces/community/dumpling-ai/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/dust/package.json
+++ b/packages/pieces/community/dust/package.json
@@ -8,7 +8,6 @@
     "@activepieces/pieces-framework": "workspace:*",
     "@dust-tt/client": "1.0.57",
     "mime-types": "2.1.35",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
   },
@@ -18,6 +17,7 @@
     "lint": "eslint 'src/**/*.ts'"
   },
   "devDependencies": {
-    "@types/mime-types": "2.1.1"
+    "@types/mime-types": "2.1.1",
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/easy-peasy-ai/package.json
+++ b/packages/pieces/community/easy-peasy-ai/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/echowin/package.json
+++ b/packages/pieces/community/echowin/package.json
@@ -8,9 +8,11 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "dayjs": "1.11.9",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/eden-ai/package.json
+++ b/packages/pieces/community/eden-ai/package.json
@@ -12,8 +12,10 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "zod": "4.3.6",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/editionguard/package.json
+++ b/packages/pieces/community/editionguard/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/elastic-email/package.json
+++ b/packages/pieces/community/elastic-email/package.json
@@ -12,8 +12,10 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "zod": "4.3.6",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/elevenlabs/package.json
+++ b/packages/pieces/community/elevenlabs/package.json
@@ -7,9 +7,11 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "@elevenlabs/elevenlabs-js": "2.4.1",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/emailit/package.json
+++ b/packages/pieces/community/emailit/package.json
@@ -6,9 +6,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/emailoctopus/package.json
+++ b/packages/pieces/community/emailoctopus/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/enrichlayer/package.json
+++ b/packages/pieces/community/enrichlayer/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/esignatures/package.json
+++ b/packages/pieces/community/esignatures/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/eth-name-service/package.json
+++ b/packages/pieces/community/eth-name-service/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/everhour/package.json
+++ b/packages/pieces/community/everhour/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/exa/package.json
+++ b/packages/pieces/community/exa/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/extracta-ai/package.json
+++ b/packages/pieces/community/extracta-ai/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/facebook-leads/package.json
+++ b/packages/pieces/community/facebook-leads/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/facebook-pages/package.json
+++ b/packages/pieces/community/facebook-pages/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/famulor/package.json
+++ b/packages/pieces/community/famulor/package.json
@@ -13,8 +13,10 @@
     "@activepieces/pieces-framework": "workspace:*",
     "dayjs": "1.11.9",
     "zod": "4.3.6",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/fathom-analytics/package.json
+++ b/packages/pieces/community/fathom-analytics/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/fathom/package.json
+++ b/packages/pieces/community/fathom/package.json
@@ -8,9 +8,11 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "fathom-typescript": "^0.0.36",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/feathery/package.json
+++ b/packages/pieces/community/feathery/package.json
@@ -8,9 +8,11 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "dayjs": "1.11.9",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/feedhive/package.json
+++ b/packages/pieces/community/feedhive/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/fellow/package.json
+++ b/packages/pieces/community/fellow/package.json
@@ -8,9 +8,11 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "dayjs": "1.11.9",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/figma/package.json
+++ b/packages/pieces/community/figma/package.json
@@ -12,8 +12,10 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "nanoid": "3.3.8",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/filetopdf/package.json
+++ b/packages/pieces/community/filetopdf/package.json
@@ -8,9 +8,11 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "form-data": "4.0.4",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/fillout-forms/package.json
+++ b/packages/pieces/community/fillout-forms/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/fireberry/package.json
+++ b/packages/pieces/community/fireberry/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/firecrawl/package.json
+++ b/packages/pieces/community/firecrawl/package.json
@@ -12,8 +12,10 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "ajv": "8.18.0",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/fireflies-ai/package.json
+++ b/packages/pieces/community/fireflies-ai/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/flipando/package.json
+++ b/packages/pieces/community/flipando/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/fliqr-ai/package.json
+++ b/packages/pieces/community/fliqr-ai/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/flow-helper/package.json
+++ b/packages/pieces/community/flow-helper/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/flow-parser/package.json
+++ b/packages/pieces/community/flow-parser/package.json
@@ -8,9 +8,11 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "dayjs": "1.11.9",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/flowise/package.json
+++ b/packages/pieces/community/flowise/package.json
@@ -4,7 +4,8 @@
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "devDependencies": {
-    "@types/is-url": "^1.2.32"
+    "@types/is-url": "^1.2.32",
+    "tslib": "2.6.2"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",
@@ -14,7 +15,6 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
   }

--- a/packages/pieces/community/flowlu/package.json
+++ b/packages/pieces/community/flowlu/package.json
@@ -12,8 +12,10 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "dayjs": "1.11.9",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/folk/package.json
+++ b/packages/pieces/community/folk/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/foreplay-co/package.json
+++ b/packages/pieces/community/foreplay-co/package.json
@@ -7,10 +7,12 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "zod": "4.3.6",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/formbricks/package.json
+++ b/packages/pieces/community/formbricks/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/formitable/package.json
+++ b/packages/pieces/community/formitable/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/formsite/package.json
+++ b/packages/pieces/community/formsite/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/formspark/package.json
+++ b/packages/pieces/community/formspark/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/formstack/package.json
+++ b/packages/pieces/community/formstack/package.json
@@ -12,8 +12,10 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "dayjs": "1.11.9",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/fountain/package.json
+++ b/packages/pieces/community/fountain/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/fragment/package.json
+++ b/packages/pieces/community/fragment/package.json
@@ -8,9 +8,11 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "dayjs": "^1.11.7",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/frame/package.json
+++ b/packages/pieces/community/frame/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/free-agent/package.json
+++ b/packages/pieces/community/free-agent/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/freshdesk/package.json
+++ b/packages/pieces/community/freshdesk/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/freshsales/package.json
+++ b/packages/pieces/community/freshsales/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/freshservice/package.json
+++ b/packages/pieces/community/freshservice/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/frill/package.json
+++ b/packages/pieces/community/frill/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/front/package.json
+++ b/packages/pieces/community/front/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/gameball/package.json
+++ b/packages/pieces/community/gameball/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/gamma/package.json
+++ b/packages/pieces/community/gamma/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/gcloud-pubsub/package.json
+++ b/packages/pieces/community/gcloud-pubsub/package.json
@@ -7,9 +7,11 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "google-auth-library": "8.9.0",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/gender-api/package.json
+++ b/packages/pieces/community/gender-api/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/generatebanners/package.json
+++ b/packages/pieces/community/generatebanners/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/getresponse/package.json
+++ b/packages/pieces/community/getresponse/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/ghostcms/package.json
+++ b/packages/pieces/community/ghostcms/package.json
@@ -12,11 +12,11 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "jsonwebtoken": "9.0.1",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
   },
   "devDependencies": {
-    "@types/jsonwebtoken": "9.0.10"
+    "@types/jsonwebtoken": "9.0.10",
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/giftbit/package.json
+++ b/packages/pieces/community/giftbit/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/gistly/package.json
+++ b/packages/pieces/community/gistly/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/gitea/package.json
+++ b/packages/pieces/community/gitea/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/github/package.json
+++ b/packages/pieces/community/github/package.json
@@ -12,11 +12,11 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "jsonwebtoken": "9.0.1",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
   },
   "devDependencies": {
-    "@types/jsonwebtoken": "9.0.10"
+    "@types/jsonwebtoken": "9.0.10",
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/gitlab/package.json
+++ b/packages/pieces/community/gitlab/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/gladia/package.json
+++ b/packages/pieces/community/gladia/package.json
@@ -8,9 +8,11 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "form-data": "4.0.4",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/glide/package.json
+++ b/packages/pieces/community/glide/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/gmail/package.json
+++ b/packages/pieces/community/gmail/package.json
@@ -13,7 +13,6 @@
     "mailparser": "3.9.3",
     "mime-types": "2.1.35",
     "nodemailer": "8.0.5",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
   },
@@ -25,6 +24,7 @@
   "devDependencies": {
     "@types/mime-types": "2.1.1",
     "@types/mailparser": "3.4.6",
-    "@types/nodemailer": "7.0.11"
+    "@types/nodemailer": "7.0.11",
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/goodmem/package.json
+++ b/packages/pieces/community/goodmem/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/google-bigquery/package.json
+++ b/packages/pieces/community/google-bigquery/package.json
@@ -7,9 +7,11 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "google-auth-library": "10.5.0",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/google-calendar/package.json
+++ b/packages/pieces/community/google-calendar/package.json
@@ -9,9 +9,11 @@
     "@googleapis/calendar": "15.0.0",
     "dayjs": "1.11.9",
     "google-auth-library": "10.5.0",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/google-cloud-storage/package.json
+++ b/packages/pieces/community/google-cloud-storage/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/google-contacts/package.json
+++ b/packages/pieces/community/google-contacts/package.json
@@ -9,9 +9,11 @@
     "@googleapis/people": "7.0.1",
     "dayjs": "1.11.9",
     "google-auth-library": "10.5.0",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/google-docs/package.json
+++ b/packages/pieces/community/google-docs/package.json
@@ -10,9 +10,11 @@
     "@googleapis/drive": "20.2.0",
     "dayjs": "1.11.9",
     "google-auth-library": "10.5.0",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/google-drive/package.json
+++ b/packages/pieces/community/google-drive/package.json
@@ -11,7 +11,6 @@
     "form-data": "4.0.4",
     "google-auth-library": "10.5.0",
     "mime-types": "2.1.35",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
   },
@@ -21,6 +20,7 @@
     "lint": "eslint 'src/**/*.ts'"
   },
   "devDependencies": {
-    "@types/mime-types": "2.1.1"
+    "@types/mime-types": "2.1.1",
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/google-forms/package.json
+++ b/packages/pieces/community/google-forms/package.json
@@ -8,9 +8,11 @@
     "@activepieces/pieces-framework": "workspace:*",
     "dayjs": "1.11.9",
     "google-auth-library": "10.5.0",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/google-gemini/package.json
+++ b/packages/pieces/community/google-gemini/package.json
@@ -11,13 +11,13 @@
     "mime-types": "2.1.35",
     "wav": "^1.0.2",
     "zod": "4.3.6",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
   },
   "devDependencies": {
     "@types/wav": "^1.0.4",
-    "@types/mime-types": "2.1.1"
+    "@types/mime-types": "2.1.1",
+    "tslib": "2.6.2"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/google-my-business/package.json
+++ b/packages/pieces/community/google-my-business/package.json
@@ -13,8 +13,10 @@
     "@activepieces/pieces-framework": "workspace:*",
     "dayjs": "1.11.9",
     "zod": "4.3.6",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/google-search-console/package.json
+++ b/packages/pieces/community/google-search-console/package.json
@@ -9,9 +9,11 @@
     "@googleapis/webmasters": "2.0.1",
     "dayjs": "1.11.9",
     "google-auth-library": "10.5.0",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/google-search/package.json
+++ b/packages/pieces/community/google-search/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/google-sheets/package.json
+++ b/packages/pieces/community/google-sheets/package.json
@@ -14,10 +14,12 @@
     "google-auth-library": "10.5.0",
     "lodash": "4.18.1",
     "nanoid": "3.3.8",
-    "tslib": "2.6.2",
     "zod": "4.3.6",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/google-slides/package.json
+++ b/packages/pieces/community/google-slides/package.json
@@ -8,9 +8,11 @@
     "@activepieces/pieces-framework": "workspace:*",
     "@googleapis/drive": "20.2.0",
     "google-auth-library": "10.5.0",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/google-tasks/package.json
+++ b/packages/pieces/community/google-tasks/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/googlechat/package.json
+++ b/packages/pieces/community/googlechat/package.json
@@ -7,10 +7,12 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "zod": "4.3.6",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/gorgias/package.json
+++ b/packages/pieces/community/gorgias/package.json
@@ -6,9 +6,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/gotify/package.json
+++ b/packages/pieces/community/gotify/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/gptzero-detect-ai/package.json
+++ b/packages/pieces/community/gptzero-detect-ai/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/granola/package.json
+++ b/packages/pieces/community/granola/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/gravityforms/package.json
+++ b/packages/pieces/community/gravityforms/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/greenhouse/package.json
+++ b/packages/pieces/community/greenhouse/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/greenpt/package.json
+++ b/packages/pieces/community/greenpt/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/greip/package.json
+++ b/packages/pieces/community/greip/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/griptape/package.json
+++ b/packages/pieces/community/griptape/package.json
@@ -8,9 +8,11 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "dayjs": "1.11.9",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/grist/package.json
+++ b/packages/pieces/community/grist/package.json
@@ -12,8 +12,10 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "form-data": "4.0.4",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/grok-xai/package.json
+++ b/packages/pieces/community/grok-xai/package.json
@@ -7,10 +7,12 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "zod": "4.3.6",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/groq/package.json
+++ b/packages/pieces/community/groq/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/guidelite/package.json
+++ b/packages/pieces/community/guidelite/package.json
@@ -8,9 +8,11 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "dayjs": "1.11.9",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/hackernews/package.json
+++ b/packages/pieces/community/hackernews/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/harvest/package.json
+++ b/packages/pieces/community/harvest/package.json
@@ -12,8 +12,10 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "zod": "4.3.6",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/hashi-corp-vault/package.json
+++ b/packages/pieces/community/hashi-corp-vault/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/hastewire/package.json
+++ b/packages/pieces/community/hastewire/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/heartbeat/package.json
+++ b/packages/pieces/community/heartbeat/package.json
@@ -12,8 +12,10 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "zod": "4.3.6",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/hedy/package.json
+++ b/packages/pieces/community/hedy/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/help-scout/package.json
+++ b/packages/pieces/community/help-scout/package.json
@@ -7,10 +7,12 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "zod": "4.3.6",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/heygen/package.json
+++ b/packages/pieces/community/heygen/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/heymarket-sms/package.json
+++ b/packages/pieces/community/heymarket-sms/package.json
@@ -8,9 +8,11 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "dayjs": "1.11.9",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/hootsuite/package.json
+++ b/packages/pieces/community/hootsuite/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/housecall-pro/package.json
+++ b/packages/pieces/community/housecall-pro/package.json
@@ -7,10 +7,12 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "zod": "4.3.6",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/http-oauth2/package.json
+++ b/packages/pieces/community/http-oauth2/package.json
@@ -7,10 +7,12 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "form-data": "4.0.4",
-    "tslib": "2.6.2",
     "undici": "7.24.6",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/hubspot/package.json
+++ b/packages/pieces/community/hubspot/package.json
@@ -8,9 +8,11 @@
     "@activepieces/pieces-framework": "workspace:*",
     "@hubspot/api-client": "12.0.1",
     "dayjs": "1.11.9",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/hugging-face/package.json
+++ b/packages/pieces/community/hugging-face/package.json
@@ -8,9 +8,11 @@
     "@activepieces/pieces-framework": "workspace:*",
     "@huggingface/inference": "4.7.1",
     "@huggingface/tasks": "0.19.85",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/hume-ai/package.json
+++ b/packages/pieces/community/hume-ai/package.json
@@ -8,9 +8,11 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "hume": "^0.15.6",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/hunter/package.json
+++ b/packages/pieces/community/hunter/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/hystruct/package.json
+++ b/packages/pieces/community/hystruct/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/ibm-cognose/package.json
+++ b/packages/pieces/community/ibm-cognose/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/iloveapi/package.json
+++ b/packages/pieces/community/iloveapi/package.json
@@ -8,9 +8,11 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "form-data": "4.0.4",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/image-router/package.json
+++ b/packages/pieces/community/image-router/package.json
@@ -8,9 +8,11 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "form-data": "4.0.4",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/imap/package.json
+++ b/packages/pieces/community/imap/package.json
@@ -9,7 +9,6 @@
     "dayjs": "1.11.9",
     "imapflow": "1.0.200",
     "mailparser": "3.9.3",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
   },
@@ -19,6 +18,7 @@
     "lint": "eslint 'src/**/*.ts'"
   },
   "devDependencies": {
-    "@types/mailparser": "3.4.6"
+    "@types/mailparser": "3.4.6",
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/imeetify/package.json
+++ b/packages/pieces/community/imeetify/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/influencers-club/package.json
+++ b/packages/pieces/community/influencers-club/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/insightly/package.json
+++ b/packages/pieces/community/insightly/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/insighto-ai/package.json
+++ b/packages/pieces/community/insighto-ai/package.json
@@ -7,10 +7,12 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "zod": "4.3.6",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/insta-charts/package.json
+++ b/packages/pieces/community/insta-charts/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/instabase/package.json
+++ b/packages/pieces/community/instabase/package.json
@@ -8,9 +8,11 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "form-data": "4.0.4",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/instagram-business/package.json
+++ b/packages/pieces/community/instagram-business/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/instantly-ai/package.json
+++ b/packages/pieces/community/instantly-ai/package.json
@@ -12,8 +12,10 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "dayjs": "1.11.9",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/instasent/package.json
+++ b/packages/pieces/community/instasent/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/intercom/package.json
+++ b/packages/pieces/community/intercom/package.json
@@ -9,9 +9,11 @@
     "dayjs": "1.11.9",
     "intercom-client": "6.2.0",
     "string-strip-html": "8.5.0",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/intruder/package.json
+++ b/packages/pieces/community/intruder/package.json
@@ -6,9 +6,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/invoiceninja/package.json
+++ b/packages/pieces/community/invoiceninja/package.json
@@ -12,8 +12,10 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "zod": "4.3.6",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/jina-ai/package.json
+++ b/packages/pieces/community/jina-ai/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/jira-cloud/package.json
+++ b/packages/pieces/community/jira-cloud/package.json
@@ -12,9 +12,11 @@
     "dayjs": "1.11.9",
     "form-data": "4.0.4",
     "zod": "4.3.6",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/jira-data-center/package.json
+++ b/packages/pieces/community/jira-data-center/package.json
@@ -9,9 +9,11 @@
     "dayjs": "1.11.9",
     "form-data": "4.0.4",
     "zod": "4.3.6",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/jogg-ai/package.json
+++ b/packages/pieces/community/jogg-ai/package.json
@@ -7,10 +7,12 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "zod": "4.3.6",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/jotform/package.json
+++ b/packages/pieces/community/jotform/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/json/package.json
+++ b/packages/pieces/community/json/package.json
@@ -12,8 +12,10 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "jsonata": "^2.0.0",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/jungle-grid/package.json
+++ b/packages/pieces/community/jungle-grid/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/just-invoice/package.json
+++ b/packages/pieces/community/just-invoice/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/kallabot-ai/package.json
+++ b/packages/pieces/community/kallabot-ai/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/kapso/package.json
+++ b/packages/pieces/community/kapso/package.json
@@ -8,9 +8,11 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "@kapso/whatsapp-cloud-api": "^0.1.1",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/katana/package.json
+++ b/packages/pieces/community/katana/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/kimai/package.json
+++ b/packages/pieces/community/kimai/package.json
@@ -12,8 +12,10 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "zod": "4.3.6",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/kissflow/package.json
+++ b/packages/pieces/community/kissflow/package.json
@@ -8,7 +8,6 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "content-disposition": "0.5.4",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
   },
@@ -18,6 +17,7 @@
     "lint": "eslint 'src/**/*.ts'"
   },
   "devDependencies": {
-    "@types/content-disposition": "0.5.9"
+    "@types/content-disposition": "0.5.9",
+    "tslib": "^2.3.0"
   }
 }

--- a/packages/pieces/community/kizeo-forms/package.json
+++ b/packages/pieces/community/kizeo-forms/package.json
@@ -12,8 +12,10 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "zod": "4.3.6",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/klaviyo/package.json
+++ b/packages/pieces/community/klaviyo/package.json
@@ -12,8 +12,10 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "dayjs": "1.11.9",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/klenty/package.json
+++ b/packages/pieces/community/klenty/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/klipy/package.json
+++ b/packages/pieces/community/klipy/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/knack/package.json
+++ b/packages/pieces/community/knack/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/knock/package.json
+++ b/packages/pieces/community/knock/package.json
@@ -6,9 +6,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/ko-fi/package.json
+++ b/packages/pieces/community/ko-fi/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/kommo/package.json
+++ b/packages/pieces/community/kommo/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/krisp-call/package.json
+++ b/packages/pieces/community/krisp-call/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/kudosity/package.json
+++ b/packages/pieces/community/kudosity/package.json
@@ -7,10 +7,12 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "zod": "4.3.6",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/kustomer/package.json
+++ b/packages/pieces/community/kustomer/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/lead-connector/package.json
+++ b/packages/pieces/community/lead-connector/package.json
@@ -13,11 +13,11 @@
     "@activepieces/pieces-framework": "workspace:*",
     "jsonwebtoken": "9.0.1",
     "zod": "4.3.6",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
   },
   "devDependencies": {
-    "@types/jsonwebtoken": "9.0.10"
+    "@types/jsonwebtoken": "9.0.10",
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/leap-ai/package.json
+++ b/packages/pieces/community/leap-ai/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/leexi/package.json
+++ b/packages/pieces/community/leexi/package.json
@@ -8,9 +8,11 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "dayjs": "1.11.9",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/lemlist/package.json
+++ b/packages/pieces/community/lemlist/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/lemon-squeezy/package.json
+++ b/packages/pieces/community/lemon-squeezy/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/letmepost/package.json
+++ b/packages/pieces/community/letmepost/package.json
@@ -10,7 +10,9 @@
   },
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
-    "@activepieces/pieces-framework": "workspace:*",
+    "@activepieces/pieces-framework": "workspace:*"
+  },
+  "devDependencies": {
     "tslib": "^2.3.0"
   }
 }

--- a/packages/pieces/community/lets-calendar/package.json
+++ b/packages/pieces/community/lets-calendar/package.json
@@ -8,9 +8,11 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "dayjs": "1.11.9",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/letta/package.json
+++ b/packages/pieces/community/letta/package.json
@@ -8,9 +8,11 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "@letta-ai/letta-client": "1.3.1",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/lever/package.json
+++ b/packages/pieces/community/lever/package.json
@@ -12,11 +12,11 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "qs": "6.14.2",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
   },
   "devDependencies": {
-    "@types/qs": "6.14.0"
+    "@types/qs": "6.14.0",
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/lightfunnels/package.json
+++ b/packages/pieces/community/lightfunnels/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/line/package.json
+++ b/packages/pieces/community/line/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/linear/package.json
+++ b/packages/pieces/community/linear/package.json
@@ -7,9 +7,11 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "@linear/sdk": "7.0.1",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/linka/package.json
+++ b/packages/pieces/community/linka/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/linkedin/package.json
+++ b/packages/pieces/community/linkedin/package.json
@@ -13,11 +13,11 @@
     "@activepieces/pieces-framework": "workspace:*",
     "form-data": "4.0.4",
     "jsonwebtoken": "9.0.1",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
   },
   "devDependencies": {
-    "@types/jsonwebtoken": "9.0.10"
+    "@types/jsonwebtoken": "9.0.10",
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/linkup/package.json
+++ b/packages/pieces/community/linkup/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/linkupapi/package.json
+++ b/packages/pieces/community/linkupapi/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/livesession/package.json
+++ b/packages/pieces/community/livesession/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/llmrails/package.json
+++ b/packages/pieces/community/llmrails/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/lobstermail/package.json
+++ b/packages/pieces/community/lobstermail/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/localai/package.json
+++ b/packages/pieces/community/localai/package.json
@@ -7,9 +7,11 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "openai": "4.67.1",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/lofty/package.json
+++ b/packages/pieces/community/lofty/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/logrocket/package.json
+++ b/packages/pieces/community/logrocket/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/logsnag/package.json
+++ b/packages/pieces/community/logsnag/package.json
@@ -6,9 +6,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/lokalise/package.json
+++ b/packages/pieces/community/lokalise/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/loops/package.json
+++ b/packages/pieces/community/loops/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/lucidya/package.json
+++ b/packages/pieces/community/lucidya/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/lusha/package.json
+++ b/packages/pieces/community/lusha/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/luxury-presence/package.json
+++ b/packages/pieces/community/luxury-presence/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/magical-api/package.json
+++ b/packages/pieces/community/magical-api/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/magicslides/package.json
+++ b/packages/pieces/community/magicslides/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/mailchain/package.json
+++ b/packages/pieces/community/mailchain/package.json
@@ -7,9 +7,11 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "@mailchain/sdk": "^0.31.0",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/mailchimp/package.json
+++ b/packages/pieces/community/mailchimp/package.json
@@ -7,7 +7,6 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "@mailchimp/mailchimp_marketing": "3.0.80",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
   },
@@ -17,6 +16,7 @@
     "lint": "eslint 'src/**/*.ts'"
   },
   "devDependencies": {
-    "@types/mailchimp__mailchimp_marketing": "3.0.22"
+    "@types/mailchimp__mailchimp_marketing": "3.0.22",
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/mailer-lite/package.json
+++ b/packages/pieces/community/mailer-lite/package.json
@@ -8,9 +8,11 @@
     "@activepieces/pieces-framework": "workspace:*",
     "@mailerlite/mailerlite-nodejs": "1.1.0",
     "dayjs": "1.11.9",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/mailercheck/package.json
+++ b/packages/pieces/community/mailercheck/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/maileroo/package.json
+++ b/packages/pieces/community/maileroo/package.json
@@ -12,8 +12,10 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "form-data": "4.0.4",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/mailgun/package.json
+++ b/packages/pieces/community/mailgun/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/mailjet/package.json
+++ b/packages/pieces/community/mailjet/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/manus/package.json
+++ b/packages/pieces/community/manus/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/manychat/package.json
+++ b/packages/pieces/community/manychat/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/mastodon/package.json
+++ b/packages/pieces/community/mastodon/package.json
@@ -12,8 +12,10 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "form-data": "4.0.4",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/matomo/package.json
+++ b/packages/pieces/community/matomo/package.json
@@ -12,8 +12,10 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "zod": "4.3.6",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/matrix/package.json
+++ b/packages/pieces/community/matrix/package.json
@@ -7,7 +7,6 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "marked": "4.3.0",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
   },
@@ -17,6 +16,7 @@
     "lint": "eslint 'src/**/*.ts'"
   },
   "devDependencies": {
-    "@types/marked": "4.3.2"
+    "@types/marked": "4.3.2",
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/mattermost/package.json
+++ b/packages/pieces/community/mattermost/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/mautic/package.json
+++ b/packages/pieces/community/mautic/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/mcp/package.json
+++ b/packages/pieces/community/mcp/package.json
@@ -12,8 +12,10 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "http-status-codes": "2.2.0",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/medullar/package.json
+++ b/packages/pieces/community/medullar/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/meetgeek-ai/package.json
+++ b/packages/pieces/community/meetgeek-ai/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/meistertask/package.json
+++ b/packages/pieces/community/meistertask/package.json
@@ -12,8 +12,10 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "dayjs": "1.11.9",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/mem/package.json
+++ b/packages/pieces/community/mem/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/mempool-space/package.json
+++ b/packages/pieces/community/mempool-space/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/messagebird/package.json
+++ b/packages/pieces/community/messagebird/package.json
@@ -12,8 +12,10 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "dayjs": "1.11.9",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/metabase/package.json
+++ b/packages/pieces/community/metabase/package.json
@@ -8,12 +8,12 @@
     "@activepieces/pieces-framework": "workspace:*",
     "jsonwebtoken": "9.0.1",
     "playwright": "1.56.0",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
   },
   "devDependencies": {
-    "@types/jsonwebtoken": "9.0.10"
+    "@types/jsonwebtoken": "9.0.10",
+    "tslib": "2.6.2"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/metatext/package.json
+++ b/packages/pieces/community/metatext/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/microsoft-365-people/package.json
+++ b/packages/pieces/community/microsoft-365-people/package.json
@@ -10,9 +10,11 @@
     "@microsoft/microsoft-graph-client": "3.0.7",
     "@microsoft/microsoft-graph-types": "2.40.0",
     "dayjs": "1.11.9",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/microsoft-365-planner/package.json
+++ b/packages/pieces/community/microsoft-365-planner/package.json
@@ -10,9 +10,11 @@
     "@microsoft/microsoft-graph-client": "3.0.7",
     "@microsoft/microsoft-graph-types": "2.40.0",
     "dayjs": "1.11.9",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/microsoft-copilot/package.json
+++ b/packages/pieces/community/microsoft-copilot/package.json
@@ -9,9 +9,11 @@
     "@activepieces/pieces-framework": "workspace:*",
     "@microsoft/microsoft-graph-client": "3.0.7",
     "@microsoft/microsoft-graph-types": "2.40.0",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/microsoft-dynamics-365-business-central/package.json
+++ b/packages/pieces/community/microsoft-dynamics-365-business-central/package.json
@@ -12,8 +12,10 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "dayjs": "1.11.9",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/microsoft-dynamics-crm/package.json
+++ b/packages/pieces/community/microsoft-dynamics-crm/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/microsoft-excel-365/package.json
+++ b/packages/pieces/community/microsoft-excel-365/package.json
@@ -9,9 +9,11 @@
     "@microsoft/microsoft-graph-client": "3.0.7",
     "@microsoft/microsoft-graph-types": "2.40.0",
     "dayjs": "1.11.9",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/microsoft-onedrive/package.json
+++ b/packages/pieces/community/microsoft-onedrive/package.json
@@ -10,7 +10,6 @@
     "@microsoft/microsoft-graph-types": "2.40.0",
     "dayjs": "1.11.9",
     "mime-types": "2.1.35",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
   },
@@ -20,6 +19,7 @@
     "lint": "eslint 'src/**/*.ts'"
   },
   "devDependencies": {
-    "@types/mime-types": "2.1.1"
+    "@types/mime-types": "2.1.1",
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/microsoft-onenote/package.json
+++ b/packages/pieces/community/microsoft-onenote/package.json
@@ -9,9 +9,11 @@
     "@activepieces/pieces-framework": "workspace:*",
     "@microsoft/microsoft-graph-client": "3.0.7",
     "dayjs": "1.11.9",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/microsoft-outlook-calendar/package.json
+++ b/packages/pieces/community/microsoft-outlook-calendar/package.json
@@ -12,8 +12,10 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "dayjs": "1.11.9",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/microsoft-outlook/package.json
+++ b/packages/pieces/community/microsoft-outlook/package.json
@@ -9,9 +9,11 @@
     "@microsoft/microsoft-graph-client": "3.0.7",
     "@microsoft/microsoft-graph-types": "2.40.0",
     "dayjs": "1.11.9",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/microsoft-power-bi/package.json
+++ b/packages/pieces/community/microsoft-power-bi/package.json
@@ -13,8 +13,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/microsoft-sharepoint/package.json
+++ b/packages/pieces/community/microsoft-sharepoint/package.json
@@ -9,9 +9,11 @@
     "@microsoft/microsoft-graph-client": "3.0.7",
     "@microsoft/microsoft-graph-types": "2.40.0",
     "dayjs": "1.11.9",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/microsoft-teams/package.json
+++ b/packages/pieces/community/microsoft-teams/package.json
@@ -9,9 +9,11 @@
     "@microsoft/microsoft-graph-client": "3.0.7",
     "@microsoft/microsoft-graph-types": "2.40.0",
     "dayjs": "1.11.9",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/microsoft-todo/package.json
+++ b/packages/pieces/community/microsoft-todo/package.json
@@ -9,9 +9,11 @@
     "@microsoft/microsoft-graph-client": "3.0.7",
     "@microsoft/microsoft-graph-types": "2.40.0",
     "dayjs": "1.11.9",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/millionverifier/package.json
+++ b/packages/pieces/community/millionverifier/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/mind-studio/package.json
+++ b/packages/pieces/community/mind-studio/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/mindee/package.json
+++ b/packages/pieces/community/mindee/package.json
@@ -12,8 +12,10 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "form-data": "4.0.4",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/missive/package.json
+++ b/packages/pieces/community/missive/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/mistral-ai/package.json
+++ b/packages/pieces/community/mistral-ai/package.json
@@ -12,8 +12,10 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "form-data": "4.0.4",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/mixmax/package.json
+++ b/packages/pieces/community/mixmax/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/mixpanel/package.json
+++ b/packages/pieces/community/mixpanel/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/modelslab/package.json
+++ b/packages/pieces/community/modelslab/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/mollie/package.json
+++ b/packages/pieces/community/mollie/package.json
@@ -8,9 +8,11 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "dayjs": "1.11.9",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/monday/package.json
+++ b/packages/pieces/community/monday/package.json
@@ -9,9 +9,11 @@
     "dayjs": "1.11.9",
     "form-data": "4.0.4",
     "monday-sdk-js": "0.5.2",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/mongodb/package.json
+++ b/packages/pieces/community/mongodb/package.json
@@ -8,9 +8,11 @@
     "@activepieces/pieces-framework": "workspace:*",
     "mongodb": "6.15.0",
     "zod": "4.3.6",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/moonclerk/package.json
+++ b/packages/pieces/community/moonclerk/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/mooninvoice/package.json
+++ b/packages/pieces/community/mooninvoice/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/motion/package.json
+++ b/packages/pieces/community/motion/package.json
@@ -12,8 +12,10 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "dayjs": "1.11.9",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/motiontools/package.json
+++ b/packages/pieces/community/motiontools/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/moveo-ai/package.json
+++ b/packages/pieces/community/moveo-ai/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/moxie-crm/package.json
+++ b/packages/pieces/community/moxie-crm/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/muna-ai/package.json
+++ b/packages/pieces/community/muna-ai/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/murf-api/package.json
+++ b/packages/pieces/community/murf-api/package.json
@@ -8,9 +8,11 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "form-data": "4.0.4",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/mycase-piece/package.json
+++ b/packages/pieces/community/mycase-piece/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/mysendingbox/package.json
+++ b/packages/pieces/community/mysendingbox/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/mysql/package.json
+++ b/packages/pieces/community/mysql/package.json
@@ -8,7 +8,6 @@
     "@activepieces/pieces-framework": "workspace:*",
     "promise-mysql": "5.2.0",
     "sqlstring": "2.3.3",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
   },
@@ -18,6 +17,7 @@
     "lint": "eslint 'src/**/*.ts'"
   },
   "devDependencies": {
-    "@types/sqlstring": "2.3.2"
+    "@types/sqlstring": "2.3.2",
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/netlify/package.json
+++ b/packages/pieces/community/netlify/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/netsuite/package.json
+++ b/packages/pieces/community/netsuite/package.json
@@ -7,9 +7,11 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "sql-formatter": "15.6.10",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/neverbounce/package.json
+++ b/packages/pieces/community/neverbounce/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/nifty/package.json
+++ b/packages/pieces/community/nifty/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/ninjapipe/package.json
+++ b/packages/pieces/community/ninjapipe/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/ninox/package.json
+++ b/packages/pieces/community/ninox/package.json
@@ -12,11 +12,11 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "mime-types": "2.1.35",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
   },
   "devDependencies": {
-    "@types/mime-types": "2.1.1"
+    "@types/mime-types": "2.1.1",
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/nocodb/package.json
+++ b/packages/pieces/community/nocodb/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/notion/package.json
+++ b/packages/pieces/community/notion/package.json
@@ -10,9 +10,11 @@
     "@tryfabric/martian": "1.2.4",
     "dayjs": "1.11.9",
     "notion-to-md": "3.1.1",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   },
   "overrides": {
     "@notionhq/client": "2.2.14"

--- a/packages/pieces/community/ntfy/package.json
+++ b/packages/pieces/community/ntfy/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/nuelink/package.json
+++ b/packages/pieces/community/nuelink/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/octopush-sms/package.json
+++ b/packages/pieces/community/octopush-sms/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/odoo/package.json
+++ b/packages/pieces/community/odoo/package.json
@@ -9,12 +9,12 @@
     "url": "^0.11.3",
     "xmlrpc": "^1.3.2",
     "zod": "4.3.6",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
   },
   "devDependencies": {
-    "@types/xmlrpc": "^1.3.10"
+    "@types/xmlrpc": "^1.3.10",
+    "tslib": "2.6.2"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/okta/package.json
+++ b/packages/pieces/community/okta/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/omni-co/package.json
+++ b/packages/pieces/community/omni-co/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/omnihr/package.json
+++ b/packages/pieces/community/omnihr/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/omnisend/package.json
+++ b/packages/pieces/community/omnisend/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/oncehub/package.json
+++ b/packages/pieces/community/oncehub/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/oneclickimpact/package.json
+++ b/packages/pieces/community/oneclickimpact/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/onfleet/package.json
+++ b/packages/pieces/community/onfleet/package.json
@@ -8,7 +8,6 @@
     "@activepieces/pieces-framework": "workspace:*",
     "@onfleet/node-onfleet": "1.3.3",
     "dayjs": "1.11.9",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
   },
@@ -18,6 +17,7 @@
     "lint": "eslint 'src/**/*.ts'"
   },
   "devDependencies": {
-    "@types/onfleet__node-onfleet": "1.3.12"
+    "@types/onfleet__node-onfleet": "1.3.12",
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/open-phone/package.json
+++ b/packages/pieces/community/open-phone/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/open-router/package.json
+++ b/packages/pieces/community/open-router/package.json
@@ -12,8 +12,10 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "zod": "4.3.6",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/openai/package.json
+++ b/packages/pieces/community/openai/package.json
@@ -11,7 +11,6 @@
     "openai": "4.67.1",
     "tiktoken": "1.0.11",
     "zod": "4.3.6",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
   },
@@ -21,6 +20,7 @@
     "lint": "eslint 'src/**/*.ts'"
   },
   "devDependencies": {
-    "@types/mime-types": "2.1.1"
+    "@types/mime-types": "2.1.1",
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/openmic-ai/package.json
+++ b/packages/pieces/community/openmic-ai/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/opnform/package.json
+++ b/packages/pieces/community/opnform/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/opportify/package.json
+++ b/packages/pieces/community/opportify/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/oracle-database/package.json
+++ b/packages/pieces/community/oracle-database/package.json
@@ -9,12 +9,12 @@
     "@activepieces/pieces-framework": "workspace:*",
     "dayjs": "1.11.9",
     "oracledb": "^6.10.0",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
   },
   "devDependencies": {
-    "@types/oracledb": "6.10.1"
+    "@types/oracledb": "6.10.1",
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/oracle-fusion-cloud-erp/package.json
+++ b/packages/pieces/community/oracle-fusion-cloud-erp/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/orimon/package.json
+++ b/packages/pieces/community/orimon/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/outseta/package.json
+++ b/packages/pieces/community/outseta/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/paddle/package.json
+++ b/packages/pieces/community/paddle/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/pagerduty/package.json
+++ b/packages/pieces/community/pagerduty/package.json
@@ -6,9 +6,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/pandadoc/package.json
+++ b/packages/pieces/community/pandadoc/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/paperform/package.json
+++ b/packages/pieces/community/paperform/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/parallel/package.json
+++ b/packages/pieces/community/parallel/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/parser-expert/package.json
+++ b/packages/pieces/community/parser-expert/package.json
@@ -8,9 +8,11 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "form-data": "4.0.4",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/parseur/package.json
+++ b/packages/pieces/community/parseur/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/pastebin/package.json
+++ b/packages/pieces/community/pastebin/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/pastefy/package.json
+++ b/packages/pieces/community/pastefy/package.json
@@ -7,7 +7,6 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "crypto-js": "4.2.0",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
   },
@@ -17,6 +16,7 @@
     "lint": "eslint 'src/**/*.ts'"
   },
   "devDependencies": {
-    "@types/crypto-js": "4.2.2"
+    "@types/crypto-js": "4.2.2",
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/paywhirl/package.json
+++ b/packages/pieces/community/paywhirl/package.json
@@ -7,10 +7,12 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "zod": "4.3.6",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/pdf-co/package.json
+++ b/packages/pieces/community/pdf-co/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/pdf4me/package.json
+++ b/packages/pieces/community/pdf4me/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/pdfcrowd/package.json
+++ b/packages/pieces/community/pdfcrowd/package.json
@@ -8,9 +8,11 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "form-data": "^4.0.0",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/pdfmonkey/package.json
+++ b/packages/pieces/community/pdfmonkey/package.json
@@ -8,9 +8,11 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "dayjs": "1.11.9",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/peekshot/package.json
+++ b/packages/pieces/community/peekshot/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/pendo/package.json
+++ b/packages/pieces/community/pendo/package.json
@@ -6,9 +6,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/perplexity-ai/package.json
+++ b/packages/pieces/community/perplexity-ai/package.json
@@ -12,8 +12,10 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "zod": "4.3.6",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/personal-ai/package.json
+++ b/packages/pieces/community/personal-ai/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/phantombuster/package.json
+++ b/packages/pieces/community/phantombuster/package.json
@@ -8,9 +8,11 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "semver": "7.6.0",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/phone-validator/package.json
+++ b/packages/pieces/community/phone-validator/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/photoroom/package.json
+++ b/packages/pieces/community/photoroom/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/pinch-payments/package.json
+++ b/packages/pieces/community/pinch-payments/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/pinecone/package.json
+++ b/packages/pieces/community/pinecone/package.json
@@ -8,9 +8,11 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "@pinecone-database/pinecone": "^6.1.1",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/pinterest/package.json
+++ b/packages/pieces/community/pinterest/package.json
@@ -12,8 +12,10 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "dayjs": "1.11.9",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/pipedrive/package.json
+++ b/packages/pieces/community/pipedrive/package.json
@@ -14,8 +14,10 @@
     "@opentelemetry/api": "1.9.0",
     "dayjs": "1.11.9",
     "form-data": "4.0.4",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/placid/package.json
+++ b/packages/pieces/community/placid/package.json
@@ -12,8 +12,10 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "form-data": "4.0.4",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/plausible/package.json
+++ b/packages/pieces/community/plausible/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/plunk/package.json
+++ b/packages/pieces/community/plunk/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/pocketbase/package.json
+++ b/packages/pieces/community/pocketbase/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/podio/package.json
+++ b/packages/pieces/community/podio/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/pollybot-ai/package.json
+++ b/packages/pieces/community/pollybot-ai/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/polydoc/package.json
+++ b/packages/pieces/community/polydoc/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/poper/package.json
+++ b/packages/pieces/community/poper/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/postgres/package.json
+++ b/packages/pieces/community/postgres/package.json
@@ -9,7 +9,6 @@
     "dayjs": "1.11.9",
     "pg": "8.11.3",
     "pg-format": "1.0.4",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
   },
@@ -20,6 +19,7 @@
   },
   "devDependencies": {
     "@types/pg": "8.16.0",
-    "@types/pg-format": "1.0.5"
+    "@types/pg-format": "1.0.5",
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/posthog/package.json
+++ b/packages/pieces/community/posthog/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/postiz/package.json
+++ b/packages/pieces/community/postiz/package.json
@@ -12,8 +12,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   }
 }

--- a/packages/pieces/community/postmark/package.json
+++ b/packages/pieces/community/postmark/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/predict-leads/package.json
+++ b/packages/pieces/community/predict-leads/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/predis-ai/package.json
+++ b/packages/pieces/community/predis-ai/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/presentation/package.json
+++ b/packages/pieces/community/presentation/package.json
@@ -8,9 +8,11 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "dayjs": "1.11.9",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/productboard/package.json
+++ b/packages/pieces/community/productboard/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/promotekit/package.json
+++ b/packages/pieces/community/promotekit/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/prompthub/package.json
+++ b/packages/pieces/community/prompthub/package.json
@@ -7,10 +7,12 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "zod": "^3.22.4",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/promptmate/package.json
+++ b/packages/pieces/community/promptmate/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/provenexpert/package.json
+++ b/packages/pieces/community/provenexpert/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/proxycurl/package.json
+++ b/packages/pieces/community/proxycurl/package.json
@@ -12,8 +12,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/pubrio/package.json
+++ b/packages/pieces/community/pubrio/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/pushbullet/package.json
+++ b/packages/pieces/community/pushbullet/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/pushover/package.json
+++ b/packages/pieces/community/pushover/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/pylon/package.json
+++ b/packages/pieces/community/pylon/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/qawafel/package.json
+++ b/packages/pieces/community/qawafel/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/qdrant/package.json
+++ b/packages/pieces/community/qdrant/package.json
@@ -7,9 +7,11 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "@qdrant/js-client-rest": "1.7.0",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/quaderno/package.json
+++ b/packages/pieces/community/quaderno/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/queue/package.json
+++ b/packages/pieces/community/queue/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/quickbase/package.json
+++ b/packages/pieces/community/quickbase/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/quickbooks/package.json
+++ b/packages/pieces/community/quickbooks/package.json
@@ -12,8 +12,10 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "dayjs": "1.11.9",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/quickzu/package.json
+++ b/packages/pieces/community/quickzu/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/quizell/package.json
+++ b/packages/pieces/community/quizell/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/qwilr/package.json
+++ b/packages/pieces/community/qwilr/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/rabbitmq/package.json
+++ b/packages/pieces/community/rabbitmq/package.json
@@ -8,12 +8,12 @@
     "@activepieces/pieces-framework": "workspace:*",
     "amqplib": "0.10.7",
     "dayjs": "1.11.9",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
   },
   "devDependencies": {
-    "@types/amqplib": "0.10.7"
+    "@types/amqplib": "0.10.7",
+    "tslib": "2.6.2"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/raia-ai/package.json
+++ b/packages/pieces/community/raia-ai/package.json
@@ -8,9 +8,11 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "form-data": "4.0.4",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/raindrop/package.json
+++ b/packages/pieces/community/raindrop/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/rapidtext-ai/package.json
+++ b/packages/pieces/community/rapidtext-ai/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/razorpay/package.json
+++ b/packages/pieces/community/razorpay/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/reachinbox/package.json
+++ b/packages/pieces/community/reachinbox/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/readwise/package.json
+++ b/packages/pieces/community/readwise/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/recall-ai/package.json
+++ b/packages/pieces/community/recall-ai/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/recurly/package.json
+++ b/packages/pieces/community/recurly/package.json
@@ -8,9 +8,11 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "recurly": "4.73.0",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/reddit/package.json
+++ b/packages/pieces/community/reddit/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/rendex/package.json
+++ b/packages/pieces/community/rendex/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/reoon-verifier/package.json
+++ b/packages/pieces/community/reoon-verifier/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/reply-io/package.json
+++ b/packages/pieces/community/reply-io/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/resend/package.json
+++ b/packages/pieces/community/resend/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/respaid/package.json
+++ b/packages/pieces/community/respaid/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/respond-io/package.json
+++ b/packages/pieces/community/respond-io/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/retable/package.json
+++ b/packages/pieces/community/retable/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/retell-ai/package.json
+++ b/packages/pieces/community/retell-ai/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/retune/package.json
+++ b/packages/pieces/community/retune/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/returning-ai/package.json
+++ b/packages/pieces/community/returning-ai/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/robolly/package.json
+++ b/packages/pieces/community/robolly/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/roe-ai/package.json
+++ b/packages/pieces/community/roe-ai/package.json
@@ -8,9 +8,11 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "@modelcontextprotocol/sdk": "1.26.0",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/rss/package.json
+++ b/packages/pieces/community/rss/package.json
@@ -8,7 +8,6 @@
     "@activepieces/pieces-framework": "workspace:*",
     "dayjs": "1.11.9",
     "feedparser": "2.2.10",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
   },
@@ -18,6 +17,7 @@
     "lint": "eslint 'src/**/*.ts'"
   },
   "devDependencies": {
-    "@types/feedparser": "2.2.8"
+    "@types/feedparser": "2.2.8",
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/runware/package.json
+++ b/packages/pieces/community/runware/package.json
@@ -8,10 +8,12 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "@runware/sdk-js": "1.1.44",
-    "tslib": "^2.3.0",
     "zod": "4.3.6",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/runway/package.json
+++ b/packages/pieces/community/runway/package.json
@@ -8,9 +8,11 @@
     "@activepieces/pieces-framework": "workspace:*",
     "@runwayml/sdk": "2.9.0",
     "zod": "4.3.6",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/saastic/package.json
+++ b/packages/pieces/community/saastic/package.json
@@ -12,8 +12,10 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "zod": "4.3.6",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/saleor/package.json
+++ b/packages/pieces/community/saleor/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/salesforce/package.json
+++ b/packages/pieces/community/salesforce/package.json
@@ -13,8 +13,10 @@
     "@activepieces/pieces-framework": "workspace:*",
     "dayjs": "1.11.9",
     "fast-xml-parser": "5.7.0",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/salesloft/package.json
+++ b/packages/pieces/community/salesloft/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/sap-ariba/package.json
+++ b/packages/pieces/community/sap-ariba/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/sardis/package.json
+++ b/packages/pieces/community/sardis/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/savvycal/package.json
+++ b/packages/pieces/community/savvycal/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/scenario/package.json
+++ b/packages/pieces/community/scenario/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/scrapegrapghai/package.json
+++ b/packages/pieces/community/scrapegrapghai/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/scrapeless/package.json
+++ b/packages/pieces/community/scrapeless/package.json
@@ -8,9 +8,11 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "@scrapeless-ai/sdk": "1.5.1",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/seek-table/package.json
+++ b/packages/pieces/community/seek-table/package.json
@@ -8,9 +8,11 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "form-data": "4.0.4",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/segment/package.json
+++ b/packages/pieces/community/segment/package.json
@@ -12,8 +12,10 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "@segment/analytics-node": "2.2.0",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/send-it/package.json
+++ b/packages/pieces/community/send-it/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/sender/package.json
+++ b/packages/pieces/community/sender/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/sendfox/package.json
+++ b/packages/pieces/community/sendfox/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/sendgrid/package.json
+++ b/packages/pieces/community/sendgrid/package.json
@@ -13,12 +13,12 @@
     "@activepieces/pieces-framework": "workspace:*",
     "mime-types": "2.1.35",
     "nodemailer": "8.0.5",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
   },
   "devDependencies": {
     "@types/mime-types": "2.1.1",
-    "@types/nodemailer": "7.0.11"
+    "@types/nodemailer": "7.0.11",
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/sendinblue/package.json
+++ b/packages/pieces/community/sendinblue/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/sendpulse/package.json
+++ b/packages/pieces/community/sendpulse/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/sendr/package.json
+++ b/packages/pieces/community/sendr/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/sendy/package.json
+++ b/packages/pieces/community/sendy/package.json
@@ -12,8 +12,10 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "zod": "4.3.6",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/senja/package.json
+++ b/packages/pieces/community/senja/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/serp-api/package.json
+++ b/packages/pieces/community/serp-api/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/serpstat/package.json
+++ b/packages/pieces/community/serpstat/package.json
@@ -12,8 +12,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/service-now/package.json
+++ b/packages/pieces/community/service-now/package.json
@@ -9,10 +9,12 @@
     "@activepieces/pieces-framework": "workspace:*",
     "dayjs": "1.11.9",
     "form-data": "^4.0.0",
-    "tslib": "^2.3.0",
     "zod": "^3.22.4",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/sessions-us/package.json
+++ b/packages/pieces/community/sessions-us/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/seven/package.json
+++ b/packages/pieces/community/seven/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/shippo/package.json
+++ b/packages/pieces/community/shippo/package.json
@@ -8,9 +8,11 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "dayjs": "1.11.9",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/shopify/package.json
+++ b/packages/pieces/community/shopify/package.json
@@ -12,8 +12,10 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "zod": "4.3.6",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/short-io/package.json
+++ b/packages/pieces/community/short-io/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/sign-now/package.json
+++ b/packages/pieces/community/sign-now/package.json
@@ -8,9 +8,11 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "form-data": "4.0.4",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/signrequest/package.json
+++ b/packages/pieces/community/signrequest/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/simplepdf/package.json
+++ b/packages/pieces/community/simplepdf/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/simpliroute/package.json
+++ b/packages/pieces/community/simpliroute/package.json
@@ -8,9 +8,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/simplybookme/package.json
+++ b/packages/pieces/community/simplybookme/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/simplyprint/package.json
+++ b/packages/pieces/community/simplyprint/package.json
@@ -6,7 +6,6 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
   },
@@ -17,6 +16,7 @@
     "test": "vitest run"
   },
   "devDependencies": {
-    "vitest": "3.0.8"
+    "vitest": "3.0.8",
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/sitespeakai/package.json
+++ b/packages/pieces/community/sitespeakai/package.json
@@ -8,9 +8,11 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "dayjs": "1.11.9",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/skyprep/package.json
+++ b/packages/pieces/community/skyprep/package.json
@@ -8,9 +8,11 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "dayjs": "1.11.9",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/skyvern/package.json
+++ b/packages/pieces/community/skyvern/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/slack/package.json
+++ b/packages/pieces/community/slack/package.json
@@ -9,9 +9,11 @@
     "@slack/web-api": "7.9.0",
     "slackify-markdown": "4.4.0",
     "zod": "4.3.6",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/slashed/package.json
+++ b/packages/pieces/community/slashed/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/slidespeak/package.json
+++ b/packages/pieces/community/slidespeak/package.json
@@ -8,9 +8,11 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "form-data": "4.0.4",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/slite/package.json
+++ b/packages/pieces/community/slite/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/smaily/package.json
+++ b/packages/pieces/community/smaily/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/smartlead/package.json
+++ b/packages/pieces/community/smartlead/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/smartsheet/package.json
+++ b/packages/pieces/community/smartsheet/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/smartsuite/package.json
+++ b/packages/pieces/community/smartsuite/package.json
@@ -12,8 +12,10 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "form-data": "4.0.4",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/smoove/package.json
+++ b/packages/pieces/community/smoove/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/smsmode/package.json
+++ b/packages/pieces/community/smsmode/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/snowflake/package.json
+++ b/packages/pieces/community/snowflake/package.json
@@ -7,9 +7,11 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "snowflake-sdk": "2.3.4",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/soap/package.json
+++ b/packages/pieces/community/soap/package.json
@@ -7,9 +7,11 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "soap": "1.1.10",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/socialkit/package.json
+++ b/packages/pieces/community/socialkit/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/softr/package.json
+++ b/packages/pieces/community/softr/package.json
@@ -8,9 +8,11 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "dayjs": "1.11.9",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/sofya/package.json
+++ b/packages/pieces/community/sofya/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/sperse/package.json
+++ b/packages/pieces/community/sperse/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/splitwise/package.json
+++ b/packages/pieces/community/splitwise/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/spotify/package.json
+++ b/packages/pieces/community/spotify/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/square/package.json
+++ b/packages/pieces/community/square/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/stability-ai/package.json
+++ b/packages/pieces/community/stability-ai/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/stable-diffusion-webui/package.json
+++ b/packages/pieces/community/stable-diffusion-webui/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/straico/package.json
+++ b/packages/pieces/community/straico/package.json
@@ -13,8 +13,10 @@
     "@activepieces/pieces-framework": "workspace:*",
     "form-data": "4.0.4",
     "zod": "4.3.6",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/strale/package.json
+++ b/packages/pieces/community/strale/package.json
@@ -6,9 +6,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/streak/package.json
+++ b/packages/pieces/community/streak/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/stripe/package.json
+++ b/packages/pieces/community/stripe/package.json
@@ -12,8 +12,10 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "stripe": "18.2.1",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/supabase/package.json
+++ b/packages/pieces/community/supabase/package.json
@@ -7,9 +7,11 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "@supabase/supabase-js": "2.49.9",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/supadata/package.json
+++ b/packages/pieces/community/supadata/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/surrealdb/package.json
+++ b/packages/pieces/community/surrealdb/package.json
@@ -12,8 +12,10 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "dayjs": "1.11.9",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/surveymonkey/package.json
+++ b/packages/pieces/community/surveymonkey/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/surveytale/package.json
+++ b/packages/pieces/community/surveytale/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/swarmnode/package.json
+++ b/packages/pieces/community/swarmnode/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/synthesia/package.json
+++ b/packages/pieces/community/synthesia/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/systeme-io/package.json
+++ b/packages/pieces/community/systeme-io/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/tableau/package.json
+++ b/packages/pieces/community/tableau/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/talkable/package.json
+++ b/packages/pieces/community/talkable/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/tally/package.json
+++ b/packages/pieces/community/tally/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/tapfiliate/package.json
+++ b/packages/pieces/community/tapfiliate/package.json
@@ -12,8 +12,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   }
 }

--- a/packages/pieces/community/tarvent/package.json
+++ b/packages/pieces/community/tarvent/package.json
@@ -12,8 +12,10 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "zod": "4.3.6",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/taskade/package.json
+++ b/packages/pieces/community/taskade/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/tavily/package.json
+++ b/packages/pieces/community/tavily/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/teable/package.json
+++ b/packages/pieces/community/teable/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/teamhood/package.json
+++ b/packages/pieces/community/teamhood/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/teamleader/package.json
+++ b/packages/pieces/community/teamleader/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/teamwork/package.json
+++ b/packages/pieces/community/teamwork/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/telegram-bot/package.json
+++ b/packages/pieces/community/telegram-bot/package.json
@@ -12,8 +12,10 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "form-data": "4.0.4",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/telnyx/package.json
+++ b/packages/pieces/community/telnyx/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/tenzo/package.json
+++ b/packages/pieces/community/tenzo/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/textcortex-ai/package.json
+++ b/packages/pieces/community/textcortex-ai/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/thankster/package.json
+++ b/packages/pieces/community/thankster/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/ticktick/package.json
+++ b/packages/pieces/community/ticktick/package.json
@@ -12,8 +12,10 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "dayjs": "1.11.9",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/tidely/package.json
+++ b/packages/pieces/community/tidely/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/tidycal/package.json
+++ b/packages/pieces/community/tidycal/package.json
@@ -12,8 +12,10 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "dayjs": "1.11.9",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/time-ops/package.json
+++ b/packages/pieces/community/time-ops/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/timelines-ai/package.json
+++ b/packages/pieces/community/timelines-ai/package.json
@@ -8,9 +8,11 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "dayjs": "1.11.9",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/tiny-talk-ai/package.json
+++ b/packages/pieces/community/tiny-talk-ai/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/tl-dv/package.json
+++ b/packages/pieces/community/tl-dv/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/todoist/package.json
+++ b/packages/pieces/community/todoist/package.json
@@ -12,8 +12,10 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "dayjs": "1.11.9",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/toggl-track/package.json
+++ b/packages/pieces/community/toggl-track/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/totalcms/package.json
+++ b/packages/pieces/community/totalcms/package.json
@@ -13,8 +13,10 @@
     "@activepieces/pieces-framework": "workspace:*",
     "form-data": "4.0.4",
     "zod": "4.3.6",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/trello/package.json
+++ b/packages/pieces/community/trello/package.json
@@ -13,8 +13,10 @@
     "@activepieces/pieces-framework": "workspace:*",
     "dayjs": "1.11.9",
     "form-data": "4.0.4",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/truelayer/package.json
+++ b/packages/pieces/community/truelayer/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/trust/package.json
+++ b/packages/pieces/community/trust/package.json
@@ -8,9 +8,11 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "form-data": "4.0.0",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/twenty/package.json
+++ b/packages/pieces/community/twenty/package.json
@@ -7,9 +7,11 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "dayjs": "1.11.9",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/twilio/package.json
+++ b/packages/pieces/community/twilio/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/twin-labs/package.json
+++ b/packages/pieces/community/twin-labs/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/twitch/package.json
+++ b/packages/pieces/community/twitch/package.json
@@ -8,9 +8,11 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "dayjs": "1.11.9",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/twitter/package.json
+++ b/packages/pieces/community/twitter/package.json
@@ -9,7 +9,6 @@
     "mime-types": "2.1.35",
     "twitter-api-v2": "1.15.1",
     "zod": "4.3.6",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
   },
@@ -19,6 +18,7 @@
     "lint": "eslint 'src/**/*.ts'"
   },
   "devDependencies": {
-    "@types/mime-types": "2.1.1"
+    "@types/mime-types": "2.1.1",
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/typeform/package.json
+++ b/packages/pieces/community/typeform/package.json
@@ -12,8 +12,10 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "nanoid": "3.3.8",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/typefully/package.json
+++ b/packages/pieces/community/typefully/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/umami/package.json
+++ b/packages/pieces/community/umami/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/upgradechat/package.json
+++ b/packages/pieces/community/upgradechat/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/uptimerobot/package.json
+++ b/packages/pieces/community/uptimerobot/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/uscreen/package.json
+++ b/packages/pieces/community/uscreen/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/useinbox/package.json
+++ b/packages/pieces/community/useinbox/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/uxsniff/package.json
+++ b/packages/pieces/community/uxsniff/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/vadoo-ai/package.json
+++ b/packages/pieces/community/vadoo-ai/package.json
@@ -7,10 +7,12 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "zod": "4.3.6",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/validatedmails/package.json
+++ b/packages/pieces/community/validatedmails/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/valyu/package.json
+++ b/packages/pieces/community/valyu/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/vapi/package.json
+++ b/packages/pieces/community/vapi/package.json
@@ -8,9 +8,11 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "@vapi-ai/server-sdk": "0.11.0",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/vbout/package.json
+++ b/packages/pieces/community/vbout/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/vercel/package.json
+++ b/packages/pieces/community/vercel/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/vero/package.json
+++ b/packages/pieces/community/vero/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/videoask/package.json
+++ b/packages/pieces/community/videoask/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/vidlab7/package.json
+++ b/packages/pieces/community/vidlab7/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/vidnoz/package.json
+++ b/packages/pieces/community/vidnoz/package.json
@@ -8,9 +8,11 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "form-data": "4.0.4",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/village/package.json
+++ b/packages/pieces/community/village/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/vimeo/package.json
+++ b/packages/pieces/community/vimeo/package.json
@@ -8,9 +8,11 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "dayjs": "1.11.9",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/visible/package.json
+++ b/packages/pieces/community/visible/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/vlm-run/package.json
+++ b/packages/pieces/community/vlm-run/package.json
@@ -8,10 +8,12 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "form-data": "4.0.4",
-    "tslib": "^2.3.0",
     "zod": "4.3.6",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/voipstudio/package.json
+++ b/packages/pieces/community/voipstudio/package.json
@@ -8,9 +8,11 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "dayjs": "1.11.9",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/vouchery-io/package.json
+++ b/packages/pieces/community/vouchery-io/package.json
@@ -7,10 +7,12 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "zod": "4.3.6",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/vtex/package.json
+++ b/packages/pieces/community/vtex/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/vtiger/package.json
+++ b/packages/pieces/community/vtiger/package.json
@@ -8,7 +8,6 @@
     "@activepieces/pieces-framework": "workspace:*",
     "crypto-js": "4.2.0",
     "dayjs": "1.11.9",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
   },
@@ -18,6 +17,7 @@
     "lint": "eslint 'src/**/*.ts'"
   },
   "devDependencies": {
-    "@types/crypto-js": "4.2.2"
+    "@types/crypto-js": "4.2.2",
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/wafeq/package.json
+++ b/packages/pieces/community/wafeq/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/waitwhile/package.json
+++ b/packages/pieces/community/waitwhile/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/wayfront/package.json
+++ b/packages/pieces/community/wayfront/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/wealthbox/package.json
+++ b/packages/pieces/community/wealthbox/package.json
@@ -8,9 +8,11 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "dayjs": "1.11.9",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/webex/package.json
+++ b/packages/pieces/community/webex/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/webflow/package.json
+++ b/packages/pieces/community/webflow/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/webling/package.json
+++ b/packages/pieces/community/webling/package.json
@@ -12,8 +12,10 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "zod": "4.3.6",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/webscraping-ai/package.json
+++ b/packages/pieces/community/webscraping-ai/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/wedof/package.json
+++ b/packages/pieces/community/wedof/package.json
@@ -12,8 +12,10 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "dayjs": "1.11.9",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/week-done/package.json
+++ b/packages/pieces/community/week-done/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/weekdone/package.json
+++ b/packages/pieces/community/weekdone/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/what-converts/package.json
+++ b/packages/pieces/community/what-converts/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/whatsable/package.json
+++ b/packages/pieces/community/whatsable/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/whatsapp/package.json
+++ b/packages/pieces/community/whatsapp/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/whatsscale/package.json
+++ b/packages/pieces/community/whatsscale/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/wistia/package.json
+++ b/packages/pieces/community/wistia/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/wonderchat/package.json
+++ b/packages/pieces/community/wonderchat/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/woocommerce/package.json
+++ b/packages/pieces/community/woocommerce/package.json
@@ -12,8 +12,10 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "zod": "4.3.6",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/woodpecker/package.json
+++ b/packages/pieces/community/woodpecker/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/wootric/package.json
+++ b/packages/pieces/community/wootric/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/wordpress/package.json
+++ b/packages/pieces/community/wordpress/package.json
@@ -13,8 +13,10 @@
     "@activepieces/pieces-framework": "workspace:*",
     "dayjs": "1.11.9",
     "form-data": "4.0.4",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/workable/package.json
+++ b/packages/pieces/community/workable/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/workday/package.json
+++ b/packages/pieces/community/workday/package.json
@@ -9,7 +9,6 @@
     "@activepieces/pieces-framework": "workspace:*",
     "dayjs": "1.11.9",
     "fast-xml-parser": "5.7.0",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
   },
@@ -20,6 +19,7 @@
     "test": "vitest run"
   },
   "devDependencies": {
-    "vitest": "3.0.8"
+    "vitest": "3.0.8",
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/wrike/package.json
+++ b/packages/pieces/community/wrike/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/writesonic-bulk/package.json
+++ b/packages/pieces/community/writesonic-bulk/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/wufoo/package.json
+++ b/packages/pieces/community/wufoo/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/xero/package.json
+++ b/packages/pieces/community/xero/package.json
@@ -12,8 +12,10 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "dayjs": "1.11.9",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/xquik/package.json
+++ b/packages/pieces/community/xquik/package.json
@@ -7,7 +7,6 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
   },
@@ -18,6 +17,7 @@
     "test": "vitest run"
   },
   "devDependencies": {
-    "vitest": "3.0.8"
+    "vitest": "3.0.8",
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/youcanbookme/package.json
+++ b/packages/pieces/community/youcanbookme/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/youform/package.json
+++ b/packages/pieces/community/youform/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/youtrack/package.json
+++ b/packages/pieces/community/youtrack/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/youtube/package.json
+++ b/packages/pieces/community/youtube/package.json
@@ -9,7 +9,6 @@
     "cheerio": "1.0.0-rc.12",
     "dayjs": "1.11.9",
     "feedparser": "2.2.10",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
   },
@@ -19,6 +18,7 @@
     "lint": "eslint 'src/**/*.ts'"
   },
   "devDependencies": {
-    "@types/feedparser": "2.2.8"
+    "@types/feedparser": "2.2.8",
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/zagomail/package.json
+++ b/packages/pieces/community/zagomail/package.json
@@ -12,8 +12,10 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "dayjs": "1.11.9",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/zendesk-sell/package.json
+++ b/packages/pieces/community/zendesk-sell/package.json
@@ -8,9 +8,11 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "buffer": "6.0.3",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/zendesk/package.json
+++ b/packages/pieces/community/zendesk/package.json
@@ -12,8 +12,10 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "dayjs": "1.11.9",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/zeplin/package.json
+++ b/packages/pieces/community/zeplin/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/zerobounce/package.json
+++ b/packages/pieces/community/zerobounce/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/zoho-bookings/package.json
+++ b/packages/pieces/community/zoho-bookings/package.json
@@ -7,10 +7,12 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "zod": "4.3.6",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/zoho-books/package.json
+++ b/packages/pieces/community/zoho-books/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/zoho-campaigns/package.json
+++ b/packages/pieces/community/zoho-campaigns/package.json
@@ -8,10 +8,12 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "dayjs": "1.11.9",
-    "tslib": "^2.3.0",
     "zod": "4.3.6",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/zoho-crm/package.json
+++ b/packages/pieces/community/zoho-crm/package.json
@@ -12,8 +12,10 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "dayjs": "1.11.9",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/zoho-desk/package.json
+++ b/packages/pieces/community/zoho-desk/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/zoho-invoice/package.json
+++ b/packages/pieces/community/zoho-invoice/package.json
@@ -12,8 +12,10 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "dayjs": "1.11.9",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/zoho-mail/package.json
+++ b/packages/pieces/community/zoho-mail/package.json
@@ -8,7 +8,6 @@
     "@activepieces/pieces-framework": "workspace:*",
     "form-data": "4.0.4",
     "mailparser": "3.9.3",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
   },
@@ -18,6 +17,7 @@
     "lint": "eslint 'src/**/*.ts'"
   },
   "devDependencies": {
-    "@types/mailparser": "3.4.6"
+    "@types/mailparser": "3.4.6",
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/zoo/package.json
+++ b/packages/pieces/community/zoo/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/zoom/package.json
+++ b/packages/pieces/community/zoom/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/zuora/package.json
+++ b/packages/pieces/community/zuora/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/core/approval/package.json
+++ b/packages/pieces/core/approval/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/core/connections/package.json
+++ b/packages/pieces/core/connections/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/core/crypto/package.json
+++ b/packages/pieces/core/crypto/package.json
@@ -9,7 +9,6 @@
     "buffer": "6.0.3",
     "openpgp": "^6.2.0",
     "zod": "4.3.6",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
   },
@@ -20,6 +19,7 @@
     "test": "vitest run"
   },
   "devDependencies": {
-    "vitest": "3.0.8"
+    "vitest": "3.0.8",
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/core/csv/package.json
+++ b/packages/pieces/core/csv/package.json
@@ -9,7 +9,6 @@
     "csv-parse": "5.6.0",
     "csv-stringify": "6.5.2",
     "safe-flat": "2.1.0",
-    "tslib": "2.6.2",
     "xlsx": "0.18.5",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
@@ -21,6 +20,7 @@
     "test": "vitest run"
   },
   "devDependencies": {
-    "vitest": "3.0.8"
+    "vitest": "3.0.8",
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/core/data-mapper/package.json
+++ b/packages/pieces/core/data-mapper/package.json
@@ -12,11 +12,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
   },
   "devDependencies": {
-    "vitest": "3.0.8"
+    "vitest": "3.0.8",
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/core/data-summarizer/package.json
+++ b/packages/pieces/core/data-summarizer/package.json
@@ -10,12 +10,12 @@
     "test": "vitest run"
   },
   "devDependencies": {
-    "vitest": "3.0.8"
+    "vitest": "3.0.8",
+    "tslib": "2.6.2"
   },
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
   }

--- a/packages/pieces/core/date-helper/package.json
+++ b/packages/pieces/core/date-helper/package.json
@@ -10,14 +10,14 @@
     "test": "vitest run"
   },
   "devDependencies": {
-    "vitest": "3.0.8"
+    "vitest": "3.0.8",
+    "tslib": "2.6.2"
   },
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "dayjs": "1.11.9",
     "zod": "4.3.6",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
   }

--- a/packages/pieces/core/delay/package.json
+++ b/packages/pieces/core/delay/package.json
@@ -13,8 +13,10 @@
     "@activepieces/pieces-framework": "workspace:*",
     "dayjs": "1.11.9",
     "zod": "4.3.6",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/core/file-helper/package.json
+++ b/packages/pieces/core/file-helper/package.json
@@ -8,7 +8,6 @@
     "@activepieces/pieces-framework": "workspace:*",
     "@zip.js/zip.js": "^2.8.15",
     "mime-types": "2.1.35",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
   },
@@ -20,6 +19,7 @@
   },
   "devDependencies": {
     "@types/mime-types": "2.1.1",
-    "vitest": "3.0.8"
+    "vitest": "3.0.8",
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/core/forms/package.json
+++ b/packages/pieces/core/forms/package.json
@@ -13,11 +13,11 @@
     "@activepieces/pieces-framework": "workspace:*",
     "http-status-codes": "2.2.0",
     "mime-types": "2.1.35",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
   },
   "devDependencies": {
-    "@types/mime-types": "2.1.1"
+    "@types/mime-types": "2.1.1",
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/core/graphql/package.json
+++ b/packages/pieces/core/graphql/package.json
@@ -8,9 +8,11 @@
     "@activepieces/pieces-framework": "workspace:*",
     "axios": "1.15.2",
     "https-proxy-agent": "7.0.4",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/core/http/package.json
+++ b/packages/pieces/core/http/package.json
@@ -7,7 +7,6 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "form-data": "4.0.4",
-    "tslib": "2.6.2",
     "undici": "7.24.6",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
@@ -19,6 +18,7 @@
     "test": "vitest run"
   },
   "devDependencies": {
-    "vitest": "3.0.8"
+    "vitest": "3.0.8",
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/core/image-helper/package.json
+++ b/packages/pieces/core/image-helper/package.json
@@ -9,7 +9,6 @@
     "exifreader": "4.20.0",
     "jimp": "^0.22.12",
     "mime-types": "2.1.35",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
   },
@@ -21,6 +20,7 @@
   },
   "devDependencies": {
     "@types/mime-types": "2.1.1",
-    "vitest": "3.0.8"
+    "vitest": "3.0.8",
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/core/manual-trigger/package.json
+++ b/packages/pieces/core/manual-trigger/package.json
@@ -7,9 +7,11 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "^2.3.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/core/math-helper/package.json
+++ b/packages/pieces/core/math-helper/package.json
@@ -14,11 +14,11 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "zod": "4.3.6",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
   },
   "devDependencies": {
-    "vitest": "3.0.8"
+    "vitest": "3.0.8",
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/core/pdf/package.json
+++ b/packages/pieces/core/pdf/package.json
@@ -10,13 +10,13 @@
     "nanoid": "3.3.8",
     "pdf-lib": "1.17.1",
     "unpdf": "1.4.0",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
   },
   "devDependencies": {
     "vitest": "3.0.8",
-    "@types/mime-types": "2.1.1"
+    "@types/mime-types": "2.1.1",
+    "tslib": "2.6.2"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/core/qrcode/package.json
+++ b/packages/pieces/core/qrcode/package.json
@@ -5,13 +5,13 @@
   "types": "./dist/src/index.d.ts",
   "devDependencies": {
     "@types/qrcode": "^1.5.5",
-    "vitest": "3.0.8"
+    "vitest": "3.0.8",
+    "tslib": "2.6.2"
   },
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "qrcode": "1.5.4",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
   },

--- a/packages/pieces/core/schedule/package.json
+++ b/packages/pieces/core/schedule/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/core/sftp/package.json
+++ b/packages/pieces/core/sftp/package.json
@@ -11,13 +11,13 @@
     "ssh2": "1.16.0",
     "ssh2-sftp-client": "9.1.0",
     "zod": "4.3.6",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
   },
   "devDependencies": {
     "@types/ssh2": "1.15.5",
-    "@types/ssh2-sftp-client": "9.0.6"
+    "@types/ssh2-sftp-client": "9.0.6",
+    "tslib": "2.6.2"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/core/smtp/package.json
+++ b/packages/pieces/core/smtp/package.json
@@ -13,12 +13,12 @@
     "@activepieces/pieces-framework": "workspace:*",
     "mime-types": "2.1.35",
     "nodemailer": "8.0.5",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
   },
   "devDependencies": {
     "@types/mime-types": "2.1.1",
-    "@types/nodemailer": "7.0.11"
+    "@types/nodemailer": "7.0.11",
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/core/store/package.json
+++ b/packages/pieces/core/store/package.json
@@ -13,11 +13,11 @@
     "@activepieces/pieces-framework": "workspace:*",
     "deep-equal": "2.2.2",
     "zod": "4.3.6",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
   },
   "devDependencies": {
-    "@types/deep-equal": "1.0.4"
+    "@types/deep-equal": "1.0.4",
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/core/subflows/package.json
+++ b/packages/pieces/core/subflows/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/core/tables/package.json
+++ b/packages/pieces/core/tables/package.json
@@ -13,11 +13,11 @@
     "@activepieces/pieces-framework": "workspace:*",
     "qs": "6.14.2",
     "zod": "4.3.6",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
   },
   "devDependencies": {
-    "@types/qs": "6.14.0"
+    "@types/qs": "6.14.0",
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/core/tags/package.json
+++ b/packages/pieces/core/tags/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/core/text-helper/package.json
+++ b/packages/pieces/core/text-helper/package.json
@@ -12,7 +12,6 @@
     "string-strip-html": "8.5.0",
     "turndown": "7.2.0",
     "zod": "4.3.6",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
   },
@@ -26,6 +25,7 @@
     "@types/jsdom": "^21.1.6",
     "@types/showdown": "2.0.6",
     "@types/turndown": "5.0.6",
-    "vitest": "3.0.8"
+    "vitest": "3.0.8",
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/core/webhook/package.json
+++ b/packages/pieces/core/webhook/package.json
@@ -10,14 +10,14 @@
     "test": "vitest run"
   },
   "devDependencies": {
-    "vitest": "3.0.8"
+    "vitest": "3.0.8",
+    "tslib": "2.6.2"
   },
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "dayjs": "1.11.9",
     "http-status-codes": "2.2.0",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
   }

--- a/packages/pieces/core/xml/package.json
+++ b/packages/pieces/core/xml/package.json
@@ -8,7 +8,6 @@
     "@activepieces/pieces-framework": "workspace:*",
     "fast-xml-parser": "5.7.0",
     "json2xml": "0.1.3",
-    "tslib": "2.6.2",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
   },
@@ -20,6 +19,7 @@
   },
   "devDependencies": {
     "@types/json2xml": "0.1.4",
-    "vitest": "3.0.8"
+    "vitest": "3.0.8",
+    "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/framework/package.json
+++ b/packages/pieces/framework/package.json
@@ -14,11 +14,11 @@
     "@activepieces/core-piece-types": "workspace:*",
     "zod": "4.3.6",
     "ai": "^6.0.0",
-    "semver": "7.6.0",
-    "tslib": "2.6.2"
+    "semver": "7.6.0"
   },
   "devDependencies": {
     "@types/semver": "7.5.6",
-    "vitest": "3.0.8"
+    "vitest": "3.0.8",
+    "tslib": "2.6.2"
   }
 }

--- a/tools/scripts/pieces/publish-pieces-to-npm.ts
+++ b/tools/scripts/pieces/publish-pieces-to-npm.ts
@@ -1,6 +1,6 @@
 import { publishNpmPackage } from '../utils/publish-npm-package'
 import { findAllPiecesDirectoryInSource } from '../utils/piece-script-utils'
-import { chunk } from '../../../packages/core/shared/src/lib/core/common/utils/utils'
+import { chunk } from '@activepieces/core-utils'
 
 function getChangedPiecePaths(): string[] | null {
   const changedPieces = process.env['CHANGED_PIECES']

--- a/tools/scripts/pieces/update-pieces-metadata.ts
+++ b/tools/scripts/pieces/update-pieces-metadata.ts
@@ -3,7 +3,7 @@ import { PieceMetadata } from '../../../packages/pieces/framework/src';
 import { StatusCodes } from 'http-status-codes';
 import { HttpHeader } from '../../../packages/pieces/common/src';
 import { AP_CLOUD_API_BASE, findNewPieces, pieceMetadataExists } from '../utils/piece-script-utils';
-import { chunk } from '../../../packages/core/shared/src/lib/core/common/utils/utils';
+import { chunk } from '@activepieces/core-utils';
 assert(process.env['AP_CLOUD_API_KEY'], 'API Key is not defined');
 
 const { AP_CLOUD_API_KEY } = process.env;

--- a/tools/scripts/utils/publish-npm-package.ts
+++ b/tools/scripts/utils/publish-npm-package.ts
@@ -31,10 +31,15 @@ function assertNoSemverRanges(packageJsonPath: string): void {
   }
 }
 
-function assertNoUnresolvedWorkspaceDeps(packageJsonPath: string): void {
+// Final, bullet-proof publish gate. A published piece is a self-contained bundle: every
+// @activepieces/* library (shared, framework, common, core-*) is inlined and NONE of them is
+// published to npm, and there must be no unresolved workspace:* dep. So refuse to publish if any
+// dependency is either still a workspace:* range OR an @activepieces/* package — regardless of how
+// it leaked into the manifest. This catches bundler/manifest regressions before they hit the registry.
+function assertNoUnpublishableDeps(packageJsonPath: string): void {
   const json = JSON.parse(readFileSync(packageJsonPath).toString())
   const depFields = ['dependencies', 'devDependencies', 'peerDependencies'] as const
-  const unresolved: string[] = []
+  const offending: string[] = []
 
   for (const field of depFields) {
     const deps: Record<string, string> | undefined = json[field]
@@ -43,14 +48,16 @@ function assertNoUnresolvedWorkspaceDeps(packageJsonPath: string): void {
     }
     for (const [name, version] of Object.entries(deps)) {
       if (version.startsWith('workspace:')) {
-        unresolved.push(`${field}.${name}: ${version}`)
+        offending.push(`${field}.${name}: ${version} (unresolved workspace dependency)`)
+      } else if (name.startsWith('@activepieces/')) {
+        offending.push(`${field}.${name}: ${version} (must be bundled, never published)`)
       }
     }
   }
 
-  if (unresolved.length > 0) {
+  if (offending.length > 0) {
     throw new Error(
-      `[publishPackage] refusing to publish ${json.name}@${json.version} — unresolved workspace dependencies:\n  ${unresolved.join('\n  ')}`,
+      `[publishPackage] refusing to publish ${json.name}@${json.version} — unpublishable dependencies:\n  ${offending.join('\n  ')}`,
     )
   }
 }
@@ -72,18 +79,17 @@ export const publishNpmPackage = async (path: string): Promise<void> => {
   }
   const { version } = await readPackageJson(path)
 
-  // Pins all dependency versions (including transitive) from bun.lock.
-  // For pieces built via CLI or prepare-pieces-for-publish, this already ran during build — calling it
-  // again is idempotent. For shared/common/framework, this is the only place it runs before publish.
-  preparePieceDistForPublish(path)
+  // Bundles the piece into a self-contained artifact and rewrites the manifest (strips the
+  // @activepieces/* + workspace deps that are now inlined). MUST be awaited — it copies the
+  // source package.json (with workspace:* deps) before the async bundle+rewrite, so reading the
+  // manifest before it resolves would see the un-stripped deps and fail the assertion below.
+  await preparePieceDistForPublish(path)
 
   const json = JSON.parse(readFileSync(`${outputPath}/package.json`).toString())
   json.version = version
-  json.main = './src/index.js'
-  json.types = './src/index.d.ts'
   writeFileSync(`${outputPath}/package.json`, JSON.stringify(json, null, 2))
 
-  assertNoUnresolvedWorkspaceDeps(`${outputPath}/package.json`)
+  assertNoUnpublishableDeps(`${outputPath}/package.json`)
   assertNoSemverRanges(`${outputPath}/package.json`)
 
   execSync(`npm publish --access public --tag latest`, { cwd: outputPath, stdio: 'inherit' })

--- a/tools/scripts/validate-publishable-packages.ts
+++ b/tools/scripts/validate-publishable-packages.ts
@@ -13,18 +13,15 @@ async function processBatches<T>(items: T[], batchSize: number, processor: (item
 
 const main = async () => {
   const piecesMetadata = await findAllPiecesDirectoryInSource()
-  const sharedDeps = ['packages/pieces/framework', 'packages/pieces/common']
-  
-  const sharedResults = await Promise.all(sharedDeps.map(packagePrePublishChecks))
-  const validationResults = await processBatches(
-    piecesMetadata.filter(p => !sharedDeps.includes(p)),
+  // pieces-framework, pieces-common and @activepieces/shared are no longer published to npm:
+  // pieces are self-contained bundles that inline these at build time. Exclude them from the
+  // publishable-package validation and only validate the pieces themselves.
+  const notPublished = ['packages/pieces/framework', 'packages/pieces/common']
+  await processBatches(
+    piecesMetadata.filter(p => !notPublished.includes(p)),
     10,
     packagePrePublishChecks
   )
-
-  if (!sharedResults.every(p => p)) {
-    validationResults.push(await packagePrePublishChecks('packages/core/shared'))
-  }
 }
 
 main();


### PR DESCRIPTION
## Summary

Pieces are now published as self-contained esbuild bundles that inline `@activepieces/*` workspace code and third-party deps. This branch finishes that transition and cleans up the published manifests.

### Changes
- **Stop publishing `@activepieces/shared` / `pieces-common` / `pieces-framework` to npm** — pieces inline them at build time.
- **`await` the piece bundle before publish**, and never publish the `@activepieces/*` libs.
- **Prune piece `dist` to exactly the published files** after bundling.
- **`tslib` cleanup** — `tslib` only backs `tsc`'s `importHelpers` down-levelling; the esbuild bundle inlines its own helpers and never requires it. This PR:
  - Moves `tslib` from `dependencies` → `devDependencies` across all 748 pieces and the `create-piece` generator (correct categorization at the source).
  - Strips `tslib` from every published `dist/package.json` in the bundler as a self-enforcing safety net.
  - Deps loaded out-of-band (e.g. `oracle-database` forking a child that `require`s `oracledb`) are untouched and stay in the published manifest.

### Verification
- `math-helper` published manifest → `dependencies: {}` (tslib gone, bundle has 0 tslib refs).
- `oracle-database` published manifest → `{ "oracledb": "6.10.0" }` retained (fork-loaded native dep).
- CLI lint + build clean.