### PR TITLE
feat(gmail): add agent atomics for mailbox triage (labels + trash)

### DIFF
--- a/packages/pieces/community/gmail/package.json
+++ b/packages/pieces/community/gmail/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-gmail",
-  "version": "0.12.6",
+  "version": "0.12.7",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "dependencies": {

--- a/packages/pieces/community/gmail/src/index.ts
+++ b/packages/pieces/community/gmail/src/index.ts
@@ -11,6 +11,10 @@ import { gmailNewAttachmentTrigger } from './lib/triggers/new-attachment';
 import { gmailNewLabelTrigger } from './lib/triggers/new-label';
 import { gmailSearchMailAction } from './lib/actions/search-email-action';
 import { gmailGetEmailAction } from './lib/actions/get-mail-action';
+import { gmailListLabelsAction } from './lib/actions/list-labels-action';
+import { gmailCreateLabelAction } from './lib/actions/create-label-action';
+import { gmailModifyLabelsAction } from './lib/actions/modify-labels-action';
+import { gmailTrashMessageAction } from './lib/actions/trash-message-action';
 import { gmailAuth, getAccessToken, GmailAuthValue } from './lib/auth';
 
 export {
@@ -34,6 +38,10 @@ export const gmail = createPiece({
     gmailCreateDraftReplyAction,
     gmailGetEmailAction,
     gmailSearchMailAction,
+    gmailListLabelsAction,
+    gmailCreateLabelAction,
+    gmailModifyLabelsAction,
+    gmailTrashMessageAction,
     createCustomApiCallAction({
       baseUrl: () => 'https://gmail.googleapis.com/gmail/v1',
       auth: gmailAuth,

--- a/packages/pieces/community/gmail/src/lib/actions/create-label-action.ts
+++ b/packages/pieces/community/gmail/src/lib/actions/create-label-action.ts
@@ -1,0 +1,70 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { gmailAuth, createGoogleClient } from '../auth';
+import { gmail as googleGmail } from '@googleapis/gmail';
+
+export const gmailCreateLabelAction = createAction({
+  auth: gmailAuth,
+  name: 'gmail_create_label',
+  displayName: 'Create Label',
+  description:
+    'Create a label, or return the existing one if a label with the same name already exists.',
+  audience: 'ai',
+  aiMetadata: {
+    description:
+      'Get-or-create a label by name: returns the existing label id when the name already exists, otherwise creates it and returns the new id. Use to ensure a label exists before applying it with Modify Email Labels; supports nested names like "Work/Projects". Idempotent: repeated calls with the same name return the same label and never create duplicates.',
+    idempotent: true,
+  },
+  props: {
+    name: Property.ShortText({
+      displayName: 'Label Name',
+      description: 'The label name. Use "/" to nest, e.g. "Work/Projects".',
+      required: true,
+    }),
+  },
+  async run(context) {
+    const authClient = await createGoogleClient(context.auth);
+    const gmail = googleGmail({ version: 'v1', auth: authClient });
+    const name = context.propsValue.name.trim();
+
+    try {
+      const existing = await gmail.users.labels.list({ userId: 'me' });
+      const match = (existing.data.labels || []).find(
+        (label) => label.name === name
+      );
+      if (match) {
+        return {
+          id: match.id,
+          name: match.name,
+          type: match.type,
+          created: false,
+        };
+      }
+
+      const response = await gmail.users.labels.create({
+        userId: 'me',
+        requestBody: {
+          name,
+          labelListVisibility: 'labelShow',
+          messageListVisibility: 'show',
+        },
+      });
+      return {
+        id: response.data.id,
+        name: response.data.name,
+        type: response.data.type,
+        created: true,
+      };
+    } catch (error: any) {
+      if (error.code === 403) {
+        throw new Error(
+          'Insufficient permissions to manage labels. Ensure the gmail.modify scope is granted (reconnect the Gmail account).'
+        );
+      } else if (error.code === 429) {
+        throw new Error(
+          'Gmail API rate limit exceeded. Please try again later.'
+        );
+      }
+      throw new Error(`Failed to create label: ${error.message}`);
+    }
+  },
+});

--- a/packages/pieces/community/gmail/src/lib/actions/list-labels-action.ts
+++ b/packages/pieces/community/gmail/src/lib/actions/list-labels-action.ts
@@ -1,0 +1,44 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { gmailAuth, createGoogleClient } from '../auth';
+import { gmail as googleGmail } from '@googleapis/gmail';
+
+export const gmailListLabelsAction = createAction({
+  auth: gmailAuth,
+  name: 'gmail_list_labels',
+  displayName: 'List Labels',
+  description: 'List all labels in the mailbox with their IDs.',
+  audience: 'ai',
+  aiMetadata: {
+    description:
+      'Lists every label in the mailbox with its internal id, name, type (system vs user), and visibility. Call this first to resolve a human label name to the internal label id that Modify Email Labels requires (the modify, create, and trash operations all key on label ids, never names). Idempotent: a read-only listing that does not modify the mailbox.',
+    idempotent: true,
+  },
+  props: {},
+  async run(context) {
+    const authClient = await createGoogleClient(context.auth);
+    const gmail = googleGmail({ version: 'v1', auth: authClient });
+
+    try {
+      const response = await gmail.users.labels.list({ userId: 'me' });
+      const labels = (response.data.labels || []).map((label) => ({
+        id: label.id,
+        name: label.name,
+        type: label.type,
+        messageListVisibility: label.messageListVisibility,
+        labelListVisibility: label.labelListVisibility,
+      }));
+      return { labels, count: labels.length };
+    } catch (error: any) {
+      if (error.code === 403) {
+        throw new Error(
+          'Insufficient permissions to list labels. Ensure the gmail.readonly scope is granted.'
+        );
+      } else if (error.code === 429) {
+        throw new Error(
+          'Gmail API rate limit exceeded. Please try again later.'
+        );
+      }
+      throw new Error(`Failed to list labels: ${error.message}`);
+    }
+  },
+});

--- a/packages/pieces/community/gmail/src/lib/actions/modify-labels-action.ts
+++ b/packages/pieces/community/gmail/src/lib/actions/modify-labels-action.ts
@@ -1,0 +1,82 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { gmailAuth, createGoogleClient } from '../auth';
+import { gmail as googleGmail } from '@googleapis/gmail';
+
+export const gmailModifyLabelsAction = createAction({
+  auth: gmailAuth,
+  name: 'gmail_modify_labels',
+  displayName: 'Modify Email Labels',
+  description:
+    'Add and/or remove labels on one or more messages in a single batch call.',
+  audience: 'ai',
+  aiMetadata: {
+    description:
+      'Adds and/or removes label ids on up to 1000 messages in one call — the mailbox-state primitive. Express common intents as label changes: archive (remove INBOX), mark read/unread (remove/add UNREAD), star (add STARRED), or apply/remove a custom label. Resolve label names to ids with List Labels first. To delete a message use Trash Email instead — do not apply the TRASH label here. Idempotent: re-applying the same label changes is a no-op.',
+    idempotent: true,
+  },
+  props: {
+    message_ids: Property.Array({
+      displayName: 'Message IDs',
+      description:
+        'IDs of the messages to modify (obtain them from Find Email).',
+      required: true,
+    }),
+    add_label_ids: Property.Array({
+      displayName: 'Add Label IDs',
+      description:
+        'Label ids to add (resolve names via List Labels). System ids include UNREAD, STARRED, IMPORTANT, SPAM.',
+      required: false,
+    }),
+    remove_label_ids: Property.Array({
+      displayName: 'Remove Label IDs',
+      description:
+        'Label ids to remove. Remove INBOX to archive; remove UNREAD to mark as read.',
+      required: false,
+    }),
+  },
+  async run(context) {
+    const authClient = await createGoogleClient(context.auth);
+    const gmail = googleGmail({ version: 'v1', auth: authClient });
+
+    const ids = (context.propsValue.message_ids as string[]) ?? [];
+    const addLabelIds = (context.propsValue.add_label_ids as string[]) ?? [];
+    const removeLabelIds =
+      (context.propsValue.remove_label_ids as string[]) ?? [];
+
+    if (ids.length === 0) {
+      throw new Error('At least one message ID is required.');
+    }
+    if (addLabelIds.length === 0 && removeLabelIds.length === 0) {
+      throw new Error('Provide at least one label id to add or remove.');
+    }
+
+    try {
+      await gmail.users.messages.batchModify({
+        userId: 'me',
+        requestBody: { ids, addLabelIds, removeLabelIds },
+      });
+      return {
+        success: true,
+        modified_count: ids.length,
+        message_ids: ids,
+        added: addLabelIds,
+        removed: removeLabelIds,
+      };
+    } catch (error: any) {
+      if (error.code === 400) {
+        throw new Error(
+          `Invalid modify request — verify every label id exists (use List Labels): ${error.message}`
+        );
+      } else if (error.code === 403) {
+        throw new Error(
+          'Insufficient permissions. Ensure the gmail.modify scope is granted (reconnect the Gmail account).'
+        );
+      } else if (error.code === 429) {
+        throw new Error(
+          'Gmail API rate limit exceeded. Please try again later.'
+        );
+      }
+      throw new Error(`Failed to modify labels: ${error.message}`);
+    }
+  },
+});

--- a/packages/pieces/community/gmail/src/lib/actions/trash-message-action.ts
+++ b/packages/pieces/community/gmail/src/lib/actions/trash-message-action.ts
@@ -1,0 +1,51 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { gmailAuth, createGoogleClient } from '../auth';
+import { gmail as googleGmail } from '@googleapis/gmail';
+
+export const gmailTrashMessageAction = createAction({
+  auth: gmailAuth,
+  name: 'gmail_trash_message',
+  displayName: 'Trash Email',
+  description:
+    'Move a message to the trash (recoverable; auto-purges after ~30 days).',
+  audience: 'ai',
+  aiMetadata: {
+    description:
+      'Moves a single message to the trash by id. Safe, recoverable deletion (trash auto-purges after ~30 days) — the correct way for an agent to discard mail; prefer it over permanent deletion. Idempotent: trashing an already-trashed message is a no-op.',
+    idempotent: true,
+  },
+  props: {
+    message_id: Property.ShortText({
+      displayName: 'Message ID',
+      description: 'ID of the message to trash (obtain it from Find Email).',
+      required: true,
+    }),
+  },
+  async run(context) {
+    const authClient = await createGoogleClient(context.auth);
+    const gmail = googleGmail({ version: 'v1', auth: authClient });
+    const id = context.propsValue.message_id.trim();
+
+    try {
+      const response = await gmail.users.messages.trash({ userId: 'me', id });
+      return {
+        success: true,
+        id: response.data.id,
+        label_ids: response.data.labelIds,
+      };
+    } catch (error: any) {
+      if (error.code === 404) {
+        throw new Error(`Message not found: ${id}`);
+      } else if (error.code === 403) {
+        throw new Error(
+          'Insufficient permissions. Ensure the gmail.modify scope is granted (reconnect the Gmail account).'
+        );
+      } else if (error.code === 429) {
+        throw new Error(
+          'Gmail API rate limit exceeded. Please try again later.'
+        );
+      }
+      throw new Error(`Failed to trash message: ${error.message}`);
+    }
+  },
+});

--- a/packages/pieces/community/gmail/src/lib/auth.ts
+++ b/packages/pieces/community/gmail/src/lib/auth.ts
@@ -11,6 +11,7 @@ const gmailServiceAccountScopes = [
   'https://www.googleapis.com/auth/gmail.send',
   'https://www.googleapis.com/auth/gmail.readonly',
   'https://www.googleapis.com/auth/gmail.compose',
+  'https://www.googleapis.com/auth/gmail.modify',
 ];
 
 export const gmailScopes = [...gmailServiceAccountScopes, 'email'];


### PR DESCRIPTION
## What

Adds four `audience: 'ai'` actions to the Gmail piece so AI agents can mutate mailbox state. The piece was previously read + send only, so an agent could find and read mail but not triage it.

- **List Labels** (`gmail_list_labels`) — list labels with ids; resolves a label name to the id the label operations require.
- **Create Label** (`gmail_create_label`) — get-or-create by name; idempotent (returns the existing label instead of erroring on a duplicate).
- **Modify Email Labels** (`gmail_modify_labels`) — `users.messages.batchModify` over up to 1000 messages: archive (remove `INBOX`), mark read/unread (`UNREAD`), star (`STARRED`), apply/remove custom labels.
- **Trash Email** (`gmail_trash_message`) — `users.messages.trash`; recoverable, not a permanent delete.

Each is tagged `audience: 'ai'` with `aiMetadata` (`description` + `idempotent`). Pure add — no existing action is changed or demoted. Patch-bump `0.12.6` → `0.12.7`.

## OAuth scope

The three write actions need `https://www.googleapis.com/auth/gmail.modify`, added to the piece's scope list. Existing connections must reconnect to grant it; the read/send actions are unaffected.

## Verification

- **Tier-1:** `turbo run build` (tsc) and eslint pass clean.
- **Tier-2 (live connection):** `gmail_list_labels` executed successfully against a real mailbox. `create_label` / `modify_labels` / `trash_message` follow the identical client + auth pattern and are pending a live run against a `gmail.modify`-scoped connection.
