### PR TITLE
fix(web): hide Second value field immediately when operator changes to Exists/Does not exist

### DIFF
--- a/packages/web/src/app/builder/step-settings/branch-settings/branch-single-condition.tsx
+++ b/packages/web/src/app/builder/step-settings/branch-settings/branch-single-condition.tsx
@@ -74,7 +74,7 @@ const BranchSingleCondition = ({
 }: BranchSingleConditionProps) => {
   const form = useFormContext<RouterAction>();
 
-  const condition = form.getValues(
+  const condition = form.watch(
     `settings.branches.${branchIndex}.conditions.${groupIndex}.${conditionIndex}`,
   );
 
@@ -215,3 +215,4 @@ const BranchSingleCondition = ({
 
 BranchSingleCondition.displayName = 'BranchSingleCondition';
 export { BranchSingleCondition };
+


### PR DESCRIPTION
## Summary

Fixes #13900

In the Router condition editor, switching the operator to `Exists` or `Does not exist` left the **Second value** field visible until a page refresh. After the fix it hides immediately on operator change.

## Root cause

`branch-single-condition.tsx` computed `isSingleValueCondition` from a one-time snapshot via `form.getValues()`:

```ts
// Before — stale snapshot, no re-render on change
const condition = form.getValues(
  `settings.branches.${branchIndex}.conditions.${groupIndex}.${conditionIndex}`,
);
```

`getValues()` does not subscribe to form state, so the component never re-rendered when the operator changed. `isSingleValueCondition` stayed `false` and the field remained visible.

The project's own CLAUDE.md mandates: *"Use `form.watch()` for conditional rendering."*

## Fix

Replace `form.getValues()` with `form.watch()` for the condition path. The component now re-renders whenever the operator changes and correctly hides the Second value field.

```ts
// After — reactive, re-renders on operator change
const condition = form.watch(
  `settings.branches.${branchIndex}.conditions.${groupIndex}.${conditionIndex}`,
);
```

`secondValue` was already being cleared to `''` on operator change (existing code), so saved and published flows are unaffected.

## Test plan

- [ ] Add a Router step, open its condition editor
- [ ] Set an operator that shows a Second value field (e.g. *Exactly matches*)
- [ ] Change the operator to `Exists` or `Does not exist`
- [ ] Expected: Second value field disappears immediately, without a page refresh
- [ ] Verify the flow still saves and runs correctly after the change

🤖 Generated with [Claude Code](https://claude.ai/claude-code)