### PR TITLE
fix: add archive, delete, and label email actions to Gmail piece

### DIFF
--- a/packages/pieces/community/gmail/src/index.ts
+++ b/packages/pieces/community/gmail/src/index.ts
@@ -11,6 +11,9 @@ import { gmailNewAttachmentTrigger } from './lib/triggers/new-attachment';
 import { gmailNewLabelTrigger } from './lib/triggers/new-label';
 import { gmailSearchMailAction } from './lib/actions/search-email-action';
 import { gmailGetEmailAction } from './lib/actions/get-mail-action';
+import { gmailArchiveEmailAction } from './lib/actions/archive-email-action';
+import { gmailDeleteEmailAction } from './lib/actions/delete-email-action';
+import { gmailLabelEmailAction } from './lib/actions/label-email-action';
 import { gmailAuth, getAccessToken, GmailAuthValue } from './lib/auth';
 
 export {
@@ -34,6 +37,9 @@ export const gmail = createPiece({
     gmailCreateDraftReplyAction,
     gmailGetEmailAction,
     gmailSearchMailAction,
+    gmailArchiveEmailAction,
+    gmailDeleteEmailAction,
+    gmailLabelEmailAction,
     createCustomApiCallAction({
       baseUrl: () => 'https://gmail.googleapis.com/gmail/v1',
       auth: gmailAuth,
@@ -44,7 +50,6 @@ export const gmail = createPiece({
   ],
   displayName: 'Gmail',
   description: 'Email service by Google',
-
   authors: [
     'kanarelo',
     'abdullahranginwala',

--- a/packages/pieces/community/gmail/src/lib/actions/archive-email-action.ts
+++ b/packages/pieces/community/gmail/src/lib/actions/archive-email-action.ts
@@ -1,23 +1,22 @@
-import { createAction } from '@activepieces/pieces-framework';
-import { gmailAuth, getAccessToken, GmailAuthValue } from '../auth';
-import { google } from 'googleapis';
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { gmailAuth, createGoogleClient } from '../auth';
+import { gmail as googleGmail } from '@googleapis/gmail';
 
 export const gmailArchiveEmailAction = createAction({
   auth: gmailAuth,
-  name: 'archive_email',
+  name: 'gmail_archive_email',
   displayName: 'Archive Email',
-  description: 'Archive an email message',
+  description: 'Archive an email by removing it from the inbox.',
   props: {
-    message_id: {
+    message_id: Property.ShortText({
       displayName: 'Message ID',
-      description: 'The ID of the message to archive',
-      singleLine: true,
+      description: 'The ID of the email message to archive.',
       required: true,
-    },
+    }),
   },
   async run(context) {
-    const auth = await getAccessToken(context.auth as GmailAuthValue);
-    const gmail = google.gmail({ version: 'v1', auth });
+    const authClient = await createGoogleClient(context.auth);
+    const gmail = googleGmail({ version: 'v1', auth: authClient });
 
     await gmail.users.messages.modify({
       userId: 'me',
@@ -27,6 +26,6 @@ export const gmailArchiveEmailAction = createAction({
       },
     });
 
-    return { success: true };
+    return { success: true, messageId: context.propsValue.message_id };
   },
 });

--- a/packages/pieces/community/gmail/src/lib/actions/archive-email-action.ts
+++ b/packages/pieces/community/gmail/src/lib/actions/archive-email-action.ts
@@ -1,0 +1,32 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { gmailAuth, getAccessToken, GmailAuthValue } from '../auth';
+import { google } from 'googleapis';
+
+export const gmailArchiveEmailAction = createAction({
+  auth: gmailAuth,
+  name: 'archive_email',
+  displayName: 'Archive Email',
+  description: 'Archive an email message',
+  props: {
+    message_id: {
+      displayName: 'Message ID',
+      description: 'The ID of the message to archive',
+      singleLine: true,
+      required: true,
+    },
+  },
+  async run(context) {
+    const auth = await getAccessToken(context.auth as GmailAuthValue);
+    const gmail = google.gmail({ version: 'v1', auth });
+
+    await gmail.users.messages.modify({
+      userId: 'me',
+      id: context.propsValue.message_id,
+      requestBody: {
+        removeLabelIds: ['INBOX'],
+      },
+    });
+
+    return { success: true };
+  },
+});

--- a/packages/pieces/community/gmail/src/lib/actions/delete-email-action.ts
+++ b/packages/pieces/community/gmail/src/lib/actions/delete-email-action.ts
@@ -1,0 +1,29 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { gmailAuth, getAccessToken, GmailAuthValue } from '../auth';
+import { google } from 'googleapis';
+
+export const gmailDeleteEmailAction = createAction({
+  auth: gmailAuth,
+  name: 'delete_email',
+  displayName: 'Delete Email',
+  description: 'Permanently delete an email message',
+  props: {
+    message_id: {
+      displayName: 'Message ID',
+      description: 'The ID of the message to delete',
+      singleLine: true,
+      required: true,
+    },
+  },
+  async run(context) {
+    const auth = await getAccessToken(context.auth as GmailAuthValue);
+    const gmail = google.gmail({ version: 'v1', auth });
+
+    await gmail.users.messages.delete({
+      userId: 'me',
+      id: context.propsValue.message_id,
+    });
+
+    return { success: true };
+  },
+});

--- a/packages/pieces/community/gmail/src/lib/actions/delete-email-action.ts
+++ b/packages/pieces/community/gmail/src/lib/actions/delete-email-action.ts
@@ -1,29 +1,45 @@
-import { createAction } from '@activepieces/pieces-framework';
-import { gmailAuth, getAccessToken, GmailAuthValue } from '../auth';
-import { google } from 'googleapis';
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { gmailAuth, createGoogleClient } from '../auth';
+import { gmail as googleGmail } from '@googleapis/gmail';
 
 export const gmailDeleteEmailAction = createAction({
   auth: gmailAuth,
-  name: 'delete_email',
+  name: 'gmail_delete_email',
   displayName: 'Delete Email',
-  description: 'Permanently delete an email message',
+  description: 'Move an email to trash or permanently delete it.',
   props: {
-    message_id: {
+    message_id: Property.ShortText({
       displayName: 'Message ID',
-      description: 'The ID of the message to delete',
-      singleLine: true,
+      description: 'The ID of the email message to delete.',
       required: true,
-    },
+    }),
+    permanent: Property.Checkbox({
+      displayName: 'Permanently Delete',
+      description: 'If enabled, permanently delete the email instead of moving it to trash.',
+      required: false,
+      defaultValue: false,
+    }),
   },
   async run(context) {
-    const auth = await getAccessToken(context.auth as GmailAuthValue);
-    const gmail = google.gmail({ version: 'v1', auth });
+    const authClient = await createGoogleClient(context.auth);
+    const gmail = googleGmail({ version: 'v1', auth: authClient });
 
-    await gmail.users.messages.delete({
-      userId: 'me',
-      id: context.propsValue.message_id,
-    });
+    if (context.propsValue.permanent) {
+      await gmail.users.messages.delete({
+        userId: 'me',
+        id: context.propsValue.message_id,
+      });
+    } else {
+      await gmail.users.messages.trash({
+        userId: 'me',
+        id: context.propsValue.message_id,
+      });
+    }
 
-    return { success: true };
+    return {
+      success: true,
+      messageId: context.propsValue.message_id,
+      action: context.propsValue.permanent ? 'permanently_deleted' : 'moved_to_trash',
+    };
   },
 });

--- a/packages/pieces/community/gmail/src/lib/actions/label-email-action.ts
+++ b/packages/pieces/community/gmail/src/lib/actions/label-email-action.ts
@@ -1,0 +1,40 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { gmailAuth, getAccessToken, GmailAuthValue } from '../auth';
+import { google } from 'googleapis';
+
+export const gmailLabelEmailAction = createAction({
+  auth: gmailAuth,
+  name: 'label_email',
+  displayName: 'Label Email',
+  description: 'Apply labels to an email message',
+  props: {
+    message_id: {
+      displayName: 'Message ID',
+      description: 'The ID of the message to label',
+      singleLine: true,
+      required: true,
+    },
+    label_ids: {
+      displayName: 'Label IDs',
+      description: 'Comma-separated list of label IDs to apply',
+      singleLine: true,
+      required: true,
+    },
+  },
+  async run(context) {
+    const auth = await getAccessToken(context.auth as GmailAuthValue);
+    const gmail = google.gmail({ version: 'v1', auth });
+
+    const labelIds = context.propsValue.label_ids.split(',').map((id: string) => id.trim());
+
+    await gmail.users.messages.modify({
+      userId: 'me',
+      id: context.propsValue.message_id,
+      requestBody: {
+        addLabelIds: labelIds,
+      },
+    });
+
+    return { success: true };
+  },
+});

--- a/packages/pieces/community/gmail/src/lib/actions/label-email-action.ts
+++ b/packages/pieces/community/gmail/src/lib/actions/label-email-action.ts
@@ -1,40 +1,55 @@
-import { createAction } from '@activepieces/pieces-framework';
-import { gmailAuth, getAccessToken, GmailAuthValue } from '../auth';
-import { google } from 'googleapis';
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { gmailAuth, createGoogleClient } from '../auth';
+import { gmail as googleGmail } from '@googleapis/gmail';
 
-export const gmailLabelEmailAction = createAction({
+export const gmailModifyLabelAction = createAction({
   auth: gmailAuth,
-  name: 'label_email',
-  displayName: 'Label Email',
-  description: 'Apply labels to an email message',
+  name: 'gmail_modify_label',
+  displayName: 'Add/Remove Label',
+  description: 'Add or remove a label from an email.',
   props: {
-    message_id: {
+    message_id: Property.ShortText({
       displayName: 'Message ID',
-      description: 'The ID of the message to label',
-      singleLine: true,
+      description: 'The ID of the email message to modify.',
       required: true,
-    },
-    label_ids: {
-      displayName: 'Label IDs',
-      description: 'Comma-separated list of label IDs to apply',
-      singleLine: true,
+    }),
+    action: Property.StaticDropdown({
+      displayName: 'Action',
+      description: 'Whether to add or remove the label.',
       required: true,
-    },
+      options: {
+        options: [
+          { label: 'Add Label', value: 'add' },
+          { label: 'Remove Label', value: 'remove' },
+        ],
+      },
+    }),
+    label_id: Property.ShortText({
+      displayName: 'Label ID',
+      description: 'The Gmail label ID to add or remove (e.g., IMPORTANT, STARRED, or a custom label ID).',
+      required: true,
+    }),
   },
   async run(context) {
-    const auth = await getAccessToken(context.auth as GmailAuthValue);
-    const gmail = google.gmail({ version: 'v1', auth });
+    const authClient = await createGoogleClient(context.auth);
+    const gmail = googleGmail({ version: 'v1', auth: authClient });
 
-    const labelIds = context.propsValue.label_ids.split(',').map((id: string) => id.trim());
+    const isAdd = context.propsValue.action === 'add';
 
     await gmail.users.messages.modify({
       userId: 'me',
       id: context.propsValue.message_id,
       requestBody: {
-        addLabelIds: labelIds,
+        addLabelIds: isAdd ? [context.propsValue.label_id] : [],
+        removeLabelIds: isAdd ? [] : [context.propsValue.label_id],
       },
     });
 
-    return { success: true };
+    return {
+      success: true,
+      messageId: context.propsValue.message_id,
+      action: isAdd ? 'label_added' : 'label_removed',
+      labelId: context.propsValue.label_id,
+    };
   },
 });


### PR DESCRIPTION
Adds archive, delete, and label email actions to the Gmail MCP piece, resolving the missing actions listed in issue #8072.

Implements:
- Archive email action
- Delete email action  
- Add/remove label action

All actions follow the existing piece pattern with proper OAuth2 authentication.

Closes #8072
