### PR TITLE
feat: piece bundle migration cli and docs

### DIFF
--- a/docs/build-pieces/misc/migrate-pieces-to-bundles.mdx
+++ b/docs/build-pieces/misc/migrate-pieces-to-bundles.mdx
@@ -1,0 +1,96 @@
+---
+title: 'Migrate Pieces to Self-Contained Bundles'
+icon: 'package'
+---
+
+<Note>
+This applies to forks with custom pieces created before pieces moved to self-contained bundles. Pieces created with `npm run cli pieces create` already use the bundle model — nothing to do.
+</Note>
+
+Activepieces builds each piece into a single self-contained bundle — see [Bundling Pieces](./bundling-pieces) for how that works. If you maintain custom pieces from before this change, update them so they conform to the new model.
+
+## What changed
+
+| | **Before** | **Now** |
+|---|---|---|
+| Piece dependencies | `@activepieces/shared` + framework + common | framework + common only |
+| Imports in piece code | `@activepieces/shared` and `@activepieces/pieces-framework` | `@activepieces/pieces-framework` only |
+| Build output | compiled files + dependency tree | one self-contained bundle |
+| `@activepieces/shared` location | `packages/shared` | `packages/core/shared` (same package name) |
+
+Pieces now import only from `@activepieces/pieces-framework` and `@activepieces/pieces-common`. The framework re-exports the foundation symbols (`isNil`, `SeekPage`, `PieceCategory`, `AppConnectionType`, and so on) that used to come from `@activepieces/shared`.
+
+## Update each piece
+
+<Steps>
+<Step title="Repoint imports to the framework">
+Replace any `@activepieces/shared` (or `@activepieces/core-*`) import with `@activepieces/pieces-framework`:
+
+```ts
+// Before
+import { PieceCategory, ExecutionType } from '@activepieces/shared';
+
+// After
+import { PieceCategory, ExecutionType } from '@activepieces/pieces-framework';
+```
+
+If a symbol isn't re-exported by the framework, it was server-only and shouldn't be imported into a piece.
+</Step>
+
+<Step title="Update package.json dependencies and scripts">
+Remove `@activepieces/shared` and move `tslib` to `devDependencies`. Add `@activepieces/core-piece-types` and `@activepieces/core-utils` — these are build-time only (they let `tsc` emit portable type declarations; your source never imports them directly). Add the `bundle` script.
+
+```jsonc
+{
+  "dependencies": {
+    "@activepieces/pieces-common": "workspace:*",
+    "@activepieces/pieces-framework": "workspace:*",
+    "@activepieces/core-piece-types": "workspace:*",
+    "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.lib.json && cp package.json dist/",
+    "bundle": "node ../../../../dist/packages/cli/src/index.js pieces bundle",
+    "lint": "eslint 'src/**/*.ts'"
+  }
+}
+```
+</Step>
+
+<Step title="Add the import-boundary lint rule">
+Add a `no-restricted-imports` rule to the `*.ts`/`*.tsx` override in the piece's `.eslintrc.json` so it can't regress to importing packages that defeat bundling:
+
+```json
+{
+  "files": ["*.ts", "*.tsx"],
+  "rules": {
+    "no-restricted-imports": ["error", {
+      "patterns": [
+        "lodash",
+        "lodash/*",
+        "@activepieces/core-*",
+        "@activepieces/server*",
+        "@activepieces/engine",
+        "@activepieces/shared"
+      ]
+    }]
+  }
+}
+```
+</Step>
+
+<Step title="Build and verify">
+```bash
+npm run build-piece your-piece
+```
+
+The archive produced in `packages/pieces/<type>/your-piece/dist/` is now a self-contained bundle.
+</Step>
+</Steps>
+
+<Tip>
+A freshly scaffolded piece (`npm run cli pieces create`) already includes all of the above. Use one as a reference if you're unsure what a migrated piece should look like.
+</Tip>

--- a/docs/build-pieces/misc/migrate-pieces-to-bundles.mdx
+++ b/docs/build-pieces/misc/migrate-pieces-to-bundles.mdx
@@ -20,7 +20,30 @@ Activepieces builds each piece into a single self-contained bundle — see [Bund
 
 Pieces now import only from `@activepieces/pieces-framework` and `@activepieces/pieces-common`. The framework re-exports the foundation symbols (`isNil`, `SeekPage`, `PieceCategory`, `AppConnectionType`, and so on) that used to come from `@activepieces/shared`.
 
-## Update each piece
+## Migrate with the CLI
+
+The `pieces migrate` command applies every change below for you:
+
+```bash
+# preview the changes without writing anything
+npm run cli -- pieces migrate <piece-name> --dry-run
+
+# apply them
+npm run cli -- pieces migrate <piece-name>
+```
+
+- Pass `--all` to migrate every piece under `packages/pieces`.
+- It is idempotent — re-running it on an already-migrated piece makes no changes.
+
+Then build the piece to verify:
+
+```bash
+npm run build-piece <piece-name>
+```
+
+To migrate by hand — or to see exactly what the command changes — follow the steps below.
+
+## What it changes (or migrate by hand)
 
 <Steps>
 <Step title="Repoint imports to the framework">

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -303,6 +303,7 @@
                      "build-pieces/misc/publish-piece",
                      "build-pieces/misc/pieces-ci-cd",
                      "build-pieces/misc/migrate-nx-to-turbo",
+                     "build-pieces/misc/migrate-pieces-to-bundles",
                      "build-pieces/misc/private-fork",
                      "build-pieces/misc/testing-pieces",
                      "build-pieces/misc/dev-container",

--- a/docs/install/configuration/breaking-changes.mdx
+++ b/docs/install/configuration/breaking-changes.mdx
@@ -12,8 +12,12 @@ icon: "hammer"
 #### Log fields are now grouped by entity
 Log fields are now grouped under the entity they belong to, so each thing has one name. A flow run id is `flowRun.id` (it used to appear as `runId`, `flowRunId`, or a bare `id`), and other ids follow the same shape (`flow.id`, `project.id`, `job.id`, …). Errors are logged under `error`. This only changes how logs look — nothing about the API, database, or flows changes.
 
+#### Pieces are now self-contained bundles
+Each piece is now built into a single self-contained bundle — its own code, the Activepieces framework, and its third-party dependencies are inlined into one artifact, so the engine provisions a piece by downloading one file instead of installing a dependency tree at runtime. As part of this, the shared libraries (`@activepieces/shared`, `@activepieces/pieces-framework`, `@activepieces/pieces-common`, `@activepieces/core-*`) are no longer published to npm, and pieces import only from `@activepieces/pieces-framework` (which re-exports the foundation symbols that used to come from `@activepieces/shared`). Built-in pieces are unaffected — this only matters for custom pieces.
+
 ### Do you need to take action?
 - Only if you build dashboards or alerts on Activepieces logs. Update them to the new grouped names, e.g. `runId` → `flowRun.id` and `err` → `error`.
+- Only if you maintain **custom pieces** (in a fork or built outside the repo). Migrate each one to the bundle model — run `npm run cli -- pieces migrate <piece-name>` (or `--all`), or follow the [migration guide](/build-pieces/misc/migrate-pieces-to-bundles). Pieces that still import `@activepieces/shared` or depend on the now-unpublished libraries will fail to build.
 
 ## 0.85.4
 ### What has changed?

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -6,6 +6,7 @@ import { syncPieceCommand } from './lib/commands/sync-pieces';
 import { publishPieceCommand } from './lib/commands/publish-piece';
 import { buildPieceCommand } from './lib/commands/build-piece';
 import { bundlePieceCommand } from './lib/commands/bundle-piece';
+import { migratePieceCommand } from './lib/commands/migrate-piece';
 import { generateWorkerTokenCommand } from './lib/commands/generate-worker-token';
 import { generateTranslationFileForAllPiecesCommand, generateTranslationFileForPieceCommand } from './lib/commands/generate-translation-file-for-piece';
 import { replaceProjectCommand } from './lib/commands/replace-project';
@@ -18,6 +19,7 @@ pieceCommand.addCommand(syncPieceCommand);
 pieceCommand.addCommand(publishPieceCommand);
 pieceCommand.addCommand(buildPieceCommand);
 pieceCommand.addCommand(bundlePieceCommand);
+pieceCommand.addCommand(migratePieceCommand);
 pieceCommand.addCommand(generateTranslationFileForPieceCommand);
 pieceCommand.addCommand(generateTranslationFileForAllPiecesCommand);
 const actionCommand = new Command('actions')

--- a/packages/cli/src/lib/commands/create-piece.ts
+++ b/packages/cli/src/lib/commands/create-piece.ts
@@ -69,7 +69,8 @@ const scaffoldPiece = async (
     dependencies: {
       '@activepieces/pieces-common': 'workspace:*',
       '@activepieces/pieces-framework': 'workspace:*',
-      '@activepieces/shared': 'workspace:*',
+      '@activepieces/core-piece-types': 'workspace:*',
+      '@activepieces/core-utils': 'workspace:*',
     },
     devDependencies: {
       tslib: '2.6.2',
@@ -82,7 +83,7 @@ const scaffoldPiece = async (
   };
   await writeFile(
     path.join(baseDir, 'package.json'),
-    JSON.stringify(packageJson, null, 2)
+    JSON.stringify(packageJson, null, 2) + '\n'
   );
 
   // Create tsconfig.json
@@ -103,7 +104,7 @@ const scaffoldPiece = async (
   };
   await writeFile(
     path.join(baseDir, 'tsconfig.json'),
-    JSON.stringify(tsconfig, null, 2)
+    JSON.stringify(tsconfig, null, 2) + '\n'
   );
 
   // Create tsconfig.lib.json
@@ -123,7 +124,7 @@ const scaffoldPiece = async (
   };
   await writeFile(
     path.join(baseDir, 'tsconfig.lib.json'),
-    JSON.stringify(tsconfigLib, null, 2)
+    JSON.stringify(tsconfigLib, null, 2) + '\n'
   );
 
   // Create .eslintrc.json
@@ -132,13 +133,30 @@ const scaffoldPiece = async (
     ignorePatterns: ['!**/*'],
     overrides: [
       { files: ['*.ts', '*.tsx', '*.js', '*.jsx'], rules: {} },
-      { files: ['*.ts', '*.tsx'], rules: {} },
+      {
+        files: ['*.ts', '*.tsx'],
+        rules: {
+          'no-restricted-imports': [
+            'error',
+            {
+              patterns: [
+                'lodash',
+                'lodash/*',
+                '@activepieces/core-*',
+                '@activepieces/server*',
+                '@activepieces/engine',
+                '@activepieces/shared',
+              ],
+            },
+          ],
+        },
+      },
       { files: ['*.js', '*.jsx'], rules: {} },
     ],
   };
   await writeFile(
     path.join(baseDir, '.eslintrc.json'),
-    JSON.stringify(eslintConfig, null, 2)
+    JSON.stringify(eslintConfig, null, 2) + '\n'
   );
 
   // Create index.ts

--- a/packages/cli/src/lib/commands/migrate-piece.ts
+++ b/packages/cli/src/lib/commands/migrate-piece.ts
@@ -1,0 +1,64 @@
+import { basename } from 'node:path'
+import { Command } from 'commander'
+import chalk from 'chalk'
+import inquirer from 'inquirer'
+import { findPiece, findPieces, piecesPath } from '../utils/piece-utils'
+import { migratePieceUtils } from '../utils/migrate-piece-utils'
+
+function reportMigration({ pieceFolder, label, dryRun }: { pieceFolder: string, label: string, dryRun: boolean }): void {
+    const report = migratePieceUtils.migratePiece({ piecePath: pieceFolder, dryRun })
+    const changes = report.repointedFiles.length + (report.manifestChanged ? 1 : 0) + (report.eslintChanged ? 1 : 0)
+    if (changes === 0) {
+        console.info(chalk.gray(`• ${label} — already conformant`))
+        return
+    }
+    console.info(chalk.green(`${dryRun ? '[dry run] ' : ''}✓ ${label}`))
+    if (report.repointedFiles.length > 0) {
+        console.info(`    repointed imports in ${report.repointedFiles.length} file(s) → @activepieces/pieces-framework`)
+    }
+    if (report.manifestChanged) {
+        console.info('    updated package.json (dropped shared, added core build deps, moved tslib to devDependencies, added bundle script)')
+    }
+    if (report.eslintChanged) {
+        console.info('    added the import-boundary lint rule')
+    }
+}
+
+async function migrateByName({ pieceName, dryRun }: { pieceName: string, dryRun: boolean }): Promise<void> {
+    const pieceFolder = await findPiece(pieceName)
+    if (!pieceFolder) {
+        console.error(chalk.red(`🚨 Piece '${pieceName}' not found under packages/pieces`))
+        process.exit(1)
+    }
+    reportMigration({ pieceFolder, label: pieceName, dryRun })
+}
+
+async function migrateAll({ dryRun }: { dryRun: boolean }): Promise<void> {
+    const folders = await findPieces(piecesPath())
+    console.info(chalk.blue(`Migrating ${folders.length} piece(s)${dryRun ? ' (dry run)' : ''}...`))
+    for (const folder of folders) {
+        reportMigration({ pieceFolder: folder, label: basename(folder), dryRun })
+    }
+}
+
+export const migratePieceCommand = new Command('migrate')
+    .description('Migrate a piece to the self-contained bundle model: repoint imports to @activepieces/pieces-framework, fix package.json, and add the import-boundary lint rule')
+    .argument('[name]', 'name of the piece to migrate')
+    .option('--name <pieceName>', 'name of the piece to migrate')
+    .option('--all', 'migrate every piece under packages/pieces')
+    .option('--dry-run', 'report the changes without writing them')
+    .action(async (positionalName, options) => {
+        const dryRun = options.dryRun ?? false
+        if (options.all) {
+            await migrateAll({ dryRun })
+        }
+        else {
+            const pieceName = positionalName ?? options.name ?? (await inquirer.prompt([
+                { type: 'input', name: 'name', message: 'Enter the piece folder name' },
+            ])).name
+            await migrateByName({ pieceName, dryRun })
+        }
+        if (!dryRun) {
+            console.info(chalk.yellow('\nNext: build the piece to verify, e.g. `npm run build-piece <name>`'))
+        }
+    })

--- a/packages/cli/src/lib/utils/migrate-piece-utils.ts
+++ b/packages/cli/src/lib/utils/migrate-piece-utils.ts
@@ -1,0 +1,161 @@
+import { existsSync, readFileSync, readdirSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+function migratePiece({ piecePath, dryRun }: MigratePieceParams): MigrateReport {
+    const repointedFiles: string[] = []
+    const srcDir = join(piecePath, 'src')
+    if (existsSync(srcDir)) {
+        for (const file of collectTsFiles(srcDir)) {
+            const original = readFileSync(file, 'utf-8')
+            const rewritten = repointImports(original)
+            if (rewritten !== original) {
+                repointedFiles.push(file)
+                if (!dryRun) {
+                    writeFileSync(file, rewritten)
+                }
+            }
+        }
+    }
+    const manifestChanged = migrateManifest({ piecePath, dryRun })
+    const eslintChanged = migrateEslintConfig({ piecePath, dryRun })
+    return { repointedFiles, manifestChanged, eslintChanged }
+}
+
+function collectTsFiles(dir: string): string[] {
+    const files: string[] = []
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+        const full = join(dir, entry.name)
+        if (entry.isDirectory()) {
+            files.push(...collectTsFiles(full))
+        }
+        else if (entry.name.endsWith('.ts') || entry.name.endsWith('.tsx')) {
+            files.push(full)
+        }
+    }
+    return files
+}
+
+// A piece imports only from @activepieces/pieces-framework (which re-exports the foundation
+// symbols). Repoint every shared / core-* import specifier to the framework; a symbol the
+// framework does not re-export was server-only and will surface as a build error.
+function repointImports(content: string): string {
+    let next = content
+    for (const moduleName of REPOINTED_MODULES) {
+        next = next.split(`from '${moduleName}'`).join(`from '${FRAMEWORK}'`)
+        next = next.split(`from "${moduleName}"`).join(`from "${FRAMEWORK}"`)
+    }
+    return next
+}
+
+function migrateManifest({ piecePath, dryRun }: MigratePieceParams): boolean {
+    const manifestPath = join(piecePath, 'package.json')
+    if (!existsSync(manifestPath)) {
+        return false
+    }
+    const raw = readFileSync(manifestPath, 'utf-8')
+    const manifest = JSON.parse(raw)
+    const dependencies: Record<string, string> = manifest.dependencies ?? {}
+    const devDependencies: Record<string, string> = manifest.devDependencies ?? {}
+    const scripts: Record<string, string> = manifest.scripts ?? {}
+
+    delete dependencies['@activepieces/shared']
+    for (const dep of REQUIRED_DEPENDENCIES) {
+        dependencies[dep] = dependencies[dep] ?? 'workspace:*'
+    }
+    if (dependencies['tslib']) {
+        devDependencies['tslib'] = devDependencies['tslib'] ?? dependencies['tslib']
+        delete dependencies['tslib']
+    }
+    devDependencies['tslib'] = devDependencies['tslib'] ?? TSLIB_VERSION
+    scripts['bundle'] = scripts['bundle'] ?? BUNDLE_SCRIPT
+
+    manifest.dependencies = dependencies
+    manifest.devDependencies = devDependencies
+    manifest.scripts = scripts
+
+    const next = JSON.stringify(manifest, null, 2) + '\n'
+    if (next === raw) {
+        return false
+    }
+    if (!dryRun) {
+        writeFileSync(manifestPath, next)
+    }
+    return true
+}
+
+function migrateEslintConfig({ piecePath, dryRun }: MigratePieceParams): boolean {
+    const configPath = join(piecePath, '.eslintrc.json')
+    const previous = existsSync(configPath) ? readFileSync(configPath, 'utf-8') : ''
+    const config = previous ? JSON.parse(previous.replace(/^﻿/, '')) : defaultEslintConfig()
+
+    const overrides: EslintOverride[] = config.overrides ?? []
+    let tsOverride = overrides.find((override) => Array.isArray(override.files) && override.files.includes('*.ts') && !override.files.includes('*.js'))
+    if (!tsOverride) {
+        tsOverride = { files: ['*.ts', '*.tsx'], rules: {} }
+        overrides.push(tsOverride)
+    }
+    tsOverride.rules = tsOverride.rules ?? {}
+    tsOverride.rules['no-restricted-imports'] = ['error', { patterns: [...IMPORT_BOUNDARY_PATTERNS] }]
+    config.overrides = overrides
+
+    const next = JSON.stringify(config, null, 2) + '\n'
+    if (next === previous) {
+        return false
+    }
+    if (!dryRun) {
+        writeFileSync(configPath, next)
+    }
+    return true
+}
+
+function defaultEslintConfig(): Record<string, unknown> {
+    return {
+        extends: ['../../../../.eslintrc.json'],
+        ignorePatterns: ['!**/*'],
+        overrides: [
+            { files: ['*.ts', '*.tsx', '*.js', '*.jsx'], rules: {} },
+            { files: ['*.js', '*.jsx'], rules: {} },
+        ],
+    }
+}
+
+const FRAMEWORK = '@activepieces/pieces-framework'
+const REPOINTED_MODULES = [
+    '@activepieces/shared',
+    '@activepieces/core-utils',
+    '@activepieces/core-piece-types',
+    '@activepieces/core-formula',
+    '@activepieces/core-execution',
+]
+const REQUIRED_DEPENDENCIES = [
+    '@activepieces/pieces-common',
+    '@activepieces/pieces-framework',
+    '@activepieces/core-piece-types',
+    '@activepieces/core-utils',
+]
+const IMPORT_BOUNDARY_PATTERNS = [
+    'lodash',
+    'lodash/*',
+    '@activepieces/core-*',
+    '@activepieces/server*',
+    '@activepieces/engine',
+    '@activepieces/shared',
+]
+const TSLIB_VERSION = '2.6.2'
+const BUNDLE_SCRIPT = 'node ../../../../dist/packages/cli/src/index.js pieces bundle'
+
+export const migratePieceUtils = { migratePiece }
+
+export type MigratePieceParams = {
+    piecePath: string
+    dryRun: boolean
+}
+export type MigrateReport = {
+    repointedFiles: string[]
+    manifestChanged: boolean
+    eslintChanged: boolean
+}
+type EslintOverride = {
+    files: string[]
+    rules?: Record<string, unknown>
+}


### PR DESCRIPTION
## What does this PR do?

<!-- We need a clear description of what the PR does, as this will be used for the marketing team to generate the release notes. -->

Brings the piece-creation CLI and the docs in line with the new **self-contained piece bundles**:

1. **CLI scaffold** — `npm run cli pieces create` now generates pieces that are bundle-ready out of the box: no `@activepieces/shared` dependency, the `@activepieces/core-*` build-time deps included, and the import-boundary ESLint rule in place. A freshly created piece now matches the already-migrated catalog with no manual cleanup.
2. **Migration docs** — adds a guide, *"Migrate Pieces to Self-Contained Bundles"*, for maintainers who need to bring existing or custom (fork) pieces onto the bundle model.

### Explain How the Feature Works
<!-- Adding a video demonstration is optional but encourged! It helps reviewers / marketing team understand your implementation better. -->
<!-- [Insert the video link here] -->

- **Scaffold:** the generated `package.json` now lists only `@activepieces/pieces-common` + `@activepieces/pieces-framework` plus the `@activepieces/core-piece-types` / `@activepieces/core-utils` build-time deps (with `tslib` in `devDependencies`), and the generated `.eslintrc.json` bans importing `@activepieces/shared`, `@activepieces/core-*`, `@activepieces/server*`, `@activepieces/engine`, and `lodash`. The output is byte-identical to an existing migrated piece (e.g. `airtable`).
- **Docs:** a new page under *Build Pieces → Misc* walks through migrating a piece — repoint imports to `@activepieces/pieces-framework`, drop `@activepieces/shared`, add the `core-*` build deps and the `bundle` script, and add the import-boundary rule. It links to the existing *Bundling Pieces* reference.

### Relevant User Scenarios

<!-- List specific use cases where this feature would be valuable. -->
<!-- [Insert Pylon tickets or community posts here if possible] -->

- A contributor creating a new piece gets a bundle-ready scaffold automatically — no failing lint and no stale `@activepieces/shared` dependency to remove by hand.
- A maintainer with custom / out-of-tree pieces (e.g. on a private fork) has a documented, step-by-step path to migrate them to self-contained bundles.

Fixes # (issue)
