### PR TITLE
fix(system-jobs): stop file-cleanup statement timeouts and resume-delay ENTITY_NOT_FOUND failures

### DIFF
--- a/packages/server/api/src/app/file/file.service.ts
+++ b/packages/server/api/src/app/file/file.service.ts
@@ -152,32 +152,45 @@ export const fileService = (log: FastifyBaseLogger) => ({
     async deleteStaleBulk(types: FileType[]) {
         const retentionDateBoundary = dayjs().subtract(EXECUTION_DATA_RETENTION_DAYS, 'days').toISOString()
         const maximumFilesToDeletePerIteration = 4000
-        let affected: undefined | number = undefined
+        const maximumFilesToDeletePerRun = 1_000_000
         let totalAffected = 0
-        while (isNil(affected) || affected === maximumFilesToDeletePerIteration) {
-            const staleFiles = await fileRepo().find({
-                select: ['id', 'created', 's3Key'],
-                where: {
-                    type: In(types),
-                    created: LessThanOrEqual(retentionDateBoundary),
-                },
-                take: maximumFilesToDeletePerIteration,
-            })
+        // Iterate one type at a time with an equality predicate so the select hits the
+        // (type, created) index (idx_file_type_created_desc) as an index scan. A `type IN (...)`
+        // predicate makes the planner fall back to a sequential scan of the file table (140M+ rows),
+        // which, as the cleanup deletes rows, wades through dead tuples and hits statement_timeout —
+        // so the cleanup never drains and the backlog grows. The delete is by primary key only.
+        // Cap the work per run so a large backlog drains across the hourly schedule instead of one
+        // multi-hour run (which could outlive its worker lock); the next run resumes from the oldest.
+        for (const type of types) {
+            let affected: undefined | number = undefined
+            while ((isNil(affected) || affected === maximumFilesToDeletePerIteration) && totalAffected < maximumFilesToDeletePerRun) {
+                const staleFiles = await fileRepo().find({
+                    select: ['id', 's3Key'],
+                    where: {
+                        type,
+                        created: LessThanOrEqual(retentionDateBoundary),
+                    },
+                    take: maximumFilesToDeletePerIteration,
+                })
 
-            const s3Keys = staleFiles.filter(f => !isNil(f.s3Key)).map(f => f.s3Key!)
-            await s3Helper(log).deleteFiles(s3Keys)
+                if (staleFiles.length === 0) {
+                    affected = 0
+                    break
+                }
 
-            const result = await fileRepo().delete({
-                type: In(types),
-                created: LessThanOrEqual(retentionDateBoundary),
-                id: In(staleFiles.map(file => file.id)),
-            })
-            affected = result.affected || 0
-            totalAffected += affected
-            log.info({
-                counts: affected,
-                types,
-            }, '[FileService#deleteStaleBulk] iteration completed')
+                const s3Keys = staleFiles.filter(f => !isNil(f.s3Key)).map(f => f.s3Key!)
+                await s3Helper(log).deleteFiles(s3Keys)
+
+                const result = await fileRepo().delete({
+                    id: In(staleFiles.map(file => file.id)),
+                })
+                affected = result.affected || 0
+                totalAffected += affected
+                log.info({
+                    counts: affected,
+                    type,
+                }, '[FileService#deleteStaleBulk] iteration completed')
+            }
         }
         log.info({
             totalAffected,

--- a/packages/server/api/src/app/flows/flow-run/flow-run-module.ts
+++ b/packages/server/api/src/app/flows/flow-run/flow-run-module.ts
@@ -1,3 +1,4 @@
+import { isNil } from '@activepieces/core-utils'
 import { FlowRunStatus, TelemetryEventName } from '@activepieces/shared'
 import dayjs from 'dayjs'
 import { FastifyPluginAsync } from 'fastify'
@@ -70,7 +71,12 @@ export const flowRunModule: FastifyPluginAsync = async (app) => {
         },
     })
     systemJobHandlers.registerJobHandler(SystemJobName.RESUME_DELAY_WAITPOINT, async (data: SystemJobData<SystemJobName.RESUME_DELAY_WAITPOINT>) => {
-        const flowRun = await flowRunService(app.log).getOneOrThrow({ id: data.flowRunId, projectId: data.projectId })
+        const flowRun = await flowRunService(app.log).getOne({ id: data.flowRunId, projectId: data.projectId })
+        if (isNil(flowRun)) {
+            app.log.info({ flowRun: { id: data.flowRunId }, waitpoint: { id: data.waitpointId } },
+                '[RESUME_DELAY_WAITPOINT] Flow run no longer exists (expired/deleted), skipping')
+            return
+        }
         if (flowRun.status !== FlowRunStatus.PAUSED) {
             app.log.info({ flowRun: { id: data.flowRunId }, waitpoint: { id: data.waitpointId }, status: flowRun.status },
                 '[RESUME_DELAY_WAITPOINT] Flow not PAUSED, skipping')


### PR DESCRIPTION
Drives the `system-job-queue` failed backlog toward zero — two repeating system jobs were failing on every run.

## file-cleanup-trigger (statement timeout, ~480 failures)
`deleteStaleBulk` selected stale files with `type IN (...)`, which the planner runs as a **sequential scan** of the `file` table (~140M rows / 279 GB). As the cleanup deletes rows it wades through dead tuples and hits `statement_timeout`, so the hourly cleanup never drains — the backlog (and DB size) only grows.

Fix: iterate **one type at a time with an equality predicate** so the query uses `idx_file_type_created_desc` as an **index scan** (verified via `EXPLAIN` on prod: seq scan → index scan), delete by primary key only, and cap files-per-run so a large backlog drains across the hourly schedule instead of one multi-hour run.

## RESUME_DELAY_WAITPOINT (ENTITY_NOT_FOUND, ~54 failures)
The handler used `getOneOrThrow`, so a delay that outlived its flow run's retention threw `ENTITY_NOT_FOUND` → the job failed + retried + accumulated. Now uses `getOne` and skips gracefully when the run is gone (nothing to resume), mirroring the existing not-PAUSED skip.

(The orphaned `chat-funnel-sync` scheduler with no handler was removed from prod manually.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)