### PR TITLE
feat(onenote): include note content in trigger and add custom API call

### DIFF
--- a/packages/pieces/community/microsoft-onenote/package.json
+++ b/packages/pieces/community/microsoft-onenote/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-microsoft-onenote",
-  "version": "0.2.4",
+  "version": "0.3.0",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/packages/pieces/community/microsoft-onenote/src/index.ts
+++ b/packages/pieces/community/microsoft-onenote/src/index.ts
@@ -1,5 +1,7 @@
-import { createPiece } from '@activepieces/pieces-framework';
+import { createCustomApiCallAction } from '@activepieces/pieces-common';
+import { createPiece, OAuth2PropertyValue } from '@activepieces/pieces-framework';
 import { PieceCategory } from '@activepieces/pieces-framework';
+import { getGraphBaseUrl } from './lib/common/microsoft-cloud';
 import { appendNote } from './lib/actions/append-note';
 import { createImageNote } from './lib/actions/create-image-note';
 import { createNoteInSection } from './lib/actions/create-note-in-section';
@@ -25,6 +27,16 @@ export const microsoftOnenote = createPiece({
     createPage,
     createImageNote,
     appendNote,
+    createCustomApiCallAction({
+      auth: oneNoteAuth,
+      baseUrl: (auth) => {
+        const cloud = (auth as OAuth2PropertyValue).props?.['cloud'] as string | undefined;
+        return getGraphBaseUrl(cloud) + '/v1.0/';
+      },
+      authMapping: async (auth) => ({
+        Authorization: `Bearer ${auth.access_token}`,
+      }),
+    }),
   ],
   triggers: [newNoteInSectionTrigger],
 });

--- a/packages/pieces/community/microsoft-onenote/src/lib/triggers/new-note-in-section.ts
+++ b/packages/pieces/community/microsoft-onenote/src/lib/triggers/new-note-in-section.ts
@@ -4,8 +4,20 @@ import { DedupeStrategy, Polling, pollingHelper } from '@activepieces/pieces-com
 import { getGraphBaseUrl } from '../common/microsoft-cloud';
 import { getNotebooksDropdown, getSectionsByNotebookDropdown } from '../common';
 import { oneNoteAuth } from '../auth';
-import { Client, PageCollection } from '@microsoft/microsoft-graph-client';
+import { Client, PageCollection, ResponseType } from '@microsoft/microsoft-graph-client';
 import dayjs from 'dayjs';
+
+async function fetchPageContent(client: Client, pageId: string): Promise<string | null> {
+	try {
+		return await client
+			.api(`/me/onenote/pages/${pageId}/content`)
+			.responseType(ResponseType.TEXT)
+			.get();
+	} catch (error) {
+		console.error(`Failed to fetch content for page ${pageId}:`, error);
+		return null;
+	}
+}
 
 const polling: Polling<AppConnectionValueForAuthProperty<typeof oneNoteAuth>, { notebook_id: string; section_id: string }> = {
 	strategy: DedupeStrategy.TIMEBASED,
@@ -46,7 +58,14 @@ const polling: Polling<AppConnectionValueForAuthProperty<typeof oneNoteAuth>, { 
 				}
 			}
 
-			return pages.map((page) => ({
+			const pagesWithContent = await Promise.all(
+				pages.map(async (page) => ({
+					...page,
+					content: await fetchPageContent(client, page.id),
+				})),
+			);
+
+			return pagesWithContent.map((page) => ({
 				epochMilliSeconds: dayjs(page.createdDateTime).valueOf(),
 				data: page,
 			}));
@@ -136,6 +155,7 @@ export const newNoteInSectionTrigger = createTrigger({
 		lastModifiedDateTime: '2025-01-09T01:00:00Z',
 		createdByAppId: 'app-id-example',
 		contentUrl: 'https://graph.microsoft.com/v1.0/me/onenote/pages/page-id-example/content',
+		content: '<html><head><title>Sample Page Title</title></head><body><p>Sample note content.</p></body></html>',
 		links: {
 			oneNoteClientUrl: {
 				href: 'onenote:https://example.com/page'


### PR DESCRIPTION
- New Note in Section trigger now fetches each page's HTML content and attaches it as a 'content' field (best-effort, null on failure)
- Add generic Custom API Call action to the OneNote piece
