### PR TITLE
fix(auth): boot cloud edition locally by auto-verifying dev signups

### DIFF
--- a/.agents/features/authentication.md
+++ b/.agents/features/authentication.md
@@ -19,7 +19,7 @@ The authentication feature handles user identity creation, sign-in, and JWT sess
 - `packages/web/src/app/routes/auth-routes.tsx` — route declarations: /sign-in, /sign-up, /forget-password, /reset-password, /verify-email, /invitation
 
 ## Edition Availability
-All editions (Community, Enterprise, Cloud). Email auth checks and domain-allow-listing guards are skipped on Community edition. OTP email verification is sent on Cloud; on Community and Enterprise the identity is automatically marked verified.
+All editions (Community, Enterprise, Cloud). Email auth checks and domain-allow-listing guards are skipped on Community edition. OTP email verification is sent on Cloud (production); on Community, Enterprise, and Cloud in development (`AP_ENVIRONMENT=development`) the identity is automatically marked verified.
 
 ## Domain Terms
 
@@ -77,8 +77,8 @@ All endpoints are rate-limited via `API_RATE_LIMIT_AUTHN_MAX` / `API_RATE_LIMIT_
 2. `User` created with `PlatformRole.ADMIN`
 3. `Platform` created (named `"<firstName>'s Platform"`)
 4. Default `Project` created with `ProjectType.PERSONAL`
-5. On Cloud: OTP email sent via `otpService`
-6. On CE/EE: identity auto-verified
+5. On Cloud (production): OTP email sent via `otpService`
+6. On CE/EE, or Cloud in development (`AP_ENVIRONMENT=development`): identity auto-verified
 7. `ApFlagId.USER_CREATED` flag saved
 8. Telemetry `SIGNED_UP` event fired
 9. Newsletter subscription attempted (production + non-embedding platforms only)

--- a/packages/server/api/src/app/authentication/authentication.service.ts
+++ b/packages/server/api/src/app/authentication/authentication.service.ts
@@ -1,6 +1,6 @@
 import { ActivepiecesError, assertNotNullOrUndefined, ErrorCode, isNil } from '@activepieces/core-utils'
 import { cryptoUtils } from '@activepieces/server-utils'
-import { ApEdition, ApFlagId, AuthenticationResponse, OtpType, PlatformWithoutSensitiveData, User, UserIdentity, UserIdentityProvider } from '@activepieces/shared'
+import { ApEdition, ApEnvironment, ApFlagId, AuthenticationResponse, OtpType, PlatformWithoutSensitiveData, User, UserIdentity, UserIdentityProvider } from '@activepieces/shared'
 import { FastifyBaseLogger } from 'fastify'
 import { otpService } from '../ee/authentication/otp/otp-service'
 import { flagService } from '../flags/flag.service'
@@ -205,8 +205,13 @@ async function getUserForPlatform(identityId: string, platform: PlatformWithoutS
 
 async function sendVerificationOrAutoVerify(userIdentity: UserIdentity, log: FastifyBaseLogger): Promise<void> {
     const edition = system.getEdition()
+    const environment = system.get(AppSystemProp.ENVIRONMENT)
     switch (edition) {
         case ApEdition.CLOUD:
+            if (environment === ApEnvironment.DEVELOPMENT) {
+                await userIdentityService(log).verify(userIdentity.id)
+                break
+            }
             if (!userIdentity.verified) {
                 await otpService(log).createAndSend({
                     platformId: null,


### PR DESCRIPTION
Cloud edition requires email verification, so the dev seeder's `dev@ap.com` (signed up without a platform) stays unverified and `getOnboardingResponse` throws `EMAIL_IS_NOT_VERIFIED`, crashing server start on a fresh DB.

This auto-verifies cloud signups when `AP_ENVIRONMENT=development` — same as CE/EE already do — so local cloud dev boots with zero setup. Production cloud is unchanged and still sends the OTP email.