### PR TITLE
fix(sandbox-pool): reject path-like piece names so one bad piece can't corrupt the shared bun.lock

### DIFF
--- a/packages/server/sandbox-pool/src/lib/cache/pieces/piece-installer.ts
+++ b/packages/server/sandbox-pool/src/lib/cache/pieces/piece-installer.ts
@@ -9,6 +9,8 @@ import { cacheUtils } from '../cache-paths'
 import { bunRunner } from '../code/bun-runner'
 
 const usedPiecesMemoryCache: Record<string, boolean> = {}
+const VALID_SCOPED_NAME_REGEX = /^@[^/]+\/[^/]+$/
+const VALID_UNSCOPED_NAME_REGEX = /^[^/]+$/
 const relativePiecePath = (piece: PiecePackage) => join('./', 'pieces', `${piece.pieceName}-${piece.pieceVersion}`)
 const piecePath = (rootWorkspace: string, piece: PiecePackage) => join(rootWorkspace, 'pieces', `${piece.pieceName}-${piece.pieceVersion}`)
 
@@ -43,7 +45,14 @@ function getCustomPiecesPath(basePath: string, platformId: string, getSettings: 
 async function installPieces(rootWorkspace: string, pieces: PiecePackage[], includeFilters: boolean, log: ApLogger, apiClient: WorkerToApiContract, getSettings: () => SandboxPoolSettings): Promise<void> {
     const devPieces = getSettings().DEV_PIECES
     const nonDevPieces = pieces.filter(piece => !devPieces.includes(getPieceNameFromAlias(piece.pieceName)))
-    const { piecesToInstall } = await partitionPiecesToInstall(rootWorkspace, nonDevPieces)
+    const { validPieces, invalidPieces } = partitionValidPieceNames(nonDevPieces)
+    if (!isEmpty(invalidPieces)) {
+        log.error({
+            rootWorkspace,
+            invalidPieces: invalidPieces.map(piece => `${piece.pieceName}@${piece.pieceVersion}`),
+        }, '[pieceInstaller] Skipping pieces with invalid package names to protect the shared lockfile')
+    }
+    const { piecesToInstall } = await partitionPiecesToInstall(rootWorkspace, validPieces)
 
     if (isEmpty(piecesToInstall)) {
         log.debug({ rootWorkspace }, '[pieceInstaller] No new pieces to install (already installed)')
@@ -57,7 +66,7 @@ async function installPieces(rootWorkspace: string, pieces: PiecePackage[], incl
     await memoryLock.runExclusive({
         key: `install-pieces-${rootWorkspace}`,
         fn: async () => {
-            const { piecesToInstall } = await partitionPiecesToInstall(rootWorkspace, pieces)
+            const { piecesToInstall } = await partitionPiecesToInstall(rootWorkspace, validPieces)
             if (isEmpty(piecesToInstall)) {
                 log.info({ rootWorkspace }, '[pieceInstaller] No new pieces to install in lock (already installed)')
                 return
@@ -122,6 +131,27 @@ async function installPieces(rootWorkspace: string, pieces: PiecePackage[], incl
             })
         },
     })
+}
+
+// A workspace member name (and its dependency key) must be a plain npm package name. A relative
+// path such as `../../../common/pieces/@activepieces/piece-x` — fed in via stale `usedPieces` data
+// from a since-reverted build — makes bun write an unparseable resolution token into the SHARED
+// bun.lock. That lock then fails to parse on the next install and takes down EVERY piece in the
+// workspace (so cache pre-warm and the deploy fail). Worse, because the install joins the name onto
+// `<workspace>/pieces/`, a `..` name escapes a per-platform `custom_pieces/<id>` workspace and lands
+// the poisoned member inside the shared `common` workspace. Such names are skipped at the source.
+export function isValidPackageName(name: string): boolean {
+    if (name.includes('..')) {
+        return false
+    }
+    return VALID_SCOPED_NAME_REGEX.test(name) || VALID_UNSCOPED_NAME_REGEX.test(name)
+}
+
+function partitionValidPieceNames(pieces: PiecePackage[]): { validPieces: PiecePackage[], invalidPieces: PiecePackage[] } {
+    return {
+        validPieces: pieces.filter(piece => isValidPackageName(piece.pieceName)),
+        invalidPieces: pieces.filter(piece => !isValidPackageName(piece.pieceName)),
+    }
 }
 
 async function rollbackInstallation(rootWorkspace: string, pieces: PiecePackage[]): Promise<void> {

--- a/packages/server/sandbox-pool/test/lib/cache/piece-installer.test.ts
+++ b/packages/server/sandbox-pool/test/lib/cache/piece-installer.test.ts
@@ -26,7 +26,7 @@ vi.mock('../../../src/lib/cache/cache-paths', () => ({
 }))
 
 // Import after mocks are registered
-const { pieceInstaller } = await import('../../../src/lib/cache/pieces/piece-installer')
+const { pieceInstaller, isValidPackageName } = await import('../../../src/lib/cache/pieces/piece-installer')
 
 function makePiece(name: string, version = '1.0.0'): OfficialPiecePackage {
     return {
@@ -204,6 +204,54 @@ describe('pieceInstaller', () => {
         expect(manifest.dependencies['@acme/piece-sample']).toContain('.tgz')
     })
 
+    it('skips pieces whose name is a relative path — they never reach the shared bun workspace', async () => {
+        const good = makePiece('@activepieces/piece-good')
+        // Stale `usedPieces` data from a since-reverted build can carry a relative path as the
+        // pieceName. Writing it as a workspace member corrupts the shared bun.lock and breaks every
+        // other piece (and cache pre-warm / deploy), so it must be dropped before any member is built.
+        const poison = makePiece('../../../common/pieces/@activepieces/piece-algolia', '0.0.3')
+        const installer = pieceInstaller(fakeLog, fakeApiClient, testWorkspace, fakeGetSettings)
+
+        mockInstall.mockResolvedValueOnce({ output: '' })
+
+        await installer.install({ pieces: [good, poison], includeFilters: true })
+
+        expect(mockInstall).toHaveBeenCalledOnce()
+        expect(mockInstall.mock.calls[0]?.[0].filtersPath).toEqual([
+            expect.stringContaining('@activepieces/piece-good-1.0.0'),
+        ])
+        expect(await pathExists(readyFilePath(good))).toBe(true)
+    })
+
+    it('install made up only of invalid-named pieces is a no-op — bun never runs', async () => {
+        const poison = makePiece('../../../common/pieces/@activepieces/piece-algolia', '0.0.3')
+        const installer = pieceInstaller(fakeLog, fakeApiClient, testWorkspace, fakeGetSettings)
+
+        await installer.install({ pieces: [poison], includeFilters: true })
+
+        expect(mockInstall).not.toHaveBeenCalled()
+    })
+
+    it('mixes valid and invalid pieces — only valid ones reach bun, both filters present for valid', async () => {
+        const goodA = makePiece('@activepieces/piece-a')
+        const goodB = makePiece('piece-b-unscoped')
+        const poison1 = makePiece('../../../common/pieces/@activepieces/piece-x', '0.0.3')
+        const poison2 = makePiece('@activepieces/piece-y/extra', '1.2.3')
+        const installer = pieceInstaller(fakeLog, fakeApiClient, testWorkspace, fakeGetSettings)
+
+        mockInstall.mockResolvedValueOnce({ output: '' })
+
+        await installer.install({ pieces: [goodA, poison1, goodB, poison2], includeFilters: true })
+
+        expect(mockInstall).toHaveBeenCalledOnce()
+        const filtersPath = mockInstall.mock.calls[0]?.[0].filtersPath as string[]
+        expect(filtersPath).toHaveLength(2)
+        expect(filtersPath.some(f => f.includes('@activepieces/piece-a-1.0.0'))).toBe(true)
+        expect(filtersPath.some(f => f.includes('piece-b-unscoped-1.0.0'))).toBe(true)
+        expect(filtersPath.some(f => f.includes('piece-x'))).toBe(false)
+        expect(filtersPath.some(f => f.includes('piece-y'))).toBe(false)
+    })
+
     it('individual fallback always passes --filter path regardless of includeFilters', async () => {
         const piece1 = makePiece('@activepieces/piece-filter-a')
         const piece2 = makePiece('@activepieces/piece-filter-b')
@@ -229,5 +277,44 @@ describe('pieceInstaller', () => {
         expect(mockInstall.mock.calls[2]?.[0]).toMatchObject({
             filtersPath: [expect.stringContaining(`${piece2.pieceName}-${piece2.pieceVersion}`)],
         })
+    })
+})
+
+describe('isValidPackageName', () => {
+    it.each([
+        '@activepieces/piece-algolia',
+        '@activepieces/piece-add-event',
+        '@acme/piece-sample',
+        // the `<name>-<version>` workspace-member form is itself a single-slash scoped name
+        '@activepieces/piece-algolia-0.0.3',
+        'tslib',
+        'piece-b-unscoped',
+        'lodash.merge',
+        '@a/b',
+        'a',
+    ])('accepts valid package name %j', (name) => {
+        expect(isValidPackageName(name)).toBe(true)
+    })
+
+    it.each([
+        // the production poison: a relative path masquerading as a piece name
+        '../../../common/pieces/@activepieces/piece-algolia',
+        '../../../common/pieces/@activepieces/piece-algolia-0.0.3',
+        '..',
+        '../foo',
+        './foo',
+        'foo/..',
+        '@activepieces/..',
+        // more than one path segment (scoped names allow exactly one slash)
+        '@activepieces/piece-y/extra',
+        'a/b/c',
+        'foo/bar',
+        // malformed scopes
+        '@/name',
+        '@scope/',
+        // empty
+        '',
+    ])('rejects invalid package name %j', (name) => {
+        expect(isValidPackageName(name)).toBe(false)
     })
 })


### PR DESCRIPTION
## Problem

Production can failed at cache pre-warm with `UnexpectedResolution: failed to parse lockfile: 'bun.lock'` and `"package.json" for "../../../common/pieces/@activepieces/piece-delay" failed to open: ENOENT`.

## Root cause

The installer writes whatever `pieceName` it is handed as a bun **workspace member** name + dependency key. A stale `usedPieces` entry (fed to `AP_PRE_WARM_CACHE` warmup) carried a **relative path** as the name — `../../../common/pieces/@activepieces/piece-x` — seeded by a since-reverted build (`f3993ff724`).

- bun records an unparseable resolution token in the **shared** `common/bun.lock`; it then fails to parse on the next install, ignores the lock, re-resolves and `ENOENT`s — so **every** piece in the workspace fails and the deploy fails. One bad piece poisons all ~3,600 members.
- Because the install joins the name onto `<workspace>/pieces/`, a `..` name **escapes** a per-platform `custom_pieces/<id>` workspace (SANDBOX_PROCESS) and lands the poisoned member inside `common`.

Verified `piece_metadata.name` in the DB is clean and no current code constructs that string — it is purely stale persisted state.

## Fix

Skip any piece whose `pieceName` is not a plain npm package name (rejects `..` and multi-segment paths) **before** any workspace member is written, so a poisoned `usedPieces` entry can no longer corrupt the shared lockfile or escape into `common`. Prevention only — already-frozen folders on the persistent cache volume are removed out-of-band.

## Tests

- New `isValidPackageName` validator table (scoped/unscoped/member form vs relative paths, `..`, multi-slash, malformed scopes, empty).
- Installer tests: poison-only install is a no-op; mixed install passes only valid pieces to bun.

32 tests pass; package lints clean.