### PR TITLE
fix(worker): reconnect after server-initiated disconnect so a deploy doesn't silently stop polling

### DIFF
--- a/packages/server/worker/src/lib/worker.ts
+++ b/packages/server/worker/src/lib/worker.ts
@@ -93,6 +93,15 @@ export const worker = {
             connectionGeneration++
             polling = false
             logger.warn({ reason }, 'Disconnected from API server')
+            // Socket.IO does NOT auto-reconnect when the server initiates the disconnect
+            // (reason 'io server disconnect' — e.g. the API process restarts during a deploy,
+            // where fastify-socket's preClose calls io.disconnectSockets(true)). Without a
+            // manual reconnect the worker stays dead and silently stops polling for jobs until
+            // the worker process is restarted. Every other non-client reason already triggers
+            // Socket.IO's built-in reconnection.
+            if (reason === 'io server disconnect') {
+                socket?.connect()
+            }
         })
 
         socket.on('connect_error', (error) => {


### PR DESCRIPTION
## Problem

Customers on 0.85.x report that flows **stop being polled from `workerJobs`** and stay stopped until the worker process is **restarted** — typically after a deploy, especially when the **worker is deployed before the app**.

## Root cause

On graceful app shutdown (SIGTERM during a deploy → `app.close()`), `fastify-socket`'s `preClose` hook runs:

```js
fastify.io.local.disconnectSockets(true); // true = close the underlying connection
```

The `true` makes every connected worker receive Socket.IO disconnect reason **`'io server disconnect'`** — the one reason the client **deliberately does not auto-reconnect** from (you must call `socket.connect()` yourself).

The worker's handler only set `polling = false` and logged a warning, with no reconnect:

```js
socket.on('disconnect', (reason) => {
    connectionGeneration++
    polling = false
    logger.warn({ reason }, 'Disconnected from API server')
})
```

So any worker already running and connected when the app restarts is silently severed and never comes back. Restarting the **worker** creates a fresh connection, which is why a restart 'fixes' it. Deploying the worker before the app exposes this: the freshly-deployed workers connect, then the app deploy disconnects them with `'io server disconnect'` and they stay dead.

This is a long-standing latent handler bug (same `fastify-socket@5.1.2` and same handler since 0.82.x); deploy topology is what makes it bite.

## Fix

Manually reconnect on `'io server disconnect'`. Every other non-client reason already triggers Socket.IO's built-in reconnection.

Backport of the reconnect fix from #13933 (which landed on `main` after 0.85.5) to the 0.85.x release line — minimal, just the reconnect.

## Testing

Reproduced the mechanism from the release branch: an app graceful shutdown emits `'io server disconnect'`; without the reconnect the worker's poll loop ends (`polling=false`) and never restarts. With the change the worker calls `socket.connect()`, re-runs `connect` → `fetchAndStoreSettings` → `startPollingWorkers`, and resumes consuming `workerJobs`.