### PR TITLE
fix(worker): stop retrying permanently-failed jobs (deleted connection / 404 payload)

### DIFF
--- a/packages/server/api/src/app/workers/job-queue/job-broker.ts
+++ b/packages/server/api/src/app/workers/job-queue/job-broker.ts
@@ -204,7 +204,20 @@ function buildFailedReason(errorMessage: string, logs?: string): string {
     return `${errorMessage}\n${logs}`
 }
 
-export { tryDequeue }
+// Engine failures whose inputs are permanently gone never recover on retry — a deleted/expired
+// connection, or a 404/410 on the trigger-payload file. Retrying them just burns attempts, clogs
+// the failed queue, and re-pages oncall. A transient 5xx file-download error must still retry, so
+// EngineFileDownloadError is only treated as permanent when the status is not-found / gone.
+const PERMANENT_FAILURE_MARKERS = ['ConnectionNotFound', 'ConnectionExpired'] as const
+
+function isPermanentEngineFailure(failedReason: string): boolean {
+    if (PERMANENT_FAILURE_MARKERS.some(marker => failedReason.includes(marker))) {
+        return true
+    }
+    return failedReason.includes('EngineFileDownloadError') && (failedReason.includes('404 Not Found') || failedReason.includes('410 Gone'))
+}
+
+export { tryDequeue, isPermanentEngineFailure }
 
 export const jobBroker = (log: FastifyBaseLogger) => ({
     async init(): Promise<void> {
@@ -247,7 +260,9 @@ export const jobBroker = (log: FastifyBaseLogger) => ({
 
         const { error } = await tryCatch(async () => {
             if (input.status === EngineResponseStatus.INTERNAL_ERROR) {
-                await job.moveToFailed(new Error(buildFailedReason(input.errorMessage ?? 'Internal error', input.logs)), input.token)
+                const failedReason = buildFailedReason(input.errorMessage ?? 'Internal error', input.logs)
+                const failure = isPermanentEngineFailure(failedReason) ? new UnrecoverableError(failedReason) : new Error(failedReason)
+                await job.moveToFailed(failure, input.token)
                 if (userJobData) {
                     await engineResponseWatcher(log).publish(userJobData.webserverId, userJobData.requestId, {
                         status: EngineResponseStatus.INTERNAL_ERROR,

--- a/packages/server/api/test/unit/app/workers/job-broker-permanent-failure.test.ts
+++ b/packages/server/api/test/unit/app/workers/job-broker-permanent-failure.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest'
+import { isPermanentEngineFailure } from '../../../../src/app/workers/job-queue/job-broker'
+
+describe('isPermanentEngineFailure', () => {
+    it('treats a deleted connection as permanent', () => {
+        expect(isPermanentEngineFailure('Internal error\nstderr:\nConnectionNotFound: { "message": "connection (X) not found" }')).toBe(true)
+    })
+
+    it('treats an expired connection as permanent', () => {
+        expect(isPermanentEngineFailure('ConnectionExpired: { "message": "connection (X) expired" }')).toBe(true)
+    })
+
+    it('treats a 404 trigger-payload download as permanent', () => {
+        expect(isPermanentEngineFailure('Internal error\nstderr:\nEngineFileDownloadError: { "message": "Failed to download file Y: 404 Not Found" }')).toBe(true)
+    })
+
+    it('keeps a transient 5xx download error retryable', () => {
+        expect(isPermanentEngineFailure('EngineFileDownloadError: { "message": "Failed to download file Y: 503 Service Unavailable" }')).toBe(false)
+    })
+
+    it('keeps a generic engine crash retryable', () => {
+        expect(isPermanentEngineFailure('SANDBOX_INTERNAL_ERROR: Worker exited with code 1 and signal null')).toBe(false)
+    })
+})


### PR DESCRIPTION
## What

Engine failures whose inputs are **permanently gone** never recover on retry:

- a deleted/expired connection — `ConnectionNotFound` / `ConnectionExpired`
- a `404 Not Found` / `410 Gone` on the trigger-payload file — `EngineFileDownloadError`

`completeJob` wrapped **every** `INTERNAL_ERROR` in a plain `Error`, so BullMQ retried per `attempts`/`backoff`. These retries can never succeed — they just burn attempts, clog the `failed` queue, and re-page oncall on each attempt.

## How

Classify these at the single `completeJob` choke point (covers every job type) and move them to failed with `UnrecoverableError`, which BullMQ never retries — the same pattern already used for deferred-failure and invalid-schema jobs in this file.

Transient `5xx` download errors stay retryable: only `404`/`410` count as permanent.

## Evidence

Found via two failed prod jobs:
- `Tx9iuIrJm5yola44BCQHX` (EXECUTE_FLOW) — 70-day-stale job, connection `IedmaJgaUqsVRqwnsYudH` deleted + payload file `iU2y9YpQJjyeUfUiFUDcc` 404'd, retried **5×**.
- (job `2M5W8jqOm9HKsK7pWV8GB` was a separate host-level engine crash — out of scope here.)

## Scope / non-goals

This stops the **retry storm**. It does not reclassify the run's `INTERNAL_ERROR` status to `FAILED` — that's a deeper engine-side change (USER vs ENGINE error typing) intentionally left out of this contained worker fix.

## Test

`isPermanentEngineFailure` unit test covers: deleted connection, expired connection, 404 payload → permanent; 5xx download + generic sandbox crash → still retryable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)