### PR TITLE
chore: deploy staging app and workers as separate kamal services

### DIFF
--- a/.github/workflows/continuous-delivery-stg.yml
+++ b/.github/workflows/continuous-delivery-stg.yml
@@ -156,12 +156,12 @@ jobs:
   # hotfix image at that point (multi-arch build takes 10–15 min), so the SSH
   # lookup returns the hotfix version.sha.beta which gets retagged as release-candidate.
   tag-release-candidate:
-    needs: [detect-hotfix-merge, deploy-staging]
+    needs: [detect-hotfix-merge, deploy-staging-app, deploy-staging-workers]
     if: |
       always() &&
       (github.event_name == 'schedule' ||
        (github.event_name == 'push' && needs.detect-hotfix-merge.outputs.is_hotfix_merge == 'true' &&
-        needs.deploy-staging.result == 'success'))
+        needs.deploy-staging-app.result == 'success' && needs.deploy-staging-workers.result == 'success'))
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/continuous-delivery-stg.yml
+++ b/.github/workflows/continuous-delivery-stg.yml
@@ -95,7 +95,7 @@ jobs:
           no-cache: true
           tags: ghcr.io/activepieces/activepieces-cloud:${{ steps.set-tag.outputs.image_tag }}
 
-  deploy-staging:
+  deploy-staging-app:
     needs: build-image
     if: always() && needs.build-image.result == 'success'
     runs-on: ubuntu-latest
@@ -121,7 +121,35 @@ jobs:
           SSH_HOST: ${{ secrets.DEV_OPS_HOST }}
       - name: Deploy to staging
         run: |
-          ssh ops -t -t 'bash -ic "cd mrsk/stg && kamal deploy --version ${{ needs.build-image.outputs.image_tag }} --skip-push; exit"'
+          ssh ops -t -t 'bash -ic "cd mrsk/stg && kamal deploy --version ${{ needs.build-image.outputs.image_tag }} --config-file=config/app.yml --skip-push; exit"'
+
+  deploy-staging-workers:
+    needs: build-image
+    if: always() && needs.build-image.result == 'success'
+    runs-on: ubuntu-latest
+    environment:
+      name: staging
+      url: https://stg.activepieces.com
+    steps:
+      - name: Configure SSH
+        run: |
+          mkdir -p ~/.ssh/
+          echo "$SSH_KEY" > ~/.ssh/ops.key
+          chmod 600 ~/.ssh/ops.key
+          cat >>~/.ssh/config <<END
+          Host ops
+            HostName $SSH_HOST
+            User $SSH_USER
+            IdentityFile ~/.ssh/ops.key
+            StrictHostKeyChecking no
+          END
+        env:
+          SSH_USER: ${{ secrets.DEV_OPS_USERNAME }}
+          SSH_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
+          SSH_HOST: ${{ secrets.DEV_OPS_HOST }}
+      - name: Deploy to staging
+        run: |
+          ssh ops -t -t 'bash -ic "cd mrsk/stg && kamal deploy --version ${{ needs.build-image.outputs.image_tag }} --config-file=config/worker.yml --skip-push; exit"'
 
   # Thursday 5 PM UTC: tag current staging image + commit as release-candidate.
   # Also runs when a hotfix branch is merged to main — staging still holds the


### PR DESCRIPTION
Splits the staging CD `deploy-staging` job into two parallel jobs — `deploy-staging-app` and `deploy-staging-workers` — each deploying via its own kamal config (`config/app.yml` / `config/worker.yml`). `tag-release-candidate` now waits on both.

Cherry-picked from `perf/queue-dispatcher`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)