### PR TITLE
fix(tables): trim leading/trailing whitespace and control chars on CS…

### DIFF
--- a/packages/pieces/core/tables/package.json
+++ b/packages/pieces/core/tables/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-tables",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {

--- a/packages/pieces/core/tables/src/lib/common/index.ts
+++ b/packages/pieces/core/tables/src/lib/common/index.ts
@@ -297,7 +297,7 @@ export const csvUtils = {
     }
 
     for (const row of rows) {
-      lines.push(columnNames.map((name) => this.escapeCsvCell(row[name] ?? '')).join(','));
+      lines.push(columnNames.map((name) => this.escapeCsvCell(trimCellEdges(row[name] ?? ''))).join(','));
     }
 
     return lines.join('\n');
@@ -309,6 +309,12 @@ export const csvUtils = {
     }
     return value;
   },
+}
+
+const CELL_EDGE_CHARS = /^[\s\u0000-\u001F\u007F-\u009F]+|[\s\u0000-\u001F\u007F-\u009F]+$/g;
+
+function trimCellEdges(value: string): string {
+  return value.replace(CELL_EDGE_CHARS, '');
 }
 
 const fetchAllTables = async (context: { server: { apiUrl: string, token: string }, project: { id: string } }): Promise<Table[]> => {


### PR DESCRIPTION
…V export


Before: cell prod\n → CSV "prod⏎" (stray line break inside quotes)
  After: cell prod\n → CSV prod
## What does this PR do?

<!-- We need a clear description of what the PR does, as this will be used for the marketing team to generate the release notes. -->


### Explain How the Feature Works
<!-- Adding a video demonstration is optional but encourged! It helps reviewers / marketing team understand your implementation better. -->
<!-- [Insert the video link here] -->

### Relevant User Scenarios

<!-- List specific use cases where this feature would be valuable. -->
<!-- [Insert Pylon tickets or community posts here if possible] -->



Fixes # (issue)
