### PR TITLE
perf(flow-run): zero-DB sync webhook dispatch (thread platformId into sendWorkerEvent)

### DIFF
--- a/.agents/features/flow-runs.md
+++ b/.agents/features/flow-runs.md
@@ -95,6 +95,7 @@ Flow Runs records every execution of a flow, tracking its full lifecycle from qu
 - `onStart()` → emit FLOW_RUN_STARTED application event
 - `onResume()` → emit FLOW_RUN_RESUMED
 - `onFinish()` → emit FLOW_RUN_FINISHED (terminal states only), notify via WebSocket, and (paid editions only) fire AI usage billing tracking (see AI Usage Billing below)
+- Each emitter takes `{ flowRun, platformId }` and passes `platformId` straight to `applicationEvents.sendWorkerEvent` — the caller already holds it, so the synchronous webhook dispatch path (`handleSync → start → onStart`) stays free of any `getPlatformId` DB lookup. The async runs-metadata worker that fires `onFinish` resolves `platformId` itself, off the hot path.
 - On run start, project telemetry (`telemetry().trackProject(...)`) is fire-and-forget via `rejectedPromiseHandler` (`helper/promise-handler`); failures are logged and never block the run
 
 ### AI Usage Billing

--- a/packages/server/api/src/app/flows/flow-run/flow-run-service.ts
+++ b/packages/server/api/src/app/flows/flow-run/flow-run-service.ts
@@ -148,7 +148,7 @@ export const flowRunService = (log: FastifyBaseLogger) => ({
                 })
                 const updatedFlowRun = await findFlowRunOrThrow(oldFlowRun.id)
                 const platformId = await projectService(log).getPlatformId(updatedFlowRun.projectId)
-                await flowRunSideEffects(log).onRetry(updatedFlowRun)
+                await flowRunSideEffects(log).onRetry({ flowRun: updatedFlowRun, platformId })
                 if (triggerFailed) {
                     return addToQueue({
                         flowRun: updatedFlowRun,
@@ -302,7 +302,7 @@ export const flowRunService = (log: FastifyBaseLogger) => ({
             streamStepProgress,
         }, log)
 
-        await flowRunSideEffects(log).onStart(newFlowRun)
+        await flowRunSideEffects(log).onStart({ flowRun: newFlowRun, platformId })
         log.info({ flowRun: { id: newFlowRun.id }, flow: { id: flowId }, project: { id: projectId }, executionType }, 'Flow run started')
         return newFlowRun
     },

--- a/packages/server/api/src/app/flows/flow-run/flow-run-side-effects.ts
+++ b/packages/server/api/src/app/flows/flow-run/flow-run-side-effects.ts
@@ -1,6 +1,7 @@
 import { ApplicationEventName,
     FlowRun,
     isFlowRunStateTerminal,
+    PlatformId,
 } from '@activepieces/shared'
 import { FastifyBaseLogger } from 'fastify'
 import { applicationEvents } from '../../helper/application-events'
@@ -8,7 +9,7 @@ import { flowRunHooks } from './flow-run-hooks'
 import { waitpointService } from './waitpoint/waitpoint-service'
 
 export const flowRunSideEffects = (log: FastifyBaseLogger) => ({
-    async onFinish(flowRun: FlowRun): Promise<void> {
+    async onFinish({ flowRun, platformId }: FlowRunSideEffectParams): Promise<void> {
         if (!isFlowRunStateTerminal({
             status: flowRun.status,
             ignoreInternalError: true,
@@ -17,32 +18,39 @@ export const flowRunSideEffects = (log: FastifyBaseLogger) => ({
         }
         await waitpointService(log).deleteByFlowRunId(flowRun.id)
         await flowRunHooks(log).onFinish(flowRun)
-        applicationEvents(log).sendWorkerEvent(flowRun.projectId, {
+        applicationEvents(log).sendWorkerEvent({
+            projectId: flowRun.projectId,
+            platformId,
             action: ApplicationEventName.FLOW_RUN_FINISHED,
             data: {
                 flowRun,
             },
         })
     },
-    async onResume(flowRun: FlowRun): Promise<void> {
-        applicationEvents(log).sendWorkerEvent(flowRun.projectId, {
+    async onResume({ flowRun, platformId }: FlowRunSideEffectParams): Promise<void> {
+        applicationEvents(log).sendWorkerEvent({
+            projectId: flowRun.projectId,
+            platformId,
             action: ApplicationEventName.FLOW_RUN_RESUMED,
             data: {
                 flowRun,
             },
         })
     },
-    async onRetry(flowRun: FlowRun): Promise<void> {
-        applicationEvents(log).sendWorkerEvent(flowRun.projectId, {
+    async onRetry({ flowRun, platformId }: FlowRunSideEffectParams): Promise<void> {
+        applicationEvents(log).sendWorkerEvent({
+            projectId: flowRun.projectId,
+            platformId,
             action: ApplicationEventName.FLOW_RUN_RETRIED,
             data: {
                 flowRun,
             },
         })
     },
-    async onStart(flowRun: FlowRun): Promise<void> {
-       
-        applicationEvents(log).sendWorkerEvent(flowRun.projectId, {
+    async onStart({ flowRun, platformId }: FlowRunSideEffectParams): Promise<void> {
+        applicationEvents(log).sendWorkerEvent({
+            projectId: flowRun.projectId,
+            platformId,
             action: ApplicationEventName.FLOW_RUN_STARTED,
             data: {
                 flowRun,
@@ -51,3 +59,7 @@ export const flowRunSideEffects = (log: FastifyBaseLogger) => ({
     },
 })
 
+type FlowRunSideEffectParams = {
+    flowRun: FlowRun
+    platformId: PlatformId
+}

--- a/packages/server/api/src/app/flows/flow-run/flow-runs-queue.ts
+++ b/packages/server/api/src/app/flows/flow-run/flow-runs-queue.ts
@@ -7,6 +7,7 @@ import { domainHelper } from '../../helper/domain-helper'
 import { exceptionHandler } from '../../helper/exception-handler'
 import { system } from '../../helper/system/system'
 import { AppSystemProp } from '../../helper/system/system-props'
+import { projectService } from '../../project/project-service'
 import { QueueName, redisMetadataKey, RunsMetadataJobData, RunsMetadataQueueConfig, runsMetadataQueueFactory, RunsMetadataUpsertData } from '../../workers/job'
 import { flowService } from '../flow/flow.service'
 import { flowRunRepo } from './flow-run-service'
@@ -109,7 +110,8 @@ export const runsMetadataQueue = (log: FastifyBaseLogger) => ({
                                 await distributedStore.deleteKeyIfFieldValueMatches(key, 'requestId', runMetadata.requestId)
                             }
                             if (!isNil(runMetadata.finishTime)) {
-                                await flowRunSideEffects(log).onFinish(savedFlowRun)
+                                const platformId = await projectService(log).getPlatformId(savedFlowRun.projectId)
+                                await flowRunSideEffects(log).onFinish({ flowRun: savedFlowRun, platformId })
                             }
 
                             if (savedFlowRun.status === FlowRunStatus.PAUSED) {

--- a/packages/server/api/src/app/flows/flow-run/waitpoint/resume-service.ts
+++ b/packages/server/api/src/app/flows/flow-run/waitpoint/resume-service.ts
@@ -113,7 +113,7 @@ async function enqueueResume(params: EnqueueResumeParams, log: FastifyBaseLogger
         executionType: ExecutionType.RESUME,
         resumeReason: ResumeReason.WAITPOINT,
     }, log)
-    await flowRunSideEffects(log).onResume(flowRun)
+    await flowRunSideEffects(log).onResume({ flowRun, platformId })
 }
 
 type SyncResumePayload = {

--- a/packages/server/api/src/app/helper/application-events.ts
+++ b/packages/server/api/src/app/helper/application-events.ts
@@ -26,6 +26,11 @@ const listeners: ListenerRegistration = {
 
 type RawAuditEventParam = Pick<ApplicationEvent, 'data' | 'action'>
 
+type SendWorkerEventParams = RawAuditEventParam & {
+    projectId: string
+    platformId: string
+}
+
 type MetaInformation = {
     platformId: string
     userId?: string
@@ -50,22 +55,19 @@ export const applicationEvents = (log: FastifyBaseLogger) => ({
             }
         }), log)
     },
-    sendWorkerEvent(projectId: string, params: RawAuditEventParam): void {
-        projectService(log).getPlatformId(projectId).then((platformId) => {
-            for (const listener of listeners.workerEventListeners) {
-                const event = {
-                    ...params,
-                    projectId,
-                    platformId,
-                    id: apId(),
-                    created: new Date().toISOString(),
-                    updated: new Date().toISOString(),
-                } as ApplicationEvent
-                listener(projectId, event)
-            }
-        }).catch((error) => {
-            log.error({ error }, '[applicationEvents#sendWorkerEvent] Failed to send worker event')
-        })
+    sendWorkerEvent({ projectId, platformId, action, data }: SendWorkerEventParams): void {
+        for (const listener of listeners.workerEventListeners) {
+            const event = {
+                action,
+                data,
+                projectId,
+                platformId,
+                id: apId(),
+                created: new Date().toISOString(),
+                updated: new Date().toISOString(),
+            } as ApplicationEvent
+            listener(projectId, event)
+        }
     },
 })
 

--- a/packages/server/api/test/integration/ce/flows/flow-run/resume-flow-run.test.ts
+++ b/packages/server/api/test/integration/ce/flows/flow-run/resume-flow-run.test.ts
@@ -358,7 +358,7 @@ describe('Resume flow run', () => {
 
         await db.update('flow_run', flowRun.id, { status: FlowRunStatus.SUCCEEDED })
         const updatedRun = await db.findOneByOrFail<{ id: string, status: string, projectId: string }>('flow_run', { id: flowRun.id })
-        await flowRunSideEffects(app.log).onFinish(updatedRun as any)
+        await flowRunSideEffects(app.log).onFinish({ flowRun: updatedRun as any, platformId: ctx.platform.id })
 
         const waitpointAfter = await db.findOneBy('waitpoint', { flowRunId: flowRun.id })
         expect(waitpointAfter).toBeNull()

--- a/packages/server/api/test/integration/cloud/event-destinations/event-destination-trigger.test.ts
+++ b/packages/server/api/test/integration/cloud/event-destinations/event-destination-trigger.test.ts
@@ -466,7 +466,9 @@ describe('Event Destination Trigger', () => {
         })
         await db.save('event_destination', [workerDestination, userDestination])
 
-        applicationEvents(app.log).sendWorkerEvent(ctx.project.id, {
+        applicationEvents(app.log).sendWorkerEvent({
+            projectId: ctx.project.id,
+            platformId: ctx.platform.id,
             action: ApplicationEventName.FLOW_RUN_FINISHED,
             data: {
                 flowRun: {


### PR DESCRIPTION
## What

Removes the one Postgres query left on the **synchronous webhook dispatch hot path** (`POST /webhooks/:flowId/sync`).

`applicationEvents.sendWorkerEvent` previously re-resolved `platformId` from `projectId` with a fresh `SELECT "platformId" FROM "project"` on every call — even though the caller already knows `platformId`. On the dispatch path this fires via `flowRunSideEffects.onStart`, so every synchronous run start did an avoidable DB round-trip.

This threads the already-known `platformId` through instead.

## How

- `sendWorkerEvent({ projectId, platformId, action, data })` — takes `platformId` from the caller; no more internal `getPlatformId`. Listener dispatch is now synchronous (the old `.then/.catch` only existed to await `getPlatformId`; all registered worker-event listeners are `async`, so none can throw synchronously into the caller).
- `flowRunSideEffects.on{Start,Finish,Resume,Retry}` now take `{ flowRun, platformId }`.
- Call sites supply the `platformId` they already hold:
  - **`onStart`** (`flow-run-service.ts`) — the hot path — uses the `platformId` param of `start()`.
  - `onRetry` / `onResume` — already had `platformId` in scope.
  - `onFinish` runs in the async runs-metadata worker (`RunsMetadataUpsertData` carries no `platformId`), so it resolves `platformId` there — off the hot path, behavior unchanged.

## Verification

Reproduced against `benchmark/docker-compose.yml` with Postgres `log_statement=all`. After warmup, the synchronous webhook request path showed exactly one `SELECT "platformId" FROM "project"` per run on the critical path (and **zero** `flow_version` queries). With this change the dispatch path (`handleSync → start → onStart → sendWorkerEvent`) is Redis-only. Remaining `getPlatformId` calls in the window belong to async background actors (runs-metadata worker, engine run-log callback, worker poll).

- `npx turbo run lint --filter=api` → 0 errors.
- `StartParams.platformId` is required and all `start()` callers supply it, so `onStart` never receives `undefined`.

> Note: CI pre-push found an unrelated failing test (`web/test/features/chat/lib/quick-replies.test.ts`, a chat-prompt contract test) that is pre-existing on `main` and untouched by this `api`-only change.