### PR TITLE
docs: clarify webhook payload size limit counts body + rawBody

### DIFF
--- a/.agents/features/webhooks.md
+++ b/.agents/features/webhooks.md
@@ -78,7 +78,7 @@ External services verify webhook ownership before sending events:
 
 ## Payload Size Limit
 
-`AP_MAX_WEBHOOK_PAYLOAD_SIZE_MB` (default 5MB). Returns 413 if exceeded.
+`AP_MAX_WEBHOOK_PAYLOAD_SIZE_MB` (default 25MB). Checked against the *constructed* payload (`getPayloadSizeInBytes` in `payload-offloader.ts`) — parsed `body` + `rawBody` + headers + query, not the raw request bytes. Since `rawBody` duplicates a text/JSON body, usable request size is ~half the limit. Returns 413 if exceeded.
 
 ## Flow Resolution
 

--- a/docs/install/reference/environment-variables.mdx
+++ b/docs/install/reference/environment-variables.mdx
@@ -168,7 +168,7 @@ run data is kept. The **Cloud** values and how these interact are covered in
 | `AP_MAX_FLOW_RUN_LOG_SIZE_MB` | Maximum combined size (MB) of all step inputs and outputs in a single run. Exceeding it ends the run with `LOG_SIZE_EXCEEDED`. | `50` |
 | `AP_FLOW_RUN_LOG_SLICE_THRESHOLD_KB` | Step outputs larger than this (KB) are offloaded to object storage instead of inlined in the run log. | `32` |
 | `AP_FLOW_RUN_LOG_INPUT_TRUNCATE_THRESHOLD_KB` | Step inputs larger than this (KB) are replaced with a placeholder in the run log; the step still receives the full value at runtime. | `2` |
-| `AP_MAX_WEBHOOK_PAYLOAD_SIZE_MB` | Maximum incoming webhook payload size (MB). Larger payloads are rejected with HTTP 413. | `25` |
+| `AP_MAX_WEBHOOK_PAYLOAD_SIZE_MB` | Maximum size (MB) of the processed webhook payload — the parsed body **plus** the raw body, headers, and query params, not just the raw request bytes. For text/JSON requests the raw body duplicates the parsed body, so the usable request size is roughly half this value (a 25 MB limit accepts a ~12 MB JSON body). File uploads (multipart or raw binary) are counted once, close to their full size. Oversized payloads are rejected with HTTP 413. | `25` |
 | `AP_WEBHOOK_PAYLOAD_INLINE_THRESHOLD_KB` | Webhook payloads below this (KB) are stored inline in Redis; larger ones are offloaded to file storage to protect Redis memory. | `512` |
 | `AP_WEBHOOK_TIMEOUT_SECONDS` | Default timeout for synchronous webhooks. Maximum 15 minutes; note Cloudflare caps it at 30 seconds. | `30` |
 | `AP_MAX_RECORDS_PER_TABLE` | Maximum number of records per table. | `10000` |

--- a/docs/install/reference/limits.mdx
+++ b/docs/install/reference/limits.mdx
@@ -110,6 +110,16 @@ inline threshold are offloaded from Redis to file storage to protect Redis
 memory; smaller payloads stay inline for the fastest path.
 </Tip>
 
+<Note>
+The payload limit is measured against the **processed** payload, not the raw
+request bytes. For text/JSON requests, Activepieces keeps both the parsed `body`
+and the original `rawBody` (needed for signature verification), so the request is
+counted roughly twice — a 25 MB limit accepts a JSON body of about 12 MB. If a
+JSON request is rejected with HTTP 413 well below the configured limit, this
+duplication is why. File uploads (multipart form data or raw binary bodies) are
+counted once, close to their actual size.
+</Note>
+
 ---
 
 ### Key / value storage


### PR DESCRIPTION
## What

Clarifies how `AP_MAX_WEBHOOK_PAYLOAD_SIZE_MB` is actually enforced, and fixes a stale default in the internal feature note.

## Why

The limit is checked against the **constructed** payload — parsed `body` + `rawBody` + headers + query (`getPayloadSizeInBytes` in `payload-offloader.ts`) — **not** the raw incoming request bytes. The docs previously called it "maximum incoming webhook payload size," which is misleading:

- **Text/JSON requests** keep both the parsed `body` and a full `rawBody` copy (the raw body is required for webhook signature verification), so the request is counted **~twice**. A 25 MB limit therefore accepts a JSON body of only ~12 MB, and a request can be rejected with HTTP 413 well below the configured limit.
- **File uploads** (multipart form data or raw binary bodies) are counted **once**, close to their actual size.

This was a real source of operator confusion ("I set 25 MB but my customers can only send ~12 MB"). Documenting the behavior is the right fix: `rawBody` is load-bearing (used by 600+ flows and many signature-verification pieces), so it can't be removed, and the limit must keep counting it to stay honest about memory.

The multipart behavior was confirmed empirically against the exact plugin versions/config (`fastify-raw-body` `runFirst: true` + `@fastify/multipart` `attachFieldsToBody: 'keyValues'`): `rawBody` is populated with the full multipart body.

## Changes

- `docs/install/reference/environment-variables.mdx` — accurate description of what the limit measures.
- `docs/install/reference/limits.mdx` — `<Note>` explaining the "413 below the limit" surprise.
- `.agents/features/webhooks.md` — fix stale "default 5MB" → 25 MB and document the mechanism.

Docs-only; no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)