### PR TITLE
fix: serialize connection refresh across projects sharing a connection

### DIFF
--- a/.agents/features/app-connections.md
+++ b/.agents/features/app-connections.md
@@ -103,7 +103,7 @@ const { token } = await response.json()
 
 Automatic on connection retrieval:
 1. `lockAndRefreshConnection()` checks if OAuth token expired (15-min early refresh threshold)
-2. If expired: acquires distributed Redis lock (`key = ${projectId}_${externalId}`, 60s timeout)
+2. If expired: acquires distributed Redis lock (`key = ${platformId}_${externalId}`, 60s timeout) — keyed on the connection's project-invariant identity so projects sharing a connection serialize on one lock
 3. Calls OAuth2 handler's `refresh()` method (different per type: cloud/platform/credentials)
 4. Re-encrypts updated tokens, stores in DB, sets status=ACTIVE
 5. On error (invalid refresh token): sets status=ERROR
@@ -130,7 +130,7 @@ PieceAuth.CustomAuth({
 1. `needRefresh()` checks `connection.value.access_token`:
    - Present → stale once `now >= token_refresh_at` (the precomputed refresh instant)
    - Absent → consult `pieceRefreshSupportCache` (in-process LRU, 500 entries, 5-min TTL keyed by `pieceName@pieceVersion`); on cache miss, load piece metadata and check for `refresh` callback; result cached for future executions
-2. If refresh needed: acquires the same distributed Redis lock (`key = ${projectId}_${externalId}`, 60s)
+2. If refresh needed: acquires the same distributed Redis lock (`key = ${platformId}_${externalId}`, 60s)
 3. Dispatches `EXECUTE_TOKEN_REFRESH` worker job (user-interaction queue, same pattern as `EXECUTE_VALIDATION`)
 4. Engine calls the piece's `refresh.generate()` callback, returns `{ access_token, expires_in? }`
 5. `access_token` and `token_refresh_at` stored encrypted in `CustomAuthConnectionValue`, status=ACTIVE. `token_refresh_at = now + expiresIn - min(15 min, expiresIn / 2)` so the 15-min early-refresh buffer never exceeds half the token's lifetime (a short-lived token would otherwise be stale the instant it is minted); `expiresIn <= 0` means "never expires" → `token_refresh_at` is left unset

--- a/packages/server/api/src/app/app-connection/app-connection-service/app-connection-service.ts
+++ b/packages/server/api/src/app/app-connection/app-connection-service/app-connection-service.ts
@@ -358,7 +358,7 @@ export const appConnectionService = (log: FastifyBaseLogger) => ({
             return oauth2Util(log).removeRefreshTokenAndClientSecret(appConnection)
         }
 
-        const refreshedConnection = await appConnectionHandler(log).lockAndRefreshConnection({ projectId, externalId: appConnection.externalId, log })
+        const refreshedConnection = await appConnectionHandler(log).lockAndRefreshConnection({ platformId: appConnection.platformId, projectId, externalId: appConnection.externalId, log })
         if (isNil(refreshedConnection)) {
             return null
         }

--- a/packages/server/api/src/app/app-connection/app-connection-service/app-connection.handler.ts
+++ b/packages/server/api/src/app/app-connection/app-connection-service/app-connection.handler.ts
@@ -124,17 +124,19 @@ export const appConnectionHandler = (log: FastifyBaseLogger) => ({
  * refreshed and it gets accessed at the same time, which could result in the wrong request saving incorrect data.
  */
     async lockAndRefreshConnection({
+        platformId,
         projectId,
         externalId,
         log,
     }: {
+        platformId: PlatformId
         projectId: ProjectId
         externalId: string
         log: FastifyBaseLogger
     }) {
 
         return distributedLock(log).runExclusive({
-            key: `${projectId}_${externalId}`,
+            key: `${platformId}_${externalId}`,
             timeoutInSeconds: 60,
             fn: async () => {
                 let appConnection: AppConnection | null = null


### PR DESCRIPTION
## Problem

OAuth/custom-auth token refresh is guarded by a distributed lock keyed on `${projectId}_${externalId}`. But a connection row is **shared across many projects** via the `projectIds` array column and is identified by `(platformId, externalId)` (there's already an index on exactly that pair).

So two flows in **different projects** that share one connection take **different lock keys** and can refresh concurrently. Both POST the *same* refresh token to the provider. With rotating refresh tokens (Google, Microsoft, …) the first response invalidates that token, so the second request fails with `BAD_REFRESH_TOKEN` — and the loser's `catch` flips the shared connection to `AppConnectionStatus.ERROR`, knocking it out for **every** project using it, even though the refresh actually succeeded.

The lock was correct *within* a project (concurrent flows in one project serialize); it just didn't cover the cross-project sharing the data model allows.

## Fix

Lock on `${platformId}_${externalId}` — the connection row's natural, project-invariant identity — so all projects sharing a connection serialize on the same key. `platformId` is taken from the already-decrypted connection at the callsite, so there's no extra query.

The in-lock re-read + `needRefresh` check is unchanged, so the race loser wakes after the winner has persisted the fresh token, sees `needRefresh === false`, and returns the refreshed connection instead of re-refreshing.

## Notes / verification

- `projectId` is still threaded through for the data-isolation read (`ArrayContains([projectId])`) and `refresh()` — only the lock key changed.
- `platformId` is `nullable: false` on the entity and present on every `AppConnection`.
- The connection refresh is the only place that locks on a connection; no save/upsert path locked on the old key, so nothing desyncs.
- Lock keys are ephemeral (RedLock) — no persisted state keyed by the old format, safe across deploy.
- `tsc --noEmit` and lint pass (0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)