### PR TITLE
fix(worker): recreate the sandbox runtime on reconnect to stop BullMQ stalls

### DIFF
--- a/.agents/features/workers.md
+++ b/.agents/features/workers.md
@@ -27,10 +27,10 @@ Workers are separate Node processes that poll the app for jobs and execute flows
 
 ## Connection & Poll Flow
 1. Worker connects → emits `FETCH_WORKER_SETTINGS`; app's `machineService.onConnection` returns `WorkerSettingsResponse` (incl. `APP_VERSION`) and registers `createHandlers` for the socket.
-2. Worker caches settings and spawns `concurrency` `pollAndExecute` loops.
+2. Worker caches settings, **shuts down any old `Runtime` (fire-and-forget) and creates a fresh one**, then spawns `concurrency` `pollAndExecute` loops. Recreating per (re)connect means an in-flight job from a prior connection is killed with its box (it fails fast and BullMQ retries it) rather than lingering on a reused box — reusing a busy box let the new generation collide on the single-operation engine child and let the lingering job's lock lapse → BullMQ `Job stalled`.
 3. Each loop calls `apiClient.poll(machineInfo)`; the app's `poll` handler returns the next job for the worker's queue, or `null`.
 4. On job: worker executes in a sandbox, periodically `extendLock`, then `completeJob`.
-5. On disconnect, `connectionGeneration++` stops the loops; Socket.IO auto-reconnects and the cycle repeats.
+5. On disconnect, `connectionGeneration++` stops the loops; Socket.IO auto-reconnects (incl. a manual reconnect on `io server disconnect`, e.g. an app restart during a deploy) and the cycle repeats — recreating the runtime as in step 2.
 
 > **Payload resolution is engine-side, not worker-side.** Jobs carry a `JobPayload` (`inline` value or `ref` `fileId`). The worker forwards it unchanged into the engine operation; the engine hydrates a `ref` via the file-download path (direct bytes or an S3 signed-link redirect). There is no worker→API payload-fetch RPC — the contract exposes no `getPayloadFile`.
 

--- a/packages/server/worker/src/lib/worker.ts
+++ b/packages/server/worker/src/lib/worker.ts
@@ -122,19 +122,35 @@ async function startPollingWorkers(apiClient: WorkerToApiContract): Promise<void
     if (!Number.isInteger(rawConcurrency) || rawConcurrency < 1) {
         logger.warn({ rawConcurrency }, 'Invalid AP_WORKER_CONCURRENCY value, falling back to 1')
     }
-    // Reuse the runtime across reconnects instead of shutting it down and recreating it: the old
-    // shutdown-before-recreate path deadlocked when a prior-generation job was still in-flight on
-    // that runtime (e.g. a long chat turn) — the await never resolved, polling never restarted, and
-    // the worker silently stopped consuming jobs after any transient Socket.IO disconnect.
-    const activeRuntime = runtime ?? createSandboxRuntime({
+    // Shut down the old runtime and bring up a fresh one on every (re)connect — a prior connection's
+    // in-flight job is killed along with its box, so it fails fast and BullMQ retries it as a new attempt
+    // instead of lingering on a reused box. Reusing the box made the next generation's poll loop run a
+    // second operation on the same single-operation engine child (acquire() hands back a busy sandbox)
+    // and let the lingering job's lock lapse during the reconnect → BullMQ marks it "stalled"; a deploy
+    // disconnects every worker at once, so reuse turned that into mass stalls.
+    if (runtime) {
+        logger.info('Shutting down old runtime before creating a new one')
+        const oldRuntime = runtime
+        runtime = null
+        // Fire-and-forget: awaiting the shutdown here is what deadlocked when a prior job was still
+        // in-flight (the await never resolved, polling never restarted, the worker silently stopped
+        // consuming jobs after any transient disconnect). The kill itself still happens.
+        void tryCatch(() => oldRuntime.shutdown(logger)).then(({ error }) => {
+            if (error) {
+                logger.error({ error }, 'Failed to shut down old runtime on reconnect')
+            }
+        })
+    }
+
+    runtime = createSandboxRuntime({
         concurrency,
         basePath: sandboxConfig.getCacheBasePath(),
         getSettings: () => sandboxConfig.getSandboxSettings(),
     })
-    runtime = activeRuntime
 
     logger.info({ concurrency }, 'Starting poll loops')
 
+    const activeRuntime = runtime
     await Promise.all(Array.from({ length: concurrency }, (_, workerIndex) =>
         pollAndExecute(apiClient, activeRuntime, workerIndex, generation),
     ))

--- a/packages/server/worker/test/lib/worker.test.ts
+++ b/packages/server/worker/test/lib/worker.test.ts
@@ -1,6 +1,6 @@
 import { createServer } from 'node:http'
 import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest'
-import { Server as IOServer } from 'socket.io'
+import { Server as IOServer, Socket } from 'socket.io'
 import {
     createRpcServer,
     PackageType,
@@ -49,6 +49,27 @@ vi.mock('../../src/lib/config/logger', () => ({
             debug: vi.fn(),
         }),
     },
+}))
+
+type StubRuntime = {
+    execute: ReturnType<typeof vi.fn>
+    getActiveExecutors: ReturnType<typeof vi.fn>
+    shutdown: ReturnType<typeof vi.fn>
+}
+
+const createdRuntimes: StubRuntime[] = []
+
+vi.mock('@activepieces/sandbox', () => ({
+    createResolver: vi.fn(() => ({})),
+    createSandboxRuntime: vi.fn(() => {
+        const rt: StubRuntime = {
+            execute: vi.fn(),
+            getActiveExecutors: vi.fn(() => []),
+            shutdown: vi.fn().mockResolvedValue(undefined),
+        }
+        createdRuntimes.push(rt)
+        return rt
+    }),
 }))
 
 import { worker } from '../../src/lib/worker'
@@ -103,6 +124,7 @@ describe('worker integration', () => {
         // poll loop. Pin concurrency to 1 so the multi-box transitional default (5) doesn't drain
         // the queued poll sequence out of order. See ADR 0004.
         process.env.AP_WORKER_CONCURRENCY = '1'
+        createdRuntimes.length = 0
     })
 
     afterEach(async () => {
@@ -476,6 +498,88 @@ describe('worker integration', () => {
             expect(completeJobCalls[2].jobId).toBe('valid-2')
             expect(completeJobCalls[2].status).toBe(EngineResponseStatus.OK)
             expect(mockGetHandler).toHaveBeenCalledTimes(2)
+        }, 15_000)
+    })
+
+    describe('runtime lifecycle on reconnect', () => {
+        async function waitFor(predicate: () => boolean, timeoutMs = 5_000): Promise<void> {
+            const start = Date.now()
+            while (!predicate()) {
+                if (Date.now() - start > timeoutMs) {
+                    throw new Error('waitFor timed out')
+                }
+                await new Promise<void>((resolve) => setTimeout(resolve, 20))
+            }
+        }
+
+        function acceptConnections(serverSockets: Socket[]): void {
+            ioServer.on('connection', (serverSocket) => {
+                serverSocket.on(WebsocketServerEvent.FETCH_WORKER_SETTINGS, (...args: unknown[]) => {
+                    const callback = args[args.length - 1]
+                    if (typeof callback === 'function') {
+                        callback({
+                            PUBLIC_URL: 'http://localhost:3000',
+                            ENVIRONMENT: 'test',
+                            EXECUTION_MODE: 'SANDBOX_CODE_AND_PROCESS',
+                            TRIGGER_TIMEOUT_SECONDS: 60,
+                            TRIGGER_HOOKS_TIMEOUT_SECONDS: 60,
+                            PAUSED_FLOW_TIMEOUT_DAYS: 30,
+                            FLOW_TIMEOUT_SECONDS: 600,
+                            LOG_LEVEL: 'info',
+                            LOG_PRETTY: 'false',
+                            APP_WEBHOOK_SECRETS: '{}',
+                            MAX_FLOW_RUN_LOG_SIZE_MB: 10,
+                            MAX_FILE_SIZE_MB: 10,
+                            SANDBOX_MEMORY_LIMIT: '1024',
+                            SANDBOX_PROPAGATED_ENV_VARS: [],
+                            DEV_PIECES: [],
+                            OTEL_ENABLED: false,
+                            FILE_STORAGE_LOCATION: '/tmp',
+                            S3_USE_SIGNED_URLS: 'false',
+                            EVENT_DESTINATION_TIMEOUT_SECONDS: 30,
+                            EDITION: 'community',
+                        })
+                    }
+                })
+                // Park the worker idle: never ack poll so it neither hot-loops nor consumes jobs.
+                createRpcServer<WorkerToApiContract>(serverSocket, {
+                    poll: vi.fn(() => new Promise(() => {})),
+                    completeJob: vi.fn(),
+                    updateRunProgress: vi.fn(),
+                    uploadRunLog: vi.fn(),
+                    sendFlowResponse: vi.fn(),
+                    updateStepProgress: vi.fn(),
+                    submitPayloads: vi.fn(),
+                    savePayloads: vi.fn(),
+                    getFlowVersion: vi.fn(),
+                    getPiece: vi.fn(),
+                    getPieceArchive: vi.fn(),
+                    extendLock: vi.fn(),
+                    disableFlow: vi.fn(),
+                } as unknown as WorkerToApiContract)
+                serverSockets.push(serverSocket)
+            })
+        }
+
+        it('shuts down the old runtime and brings up a fresh one when the server drops the connection', async () => {
+            const serverSockets: Socket[] = []
+            acceptConnections(serverSockets)
+
+            worker.start({
+                apiUrl: `http://127.0.0.1:${port}/api/`,
+                socketUrl: { url: `http://127.0.0.1:${port}`, path: '/api/socket.io' },
+                workerToken: 'test-token',
+            })
+
+            await waitFor(() => createdRuntimes.length === 1)
+
+            // Simulate the API restarting during a deploy: the server drops the socket, which the client
+            // sees as 'io server disconnect' and reconnects to. The reconnect must tear down the old
+            // runtime (killing any in-flight box) and build a fresh one — not reuse the old box.
+            serverSockets[0].disconnect(true)
+
+            await waitFor(() => createdRuntimes.length === 2)
+            expect(createdRuntimes[0].shutdown).toHaveBeenCalledTimes(1)
         }, 15_000)
     })
 


### PR DESCRIPTION
## Problem

After releasing to canary from `main`, many flows showed BullMQ **`Job stalled`** (logged in `job-broker.ts`). This did **not** happen on `deploy/cloud/2026-06-25`.

The BullMQ polling/broker logic is unchanged. The regression is the worker's runtime lifecycle on reconnect:

- **#13909** "worker is the sandbox now" — the engine runs in reused in-process boxes (one per `workerIndex`).
- **#13933** "chat runtime — reliability" changed the worker to **reuse the runtime across Socket.IO reconnects** instead of the previous shut-down-and-recreate, and added **auto-reconnect on `io server disconnect`**.

### Mechanism (mass stalls on every deploy)

1. A deploy rolls the API → **every worker** gets `io server disconnect` at once → reconnects → a **new generation of poll loops starts on the SAME reused boxes** while the prior generation's job is still in-flight.
2. The new loop dequeues a fresh BullMQ job and calls `runtime.execute({workerIndex})` → `manager.acquire()`.
3. `createSandboxManager.acquire()` only checks `isReady()`, **not `isBusy()`**, so in reuse mode (cloud `SANDBOX_CODE_ONLY`) it returns the **same sandbox mid-execution** → a second operation hits the engine child already running the first; meanwhile the lingering job's `extendLock` can't ack through the API restart → its lock lapses → BullMQ marks it stalled and re-dispatches. All workers hit it together → **mass stalls**.

## Fix

Restore the original lifecycle: on every (re)connect, **shut down the old runtime and bring up a fresh one** (`worker.ts` `startPollingWorkers`). A prior connection's in-flight job is killed along with its box — it fails fast and BullMQ retries it as a new attempt — instead of lingering on a reused box that the next generation collides with.

The one deviation from the literal original code: the shutdown is **fire-and-forget**. Awaiting it is exactly what deadlocked when a prior job was still in-flight (the await never resolved, polling never restarted, the worker silently stopped consuming jobs after any transient disconnect) — which is why #13933 switched to reuse. The kill still happens; only the `await` is dropped.

## Tests

`packages/server/worker/test/lib/worker.test.ts` → **`runtime lifecycle on reconnect`**: drives a server-side disconnect and asserts the old runtime is shut down and a fresh one is created. Verified it **fails under the reused-runtime behavior** and passes with the fix. Full worker suite: 20/20 pass; `turbo run lint --filter=worker` → 0 errors.

> Note: the pre-push unit gate currently fails on an unrelated pre-existing test (`packages/web/.../chat/lib/quick-replies.test.ts`); this PR only touches `packages/server/worker`.