### PR TITLE
fix(mcp): scope conversation header override to token's authorized project

### DIFF
--- a/.agents/features/mcp.md
+++ b/.agents/features/mcp.md
@@ -102,6 +102,8 @@ OAuth 2.0 PKCE flow is supported for AI clients that require OAuth. The MCP OAut
 
 **RFC 9728 §5.1** — MCP `401` responses include a `WWW-Authenticate: Bearer resource_metadata="…"` header pointing at the prefixed protected-resource metadata URL (`/.well-known/oauth-protected-resource/mcp` for project, `/mcp/platform` for platform), so clients can locate discovery without guessing host-root well-known paths. Clients that ignore the header and probe host-root well-known paths still require the operator to forward `host/.well-known/oauth-*` to AP (that namespace is host-root-anchored by RFC 8414/9728).
 
+**Conversation-project scoping** — The optional `x-ap-conversation-id` request header (sent by the EE chat path) switches the built server to the project a prior conversation is bound to. The override is scoped to the token so it can never widen the grant: a project-scoped token resolves the header only when the conversation's project equals the token's own project, otherwise the header is ignored; a platform-scoped token requires the conversation's `platformId` to match the token's and re-validates the user's current project membership (`chatHelpers.getUserProjects`) before honoring it. A conversation with no `projectId` is ignored.
+
 ## Server Building
 
 `mcpServerService.buildServer()` — built per-request:

--- a/packages/server/api/src/app/mcp/oauth/mcp-oauth.controller.ts
+++ b/packages/server/api/src/app/mcp/oauth/mcp-oauth.controller.ts
@@ -6,6 +6,7 @@ import { FastifyPluginAsyncZod } from 'fastify-type-provider-zod'
 import { repoFactory } from '../../core/db/repo-factory'
 import { securityAccess } from '../../core/security/authorization/fastify-security'
 import { ChatConversationEntity } from '../../ee/chat/chat-conversation-entity'
+import { chatHelpers } from '../../ee/chat/chat-helpers'
 import { CONVERSATION_ID_HEADER } from '../../ee/chat/mcp/chat-mcp'
 import { domainHelper } from '../../helper/domain-helper'
 import { rejectedPromiseHandler } from '../../helper/promise-handler'
@@ -66,8 +67,8 @@ function registerMcpEndpoint(app: Parameters<FastifyPluginAsyncZod>[0], scope: M
         }
 
         const conversationId = req.headers[CONVERSATION_ID_HEADER] as string | undefined
-        const conversationProjectId = conversationId && userId
-            ? await resolveConversationProjectId({ conversationId, userId, log: req.log })
+        const conversationProjectId = !isNil(conversationId)
+            ? await resolveConversationProjectId({ conversationId, identity, log: req.log })
             : null
         const serverMcp = conversationProjectId
             ? await mcpServerService(req.log).getPopulatedByProjectId(conversationProjectId) ?? mcp
@@ -161,23 +162,38 @@ type ResolvedIdentity =
 
 const chatConversationRepo = repoFactory(ChatConversationEntity)
 
-async function resolveConversationProjectId({ conversationId, userId, log }: {
+async function resolveConversationProjectId({ conversationId, identity, log }: {
     conversationId: string
-    userId: string
+    identity: ResolvedIdentity
     log: FastifyBaseLogger
 }): Promise<string | null> {
     const { data: conversation, error } = await tryCatch(async () =>
-        chatConversationRepo().findOne({ where: { id: conversationId, userId }, select: ['projectId'] }),
+        chatConversationRepo().findOne({ where: { id: conversationId, userId: identity.userId }, select: ['projectId', 'platformId'] }),
     )
     if (error) {
         log.warn({ error, conversation: { id: conversationId } }, 'DB error resolving conversation project')
         return null
     }
-    if (!conversation) {
+    if (isNil(conversation) || isNil(conversation.projectId)) {
         log.debug({ conversation: { id: conversationId } }, 'Conversation not found for project resolution')
         return null
     }
-    return conversation.projectId ?? null
+    const conversationProjectId = conversation.projectId
+
+    if (identity.type === McpServerType.PROJECT) {
+        return conversationProjectId === identity.projectId ? conversationProjectId : null
+    }
+
+    if (conversation.platformId !== identity.platformId) {
+        log.warn({ conversation: { id: conversationId } }, 'Conversation platform does not match token platform')
+        return null
+    }
+    const userProjects = await chatHelpers.getUserProjects({ platformId: identity.platformId, userId: identity.userId, log })
+    if (!userProjects.some((project) => project.id === conversationProjectId)) {
+        log.warn({ conversation: { id: conversationId }, project: { id: conversationProjectId } }, 'User no longer has access to conversation project')
+        return null
+    }
+    return conversationProjectId
 }
 
 const McpEndpointConfig = {


### PR DESCRIPTION
## Summary

The public MCP endpoint honored `x-ap-conversation-id` to switch the project a bearer token operates on, resolving the conversation by `userId` only. A project-scoped token for project A could pass a conversation the user owns in project B and reach project B's MCP server — enumerating its flow/tool inventory and executing permissionless tools — bypassing the OAuth grant's per-project consent.

## Fix

`resolveConversationProjectId` now scopes the header to the token:

- **Project token** — resolves only to the token's own project; any other conversation project is ignored.
- **Platform token** (the legitimate chat path) — asserts `conversation.platformId === identity.platformId` and re-validates the user's *current* project access via `chatHelpers.getUserProjects`, rather than trusting the stored `projectId`.

Also early-returns when the conversation has no `projectId`.