### PR TITLE
fix(trello): set minimumSupportedRelease to 0.85.5 for HEAD_REQUEST handshake

### DIFF
--- a/packages/pieces/community/trello/package.json
+++ b/packages/pieces/community/trello/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-trello",
-  "version": "0.4.8",
+  "version": "0.4.9",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {

--- a/packages/pieces/community/trello/src/index.ts
+++ b/packages/pieces/community/trello/src/index.ts
@@ -75,7 +75,7 @@ export const trelloAuth = PieceAuth.BasicAuth({
 export const trello = createPiece({
   displayName: 'Trello',
   description: 'Project management tool for teams',
-  minimumSupportedRelease: '0.30.0',
+  minimumSupportedRelease: '0.85.5',
   logoUrl: 'https://cdn.activepieces.com/pieces/trello.png',
   authors: ["Salem-Alaa", "kishanprmr", "MoShizzle", "khaledmashaly", "abuaboud", "AshotZaqoyan"],
   categories: [PieceCategory.PRODUCTIVITY],


### PR DESCRIPTION
## Why

PR #13886 added the `WebhookHandshakeStrategy.HEAD_REQUEST` strategy to `@activepieces/shared` and switched the Trello `new_card` / `card_moved_to_list` triggers to use it. That strategy is only understood by the backend from the upcoming **0.85.5** release onward (it ships via the cloud/backend image, not the piece bundle).

The Trello piece currently declared `minimumSupportedRelease: '0.30.0'`, so older servers — which don't recognize `HEAD_REQUEST` — would still be offered this piece version and fail at webhook handshake validation. (This is also the root cause of the red `Release Pieces` pipeline: the live cloud `/admin/pieces` endpoint validates incoming metadata against its deployed copy of the enum, which doesn't yet include `HEAD_REQUEST`.)

## What

- Raise `minimumSupportedRelease` from `0.30.0` → `0.85.5` so the piece is only served to servers that support the new handshake strategy.
- Bump the piece version `0.4.8` → `0.4.9`.

## Notes / follow-up

- `0.85.5` is the **next** release after the currently-cut `0.85.4`. **Confirm with whoever cuts the release** that the backend with `HEAD_REQUEST` ships as `0.85.5` and not a minor bump (`0.86.0`); adjust to match the actual release tag if needed.
- This does **not** by itself turn the `Release Pieces` pipeline green — the cloud/backend release deploying the `HEAD_REQUEST` schema must land first. This PR is the compatibility guard so older self-hosted servers don't pull a piece version they can't run.

## Test plan

- [ ] Confirm the next release version is `0.85.5` (else update the value).
- [ ] After the backend release lands, verify `Release Pieces` publishes `piece-trello@0.4.9` successfully.
