### PR TITLE
fix(ci): build core deps before shared in canary/release workflows

### DIFF
--- a/.github/workflows/continuous-delivery-canary.yml
+++ b/.github/workflows/continuous-delivery-canary.yml
@@ -72,11 +72,8 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
-      - name: Build shared package
-        run: bun run --cwd packages/core/shared build
-
-      - name: Build server-utils package
-        run: bun run --cwd packages/server/utils build
+      - name: Build shared and server-utils packages
+        run: bunx turbo run build --filter=@activepieces/shared --filter=@activepieces/server-utils
 
       - name: Configure SSH
         run: |

--- a/.github/workflows/continuous-delivery-release.yml
+++ b/.github/workflows/continuous-delivery-release.yml
@@ -27,11 +27,8 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
-      - name: Build shared package
-        run: bun run --cwd packages/core/shared build
-
-      - name: Build server-utils package
-        run: bun run --cwd packages/server/utils build
+      - name: Build shared and server-utils packages
+        run: bunx turbo run build --filter=@activepieces/shared --filter=@activepieces/server-utils
 
       - name: Set version from package.json
         id: version


### PR DESCRIPTION
## Problem

The scheduled **Continuous Delivery — Canary** `check-migrations` job was failing during the *Build shared package* step ([run 28019283285](https://github.com/activepieces/activepieces/actions/runs/28019283285/job/82933049516)):

```
error TS2307: Cannot find module '@activepieces/core-utils' ...
error TS2307: Cannot find module '@activepieces/core-execution' ...
```

## Root cause

After #13822 decoupled the core packages, `packages/core/shared/tsconfig.json` points its `paths` at the **built dist** (`packages/core/utils/dist/src/index.d.ts`, etc.) of `core-utils` / `core-execution` / `core-formula`. The canary and release workflows built `shared` directly via `bun run --cwd packages/core/shared build`, bypassing turbo's dependency ordering — so those core packages were never built first and `tsc` couldn't resolve them.

## Fix

Build `shared` and `server-utils` through turbo, which respects the `^build` dependency graph and builds the core packages first:

```yaml
- name: Build shared and server-utils packages
  run: bunx turbo run build --filter=@activepieces/shared --filter=@activepieces/server-utils
```

Applied to both `continuous-delivery-canary.yml` and `continuous-delivery-release.yml` (same broken pattern).

Verified locally by removing all `dist/` folders and running the turbo command — core-utils, core-formula, core-piece-types and core-execution build before shared/server-utils, all green.