### PR TITLE
fix(webhook): process handshake ping for DISABLED and ENABLED flows

### DIFF
--- a/.agents/features/webhooks.md
+++ b/.agents/features/webhooks.md
@@ -74,7 +74,7 @@ External services verify webhook ownership before sending events:
 - **HEADER_PRESENT**: Check for specific header
 - **QUERY_PRESENT**: Check for query parameter
 - **BODY_PARAM_PRESENT**: Check for body field
-- Submits HANDSHAKE hook job to worker → piece validates signature → returns verification response
+- Submits HANDSHAKE hook job to worker → piece validates signature → returns verification response. The check runs **before** the disabled-flow guard so that handshake pings are processed both during the publish window (flow still DISABLED) and for third-party re-verification pings on ENABLED flows.
 
 ## Payload Size Limit
 
@@ -84,4 +84,4 @@ External services verify webhook ownership before sending events:
 
 - Uses `flowExecutionCache` for fast lookup
 - LOCKED_FALL_BACK_TO_LATEST: uses `publishedVersionId` if exists, else latest
-- Returns 410 GONE if flow not found, 404 if disabled
+- Returns 410 GONE if flow not found; 404 if disabled (unless the request matches the flow's `handshakeConfiguration`, in which case the handshake is processed and the disabled check is skipped)

--- a/packages/server/api/src/app/webhooks/webhook.service.ts
+++ b/packages/server/api/src/app/webhooks/webhook.service.ts
@@ -84,17 +84,6 @@ export const webhookService = {
             }
         }
         const { flow } = flowExecutionResult
-        if (flow.status === FlowStatus.DISABLED && !saveSampleData) {
-            pinoLogger.warn({ flow: { id: flowId } }, 'Webhook received for disabled flow')
-            wideEvent.set({ webhook: { flowFound: false } })
-            return {
-                status: StatusCodes.NOT_FOUND,
-                body: {},
-                headers: {
-                    [webhookHeader]: webhookRequestId,
-                },
-            }
-        }
 
         wideEvent.set({
             webhook: {
@@ -106,25 +95,44 @@ export const webhookService = {
         const flowVersionIdToRun = await webhookService.getFlowVersionIdToRun(flowVersionToRun, flow)
         wideEvent.set({ flowVersion: { id: flowVersionIdToRun } })
 
-        const response = await webhookHandshake.handleHandshakeRequest({
-            payload: (payload ?? await data(flow.projectId)) as TriggerPayload,
-            handshakeConfiguration: flowExecutionResult.handshakeConfiguration ?? null,
-            flowId: flow.id,
-            flowVersionId: flowVersionIdToRun,
-            projectId: flow.projectId,
-            logger: pinoLogger,
-        })
-        if (!isNil(response)) {
-            logger.info({
-                flow: { id: flow.id },
-                flowVersion: { id: flowVersionIdToRun },
-                webhookRequestId,
-            }, 'Handshake request completed')
-            wideEvent.set({ webhook: { handshake: true } })
+        // Handshake pings arrive during the publish window: the trigger source is created and
+        // onEnable fires (registering the webhook with the third party), but flow.status is
+        // still DISABLED until the publish transaction completes. Checking here — before the
+        // status guard — lets the ping succeed. The DISABLED guard means enabled flows paying
+        // no cost on every payload webhook.
+        if (flow.status === FlowStatus.DISABLED && !isNil(flowExecutionResult.handshakeConfiguration)) {
+            const response = await webhookHandshake.handleHandshakeRequest({
+                payload: (payload ?? await data(flow.projectId)) as TriggerPayload,
+                handshakeConfiguration: flowExecutionResult.handshakeConfiguration,
+                flowId: flow.id,
+                flowVersionId: flowVersionIdToRun,
+                projectId: flow.projectId,
+                logger: pinoLogger,
+            })
+            if (!isNil(response)) {
+                logger.info({
+                    flow: { id: flow.id },
+                    flowVersion: { id: flowVersionIdToRun },
+                    webhookRequestId,
+                }, 'Handshake request completed')
+                wideEvent.set({ webhook: { handshake: true } })
+                return {
+                    status: response.status,
+                    body: response.body,
+                    headers: response.headers ?? {},
+                }
+            }
+        }
+
+        if (flow.status === FlowStatus.DISABLED && !saveSampleData) {
+            pinoLogger.warn({ flow: { id: flowId } }, 'Webhook received for disabled flow')
+            wideEvent.set({ webhook: { flowFound: false } })
             return {
-                status: response.status,
-                body: response.body,
-                headers: response.headers ?? {},
+                status: StatusCodes.NOT_FOUND,
+                body: {},
+                headers: {
+                    [webhookHeader]: webhookRequestId,
+                },
             }
         }
 

--- a/packages/server/api/src/app/webhooks/webhook.service.ts
+++ b/packages/server/api/src/app/webhooks/webhook.service.ts
@@ -95,12 +95,10 @@ export const webhookService = {
         const flowVersionIdToRun = await webhookService.getFlowVersionIdToRun(flowVersionToRun, flow)
         wideEvent.set({ flowVersion: { id: flowVersionIdToRun } })
 
-        // Handshake pings arrive during the publish window: the trigger source is created and
-        // onEnable fires (registering the webhook with the third party), but flow.status is
-        // still DISABLED until the publish transaction completes. Checking here — before the
-        // status guard — lets the ping succeed. The DISABLED guard means enabled flows paying
-        // no cost on every payload webhook.
-        if (flow.status === FlowStatus.DISABLED && !isNil(flowExecutionResult.handshakeConfiguration)) {
+        // Handshake pings can arrive both during the publish window (when flow.status is still
+        // DISABLED before the transaction completes) and after the flow is ENABLED (third-party
+        // re-verification). Checking before the DISABLED guard handles both cases.
+        if (!isNil(flowExecutionResult.handshakeConfiguration)) {
             const response = await webhookHandshake.handleHandshakeRequest({
                 payload: (payload ?? await data(flow.projectId)) as TriggerPayload,
                 handshakeConfiguration: flowExecutionResult.handshakeConfiguration,

--- a/packages/server/api/test/integration/ce/webhooks/webhook.test.ts
+++ b/packages/server/api/test/integration/ce/webhooks/webhook.test.ts
@@ -456,6 +456,76 @@ describe('Webhook Service', () => {
         interactionSpy.mockRestore()
     })
 
+    it('should process handshake for ENABLED flow on re-verification ping', async () => {
+        const { mockProject, mockPlatform } = await mockAndSaveBasicSetup()
+
+        const triggerName = 'new_webhook'
+        const pieceName = 'test-handshake-piece-enabled'
+        const pieceVersion = '1.0.0'
+
+        const mockPiece = createMockPieceMetadata({
+            platformId: mockPlatform.id,
+            name: pieceName,
+            version: pieceVersion,
+            triggers: {
+                [triggerName]: {
+                    handshakeConfiguration: {
+                        strategy: WebhookHandshakeStrategy.QUERY_PRESENT,
+                        paramName: 'hub_challenge',
+                    },
+                },
+            },
+        })
+        await db.save('piece_metadata', [mockPiece])
+
+        const mockFlow = createMockFlow({
+            projectId: mockProject.id,
+            status: FlowStatus.ENABLED,
+        })
+        await db.save('flow', [mockFlow])
+
+        const mockFlowVersion = createMockFlowVersion({ flowId: mockFlow.id })
+        await db.save('flow_version', [mockFlowVersion])
+        await db.update('flow', mockFlow.id, { publishedVersionId: mockFlowVersion.id })
+
+        await db.save('trigger_source', [{
+            id: apId(),
+            created: new Date().toISOString(),
+            updated: new Date().toISOString(),
+            flowId: mockFlow.id,
+            flowVersionId: mockFlowVersion.id,
+            projectId: mockProject.id,
+            pieceName,
+            pieceVersion,
+            triggerName,
+            type: TriggerStrategy.WEBHOOK,
+            simulate: false,
+            schedule: null,
+            deleted: null,
+        }])
+
+        const interactionSpy = vi.spyOn(userInteractionWatcher, 'submitAndWaitForResponse').mockResolvedValue({
+            status: EngineResponseStatus.OK,
+            response: {
+                response: {
+                    status: StatusCodes.OK,
+                    body: { challenge: 'test-challenge' },
+                },
+            },
+            error: undefined,
+        })
+
+        const response = await app?.inject({
+            method: 'GET',
+            url: `/api/v1/webhooks/${mockFlow.id}?hub_challenge=test-challenge`,
+        })
+
+        expect(response?.statusCode).toBe(StatusCodes.OK)
+        expect(interactionSpy).toHaveBeenCalled()
+
+        interactionSpy.mockRestore()
+    })
+
     it('should accept webhook on test endpoint without execution', async () => {
         const { mockProject, mockPlatform, mockOwner } = await mockAndSaveBasicSetup()
         const mockFlow = createMockFlow({

--- a/packages/server/api/test/integration/ce/webhooks/webhook.test.ts
+++ b/packages/server/api/test/integration/ce/webhooks/webhook.test.ts
@@ -1,10 +1,11 @@
-import { FlowStatus, PrincipalType } from '@activepieces/shared'
+import { apId, EngineResponseStatus, FlowStatus, PrincipalType, TriggerStrategy, WebhookHandshakeStrategy } from '@activepieces/shared'
 import { FastifyInstance } from 'fastify'
 import { StatusCodes } from 'http-status-codes'
 import { generateMockToken } from '../../../helpers/auth'
 import { db } from '../../../helpers/db'
-import { createMockFlow, createMockFlowVersion, mockAndSaveBasicSetup } from '../../../helpers/mocks'
+import { createMockFlow, createMockFlowVersion, createMockPieceMetadata, mockAndSaveBasicSetup } from '../../../helpers/mocks'
 import { setupTestEnvironment, teardownTestEnvironment } from '../../../helpers/test-setup'
+import { userInteractionWatcher } from '../../../../src/app/workers/user-interaction-watcher'
 
 let app: FastifyInstance | null = null
 const MOCK_FLOW_ID = '8hfKOpm3kY1yAi1ApYOa1'
@@ -383,6 +384,76 @@ describe('Webhook Service', () => {
             body: largePayload,
         })
         expect(response?.statusCode).toBe(StatusCodes.REQUEST_TOO_LONG)
+    })
+
+    it('should process handshake for DISABLED flow during publish window', async () => {
+        const { mockProject, mockPlatform } = await mockAndSaveBasicSetup()
+
+        const triggerName = 'new_webhook'
+        const pieceName = 'test-handshake-piece'
+        const pieceVersion = '1.0.0'
+
+        const mockPiece = createMockPieceMetadata({
+            platformId: mockPlatform.id,
+            name: pieceName,
+            version: pieceVersion,
+            triggers: {
+                [triggerName]: {
+                    handshakeConfiguration: {
+                        strategy: WebhookHandshakeStrategy.QUERY_PRESENT,
+                        paramName: 'hub_challenge',
+                    },
+                },
+            },
+        })
+        await db.save('piece_metadata', [mockPiece])
+
+        const mockFlow = createMockFlow({
+            projectId: mockProject.id,
+            status: FlowStatus.DISABLED,
+        })
+        await db.save('flow', [mockFlow])
+
+        const mockFlowVersion = createMockFlowVersion({ flowId: mockFlow.id })
+        await db.save('flow_version', [mockFlowVersion])
+        await db.update('flow', mockFlow.id, { publishedVersionId: mockFlowVersion.id })
+
+        await db.save('trigger_source', [{
+            id: apId(),
+            created: new Date().toISOString(),
+            updated: new Date().toISOString(),
+            flowId: mockFlow.id,
+            flowVersionId: mockFlowVersion.id,
+            projectId: mockProject.id,
+            pieceName,
+            pieceVersion,
+            triggerName,
+            type: TriggerStrategy.WEBHOOK,
+            simulate: false,
+            schedule: null,
+            deleted: null,
+        }])
+
+        const interactionSpy = vi.spyOn(userInteractionWatcher, 'submitAndWaitForResponse').mockResolvedValue({
+            status: EngineResponseStatus.OK,
+            response: {
+                response: {
+                    status: StatusCodes.OK,
+                    body: { challenge: 'test-challenge' },
+                },
+            },
+            error: undefined,
+        })
+
+        const response = await app?.inject({
+            method: 'GET',
+            url: `/api/v1/webhooks/${mockFlow.id}?hub_challenge=test-challenge`,
+        })
+
+        expect(response?.statusCode).toBe(StatusCodes.OK)
+        expect(interactionSpy).toHaveBeenCalled()
+
+        interactionSpy.mockRestore()
     })
 
     it('should accept webhook on test endpoint without execution', async () => {


### PR DESCRIPTION
## Summary

- Triggers with `handshakeConfiguration` (e.g. smartsheet, monday.com) were always returning 404 during setup, causing webhook registration to fail
- The root cause is a regression introduced in commit `0fe5c1a3ee` ("feat: cache flow status") which replaced a trigger-source existence check with a flow-status check
- Fix: run the handshake check before the `DISABLED → 404` status guard, for any flow that has a `handshakeConfiguration` — regardless of status

## The Regression

**Original behavior (correct):**
```
triggerSource = await triggerSourceService.getByFlowIdPopulated(...)
if (!flowExists)          → 410 GONE
if (isNil(triggerSource)) → 404           ← gated on trigger source
handleHandshakeRequest(...)               ← always ran when trigger source existed
```

**After `0fe5c1a3ee` (broken):**
```
flowExecutionResult = await flowExecutionCache.get(...)
if (!flowExists)                   → 410 GONE
if (flow.status === DISABLED)      → 404  ← too early, blocks handshake
handleHandshakeRequest(...)               ← never reached during publish
```

## Why It Breaks

During flow publish (`LOCK_AND_PUBLISH`), the sequence is:

1. Draft version locked → `flow.status = DISABLED`, `publishedVersionId` set → **cache invalidated**
2. **Trigger source saved to DB** (`triggerSourceRepo().save()`)
3. **`onEnable` called** → piece registers webhook URL with third party → **handshake ping arrives**
4. `flow.status = ENABLED`

When the handshake ping hits step 3, the flow is still `DISABLED`. The old code saw a non-null trigger source and allowed the handshake through. The new code hit the `DISABLED → 404` guard before reaching the handshake check.

A second scenario also broke: once a flow is `ENABLED`, some third parties send periodic **re-verification pings**. The intermediate fix gated the handshake on `flow.status === DISABLED`, which meant ENABLED flows could never complete a re-verification handshake.

## The Fix

Attempt the handshake for any flow that has a `handshakeConfiguration`, regardless of status, before the `DISABLED → 404` guard:

```typescript
// Handshake pings can arrive both during the publish window (flow still DISABLED)
// and after the flow is ENABLED (third-party re-verification).
if (!isNil(flowExecutionResult.handshakeConfiguration)) {
    const response = await webhookHandshake.handleHandshakeRequest({ ... })
    if (!isNil(response)) {
        return response  // handshake succeeded
    }
}

if (flow.status === FlowStatus.DISABLED && !saveSampleData) {
    return 404  // not a handshake ping, flow is genuinely disabled
}
```

## Test Plan

- [x] Integration test: `should process handshake for DISABLED flow during publish window` — DISABLED flow with handshake config returns 200 instead of 404
- [x] Integration test: `should process handshake for ENABLED flow on re-verification ping` — ENABLED flow with handshake config returns 200 instead of being queued as a normal execution
- [x] Existing webhook tests still pass
- [x] Lint clean

Closes #12436