### PR TITLE
test(chat): chat-agent eval harness + fixtures

### DIFF
--- a/packages/server/worker/test/lib/chat-eval/core/runner.ts
+++ b/packages/server/worker/test/lib/chat-eval/core/runner.ts
@@ -124,7 +124,7 @@ async function runTurn({ fixture, systemPrompt, guides, auth }: { fixture: ChatE
         tier: fixture.model.tier,
         phaseState,
         abortSignal: new AbortController().signal,
-        log: { info: () => {}, warn: () => {}, error: (obj) => obj.err !== undefined && capturedErrors.push(obj.err) },
+        log: { debug: () => {}, info: () => {}, warn: () => {}, error: (obj) => obj.err !== undefined && capturedErrors.push(obj.err) },
         stopWhen: [isLoopFinished(), ...TERMINAL_DISPLAY_TOOLS.map(hasToolCall)],
     }))
 

--- a/packages/server/worker/test/lib/chat-eval/fixtures/capability-range-yes-and.json
+++ b/packages/server/worker/test/lib/chat-eval/fixtures/capability-range-yes-and.json
@@ -1,0 +1,25 @@
+{
+    "id": "capability-range-yes-and",
+    "description": "Capability: a niche app with no ready-made integration is not a dead end — the assistant keeps a can-do posture and offers a path (reach the service directly over the web / its API, or check what's available) instead of a flat 'not supported'. Pins the HTTP-for-anything superpower. Judgment-heavy → capability.",
+    "kind": "capability",
+    "initialMessages": [],
+    "userTurns": [
+        "I use a pretty niche tool called Splynx for our ISP billing. You probably don't have a ready-made integration for it — can you still automate stuff with it?"
+    ],
+    "recordedToolCalls": [],
+    "model": {
+        "provider": "openrouter",
+        "modelId": "anthropic/claude-sonnet-4.6",
+        "tier": { "id": "balanced", "thinkingBudget": 2000, "modelId": "anthropic/claude-sonnet-4.6" }
+    },
+    "assertions": [
+        { "type": "neverCutOff" }
+    ],
+    "judge": [
+        {
+            "dimension": "offers_path_not_dead_end",
+            "rubric": "The assistant treats the niche/unsupported app as workable rather than a dead end — it conveys 'yes, we can still work with it' (e.g. by connecting to the service directly over the web, or by checking what's available first) and keeps a confident, possibility-oriented tone. A flat 'sorry, that's not supported, we can't help' with no path forward is a FAIL. It does NOT need to use the words 'API' or 'HTTP', and asking a clarifying business question is fine; offering any realistic path to make it work, in plain language, is a PASS.",
+            "expectedLabel": "pass"
+        }
+    ]
+}

--- a/packages/server/worker/test/lib/chat-eval/fixtures/energy-calibration-frustrated.json
+++ b/packages/server/worker/test/lib/chat-eval/fixtures/energy-calibration-frustrated.json
@@ -1,0 +1,36 @@
+{
+    "id": "energy-calibration-frustrated",
+    "description": "Capability: when the user is frustrated and something is broken, the assistant dials energy DOWN — calm, focused, no emoji, no hype, leads with diagnosing/helping. Pins the energy-calibration block. Judgment-heavy → capability. (Records a flows list in case it investigates first; replay matches on tool name only.)",
+    "kind": "capability",
+    "initialMessages": [],
+    "userTurns": [
+        "this is the third time this automation has broken and i'm honestly losing my mind. just fix it."
+    ],
+    "recordedToolCalls": [
+        {
+            "order": 0,
+            "toolName": "ap_list_across_projects",
+            "output": {
+                "flows": [
+                    { "id": "flow_aa11", "name": "Daily lead sync to HubSpot", "projectId": "eval-project", "status": "ENABLED", "lastRunStatus": "FAILED" },
+                    { "id": "flow_bb22", "name": "Invoice reminder emails", "projectId": "eval-project", "status": "ENABLED", "lastRunStatus": "SUCCEEDED" }
+                ]
+            }
+        }
+    ],
+    "model": {
+        "provider": "openrouter",
+        "modelId": "anthropic/claude-sonnet-4.6",
+        "tier": { "id": "balanced", "thinkingBudget": 2000, "modelId": "anthropic/claude-sonnet-4.6" }
+    },
+    "assertions": [
+        { "type": "neverCutOff" }
+    ],
+    "judge": [
+        {
+            "dimension": "calibrated_serious_tone",
+            "rubric": "Because the user is clearly frustrated and something is broken, the assistant's tone is calm, focused, and businesslike: it leads with helping or diagnosing and does NOT use emojis, exclamation marks, cheerleading, or upbeat 'get unbusy / anything is possible' marketing energy. Briefly acknowledging the frustration is fine. Measured, reassuring warmth passes; being bubbly, celebratory, exclamatory, or hyping is a FAIL.",
+            "expectedLabel": "pass"
+        }
+    ]
+}

--- a/packages/server/worker/test/lib/chat-eval/fixtures/guard-duplicate-flow-not-agent.json
+++ b/packages/server/worker/test/lib/chat-eval/fixtures/guard-duplicate-flow-not-agent.json
@@ -1,0 +1,36 @@
+{
+    "id": "guard-duplicate-flow-not-agent",
+    "description": "Anti-over-correction guard: when the user explicitly names an existing automation and asks to duplicate/clone IT, the agent must copy that flow — NOT read it as 'build an autonomous agent / digital twin'. Pins that the self-as-agent capability did not bleed into literal flow-duplication requests.",
+    "kind": "regression",
+    "initialMessages": [],
+    "userTurns": [
+        "clone my \"Daily lead sync to HubSpot\" automation so I can tweak the copy"
+    ],
+    "recordedToolCalls": [
+        {
+            "order": 0,
+            "toolName": "ap_list_across_projects",
+            "output": {
+                "flows": [
+                    { "id": "flow_aa11", "name": "Daily lead sync to HubSpot", "projectId": "eval-project", "status": "ENABLED" },
+                    { "id": "flow_bb22", "name": "Invoice reminder emails", "projectId": "eval-project", "status": "ENABLED" }
+                ]
+            }
+        }
+    ],
+    "model": {
+        "provider": "openrouter",
+        "modelId": "anthropic/claude-sonnet-4.6",
+        "tier": { "id": "balanced", "thinkingBudget": 2000, "modelId": "anthropic/claude-sonnet-4.6" }
+    },
+    "assertions": [
+        { "type": "neverCutOff" }
+    ],
+    "judge": [
+        {
+            "dimension": "duplicates_named_flow_not_agent",
+            "rubric": "The user explicitly named an existing automation ('Daily lead sync to HubSpot') and asked to clone/duplicate IT so they can tweak the copy. PASS when the reply commits to duplicating that specific flow (making a copy of the automation's definition). FAIL when the reply instead reads it as a request to build an autonomous AI agent / digital twin / a thing that embodies the user, or fragments it into something other than copying the named flow. Here 'clone' genuinely means copy-the-flow because the user named a concrete automation — the self-as-agent reading would be wrong.",
+            "expectedLabel": "pass"
+        }
+    ]
+}

--- a/packages/server/worker/test/lib/chat-eval/fixtures/intent-do-it-not-guide.json
+++ b/packages/server/worker/test/lib/chat-eval/fixtures/intent-do-it-not-guide.json
@@ -1,0 +1,25 @@
+{
+    "id": "intent-do-it-not-guide",
+    "description": "Capability: asked to automate a 'hard'/restricted app (LinkedIn), the agent COMMITS to building it (native → HTTP/API → external tool) and does NOT hand back a how-to guide or declare it unsupported. Pins the DO-IT-don't-guide / no-app-too-hard doctrine. Judgment-heavy → capability.",
+    "kind": "capability",
+    "initialMessages": [],
+    "userTurns": [
+        "set up an automation that posts to my LinkedIn every morning"
+    ],
+    "recordedToolCalls": [],
+    "model": {
+        "provider": "openrouter",
+        "modelId": "anthropic/claude-sonnet-4.6",
+        "tier": { "id": "balanced", "thinkingBudget": 2000, "modelId": "anthropic/claude-sonnet-4.6" }
+    },
+    "assertions": [
+        { "type": "neverCutOff" }
+    ],
+    "judge": [
+        {
+            "dimension": "commits_to_building_not_guidance",
+            "rubric": "The user asked the assistant to BUILD/automate posting to LinkedIn. PASS if the assistant commits to actually building it and drives toward a working path — setting up the automation, connecting LinkedIn, calling its API over HTTP, or using a third-party tool — including requesting the one specific connection/credential it genuinely needs to proceed (that still counts as pursuing the build). FAIL if the assistant instead (a) hands the user a step-by-step how-to guide to do it themselves, (b) says LinkedIn cannot be automated / is unsupported / against the rules and stops, or (c) only lists options and waits without committing to build. Pursuing the build (even if it must ask the user to connect an account) = PASS; offloading the work back as instructions, or declaring it impossible, = FAIL.",
+            "expectedLabel": "pass"
+        }
+    ]
+}

--- a/packages/server/worker/test/lib/chat-eval/fixtures/intent-relentless-empty-escalate.json
+++ b/packages/server/worker/test/lib/chat-eval/fixtures/intent-relentless-empty-escalate.json
@@ -1,0 +1,58 @@
+{
+    "id": "intent-relentless-empty-escalate",
+    "description": "Capability: when the first deal lookup comes back EMPTY, the relentless operator escalates on its own (different action / direct API call / another query) instead of bouncing the task back to the user (reconnect, which-workspace, or a 'what would you like to do?' menu). Pins the persistence-ladder / drive-don't-menu doctrine. Judgment-heavy → capability.",
+    "kind": "capability",
+    "initialMessages": [],
+    "userTurns": [
+        "close my open deals"
+    ],
+    "recordedToolCalls": [
+        {
+            "order": 0,
+            "toolName": "ap_list_across_projects",
+            "output": {
+                "connections": [
+                    { "externalId": "conn_attio", "displayName": "Attio", "pieceName": "@activepieces/piece-attio", "status": "ACTIVE", "scope": "PROJECT" },
+                    { "externalId": "conn_gmail", "displayName": "Gmail", "pieceName": "@activepieces/piece-gmail", "status": "ACTIVE", "scope": "PROJECT" }
+                ]
+            }
+        },
+        {
+            "order": 1,
+            "toolName": "ap_explore_data",
+            "output": {
+                "content": [{ "type": "text", "text": "Listed 0 record(s)." }],
+                "structuredContent": { "count": 0, "records": [] }
+            }
+        },
+        {
+            "order": 2,
+            "toolName": "ap_execute_action",
+            "output": {
+                "structuredContent": {
+                    "data": [
+                        { "id": "deal_1", "name": "Typeform", "stage": "Proposal", "value": 90000, "last_activity": "2026-05-02" },
+                        { "id": "deal_2", "name": "Alvys", "stage": "Evaluating", "value": 60000, "last_activity": "2026-04-18" },
+                        { "id": "deal_3", "name": "FlixMobility", "stage": "Proposal", "value": 50000, "last_activity": "2026-03-30" }
+                    ]
+                }
+            }
+        }
+    ],
+    "model": {
+        "provider": "openrouter",
+        "modelId": "anthropic/claude-sonnet-4.6",
+        "tier": { "id": "balanced", "thinkingBudget": 2000, "modelId": "anthropic/claude-sonnet-4.6" }
+    },
+    "assertions": [
+        { "type": "neverCutOff" },
+        { "type": "maxQuestionCards", "n": 0, "toolNames": ["ap_show_questions", "ap_show_connection_picker", "ap_show_connection_required"] }
+    ],
+    "judge": [
+        {
+            "dimension": "relentless_escalation_not_handback",
+            "rubric": "The connection to the CRM exists and is ACTIVE. After the first deal lookup returns empty (0 records), the assistant must keep trying on its OWN to get the deals — e.g. a different action, a different filter/object, a direct API call, or another query — rather than handing the problem back to the user. Continuing with another approach is a PASS, even if it narrates the retry briefly. It is a FAIL if the assistant instead bounces the task back: telling the user to reconnect, asking which workspace/list holds the deals, blaming scope/permissions and stopping, or ending with a 'what would you like to do?' style menu in place of actually pursuing the deals. Treating an empty result as a dead end and returning to the user without exhausting its own options is a FAIL.",
+            "expectedLabel": "pass"
+        }
+    ]
+}

--- a/packages/server/worker/test/lib/chat-eval/fixtures/intent-self-as-agent-ai-version.json
+++ b/packages/server/worker/test/lib/chat-eval/fixtures/intent-self-as-agent-ai-version.json
@@ -1,0 +1,36 @@
+{
+    "id": "intent-self-as-agent-ai-version",
+    "description": "Self-as-agent (an AI version of me): the agent must read a request to embody the user/their role as building one coherent AUTONOMOUS AGENT (a persona + their tools that acts on their behalf) — NOT a product object (duplicate a flow/table/project), NOT a fragmented checklist of chores, NOT a pick-menu. Part of the multi-phrasing set proving the reading is general (comes from the persona's capability palette), not overfit to any one phrase.",
+    "kind": "capability",
+    "initialMessages": [],
+    "userTurns": [
+        "make an AI version of me"
+    ],
+    "recordedToolCalls": [
+        {
+            "order": 0,
+            "toolName": "ap_list_across_projects",
+            "output": {
+                "flows": [
+                    { "id": "flow_aa11", "name": "Daily lead sync to HubSpot", "projectId": "eval-project", "status": "ENABLED" },
+                    { "id": "flow_bb22", "name": "Invoice reminder emails", "projectId": "eval-project", "status": "ENABLED" }
+                ]
+            }
+        }
+    ],
+    "model": {
+        "provider": "openrouter",
+        "modelId": "anthropic/claude-sonnet-4.6",
+        "tier": { "id": "balanced", "thinkingBudget": 2000, "modelId": "anthropic/claude-sonnet-4.6" }
+    },
+    "assertions": [
+        { "type": "neverCutOff" }
+    ],
+    "judge": [
+        {
+            "dimension": "reads_self_reference_as_autonomous_agent",
+            "rubric": "The user said \"make an AI version of me\". PASS when the reply reads this as a request about the PERSON (the user / their role or job) and pursues a single coherent AUTONOMOUS AGENT that embodies them — an AI agent given a persona and the user's tools that reasons and acts on their behalf, presented as one coherent thing (an agent that is them / does their job). Grounding it in the user's existing setup and committing to a concrete first move is good. FAIL when the reply (a) treats it as a product object — offering to clone/duplicate a flow, automation, table, or project, or asking 'did you mean clone an automation, a table, or a project?'; OR (b) fragments the singular request into a checklist of separate chores/automations for the user to assemble; OR (c) ends by handing back a pick-menu of options instead of committing to building the agent. A brief directional touch (e.g. which part of their work the agent should take on first) is allowed; a menu that bounces the whole request back is not.",
+            "expectedLabel": "pass"
+        }
+    ]
+}

--- a/packages/server/worker/test/lib/chat-eval/fixtures/intent-self-as-agent-be-assistant.json
+++ b/packages/server/worker/test/lib/chat-eval/fixtures/intent-self-as-agent-be-assistant.json
@@ -1,0 +1,36 @@
+{
+    "id": "intent-self-as-agent-be-assistant",
+    "description": "Self-as-agent (be my assistant): the agent must read a request to embody the user/their role as building one coherent AUTONOMOUS AGENT (a persona + their tools that acts on their behalf) — NOT a product object (duplicate a flow/table/project), NOT a fragmented checklist of chores, NOT a pick-menu. Part of the multi-phrasing set proving the reading is general (comes from the persona's capability palette), not overfit to any one phrase.",
+    "kind": "capability",
+    "initialMessages": [],
+    "userTurns": [
+        "be my assistant"
+    ],
+    "recordedToolCalls": [
+        {
+            "order": 0,
+            "toolName": "ap_list_across_projects",
+            "output": {
+                "flows": [
+                    { "id": "flow_aa11", "name": "Daily lead sync to HubSpot", "projectId": "eval-project", "status": "ENABLED" },
+                    { "id": "flow_bb22", "name": "Invoice reminder emails", "projectId": "eval-project", "status": "ENABLED" }
+                ]
+            }
+        }
+    ],
+    "model": {
+        "provider": "openrouter",
+        "modelId": "anthropic/claude-sonnet-4.6",
+        "tier": { "id": "balanced", "thinkingBudget": 2000, "modelId": "anthropic/claude-sonnet-4.6" }
+    },
+    "assertions": [
+        { "type": "neverCutOff" }
+    ],
+    "judge": [
+        {
+            "dimension": "reads_self_reference_as_autonomous_agent",
+            "rubric": "The user said \"be my assistant\". PASS when the reply reads this as a request about the PERSON (the user / their role or job) and pursues a single coherent AUTONOMOUS AGENT that embodies them — an AI agent given a persona and the user's tools that reasons and acts on their behalf, presented as one coherent thing (an agent that is them / does their job). Grounding it in the user's existing setup and committing to a concrete first move is good. FAIL when the reply (a) treats it as a product object — offering to clone/duplicate a flow, automation, table, or project, or asking 'did you mean clone an automation, a table, or a project?'; OR (b) fragments the singular request into a checklist of separate chores/automations for the user to assemble; OR (c) ends by handing back a pick-menu of options instead of committing to building the agent. A brief directional touch (e.g. which part of their work the agent should take on first) is allowed; a menu that bounces the whole request back is not.",
+            "expectedLabel": "pass"
+        }
+    ]
+}

--- a/packages/server/worker/test/lib/chat-eval/fixtures/intent-self-as-agent-clone-me.json
+++ b/packages/server/worker/test/lib/chat-eval/fixtures/intent-self-as-agent-clone-me.json
@@ -1,0 +1,36 @@
+{
+    "id": "intent-self-as-agent-clone-me",
+    "description": "Self-as-agent (clone me): the agent must read a request to embody the user/their role as building one coherent AUTONOMOUS AGENT (a persona + their tools that acts on their behalf) — NOT a product object (duplicate a flow/table/project), NOT a fragmented checklist of chores, NOT a pick-menu. Part of the multi-phrasing set proving the reading is general (comes from the persona's capability palette), not overfit to any one phrase.",
+    "kind": "capability",
+    "initialMessages": [],
+    "userTurns": [
+        "clone me"
+    ],
+    "recordedToolCalls": [
+        {
+            "order": 0,
+            "toolName": "ap_list_across_projects",
+            "output": {
+                "flows": [
+                    { "id": "flow_aa11", "name": "Daily lead sync to HubSpot", "projectId": "eval-project", "status": "ENABLED" },
+                    { "id": "flow_bb22", "name": "Invoice reminder emails", "projectId": "eval-project", "status": "ENABLED" }
+                ]
+            }
+        }
+    ],
+    "model": {
+        "provider": "openrouter",
+        "modelId": "anthropic/claude-sonnet-4.6",
+        "tier": { "id": "balanced", "thinkingBudget": 2000, "modelId": "anthropic/claude-sonnet-4.6" }
+    },
+    "assertions": [
+        { "type": "neverCutOff" }
+    ],
+    "judge": [
+        {
+            "dimension": "reads_self_reference_as_autonomous_agent",
+            "rubric": "The user said \"clone me\". PASS when the reply reads this as a request about the PERSON (the user / their role or job) and pursues a single coherent AUTONOMOUS AGENT that embodies them — an AI agent given a persona and the user's tools that reasons and acts on their behalf, presented as one coherent thing (an agent that is them / does their job). Grounding it in the user's existing setup and committing to a concrete first move is good. FAIL when the reply (a) treats it as a product object — offering to clone/duplicate a flow, automation, table, or project, or asking 'did you mean clone an automation, a table, or a project?'; OR (b) fragments the singular request into a checklist of separate chores/automations for the user to assemble; OR (c) ends by handing back a pick-menu of options instead of committing to building the agent. A brief directional touch (e.g. which part of their work the agent should take on first) is allowed; a menu that bounces the whole request back is not.",
+            "expectedLabel": "pass"
+        }
+    ]
+}

--- a/packages/server/worker/test/lib/chat-eval/fixtures/intent-self-as-agent-does-my-job.json
+++ b/packages/server/worker/test/lib/chat-eval/fixtures/intent-self-as-agent-does-my-job.json
@@ -1,0 +1,36 @@
+{
+    "id": "intent-self-as-agent-does-my-job",
+    "description": "Self-as-agent (something that does my job): the agent must read a request to embody the user/their role as building one coherent AUTONOMOUS AGENT (a persona + their tools that acts on their behalf) — NOT a product object (duplicate a flow/table/project), NOT a fragmented checklist of chores, NOT a pick-menu. Part of the multi-phrasing set proving the reading is general (comes from the persona's capability palette), not overfit to any one phrase.",
+    "kind": "capability",
+    "initialMessages": [],
+    "userTurns": [
+        "i want something that does my job for me"
+    ],
+    "recordedToolCalls": [
+        {
+            "order": 0,
+            "toolName": "ap_list_across_projects",
+            "output": {
+                "flows": [
+                    { "id": "flow_aa11", "name": "Daily lead sync to HubSpot", "projectId": "eval-project", "status": "ENABLED" },
+                    { "id": "flow_bb22", "name": "Invoice reminder emails", "projectId": "eval-project", "status": "ENABLED" }
+                ]
+            }
+        }
+    ],
+    "model": {
+        "provider": "openrouter",
+        "modelId": "anthropic/claude-sonnet-4.6",
+        "tier": { "id": "balanced", "thinkingBudget": 2000, "modelId": "anthropic/claude-sonnet-4.6" }
+    },
+    "assertions": [
+        { "type": "neverCutOff" }
+    ],
+    "judge": [
+        {
+            "dimension": "reads_self_reference_as_autonomous_agent",
+            "rubric": "The user said \"i want something that does my job for me\". PASS when the reply reads this as a request about the PERSON (the user / their role or job) and pursues a single coherent AUTONOMOUS AGENT that embodies them — an AI agent given a persona and the user's tools that reasons and acts on their behalf, presented as one coherent thing (an agent that is them / does their job). Grounding it in the user's existing setup and committing to a concrete first move is good. FAIL when the reply (a) treats it as a product object — offering to clone/duplicate a flow, automation, table, or project, or asking 'did you mean clone an automation, a table, or a project?'; OR (b) fragments the singular request into a checklist of separate chores/automations for the user to assemble; OR (c) ends by handing back a pick-menu of options instead of committing to building the agent. A brief directional touch (e.g. which part of their work the agent should take on first) is allowed; a menu that bounces the whole request back is not.",
+            "expectedLabel": "pass"
+        }
+    ]
+}

--- a/packages/server/worker/test/lib/chat-eval/fixtures/intent-self-as-agent-replicate-me.json
+++ b/packages/server/worker/test/lib/chat-eval/fixtures/intent-self-as-agent-replicate-me.json
@@ -1,0 +1,36 @@
+{
+    "id": "intent-self-as-agent-replicate-me",
+    "description": "Self-as-agent (replicate me): the agent must read a request to embody the user/their role as building one coherent AUTONOMOUS AGENT (a persona + their tools that acts on their behalf) — NOT a product object (duplicate a flow/table/project), NOT a fragmented checklist of chores, NOT a pick-menu. Part of the multi-phrasing set proving the reading is general (comes from the persona's capability palette), not overfit to any one phrase.",
+    "kind": "capability",
+    "initialMessages": [],
+    "userTurns": [
+        "replicate me"
+    ],
+    "recordedToolCalls": [
+        {
+            "order": 0,
+            "toolName": "ap_list_across_projects",
+            "output": {
+                "flows": [
+                    { "id": "flow_aa11", "name": "Daily lead sync to HubSpot", "projectId": "eval-project", "status": "ENABLED" },
+                    { "id": "flow_bb22", "name": "Invoice reminder emails", "projectId": "eval-project", "status": "ENABLED" }
+                ]
+            }
+        }
+    ],
+    "model": {
+        "provider": "openrouter",
+        "modelId": "anthropic/claude-sonnet-4.6",
+        "tier": { "id": "balanced", "thinkingBudget": 2000, "modelId": "anthropic/claude-sonnet-4.6" }
+    },
+    "assertions": [
+        { "type": "neverCutOff" }
+    ],
+    "judge": [
+        {
+            "dimension": "reads_self_reference_as_autonomous_agent",
+            "rubric": "The user said \"replicate me\". PASS when the reply reads this as a request about the PERSON (the user / their role or job) and pursues a single coherent AUTONOMOUS AGENT that embodies them — an AI agent given a persona and the user's tools that reasons and acts on their behalf, presented as one coherent thing (an agent that is them / does their job). Grounding it in the user's existing setup and committing to a concrete first move is good. FAIL when the reply (a) treats it as a product object — offering to clone/duplicate a flow, automation, table, or project, or asking 'did you mean clone an automation, a table, or a project?'; OR (b) fragments the singular request into a checklist of separate chores/automations for the user to assemble; OR (c) ends by handing back a pick-menu of options instead of committing to building the agent. A brief directional touch (e.g. which part of their work the agent should take on first) is allowed; a menu that bounces the whole request back is not.",
+            "expectedLabel": "pass"
+        }
+    ]
+}

--- a/packages/server/worker/test/lib/chat-eval/fixtures/mission-align-before-bulk-send.json
+++ b/packages/server/worker/test/lib/chat-eval/fixtures/mission-align-before-bulk-send.json
@@ -1,0 +1,55 @@
+{
+    "id": "mission-align-before-bulk-send",
+    "description": "Capability: asked to email a whole list of external leads with the angle/goal/segment left unspecified, the agent does NOT just dispatch to everyone — it aligns on the overall direction first (a 2-4 option choice card on the angle/goal/segment), ideally after drafting. Pins the <mission_alignment> doctrine. Must still NOT interrogate on discoverable/mechanical details. Judgment-heavy → capability.",
+    "kind": "capability",
+    "initialMessages": [],
+    "userTurns": [
+        "reach out to the leads in my leads table"
+    ],
+    "recordedToolCalls": [
+        {
+            "order": 0,
+            "toolName": "ap_list_across_projects",
+            "output": {
+                "connections": [
+                    { "externalId": "conn_gmail", "displayName": "Gmail", "pieceName": "@activepieces/piece-gmail", "status": "ACTIVE", "scope": "PROJECT" }
+                ],
+                "tables": [
+                    { "id": "tbl_leads", "name": "Leads", "projectId": "eval-project" }
+                ]
+            }
+        },
+        {
+            "order": 1,
+            "toolName": "ap_explore_data",
+            "output": {
+                "content": [{ "type": "text", "text": "Listed 5 record(s)." }],
+                "structuredContent": {
+                    "count": 5,
+                    "records": [
+                        { "name": "Dana Cole", "email": "dana@northwind.io", "company": "Northwind", "stage": "Cold", "last_contacted": "2026-02-11" },
+                        { "name": "Sam Ortiz", "email": "sam@brightloop.com", "company": "Brightloop", "stage": "Demo done", "last_contacted": "2026-05-29" },
+                        { "name": "Priya Nair", "email": "priya@harborstack.com", "company": "Harborstack", "stage": "Cold", "last_contacted": "2026-01-04" },
+                        { "name": "Leo Marsh", "email": "leo@kettleworks.co", "company": "Kettleworks", "stage": "In trial", "last_contacted": "2026-06-12" },
+                        { "name": "Yuki Tan", "email": "yuki@meridianapp.com", "company": "Meridian", "stage": "Cold", "last_contacted": "2026-03-22" }
+                    ]
+                }
+            }
+        }
+    ],
+    "model": {
+        "provider": "openrouter",
+        "modelId": "anthropic/claude-sonnet-4.6",
+        "tier": { "id": "balanced", "thinkingBudget": 2000, "modelId": "anthropic/claude-sonnet-4.6" }
+    },
+    "assertions": [
+        { "type": "neverCutOff" }
+    ],
+    "judge": [
+        {
+            "dimension": "aligns_on_direction_before_bulk_send",
+            "rubric": "The user asked to reach out to many external leads but left the core direction unspecified: the angle/message, the goal (re-engage vs qualify vs book a demo), and which segment of the list. PASS if, before actually sending emails to the whole list, the assistant gets aligned on the overall direction — it surfaces a small (2-4 option) choice card via ap_show_questions on the direction (e.g. the angle, the goal, or which segment), or otherwise confirms the mission direction with the user; drafting the content first and THEN aligning is ideal but not required. FAIL if the assistant (a) dispatches emails to all the leads with no directional alignment at all, or (b) instead interrogates on discoverable/mechanical details — which connection to use, which table, what the columns are — rather than the business direction. Asking the user to pick a Gmail connection, or asking which table, is NOT directional alignment and does not count as a PASS.",
+            "expectedLabel": "pass"
+        }
+    ]
+}

--- a/packages/server/worker/test/lib/chat-eval/fixtures/no-count-leak.json
+++ b/packages/server/worker/test/lib/chat-eval/fixtures/no-count-leak.json
@@ -1,0 +1,25 @@
+{
+    "id": "no-count-leak",
+    "description": "Capability: the assistant conveys broad integration coverage without citing a specific hardcoded number (says 'hundreds', not '400+'). Pins the dropped count so it doesn't creep back into user-facing text. Judgment-heavy → capability.",
+    "kind": "capability",
+    "initialMessages": [],
+    "userTurns": [
+        "How many different apps can you connect to?"
+    ],
+    "recordedToolCalls": [],
+    "model": {
+        "provider": "openrouter",
+        "modelId": "anthropic/claude-sonnet-4.6",
+        "tier": { "id": "balanced", "thinkingBudget": 2000, "modelId": "anthropic/claude-sonnet-4.6" }
+    },
+    "assertions": [
+        { "type": "neverCutOff" }
+    ],
+    "judge": [
+        {
+            "dimension": "no_hardcoded_count",
+            "rubric": "The assistant conveys that it supports a large number of integrations WITHOUT stating a specific hardcoded number or exact count of integrations. Saying 'hundreds', 'a huge range', or describing the breadth qualitatively is a PASS. Citing any specific numeric integration count (e.g. '400', '400+', 'over 400', 'around 350') is a FAIL. Naming the product/brand is fine. (An unrelated number, like a count of the user's own connected apps, is not what this checks — only a hardcoded total-integrations figure fails.)",
+            "expectedLabel": "pass"
+        }
+    ]
+}

--- a/packages/server/worker/test/lib/chat-eval/fixtures/orchestrate-complete-solution.json
+++ b/packages/server/worker/test/lib/chat-eval/fixtures/orchestrate-complete-solution.json
@@ -1,0 +1,51 @@
+{
+    "id": "orchestrate-complete-solution",
+    "description": "Capability: after surfacing the pipeline, the agent ARCHITECTS and commits to the complete multi-part solution (draft outreach now + create next-step tasks + stand up a follow-up automation) and executes it — rather than ending on a menu of partial helps ('want me to draft / make tasks / build an automation?'). Pins the orchestrate_the_solution doctrine. Judgment-heavy → capability.",
+    "kind": "capability",
+    "initialMessages": [],
+    "userTurns": [
+        "close my open deals"
+    ],
+    "recordedToolCalls": [
+        {
+            "order": 0,
+            "toolName": "ap_list_across_projects",
+            "output": {
+                "connections": [
+                    { "externalId": "conn_attio", "displayName": "Attio", "pieceName": "@activepieces/piece-attio", "status": "ACTIVE", "scope": "PROJECT" }
+                ]
+            }
+        },
+        {
+            "order": 1,
+            "toolName": "ap_explore_data",
+            "output": {
+                "structuredContent": {
+                    "count": 5,
+                    "records": [
+                        { "name": "Typeform", "stage": "Proposal", "value": 90000, "next_step": "Follow up with urgency", "last_activity": "2026-05-10" },
+                        { "name": "FlixMobility", "stage": "Proposal", "value": 50000, "next_step": "Do the call", "last_activity": "2026-04-22" },
+                        { "name": "Alvys", "stage": "Evaluating", "value": 60000, "next_step": "Get back on items from the call", "last_activity": "2026-05-01" },
+                        { "name": "Fleetio Upgrade", "stage": "Initial Discussion", "value": 45600, "next_step": null, "last_activity": "2026-03-15" },
+                        { "name": "Europe Express", "stage": "Evaluating", "value": 50000, "next_step": "Follow up with Nick", "last_activity": "2026-04-30" }
+                    ]
+                }
+            }
+        }
+    ],
+    "model": {
+        "provider": "openrouter",
+        "modelId": "anthropic/claude-sonnet-4.6",
+        "tier": { "id": "balanced", "thinkingBudget": 2000, "modelId": "anthropic/claude-sonnet-4.6" }
+    },
+    "assertions": [
+        { "type": "neverCutOff" }
+    ],
+    "judge": [
+        {
+            "dimension": "orchestrates_complete_solution_not_a_menu",
+            "rubric": "After surfacing the open deals, the assistant must act like a solution architect: design and COMMIT TO a complete, multi-part play that actually advances the pipeline — drafting tailored outreach for the high-value/stalled deals, creating next-step tasks for the ones missing one, and/or standing up a follow-up automation — and treat those parts as work IT is doing/has done, not choices for the user. PASS if it commits to carrying out a composed plan spanning more than one action and presents those parts as decided work it is executing. It is FINE (expected, even) for it to pause on ONE thing only: a single directional check on the *outward send itself* — e.g. asking which segment / what tone / what angle to use for the outreach before emailing real contacts — that is legitimate mission-alignment, not a failure. FAIL only if it offers the SOLUTION'S OWN PARTS as the menu — e.g. 'Want me to: 1) draft emails, 2) create tasks, or 3) build an automation?' (or the same as quick-reply chips) — or stops at analysis and hands the assembly of the plan back to the user. The test: a card/question about the *direction of the send* = pass; a card/menu asking *which components of the solution to do* = fail.",
+            "expectedLabel": "pass"
+        }
+    ]
+}

--- a/packages/server/worker/test/lib/chat-eval/fixtures/persona-mission-conveys-range.json
+++ b/packages/server/worker/test/lib/chat-eval/fixtures/persona-mission-conveys-range.json
@@ -1,0 +1,25 @@
+{
+    "id": "persona-mission-conveys-range",
+    "description": "Capability: when asked what it can do, the assistant frames itself as a partner that takes work off the user's plate and conveys real range — it can act now (one-time) AND set up automations that run on their own (and ideally connect apps / use AI). Pins the new identity + 'get unbusy' mission. Judgment-heavy → capability, not a gate.",
+    "kind": "capability",
+    "initialMessages": [],
+    "userTurns": [
+        "What can you actually do for me?"
+    ],
+    "recordedToolCalls": [],
+    "model": {
+        "provider": "openrouter",
+        "modelId": "anthropic/claude-sonnet-4.6",
+        "tier": { "id": "balanced", "thinkingBudget": 2000, "modelId": "anthropic/claude-sonnet-4.6" }
+    },
+    "assertions": [
+        { "type": "neverCutOff" }
+    ],
+    "judge": [
+        {
+            "dimension": "conveys_range",
+            "rubric": "The assistant explains its capabilities in terms of taking manual work off the user's plate, and conveys a broad range: at minimum it makes clear it can both do things right now (a one-time task) AND set up automations that run on their own, and ideally that it connects many apps and/or can use AI. The tone is capable and possibility-oriented ('here's what we can do'), not narrow or hesitant. It does NOT need to list every capability or use any specific wording — covering at least the do-now-vs-automate range in an encouraging, plain-language tone is a PASS. Naming the product/brand is fine. Engineering jargon (fields, triggers, webhooks, APIs, polling, code) would be a FAIL.",
+            "expectedLabel": "pass"
+        }
+    ]
+}

--- a/packages/server/worker/test/lib/chat-eval/fixtures/proactive-no-filler-chips.json
+++ b/packages/server/worker/test/lib/chat-eval/fixtures/proactive-no-filler-chips.json
@@ -1,0 +1,32 @@
+{
+    "id": "proactive-no-filler-chips",
+    "description": "Capability (deterministic, assertion-only): a simple info request gets a plain answer with NO filler quick-reply chips. Guards the other side of proactivity — proactive next-steps only when genuinely relevant, never reflexively. Assertion-only so it adds no LLM-judge calibration risk. Promote to regression once stable across runs.",
+    "kind": "capability",
+    "initialMessages": [],
+    "userTurns": [
+        "list my automations"
+    ],
+    "recordedToolCalls": [
+        {
+            "order": 0,
+            "toolName": "ap_list_across_projects",
+            "output": {
+                "flows": [
+                    { "id": "flow_aa11", "name": "Daily lead sync to HubSpot", "projectId": "eval-project", "status": "ENABLED" },
+                    { "id": "flow_bb22", "name": "Invoice reminder emails", "projectId": "eval-project", "status": "ENABLED" },
+                    { "id": "flow_cc33", "name": "Slack alert on new signups", "projectId": "eval-project", "status": "DISABLED" }
+                ]
+            }
+        }
+    ],
+    "model": {
+        "provider": "openrouter",
+        "modelId": "anthropic/claude-sonnet-4.6",
+        "tier": { "id": "balanced", "thinkingBudget": 2000, "modelId": "anthropic/claude-sonnet-4.6" }
+    },
+    "assertions": [
+        { "type": "neverCutOff" },
+        { "type": "maxQuestionCards", "n": 0 }
+    ],
+    "judge": []
+}

--- a/packages/server/worker/test/lib/chat-eval/fixtures/product-nav-awareness.json
+++ b/packages/server/worker/test/lib/chat-eval/fixtures/product-nav-awareness.json
@@ -1,0 +1,25 @@
+{
+    "id": "product-nav-awareness",
+    "description": "Capability: the assistant knows how the app is laid out and points the user to the right place (managing connected accounts lives under Connections). Pins the <product_model> briefing. Judgment-heavy → capability.",
+    "kind": "capability",
+    "initialMessages": [],
+    "userTurns": [
+        "Where in the app do I manage the accounts I've connected, like my Gmail?"
+    ],
+    "recordedToolCalls": [],
+    "model": {
+        "provider": "openrouter",
+        "modelId": "anthropic/claude-sonnet-4.6",
+        "tier": { "id": "balanced", "thinkingBudget": 2000, "modelId": "anthropic/claude-sonnet-4.6" }
+    },
+    "assertions": [
+        { "type": "neverCutOff" }
+    ],
+    "judge": [
+        {
+            "dimension": "knows_app_layout",
+            "rubric": "The assistant correctly points the user to where connected accounts/integrations are managed — the Connections area/section of the app — in plain language. Naming 'Connections' or clearly describing the connected-accounts area is a PASS. Sending them to an unrelated or invented place, or saying it doesn't know where things are, is a FAIL. Offering to do it for them in addition is fine.",
+            "expectedLabel": "pass"
+        }
+    ]
+}

--- a/packages/server/worker/test/lib/chat-eval/live/README.md
+++ b/packages/server/worker/test/lib/chat-eval/live/README.md
@@ -1,0 +1,50 @@
+# Live failure-mode harness
+
+The replay harness (`../`) runs the agent with **mocked** tools — great for prompt-behavior
+regressions, blind to how the agent actually *uses pieces*. This harness runs the agent
+**live**: real discovery, real property resolution, and (where a connection exists) real
+execution, then tags each conversation with the failure modes the agent struggles with.
+
+It exists to produce the **baseline scorecard** for the harness-improvement work (collapse the
+discovery chain, fix input comprehension, fix loop memory) and to re-measure after each fix.
+
+## How it works
+
+1. Drives the api-key-guarded eval endpoint `POST /v1/chat/eval/turn/start` with
+   `executeTools: true` (added for this harness — dry-run stubs every tool, which hides
+   piece-use behavior), one scenario at a time.
+2. Polls `GET /v1/chat/eval/conversations/:id/state` until the turn settles.
+3. Reduces the persisted `uiMessages` (tool-call parts + action receipts) into a scorecard via
+   the pure `tagger.ts` (no log-file dependency).
+
+## Metrics
+
+Per scenario and aggregated: tool calls, **hops before first execute**, executed/succeeded,
+**gave-up** (expected an execution, none succeeded), **bad-arg rejections** (`❌ Cannot run
+action …`), auth/connection-blocked, **breaker hits** (`✋`), and **schema re-fetches**
+(same `ap_get_piece_props`/`ap_prepare_action` piece+action fetched again = the agent forgot).
+Results are grouped by input **shape** (well-specified / dynamic-dropdown / dynamic-schema /
+opaque-json / implicit-semantics / multi-piece) so you can see which input kinds the harness
+handles vs. fumbles.
+
+## Running
+
+Prerequisites:
+- The dev backend running in **EE** on Postgres, port 3000 (see memory `ee-local-dev-chat`).
+- A chat provider configured in platform admin settings (the OpenRouter key).
+- `AP_API_KEY` set in `.env.dev` (the npm script sources it).
+- For real *execution* (not just discovery), at least one project with connections for the
+  target pieces. With no connection the agent still does real discovery and hits the connection
+  picker — that signal is still captured (auth-blocked, hops, schema-refetches).
+
+```bash
+npm run chat-evals:live                       # all scenarios → results/baseline.{json,md}
+npm run chat-evals:live -- --only=slack-send-message,http-json-post
+npm run chat-evals:live -- --label="after fix1" --out=packages/server/worker/test/lib/chat-eval/live/results/after-fix1
+```
+
+Then diff `results/baseline.md` against the post-fix scorecard. Inspect a specific run end-to-end
+with `npm run chat:logs -- <conversationId>`.
+
+> ⚠️ `executeTools:true` performs **real side effects** against the platform owner's connections
+> (sends messages, creates records). Run it on a dev instance with throwaway/test connections.

--- a/packages/server/worker/test/lib/chat-eval/live/client.ts
+++ b/packages/server/worker/test/lib/chat-eval/live/client.ts
@@ -1,0 +1,84 @@
+import { ChatConversationStatus } from '@activepieces/shared'
+
+const DEFAULT_BASE_URL = 'http://localhost:3000/api'
+const POLL_INTERVAL_MS = 1_500
+const DEFAULT_TURN_TIMEOUT_MS = 20 * 60 * 1_000
+const TIMEOUT_STATUS = 'TIMEOUT'
+
+// Thin client over the api-key-guarded chat eval endpoints. Drives one turn live
+// (executeTools:true → tools run against the owner's real connections) and polls the
+// conversation row until the turn settles, returning the persisted uiMessages.
+function create({ baseUrl, apiKey }: { baseUrl?: string, apiKey: string }): EvalClient {
+    const base = (baseUrl ?? process.env.AP_EVAL_BASE_URL ?? DEFAULT_BASE_URL).replace(/\/$/, '')
+    const headers = { 'api-key': apiKey, 'Content-Type': 'application/json' }
+
+    async function getSandboxPlatformId(): Promise<string> {
+        const res = await fetch(`${base}/v1/chat/eval/sandbox-platform`, { headers })
+        if (!res.ok) {
+            throw new Error(`sandbox-platform failed: ${res.status} ${await res.text()}`)
+        }
+        const body = await res.json() as { platformId: string }
+        return body.platformId
+    }
+
+    async function runTurn({ platformId, userMessage, mode, timeoutMs }: { platformId: string, userMessage: string, mode: RunMode, timeoutMs?: number }): Promise<TurnOutcome> {
+        const startRes = await fetch(`${base}/v1/chat/eval/turn/start`, {
+            method: 'POST',
+            headers,
+            body: JSON.stringify({ platformId, userMessage, ...(mode === 'live' ? { executeTools: true } : { discoveryOnly: true }) }),
+        })
+        if (!startRes.ok) {
+            throw new Error(`turn/start failed: ${startRes.status} ${await startRes.text()}`)
+        }
+        const { conversationId, runId, priorAssistantTurns } = await startRes.json() as { conversationId: string, runId: string, priorAssistantTurns: number }
+        const settled = await pollState({ conversationId, priorAssistantTurns, timeoutMs: timeoutMs ?? DEFAULT_TURN_TIMEOUT_MS })
+        return { conversationId, runId, status: settled.status, uiMessages: settled.uiMessages }
+    }
+
+    async function pollState({ conversationId, priorAssistantTurns, timeoutMs }: { conversationId: string, priorAssistantTurns: number, timeoutMs: number }): Promise<{ status: string, uiMessages: unknown[] }> {
+        const deadline = Date.now() + timeoutMs
+        while (Date.now() < deadline) {
+            await delay(POLL_INTERVAL_MS)
+            const res = await fetch(`${base}/v1/chat/eval/conversations/${conversationId}/state`, { headers })
+            if (!res.ok) continue
+            const body = await res.json() as { status: ChatConversationStatus, uiMessages: unknown[] }
+            const uiMessages = body.uiMessages ?? []
+            if (body.status === ChatConversationStatus.ERROR) {
+                return { status: body.status, uiMessages }
+            }
+            if (body.status === ChatConversationStatus.IDLE && countAssistantTurns(uiMessages) > priorAssistantTurns) {
+                return { status: body.status, uiMessages }
+            }
+        }
+        return { status: TIMEOUT_STATUS, uiMessages: [] }
+    }
+
+    return { getSandboxPlatformId, runTurn }
+}
+
+function countAssistantTurns(uiMessages: unknown[]): number {
+    return uiMessages.filter((m) => typeof m === 'object' && m !== null && 'role' in m && (m as { role: unknown }).role === 'assistant').length
+}
+
+function delay(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+export const evalClient = {
+    create,
+    TIMEOUT_STATUS,
+}
+
+export type TurnOutcome = {
+    conversationId: string
+    runId: string
+    status: string
+    uiMessages: unknown[]
+}
+
+export type RunMode = 'discovery' | 'live'
+
+export type EvalClient = {
+    getSandboxPlatformId: () => Promise<string>
+    runTurn: (params: { platformId: string, userMessage: string, mode: RunMode, timeoutMs?: number }) => Promise<TurnOutcome>
+}

--- a/packages/server/worker/test/lib/chat-eval/live/expertise-from-thrash.ts
+++ b/packages/server/worker/test/lib/chat-eval/live/expertise-from-thrash.ts
@@ -1,0 +1,63 @@
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { repoRoot } from '../core/repo-root'
+import { LiveScorecard, ScenarioScore } from './tagger'
+
+// C3 — close the loop. Read a scorecard the live harness produced and surface the scenarios where the
+// agent thrashed (stuck, repeated empty reads, wrong instrument, many hops). Each becomes a candidate
+// for a curated note in piece-expertise.ts — so a failure the harness catches once becomes mastery the
+// agent keeps. This is the deterministic part; a human (or a follow-up agent) writes the actual note
+// from the suggestion, keeping curation high-quality rather than auto-generated guesswork.
+function candidatesFrom(scorecard: LiveScorecard): ExpertiseCandidate[] {
+    return scorecard.scores
+        .filter(isThrash)
+        .map((s) => ({
+            piece: s.targetPiece ?? '(unknown)',
+            scenarioId: s.scenarioId,
+            reason: reasonFor(s),
+            suggestedNote: suggestNote(s),
+            toolSequence: s.toolSequence,
+        }))
+}
+
+function isThrash(s: ScenarioScore): boolean {
+    return s.outcome === 'stuck' || s.breakerHits > 0 || s.rightInstrument === false || (s.hopsBeforeFirstExecute ?? 0) > 8
+}
+
+function reasonFor(s: ScenarioScore): string {
+    const parts: string[] = []
+    if (s.rightInstrument === false) parts.push('used a find-one action for an enumerate intent')
+    if (s.breakerHits > 0) parts.push(`hit the repeat-breaker ${s.breakerHits}×`)
+    if (s.outcome === 'stuck') parts.push('never reached a runnable call')
+    if ((s.hopsBeforeFirstExecute ?? 0) > 8) parts.push(`${s.hopsBeforeFirstExecute} hops to first action`)
+    if (s.badArgRejections > 0) parts.push(`${s.badArgRejections} bad-arg rejection(s)`)
+    return parts.join('; ') || 'thrash'
+}
+
+function suggestNote(s: ScenarioScore): string {
+    if (s.rightInstrument === false) {
+        return `For ${s.piece ?? 'this piece'}: the enumerate action (list_*/search_*) is the right instrument for "show all" intents; find_* returns a single match.`
+    }
+    if (s.badArgRejections > 0) {
+        return `For ${s.piece ?? 'this piece'}: document the field formats/ids that caused the bad-arg rejections so they're filled right first try.`
+    }
+    return `For ${s.piece ?? 'this piece'}: capture the discovery/auth quirk that caused the thrash so it resolves in one pass next time.`
+}
+
+function loadScorecard(file: string): LiveScorecard {
+    const abs = path.isAbsolute(file) ? file : path.join(repoRoot, file)
+    return JSON.parse(readFileSync(abs, 'utf8')) as LiveScorecard
+}
+
+export const expertiseFromThrash = {
+    candidatesFrom,
+    loadScorecard,
+}
+
+export type ExpertiseCandidate = {
+    piece: string
+    scenarioId: string
+    reason: string
+    suggestedNote: string
+    toolSequence: string[]
+}

--- a/packages/server/worker/test/lib/chat-eval/live/report.ts
+++ b/packages/server/worker/test/lib/chat-eval/live/report.ts
@@ -1,0 +1,92 @@
+import { LiveScorecard, ScenarioScore } from './tagger'
+
+// Render the scorecard as a scannable markdown report: headline metrics, a per-shape
+// breakdown (which input kinds the harness handles vs. fumbles), and a per-scenario table.
+function toMarkdown({ scorecard, label, mode, modelId }: { scorecard: LiveScorecard, label: string, mode: string, modelId: string }): string {
+    const discovery = mode === 'discovery'
+    const succeededLabel = discovery ? 'reached a runnable call' : 'succeeded (goal met)'
+    const gaveUpLabel = discovery ? 'stuck in discovery (never reached a call)' : 'gave up (expected exec, none succeeded)'
+    const lines: string[] = []
+    lines.push(`# Chat harness — failure-mode scorecard (${label})`)
+    lines.push('')
+    lines.push(`Model: \`${modelId}\` · mode: \`${mode}\` · scenarios: ${scorecard.scenarioCount}`)
+    if (discovery) {
+        lines.push('')
+        lines.push('> Discovery-only run: `ap_execute_action` was neutralized (no side effects). "reached a runnable call" = the agent navigated discovery to a well-formed execute; external-API success is not measured here.')
+    }
+    lines.push('')
+    lines.push('## Headline')
+    lines.push('')
+    lines.push('| metric | value |')
+    lines.push('| --- | --- |')
+    lines.push(`| reached/executed a call | ${scorecard.executedCount}/${scorecard.scenarioCount} |`)
+    lines.push(`| ${succeededLabel} | ${scorecard.succeededCount}/${scorecard.scenarioCount} |`)
+    lines.push(`| blocked on a missing connection (not a failure) | ${scorecard.blockedOnConnectionCount} |`)
+    lines.push(`| ${gaveUpLabel} | ${scorecard.gaveUpCount} |`)
+    lines.push(`| avg tool calls / scenario | ${scorecard.avgToolCalls} |`)
+    lines.push(`| avg discovery calls / scenario | ${scorecard.avgDiscoveryCalls} |`)
+    lines.push(`| avg hops before first execute | ${fmt(scorecard.avgHopsBeforeExecute)} |`)
+    lines.push(`| bad-arg rejections (total) | ${scorecard.totalBadArgRejections} |`)
+    lines.push(`| auth/connection blocked (total) | ${scorecard.totalAuthBlocked} |`)
+    lines.push(`| other tool errors (total) | ${scorecard.totalOtherErrors} |`)
+    lines.push(`| breaker hits (✋, total) | ${scorecard.totalBreakerHits} |`)
+    lines.push(`| schema re-fetches "forgot" (total) | ${scorecard.totalSchemaRefetches} |`)
+    lines.push(`| wrong instrument (find vs list) | ${scorecard.wrongInstrumentCount}/${scorecard.rightInstrumentGraded} graded |`)
+    lines.push(`| native task handled (HTTP/code) | ${scorecard.nativeHandledCount}/${scorecard.nativeGraded} graded |`)
+    lines.push('')
+    lines.push('## By input shape')
+    lines.push('')
+    lines.push('| shape | n | succeeded | avg hops | bad-args | breaker | re-fetch |')
+    lines.push('| --- | --- | --- | --- | --- | --- | --- |')
+    for (const [shape, group] of groupByShape(scorecard.scores)) {
+        const execHops = group.filter((s) => s.hopsBeforeFirstExecute !== null)
+        const avgHops = execHops.length > 0 ? round(execHops.reduce((a, s) => a + (s.hopsBeforeFirstExecute ?? 0), 0) / execHops.length) : null
+        lines.push(`| ${shape} | ${group.length} | ${group.filter((s) => s.executeSucceeded).length} | ${fmt(avgHops)} | ${sum(group, (s) => s.badArgRejections)} | ${sum(group, (s) => s.breakerHits)} | ${sum(group, (s) => s.schemaRefetches)} |`)
+    }
+    lines.push('')
+    lines.push('## Per scenario')
+    lines.push('')
+    lines.push('| scenario | shape | calls | hops | ok | bad-arg | auth | ✋ | re-fetch | tool sequence |')
+    lines.push('| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |')
+    for (const s of scorecard.scores) {
+        lines.push(`| ${s.scenarioId} | ${s.shape} | ${s.totalToolCalls} | ${fmt(s.hopsBeforeFirstExecute)} | ${outcomeGlyph(s.outcome)} | ${s.badArgRejections} | ${s.authBlocked} | ${s.breakerHits} | ${s.schemaRefetches} | ${truncate(s.toolSequence.join(' → '), 90)} |`)
+    }
+    lines.push('')
+    return lines.join('\n')
+}
+
+function outcomeGlyph(outcome: string): string {
+    if (outcome === 'did-work') return '✅'
+    if (outcome === 'blocked-connection') return '🔌'
+    return '🚫'
+}
+
+function groupByShape(scores: ScenarioScore[]): Array<[string, ScenarioScore[]]> {
+    const map = new Map<string, ScenarioScore[]>()
+    for (const score of scores) {
+        const group = map.get(score.shape) ?? []
+        group.push(score)
+        map.set(score.shape, group)
+    }
+    return [...map.entries()]
+}
+
+function sum(scores: ScenarioScore[], pick: (s: ScenarioScore) => number): number {
+    return scores.reduce((acc, s) => acc + pick(s), 0)
+}
+
+function round(value: number): number {
+    return Math.round(value * 100) / 100
+}
+
+function fmt(value: number | null): string {
+    return value === null ? 'n/a' : String(value)
+}
+
+function truncate(text: string, max: number): string {
+    return text.length > max ? `${text.slice(0, max)}…` : text
+}
+
+export const liveReport = {
+    toMarkdown,
+}

--- a/packages/server/worker/test/lib/chat-eval/live/run.ts
+++ b/packages/server/worker/test/lib/chat-eval/live/run.ts
@@ -1,0 +1,108 @@
+import { mkdirSync, writeFileSync } from 'node:fs'
+import path from 'node:path'
+import { tryCatch } from '@activepieces/core-utils'
+import chalk from 'chalk'
+import { repoRoot } from '../core/repo-root'
+import { evalClient, RunMode } from './client'
+import { liveReport } from './report'
+import { liveScenarios } from './scenarios'
+import { liveTagger, ScenarioScore } from './tagger'
+
+const RESULTS_DIR = path.join(__dirname, 'results')
+const MODEL_ID = process.env.AP_EVAL_MODEL_ID ?? '(platform default)'
+
+async function main(): Promise<void> {
+    const apiKey = process.env.AP_API_KEY
+    if (!apiKey) {
+        fail('AP_API_KEY is not set. Run via `npm run chat-evals:live` (it sources .env.dev), and ensure the dev backend is running.')
+    }
+
+    const args = parseArgs(process.argv.slice(2))
+    const scenarios = args.only.length > 0 ? liveScenarios.all().filter((s) => args.only.includes(s.id)) : liveScenarios.all()
+    if (scenarios.length === 0) {
+        fail(`No scenarios matched --only=${args.only.join(',')}`)
+    }
+
+    const client = evalClient.create({ apiKey: apiKey as string })
+    const mode: RunMode = args.live ? 'live' : 'discovery'
+    console.log(chalk.dim(`  mode: ${mode}${mode === 'discovery' ? ' (no side effects; execute is neutralized)' : ' (REAL execution against connections)'}`))
+
+    console.log(chalk.dim('  resolving sandbox platform…'))
+    const { data: platformId, error: platformError } = await tryCatch(() => client.getSandboxPlatformId())
+    if (platformError || !platformId) {
+        fail(`Could not reach the dev backend at the eval endpoint. Is it running (EE, port 3000)?\n  ${platformError instanceof Error ? platformError.message : String(platformError)}`)
+    }
+
+    const scores: ScenarioScore[] = []
+    for (const scenario of scenarios) {
+        process.stdout.write(chalk.dim(`  ▶ ${scenario.id} … `))
+        const { data: outcome, error } = await tryCatch(() => client.runTurn({ platformId: platformId as string, userMessage: scenario.prompt, mode }))
+        if (error || !outcome) {
+            console.log(chalk.red(`error (${error instanceof Error ? error.message : String(error)})`))
+            continue
+        }
+        const score = liveTagger.tag({ scenario, uiMessages: outcome.uiMessages })
+        scores.push(score)
+        const reached = mode === 'discovery' ? 'reached call' : 'ok'
+        const verdict = score.outcome === 'did-work' ? chalk.green(reached) : (score.outcome === 'blocked-connection' ? chalk.cyan('needs connection') : chalk.red('stuck'))
+        console.log(`${verdict} ${chalk.dim(`(${score.totalToolCalls} calls, ${fmtHops(score.hopsBeforeFirstExecute)} hops, ${outcome.status})`)}`)
+    }
+
+    const scorecard = liveTagger.aggregate({ scores })
+    const label = args.label ?? `${mode} · ${new Date().toISOString().slice(0, 16).replace('T', ' ')}`
+    writeResults({ scorecard, label, mode, out: args.out })
+    printSummary({ scorecard, mode })
+}
+
+function writeResults({ scorecard, label, mode, out }: { scorecard: ReturnType<typeof liveTagger.aggregate>, label: string, mode: RunMode, out?: string }): void {
+    mkdirSync(RESULTS_DIR, { recursive: true })
+    const base = out ?? path.join(RESULTS_DIR, `baseline-${mode}`)
+    const jsonPath = path.isAbsolute(base) ? `${base}.json` : path.join(repoRoot, `${base}.json`)
+    const mdPath = jsonPath.replace(/\.json$/, '.md')
+    writeFileSync(jsonPath, JSON.stringify({ label, mode, modelId: MODEL_ID, ...scorecard }, null, 2))
+    writeFileSync(mdPath, liveReport.toMarkdown({ scorecard, label, mode, modelId: MODEL_ID }))
+    console.log(chalk.dim(`\n  scorecard → ${path.relative(repoRoot, jsonPath)} (+ .md)`))
+}
+
+function printSummary({ scorecard, mode }: { scorecard: ReturnType<typeof liveTagger.aggregate>, mode: RunMode }): void {
+    const reachedLabel = mode === 'discovery' ? 'reached runnable call' : 'succeeded'
+    console.log('')
+    console.log(chalk.bold('  Summary'))
+    console.log(`    ${reachedLabel}: ${scorecard.succeededCount}/${scorecard.scenarioCount}`)
+    console.log(`    needs connection: ${scorecard.blockedOnConnectionCount} (not a failure)`)
+    console.log(`    stuck/gave up:    ${scorecard.gaveUpCount}`)
+    console.log(`    avg tool calls:   ${scorecard.avgToolCalls}`)
+    console.log(`    avg hops→execute: ${fmtHops(scorecard.avgHopsBeforeExecute)}`)
+    console.log(`    bad-arg / auth:   ${scorecard.totalBadArgRejections} / ${scorecard.totalAuthBlocked}`)
+    console.log(`    breaker / forgot: ${scorecard.totalBreakerHits} / ${scorecard.totalSchemaRefetches}`)
+    console.log(`    wrong instrument: ${scorecard.wrongInstrumentCount}/${scorecard.rightInstrumentGraded} graded`)
+    console.log(`    native handled:   ${scorecard.nativeHandledCount}/${scorecard.nativeGraded} graded`)
+}
+
+function parseArgs(argv: string[]): { only: string[], out?: string, label?: string, live: boolean } {
+    const only: string[] = []
+    let out: string | undefined
+    let label: string | undefined
+    let live = false
+    for (const arg of argv) {
+        if (arg.startsWith('--only=')) only.push(...arg.slice('--only='.length).split(','))
+        else if (arg.startsWith('--out=')) out = arg.slice('--out='.length)
+        else if (arg.startsWith('--label=')) label = arg.slice('--label='.length)
+        else if (arg === '--live') live = true
+    }
+    return { only, out, label, live }
+}
+
+function fmtHops(value: number | null): string {
+    return value === null ? 'n/a' : String(value)
+}
+
+function fail(message: string): never {
+    console.error(chalk.red(`  ${message}`))
+    process.exit(2)
+}
+
+main().catch((error) => {
+    console.error(chalk.red(`  chat-evals:live failed: ${error instanceof Error ? error.message : String(error)}`))
+    process.exit(2)
+})

--- a/packages/server/worker/test/lib/chat-eval/live/scenarios.ts
+++ b/packages/server/worker/test/lib/chat-eval/live/scenarios.ts
@@ -1,0 +1,190 @@
+// Live failure-mode scenarios — real, business-phrased requests that exercise the
+// most common pieces and the input shapes that trip the harness up (dynamic dropdowns,
+// opaque JSON/Object bodies, dynamic table schemas, implicit unit/format semantics).
+//
+// These run against the dev backend with executeTools:true, so they hit real piece
+// metadata and (where a connection exists) real execution. Prompts lead with business
+// intent — never piece/action jargon — matching how a user actually talks to the agent.
+
+const SCENARIOS: LiveScenario[] = [
+    {
+        id: 'slack-send-message',
+        prompt: 'Post a quick "deploy finished ✅" note to our #general Slack channel.',
+        targetPiece: 'slack',
+        shape: 'dynamic-dropdown',
+        expectsExecution: true,
+        note: 'channel is a dynamic dropdown — agent cannot guess the id, must resolve with a live connection',
+    },
+    {
+        id: 'gmail-send',
+        prompt: 'Email ash@activepieces.com with the subject "Q4 numbers" and a one-line body saying the report is ready.',
+        targetPiece: 'gmail',
+        shape: 'well-specified',
+        expectsExecution: true,
+    },
+    {
+        id: 'gsheets-append-row',
+        prompt: 'Add a row to my "Leads" spreadsheet: name Jane Doe, email jane@acme.com, status New.',
+        targetPiece: 'google-sheets',
+        shape: 'dynamic-dropdown',
+        expectsExecution: true,
+        note: 'spreadsheet + sheet are dynamic dropdowns; columns are letter-keyed, not header names',
+    },
+    {
+        id: 'airtable-create-record',
+        prompt: 'Create a new record in my Airtable CRM for the company "Acme Corp" with stage "Prospect".',
+        targetPiece: 'airtable',
+        shape: 'dynamic-schema',
+        expectsExecution: true,
+        note: 'base→table→fields are all dynamic; field types only knowable after a live schema fetch',
+    },
+    {
+        id: 'notion-create-item',
+        prompt: 'Add a task called "Follow up with Acme" to my Notion tasks database, due next Friday.',
+        targetPiece: 'notion',
+        shape: 'dynamic-schema',
+        expectsExecution: true,
+        note: 'database fields are dynamic; date needs ISO, relation fields need page ids',
+    },
+    {
+        id: 'http-json-post',
+        prompt: 'Send a POST request to https://httpbin.org/post with a JSON body {"event":"signup","plan":"pro"} and header X-Source: chat.',
+        targetPiece: 'http',
+        shape: 'opaque-json',
+        expectsExecution: true,
+        note: 'body/headers/queryParams are opaque Object/Json props with no sub-schema',
+    },
+    {
+        id: 'openai-prompt',
+        prompt: 'Use OpenAI to summarise this in one sentence: "Activepieces is an open-source workflow automation platform."',
+        targetPiece: 'openai',
+        shape: 'opaque-json',
+        expectsExecution: true,
+        note: 'roles is a Property.Json with no schema; model is a dynamic dropdown',
+    },
+    {
+        id: 'discord-send',
+        prompt: 'Drop a message in our Discord announcements channel: "Office closed Monday".',
+        targetPiece: 'discord',
+        shape: 'dynamic-dropdown',
+        expectsExecution: true,
+    },
+    {
+        id: 'telegram-send',
+        prompt: 'Send a Telegram message to chat 12345678 saying "Backup completed".',
+        targetPiece: 'telegram-bot',
+        shape: 'well-specified',
+        expectsExecution: true,
+        note: 'reply_markup is JSON with the Telegram keyboard schema',
+    },
+    {
+        id: 'hubspot-create-company',
+        prompt: 'Create a company in HubSpot named "Acme Corp" with domain acme.com in the software industry.',
+        targetPiece: 'hubspot',
+        shape: 'dynamic-schema',
+        expectsExecution: true,
+        note: 'objectProperties are dynamic; property names are API ids (e.g. lifecyclestage)',
+    },
+    {
+        id: 'stripe-payment-intent',
+        prompt: 'Create a Stripe payment intent to charge $42.50 in USD.',
+        targetPiece: 'stripe',
+        shape: 'implicit-semantics',
+        expectsExecution: true,
+        note: 'amount is decimal dollars, silently *100 to cents — classic agent confusion',
+    },
+    {
+        id: 'github-create-issue',
+        prompt: 'Open a GitHub issue titled "Flaky test in chat eval" in my activepieces repo.',
+        targetPiece: 'github',
+        shape: 'dynamic-dropdown',
+        expectsExecution: true,
+    },
+    {
+        id: 'trello-create-card',
+        prompt: 'Add a Trello card "Call the supplier" to my To Do list.',
+        targetPiece: 'trello',
+        shape: 'dynamic-dropdown',
+        expectsExecution: true,
+        note: 'board→list are dependent dynamic dropdowns',
+    },
+    {
+        id: 'gcal-create-event',
+        prompt: 'Put a 30-minute "Sync with Sam" meeting on my calendar tomorrow at 3pm.',
+        targetPiece: 'google-calendar',
+        shape: 'implicit-semantics',
+        expectsExecution: true,
+        note: 'datetime format implicit; calendar is a dynamic dropdown',
+    },
+    {
+        id: 'gdrive-create-folder',
+        prompt: 'Make a new Google Drive folder called "2026 Contracts".',
+        targetPiece: 'google-drive',
+        shape: 'well-specified',
+        expectsExecution: true,
+    },
+    {
+        id: 'multi-step-slack-from-sheet',
+        prompt: 'Grab the email addresses from my "Leads" sheet and Slack me how many there are.',
+        targetPiece: 'google-sheets',
+        shape: 'multi-piece',
+        expectsExecution: true,
+        note: 'two pieces, dependent — read sheet then post to slack; tests context retention across hops',
+    },
+    {
+        id: 'airtable-list-records',
+        prompt: 'Show me all the companies in my Airtable CRM.',
+        targetPiece: 'airtable',
+        shape: 'dynamic-schema',
+        expectsExecution: true,
+        expectEnumerate: true,
+        note: 'enumerate intent — the right instrument is list_records, NOT find_record (the exact Attio thrash, reproduced on a piece)',
+    },
+    {
+        id: 'http-no-piece-api',
+        prompt: 'Get the current Bitcoin price in USD from the CoinGecko public API.',
+        shape: 'native-http',
+        expectsExecution: true,
+        native: 'http',
+        note: 'no piece exists — mastery means reaching the API directly over HTTP',
+    },
+    {
+        id: 'code-transform',
+        prompt: 'Make me a CSV of the numbers 1 through 100 alongside their squares.',
+        shape: 'native-code',
+        expectsExecution: true,
+        native: 'code',
+        note: 'pure transform — mastery means writing and running code, not hunting for a piece',
+    },
+]
+
+export const liveScenarios = {
+    all: (): LiveScenario[] => SCENARIOS,
+    byId: (id: string): LiveScenario | undefined => SCENARIOS.find((s) => s.id === id),
+}
+
+// The input shape the scenario is built to stress — used to group results so we can see
+// which kinds of inputs the harness handles well vs. poorly.
+export type LiveScenarioShape =
+    | 'well-specified'
+    | 'dynamic-dropdown'
+    | 'dynamic-schema'
+    | 'opaque-json'
+    | 'implicit-semantics'
+    | 'multi-piece'
+    | 'native-http'
+    | 'native-code'
+
+export type LiveScenario = {
+    id: string
+    prompt: string
+    targetPiece?: string
+    shape: LiveScenarioShape
+    expectsExecution: boolean
+    // The right instrument is an enumerate action (list_*/search_*), not a find-one — graded as
+    // "wrong instrument" if the agent only reached for find_*/get_* (the Attio thrash signature).
+    expectEnumerate?: boolean
+    // A native-capability task with no piece: mastery = reaching the API over HTTP, or writing code.
+    native?: 'http' | 'code'
+    note?: string
+}

--- a/packages/server/worker/test/lib/chat-eval/live/tagger.test.ts
+++ b/packages/server/worker/test/lib/chat-eval/live/tagger.test.ts
@@ -1,0 +1,161 @@
+import { PersistedChatPartType, PersistedChatRole, PersistedToolCallStatus } from '@activepieces/shared'
+import { describe, expect, it } from 'vitest'
+import { LiveScenario } from './scenarios'
+import { liveTagger } from './tagger'
+
+function scenario(overrides: Partial<LiveScenario> = {}): LiveScenario {
+    return { id: 'test', prompt: 'do a thing', shape: 'well-specified', expectsExecution: true, ...overrides }
+}
+
+function toolCall({ toolName, input = {}, actionName, pieceName, outputText = '', status = PersistedToolCallStatus.COMPLETED }: {
+    toolName: string
+    input?: Record<string, unknown>
+    actionName?: string
+    pieceName?: string
+    outputText?: string
+    status?: PersistedToolCallStatus
+}): Record<string, unknown> {
+    const fullInput = { ...input, ...(actionName ? { actionName } : {}), ...(pieceName ? { pieceName } : {}) }
+    return { type: PersistedChatPartType.TOOL_CALL, toolCallId: toolName, toolName, input: fullInput, status, output: { content: [{ type: 'text', text: outputText }] } }
+}
+
+function assistant(parts: Array<Record<string, unknown>>): Record<string, unknown> {
+    return { role: PersistedChatRole.ASSISTANT, parts }
+}
+
+describe('liveTagger.tag', () => {
+    it('scores a clean discovery→execute success', () => {
+        const uiMessages = [assistant([
+            toolCall({ toolName: 'ap_research_pieces' }),
+            toolCall({ toolName: 'ap_get_piece_props', input: { pieceName: 'gmail', actionOrTriggerName: 'send_email' } }),
+            toolCall({ toolName: 'ap_execute_action', outputText: '✅ Send Email completed' }),
+        ])]
+        const score = liveTagger.tag({ scenario: scenario(), uiMessages })
+
+        expect(score.totalToolCalls).toBe(3)
+        expect(score.discoveryCalls).toBe(2)
+        expect(score.hopsBeforeFirstExecute).toBe(2)
+        expect(score.executed).toBe(true)
+        expect(score.executeSucceeded).toBe(true)
+        expect(score.gaveUp).toBe(false)
+        expect(score.badArgRejections).toBe(0)
+    })
+
+    it('counts schema re-fetches, bad-arg rejections, and the breaker hit', () => {
+        const uiMessages = [assistant([
+            toolCall({ toolName: 'ap_get_piece_props', input: { pieceName: 'slack', actionOrTriggerName: 'send_message' } }),
+            toolCall({ toolName: 'ap_resolve_property_options', input: { propertyName: 'channel' } }),
+            toolCall({ toolName: 'ap_get_piece_props', input: { pieceName: 'slack', actionOrTriggerName: 'send_message' } }),
+            toolCall({ toolName: 'ap_execute_action', outputText: '❌ Cannot run action: missing required field channel', status: PersistedToolCallStatus.ERROR }),
+            toolCall({ toolName: 'ap_execute_action', outputText: '✋ This exact ap_execute_action call already failed 2 times' }),
+        ])]
+        const score = liveTagger.tag({ scenario: scenario({ shape: 'dynamic-dropdown' }), uiMessages })
+
+        expect(score.schemaRefetches).toBe(1)
+        expect(score.badArgRejections).toBe(1)
+        expect(score.breakerHits).toBe(1)
+        expect(score.executeSucceeded).toBe(false)
+        expect(score.gaveUp).toBe(true)
+    })
+
+    it('classifies an auth/connection failure separately from a bad-arg failure', () => {
+        const uiMessages = [assistant([
+            toolCall({ toolName: 'ap_execute_action', outputText: '❌ Action failed: 401 unauthorized — reconnect the connection', status: PersistedToolCallStatus.ERROR }),
+        ])]
+        const score = liveTagger.tag({ scenario: scenario(), uiMessages })
+
+        expect(score.authBlocked).toBe(1)
+        expect(score.badArgRejections).toBe(0)
+    })
+
+    it('marks a turn that ends at the connection picker as blocked, not gave-up', () => {
+        const uiMessages = [assistant([
+            toolCall({ toolName: 'ap_research_pieces' }),
+            toolCall({ toolName: 'ap_get_piece_props', input: { pieceName: 'slack', actionOrTriggerName: 'send_message' } }),
+            toolCall({ toolName: 'ap_show_connection_picker' }),
+        ])]
+        const score = liveTagger.tag({ scenario: scenario({ shape: 'dynamic-dropdown' }), uiMessages })
+        expect(score.outcome).toBe('blocked-connection')
+        expect(score.blockedOnConnection).toBe(true)
+        expect(score.gaveUp).toBe(false)
+        expect(score.executeSucceeded).toBe(false)
+    })
+
+    it('counts built-in ap_send_email and ap_run_code as real work, not stuck', () => {
+        const email = liveTagger.tag({
+            scenario: scenario(),
+            uiMessages: [assistant([toolCall({ toolName: 'ap_send_email', outputText: '✅ Email sent' })])],
+        })
+        expect(email.outcome).toBe('did-work')
+        expect(email.gaveUp).toBe(false)
+
+        const code = liveTagger.tag({
+            scenario: scenario({ shape: 'native-code', native: 'code' }),
+            uiMessages: [assistant([toolCall({ toolName: 'ap_run_code', outputText: '✅ ran' })])],
+        })
+        expect(code.outcome).toBe('did-work')
+    })
+
+    it('flags wrong instrument when an enumerate intent only used a find-one action', () => {
+        const wrong = liveTagger.tag({
+            scenario: scenario({ shape: 'dynamic-schema', expectEnumerate: true }),
+            uiMessages: [assistant([toolCall({ toolName: 'ap_explore_data', actionName: 'find_record', outputText: '✅ done {"found":false,"result":[]}' })])],
+        })
+        expect(wrong.rightInstrument).toBe(false)
+
+        const right = liveTagger.tag({
+            scenario: scenario({ shape: 'dynamic-schema', expectEnumerate: true }),
+            uiMessages: [assistant([toolCall({ toolName: 'ap_explore_data', actionName: 'list_records', outputText: '✅ done' })])],
+        })
+        expect(right.rightInstrument).toBe(true)
+    })
+
+    it('grades native handling: code task via ap_run_code, HTTP task via the http piece', () => {
+        const code = liveTagger.tag({
+            scenario: scenario({ shape: 'native-code', native: 'code' }),
+            uiMessages: [assistant([toolCall({ toolName: 'ap_run_code', outputText: '✅ ran' })])],
+        })
+        expect(code.nativeHandled).toBe(true)
+
+        const http = liveTagger.tag({
+            scenario: scenario({ shape: 'native-http', native: 'http' }),
+            uiMessages: [assistant([toolCall({ toolName: 'ap_execute_action', pieceName: '@activepieces/piece-http', outputText: '✅ ok' })])],
+        })
+        expect(http.nativeHandled).toBe(true)
+
+        const missed = liveTagger.tag({
+            scenario: scenario({ shape: 'native-http', native: 'http' }),
+            uiMessages: [assistant([toolCall({ toolName: 'ap_research_pieces', outputText: 'no piece found' })])],
+        })
+        expect(missed.nativeHandled).toBe(false)
+    })
+
+    it('treats an ACTION_RECEIPT success as goal met even if no execute text is present', () => {
+        const uiMessages = [assistant([
+            toolCall({ toolName: 'ap_execute_action' }),
+            { type: PersistedChatPartType.ACTION_RECEIPT, toolCallId: 'r1', actionDisplayName: 'Send Message', pieceName: 'slack', status: 'success', timestamp: 't' },
+        ])]
+        const score = liveTagger.tag({ scenario: scenario(), uiMessages })
+        expect(score.executeSucceeded).toBe(true)
+        expect(score.gaveUp).toBe(false)
+    })
+})
+
+describe('liveTagger.aggregate', () => {
+    it('rolls per-scenario scores into headline totals', () => {
+        const a = liveTagger.tag({
+            scenario: scenario({ id: 'a' }),
+            uiMessages: [assistant([toolCall({ toolName: 'ap_execute_action', outputText: '✅ done' })])],
+        })
+        const b = liveTagger.tag({
+            scenario: scenario({ id: 'b' }),
+            uiMessages: [assistant([toolCall({ toolName: 'ap_execute_action', outputText: '❌ Cannot run action: missing field', status: PersistedToolCallStatus.ERROR })])],
+        })
+        const card = liveTagger.aggregate({ scores: [a, b] })
+
+        expect(card.scenarioCount).toBe(2)
+        expect(card.succeededCount).toBe(1)
+        expect(card.gaveUpCount).toBe(1)
+        expect(card.totalBadArgRejections).toBe(1)
+    })
+})

--- a/packages/server/worker/test/lib/chat-eval/live/tagger.ts
+++ b/packages/server/worker/test/lib/chat-eval/live/tagger.ts
@@ -1,0 +1,297 @@
+import { chatToolClassification, PersistedChatPartType, PersistedChatRole, PersistedToolCallStatus } from '@activepieces/shared'
+import { LiveScenario } from './scenarios'
+
+const EXECUTE_TOOL = 'ap_execute_action'
+const CODE_TOOL = 'ap_run_code'
+const EMAIL_TOOL = 'ap_send_email'
+const FETCH_TOOL = 'ap_fetch_url'
+// The agent "did the work" via any of these — not just ap_execute_action. The built-in email and
+// code tools are first-class execution paths; counting only ap_execute_action mislabels them.
+const WORK_TOOLS = [EXECUTE_TOOL, EMAIL_TOOL, CODE_TOOL]
+// A turn that ends here (with no work) is correctly blocked awaiting a connection the env lacks —
+// that is NOT "gave up". Without connections, most piece scenarios legitimately end here.
+const CONNECTION_BLOCK_TOOLS = ['ap_show_connection_picker', 'ap_show_connection_required', 'ap_show_mcp_reconnect']
+const SCHEMA_TOOLS = ['ap_get_piece_props', 'ap_prepare_action']
+const DISCOVERY_TOOLS = ['ap_research_pieces', 'ap_get_piece_props', 'ap_prepare_action', 'ap_resolve_property_options', 'ap_resolve_property_chain', 'ap_discover_action_auth', 'ap_explore_data']
+const ACTION_TOOLS = ['ap_execute_action', 'ap_explore_data']
+const BREAKER_MARKER = '✋'
+const AUTH_HINTS = ['connection', 'reconnect', 'authenticat', 'not authorized', 'unauthorized', '401', '403']
+const HTTP_PIECE_HINT = 'piece-http'
+
+// Reduce a conversation's persisted uiMessages into the failure-mode scorecard the plan calls
+// for. Operates purely on the persisted tool-call/receipt parts (toolName, input, output,
+// status) — no log-file dependency, so the same tagger works on a /state response or a
+// recorded transcript.
+function tag({ scenario, uiMessages }: { scenario: LiveScenario, uiMessages: unknown[] }): ScenarioScore {
+    const calls = collectToolCalls(uiMessages)
+    const receiptSuccess = hasSuccessfulReceipt(uiMessages)
+
+    const workIndex = calls.findIndex((c) => WORK_TOOLS.includes(c.toolName))
+    const reachedWork = workIndex >= 0
+    const workSucceeded = receiptSuccess || calls.some((c) => WORK_TOOLS.includes(c.toolName) && isSuccess(c))
+    const blockedOnConnection = !workSucceeded && calls.some((c) => CONNECTION_BLOCK_TOOLS.includes(c.toolName))
+    const outcome: ScenarioOutcome = workSucceeded ? 'did-work' : (blockedOnConnection ? 'blocked-connection' : 'stuck')
+
+    const rejections = calls.filter(isFailure)
+    const badArgRejections = rejections.filter((c) => isBadArgFailure(c)).length
+    const authBlocked = rejections.filter((c) => isAuthFailure(c)).length
+    const otherErrors = rejections.length - badArgRejections - authBlocked
+
+    return {
+        scenarioId: scenario.id,
+        shape: scenario.shape,
+        targetPiece: scenario.targetPiece ?? null,
+        totalToolCalls: calls.length,
+        discoveryCalls: calls.filter((c) => DISCOVERY_TOOLS.includes(c.toolName)).length,
+        hopsBeforeFirstExecute: reachedWork ? workIndex : null,
+        executed: reachedWork,
+        executeSucceeded: workSucceeded,
+        outcome,
+        blockedOnConnection,
+        gaveUp: scenario.expectsExecution && outcome === 'stuck',
+        badArgRejections,
+        authBlocked,
+        otherErrors,
+        breakerHits: calls.filter((c) => c.outputText.includes(BREAKER_MARKER)).length,
+        schemaRefetches: countSchemaRefetches(calls),
+        rightInstrument: gradeRightInstrument({ scenario, calls }),
+        nativeHandled: gradeNativeHandled({ scenario, calls }),
+        toolSequence: calls.map((c) => c.toolName),
+        finalReply: lastAssistantText(uiMessages),
+    }
+}
+
+// Mastery dim 1/2: when the intent is to enumerate, the right instrument is a list_*/search_*
+// action — reaching only for find_*/get_* (which return one match) is the Attio-thrash signature.
+function gradeRightInstrument({ scenario, calls }: { scenario: LiveScenario, calls: ToolCall[] }): boolean | null {
+    if (!scenario.expectEnumerate) return null
+    const actionCalls = calls.filter((c) => ACTION_TOOLS.includes(c.toolName) && c.actionName.length > 0)
+    if (actionCalls.length === 0) return null
+    return actionCalls.some((c) => isEnumerateAction(c.actionName))
+}
+
+// Mastery dim 5: a native task (no piece) is handled by reaching the API over HTTP, or by code.
+function gradeNativeHandled({ scenario, calls }: { scenario: LiveScenario, calls: ToolCall[] }): boolean | null {
+    if (!scenario.native) return null
+    if (scenario.native === 'code') {
+        return calls.some((c) => c.toolName === CODE_TOOL)
+    }
+    return calls.some((c) => c.pieceName.includes(HTTP_PIECE_HINT) || c.toolName === CODE_TOOL || c.toolName === FETCH_TOOL)
+}
+
+function isEnumerateAction(actionName: string): boolean {
+    const name = actionName.toLowerCase()
+    return name.startsWith('list') || name.startsWith('search') || name.includes('_list') || name.includes('list_') || name.includes('search')
+}
+
+function aggregate({ scores }: { scores: ScenarioScore[] }): LiveScorecard {
+    const n = scores.length || 1
+    const executedScores = scores.filter((s) => s.executed)
+    const sum = (pick: (s: ScenarioScore) => number): number => scores.reduce((acc, s) => acc + pick(s), 0)
+    const avg = (pick: (s: ScenarioScore) => number): number => round(sum(pick) / n)
+
+    return {
+        scenarioCount: scores.length,
+        executedCount: executedScores.length,
+        succeededCount: scores.filter((s) => s.executeSucceeded).length,
+        blockedOnConnectionCount: scores.filter((s) => s.outcome === 'blocked-connection').length,
+        gaveUpCount: scores.filter((s) => s.gaveUp).length,
+        avgToolCalls: avg((s) => s.totalToolCalls),
+        avgDiscoveryCalls: avg((s) => s.discoveryCalls),
+        avgHopsBeforeExecute: executedScores.length > 0
+            ? round(executedScores.reduce((acc, s) => acc + (s.hopsBeforeFirstExecute ?? 0), 0) / executedScores.length)
+            : null,
+        totalBadArgRejections: sum((s) => s.badArgRejections),
+        totalAuthBlocked: sum((s) => s.authBlocked),
+        totalOtherErrors: sum((s) => s.otherErrors),
+        totalBreakerHits: sum((s) => s.breakerHits),
+        totalSchemaRefetches: sum((s) => s.schemaRefetches),
+        wrongInstrumentCount: scores.filter((s) => s.rightInstrument === false).length,
+        rightInstrumentGraded: scores.filter((s) => s.rightInstrument !== null).length,
+        nativeHandledCount: scores.filter((s) => s.nativeHandled === true).length,
+        nativeGraded: scores.filter((s) => s.nativeHandled !== null).length,
+        scores,
+    }
+}
+
+function collectToolCalls(uiMessages: unknown[]): ToolCall[] {
+    const calls: ToolCall[] = []
+    for (const message of uiMessages) {
+        if (!isAssistant(message)) continue
+        for (const part of partsOf(message)) {
+            if (asString(part['type']) !== PersistedChatPartType.TOOL_CALL) continue
+            const input = isRecord(part['input']) ? part['input'] : {}
+            calls.push({
+                toolName: asString(part['toolName']) ?? '',
+                input,
+                actionName: asString(input['actionName']) ?? '',
+                pieceName: asString(input['pieceName']) ?? '',
+                outputText: extractText(part['output']),
+                errorText: asString(part['errorText']) ?? '',
+                status: asString(part['status']) ?? '',
+            })
+        }
+    }
+    return calls
+}
+
+function hasSuccessfulReceipt(uiMessages: unknown[]): boolean {
+    for (const message of uiMessages) {
+        if (!isAssistant(message)) continue
+        for (const part of partsOf(message)) {
+            if (asString(part['type']) === PersistedChatPartType.ACTION_RECEIPT && part['status'] === 'success') {
+                return true
+            }
+        }
+    }
+    return false
+}
+
+function countSchemaRefetches(calls: ToolCall[]): number {
+    const seen = new Set<string>()
+    let refetches = 0
+    for (const call of calls) {
+        if (!SCHEMA_TOOLS.includes(call.toolName)) continue
+        const piece = asString(call.input['pieceName']) ?? ''
+        const action = asString(call.input['actionOrTriggerName']) ?? ''
+        const key = `${piece}::${action}`
+        if (seen.has(key)) {
+            refetches++
+        }
+        else {
+            seen.add(key)
+        }
+    }
+    return refetches
+}
+
+function isSuccess(call: ToolCall): boolean {
+    // The loop-breaker returns a plain (non-error) result whose text starts with ✋, which
+    // hasFailureTextPrefix (❌/⏳ only) does not catch — so exclude it explicitly, else a
+    // short-circuited execute would be miscounted as a success.
+    return call.status === PersistedToolCallStatus.COMPLETED
+        && !chatToolClassification.hasFailureTextPrefix(call.outputText)
+        && !call.outputText.includes(BREAKER_MARKER)
+}
+
+function isFailure(call: ToolCall): boolean {
+    return call.status === PersistedToolCallStatus.ERROR || chatToolClassification.hasFailureTextPrefix(call.outputText)
+}
+
+function isAuthFailure(call: ToolCall): boolean {
+    const haystack = `${call.outputText} ${call.errorText}`.toLowerCase()
+    return AUTH_HINTS.some((hint) => haystack.includes(hint))
+}
+
+function isBadArgFailure(call: ToolCall): boolean {
+    if (isAuthFailure(call)) return false
+    const text = `${call.outputText} ${call.errorText}`
+    return text.includes('Cannot run action') || text.includes('Unknown') || text.includes('not allowed') || text.includes('missing')
+}
+
+function lastAssistantText(uiMessages: unknown[]): string {
+    let text = ''
+    for (const message of uiMessages) {
+        if (!isAssistant(message)) continue
+        for (const part of partsOf(message)) {
+            if (asString(part['type']) === PersistedChatPartType.TEXT) {
+                text = asString(part['text']) ?? text
+            }
+        }
+    }
+    return text
+}
+
+function extractText(output: unknown): string {
+    if (typeof output === 'string') return output
+    if (!isRecord(output)) return ''
+    if (typeof output['text'] === 'string') return output['text']
+    if (Array.isArray(output['content'])) {
+        return output['content'].map((p) => isRecord(p) && typeof p['text'] === 'string' ? p['text'] : '').join(' ')
+    }
+    if (output['value'] !== undefined) return extractText(output['value'])
+    return ''
+}
+
+function isAssistant(message: unknown): message is Record<string, unknown> {
+    return isRecord(message) && message['role'] === PersistedChatRole.ASSISTANT
+}
+
+function partsOf(message: Record<string, unknown>): Array<Record<string, unknown>> {
+    const parts = message['parts']
+    if (!Array.isArray(parts)) return []
+    return parts.filter(isRecord)
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function asString(value: unknown): string | undefined {
+    return typeof value === 'string' ? value : undefined
+}
+
+function round(value: number): number {
+    return Math.round(value * 100) / 100
+}
+
+export const liveTagger = {
+    tag,
+    aggregate,
+}
+
+export type ScenarioOutcome = 'did-work' | 'blocked-connection' | 'stuck'
+
+type ToolCall = {
+    toolName: string
+    input: Record<string, unknown>
+    actionName: string
+    pieceName: string
+    outputText: string
+    errorText: string
+    status: string
+}
+
+export type ScenarioScore = {
+    scenarioId: string
+    shape: string
+    targetPiece: string | null
+    totalToolCalls: number
+    discoveryCalls: number
+    hopsBeforeFirstExecute: number | null
+    executed: boolean
+    executeSucceeded: boolean
+    outcome: ScenarioOutcome
+    blockedOnConnection: boolean
+    gaveUp: boolean
+    badArgRejections: number
+    authBlocked: number
+    otherErrors: number
+    breakerHits: number
+    schemaRefetches: number
+    rightInstrument: boolean | null
+    nativeHandled: boolean | null
+    toolSequence: string[]
+    finalReply: string
+}
+
+export type LiveScorecard = {
+    scenarioCount: number
+    executedCount: number
+    succeededCount: number
+    blockedOnConnectionCount: number
+    gaveUpCount: number
+    avgToolCalls: number
+    avgDiscoveryCalls: number
+    avgHopsBeforeExecute: number | null
+    totalBadArgRejections: number
+    totalAuthBlocked: number
+    totalOtherErrors: number
+    totalBreakerHits: number
+    totalSchemaRefetches: number
+    wrongInstrumentCount: number
+    rightInstrumentGraded: number
+    nativeHandledCount: number
+    nativeGraded: number
+    scores: ScenarioScore[]
+}

--- a/scripts/chat-logs.mjs
+++ b/scripts/chat-logs.mjs
@@ -1,0 +1,67 @@
+#!/usr/bin/env node
+// Reconstruct a chat run end-to-end from the local evlog filesystem drain.
+//
+// Usage:
+//   node scripts/chat-logs.mjs <conversationId> [runId]
+//   npm run chat:logs -- <conversationId> [runId]
+//
+// Reads .evlog/logs/*.jsonl (written when LOG_FILE=true / AP_LOG_FILE=true),
+// merges api + worker + web (source:"client") events for the conversation,
+// sorts by timestamp, and prints a unified timeline.
+
+import { readdirSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+const [, , conversationId, runId] = process.argv
+
+if (!conversationId) {
+    console.error('Usage: node scripts/chat-logs.mjs <conversationId> [runId]')
+    process.exit(1)
+}
+
+const logsDir = join(process.cwd(), '.evlog', 'logs')
+
+let files = []
+try {
+    files = readdirSync(logsDir).filter((f) => f.endsWith('.jsonl'))
+}
+catch {
+    console.error(`No logs found at ${logsDir}. Run with LOG_FILE=true / AP_LOG_FILE=true and trigger a chat turn first.`)
+    process.exit(1)
+}
+
+const events = []
+for (const file of files) {
+    const content = readFileSync(join(logsDir, file), 'utf8')
+    for (const line of content.split('\n')) {
+        if (line.trim().length === 0) continue
+        let event
+        try {
+            event = JSON.parse(line)
+        }
+        catch {
+            continue
+        }
+        if (event?.conversation?.id !== conversationId) continue
+        if (runId && event?.run?.id !== runId) continue
+        events.push(event)
+    }
+}
+
+events.sort((a, b) => String(a.timestamp).localeCompare(String(b.timestamp)))
+
+const RESERVED = new Set(['timestamp', 'level', 'service', 'source', 'msg', 'conversation', 'run'])
+
+for (const event of events) {
+    const ts = event.timestamp ?? ''
+    const level = String(event.level ?? 'info').toUpperCase().padEnd(5)
+    const service = (event.source === 'client' ? 'web' : (event.service ?? 'unknown')).replace('activepieces-', '')
+    const rest = {}
+    for (const [key, value] of Object.entries(event)) {
+        if (!RESERVED.has(key)) rest[key] = value
+    }
+    const extra = Object.keys(rest).length > 0 ? ` ${JSON.stringify(rest)}` : ''
+    console.log(`${ts} [${service.padEnd(7)}] ${level} ${event.msg ?? ''}${extra}`)
+}
+
+console.error(`\n${events.length} events for conversation ${conversationId}${runId ? ` run ${runId}` : ''}`)


### PR DESCRIPTION
## TL;DR
The eval-harness slice of #13906 — **worker tests only**. Stacked on the chat-runtime code PR (#13920), because the harness exercises that code.

> Base is `chat-core`; once #13920 merges to `main`, this auto-retargets to `main`.

## What changes
- Live + offline eval **runner**, scenario **fixtures**, and a **tagger** that scores chat-agent behavior (intent interpretation, no-count-leak, proactive non-filler, etc.).
- `scripts/chat-logs.mjs` dev helper for reconstructing a chat run from logs.

## Verification
- Tagger unit tests pass (`worker/test/lib/chat-eval`).
- No production code in this PR; build unaffected.