### PR TITLE
docs(pieces): fix token refresh buffer description and polish style

### DIFF
--- a/.agents/skills/piece-builder/auth-patterns.md
+++ b/.agents/skills/piece-builder/auth-patterns.md
@@ -184,7 +184,7 @@ Inside `validate`, the callback receives the flat shape — `auth.base_url`, `au
 
 Use this when the API requires a login call to get a short-lived token (e.g. username/password → JWT). Without caching, every action triggers a login request and can cause **429 rate limit errors**.
 
-Add a `refresh` field to cache the token server-side. Activepieces renews it automatically 15 minutes before expiry.
+Add a `refresh` field to cache the token server-side. Activepieces renews it automatically up to 15 minutes before expiry (clamped to half the token lifetime for short-lived tokens).
 
 ```typescript
 export const myAppAuth = PieceAuth.CustomAuth({

--- a/docs/build-pieces/piece-reference/authentication.mdx
+++ b/docs/build-pieces/piece-reference/authentication.mdx
@@ -113,9 +113,11 @@ PieceAuth.CustomAuth({
 
 #### Token Refresh (Server-Side Caching)
 
-Some APIs require exchanging credentials for a short-lived token on every request (e.g. username/password → JWT). Without caching, this causes a login call before each action and can trigger **429 rate limit errors** from the third-party API.
+Some APIs require a login call to exchange credentials for a short-lived token. Without caching, this login happens before every action and can trigger **429 rate limit errors** from the third-party API.
 
 Add an optional `refresh` callback to have Activepieces fetch the token once, cache it server-side, and inject it into every action/trigger as `context.auth.access_token`. The token is automatically renewed up to 15 minutes before it expires (clamped to half the token lifetime for short-lived tokens).
+
+**Example:**
 
 ```typescript
 PieceAuth.CustomAuth({
@@ -135,7 +137,8 @@ PieceAuth.CustomAuth({
         }),
     },
     validate: async ({ auth }) => {
-        // validate credentials as usual
+        // validate credentials here and return { valid: true } or { valid: false, error: '...' }
+        return { valid: true }
     },
     // Optional: cache the token server-side to avoid a login call per action
     refresh: {
@@ -157,11 +160,11 @@ PieceAuth.CustomAuth({
 })
 ```
 
-**Inside actions/triggers**, read the cached token from `context.auth.access_token`:
+Inside actions and triggers, read the cached token from `context.auth.access_token`:
 
 ```typescript
 async run(context) {
-    const token = context.auth.access_token; // cached by the server
+    const token = context.auth.access_token; // injected by the server after refresh
     const baseUrl = context.auth.props.baseUrl;
 
     await httpClient.sendRequest({

--- a/docs/build-pieces/piece-reference/authentication.mdx
+++ b/docs/build-pieces/piece-reference/authentication.mdx
@@ -115,7 +115,7 @@ PieceAuth.CustomAuth({
 
 Some APIs require exchanging credentials for a short-lived token on every request (e.g. username/password → JWT). Without caching, this causes a login call before each action and can trigger **429 rate limit errors** from the third-party API.
 
-Add an optional `refresh` callback to have Activepieces fetch the token once, cache it server-side, and inject it into every action/trigger as `context.auth.access_token`. The token is automatically renewed 15 minutes before it expires.
+Add an optional `refresh` callback to have Activepieces fetch the token once, cache it server-side, and inject it into every action/trigger as `context.auth.access_token`. The token is automatically renewed up to 15 minutes before it expires (clamped to half the token lifetime for short-lived tokens).
 
 ```typescript
 PieceAuth.CustomAuth({


### PR DESCRIPTION
## Summary

- Corrects the claim that the custom-auth refresh buffer is always 15 minutes — the actual server logic clamps it to `min(15 min, expiresIn / 2)` so short-lived tokens aren't refreshed on every call
- Updates the same wording in the piece-builder agent skill reference
- Polishes the Token Refresh section in the user-facing auth docs to match the style of surrounding sections (adds `**Example:**` label, removes arrow symbol, fixes incomplete `validate` stub, converts bold label to plain prose)

## Files changed

- `docs/build-pieces/piece-reference/authentication.mdx` — user-facing piece auth docs
- `.agents/skills/piece-builder/auth-patterns.md` — agent skill reference for piece builders

## Test plan

- [ ] Verify the Token Refresh section renders correctly in the docs site
- [ ] Confirm no other occurrences of the incorrect "15 minutes" claim remain (only the framework JSDoc and agent feature file, which were already accurate)