### PR TITLE
fix: wrap draft creation in transaction to prevent orphaned drafts

### DIFF
--- a/.agents/features/flows.md
+++ b/.agents/features/flows.md
@@ -88,6 +88,8 @@ All flow modifications go through `POST /v1/flows/:id` with a `FlowOperationRequ
 - USE_AS_DRAFT → copies published version back to draft for editing
 - Only published flows can be enabled (triggers registered)
 
+**Editing a locked version** (`createNewDraftIfVersionIsPublished`): when any structural edit operation arrives and the latest version is LOCKED, the service creates a new empty DRAFT and imports the locked content into it. Both the empty-draft insert (`createEmptyVersion`) and the import operation loop run inside a single `transaction()` — if the import throws (e.g. stack overflow on a deeply nested flow), the entire transaction rolls back and no orphaned empty draft is left in the DB.
+
 ## Publishing Side Effects
 
 When LOCK_AND_PUBLISH or CHANGE_STATUS to ENABLED:

--- a/packages/server/api/src/app/flows/flow-version/flow-version.service.ts
+++ b/packages/server/api/src/app/flows/flow-version/flow-version.service.ts
@@ -260,6 +260,7 @@ export const flowVersionService = (log: FastifyBaseLogger) => ({
             notes: Note[]
             schemaVersion: string | undefined | null
         },
+        entityManager?: EntityManager,
     ): Promise<FlowVersion> {
         const flowVersion: NewFlowVersion = {
             id: apId(),
@@ -280,7 +281,7 @@ export const flowVersionService = (log: FastifyBaseLogger) => ({
             state: FlowVersionState.DRAFT,
             notes: request.notes,
         }
-        return flowVersionRepo().save(flowVersion)
+        return flowVersionRepo(entityManager).save(flowVersion)
     },
     removeConnectionsAndSampleDataFromFlowVersion(
         flowVersion: FlowVersion,

--- a/packages/server/api/src/app/flows/flow/flow.service.ts
+++ b/packages/server/api/src/app/flows/flow/flow.service.ts
@@ -821,7 +821,11 @@ type UpdateMetadataParams = {
     metadata: Metadata | null | undefined
 }
 
-/** When the latest version is locked (published snapshot), creates a new draft and imports it. */
+/** When the latest version is locked (published snapshot), creates a new draft and imports it.
+ *  Both the empty-draft insert and every subsequent import operation run inside a single
+ *  transaction so that a failure mid-import (e.g. stack overflow on a deeply-nested flow)
+ *  rolls back the empty draft instead of leaving an orphaned row in the DB.
+ */
 async function createNewDraftIfVersionIsPublished({
     flowId,
     projectId,
@@ -835,17 +839,25 @@ async function createNewDraftIfVersionIsPublished({
     userId: UserId | null
     log: FastifyBaseLogger
 }): Promise<FlowVersion> {
-    let lastVersion = await flowVersionService(log).getFlowVersionOrThrow({
+    const lastVersion = await flowVersionService(log).getFlowVersionOrThrow({
         flowId,
         versionId: undefined,
     })
-    if (lastVersion.state === FlowVersionState.LOCKED) {
-        const lockedVersion = lastVersion
-        lastVersion = await flowVersionService(log).createEmptyVersion(flowId, {
-            displayName: lockedVersion.displayName,
-            notes: lockedVersion.notes,
-            schemaVersion: lockedVersion.schemaVersion,
-        })
+    if (lastVersion.state !== FlowVersionState.LOCKED) {
+        return lastVersion
+    }
+
+    const lockedVersion = lastVersion
+    return transaction(async (entityManager) => {
+        let draftVersion = await flowVersionService(log).createEmptyVersion(
+            flowId,
+            {
+                displayName: lockedVersion.displayName,
+                notes: lockedVersion.notes,
+                schemaVersion: lockedVersion.schemaVersion,
+            },
+            entityManager,
+        )
         const operations: FlowOperationRequest[] = [{
             type: FlowOperationType.IMPORT_FLOW,
             request: lockedVersion,
@@ -863,14 +875,15 @@ async function createNewDraftIfVersionIsPublished({
             })
         }
         for (const operation of operations) {
-            lastVersion = await flowVersionService(log).applyOperation({
+            draftVersion = await flowVersionService(log).applyOperation({
                 userId,
                 projectId,
                 platformId,
-                flowVersion: lastVersion,
+                flowVersion: draftVersion,
                 userOperation: operation,
+                entityManager,
             })
         }
-    }
-    return lastVersion
+        return draftVersion
+    })
 }


### PR DESCRIPTION
## What does this PR do?

Fixes orphaned empty draft flow versions that accumulate in the database when editing a published flow fails mid-import. 


### Explain How the Feature Works
 When a user edits a published (LOCKED) flow, the system creates a new empty DRAFT version and then imports the locked content into it. Previously these were two separate, uncommitted DB writes with no transaction around them. If the import step threw an error (e.g. a stack overflow on a deeply nested flow), the empty DRAFT row was already committed and left permanently in the database.

This fix wraps both writes — the empty draft creation and the entire import operation loop — in a single database transaction inside createNewDraftIfVersionIsPublished. If anything fails mid-import, the transaction rolls back and no orphaned draft is left behind.. 

Changes:

 - flow-version.service.ts — createEmptyVersion now accepts an optional entityManager parameter so it can
      participate in a caller-supplied transaction
 - flow.service.ts — createNewDraftIfVersionIsPublished wraps the full draft creation + import in a 
      transaction(), mirroring the pattern already used by updatedPublishedVersionId

### Relevant User Scenarios

 A user edits a published flow that is deeply nested, triggering a stack overflow during import — previously left an orphaned empty draft in the DB, now rolls back cleanly
Any failure during the import-into-draft step no longer leaves ghost draft versions accumulating per project



Fixes #13931 
