### PR TITLE
feat: add AI/ML API AI provider

### DIFF
--- a/.agents/features/ai-providers.md
+++ b/.agents/features/ai-providers.md
@@ -1,10 +1,11 @@
 # AI Providers
 
 ## Summary
-The AI Providers module lets platform admins configure one or more LLM backends (OpenAI, Anthropic, Google, Azure, OpenRouter, Cloudflare, or a custom OpenAI-compatible endpoint) for use by AI pieces inside flows. It also supports an auto-provisioned "Activepieces" provider backed by OpenRouter when the platform's `aiCreditsEnabled` plan flag is set, complete with a Stripe-integrated credit top-up system and monthly reset via a system job.
+The AI Providers module lets platform admins configure one or more LLM backends (OpenAI, Anthropic, Google, Azure, OpenRouter, Cloudflare, AIMLAPI, or a custom OpenAI-compatible endpoint) for use by AI pieces inside flows. It also supports an auto-provisioned "Activepieces" provider backed by OpenRouter when the platform's `aiCreditsEnabled` plan flag is set, complete with a Stripe-integrated credit top-up system and monthly reset via a system job.
 
 ## Key Files
 - `packages/server/api/src/app/ai/` — backend module (controller, service, entity)
+- `packages/server/api/src/app/ai/providers/aimlapi-provider.ts` - AIMLAPI provider strategy
 - `packages/core/shared/src/lib/management/ai-providers/index.ts` — all shared Zod schemas, enums, and request/response types
 - `packages/web/src/features/platform-admin/api/ai-provider-api.ts` — frontend API client
 - `packages/web/src/features/platform-admin/hooks/ai-provider-hooks.ts` — TanStack Query hooks
@@ -23,7 +24,8 @@ The AI Providers module lets platform admins configure one or more LLM backends 
 
 ## Domain Terms
 - **AIProvider**: A platform-scoped entity linking an LLM vendor's credentials to the platform.
-- **AIProviderName**: Enum of supported vendors (`openai`, `anthropic`, `google`, `azure`, `openrouter`, `cloudflare-gateway`, `custom`, `activepieces`).
+- **AIProviderName**: Enum of supported vendors (`openai`, `anthropic`, `google`, `azure`, `openrouter`, `cloudflare-gateway`, `aimlapi`, `custom`, `activepieces`).
+- **aimlapi**: AI/ML API, a curated OpenAI-compatible gateway with fixed endpoint `https://api.aimlapi.com/v1`.
 - **EncryptedObject**: The `auth` field is AES-256-encrypted at rest; decrypted only for engine access.
 - **AI Credits**: Platform-level usage budget (1000 credits = $1 USD) metered through OpenRouter; drives the ACTIVEPIECES auto-provision flow.
 - **aiCreditsEnabled**: Platform plan flag that triggers auto-provisioning of the ACTIVEPIECES provider.
@@ -33,7 +35,7 @@ The AI Providers module lets platform admins configure one or more LLM backends 
 
 **AIProvider**: id, displayName, platformId (UNIQUE with provider), provider (AIProviderName enum), auth (EncryptedObject), config (JSON). Relation: platform (CASCADE).
 
-## Supported Providers (8)
+## Supported Providers (9)
 
 | Provider | Auth Fields | Notes |
 |----------|------------|-------|
@@ -43,6 +45,7 @@ The AI Providers module lets platform admins configure one or more LLM backends 
 | AZURE | apiKey, deploymentName, instanceName | Azure OpenAI |
 | OPENROUTER | apiKey | 200+ models |
 | CLOUDFLARE | apiKey, accountId, gatewayId | Proxied via Cloudflare Workers AI |
+| AIMLAPI | apiKey | Fixed OpenAI-compatible endpoint; curated chat models; no live `/models` discovery |
 | CUSTOM | apiKey, baseUrl | OpenAI-compatible (LM Studio, Ollama) |
 | ACTIVEPIECES | apiKey, apiKeyHash (auto-provisioned) | Uses OpenRouter, managed by platform |
 

--- a/packages/core/shared/src/lib/management/ai-providers/index.ts
+++ b/packages/core/shared/src/lib/management/ai-providers/index.ts
@@ -46,6 +46,9 @@ export type BedrockProviderAuthConfig = z.infer<typeof BedrockProviderAuthConfig
 export const MistralProviderAuthConfig = BaseAIProviderAuthConfig
 export type MistralProviderAuthConfig = z.infer<typeof MistralProviderAuthConfig>
 
+export const AIMLAPIProviderAuthConfig = BaseAIProviderAuthConfig
+export type AIMLAPIProviderAuthConfig = z.infer<typeof AIMLAPIProviderAuthConfig>
+
 export const AnthropicProviderConfig = z.object({})
 export type AnthropicProviderConfig = z.infer<typeof AnthropicProviderConfig>
 
@@ -105,6 +108,9 @@ export type BedrockProviderConfig = z.infer<typeof BedrockProviderConfig>
 export const MistralProviderConfig = z.object({})
 export type MistralProviderConfig = z.infer<typeof MistralProviderConfig>
 
+export const AIMLAPIProviderConfig = z.object({})
+export type AIMLAPIProviderConfig = z.infer<typeof AIMLAPIProviderConfig>
+
 export const AIProviderAuthConfig = z.union([
     AnthropicProviderAuthConfig,
     AzureProviderAuthConfig,
@@ -116,6 +122,7 @@ export const AIProviderAuthConfig = z.union([
     ActivePiecesProviderAuthConfig,
     BedrockProviderAuthConfig,
     MistralProviderAuthConfig,
+    AIMLAPIProviderAuthConfig,
 ])
 export type AIProviderAuthConfig = z.infer<typeof AIProviderAuthConfig>
 // Order matters, put schemas with required fields first, empty ones last. This is to avoid empty objects matching any object.
@@ -130,6 +137,7 @@ export const AIProviderConfig = z.union([
     OpenRouterProviderConfig,
     ActivePiecesProviderConfig,
     MistralProviderConfig,
+    AIMLAPIProviderConfig,
 ])
 export type AIProviderConfig = z.infer<typeof AIProviderConfig>
 
@@ -193,6 +201,12 @@ const ProviderConfigUnion = z.discriminatedUnion('provider', [
         provider: z.literal(AIProviderName.MISTRAL),
         config: MistralProviderConfig,
         auth: MistralProviderAuthConfig,
+    }),
+    z.object({
+        displayName: z.string().min(1),
+        provider: z.literal(AIProviderName.AIMLAPI),
+        config: AIMLAPIProviderConfig,
+        auth: AIMLAPIProviderAuthConfig,
     }),
 ])
 
@@ -272,6 +286,16 @@ export const ALLOWED_CHAT_MODELS_BY_PROVIDER: Partial<Record<AIProviderName, rea
     [AIProviderName.OPENAI]: OPENAI_CHAT_MODELS,
     [AIProviderName.ANTHROPIC]: ANTHROPIC_CHAT_MODELS,
     [AIProviderName.GOOGLE]: GOOGLE_CHAT_MODELS,
+    [AIProviderName.AIMLAPI]: [
+        'gpt-5-chat',
+        'openai/gpt-4o-mini',
+        'openai/gpt-4o',
+        'anthropic/claude-sonnet-4.5',
+        'google/gemini-2.5-flash',
+        'google/gemini-3-flash-preview',
+        'deepseek/deepseek-chat',
+        'x-ai/grok-4',
+    ],
     [AIProviderName.ACTIVEPIECES]: [
         ...ANTHROPIC_OPENROUTER_CHAT_MODELS.map((m) => `${AIProviderName.ANTHROPIC}/${m}`),
         ...OPENAI_CHAT_MODELS.map((m) => `${AIProviderName.OPENAI}/${m}`),
@@ -373,6 +397,7 @@ const PROVIDER_MAX_CONTEXT_TOKENS: Partial<Record<AIProviderName, number>> = {
     [AIProviderName.OPENROUTER]: 128_000,
     [AIProviderName.ACTIVEPIECES]: 200_000,
     [AIProviderName.MISTRAL]: 128_000,
+    [AIProviderName.AIMLAPI]: 128_000,
 }
 
 function getMaxContextTokens({ provider }: { provider: AIProviderName | undefined }): number {

--- a/packages/core/shared/src/lib/management/ai-providers/index.ts
+++ b/packages/core/shared/src/lib/management/ai-providers/index.ts
@@ -281,21 +281,22 @@ const ANTHROPIC_CHAT_MODELS = ['claude-sonnet-4-6', 'claude-opus-4-7', 'claude-h
 const ANTHROPIC_OPENROUTER_CHAT_MODELS = ['claude-sonnet-4.6', 'claude-opus-4.7', 'claude-haiku-4.5'] as const
 const GOOGLE_CHAT_MODELS = ['gemini-2.5-pro', 'gemini-2.5-flash', 'gemini-3.1-pro-preview', 'gemini-3-flash-preview'] as const
 const X_AI_OPENROUTER_CHAT_MODELS = ['grok-4.20', 'grok-4.1-fast'] as const
+export const AIMLAPI_CHAT_MODELS = [
+    'gpt-5-chat',
+    'openai/gpt-4o-mini',
+    'openai/gpt-4o',
+    'anthropic/claude-sonnet-4.5',
+    'google/gemini-2.5-flash',
+    'google/gemini-3-flash-preview',
+    'deepseek/deepseek-chat',
+    'x-ai/grok-4',
+] as const
 
 export const ALLOWED_CHAT_MODELS_BY_PROVIDER: Partial<Record<AIProviderName, readonly string[]>> = {
     [AIProviderName.OPENAI]: OPENAI_CHAT_MODELS,
     [AIProviderName.ANTHROPIC]: ANTHROPIC_CHAT_MODELS,
     [AIProviderName.GOOGLE]: GOOGLE_CHAT_MODELS,
-    [AIProviderName.AIMLAPI]: [
-        'gpt-5-chat',
-        'openai/gpt-4o-mini',
-        'openai/gpt-4o',
-        'anthropic/claude-sonnet-4.5',
-        'google/gemini-2.5-flash',
-        'google/gemini-3-flash-preview',
-        'deepseek/deepseek-chat',
-        'x-ai/grok-4',
-    ],
+    [AIProviderName.AIMLAPI]: AIMLAPI_CHAT_MODELS,
     [AIProviderName.ACTIVEPIECES]: [
         ...ANTHROPIC_OPENROUTER_CHAT_MODELS.map((m) => `${AIProviderName.ANTHROPIC}/${m}`),
         ...OPENAI_CHAT_MODELS.map((m) => `${AIProviderName.OPENAI}/${m}`),

--- a/packages/core/utils/src/lib/permission.ts
+++ b/packages/core/utils/src/lib/permission.ts
@@ -53,4 +53,5 @@ export enum AIProviderName {
     CUSTOM = 'custom',
     BEDROCK = 'bedrock',
     MISTRAL = 'mistral',
+    AIMLAPI = 'aimlapi',
 }

--- a/packages/pieces/community/ai/src/lib/common/ai-sdk.ts
+++ b/packages/pieces/community/ai/src/lib/common/ai-sdk.ts
@@ -202,6 +202,18 @@ export async function createAIModel({
             })
             return provider.chatModel(modelId)
         }
+        case AIProviderName.AIMLAPI: {
+            const { apiKey } = auth as BaseAIProviderAuthConfig
+            if (isImage) {
+                throw new Error(`Provider ${AIProviderName.AIMLAPI} does not support image models`)
+            }
+            const provider = createOpenAICompatible({
+                name: 'aimlapi',
+                baseURL: 'https://api.aimlapi.com/v1',
+                apiKey,
+            })
+            return provider.chatModel(modelId)
+        }
         case AIProviderName.ACTIVEPIECES:
         case AIProviderName.OPENROUTER: {
             const { apiKey } = auth as BaseAIProviderAuthConfig

--- a/packages/server/api/src/app/ai/providers/aimlapi-provider.ts
+++ b/packages/server/api/src/app/ai/providers/aimlapi-provider.ts
@@ -18,7 +18,7 @@ export const aimlapiProvider: AIProviderStrategy<AIMLAPIProviderAuthConfig, AIML
     name: 'AI/ML API',
     async validateConnection(authConfig: AIMLAPIProviderAuthConfig, _config: AIMLAPIProviderConfig, _log: FastifyBaseLogger): Promise<void> {
         await httpClient.sendRequest({
-            url: 'https://api.aimlapi.com/v1/models',
+            url: 'https://api.aimlapi.com/v2/billing',
             method: HttpMethod.GET,
             headers: {
                 'Authorization': `Bearer ${authConfig.apiKey}`,

--- a/packages/server/api/src/app/ai/providers/aimlapi-provider.ts
+++ b/packages/server/api/src/app/ai/providers/aimlapi-provider.ts
@@ -1,0 +1,24 @@
+import { AIMLAPIProviderAuthConfig, AIMLAPIProviderConfig, AIProviderModel, AIProviderModelType } from '@activepieces/shared'
+import { FastifyBaseLogger } from 'fastify'
+import { AIProviderStrategy } from './ai-provider'
+
+const AIMLAPI_CHAT_MODELS: AIProviderModel[] = [
+    { id: 'gpt-5-chat', name: 'GPT-5 Chat', type: AIProviderModelType.TEXT },
+    { id: 'openai/gpt-4o-mini', name: 'GPT-4o Mini', type: AIProviderModelType.TEXT },
+    { id: 'openai/gpt-4o', name: 'GPT-4o', type: AIProviderModelType.TEXT },
+    { id: 'anthropic/claude-sonnet-4.5', name: 'Claude Sonnet 4.5', type: AIProviderModelType.TEXT },
+    { id: 'google/gemini-2.5-flash', name: 'Gemini 2.5 Flash', type: AIProviderModelType.TEXT },
+    { id: 'google/gemini-3-flash-preview', name: 'Gemini 3 Flash Preview', type: AIProviderModelType.TEXT },
+    { id: 'deepseek/deepseek-chat', name: 'DeepSeek Chat', type: AIProviderModelType.TEXT },
+    { id: 'x-ai/grok-4', name: 'Grok 4', type: AIProviderModelType.TEXT },
+]
+
+export const aimlapiProvider: AIProviderStrategy<AIMLAPIProviderAuthConfig, AIMLAPIProviderConfig> = {
+    name: 'AI/ML API',
+    async validateConnection(_authConfig: AIMLAPIProviderAuthConfig, _config: AIMLAPIProviderConfig, _log: FastifyBaseLogger): Promise<void> {
+        // AI/ML API uses a curated starter catalog here; avoid requiring /models discovery for setup.
+    },
+    async listModels(_authConfig: AIMLAPIProviderAuthConfig, _config: AIMLAPIProviderConfig): Promise<AIProviderModel[]> {
+        return AIMLAPI_CHAT_MODELS
+    },
+}

--- a/packages/server/api/src/app/ai/providers/aimlapi-provider.ts
+++ b/packages/server/api/src/app/ai/providers/aimlapi-provider.ts
@@ -1,24 +1,36 @@
-import { AIMLAPIProviderAuthConfig, AIMLAPIProviderConfig, AIProviderModel, AIProviderModelType } from '@activepieces/shared'
+import { httpClient, HttpMethod } from '@activepieces/pieces-common'
+import { AIMLAPI_CHAT_MODELS, AIMLAPIProviderAuthConfig, AIMLAPIProviderConfig, AIProviderModel, AIProviderModelType } from '@activepieces/shared'
 import { FastifyBaseLogger } from 'fastify'
 import { AIProviderStrategy } from './ai-provider'
 
-const AIMLAPI_CHAT_MODELS: AIProviderModel[] = [
-    { id: 'gpt-5-chat', name: 'GPT-5 Chat', type: AIProviderModelType.TEXT },
-    { id: 'openai/gpt-4o-mini', name: 'GPT-4o Mini', type: AIProviderModelType.TEXT },
-    { id: 'openai/gpt-4o', name: 'GPT-4o', type: AIProviderModelType.TEXT },
-    { id: 'anthropic/claude-sonnet-4.5', name: 'Claude Sonnet 4.5', type: AIProviderModelType.TEXT },
-    { id: 'google/gemini-2.5-flash', name: 'Gemini 2.5 Flash', type: AIProviderModelType.TEXT },
-    { id: 'google/gemini-3-flash-preview', name: 'Gemini 3 Flash Preview', type: AIProviderModelType.TEXT },
-    { id: 'deepseek/deepseek-chat', name: 'DeepSeek Chat', type: AIProviderModelType.TEXT },
-    { id: 'x-ai/grok-4', name: 'Grok 4', type: AIProviderModelType.TEXT },
-]
+const AIMLAPI_CHAT_MODEL_NAMES: Record<(typeof AIMLAPI_CHAT_MODELS)[number], string> = {
+    'gpt-5-chat': 'GPT-5 Chat',
+    'openai/gpt-4o-mini': 'GPT-4o Mini',
+    'openai/gpt-4o': 'GPT-4o',
+    'anthropic/claude-sonnet-4.5': 'Claude Sonnet 4.5',
+    'google/gemini-2.5-flash': 'Gemini 2.5 Flash',
+    'google/gemini-3-flash-preview': 'Gemini 3 Flash Preview',
+    'deepseek/deepseek-chat': 'DeepSeek Chat',
+    'x-ai/grok-4': 'Grok 4',
+}
 
 export const aimlapiProvider: AIProviderStrategy<AIMLAPIProviderAuthConfig, AIMLAPIProviderConfig> = {
     name: 'AI/ML API',
-    async validateConnection(_authConfig: AIMLAPIProviderAuthConfig, _config: AIMLAPIProviderConfig, _log: FastifyBaseLogger): Promise<void> {
-        // AI/ML API uses a curated starter catalog here; avoid requiring /models discovery for setup.
+    async validateConnection(authConfig: AIMLAPIProviderAuthConfig, _config: AIMLAPIProviderConfig, _log: FastifyBaseLogger): Promise<void> {
+        await httpClient.sendRequest({
+            url: 'https://api.aimlapi.com/v1/models',
+            method: HttpMethod.GET,
+            headers: {
+                'Authorization': `Bearer ${authConfig.apiKey}`,
+                'Content-Type': 'application/json',
+            },
+        })
     },
     async listModels(_authConfig: AIMLAPIProviderAuthConfig, _config: AIMLAPIProviderConfig): Promise<AIProviderModel[]> {
-        return AIMLAPI_CHAT_MODELS
+        return AIMLAPI_CHAT_MODELS.map((model) => ({
+            id: model,
+            name: AIMLAPI_CHAT_MODEL_NAMES[model],
+            type: AIProviderModelType.TEXT,
+        }))
     },
 }

--- a/packages/server/api/src/app/ai/providers/index.ts
+++ b/packages/server/api/src/app/ai/providers/index.ts
@@ -1,6 +1,7 @@
 import { AIProviderName } from '@activepieces/core-utils'
 import { AIProviderAuthConfig, AIProviderConfig } from '@activepieces/shared'
 import { AIProviderStrategy } from './ai-provider'
+import { aimlapiProvider } from './aimlapi-provider'
 import { anthropicProvider } from './anthropic-provider'
 import { azureProvider } from './azure-provider'
 import { bedrockProvider } from './bedrock-provider'
@@ -21,6 +22,7 @@ export const aiProviders: Record<AIProviderName, AIProviderStrategy<AIProviderAu
     [AIProviderName.CUSTOM]: openAICompatibleProvider,
     [AIProviderName.BEDROCK]: bedrockProvider,
     [AIProviderName.MISTRAL]: mistralProvider,
+    [AIProviderName.AIMLAPI]: aimlapiProvider,
     [AIProviderName.ACTIVEPIECES]: {
         ...openRouterProvider,
         name: 'Activepieces',

--- a/packages/server/api/test/unit/app/ai/providers/aimlapi-provider.test.ts
+++ b/packages/server/api/test/unit/app/ai/providers/aimlapi-provider.test.ts
@@ -1,0 +1,19 @@
+import { AIProviderModelType } from '@activepieces/shared'
+import { describe, expect, it } from 'vitest'
+import { aimlapiProvider } from '../../../../../src/app/ai/providers/aimlapi-provider'
+
+describe('aimlapiProvider', () => {
+    it('returns a curated text-only starter model catalog', async () => {
+        const models = await aimlapiProvider.listModels({ apiKey: 'test-key' }, {})
+
+        expect(models).toEqual(
+            expect.arrayContaining([
+                { id: 'gpt-5-chat', name: 'GPT-5 Chat', type: AIProviderModelType.TEXT },
+                { id: 'openai/gpt-4o-mini', name: 'GPT-4o Mini', type: AIProviderModelType.TEXT },
+                { id: 'anthropic/claude-sonnet-4.5', name: 'Claude Sonnet 4.5', type: AIProviderModelType.TEXT },
+                { id: 'google/gemini-2.5-flash', name: 'Gemini 2.5 Flash', type: AIProviderModelType.TEXT },
+            ]),
+        )
+        expect(models.every((model) => model.type === AIProviderModelType.TEXT)).toBe(true)
+    })
+})

--- a/packages/server/utils/src/chat-ai-utils.ts
+++ b/packages/server/utils/src/chat-ai-utils.ts
@@ -99,6 +99,14 @@ function createChatModel({ provider, auth, config, modelId, webSearchEnabled = f
                 },
             }).chatModel(modelId)
         }
+        case AIProviderName.AIMLAPI: {
+            const { apiKey } = auth as BaseAIProviderAuthConfig
+            return createOpenAICompatible({
+                name: 'aimlapi',
+                baseURL: 'https://api.aimlapi.com/v1',
+                apiKey,
+            }).chatModel(modelId)
+        }
         case AIProviderName.MISTRAL:
         case AIProviderName.ACTIVEPIECES:
         case AIProviderName.OPENROUTER: {

--- a/packages/web/src/app/routes/platform/setup/ai/universal-pieces/upsert-provider-dialog.tsx
+++ b/packages/web/src/app/routes/platform/setup/ai/universal-pieces/upsert-provider-dialog.tsx
@@ -1,6 +1,8 @@
 import { AIProviderName, isNil } from '@activepieces/core-utils';
 import {
   AIProviderConfig,
+  AIMLAPIProviderAuthConfig,
+  AIMLAPIProviderConfig,
   AnthropicProviderAuthConfig,
   AnthropicProviderConfig,
   AzureProviderAuthConfig,
@@ -159,7 +161,7 @@ export const UpsertAIProviderDialogContent = ({
     defaultValues: {
       provider,
       displayName: defaultDisplayName,
-      config: config,
+      config: config ?? (provider === AIProviderName.AIMLAPI ? {} : undefined),
     } as CreateAIProviderRequest,
   });
 
@@ -324,6 +326,14 @@ const createFormSchema = (provider: AIProviderName, editMode: boolean) => {
       provider: z.literal(AIProviderName.BEDROCK),
       config: BedrockProviderConfig,
       auth: editMode ? OptionalAuthSchema : BedrockProviderAuthConfig,
+    });
+  }
+  if (provider === AIProviderName.AIMLAPI) {
+    return z.object({
+      displayName: z.string().min(1),
+      provider: z.literal(AIProviderName.AIMLAPI),
+      config: AIMLAPIProviderConfig,
+      auth: editMode ? OptionalAuthSchema : AIMLAPIProviderAuthConfig,
     });
   }
   const authSchema = z.union([

--- a/packages/web/src/features/agents/ai-providers.ts
+++ b/packages/web/src/features/agents/ai-providers.ts
@@ -3,6 +3,17 @@ import { t } from 'i18next';
 
 export const SUPPORTED_AI_PROVIDERS: AiProviderInfo[] = [
   {
+    provider: AIProviderName.AIMLAPI,
+    name: 'AI/ML API',
+    logoUrl: 'https://aimlapi.com/favicon.ico',
+    markdown: t(`Follow these instructions to get your AI/ML API key:
+
+1. Go to https://aimlapi.com/app/keys.
+2. Create or copy an API key and paste it below.
+3. Activepieces will use the fixed OpenAI-compatible endpoint https://api.aimlapi.com/v1.
+`),
+  },
+  {
     provider: AIProviderName.ANTHROPIC,
     name: 'Anthropic',
     markdown: t(`Follow these instructions to get your Claude API Key:


### PR DESCRIPTION
## What changed
- Adds AI/ML API as a built-in AI provider option.
- Uses a fixed OpenAI-compatible endpoint: `https://api.aimlapi.com/v1`.
- Reuses bearer API key auth via the existing base provider auth config.
- Provides a curated TEXT-only starter catalog, with no live `/models` discovery requirement.
- Wires the provider through the provider registry, chat model creation, Universal AI piece runtime, and platform setup UI.

## Scope notes
- This PR intentionally does not add image/video/audio/embedding model support.
- Setup validation does not call `/models`; invalid keys surface on first real model usage, matching the fixed curated catalog scope.

Closes #13758

## Test plan
- PASS: `vitest run packages/server/api/test/unit/app/ai/providers/aimlapi-provider.test.ts`
- PASS: `bun run --filter @activepieces/core-utils build`
- PASS before rebasing, on the earlier repo layout: `@activepieces/shared` build, `api` build, `web` build, `piece-ai` build, and `npm run lint-dev` with existing warnings.
- After rebasing onto the latest `main`, broader `@activepieces/shared` / `api` builds currently fail on unrelated upstream TypeScript errors in audit-events, git-sync/project-release/template/rpc areas. The new AIML API provider unit test still passes on the rebased branch.