### PR TITLE
feat(embedding): generate MCP token from embed SDK

### DIFF
--- a/.agents/features/mcp.md
+++ b/.agents/features/mcp.md
@@ -5,7 +5,7 @@ Exposes an Activepieces project as a Model Context Protocol (MCP) server so that
 
 ## Key Files
 - `packages/server/api/src/app/mcp/mcp-service.ts` — server build logic, tool registration, token auth
-- `packages/server/api/src/app/mcp/mcp-server-controller.ts` — HTTP endpoints (get, update, rotate, protocol handler, agent validator)
+- `packages/server/api/src/app/mcp/mcp-server-controller.ts` — HTTP endpoints (get, update, rotate, issue embed token, protocol handler, agent validator)
 - `packages/server/api/src/app/mcp/mcp-entity.ts` — McpServer entity
 - `packages/server/api/src/app/mcp/tools/index.ts` — static tool exports
 - `packages/server/api/src/app/mcp/oauth/` — OAuth 2.0 PKCE flow for MCP clients that require OAuth
@@ -19,7 +19,7 @@ Exposes an Activepieces project as a Model Context Protocol (MCP) server so that
 - `packages/web/src/app/routes/mcp-authorize/permission-item.tsx` — shared permission-item component used by the MCP OAuth consent screens
 - `packages/web/src/app/routes/embed/embedded-mcp-authorize-dialog.tsx` — in-embed MCP OAuth consent dialog for managed-auth (embedded) users
 - `packages/web/src/app/routes/embed/embedded-mcp-settings-dialog.tsx` — in-embed MCP settings dialog for managed-auth (embedded) users
-- `packages/ee/embed-sdk/src/index.ts` — embed SDK; adds `authorizeMcp()` (in-embed OAuth consent) and `mcpSettings()` (MCP settings dialog) public methods
+- `packages/ee/embed-sdk/src/index.ts` — embed SDK; adds `authorizeMcp()` (in-embed OAuth consent), `mcpSettings()` (MCP settings dialog), and `generateMcpToken()` (mints `{ mcpServerUrl, mcpToken }` for the embed user's project without the OAuth flow) public methods
 - `packages/web/src/features/agents/agent-tools/mcp-tool-dialog/index.tsx` — dialog to add an external MCP server as an agent tool
 - `packages/web/src/features/agents/agent-tools/mcp-tool-dialog/add-mcp-tool-form.tsx` — form inside the dialog
 - `packages/web/src/features/agents/agent-tools/components/mcp-tool.tsx` — inline display of an MCP tool in agent settings
@@ -87,6 +87,7 @@ Exposes an Activepieces project as a Model Context Protocol (MCP) server so that
 - `GET /v1/mcp/:projectId` — get MCP server config + populated flows
 - `POST /v1/mcp/:projectId` — update disabledTools
 - `POST /v1/mcp/:projectId/rotate` — rotate auth token
+- `POST /v1/projects/:projectId/mcp-server/token` — mint a short-lived (15-min, `scopes: ['mcp']`), project-scoped MCP OAuth access token and return `{ mcpServerUrl, mcpToken }`. Secured with `securityAccess.project([USER], READ_MCP, { PARAM })`; reuses `mcpOAuthTokenService.issueInternalAccessToken` (the same path the chat assistant uses internally). Powers the embed SDK's `generateMcpToken()` — a no-OAuth alternative to the `authorizeMcp()` consent flow for hosts that already have an embed session.
 - `POST /v1/mcp/:projectId/http` — StreamableHTTP MCP protocol endpoint (main protocol handler)
 
 External MCP server validation for the **agent piece** lives under `packages/server/api/src/app/agents/` (endpoint: `POST /v1/projects/:projectId/agent-tools/mcp/validate`), not here — it's a probe for URLs the agent will later connect to, not part of the Activepieces-as-MCP-server feature.

--- a/docs/embedding/embeddable-mcp.mdx
+++ b/docs/embedding/embeddable-mcp.mdx
@@ -23,6 +23,24 @@ Embeddable MCP fixes that. Your user clicks one **Authorize** button inside your
 It's normal OAuth. The only Activepieces-specific part is one SDK call (`authorizeMcp`) that shows the Authorize popup inside your app.
 </Info>
 
+## Quick token (no OAuth)
+
+If you don't need the full OAuth flow — you just want a token to point an AI at the embedded user's project — call `generateMcpToken()` from the frontend. It uses the embed session you already configured, so there's no app registration, no PKCE, and no popup.
+
+```ts
+const { mcpServerUrl, mcpToken } = await activepieces.generateMcpToken();
+
+// Point your MCP client at mcpServerUrl with Authorization: Bearer <mcpToken>
+```
+
+This is the same kind of credential the built-in chat assistant uses internally. The token:
+- is scoped to **that user's project** (the `externalProjectId` in their embed JWT),
+- works for **15 minutes** — call `generateMcpToken()` again to get a fresh one.
+
+<Note>
+Use this when your app holds the MCP client and the embedded user is already signed in through the SDK. Use the **OAuth flow below** when a separate third-party app needs long-lived, revocable access on the user's behalf (it returns a refresh token).
+</Note>
+
 ## Before you start
 
 Embedding should already work for you:

--- a/packages/ee/embed-sdk/package.json
+++ b/packages/ee/embed-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ee-embed-sdk",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "type": "commonjs",
   "main": "./src/index.js",
   "typings": "./src/index.d.ts",

--- a/packages/ee/embed-sdk/src/index.ts
+++ b/packages/ee/embed-sdk/src/index.ts
@@ -186,9 +186,14 @@ export type McpOAuthDialogResult =
   | { redirectUrl: string }
   | { denied: true };
 
+export type McpCredentials = {
+  mcpServerUrl: string;
+  mcpToken: string;
+};
+
 type RequestMethod = Required<Parameters<typeof fetch>>[1]['method'];
 class ActivepiecesEmbedded {
-  readonly _sdkVersion = "0.10.0";
+  readonly _sdkVersion = "0.11.0";
   //used for  Automatically Sync URL feature i.e /org/1234
   _prefix = '/';
   _instanceUrl = '';
@@ -483,6 +488,21 @@ class ActivepiecesEmbedded {
       },
       errorMessage: 'unable to add mcp oauth embedding',
     });
+  }
+
+  /**
+   * Mints a short-lived MCP access token for the embedded user's project and
+   * returns it together with the MCP server URL — the same credentials the chat
+   * assistant uses internally. Drop these straight into your own MCP client
+   * (`Authorization: Bearer <mcpToken>` against `mcpServerUrl`) without running
+   * the full OAuth flow. Uses the embed session, so no extra auth is needed.
+   */
+  async generateMcpToken(): Promise<McpCredentials> {
+    const auth = await this.fetchEmbeddingAuth({ jwtToken: this._jwtToken });
+    return this.request(
+      { path: `projects/${auth.projectId}/mcp-server/token`, method: 'POST' },
+      true,
+    );
   }
 
   private _addOverlayIframe(initialRoute: string): IframeWithWindow {

--- a/packages/server/api/src/app/mcp/mcp-server-controller.ts
+++ b/packages/server/api/src/app/mcp/mcp-server-controller.ts
@@ -1,10 +1,14 @@
 import { ApId, Permission } from '@activepieces/core-utils'
 import { PrincipalType, SERVICE_KEY_SECURITY_OPENAPI, UpdateMcpServerRequest } from '@activepieces/shared'
 import { FastifyPluginAsyncZod } from 'fastify-type-provider-zod'
+import { StatusCodes } from 'http-status-codes'
 import { z } from 'zod'
 import { ProjectResourceType } from '../core/security/authorization/common'
 import { securityAccess } from '../core/security/authorization/fastify-security'
+import { system } from '../helper/system/system'
+import { AppSystemProp } from '../helper/system/system-props'
 import { mcpServerService } from './mcp-service'
+import { mcpOAuthTokenService } from './oauth/token/mcp-oauth-token.service'
 
 export const mcpServerController: FastifyPluginAsyncZod = async (app) => {
 
@@ -24,6 +28,19 @@ export const mcpServerController: FastifyPluginAsyncZod = async (app) => {
         return mcpServerService(req.log).rotateToken({
             projectId: req.projectId,
         })
+    })
+
+    app.post('/token', GenerateMcpTokenRequest, async (req) => {
+        const mcpToken = await mcpOAuthTokenService.issueInternalAccessToken({
+            userId: req.principal.id,
+            platformId: req.principal.platform.id,
+            projectId: req.projectId,
+        })
+        const frontendUrl = system.getOrThrow(AppSystemProp.FRONTEND_URL)
+        return {
+            mcpServerUrl: `${frontendUrl}/mcp`,
+            mcpToken,
+        }
     })
 }
 
@@ -85,4 +102,32 @@ const RotateTokenRequest = {
     params: z.object({
         projectId: ApId,
     }),
+}
+
+const GenerateMcpTokenResponse = z.object({
+    mcpServerUrl: z.string(),
+    mcpToken: z.string(),
+})
+
+const GenerateMcpTokenRequest = {
+    config: {
+        security: securityAccess.project(
+            [PrincipalType.USER],
+            Permission.READ_MCP,
+            {
+                type: ProjectResourceType.PARAM,
+            },
+        ),
+    },
+    schema: {
+        tags: ['mcp'],
+        description: 'Generate a short-lived MCP access token and server URL for the project',
+        security: [SERVICE_KEY_SECURITY_OPENAPI],
+        params: z.object({
+            projectId: ApId,
+        }),
+        response: {
+            [StatusCodes.OK]: GenerateMcpTokenResponse,
+        },
+    },
 }


### PR DESCRIPTION
## What

Adds a lightweight way for embedded SDK users to get MCP credentials, mirroring what the chat assistant does internally — without running the full OAuth flow.

- **SDK** — new `activepieces.generateMcpToken()` returns `{ mcpServerUrl, mcpToken }`. It reuses the existing embed session (`fetchEmbeddingAuth` + `request`), so no extra auth is needed. SDK bumped `0.10.0 → 0.11.0`.
- **Backend** — new `POST /v1/projects/:projectId/mcp-server/token` on the existing project MCP controller. It mints the token via the same `mcpOAuthTokenService.issueInternalAccessToken` chat uses (15‑min, `scopes: ['mcp']`), scoped to the embed user's project, and returns `{ mcpServerUrl: <instance>/mcp, mcpToken }`. Secured with `securityAccess.project([USER], READ_MCP, { PARAM })`.
- **Docs** — `embeddable-mcp.mdx` gets a "Quick token (no OAuth)" section contrasting this with the OAuth flow (which remains the right choice for long-lived, revocable third‑party access).

## Why

We already shipped Embeddable MCP via OAuth (#13782), but that flow is heavy (client registration, PKCE, consent popup, code exchange). When the embedder's own app holds the MCP client and the user is already signed in through the SDK, a one-call token is all that's needed — exactly what chat does internally.

## Scope decision

The token is **project-scoped** (`/mcp`, carries the embed user's `projectId`), not platform-scoped like chat's (`/mcp/platform`, `projectId: null`) — embedded users are scoped to a project, so they get their project's MCP tools.

## Testing

Verified end-to-end against a local EE instance + the Angular `sdk-demo`:
- `initialize` → 200, returns the Activepieces MCP server info
- `tools/list` → 41 project tools
- `tools/call` `ap_list_flows` → success
- invalid token → 401

Token decodes as expected: `clientId: internal-chat`, `scopes: ['mcp']`, `aud: MCP_OAUTH_ACCESS`, non-null `projectId`, 15-min TTL.
