### PR TITLE
fix(trello): handle HEAD request handshake for webhook validation

### DIFF
--- a/.agents/features/webhooks.md
+++ b/.agents/features/webhooks.md
@@ -27,7 +27,7 @@ Ingests inbound HTTP requests from external services and routes them to flows fo
 - **Draft webhook** — routes to the latest (draft) flow version instead of the published version; used for testing
 - **Test endpoint** (`/:flowId/test`) — captures the request as sample data without executing the flow
 - **Handshake** — a one-time ownership challenge sent by external services before activating a webhook subscription
-- **HandshakeStrategy** — how ownership is verified: `HEADER_PRESENT`, `QUERY_PRESENT`, `BODY_PARAM_PRESENT`, `NONE`
+- **HandshakeStrategy** — how ownership is verified: `HEADER_PRESENT`, `QUERY_PRESENT`, `BODY_PARAM_PRESENT`, `NONE`, `HEAD_REQUEST` (for services like Trello that validate by sending a HEAD request)
 - **engineResponseWatcher** — a one-time listener that bridges the BullMQ engine response back to the waiting HTTP connection for sync mode
 - **LOCKED_FALL_BACK_TO_LATEST** — version resolution: uses `publishedVersionId` if set, falls back to latest draft
 - **flowExecutionCache** — Redis-backed fast path for resolving flow metadata without hitting PostgreSQL on every webhook

--- a/packages/core/execution/src/lib/engine/engine-operation.ts
+++ b/packages/core/execution/src/lib/engine/engine-operation.ts
@@ -134,6 +134,7 @@ export type ExecuteTriggerOperation<HT extends TriggerHookType> = BaseEngineOper
 export const TriggerPayload = z.object({
     body: z.unknown(),
     rawBody: z.unknown().optional(),
+    method: z.string().optional(),
     headers: z.record(z.string(), z.string()),
     queryParams: z.record(z.string(), z.string()),
 })
@@ -141,6 +142,7 @@ export const TriggerPayload = z.object({
 export type TriggerPayload<T = unknown> = {
     body: T
     rawBody?: unknown
+    method?: string
     headers: Record<string, string>
     queryParams: Record<string, string>
 }

--- a/packages/core/piece-types/package.json
+++ b/packages/core/piece-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/core-piece-types",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "scripts": {

--- a/packages/core/piece-types/src/lib/engine.ts
+++ b/packages/core/piece-types/src/lib/engine.ts
@@ -10,6 +10,7 @@ export const TriggerPayload = z.object({
 export type TriggerPayload<T = unknown> = {
     body: T
     rawBody?: unknown
+    method?: string
     headers: Record<string, string>
     queryParams: Record<string, string>
 }

--- a/packages/core/piece-types/src/lib/trigger.ts
+++ b/packages/core/piece-types/src/lib/trigger.ts
@@ -12,6 +12,7 @@ export enum WebhookHandshakeStrategy {
     HEADER_PRESENT = 'HEADER_PRESENT',
     QUERY_PRESENT = 'QUERY_PRESENT',
     BODY_PARAM_PRESENT = 'BODY_PARAM_PRESENT',
+    HEAD_REQUEST = 'HEAD_REQUEST',
 }
 
 export const WebhookHandshakeConfiguration = z.object({

--- a/packages/core/shared/package.json
+++ b/packages/core/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/shared",
-  "version": "0.101.0",
+  "version": "0.101.1",
   "type": "commonjs",
   "sideEffects": false,
   "main": "./dist/src/index.js",

--- a/packages/core/shared/src/lib/automation/trigger/index.ts
+++ b/packages/core/shared/src/lib/automation/trigger/index.ts
@@ -13,6 +13,7 @@ export enum WebhookHandshakeStrategy {
     HEADER_PRESENT = 'HEADER_PRESENT',
     QUERY_PRESENT = 'QUERY_PRESENT',
     BODY_PARAM_PRESENT = 'BODY_PARAM_PRESENT',
+    HEAD_REQUEST = 'HEAD_REQUEST',
 }
 
 export enum TriggerSourceScheduleType {

--- a/packages/pieces/community/trello/package.json
+++ b/packages/pieces/community/trello/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-trello",
-  "version": "0.4.7",
+  "version": "0.4.8",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {

--- a/packages/pieces/community/trello/src/lib/triggers/cardMoved.ts
+++ b/packages/pieces/community/trello/src/lib/triggers/cardMoved.ts
@@ -18,14 +18,11 @@ export const cardMovedTrigger = createTrigger({
 		list_id: trelloCommon.list_id,
 	},
 	type: TriggerStrategy.WEBHOOK,
-	handshakeConfiguration:{
-		strategy:WebhookHandshakeStrategy.NONE
+	handshakeConfiguration: {
+		strategy: WebhookHandshakeStrategy.HEAD_REQUEST,
 	},
-	async onHandshake(context)
-	{
-		return{
-			status:200
-		}
+	async onHandshake() {
+		return { status: 200 }
 	},
 	async onEnable(context) {
 		const element_id = context.propsValue.list_id;

--- a/packages/pieces/community/trello/src/lib/triggers/newCard.ts
+++ b/packages/pieces/community/trello/src/lib/triggers/newCard.ts
@@ -18,15 +18,12 @@ export const newCardTrigger = createTrigger({
 		list_id_opt: trelloCommon.list_id_opt,
 	},
 	type: TriggerStrategy.WEBHOOK,
-		handshakeConfiguration:{
-			strategy:WebhookHandshakeStrategy.NONE
-		},
-		async onHandshake(context)
-		{
-			return{
-				status:200
-			}
-		},
+	handshakeConfiguration: {
+		strategy: WebhookHandshakeStrategy.HEAD_REQUEST,
+	},
+	async onHandshake() {
+		return { status: 200 }
+	},
 	async onEnable(context) {
 		const element_id = context.propsValue.list_id_opt || context.propsValue.board_id;
 		const webhooks = await trelloCommon.list_webhooks(context.auth);

--- a/packages/server/api/src/app/webhooks/webhook-handshake.ts
+++ b/packages/server/api/src/app/webhooks/webhook-handshake.ts
@@ -52,7 +52,7 @@ export const webhookHandshake = {
 export function isHandshakeRequest(params: IsHandshakeRequestParams): boolean {
     const { payload, handshakeConfiguration } = params
 
-    if (isNil(handshakeConfiguration) || isNil(handshakeConfiguration.strategy) || isNil(handshakeConfiguration.paramName)) {
+    if (isNil(handshakeConfiguration) || isNil(handshakeConfiguration.strategy)) {
         return false
     }
 
@@ -60,15 +60,19 @@ export function isHandshakeRequest(params: IsHandshakeRequestParams): boolean {
 
     switch (strategy) {
         case WebhookHandshakeStrategy.HEADER_PRESENT:
-            return paramName.toLowerCase() in payload.headers
+            return !isNil(paramName) && paramName.toLowerCase() in payload.headers
 
         case WebhookHandshakeStrategy.QUERY_PRESENT:
-            return paramName in payload.queryParams
+            return !isNil(paramName) && paramName in payload.queryParams
 
         case WebhookHandshakeStrategy.BODY_PARAM_PRESENT:
-            return typeof payload.body === 'object' &&
+            return !isNil(paramName) &&
+                typeof payload.body === 'object' &&
                 payload.body !== null &&
                 paramName in payload.body
+
+        case WebhookHandshakeStrategy.HEAD_REQUEST:
+            return payload.method?.toUpperCase() === 'HEAD'
 
         default:
             return false


### PR DESCRIPTION
## Summary

- Adds `HEAD_REQUEST` to `WebhookHandshakeStrategy` — for services like Trello that validate webhook URLs by sending a HEAD request
- Fixes `isHandshakeRequest` early-return guard that incorrectly required `paramName` for all strategies (including ones like `HEAD_REQUEST` that don't use it), causing the handshake path to be skipped entirely and the disabled-flow guard to return 404
- Adds `method?: string` to `TriggerPayload` so the HEAD check is type-safe without casts
- Updates Trello `cardMoved` and `newCard` triggers from `NONE` → `HEAD_REQUEST` strategy

## Test plan

- [ ] Publish a Trello "Card Moved" flow — Trello sends a HEAD request on `onEnable`; should now return 200 and activate successfully
- [ ] Publish a Trello "New Card" flow — same validation
- [ ] Verify existing HEADER_PRESENT / QUERY_PRESENT / BODY_PARAM_PRESENT handshakes still work (paramName guard moved per-case)