### PR TITLE
fix(sandbox): surface real crash diagnostics instead of empty error on fatal engine exit

### DIFF
--- a/packages/server/sandbox/src/lib/sandbox/fork.ts
+++ b/packages/server/sandbox/src/lib/sandbox/fork.ts
@@ -5,6 +5,11 @@ export function simpleProcess(enginePath: string, codeDirectory: string): Sandbo
     return {
         create: async (params) => {
             return fork(enginePath, [], {
+                // Pipe the child's stdout/stderr instead of inheriting them, so the sandbox can
+                // capture native runtime output (uncaught-exception stacks, V8 "JavaScript heap out
+                // of memory" aborts) that never travels over the RPC socket. Without this, a hard
+                // engine crash surfaces only as an opaque "Worker exited with code 1 ... standardError=".
+                silent: true,
                 execArgv: [
                     // IMPORTANT DO NOT REMOVE THIS ARGUMENT: https://github.com/laverdet/isolated-vm/issues/424
                     '--no-node-snapshot',

--- a/packages/server/sandbox/src/lib/sandbox/isolate.ts
+++ b/packages/server/sandbox/src/lib/sandbox/isolate.ts
@@ -127,13 +127,6 @@ export function isolateProcess(log: SandboxLogger, enginePath: string, _codeDire
                 shell: false,
             })
 
-            child.stdout?.on('data', (data: Buffer) => {
-                process.stdout.write(data)
-            })
-            child.stderr?.on('data', (data: Buffer) => {
-                process.stderr.write(data)
-            })
-
             return child
         },
     }

--- a/packages/server/sandbox/src/lib/sandbox/sandbox.ts
+++ b/packages/server/sandbox/src/lib/sandbox/sandbox.ts
@@ -230,13 +230,15 @@ export function createSandbox(
             })
 
             const exitPromise = new Promise<never>((_, reject) => {
-                childProcess!.once('exit', (code, signal) => {
+                // 'close' (not 'exit') so the child's stdout/stderr pipes are fully drained first —
+                // 'exit' can fire before the final 'data' chunk, leaving nativeStdError empty.
+                childProcess!.once('close', (code, signal) => {
                     reject(new Error(`Sandbox ${sandboxId} exited before connecting (code=${code}, signal=${signal}) standardError=${nativeStdError}`))
                 })
             })
 
             await Promise.race([waitForConnection(), exitPromise])
-            childProcess!.removeAllListeners('exit')
+            childProcess!.removeAllListeners('close')
 
             log.debug({
                 sandbox: { id: sandboxId },
@@ -250,6 +252,10 @@ export function createSandbox(
             let timeout: NodeJS.Timeout | null = null
             const executeSocket = connectedSocket
             const executeProcess = childProcess
+            // Reset per-execute so a reused sandbox doesn't prefix this run's crash output with
+            // native output accumulated during previous (healthy) executions.
+            nativeStdOut = ''
+            nativeStdError = ''
             const operationPromise = new Promise<SandboxResult>((resolve, reject) => {
                 assertNotNullOrUndefined(executeProcess, 'Sandbox process should not be null')
                 assertNotNullOrUndefined(executeSocket, 'Connected socket should not be null')
@@ -278,7 +284,7 @@ export function createSandbox(
                     log.error({ sandbox: { id: sandboxId }, error: String(error) }, 'Sandbox process error')
                 })
 
-                executeProcess.on('exit', (code, signal) => {
+                executeProcess.on('close', (code, signal) => {
                     handleProcessExit(log, {
                         sandboxId,
                         operationType,
@@ -317,7 +323,7 @@ export function createSandbox(
                     clearTimeout(timeout)
                 }
                 executeSocket?.removeAllListeners('rpc-notify')
-                executeProcess?.removeAllListeners('exit')
+                executeProcess?.removeAllListeners('close')
                 executeProcess?.removeAllListeners('error')
             }
         },

--- a/packages/server/sandbox/src/lib/sandbox/sandbox.ts
+++ b/packages/server/sandbox/src/lib/sandbox/sandbox.ts
@@ -68,6 +68,8 @@ export function createSandbox(
     let wsRpcToken: string | null = null
     let busy = false
     let killedByShutdown = false
+    let nativeStdOut = ''
+    let nativeStdError = ''
 
     function wireConnectionHandler(ioServer: SocketIOServer): void {
         ioServer.use(authenticateHandshake({ getExpectedToken: () => wsRpcToken, log, sandboxId }))
@@ -216,9 +218,20 @@ export function createSandbox(
                 },
             })
 
+            nativeStdOut = ''
+            nativeStdError = ''
+            childProcess.stdout?.on('data', (data: Buffer) => {
+                nativeStdOut = appendBounded(nativeStdOut, data.toString())
+                process.stdout.write(data)
+            })
+            childProcess.stderr?.on('data', (data: Buffer) => {
+                nativeStdError = appendBounded(nativeStdError, data.toString())
+                process.stderr.write(data)
+            })
+
             const exitPromise = new Promise<never>((_, reject) => {
                 childProcess!.once('exit', (code, signal) => {
-                    reject(new Error(`Sandbox ${sandboxId} exited before connecting (code=${code}, signal=${signal})`))
+                    reject(new Error(`Sandbox ${sandboxId} exited before connecting (code=${code}, signal=${signal}) standardError=${nativeStdError}`))
                 })
             })
 
@@ -273,8 +286,8 @@ export function createSandbox(
                         signal,
                         killedByTimeout,
                         killedByShutdown,
-                        stdOut,
-                        stdError,
+                        stdOut: stdOut + nativeStdOut,
+                        stdError: stdError + nativeStdError,
                         reject,
                     })
                 })
@@ -354,6 +367,16 @@ function closeServer(ioServer: SocketIOServer): Promise<void> {
 
 function delay(ms: number): Promise<void> {
     return new Promise<void>((resolve) => setTimeout(resolve, ms))
+}
+
+const MAX_NATIVE_OUTPUT_CHARS = 8192
+
+function appendBounded(existing: string, chunk: string): string {
+    const combined = existing + chunk
+    if (combined.length <= MAX_NATIVE_OUTPUT_CHARS) {
+        return combined
+    }
+    return combined.slice(combined.length - MAX_NATIVE_OUTPUT_CHARS)
 }
 
 function handleProcessExit(log: SandboxLogger, params: ProcessExitParams): void {

--- a/packages/server/sandbox/test/lib/sandbox/sandbox.test.ts
+++ b/packages/server/sandbox/test/lib/sandbox/sandbox.test.ts
@@ -561,7 +561,7 @@ describe('createSandbox', () => {
 
             // Don't respond to RPC — let it timeout
             treeKillMock.mockImplementation((_pid: number, _signal: string, cb: (err?: Error) => void) => {
-                child.emit('exit', null, 'SIGKILL')
+                child.emit('close', null, 'SIGKILL')
                 cb()
             })
 
@@ -586,7 +586,7 @@ describe('createSandbox', () => {
             const child = testPM.getChild()
 
             client.on('rpc', () => {
-                child.emit('exit', 134, null)
+                child.emit('close', 134, null)
             })
 
             const executePromise = sandbox.execute(
@@ -612,7 +612,7 @@ describe('createSandbox', () => {
             client.on('rpc', () => {
                 client.emit('rpc-notify', { method: 'stderr', payload: { message: 'Flow run data size exceeded the maximum allowed size' } })
                 setTimeout(() => {
-                    child.emit('exit', 1, null)
+                    child.emit('close', 1, null)
                 }, 50)
             })
 
@@ -637,7 +637,7 @@ describe('createSandbox', () => {
             const child = testPM.getChild()
 
             client.on('rpc', () => {
-                child.emit('exit', 1, null)
+                child.emit('close', 1, null)
             })
 
             const executePromise = sandbox.execute(
@@ -663,7 +663,7 @@ describe('createSandbox', () => {
 
             client.on('rpc', () => {
                 ;(child.stderr as unknown as EventEmitter).emit('data', Buffer.from(nativeStack))
-                setTimeout(() => child.emit('exit', 1, null), 20)
+                setTimeout(() => child.emit('close', 1, null), 20)
             })
 
             const executePromise = sandbox.execute(
@@ -690,7 +690,7 @@ describe('createSandbox', () => {
 
             client.on('rpc', () => {
                 ;(child.stderr as unknown as EventEmitter).emit('data', Buffer.from('FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory\n'))
-                setTimeout(() => child.emit('exit', 1, null), 20)
+                setTimeout(() => child.emit('close', 1, null), 20)
             })
 
             const executePromise = sandbox.execute(
@@ -726,7 +726,7 @@ describe('createSandbox', () => {
                 { timeoutInSeconds: 10 },
             )
 
-            expect(removeAllListenersSpy).toHaveBeenCalledWith('exit')
+            expect(removeAllListenersSpy).toHaveBeenCalledWith('close')
             expect(removeAllListenersSpy).toHaveBeenCalledWith('error')
         })
     })

--- a/packages/server/sandbox/test/lib/sandbox/sandbox.test.ts
+++ b/packages/server/sandbox/test/lib/sandbox/sandbox.test.ts
@@ -44,6 +44,8 @@ function createTestProcessMaker() {
             ;(child as ChildProcess).pid = 12345
             ;(child as ChildProcess).exitCode = null
             ;(child as ChildProcess).kill = vi.fn()
+            ;(child as unknown as { stdout: EventEmitter }).stdout = new EventEmitter()
+            ;(child as unknown as { stderr: EventEmitter }).stderr = new EventEmitter()
 
             client = ioClient(`http://127.0.0.1:${port}`, {
                 path: '/worker/ws',
@@ -650,6 +652,59 @@ describe('createSandbox', () => {
             }
             catch (err) {
                 expect((err as ActivepiecesError).error.code).toBe(ErrorCode.SANDBOX_INTERNAL_ERROR)
+            }
+        })
+
+        it('captures native process stderr into the error when the engine crashes without socket output', async () => {
+            const { sandbox } = await startSandbox()
+            const client = testPM.getClient()
+            const child = testPM.getChild()
+            const nativeStack = 'Error: Boom inside engine trigger hook: cannot read properties of undefined\n    at run (google-sheets)\n'
+
+            client.on('rpc', () => {
+                ;(child.stderr as unknown as EventEmitter).emit('data', Buffer.from(nativeStack))
+                setTimeout(() => child.emit('exit', 1, null), 20)
+            })
+
+            const executePromise = sandbox.execute(
+                'EXECUTE_TRIGGER_HOOK' as any,
+                {} as any,
+                { timeoutInSeconds: 10 },
+            )
+
+            await expect(executePromise).rejects.toThrow()
+            try {
+                await executePromise
+            }
+            catch (err) {
+                const activepiecesError = err as ActivepiecesError
+                expect(activepiecesError.error.code).toBe(ErrorCode.SANDBOX_INTERNAL_ERROR)
+                expect((activepiecesError.error.params as { standardError: string }).standardError).toContain('Boom inside engine trigger hook')
+            }
+        })
+
+        it('classifies a native heap-OOM crash (exit code 1 / null) as SANDBOX_MEMORY_ISSUE', async () => {
+            const { sandbox } = await startSandbox()
+            const client = testPM.getClient()
+            const child = testPM.getChild()
+
+            client.on('rpc', () => {
+                ;(child.stderr as unknown as EventEmitter).emit('data', Buffer.from('FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory\n'))
+                setTimeout(() => child.emit('exit', 1, null), 20)
+            })
+
+            const executePromise = sandbox.execute(
+                'EXECUTE_TRIGGER_HOOK' as any,
+                {} as any,
+                { timeoutInSeconds: 10 },
+            )
+
+            await expect(executePromise).rejects.toThrow()
+            try {
+                await executePromise
+            }
+            catch (err) {
+                expect((err as ActivepiecesError).error.code).toBe(ErrorCode.SANDBOX_MEMORY_ISSUE)
             }
         })
 


### PR DESCRIPTION
## Problem

A failed production webhook run (Google Sheets `new_row_added` trigger hook) surfaced only as an opaque, undiagnosable error:

```
SANDBOX_INTERNAL_ERROR: Worker exited with code 1 and signal null standardOutput= standardError=
```

The engine runs as a **forked child process** and the sandbox collects its stdout/stderr **only over the RPC socket** (`EngineStdout`/`EngineStderr` messages). When the engine dies abruptly — an uncaught exception (`exit 1`) or a V8 heap-OOM abort — it writes the real diagnostic to its **native OS stderr** and never sends a socket message. So:

- `stdError` stays empty → the job error / BullMQ `failedReason` carries no cause.
- The OOM heuristic in `handleProcessExit` greps `stdError` for `"JavaScript heap out of memory"`, which can never match → memory crashes get misclassified as generic `SANDBOX_INTERNAL_ERROR`.

Root cause: the child's **native stderr pipe is never drained**. (For `fork.ts` it wasn't even a pipe — `silent` defaulted to false, so `child.stderr` was `null`.)

## Fix

- **`fork.ts`** — fork with `silent: true` so the child's stdout/stderr are pipes the worker can read.
- **`sandbox.ts`** — drain the child's native stdout/stderr into a bounded (8 KB tail) buffer and fold it into `handleProcessExit`, so crash output lands in the job error and reaches the RAM / log-size classifiers.
- **`isolate.ts`** — remove its private stdout/stderr forwarding now that capture is centralized in `sandbox.ts` (avoids double-writing to the worker console).

## Effect

| Situation | Before | After |
|---|---|---|
| Engine uncaught exception (`code 1`) | `standardError=` empty, opaque `SANDBOX_INTERNAL_ERROR` | error carries the real stack trace |
| Heap OOM exiting `code 1 / null` | misclassified `SANDBOX_INTERNAL_ERROR` | `SANDBOX_MEMORY_ISSUE` |
| Heap OOM aborting (`SIGABRT`) | `SANDBOX_MEMORY_ISSUE` | unchanged, now with diagnostic text attached |
| Normal run | logs from socket | unchanged (native buffer only used on crash path) |

## Verification

- Reproduced the exact production signature (`code 1 / signal null`, empty stderr) with a forked child; confirmed the fixed wiring captures the crash text.
- Added 2 regression tests in `sandbox.test.ts`: native stderr is attached to the error, and an OOM exiting `code 1/null` is now classified `SANDBOX_MEMORY_ISSUE`. **Both fail without the fix**, all **42** sandbox tests pass with it.
- `tsc` build + eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)