### PR TITLE
fix(chat): prefer inline expressions over CODE steps in flow building

### DIFF
--- a/.agents/features/chat.md
+++ b/.agents/features/chat.md
@@ -28,6 +28,8 @@ A platform-level AI chat assistant that lets users interact with an LLM to manag
 | Change the streaming loop behavior | `worker/.../ee/chat/run-chat-turn.ts` |
 | Add an endpoint | `ee/chat/chat-controller.ts` |
 
+**Flow-building guidance (prompts).** When building a flow the agent prefers, in order: a native piece action → a router condition → an **inline formula expression** (`ap-formula-v1::{ … }::ap-formula-v1`; ~100 functions in `core-formula`, evaluated at runtime by the engine props resolver) → a CODE step as a last resort. This lives in `guides/build_flow.md` (the ladder + function vocabulary) and is reinforced in `guides/ai.md`, `guides/control_flow.md`, and the `ap_build_flow` / `ap_add_step` tool descriptions. Formulas go in free-text/value inputs, not dropdowns.
+
 ## Key Files
 - `packages/server/api/src/app/ee/chat/chat.module.ts` — module registration; gates `/v1/chat` with `chatVisibilityGuard` (per-user visibility, not just the `chatEnabled` flag)
 - `packages/server/api/src/app/ee/chat/chat-visibility-helper.ts` — `chatVisibilityGuard` + `resolveChatEnabledForUser` (edition + embed + rollout/grandfather); also used by the platform endpoint to surface the effective `plan.chatEnabled`

--- a/packages/server/api/src/app/mcp/tools/ap-add-step.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-add-step.ts
@@ -28,13 +28,13 @@ export const apAddStepTool = (mcp: ProjectScopedMcpServer, log: FastifyBaseLogge
     return {
         title: 'ap_add_step',
         permission: Permission.WRITE_FLOW,
-        description: 'Add a new step to a flow. Optionally configure it in the same call by providing input/auth/sourceCode. Prefer PIECE over CODE.',
+        description: 'Add a new step to a flow. Optionally configure it in the same call by providing input/auth/sourceCode. Prefer PIECE actions and inline formula expressions over CODE.',
         inputSchema: {
             flowId: z.string().describe('The id of the flow'),
             parentStepName: z.string().describe('The step name to insert after/into (e.g. "trigger", "step_1"). Use ap_flow_structure to get valid values.'),
             stepLocationRelativeToParent: z.enum(Object.values(StepLocationRelativeToParent) as [string, ...string[]]).describe('Where to place the step: AFTER = after the parent, INSIDE_LOOP = first action inside a loop, INSIDE_BRANCH = first action inside a router branch, INSIDE_ON_SUCCESS_BRANCH / INSIDE_ON_FAILURE_BRANCH = first action inside the On success / On failure branch of a continue-on-failure step (set continueOnFailure on the parent first).'),
             branchIndex: z.number().optional().describe('Branch index (required when stepLocationRelativeToParent is INSIDE_BRANCH)'),
-            stepType: z.enum([FlowActionType.CODE, FlowActionType.PIECE, FlowActionType.LOOP_ON_ITEMS, FlowActionType.ROUTER]).describe('The type of step to add. Prefer PIECE over CODE — only use CODE when no piece exists for the task.'),
+            stepType: z.enum([FlowActionType.CODE, FlowActionType.PIECE, FlowActionType.LOOP_ON_ITEMS, FlowActionType.ROUTER]).describe('The type of step to add. Prefer PIECE over CODE — only use CODE when no piece fits and the logic can\'t be done with an inline formula expression (in a free-text/value input) or a router condition.'),
             displayName: z.string().describe('Display name for the step'),
             pieceName: z.string().optional().describe('For PIECE steps: the piece name (e.g. "@activepieces/piece-gmail"). Use ap_research_pieces to get valid values.'),
             actionName: z.string().optional().describe('For PIECE steps: the action name within the piece. Use ap_research_pieces with includeActions=true to get valid values.'),

--- a/packages/server/api/src/app/mcp/tools/ap-build-flow.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-build-flow.ts
@@ -42,7 +42,7 @@ export const apBuildFlowTool = ({ mcp, userId }: McpToolContext, log: FastifyBas
     return {
         title: 'ap_build_flow',
         permission: Permission.WRITE_FLOW,
-        description: 'Create a NEW flow from scratch in one call: trigger + steps. Steps are added sequentially by default (trigger → step_1 → step_2 → ...). To nest steps inside a loop, set parentStepName to the loop step name and stepLocationRelativeToParent to INSIDE_LOOP. ROUTER steps are NOT supported here (branches and conditions cannot be configured in one call) — build the rest of the flow first, then add the router with ap_add_step and configure branches with ap_add_branch / ap_update_branch. For EDITING an existing flow, do NOT rebuild it — use the granular ap_add_step / ap_update_step / ap_update_trigger instead.',
+        description: 'Create a NEW flow from scratch in one call: trigger + steps. Steps are added sequentially by default (trigger → step_1 → step_2 → ...). To nest steps inside a loop, set parentStepName to the loop step name and stepLocationRelativeToParent to INSIDE_LOOP. ROUTER steps are NOT supported here (branches and conditions cannot be configured in one call) — build the rest of the flow first, then add the router with ap_add_step and configure branches with ap_add_branch / ap_update_branch. For EDITING an existing flow, do NOT rebuild it — use the granular ap_add_step / ap_update_step / ap_update_trigger instead. Prefer PIECE actions and inline formula expressions (in a free-text/value input — never a dropdown/option field — wrapped `ap-formula-v1::{…}::ap-formula-v1`) over CODE steps — only emit a CODE step when no piece fits AND the logic exceeds the inline formula functions (see the build_flow guide expression ladder).',
         inputSchema: {
             flowName: z.string().describe('Name for the new flow'),
             trigger: z.object({
@@ -51,7 +51,7 @@ export const apBuildFlowTool = ({ mcp, userId }: McpToolContext, log: FastifyBas
                 input: z.record(z.string(), z.unknown()).optional().describe('Trigger input config'),
                 auth: z.string().optional().describe('Connection externalId for trigger auth'),
             }).describe('Trigger configuration'),
-            steps: z.array(stepSpec).describe('Array of steps. By default added sequentially after trigger. Use parentStepName + stepLocationRelativeToParent to nest steps inside loops. Each step supports: PIECE (pieceName+actionName+input), CODE (sourceCode+input), LOOP_ON_ITEMS (loopItems). ROUTER is not supported here — add it afterwards with ap_add_step + ap_add_branch.'),
+            steps: z.array(stepSpec).describe('Array of steps. By default added sequentially after trigger. Use parentStepName + stepLocationRelativeToParent to nest steps inside loops. Each step supports: PIECE (pieceName+actionName+input), CODE (sourceCode+input), LOOP_ON_ITEMS (loopItems). Prefer PIECE and inline formula expressions (in free-text/value inputs, not dropdowns) over CODE — reach for a CODE step only when no piece fits and the transform exceeds the inline formula functions. ROUTER is not supported here — add it afterwards with ap_add_step + ap_add_branch.'),
         },
         annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false, openWorldHint: false },
         execute: async (args) => {

--- a/packages/server/api/src/assets/prompts/guides/ai.md
+++ b/packages/server/api/src/assets/prompts/guides/ai.md
@@ -39,9 +39,9 @@ For "AI decides, a human only handles the hard ones": AI emits a confidence scor
 
 This is your call, not the user's — never surface it as a question. The rule:
 - **Language, drafting, summarizing, classifying, extracting, judgment** → use the native AI piece (`@activepieces/piece-ai`). When a task could plausibly go either way (e.g. "draft a reply", "summarize these", "categorize this"), **default to the AI piece** — don't quietly build a CODE step that hard-codes rules for something that's really a language/judgment task.
-- **Deterministic comparisons, arithmetic, reshaping/formatting data** → use a router condition or a `CODE` step. They run instantly, free, and exactly.
+- **Deterministic comparisons, arithmetic, reshaping/formatting data** → use a router condition or an **inline formula expression** (`filter_list`, `if`, `round`, `format_currency`, … — see the expression ladder in `build_flow`). Reach for a `CODE` step only when the logic is genuinely beyond those functions. They run instantly, free, and exactly.
 
-Don't use `askAi` as a comparison or arithmetic engine (e.g. "did the price change?", "is this number bigger?"). A router condition or a `CODE` step does it deterministically, instantly, and free. Use AI for language, extraction, and judgment — not exact comparisons or math.
+Don't use `askAi` as a comparison or arithmetic engine (e.g. "did the price change?", "is this number bigger?"). A router condition or an inline formula expression does it deterministically, instantly, and free. Use AI for language, extraction, and judgment — not exact comparisons or math.
 
 ## Feeding AI output into an email (or other formatted destination)
 

--- a/packages/server/api/src/assets/prompts/guides/build_flow.md
+++ b/packages/server/api/src/assets/prompts/guides/build_flow.md
@@ -46,6 +46,35 @@ Activepieces ships pieces that need no external app or connection; registry sear
 | "wait/pause" | `@activepieces/piece-delay` | delay step |
 | "split big work" | `@activepieces/piece-subflows` | call another flow |
 
+## CODE is the last resort — use inline expressions & conditions first
+Dropping a **CODE step** into a flow to filter, reshape, calculate, or format data is almost always the wrong first move — it's slower to build, opaque to a non-coder, and harder to debug. Walk this ladder and stop at the first rung that fits; only the last rung is code:
+1. **A native piece action** — anything that talks to an app or is a normal automation step.
+2. **A router condition** (`ROUTER`; `ap_load_guide('control_flow')`) — to *route/branch* on a value, using the structured `BranchOperator`s.
+3. **An inline formula expression** — to *derive, filter, format, or calculate* a value right inside a step's input. No extra step, runs instantly, and covers the large majority of "I'll just write a quick CODE step to massage this" cases.
+4. **A CODE step** — ONLY when none of the above fit: genuinely procedural multi-step logic, parsing the functions can't express, or a real npm library is needed.
+
+### Writing an inline formula expression
+Put it directly in a step's input value, wrapped EXACTLY like this (the wrapper is what makes it evaluate as a formula instead of a literal string):
+`ap-formula-v1::{ <expression> }::ap-formula-v1`
+Inside: call functions with `;`-separated args, double-quote string literals, and reference earlier steps with the normal `{{step['output'].field}}` syntax. Real examples:
+- Keep only open tickets → `ap-formula-v1::{filter_list({{trigger['output'].tickets}};"status";"open")}::ap-formula-v1`
+- Count rows → `ap-formula-v1::{count({{step_1['output'].rows}})}::ap-formula-v1`
+- Every email on one line → `ap-formula-v1::{join_list(pluck({{step_1['output'].users}};"email");", ")}::ap-formula-v1`
+- Sum a column → `ap-formula-v1::{sum({{step_1['output'].orders}};"amount")}::ap-formula-v1`
+- Label by threshold → `ap-formula-v1::{if({{step_1['output'].amount}} > 1000;"High value";"Standard")}::ap-formula-v1`
+- Format money / clean text → `ap-formula-v1::{format_currency({{step_1['output'].total}};"$")}::ap-formula-v1`, `ap-formula-v1::{titlecase({{trigger['output'].name}})}::ap-formula-v1`
+
+**Where formulas go:** use them in **free-text / value** inputs (a Store value, a message or email body, a field you type into). Do NOT put a formula in a **dropdown, connection, or option-picker** field — those need a resolved option id/value, and a formula string will fail validation.
+
+### The function vocabulary (~100 built-ins; args separated by `;`; for numeric comparisons use `>` `<` `>=` `<=`, and the `is_equal` function for equality — not a bare `=`)
+- **List** (reshape/filter — these replace most CODE steps): `filter_list(list;field;value)` · `sort_list(list;field;order)` · `pluck(list;field)` · `join_list(list;sep)` · `count(list)` · `sum(list;field)` · `average(list;field)` · `min_in_list`/`max_in_list(list;field)` · `deduplicate(list;field)` · `first_item`/`last_item(list)` · `item_at(list;i)` · `contains_item(list;value)` · `flatten(list)` · `reverse_list(list)` · `split_text_to_list(text;sep)`
+- **Logic**: `if(cond;then;else)` · `switch(value;k1;r1;…)` · `coalesce(a;b;…)` · `if_empty`/`if_null(value;fallback)` · `is_empty`/`is_not_empty(value)` · `is_equal(a;b)` · `and`/`or(a;b)` · `not(x)`
+- **Text**: `combine` · `uppercase`/`lowercase`/`titlecase` · `trim` · `replace(text;find;with)` · `split(text;sep;i)` · `contains(text;value)` · `starts_with`/`ends_with` · `extract_email`/`extract_url` · `truncate(text;n)` · `slug` · `length`
+- **Number**: `add`/`subtract`/`multiply`/`divide` · `round(n;decimals)` · `round_up`/`round_down` · `min`/`max` · `percentage(v;total)` · `format_number(n;decimals)` · `format_currency(n;symbol)` · `to_number` · `absolute` · `modulo`
+- **Date**: `format_date(date;fmt)` · `format_time` · `relative_time` · `add_days`/`subtract_days(date;n)` · `add_hours`/`add_minutes` · `days_between`/`hours_between` · `is_before`/`is_after`/`is_same_day` · `now()` · `today()` · `to_date(text)` · `start_of_day`/`end_of_day` · `start_of_month`/`end_of_month` · `get_year`/`get_month`/`get_day`/`get_day_of_week`
+
+Validate a formula input with `ap_validate_step_config` like any step, and confirm the resolved value with `ap_test_step`/`ap_test_flow` — a wrong field name resolves to empty, exactly like a `{{...}}` reference does.
+
 ## Hard limits to design around
 | Limit | Value | If exceeded |
 |---|---|---|

--- a/packages/server/api/src/assets/prompts/guides/control_flow.md
+++ b/packages/server/api/src/assets/prompts/guides/control_flow.md
@@ -57,4 +57,4 @@ So to use **all** results after the loop, read `{{loopStep['output'].iterations}
 
 ## Deep nesting → flatten
 
-More than ~2 levels of nested routers is a smell. Compute the decision once in a `CODE` step (return a single tag string), then use one router keyed on that tag instead of a deep tree.
+More than ~2 levels of nested routers is a smell. Compute the decision once — prefer an inline formula expression that returns a single tag string (e.g. `ap-formula-v1::{switch({{step_1['output'].country}};"US";"NA";"DE";"EU")}::ap-formula-v1`), or a `CODE` step only if the logic is too complex for a formula — then use one router keyed on that tag instead of a deep tree.


### PR DESCRIPTION
## Problem

When building a flow, the chat/MCP agent reaches for a **Code step** to filter, reshape, calculate, or format data — even when an inline formula expression or a native piece action does the same thing. The result is automations that are harder for a non-coder to read, debug, and trust.

## Root cause (guidance, not the engine)

- The agent is **never told the inline formula functions exist** — `filter_list`, `count`, `sum`, `if`, `switch`, `format_currency`, … (~100 built-ins in `core-formula`). Grepping `formula`/`filter_list` across the chat prompts & guides returns 0 hits.
- Two guides actively recommend a Code step for exactly the work formulas cover: `ai.md` ("reshaping/formatting data → … a `CODE` step") and `control_flow.md` ("compute the decision once in a `CODE` step").
- `ap_build_flow` lists CODE as a neutral peer of PIECE with no preference (only `ap_add_step` had a weak nudge).

## Change

Prompt + tool-description only — **no engine change**. Inline formulas are already evaluated at runtime by the engine's props resolver (`props-resolver.ts`), so this only shifts which tool the agent reaches for.

- **`build_flow.md`**: a "CODE is the last resort" ladder — *native piece → router condition → inline formula expression → CODE* — plus the `ap-formula-v1::{ … }::ap-formula-v1` wrapper syntax and the function vocabulary.
- **`ai.md` / `control_flow.md`**: point reshaping/decision work at an inline expression first; CODE only when the functions can't express it.
- **`ap_build_flow` / `ap_add_step`** descriptions: prefer PIECE + inline expressions over CODE.

## Verification

Built the same three flows (filter + count, sum + format-as-currency, score → tier label) with and without this change, on both Opus and Sonnet:

- **Before:** a Code step every time — e.g. `orders.filter(o => o.status === 'paid').length`.
- **After:** an inline expression every time, unprompted — e.g. `ap-formula-v1::{count(filter_list({{trigger['output'].body.orders}};"status";"paid"))}::ap-formula-v1` — one step instead of two, no code.
