### PR TITLE
feat(pieces): add agent atomics to google-calendar and google-docs

### DIFF
--- a/packages/pieces/community/google-calendar/package.json
+++ b/packages/pieces/community/google-calendar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-google-calendar",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "dependencies": {

--- a/packages/pieces/community/google-calendar/src/index.ts
+++ b/packages/pieces/community/google-calendar/src/index.ts
@@ -13,6 +13,10 @@ import { calendarEventChanged } from './lib/triggers/calendar-event';
 import { addAttendeesToEventAction } from './lib/actions/add-attendees.action';
 import { findFreeBusy } from './lib/actions/find-busy-free-periods';
 import { getEventById } from './lib/actions/get-event-by-id';
+import { searchEventsAllCalendars } from './lib/actions/search-events-all-calendars';
+import { findFreeSlots } from './lib/actions/find-free-slots';
+import { listRecurringEventInstances } from './lib/actions/list-recurring-event-instances';
+import { moveEvent } from './lib/actions/move-event';
 import { newEvent } from './lib/triggers/new-event';
 import { eventEnds } from './lib/triggers/event-ends';
 import { eventStartTimeBefore } from './lib/triggers/event-start-time-before';
@@ -53,6 +57,10 @@ export const googleCalendar = createPiece({
     deleteEventAction,
     findFreeBusy,
     getEventById,
+    searchEventsAllCalendars,
+    findFreeSlots,
+    listRecurringEventInstances,
+    moveEvent,
     // TODO: add action after calendarList scope is verified
     // addCalendarToCalendarlist,
     createCustomApiCallAction({

--- a/packages/pieces/community/google-calendar/src/lib/actions/find-free-slots.ts
+++ b/packages/pieces/community/google-calendar/src/lib/actions/find-free-slots.ts
@@ -1,0 +1,247 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import {
+  HttpRequest,
+  HttpMethod,
+  AuthenticationType,
+  httpClient,
+} from '@activepieces/pieces-common';
+import {
+  googleCalendarCommon,
+  googleCalendarAuth,
+  getAccessToken,
+  GoogleCalendarAuthValue,
+} from '../common';
+import { getCalendars } from '../common/helper';
+import dayjs from 'dayjs';
+
+interface FreeBusyResponse {
+  kind: 'calendar#freeBusy';
+  timeMin: string;
+  timeMax: string;
+  calendars: {
+    [calendarId: string]: {
+      busy: { start: string; end: string }[];
+      errors?: { domain: string; reason: string }[];
+    };
+  };
+}
+
+interface Interval {
+  start: number;
+  end: number;
+}
+
+function mergeIntervals(intervals: Interval[]): Interval[] {
+  if (intervals.length === 0) {
+    return [];
+  }
+  const sorted = [...intervals].sort((a, b) => a.start - b.start);
+  const merged: Interval[] = [{ ...sorted[0] }];
+  for (let i = 1; i < sorted.length; i++) {
+    const last = merged[merged.length - 1];
+    const current = sorted[i];
+    if (current.start <= last.end) {
+      last.end = Math.max(last.end, current.end);
+    } else {
+      merged.push({ ...current });
+    }
+  }
+  return merged;
+}
+
+function complement(
+  busy: Interval[],
+  windowStart: number,
+  windowEnd: number
+): Interval[] {
+  const free: Interval[] = [];
+  let cursor = windowStart;
+  for (const block of busy) {
+    if (block.start > cursor) {
+      free.push({ start: cursor, end: Math.min(block.start, windowEnd) });
+    }
+    cursor = Math.max(cursor, block.end);
+    if (cursor >= windowEnd) {
+      break;
+    }
+  }
+  if (cursor < windowEnd) {
+    free.push({ start: cursor, end: windowEnd });
+  }
+  return free.filter((interval) => interval.end > interval.start);
+}
+
+function clipToWorkingHours(
+  free: Interval[],
+  startHour: number,
+  endHour: number
+): Interval[] {
+  const clipped: Interval[] = [];
+  for (const interval of free) {
+    let dayCursor = dayjs(interval.start).startOf('day');
+    const intervalEnd = dayjs(interval.end);
+    while (dayCursor.valueOf() < interval.end) {
+      const workStart = dayCursor.add(startHour, 'hour');
+      const workEnd = dayCursor.add(endHour, 'hour');
+      const slotStart = Math.max(interval.start, workStart.valueOf());
+      const slotEnd = Math.min(interval.end, workEnd.valueOf());
+      if (slotEnd > slotStart) {
+        clipped.push({ start: slotStart, end: slotEnd });
+      }
+      dayCursor = dayCursor.add(1, 'day');
+      if (dayCursor.valueOf() > intervalEnd.valueOf()) {
+        break;
+      }
+    }
+  }
+  return clipped;
+}
+
+export const findFreeSlots = createAction({
+  auth: googleCalendarAuth,
+  name: 'google_calendar_find_free_slots',
+  displayName: 'Find Free Time Slots',
+  description:
+    'Computes open time slots shared across one or more calendars within a window, by inverting their busy blocks.',
+  audience: 'ai',
+  aiMetadata: {
+    description:
+      'Return the OPEN time slots common to the selected calendars within a window — the inverse of their combined busy blocks, optionally filtered to a minimum duration and to working hours. Use this instead of Find Busy/Free Periods (which returns only busy blocks and forces you to invert and reconcile them yourself) when you need the actual free intervals to answer "when can everyone meet". Idempotent because it performs no writes, but the result depends entirely on the window: pass absolute start/end times, since a window relative to "now" yields a shifting set of slots.',
+    idempotent: true,
+  },
+  props: {
+    calendar_ids: Property.MultiSelectDropdown({
+      auth: googleCalendarAuth,
+      displayName: 'Calendars',
+      description:
+        'The calendars whose schedules must all be free. A slot is returned only when it is open on every selected calendar.',
+      required: true,
+      refreshers: [],
+      options: async ({ auth }) => {
+        if (!auth) {
+          return {
+            disabled: true,
+            placeholder: 'Connect your account first',
+            options: [],
+          };
+        }
+        const authProp = auth as GoogleCalendarAuthValue;
+        const calendars = await getCalendars(authProp);
+        return {
+          disabled: false,
+          options: calendars.map((calendar) => ({
+            label: calendar.summary,
+            value: calendar.id,
+          })),
+        };
+      },
+    }),
+    start_date: Property.DateTime({
+      displayName: 'Window Start',
+      description:
+        'Start of the search window, as an absolute ISO 8601 timestamp (e.g. "2026-06-01T09:00:00Z"). Prefer absolute times over relative ones.',
+      required: true,
+    }),
+    end_date: Property.DateTime({
+      displayName: 'Window End',
+      description:
+        'End of the search window, as an absolute ISO 8601 timestamp (e.g. "2026-06-05T18:00:00Z").',
+      required: true,
+    }),
+    min_duration_minutes: Property.Number({
+      displayName: 'Minimum Slot Duration (minutes)',
+      description:
+        'Discard any open slot shorter than this many minutes. Leave empty to return every open slot regardless of length.',
+      required: false,
+    }),
+    working_hours_start: Property.Number({
+      displayName: 'Working Hours Start (hour 0-23)',
+      description:
+        'If set together with Working Hours End, each day\'s open slots are clipped to this hour range (in the calendars\' time zone). Example: 9 for 9 AM.',
+      required: false,
+    }),
+    working_hours_end: Property.Number({
+      displayName: 'Working Hours End (hour 0-23)',
+      description:
+        'Upper bound of the daily working-hours window. Example: 17 for 5 PM. Ignored unless Working Hours Start is also set.',
+      required: false,
+    }),
+  },
+  async run(context) {
+    const {
+      calendar_ids,
+      start_date,
+      end_date,
+      min_duration_minutes,
+      working_hours_start,
+      working_hours_end,
+    } = context.propsValue;
+    const token = await getAccessToken(context.auth);
+
+    const windowStart = dayjs(start_date).valueOf();
+    const windowEnd = dayjs(end_date).valueOf();
+    if (windowEnd <= windowStart) {
+      throw new Error('Window End must be after Window Start.');
+    }
+
+    const request: HttpRequest = {
+      method: HttpMethod.POST,
+      url: `${googleCalendarCommon.baseUrl}/freeBusy`,
+      body: {
+        timeMin: dayjs(start_date).toISOString(),
+        timeMax: dayjs(end_date).toISOString(),
+        items: calendar_ids.map((id) => ({ id })),
+      },
+      authentication: {
+        type: AuthenticationType.BEARER_TOKEN,
+        token,
+      },
+    };
+
+    const response = await httpClient.sendRequest<FreeBusyResponse>(request);
+
+    const allBusy: Interval[] = [];
+    for (const calendarId of Object.keys(response.body.calendars)) {
+      const blocks = response.body.calendars[calendarId].busy ?? [];
+      for (const block of blocks) {
+        allBusy.push({
+          start: dayjs(block.start).valueOf(),
+          end: dayjs(block.end).valueOf(),
+        });
+      }
+    }
+
+    const mergedBusy = mergeIntervals(allBusy);
+    let freeIntervals = complement(mergedBusy, windowStart, windowEnd);
+
+    if (
+      working_hours_start !== undefined &&
+      working_hours_end !== undefined &&
+      working_hours_end > working_hours_start
+    ) {
+      freeIntervals = clipToWorkingHours(
+        freeIntervals,
+        working_hours_start,
+        working_hours_end
+      );
+    }
+
+    if (min_duration_minutes !== undefined && min_duration_minutes > 0) {
+      const minMs = min_duration_minutes * 60 * 1000;
+      freeIntervals = freeIntervals.filter(
+        (interval) => interval.end - interval.start >= minMs
+      );
+    }
+
+    const freeSlots = freeIntervals.map((interval) => ({
+      start: dayjs(interval.start).toISOString(),
+      end: dayjs(interval.end).toISOString(),
+      duration_minutes: Math.round((interval.end - interval.start) / 60000),
+    }));
+
+    return {
+      free_slots: freeSlots,
+      count: freeSlots.length,
+    };
+  },
+});

--- a/packages/pieces/community/google-calendar/src/lib/actions/list-recurring-event-instances.ts
+++ b/packages/pieces/community/google-calendar/src/lib/actions/list-recurring-event-instances.ts
@@ -1,0 +1,105 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { calendar as googleCalendar } from '@googleapis/calendar';
+import {
+  googleCalendarCommon,
+  googleCalendarAuth,
+  createGoogleClient,
+} from '../common';
+import dayjs from 'dayjs';
+
+export const listRecurringEventInstances = createAction({
+  auth: googleCalendarAuth,
+  name: 'google_calendar_list_recurring_event_instances',
+  displayName: 'List Recurring Event Instances',
+  description:
+    'Lists the individual occurrences of one recurring event series, each with its own instance event ID.',
+  audience: 'ai',
+  aiMetadata: {
+    description:
+      'List the individual occurrences of a single recurring event series, identified by its recurring-event ID, each returned with its own distinct instance event ID. Use this when you need to inspect, reschedule, or cancel ONE occurrence of a series rather than the whole series; Get all Events expands recurring events only across a whole-calendar window and cannot target one series by ID. Requires the recurring series\' event ID; optionally bound by a time range. Read-only and idempotent.',
+    idempotent: true,
+  },
+  props: {
+    calendar_id: googleCalendarCommon.calendarDropdown(),
+    event_id: Property.ShortText({
+      displayName: 'Recurring Event ID',
+      description:
+        'The event ID of the recurring SERIES (the parent), e.g. "abc123def456". Obtain it from Search Events Across Calendars or Get all Events. Individual instance IDs will not work here.',
+      required: true,
+    }),
+    time_min: Property.DateTime({
+      displayName: 'Start Time',
+      description:
+        'Optional lower bound (inclusive) for an instance\'s end time, as an ISO 8601 timestamp with offset (e.g. "2026-06-01T00:00:00Z").',
+      required: false,
+    }),
+    time_max: Property.DateTime({
+      displayName: 'End Time',
+      description:
+        'Optional upper bound (exclusive) for an instance\'s start time, as an ISO 8601 timestamp with offset (e.g. "2026-06-30T23:59:59Z").',
+      required: false,
+    }),
+    show_deleted: Property.Checkbox({
+      displayName: 'Include Cancelled Instances',
+      description:
+        'Whether to include cancelled (deleted) instances of the series in the result. Defaults to false.',
+      required: false,
+      defaultValue: false,
+    }),
+    max_results: Property.Number({
+      displayName: 'Max Results',
+      description:
+        'Maximum number of instances to return per page (1-2500). Defaults to the API default of 250.',
+      required: false,
+    }),
+  },
+  async run(context) {
+    const {
+      calendar_id: calendarId,
+      event_id: eventId,
+      time_min,
+      time_max,
+      show_deleted,
+      max_results,
+    } = context.propsValue;
+
+    const authClient = await createGoogleClient(context.auth);
+    const calendar = googleCalendar({ version: 'v3', auth: authClient });
+
+    try {
+      const response = await calendar.events.instances({
+        calendarId,
+        eventId,
+        timeMin: time_min ? dayjs(time_min).toISOString() : undefined,
+        timeMax: time_max ? dayjs(time_max).toISOString() : undefined,
+        showDeleted: show_deleted ?? false,
+        maxResults: max_results,
+      });
+
+      const items = response.data.items ?? [];
+      return {
+        instances: items,
+        count: items.length,
+        nextPageToken: response.data.nextPageToken ?? null,
+      };
+    } catch (error: any) {
+      const status = error.response?.status ?? error.code;
+      if (status === 404) {
+        throw new Error(
+          `Recurring event "${eventId}" not found in calendar "${calendarId}". Verify the ID belongs to a recurring series.`
+        );
+      }
+      if (status === 400) {
+        throw new Error(
+          `Invalid request: "${eventId}" may not be a recurring event. The instances endpoint only works on recurring series.`
+        );
+      }
+      if (status === 403) {
+        throw new Error(
+          `Access denied to event "${eventId}" in calendar "${calendarId}". Check your permissions.`
+        );
+      }
+      throw error;
+    }
+  },
+});

--- a/packages/pieces/community/google-calendar/src/lib/actions/move-event.ts
+++ b/packages/pieces/community/google-calendar/src/lib/actions/move-event.ts
@@ -1,0 +1,131 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { calendar as googleCalendar } from '@googleapis/calendar';
+import {
+  googleCalendarCommon,
+  googleCalendarAuth,
+  createGoogleClient,
+  GoogleCalendarAuthValue,
+} from '../common';
+import { getCalendars } from '../common/helper';
+
+export const moveEvent = createAction({
+  auth: googleCalendarAuth,
+  name: 'google_calendar_move_event',
+  displayName: 'Move Event to Another Calendar',
+  description:
+    'Moves an existing event from one calendar to another, preserving its event ID and metadata.',
+  audience: 'ai',
+  aiMetadata: {
+    description:
+      'Move an existing event from a source calendar to a destination calendar in place, preserving the event ID, conferencing, and attendee state. Use this instead of deleting and recreating the event (which loses the ID and metadata) when you need to transfer an event between calendars. Idempotent: moving an event to the calendar it already lives on is treated as a no-op. The source and destination must be writable calendars.',
+    idempotent: true,
+  },
+  props: {
+    calendar_id: googleCalendarCommon.calendarDropdown('writer'),
+    event_id: Property.ShortText({
+      displayName: 'Event ID',
+      description:
+        'The ID of the event to move, e.g. "abc123def456". Obtain it from Search Events Across Calendars or Get all Events.',
+      required: true,
+    }),
+    destination_calendar_id: Property.Dropdown({
+      auth: googleCalendarAuth,
+      displayName: 'Destination Calendar',
+      description: 'The calendar to move the event to.',
+      refreshers: [],
+      required: true,
+      options: async ({ auth }) => {
+        if (!auth) {
+          return {
+            disabled: true,
+            placeholder: 'Please connect your account first',
+            options: [],
+          };
+        }
+        const calendars = await getCalendars(auth as GoogleCalendarAuthValue, 'writer');
+        return {
+          disabled: false,
+          options: calendars.map((calendar) => ({
+            label: calendar.summary,
+            value: calendar.id,
+          })),
+        };
+      },
+    }),
+    send_updates: Property.StaticDropdown({
+      displayName: 'Send Notifications',
+      description:
+        'Who should receive notifications about the change of the event\'s organizer.',
+      required: false,
+      defaultValue: 'none',
+      options: {
+        options: [
+          { label: 'To everyone', value: 'all' },
+          { label: 'To external guests only', value: 'externalOnly' },
+          { label: 'To no one', value: 'none' },
+        ],
+      },
+    }),
+  },
+  async run(context) {
+    const {
+      calendar_id: sourceCalendarId,
+      event_id: eventId,
+      destination_calendar_id: destinationCalendarId,
+      send_updates: sendUpdates,
+    } = context.propsValue;
+
+    const authClient = await createGoogleClient(context.auth);
+    const calendar = googleCalendar({ version: 'v3', auth: authClient });
+
+    if (sourceCalendarId === destinationCalendarId) {
+      const existing = await calendar.events.get({
+        calendarId: destinationCalendarId,
+        eventId,
+      });
+      return {
+        moved: false,
+        already_in_destination: true,
+        event: existing.data,
+      };
+    }
+
+    try {
+      await calendar.events.move({
+        calendarId: sourceCalendarId,
+        eventId,
+        destination: destinationCalendarId,
+        sendUpdates: sendUpdates ?? 'none',
+      });
+
+      const verified = await calendar.events.get({
+        calendarId: destinationCalendarId,
+        eventId,
+      });
+
+      return {
+        moved: true,
+        already_in_destination: false,
+        event: verified.data,
+      };
+    } catch (error: any) {
+      const status = error.response?.status ?? error.code;
+      if (status === 404) {
+        throw new Error(
+          `Event "${eventId}" not found in source calendar "${sourceCalendarId}". Verify the event ID and source calendar.`
+        );
+      }
+      if (status === 403) {
+        throw new Error(
+          `Access denied while moving event "${eventId}". Both the source and destination calendars must be writable.`
+        );
+      }
+      if (status === 400) {
+        throw new Error(
+          `Invalid move request for event "${eventId}". The destination must differ from the source and both must be valid calendars.`
+        );
+      }
+      throw error;
+    }
+  },
+});

--- a/packages/pieces/community/google-calendar/src/lib/actions/search-events-all-calendars.ts
+++ b/packages/pieces/community/google-calendar/src/lib/actions/search-events-all-calendars.ts
@@ -1,0 +1,118 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import {
+  HttpRequest,
+  HttpMethod,
+  AuthenticationType,
+  httpClient,
+} from '@activepieces/pieces-common';
+import { googleCalendarCommon, googleCalendarAuth, getAccessToken } from '../common';
+import { getCalendars } from '../common/helper';
+import { GoogleCalendarEvent, GoogleCalendarEventList } from '../common/types';
+import dayjs from 'dayjs';
+
+export const searchEventsAllCalendars = createAction({
+  auth: googleCalendarAuth,
+  name: 'google_calendar_search_events_all_calendars',
+  displayName: 'Search Events Across Calendars',
+  description:
+    'Searches every calendar the account can access for events matching a keyword within a required time window.',
+  audience: 'ai',
+  aiMetadata: {
+    description:
+      'Search all of the user\'s calendars at once for events matching a text query within a required time window, returning each match tagged with its owning calendarId so you can then get/update/delete it. Use this instead of Get all Events when you know a keyword and time range but do NOT know which calendar the event lives in (Get all Events searches a single calendar). A start and end time are mandatory to bound the cross-calendar scan; matching uses Google\'s native q= filter, not semantic search. Read-only and idempotent.',
+    idempotent: true,
+  },
+  props: {
+    query: Property.ShortText({
+      displayName: 'Search Term',
+      description:
+        'Free-text query matched against event fields (summary, description, location, attendee names/emails) using Google\'s native search. Example: "budget review".',
+      required: true,
+    }),
+    start_date: Property.DateTime({
+      displayName: 'Start Time',
+      description:
+        'Lower bound (inclusive) for an event\'s end time, as an ISO 8601 timestamp (e.g. "2026-06-01T00:00:00Z"). Required to bound the cross-calendar scan.',
+      required: true,
+    }),
+    end_date: Property.DateTime({
+      displayName: 'End Time',
+      description:
+        'Upper bound (exclusive) for an event\'s start time, as an ISO 8601 timestamp (e.g. "2026-06-30T23:59:59Z"). Required to bound the cross-calendar scan.',
+      required: true,
+    }),
+    single_events: Property.Checkbox({
+      displayName: 'Expand Recurring Events?',
+      description:
+        'When enabled, recurring events are expanded into their individual instances instead of returning the underlying recurring event.',
+      required: false,
+      defaultValue: true,
+    }),
+  },
+  async run(context) {
+    const { query, start_date, end_date, single_events } = context.propsValue;
+    const token = await getAccessToken(context.auth);
+
+    const timeMin = dayjs(start_date).toISOString();
+    const timeMax = dayjs(end_date).toISOString();
+
+    const calendars = await getCalendars(context.auth);
+
+    const matches: (GoogleCalendarEvent & { calendarId: string })[] = [];
+
+    for (const calendar of calendars) {
+      let pageToken = '';
+      do {
+        const queryParams: Record<string, string> = {
+          q: query,
+          timeMin,
+          timeMax,
+          singleEvents: single_events ? 'true' : 'false',
+          showDeleted: 'false',
+          maxResults: '250',
+        };
+        if (pageToken) {
+          queryParams['pageToken'] = pageToken;
+        }
+        const request: HttpRequest = {
+          method: HttpMethod.GET,
+          url: `${googleCalendarCommon.baseUrl}/calendars/${encodeURIComponent(
+            calendar.id
+          )}/events`,
+          queryParams,
+          authentication: {
+            type: AuthenticationType.BEARER_TOKEN,
+            token,
+          },
+        };
+        try {
+          const response =
+            await httpClient.sendRequest<GoogleCalendarEventList>(request);
+          const items = response.body.items ?? [];
+          for (const event of items) {
+            matches.push({ ...event, calendarId: calendar.id });
+          }
+          pageToken = response.body.nextPageToken;
+        } catch (error: any) {
+          const status = error.response?.status;
+          if (status === 403 || status === 404) {
+            pageToken = '';
+            continue;
+          }
+          if (status === 429) {
+            throw new Error(
+              'Google Calendar rate limit reached while searching calendars. Please retry shortly.'
+            );
+          }
+          throw error;
+        }
+      } while (pageToken);
+    }
+
+    return {
+      events: matches,
+      count: matches.length,
+      calendars_searched: calendars.length,
+    };
+  },
+});

--- a/packages/pieces/community/google-docs/package.json
+++ b/packages/pieces/community/google-docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-google-docs",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "dependencies": {

--- a/packages/pieces/community/google-docs/src/index.ts
+++ b/packages/pieces/community/google-docs/src/index.ts
@@ -7,6 +7,10 @@ import { createDocumentBasedOnTemplate } from './lib/actions/create-document-bas
 import { readDocument } from './lib/actions/read-document.action';
 import { appendText } from './lib/actions/append-text';
 import { findDocumentAction } from './lib/actions/find-document';
+import { getDocumentPlaintext } from './lib/actions/get-document-plaintext.action';
+import { replaceAllText } from './lib/actions/replace-all-text.action';
+import { searchDocuments } from './lib/actions/search-documents.action';
+import { copyDocument } from './lib/actions/copy-document.action';
 import { newDocumentTrigger } from './lib/triggers/new-document';
 import { googleDocsAuth, getAccessToken, GoogleDocsAuthValue } from './lib/auth';
 
@@ -33,6 +37,10 @@ export const googleDocs = createPiece({
 		createDocumentBasedOnTemplate,
 		readDocument,
 		findDocumentAction,
+		getDocumentPlaintext,
+		replaceAllText,
+		searchDocuments,
+		copyDocument,
 		createCustomApiCallAction({
 			baseUrl: () => 'https://docs.googleapis.com/v1',
 			auth: googleDocsAuth,

--- a/packages/pieces/community/google-docs/src/lib/actions/copy-document.action.ts
+++ b/packages/pieces/community/google-docs/src/lib/actions/copy-document.action.ts
@@ -1,0 +1,73 @@
+import { googleDocsAuth, createGoogleClient } from '../auth';
+import { Property, createAction } from '@activepieces/pieces-framework';
+import { drive as googleDrive } from '@googleapis/drive';
+import { folderIdProp } from '../common/props';
+
+export const copyDocument = createAction({
+	auth: googleDocsAuth,
+	name: 'copy_document',
+	displayName: 'Copy Document',
+	description: 'Create a copy of an existing Google Docs document.',
+	audience: 'ai',
+	aiMetadata: {
+		description:
+			'Duplicates an existing Google Docs document into a new file with the given title. Pick this to spin a working copy off a template or snapshot a version before editing; it is distinct from Edit Template File, which merges data in place. Each call creates a new file, so it is not idempotent (retries produce duplicates).',
+		idempotent: false,
+	},
+	props: {
+		fileId: Property.ShortText({
+			displayName: 'Source Document ID',
+			description:
+				"The ID of the document to copy, found in its URL: 'https://docs.google.com/document/d/<documentId>/edit'.",
+			required: true,
+		}),
+		title: Property.ShortText({
+			displayName: 'New Document Title',
+			description: 'The name to give the copied document.',
+			required: true,
+		}),
+		// Destination folder is sourced directly from the native Drive files.copy
+		// endpoint (the requestBody.parents field). This goes beyond the cited
+		// Composio GOOGLEDOCS_COPY_DOCUMENT, which exposes only title +
+		// include_shared_drives and no arbitrary parents.
+		parents: folderIdProp,
+	},
+	async run(context) {
+		const { fileId, title, parents } = context.propsValue;
+
+		const authClient = await createGoogleClient(context.auth);
+		const drive = googleDrive({ version: 'v3', auth: authClient });
+
+		try {
+			const response = await drive.files.copy({
+				fileId,
+				supportsAllDrives: true,
+				fields: 'id, name, webViewLink, parents',
+				requestBody: {
+					name: title,
+					...(parents ? { parents: [parents] } : {}),
+				},
+			});
+
+			return {
+				id: response.data.id ?? '',
+				name: response.data.name ?? '',
+				webViewLink: response.data.webViewLink ?? '',
+				parents: response.data.parents ?? [],
+			};
+		} catch (e) {
+			const error = e as { code?: number; message?: string };
+			if (error.code === 403) {
+				throw new Error(
+					'Permission denied copying the document. Ensure the connected account has access to the source document and the destination folder.'
+				);
+			}
+			if (error.code === 404) {
+				throw new Error(
+					`Source document not found for ID '${fileId}'. Verify the document ID.`
+				);
+			}
+			throw e;
+		}
+	},
+});

--- a/packages/pieces/community/google-docs/src/lib/actions/get-document-plaintext.action.ts
+++ b/packages/pieces/community/google-docs/src/lib/actions/get-document-plaintext.action.ts
@@ -1,0 +1,72 @@
+import { googleDocsAuth, createGoogleClient } from '../auth';
+import { Property, createAction } from '@activepieces/pieces-framework';
+import { docs as googleDocs, docs_v1 } from '@googleapis/docs';
+
+// Minimal prose projection: only top-level body paragraph text runs are
+// flattened. Content inside tables, headers, footers, footnotes, and tabs is
+// intentionally NOT included — keep the contract unambiguous for agents that
+// just want the document prose. Use read_document for the full structural JSON.
+function flattenBodyToPlainText(body: docs_v1.Schema$Body | undefined): string {
+	const lines: string[] = [];
+	for (const element of body?.content ?? []) {
+		const paragraph = element.paragraph;
+		if (!paragraph) continue;
+		const text = (paragraph.elements ?? [])
+			.map((paragraphElement) => paragraphElement.textRun?.content ?? '')
+			.join('');
+		lines.push(text);
+	}
+	return lines.join('').replace(/\n+$/, '');
+}
+
+export const getDocumentPlaintext = createAction({
+	auth: googleDocsAuth,
+	name: 'get_document_plaintext',
+	displayName: 'Get Document Plain Text',
+	description: 'Get the plain text content of a Google Docs document.',
+	audience: 'ai',
+	aiMetadata: {
+		description:
+			'Returns just the body prose of a Google Docs document as a plain string, flattened from the document.get response. Pick this over Read Document when you only need the text to summarize/extract/classify and want to avoid the large nested structural JSON. Only top-level paragraph text is included — tables, headers, footers, footnotes, and tabs are omitted. Read-only and idempotent.',
+		idempotent: true,
+	},
+	props: {
+		documentId: Property.ShortText({
+			displayName: 'Document ID',
+			description:
+				"The ID of the document to read, found in its URL: 'https://docs.google.com/document/d/<documentId>/edit'. Obtain it from Search Documents or Find Document if you only have a name.",
+			required: true,
+		}),
+	},
+	async run(context) {
+		const authClient = await createGoogleClient(context.auth);
+		const docs = googleDocs({ version: 'v1', auth: authClient });
+
+		try {
+			const response = await docs.documents.get({
+				documentId: context.propsValue.documentId,
+			});
+
+			const plainText = flattenBodyToPlainText(response.data.body);
+
+			return {
+				documentId: response.data.documentId ?? context.propsValue.documentId,
+				title: response.data.title ?? '',
+				plainText,
+			};
+		} catch (e) {
+			const error = e as { code?: number; message?: string };
+			if (error.code === 403) {
+				throw new Error(
+					'Permission denied reading the document. Ensure the connected account has access to this document.'
+				);
+			}
+			if (error.code === 404) {
+				throw new Error(
+					`Document not found for ID '${context.propsValue.documentId}'. Verify the document ID.`
+				);
+			}
+			throw e;
+		}
+	},
+});

--- a/packages/pieces/community/google-docs/src/lib/actions/replace-all-text.action.ts
+++ b/packages/pieces/community/google-docs/src/lib/actions/replace-all-text.action.ts
@@ -1,0 +1,93 @@
+import { googleDocsAuth, createGoogleClient } from '../auth';
+import { Property, createAction } from '@activepieces/pieces-framework';
+import { docs as googleDocs } from '@googleapis/docs';
+
+export const replaceAllText = createAction({
+	auth: googleDocsAuth,
+	name: 'replace_all_text',
+	displayName: 'Replace All Text in Document',
+	description:
+		'Replace every occurrence of a literal string in a Google Docs document with another string.',
+	audience: 'ai',
+	aiMetadata: {
+		// Idempotent matches the sibling create_document_based_on_template, which
+		// wraps the identical replaceAllText request and is labeled idempotent:true:
+		// re-running with the same find/replace leaves the same end state (the
+		// second run matches zero occurrences). Caveat noted below for the
+		// overlapping find/replace-literals edge case.
+		description:
+			'Find-and-replaces every occurrence of a literal string across a whole Google Docs document. Pick this for a bare ad-hoc text edit; use Edit Template File instead for placeholder-token merges or image swaps. Idempotent for normal use (a repeat run matches nothing and leaves the same end state); the exception is overlapping find/replace literals (e.g. replacing "a" with "ab"), which can re-match on a second run.',
+		idempotent: true,
+	},
+	props: {
+		documentId: Property.ShortText({
+			displayName: 'Document ID',
+			description:
+				"The ID of the document to edit, found in its URL: 'https://docs.google.com/document/d/<documentId>/edit'.",
+			required: true,
+		}),
+		find_text: Property.ShortText({
+			displayName: 'Find Text',
+			description: 'The literal text to search for in the document.',
+			required: true,
+		}),
+		replace_text: Property.ShortText({
+			displayName: 'Replace With',
+			description: 'The text to replace every matched occurrence with.',
+			required: true,
+		}),
+		match_case: Property.Checkbox({
+			displayName: 'Match Case',
+			description: 'When enabled, the search is case-sensitive.',
+			required: false,
+			defaultValue: false,
+		}),
+	},
+	async run(context) {
+		const { documentId, find_text, replace_text, match_case } =
+			context.propsValue;
+
+		const authClient = await createGoogleClient(context.auth);
+		const docs = googleDocs({ version: 'v1', auth: authClient });
+
+		try {
+			const response = await docs.documents.batchUpdate({
+				documentId,
+				requestBody: {
+					requests: [
+						{
+							replaceAllText: {
+								containsText: {
+									text: find_text,
+									matchCase: match_case ?? false,
+								},
+								replaceText: replace_text,
+							},
+						},
+					],
+				},
+			});
+
+			const occurrencesChanged =
+				response.data.replies?.[0]?.replaceAllText?.occurrencesChanged ?? 0;
+
+			return {
+				documentId,
+				occurrencesChanged,
+			};
+		} catch (e) {
+			const error = e as { code?: number; message?: string };
+			if (error.code === 403) {
+				throw new Error(
+					'Permission denied editing the document. Ensure the connected account has edit access to this document.'
+				);
+			}
+			if (error.code === 404) {
+				throw new Error(
+					`Document not found for ID '${documentId}'. Verify the document ID.`
+				);
+			}
+			throw e;
+		}
+	},
+});

--- a/packages/pieces/community/google-docs/src/lib/actions/search-documents.action.ts
+++ b/packages/pieces/community/google-docs/src/lib/actions/search-documents.action.ts
@@ -1,0 +1,127 @@
+import { googleDocsAuth, createGoogleClient } from '../auth';
+import { Property, createAction } from '@activepieces/pieces-framework';
+import { drive as googleDrive } from '@googleapis/drive';
+
+export const searchDocuments = createAction({
+	auth: googleDocsAuth,
+	name: 'search_documents',
+	displayName: 'Search Documents',
+	description:
+		'Search Google Drive for Google Docs documents by name or full-text content.',
+	audience: 'ai',
+	aiMetadata: {
+		description:
+			"Searches Drive for Google Docs documents by name and/or full-text content, returning multiple ordered results with their IDs. Pick this over Find Document to discover documents by their content (not just an exact name) or to get more than one match; Find Document returns only the first name match and can also create-if-missing. Read-only and idempotent. At least one of name/content text is required.",
+		idempotent: true,
+	},
+	props: {
+		name_contains: Property.ShortText({
+			displayName: 'Name Contains',
+			description:
+				'Return documents whose name contains this text. Provide this and/or Content Contains.',
+			required: false,
+		}),
+		full_text_contains: Property.ShortText({
+			displayName: 'Content Contains',
+			description:
+				'Return documents whose full text content contains this text. Provide this and/or Name Contains.',
+			required: false,
+		}),
+		max_results: Property.Number({
+			displayName: 'Max Results',
+			description: 'Maximum number of documents to return (1-100).',
+			required: false,
+			defaultValue: 10,
+		}),
+		order_by: Property.StaticDropdown({
+			displayName: 'Order By',
+			description: 'How to sort the results.',
+			required: false,
+			defaultValue: 'modifiedTime desc',
+			options: {
+				options: [
+					{ label: 'Last modified (newest first)', value: 'modifiedTime desc' },
+					{ label: 'Last modified (oldest first)', value: 'modifiedTime' },
+					{ label: 'Created (newest first)', value: 'createdTime desc' },
+					{ label: 'Created (oldest first)', value: 'createdTime' },
+					{ label: 'Name (A-Z)', value: 'name' },
+					{ label: 'Name (Z-A)', value: 'name desc' },
+				],
+			},
+		}),
+		page_token: Property.ShortText({
+			displayName: 'Page Token',
+			description:
+				'Token for the next page of results, taken from the nextPageToken of a previous call. Leave empty for the first page.',
+			required: false,
+		}),
+	},
+	async run(context) {
+		const { name_contains, full_text_contains, max_results, order_by, page_token } =
+			context.propsValue;
+
+		if (!name_contains && !full_text_contains) {
+			throw new Error(
+				'Provide at least one of "Name Contains" or "Content Contains" to search.'
+			);
+		}
+
+		const pageSize = Math.min(Math.max(max_results ?? 10, 1), 100);
+
+		const matchClauses: string[] = [];
+		if (name_contains) {
+			matchClauses.push(`name contains '${name_contains.replace(/'/g, "\\'")}'`);
+		}
+		if (full_text_contains) {
+			matchClauses.push(
+				`fullText contains '${full_text_contains.replace(/'/g, "\\'")}'`
+			);
+		}
+
+		const query = [
+			`mimeType='application/vnd.google-apps.document'`,
+			`(${matchClauses.join(' or ')})`,
+			'trashed=false',
+		].join(' and ');
+
+		const authClient = await createGoogleClient(context.auth);
+		const drive = googleDrive({ version: 'v3', auth: authClient });
+
+		try {
+			const response = await drive.files.list({
+				q: query,
+				orderBy: order_by ?? 'modifiedTime desc',
+				pageSize,
+				pageToken: page_token || undefined,
+				supportsAllDrives: true,
+				includeItemsFromAllDrives: true,
+				corpora: 'allDrives',
+				fields:
+					'nextPageToken, files(id, name, mimeType, createdTime, modifiedTime, webViewLink, owners(emailAddress))',
+			});
+
+			const documents = (response.data.files ?? []).map((file) => ({
+				id: file.id ?? '',
+				name: file.name ?? '',
+				createdTime: file.createdTime ?? '',
+				modifiedTime: file.modifiedTime ?? '',
+				webViewLink: file.webViewLink ?? '',
+				ownerEmail: file.owners?.[0]?.emailAddress ?? '',
+			}));
+
+			return {
+				documents,
+				count: documents.length,
+				nextPageToken: response.data.nextPageToken ?? null,
+			};
+		} catch (e) {
+			const error = e as { code?: number; message?: string };
+			if (error.code === 403) {
+				throw new Error(
+					'Permission denied searching Drive. Ensure the connected account has Drive access.'
+				);
+			}
+			throw e;
+		}
+	},
+});


### PR DESCRIPTION
Adds net-new `audience: 'ai'` agent atomics to two existing Google pieces. Pure augment — no existing actions are changed or demoted; each atomic fills a capability gap that agents hit when driving these pieces. No new OAuth scopes (all fit within each piece's existing scopes).

## google-calendar (0.9.3 → 0.9.4)
- **search_events_all_calendars** — keyword + time-window search fanned across all of the user's calendars (the existing Get Events is single-calendar). Read-only. Reuses the existing `getCalendars` helper.
- **find_free_slots** — returns the open intervals (complement of `freeBusy` busy blocks, intersected across the selected calendars, with optional minimum-duration / working-hours filtering). The existing Find Busy/Free Periods returns busy blocks only. Read-only.
- **list_recurring_event_instances** — lists the individual occurrences of one recurring series by its event ID (`events.instances`). Read-only.
- **move_event** — moves an event between calendars in place (`events.move`), preserving the event ID and metadata; guards the same-source-destination case as a no-op.

## google-docs (0.4.3 → 0.4.4)
- **get_document_plaintext** — flattens a document to plain text (the existing Read Document returns the full structural JSON, which is token-heavy for agents that only need the prose). Read-only. Minimal projection: paragraph text only (tables/headers/footers excluded).
- **replace_all_text** — find-and-replace across a document (`batchUpdate` `replaceAllText`) with optional match-case.
- **search_documents** — Drive query by name and/or full-text, multi-result, with ordering and pagination (the existing Find Document is name-only, first match, and mixes in a create-if-not-found side effect). Read-only.
- **copy_document** — duplicates a document (Drive `files.copy`), with an optional destination folder.

## Verification
- `tsc` build + eslint: 0 errors on both pieces.
- Live-tested each atomic against a real Google account via the test-step path: **7 of 8 verified end-to-end** (the three Calendar reads, the four Docs atomics — all returned correct live results, e.g. `replace_all_text` confirmed by re-reading the document, `list_recurring_event_instances` returned the expected per-occurrence instances).
- **move_event**: its same-calendar guard path was verified against the live API; a true cross-calendar transfer was not exercised because the test account had only one writable calendar. The transfer path uses the standard `events.move` call.
