### PR TITLE
fix(google-drive): upload/create file writing empty, untitled files

### DIFF
--- a/packages/pieces/community/google-drive/package.json
+++ b/packages/pieces/community/google-drive/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-google-drive",
-  "version": "0.7.9",
+  "version": "0.7.10",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "dependencies": {

--- a/packages/pieces/community/google-drive/src/lib/action/create-new-text-file.ts
+++ b/packages/pieces/community/google-drive/src/lib/action/create-new-text-file.ts
@@ -1,11 +1,6 @@
 import { createAction, Property } from '@activepieces/pieces-framework';
-import {
-  httpClient,
-  HttpMethod,
-  AuthenticationType,
-} from '@activepieces/pieces-common';
-import FormData from 'form-data';
-import { googleDriveAuth, getAccessToken } from '../auth';
+import { drive as googleDrive } from '@googleapis/drive';
+import { googleDriveAuth, createGoogleClient } from '../auth';
 import { common } from '../common';
 import { createNewGdriveFileActionOutputSchema } from '../output-schemas';
 
@@ -54,40 +49,25 @@ export const googleDriveCreateNewTextFile = createAction({
   },
   outputSchema: createNewGdriveFileActionOutputSchema,
   async run(context) {
-    const meta = {
-      mimeType: context.propsValue.fileType,
-      name: context.propsValue.fileName,
-      ...(context.propsValue.parentFolder
-        ? { parents: [context.propsValue.parentFolder] }
-        : {}),
-    };
+    const authClient = await createGoogleClient(context.auth);
+    const drive = googleDrive({ version: 'v3', auth: authClient });
 
-    const metaBuffer = Buffer.from(JSON.stringify(meta), 'utf-8');
-    const textBuffer = Buffer.from(context.propsValue.text!, 'utf-8');
-
-    const form = new FormData();
-    form.append('Metadata', metaBuffer, { contentType: 'application/json' });
-    form.append('Media', textBuffer, {
-      contentType: context.propsValue.fileType,
+    const response = await drive.files.create({
+      requestBody: {
+        name: context.propsValue.fileName,
+        mimeType: context.propsValue.fileType,
+        ...(context.propsValue.parentFolder
+          ? { parents: [context.propsValue.parentFolder] }
+          : {}),
+      },
+      media: {
+        mimeType: context.propsValue.fileType,
+        body: context.propsValue.text,
+      },
+      supportsAllDrives: context.propsValue.include_team_drives ?? false,
+      fields: 'id, name, mimeType, kind',
     });
 
-    const result = await httpClient.sendRequest({
-      method: HttpMethod.POST,
-      url: `https://www.googleapis.com/upload/drive/v3/files?uploadType=multipart`,
-      body: form,
-      headers: {
-        ...form.getHeaders(),
-      },
-      queryParams: {
-        supportsAllDrives: String(context.propsValue.include_team_drives || false),
-      },
-      authentication: {
-        type: AuthenticationType.BEARER_TOKEN,
-        token: await getAccessToken(context.auth),
-      },
-    });
-
-    console.debug('File creation response', result);
-    return result.body;
+    return response.data;
   },
 });

--- a/packages/pieces/community/google-drive/src/lib/action/create-new-text-file.ts
+++ b/packages/pieces/community/google-drive/src/lib/action/create-new-text-file.ts
@@ -26,12 +26,12 @@ export const googleDriveCreateNewTextFile = createAction({
       displayName: 'Content type',
       description: 'Select file type',
       required: true,
-      defaultValue: 'plain/text',
+      defaultValue: 'text/plain',
       options: {
         options: [
           {
             label: 'Text',
-            value: 'plain/text',
+            value: 'text/plain',
           },
           {
             label: 'CSV',
@@ -52,16 +52,23 @@ export const googleDriveCreateNewTextFile = createAction({
     const authClient = await createGoogleClient(context.auth);
     const drive = googleDrive({ version: 'v3', auth: authClient });
 
+    // Normalize the legacy 'plain/text' value saved by existing flows to the
+    // valid 'text/plain' MIME type Google Drive expects.
+    const mimeType =
+      context.propsValue.fileType === 'plain/text'
+        ? 'text/plain'
+        : context.propsValue.fileType;
+
     const response = await drive.files.create({
       requestBody: {
         name: context.propsValue.fileName,
-        mimeType: context.propsValue.fileType,
+        mimeType,
         ...(context.propsValue.parentFolder
           ? { parents: [context.propsValue.parentFolder] }
           : {}),
       },
       media: {
-        mimeType: context.propsValue.fileType,
+        mimeType,
         body: context.propsValue.text,
       },
       supportsAllDrives: context.propsValue.include_team_drives ?? false,

--- a/packages/pieces/community/google-drive/src/lib/action/upload-file.ts
+++ b/packages/pieces/community/google-drive/src/lib/action/upload-file.ts
@@ -1,12 +1,8 @@
 import { createAction, Property } from '@activepieces/pieces-framework';
-import {
-  httpClient,
-  HttpMethod,
-  AuthenticationType,
-} from '@activepieces/pieces-common';
-import FormData from 'form-data';
-import { googleDriveAuth, getAccessToken } from '../auth';
+import { Readable } from 'stream';
 import mime from 'mime-types';
+import { drive as googleDrive } from '@googleapis/drive';
+import { googleDriveAuth, createGoogleClient } from '../auth';
 import { common } from '../common';
 import { uploadGdriveFileActionOutputSchema } from '../output-schemas';
 
@@ -34,43 +30,26 @@ export const googleDriveUploadFile = createAction({
   outputSchema: uploadGdriveFileActionOutputSchema,
   async run(context) {
     const fileData = context.propsValue.file;
-    const mimeType = mime.lookup(fileData.extension ? fileData.extension : '');
+    const mimeType = mime.lookup(fileData.extension ?? '') || 'application/octet-stream';
 
-    const meta = {
-      mimeType: mimeType,
-      name: context.propsValue.fileName,
-      ...(context.propsValue.parentFolder
-        ? { parents: [context.propsValue.parentFolder] }
-        : {}),
-    };
+    const authClient = await createGoogleClient(context.auth);
+    const drive = googleDrive({ version: 'v3', auth: authClient });
 
-    const metaBuffer = Buffer.from(JSON.stringify(meta), 'utf-8');
-    const fileBuffer = Buffer.from(fileData.base64, 'base64');
-
-    const form = new FormData();
-    form.append('Metadata', metaBuffer, { contentType: 'application/json' });
-    form.append('Media', fileBuffer);
-
-    const result = await httpClient.sendRequest({
-      method: HttpMethod.POST,
-      url: `https://www.googleapis.com/upload/drive/v3/files`,
-      queryParams: {
-        uploadType: 'multipart',
-        supportsAllDrives: String(
-          context.propsValue.include_team_drives || false
-        ),
+    const response = await drive.files.create({
+      requestBody: {
+        name: context.propsValue.fileName,
+        ...(context.propsValue.parentFolder
+          ? { parents: [context.propsValue.parentFolder] }
+          : {}),
       },
-      body: form,
-      headers: {
-        ...form.getHeaders(),
+      media: {
+        mimeType,
+        body: Readable.from(Buffer.from(fileData.base64, 'base64')),
       },
-      authentication: {
-        type: AuthenticationType.BEARER_TOKEN,
-        token: await getAccessToken(context.auth),
-      },
+      supportsAllDrives: context.propsValue.include_team_drives ?? false,
+      fields: 'id, name, mimeType, kind',
     });
 
-    console.debug('File upload response', result);
-    return result.body;
+    return response.data;
   },
 });


### PR DESCRIPTION
The Upload file and Create new file actions built the request with the form-data library, which sends Content-Type: multipart/form-data. Google Drive's uploadType=multipart endpoint requires multipart/related; with the wrong content type Drive ignored both the metadata and media parts, producing an empty, "Untitled" file placed outside the chosen folder.

Switch both actions to the official @googleapis/drive files.create client (already used elsewhere in this piece), which builds a correct multipart/related upload. This also fixes the metadata mimeType, which was serialized as `false` when the extension was unknown.

## What does this PR do?

<!-- We need a clear description of what the PR does, as this will be used for the marketing team to generate the release notes. -->


### Explain How the Feature Works
<!-- Adding a video demonstration is optional but encourged! It helps reviewers / marketing team understand your implementation better. -->
<!-- [Insert the video link here] -->

### Relevant User Scenarios

<!-- List specific use cases where this feature would be valuable. -->
<!-- [Insert Pylon tickets or community posts here if possible] -->



Fixes # (issue)
