### PR TITLE
feat(pieces): add LoopQuest piece

### DIFF
--- a/packages/pieces/community/loopquest/.eslintrc.json
+++ b/packages/pieces/community/loopquest/.eslintrc.json
@@ -1,0 +1,47 @@
+{
+  "extends": [
+    "../../../../.eslintrc.base.json"
+  ],
+  "ignorePatterns": [
+    "!**/*"
+  ],
+  "overrides": [
+    {
+      "files": [
+        "*.ts",
+        "*.tsx",
+        "*.js",
+        "*.jsx"
+      ],
+      "rules": {}
+    },
+    {
+      "files": [
+        "*.ts",
+        "*.tsx"
+      ],
+      "rules": {
+        "no-restricted-imports": [
+          "error",
+          {
+            "patterns": [
+              "lodash",
+              "lodash/*",
+              "@activepieces/core-*",
+              "@activepieces/server*",
+              "@activepieces/engine",
+              "@activepieces/shared"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "files": [
+        "*.js",
+        "*.jsx"
+      ],
+      "rules": {}
+    }
+  ]
+}

--- a/packages/pieces/community/loopquest/README.md
+++ b/packages/pieces/community/loopquest/README.md
@@ -1,0 +1,15 @@
+# LoopQuest
+
+Human-in-the-loop review for AI output. Gate an automation until a person approves (block), or monitor its quality in the background.
+
+## Actions
+- **Create Review Task** — send output to a human; pick a game (Swiper, Versus, Sorter, Detective, Fixer, Redact, Grounding) and a mode (gate or monitor), with an optional timeout + on-timeout fallback.
+- **Get Task Status** — poll a task's status / verdict.
+
+## Triggers
+- **New Verdict** — fires when a review resolves. Auto-subscribes the flow's webhook to LoopQuest on enable and unsubscribes on disable.
+
+## Auth
+A LoopQuest API key (Workspaces → API keys) and an optional Base URL for self-hosted deployments.
+
+Docs: https://loopquest.tomphillips.uk/docs

--- a/packages/pieces/community/loopquest/package.json
+++ b/packages/pieces/community/loopquest/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@activepieces/piece-loopquest",
+  "version": "0.0.1",
+  "main": "./dist/src/index.js",
+  "types": "./dist/src/index.d.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.lib.json && cp package.json dist/",
+    "bundle": "node ../../../../dist/packages/cli/src/index.js pieces bundle",
+    "lint": "eslint 'src/**/*.ts'"
+  },
+  "dependencies": {
+    "@activepieces/pieces-common": "workspace:*",
+    "@activepieces/pieces-framework": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
+  }
+}

--- a/packages/pieces/community/loopquest/src/index.ts
+++ b/packages/pieces/community/loopquest/src/index.ts
@@ -1,0 +1,18 @@
+import { createPiece, PieceCategory } from '@activepieces/pieces-framework';
+import { loopquestAuth } from './lib/auth';
+import { createReviewTask } from './lib/actions/create-review-task';
+import { getTaskStatus } from './lib/actions/get-task-status';
+import { newVerdict } from './lib/triggers/new-verdict';
+
+export const loopquest = createPiece({
+  displayName: 'LoopQuest',
+  description:
+    'Human-in-the-loop review for AI output — gate an automation until a person approves, or monitor its quality in the background.',
+  auth: loopquestAuth,
+  minimumSupportedRelease: '0.30.0',
+  logoUrl: 'https://loopquest.tomphillips.uk/icon.svg',
+  categories: [PieceCategory.ARTIFICIAL_INTELLIGENCE, PieceCategory.PRODUCTIVITY],
+  authors: ['TomPhillipsLabs'],
+  actions: [createReviewTask, getTaskStatus],
+  triggers: [newVerdict],
+});

--- a/packages/pieces/community/loopquest/src/lib/actions/create-review-task.ts
+++ b/packages/pieces/community/loopquest/src/lib/actions/create-review-task.ts
@@ -1,0 +1,109 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+import { loopquestAuth, baseUrl, authHeaders, LoopQuestAuth } from '../auth';
+import { buildTaskBody } from '../common/build-task-body';
+
+export const createReviewTask = createAction({
+  auth: loopquestAuth,
+  name: 'create_review_task',
+  displayName: 'Create Review Task',
+  description:
+    "Send AI/automation output to a human. Gate a downstream step until it's approved, or monitor quality in the background.",
+  props: {
+    content: Property.LongText({
+      displayName: 'Content',
+      required: true,
+      description: 'The output a human should review.',
+    }),
+    title: Property.ShortText({ displayName: 'Title', required: false }),
+    module: Property.StaticDropdown({
+      displayName: 'Game',
+      required: false,
+      defaultValue: 'swiper',
+      description: 'How the reviewer sees the item.',
+      options: {
+        options: [
+          { label: 'Swiper — approve or reject', value: 'swiper' },
+          { label: 'Versus — pick the better of two', value: 'versus' },
+          { label: 'Sorter — bucket into categories', value: 'sorter' },
+          { label: 'Detective — spot the problem', value: 'detective' },
+          { label: 'Fixer — correct the output', value: 'fixer' },
+          { label: 'Redact — mask sensitive text', value: 'redact' },
+          { label: 'Grounding — verify a claim against a source', value: 'grounding' },
+        ],
+      },
+    }),
+    mode: Property.StaticDropdown({
+      displayName: 'Mode',
+      required: false,
+      defaultValue: 'monitor',
+      description:
+        'Gate blocks a downstream step until a human approves (pair with the New Verdict trigger). Monitor reviews in the background.',
+      options: {
+        options: [
+          { label: 'Monitor — review in the background', value: 'monitor' },
+          { label: 'Gate — block until a human approves', value: 'gate' },
+        ],
+      },
+    }),
+    claim: Property.LongText({
+      displayName: 'Claim',
+      required: false,
+      description: 'Grounding only: the statement to verify.',
+    }),
+    sourceText: Property.LongText({
+      displayName: 'Source text',
+      required: false,
+      description: 'Grounding only: the reference the claim is checked against.',
+    }),
+    timeoutSeconds: Property.Number({
+      displayName: 'Timeout (seconds)',
+      required: false,
+      description:
+        'Gate only: apply the fallback if no one reviews in time (30–2592000).',
+    }),
+    onTimeout: Property.StaticDropdown({
+      displayName: 'On timeout',
+      required: false,
+      description:
+        'Gate only: what to do if the timeout is hit. Defaults to escalate (fail-closed).',
+      options: {
+        options: [
+          { label: 'Escalate — flag for a human', value: 'escalate' },
+          { label: 'Reject — treat as a flag', value: 'reject' },
+          { label: 'Approve — treat as approved', value: 'approve' },
+        ],
+      },
+    }),
+    source: Property.ShortText({
+      displayName: 'Source',
+      required: false,
+      defaultValue: 'activepieces',
+    }),
+    externalId: Property.ShortText({
+      displayName: 'External ID',
+      required: false,
+      description: 'Your own id — echoed back in the verdict for correlation.',
+    }),
+    callbackUrl: Property.ShortText({
+      displayName: 'Callback URL',
+      required: false,
+      description:
+        "Optional single webhook for this task's verdict. Leave blank if you use the New Verdict trigger.",
+    }),
+    reviewsRequired: Property.Number({
+      displayName: 'Reviewers required',
+      required: false,
+    }),
+  },
+  async run(context) {
+    const auth = context.auth as LoopQuestAuth;
+    const res = await httpClient.sendRequest({
+      method: HttpMethod.POST,
+      url: `${baseUrl(auth)}/api/v1/tasks`,
+      headers: authHeaders(auth),
+      body: buildTaskBody(context.propsValue as Record<string, unknown>),
+    });
+    return res.body;
+  },
+});

--- a/packages/pieces/community/loopquest/src/lib/actions/get-task-status.ts
+++ b/packages/pieces/community/loopquest/src/lib/actions/get-task-status.ts
@@ -1,6 +1,6 @@
 import { createAction, Property } from '@activepieces/pieces-framework';
 import { httpClient, HttpMethod } from '@activepieces/pieces-common';
-import { loopquestAuth, baseUrl, LoopQuestAuth } from '../auth';
+import { loopquestAuth, baseUrl, authHeaders, LoopQuestAuth } from '../auth';
 
 export const getTaskStatus = createAction({
   auth: loopquestAuth,
@@ -19,7 +19,7 @@ export const getTaskStatus = createAction({
     const res = await httpClient.sendRequest({
       method: HttpMethod.GET,
       url: `${baseUrl(auth)}/api/v1/tasks/${context.propsValue.taskId}`,
-      headers: { authorization: `Bearer ${auth.apiKey}` },
+      headers: authHeaders(auth),
     });
     return res.body;
   },

--- a/packages/pieces/community/loopquest/src/lib/actions/get-task-status.ts
+++ b/packages/pieces/community/loopquest/src/lib/actions/get-task-status.ts
@@ -1,0 +1,26 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+import { loopquestAuth, baseUrl, LoopQuestAuth } from '../auth';
+
+export const getTaskStatus = createAction({
+  auth: loopquestAuth,
+  name: 'get_task_status',
+  displayName: 'Get Task Status',
+  description: "Check a LoopQuest task's status / verdict.",
+  props: {
+    taskId: Property.ShortText({
+      displayName: 'Task ID',
+      required: true,
+      description: 'The id returned by Create Review Task.',
+    }),
+  },
+  async run(context) {
+    const auth = context.auth as LoopQuestAuth;
+    const res = await httpClient.sendRequest({
+      method: HttpMethod.GET,
+      url: `${baseUrl(auth)}/api/v1/tasks/${context.propsValue.taskId}`,
+      headers: { authorization: `Bearer ${auth.apiKey}` },
+    });
+    return res.body;
+  },
+});

--- a/packages/pieces/community/loopquest/src/lib/auth.ts
+++ b/packages/pieces/community/loopquest/src/lib/auth.ts
@@ -1,4 +1,15 @@
 import { PieceAuth, Property } from '@activepieces/pieces-framework';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+
+export type LoopQuestAuth = { apiKey: string; baseUrl?: string };
+
+export const baseUrl = (auth: LoopQuestAuth) =>
+  (auth.baseUrl || 'https://loopquest.tomphillips.uk').replace(/\/+$/, '');
+
+export const authHeaders = (auth: LoopQuestAuth) => ({
+  authorization: `Bearer ${auth.apiKey}`,
+  'content-type': 'application/json',
+});
 
 export const loopquestAuth = PieceAuth.CustomAuth({
   description:
@@ -12,14 +23,17 @@ export const loopquestAuth = PieceAuth.CustomAuth({
       defaultValue: 'https://loopquest.tomphillips.uk',
     }),
   },
-});
-
-export type LoopQuestAuth = { apiKey: string; baseUrl?: string };
-
-export const baseUrl = (auth: LoopQuestAuth) =>
-  (auth.baseUrl || 'https://loopquest.tomphillips.uk').replace(/\/+$/, '');
-
-export const authHeaders = (auth: LoopQuestAuth) => ({
-  authorization: `Bearer ${auth.apiKey}`,
-  'content-type': 'application/json',
+  validate: async ({ auth }) => {
+    const a = auth as LoopQuestAuth;
+    try {
+      await httpClient.sendRequest({
+        method: HttpMethod.GET,
+        url: `${baseUrl(a)}/api/v1/me`,
+        headers: authHeaders(a),
+      });
+      return { valid: true };
+    } catch {
+      return { valid: false, error: 'Invalid API key or base URL.' };
+    }
+  },
 });

--- a/packages/pieces/community/loopquest/src/lib/auth.ts
+++ b/packages/pieces/community/loopquest/src/lib/auth.ts
@@ -1,0 +1,25 @@
+import { PieceAuth, Property } from '@activepieces/pieces-framework';
+
+export const loopquestAuth = PieceAuth.CustomAuth({
+  description:
+    'Your LoopQuest API key (Workspaces → API keys) and, if self-hosting, your deployment URL.',
+  required: true,
+  props: {
+    apiKey: PieceAuth.SecretText({ displayName: 'API Key', required: true }),
+    baseUrl: Property.ShortText({
+      displayName: 'Base URL',
+      required: false,
+      defaultValue: 'https://loopquest.tomphillips.uk',
+    }),
+  },
+});
+
+export type LoopQuestAuth = { apiKey: string; baseUrl?: string };
+
+export const baseUrl = (auth: LoopQuestAuth) =>
+  (auth.baseUrl || 'https://loopquest.tomphillips.uk').replace(/\/+$/, '');
+
+export const authHeaders = (auth: LoopQuestAuth) => ({
+  authorization: `Bearer ${auth.apiKey}`,
+  'content-type': 'application/json',
+});

--- a/packages/pieces/community/loopquest/src/lib/common/build-task-body.ts
+++ b/packages/pieces/community/loopquest/src/lib/common/build-task-body.ts
@@ -1,0 +1,23 @@
+/** Build the POST /api/v1/tasks body from the action props. Pure. */
+export function buildTaskBody(
+  p: Record<string, unknown>
+): Record<string, unknown> {
+  const content = p['content'];
+  const payload: Record<string, unknown> = { content, body: content };
+  if (p['claim']) payload['claim'] = p['claim'];
+  if (p['sourceText']) payload['source'] = p['sourceText'];
+
+  const body: Record<string, unknown> = {
+    module: p['module'] ?? 'swiper',
+    mode: p['mode'] ?? 'monitor',
+    payload,
+    card: { title: p['title'] || 'Review', body: content },
+  };
+  if (p['source']) body['source'] = p['source'];
+  if (p['externalId']) body['external_id'] = p['externalId'];
+  if (p['callbackUrl']) body['callback_url'] = p['callbackUrl'];
+  if (p['timeoutSeconds']) body['timeout_seconds'] = p['timeoutSeconds'];
+  if (p['onTimeout']) body['on_timeout'] = p['onTimeout'];
+  if (p['reviewsRequired']) body['reviews_required'] = p['reviewsRequired'];
+  return body;
+}

--- a/packages/pieces/community/loopquest/src/lib/triggers/new-verdict.ts
+++ b/packages/pieces/community/loopquest/src/lib/triggers/new-verdict.ts
@@ -1,0 +1,51 @@
+import { createTrigger, TriggerStrategy } from '@activepieces/pieces-framework';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+import { loopquestAuth, baseUrl, authHeaders, LoopQuestAuth } from '../auth';
+
+export const newVerdict = createTrigger({
+  auth: loopquestAuth,
+  name: 'new_verdict',
+  displayName: 'New Verdict',
+  description:
+    'Fires the moment a human reviewer resolves a task — approve, flag, escalate or timeout. Use it to resume a gated action or act on a monitored review.',
+  type: TriggerStrategy.WEBHOOK,
+  props: {},
+  sampleData: {
+    task_id: '00000000-0000-0000-0000-000000000000',
+    external_id: 'order-42',
+    module: 'swiper',
+    source: 'activepieces',
+    verdict: true,
+    choice: null,
+    reason: null,
+    escalated: false,
+    timed_out: false,
+    reviewed_at: '2026-01-01T00:00:00Z',
+  },
+  // Auto-subscribe: register this flow's webhook URL with LoopQuest on enable,
+  // remove it on disable. Idempotent by URL server-side.
+  async onEnable(context) {
+    const auth = context.auth as LoopQuestAuth;
+    const res = await httpClient.sendRequest<{ id: string }>({
+      method: HttpMethod.POST,
+      url: `${baseUrl(auth)}/api/v1/hooks`,
+      headers: authHeaders(auth),
+      body: { url: context.webhookUrl },
+    });
+    await context.store.put('hookId', res.body.id);
+  },
+  async onDisable(context) {
+    const auth = context.auth as LoopQuestAuth;
+    const hookId = await context.store.get<string>('hookId');
+    if (hookId) {
+      await httpClient.sendRequest({
+        method: HttpMethod.DELETE,
+        url: `${baseUrl(auth)}/api/v1/hooks/${hookId}`,
+        headers: { authorization: `Bearer ${auth.apiKey}` },
+      });
+    }
+  },
+  async run(context) {
+    return [context.payload.body];
+  },
+});

--- a/packages/pieces/community/loopquest/src/lib/triggers/new-verdict.ts
+++ b/packages/pieces/community/loopquest/src/lib/triggers/new-verdict.ts
@@ -41,7 +41,7 @@ export const newVerdict = createTrigger({
       await httpClient.sendRequest({
         method: HttpMethod.DELETE,
         url: `${baseUrl(auth)}/api/v1/hooks/${hookId}`,
-        headers: { authorization: `Bearer ${auth.apiKey}` },
+        headers: authHeaders(auth),
       });
     }
   },

--- a/packages/pieces/community/loopquest/tsconfig.json
+++ b/packages/pieces/community/loopquest/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "noPropertyAccessFromIndexSignature": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/packages/pieces/community/loopquest/tsconfig.lib.json
+++ b/packages/pieces/community/loopquest/tsconfig.lib.json
@@ -1,0 +1,15 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "rootDir": ".",
+    "baseUrl": ".",
+    "paths": {},
+    "outDir": "./dist",
+    "declaration": true,
+    "declarationMap": true,
+    "types": ["node"]
+  },
+  "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"],
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
## New piece: LoopQuest

Adds a piece for [LoopQuest](https://loopquest.tomphillips.uk) — human-in-the-loop review for AI/automation output. Gate an automation until a person approves (block), or monitor its quality in the background.

### Actions
- **Create Review Task** — `POST /api/v1/tasks`. Pick a review game (swiper, versus, sorter, detective, fixer, redact, grounding) and a mode (`gate` blocks a downstream step until approval, `monitor` reviews out-of-band), with an optional timeout + on-timeout fallback.
- **Get Task Status** — `GET /api/v1/tasks/{id}`.

### Triggers
- **New Verdict** — a `WEBHOOK` trigger. Auto-subscribes the flow's webhook to LoopQuest (`POST /api/v1/hooks`) in `onEnable` and unsubscribes (`DELETE /api/v1/hooks/{id}`) in `onDisable`. Subscriptions are idempotent by URL.

### Auth
Custom auth: an API key (`apiKey`, secret) sent as `Authorization: Bearer`, plus an optional `baseUrl` for self-hosted deployments. Verifiable with `GET /api/v1/me`.

### Notes
- Structure and configs mirror an existing community piece; the request builder is factored into `src/lib/common/build-task-body.ts` and unit-tested in the source repo.
- If CI needs `pnpm-lock.yaml` regenerated for the new package, happy to update — flag it and I'll follow up.
- API docs: https://loopquest.tomphillips.uk/docs · OpenAPI: https://loopquest.tomphillips.uk/openapi.json

Checklist:
- [x] New piece under `packages/pieces/community/loopquest`
- [x] Actions + trigger with a custom (API key) auth
- [x] `package.json`, `tsconfig`, `.eslintrc` per community-piece layout
