### PR TITLE
docs: drop CLAUDE_PUSH=yes force-verify-on-push guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,10 +86,6 @@ npx turbo run serve --filter=web -- --mode=cloud # Run local frontend against th
 
 When running in `--mode=cloud`, do not use OAuth2 connections — the OAuth provider will redirect back to `cloud.activepieces.com` after sign-in instead of your local frontend, breaking the flow. Use API-key / basic-auth connections, or test OAuth2 against a fully local backend.
 
-## Git Push
-
-- Always prefix `git push` with `CLAUDE_PUSH=yes` to auto-approve the pre-push lint/test gate, e.g. `CLAUDE_PUSH=yes git push -u origin HEAD`.
-
 ## Pull Requests
 
 - When creating a PR with `gh pr create`, always apply exactly one of these labels based on the nature of the change:

--- a/docs/handbook/engineering/playbooks/ai-engineering-guide.mdx
+++ b/docs/handbook/engineering/playbooks/ai-engineering-guide.mdx
@@ -198,7 +198,7 @@ npm run test-unit             # Run unit tests
 ```
 
 ```bash Ship
-CLAUDE_PUSH=yes git push -u origin HEAD
+git push -u origin HEAD
 ```
 
 </CodeGroup>


### PR DESCRIPTION
## What

Removes the guidance telling Claude to prefix `git push` with `CLAUDE_PUSH=yes`.

- `AGENTS.md` (and `CLAUDE.md`, a symlink to it): dropped the `## Git Push` section.
- `docs/handbook/engineering/playbooks/ai-engineering-guide.mdx`: "Ship" snippet now uses plain `git push -u origin HEAD`.

## Why

`CLAUDE_PUSH=yes` forces the full pre-push lint/test gate (`.husky/pre-push` sets `RUN_CHECKS="y"`) on every push, which is unnecessary and slows things down. With the flag gone, a plain `git push` from a non-interactive shell falls through to skipping the checks, while interactive users still get the prompt.

The `.husky/pre-push` hook is left untouched — it still supports `CLAUDE_PUSH=yes` opt-in and still blocks direct pushes to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)