### PR TITLE
fix(engine): EXECUTE_PROPERTY stalls for minutes on flows with huge sample data (0.79 release line)

### DIFF
--- a/packages/server/engine/src/lib/handler/context/test-execution-context.ts
+++ b/packages/server/engine/src/lib/handler/context/test-execution-context.ts
@@ -1,7 +1,9 @@
 import { LATEST_CONTEXT_VERSION } from '@activepieces/pieces-framework'
 import {
+    FlowAction,
     FlowActionType,
     flowStructureUtil,
+    FlowTrigger,
     FlowTriggerType,
     FlowVersion,
     GenericStepOutput,
@@ -11,7 +13,7 @@ import {
     spreadIfDefined,
     StepOutputStatus,
 } from '@activepieces/shared'
-import { createPropsResolver } from '../../variables/props-resolver'
+import { createPropsResolver, extractReferencedStepNames } from '../../variables/props-resolver'
 import { EngineConstants } from './engine-constants'
 import { FlowExecutorContext } from './flow-execution-context'
 
@@ -24,13 +26,19 @@ export const testExecutionContext = {
         apiUrl,
         sampleData,
         engineConstants,
+        unresolvedInput,
     }: TestExecutionParams): Promise<FlowExecutorContext> {
         let flowExecutionContext = FlowExecutorContext.empty()
         if (isNil(flowVersion)) {
             return flowExecutionContext
         }
-        
+
         const flowSteps = flowStructureUtil.getAllSteps(flowVersion.trigger)
+        const relevantStepNames = computeRelevantStepNames({
+            unresolvedInput,
+            flowSteps,
+            stepNames: engineConstants.stepNames,
+        })
 
         for (const step of flowSteps) {
             const { name } = step
@@ -52,6 +60,20 @@ export const testExecutionContext = {
                     )
                     break
                 case FlowActionType.LOOP_ON_ITEMS: {
+                    const isRelevantToInput = isNil(relevantStepNames) || relevantStepNames.has(step.name)
+                    if (!isRelevantToInput) {
+                        // Resolving a loop's settings copies every referenced step
+                        // output into the code sandbox — with multi-megabyte sample
+                        // data this takes minutes. Skip loops the resolved input
+                        // never references (directly or through another loop).
+                        flowExecutionContext = flowExecutionContext.upsertStep(
+                            step.name,
+                            LoopStepOutput.init({
+                                input: step.settings,
+                            }),
+                        )
+                        break
+                    }
                     const { resolvedInput } = await createPropsResolver({
                         apiUrl,
                         projectId,
@@ -91,6 +113,42 @@ export const testExecutionContext = {
     },
 }
 
+/**
+ * Steps whose output can influence resolving `unresolvedInput`: the steps it
+ * references textually, expanded transitively through loop settings (a
+ * referenced loop's `item` depends on the steps its own settings reference).
+ * Returns undefined when no input is provided, meaning "everything is
+ * relevant" — callers like single-step test runs keep the old behavior.
+ */
+function computeRelevantStepNames({ unresolvedInput, flowSteps, stepNames }: ComputeRelevantStepNamesParams): Set<string> | undefined {
+    if (isNil(unresolvedInput)) {
+        return undefined
+    }
+    const relevantStepNames = extractReferencedStepNames(unresolvedInput, stepNames)
+    const loopSteps = flowSteps.filter((step) => step.type === FlowActionType.LOOP_ON_ITEMS)
+    let changed = true
+    while (changed) {
+        changed = false
+        for (const loopStep of loopSteps) {
+            if (!relevantStepNames.has(loopStep.name)) {
+                continue
+            }
+            for (const referencedStepName of extractReferencedStepNames(loopStep.settings, stepNames)) {
+                if (!relevantStepNames.has(referencedStepName)) {
+                    relevantStepNames.add(referencedStepName)
+                    changed = true
+                }
+            }
+        }
+    }
+    return relevantStepNames
+}
+
+type ComputeRelevantStepNamesParams = {
+    unresolvedInput: unknown
+    flowSteps: (FlowAction | FlowTrigger)[]
+    stepNames: string[]
+}
 
 type TestExecutionParams = {
     engineConstants: EngineConstants
@@ -100,4 +158,5 @@ type TestExecutionParams = {
     apiUrl: string
     engineToken: string
     sampleData?: Record<string, unknown>
+    unresolvedInput?: unknown
 }

--- a/packages/server/engine/src/lib/helper/piece-helper.ts
+++ b/packages/server/engine/src/lib/helper/piece-helper.ts
@@ -37,6 +37,7 @@ export const pieceHelper = {
             engineToken: operation.engineToken,
             sampleData: operation.sampleData,
             engineConstants: constants,
+            unresolvedInput: operation.input,
         })
         const { property, piece } = await pieceLoader.getPropOrThrow({ pieceName: operation.pieceName, pieceVersion: operation.pieceVersion, actionOrTriggerName: operation.actionOrTriggerName, propertyName: operation.propertyName, devPieces: EngineConstants.DEV_PIECES })
     

--- a/packages/server/engine/src/lib/utils.ts
+++ b/packages/server/engine/src/lib/utils.ts
@@ -2,7 +2,7 @@ import fs from 'fs/promises'
 import { inspect } from 'node:util'
 import path from 'path'
 import { ConnectionsManager, ContextVersion, PauseHookParams, RespondHookParams, StopHookParams } from '@activepieces/pieces-framework'
-import { ExecutionError, ExecutionErrorType, Result, tryCatch } from '@activepieces/shared'
+import { ExecutionError, ExecutionErrorType, isNil, Result, tryCatch } from '@activepieces/shared'
 import { createConnectionService } from './services/connections.service'
 
 export type FileEntry = {
@@ -82,7 +82,10 @@ export const utils = {
         }
     },
     sizeof(object: unknown): number {
-        const objectList = []
+        // A Set keeps the seen-object lookup O(1); the previous
+        // objectList.indexOf() scan made this quadratic and pinned the CPU
+        // for minutes on multi-megabyte deeply-nested step outputs.
+        const seenObjects = new Set<object>()
         const stack = [object]
         let bytes = 0
 
@@ -98,8 +101,8 @@ export const utils = {
             else if (typeof value === 'number') {
                 bytes += 8
             }
-            else if (typeof value === 'object' && objectList.indexOf( value ) === -1) {
-                objectList.push(value)
+            else if (typeof value === 'object' && !isNil(value) && !seenObjects.has(value)) {
+                seenObjects.add(value)
                 // if the object is not an array, add the sizes of the keys
                 if (Object.prototype.toString.call(value) != '[object Array]') {
                     for (const key in value) bytes += 2 * key.length

--- a/packages/server/engine/src/lib/variables/props-resolver.ts
+++ b/packages/server/engine/src/lib/variables/props-resolver.ts
@@ -82,7 +82,7 @@ const mergeFlattenedKeysArraysIntoOneArray = async (token: string, partsThatNeed
 
 export type PropsResolver = ReturnType<typeof createPropsResolver>
 
-function extractReferencedStepNames(input: unknown, stepNames: string[]): Set<string> {
+export function extractReferencedStepNames(input: unknown, stepNames: string[]): Set<string> {
     const stringifiedInput = JSON.stringify(input)
     const referencedSteps = new Set<string>()
     for (const stepName of stepNames) {

--- a/packages/server/engine/test/services/execute-property-sample-data.test.ts
+++ b/packages/server/engine/test/services/execute-property-sample-data.test.ts
@@ -2,16 +2,15 @@
  * Reproduces a production incident: a single EXECUTE_PROPERTY request stalls
  * for minutes (then hits the sandbox timeout → SIGKILL → retry storm) under
  * SANDBOX_CODE_ONLY when the flow contains a step with a huge, deeply-nested
- * sample output (e.g. a full Google Docs `documents.get` response, ~17 MB) —
- * even though the property being resolved never references that step.
+ * sample output (e.g. a full Google Docs `documents.get` response, ~17 MB)
+ * that is referenced by a loop step — even though the property being resolved
+ * never references that step.
  *
- * Root cause: utils.sizeof deduplicated visited objects with a linear
- * objectList.indexOf scan — O(n²) over the ~750k tiny objects such a
- * document contains — and upsertStep runs trimExecutionInput → sizeof over
- * the whole step map on every upsert while stateFromFlowVersion builds the
- * property-resolution state. Before the fix this test took ~164s on an
- * M-series laptop; after, well under a second of sizeof time (the remaining
- * seconds are the loop settings resolving through isolated-vm).
+ * Mechanism: testExecutionContext.stateFromFlowVersion() eagerly resolves
+ * EVERY loop step's settings through the props resolver. Each `{{...}}` token
+ * pushes the whole referenced state through JSON.stringify + JSON.parse +
+ * ivm.ExternalCopy into a fresh 128 MB isolate, twice (resolved + censored
+ * pass) — regardless of what the EXECUTE_PROPERTY input actually references.
  *
  * AP_EXECUTION_MODE must be set before the engine's code-sandbox module is
  * evaluated (it captures the env var at import time), hence the dynamic
@@ -28,10 +27,7 @@ import {
 
 const HUGE_STEP_NAME = 'step_1'
 const PARAGRAPH_COUNT = 25_000
-// Post-fix cost is dominated by the two loops copying the 31MB sample into
-// isolated-vm (~4s locally); pre-fix the quadratic sizeof took ~164s. The
-// threshold sits between the two with headroom for slow CI machines.
-const MAX_ACCEPTABLE_DURATION_MS = 20_000
+const MAX_ACCEPTABLE_DURATION_MS = 5_000
 
 describe('executeProps with huge sample data on an unreferenced step', () => {
     it('resolves a property that does not reference the huge step without stalling', async () => {
@@ -67,6 +63,7 @@ describe('executeProps with huge sample data on an unreferenced step', () => {
             engineToken: constants.engineToken,
             sampleData,
             engineConstants: constants,
+            unresolvedInput,
         })
 
         const { resolvedInput } = await createPropsResolver({
@@ -102,8 +99,8 @@ describe('executeProps with huge sample data on an unreferenced step', () => {
         const stepNames = ['trigger', HUGE_STEP_NAME, 'step_2', 'step_3', 'step_4']
         const constants = generateMockEngineConstants({ stepNames })
 
-        // References the loop's item: guards that loop settings still resolve
-        // into the state used for property resolution.
+        // References the loop's item: the loop must resolve even though the
+        // huge step is only referenced transitively through the loop settings.
         const unresolvedInput = {
             paragraphStart: '{{step_2[\'item\'][\'startIndex\']}}',
         }
@@ -115,6 +112,7 @@ describe('executeProps with huge sample data on an unreferenced step', () => {
             engineToken: constants.engineToken,
             sampleData,
             engineConstants: constants,
+            unresolvedInput,
         })
 
         const { resolvedInput } = await createPropsResolver({

--- a/packages/server/engine/test/services/execute-property-sample-data.test.ts
+++ b/packages/server/engine/test/services/execute-property-sample-data.test.ts
@@ -1,0 +1,258 @@
+/**
+ * Reproduces a production incident: a single EXECUTE_PROPERTY request stalls
+ * for minutes (then hits the sandbox timeout → SIGKILL → retry storm) under
+ * SANDBOX_CODE_ONLY when the flow contains a step with a huge, deeply-nested
+ * sample output (e.g. a full Google Docs `documents.get` response, ~17 MB) —
+ * even though the property being resolved never references that step.
+ *
+ * Root cause: utils.sizeof deduplicated visited objects with a linear
+ * objectList.indexOf scan — O(n²) over the ~750k tiny objects such a
+ * document contains — and upsertStep runs trimExecutionInput → sizeof over
+ * the whole step map on every upsert while stateFromFlowVersion builds the
+ * property-resolution state. Before the fix this test took ~164s on an
+ * M-series laptop; after, well under a second of sizeof time (the remaining
+ * seconds are the loop settings resolving through isolated-vm).
+ *
+ * AP_EXECUTION_MODE must be set before the engine's code-sandbox module is
+ * evaluated (it captures the env var at import time), hence the dynamic
+ * imports below.
+ */
+process.env.AP_EXECUTION_MODE = 'SANDBOX_CODE_ONLY'
+
+import {
+    FlowActionType,
+    FlowTriggerType,
+    FlowVersion,
+    FlowVersionState,
+} from '@activepieces/shared'
+
+const HUGE_STEP_NAME = 'step_1'
+const PARAGRAPH_COUNT = 25_000
+// Post-fix cost is dominated by the two loops copying the 31MB sample into
+// isolated-vm (~4s locally); pre-fix the quadratic sizeof took ~164s. The
+// threshold sits between the two with headroom for slow CI machines.
+const MAX_ACCEPTABLE_DURATION_MS = 20_000
+
+describe('executeProps with huge sample data on an unreferenced step', () => {
+    it('resolves a property that does not reference the huge step without stalling', async () => {
+        const { testExecutionContext } = await import('../../src/lib/handler/context/test-execution-context')
+        const { createPropsResolver } = await import('../../src/lib/variables/props-resolver')
+        const { generateMockEngineConstants } = await import('../handler/test-helper')
+
+        const flowVersion = buildFlowVersion()
+        const hugeDocument = buildGoogleDocsLikeDocument({ paragraphCount: PARAGRAPH_COUNT })
+        const sampleData = {
+            trigger: { body: { filter: 'active' } },
+            [HUGE_STEP_NAME]: hugeDocument,
+        }
+        console.log(`sample data size: ${(JSON.stringify(hugeDocument).length / 1024 / 1024).toFixed(1)} MB`)
+
+        const stepNames = ['trigger', HUGE_STEP_NAME, 'step_2', 'step_3', 'step_4']
+        const constants = generateMockEngineConstants({ stepNames })
+
+        // A dropdown input on an unrelated step: no reference to step_1
+        const unresolvedInput = {
+            authType: 'basic',
+            filter: '{{trigger[\'body\'][\'filter\']}}',
+        }
+
+        const startedAt = performance.now()
+
+        // Mirrors pieceHelper.executeProps: build the test state, then resolve
+        // the queried property's input against it.
+        const executionState = await testExecutionContext.stateFromFlowVersion({
+            apiUrl: constants.internalApiUrl,
+            flowVersion,
+            projectId: constants.projectId,
+            engineToken: constants.engineToken,
+            sampleData,
+            engineConstants: constants,
+        })
+
+        const { resolvedInput } = await createPropsResolver({
+            apiUrl: constants.internalApiUrl,
+            projectId: constants.projectId,
+            engineToken: constants.engineToken,
+            contextVersion: undefined,
+            stepNames,
+        }).resolve<{ authType: string, filter: string }>({
+            unresolvedInput,
+            executionState,
+        })
+
+        const elapsedMs = performance.now() - startedAt
+        console.log(`EXECUTE_PROPERTY resolution took ${Math.round(elapsedMs)} ms`)
+
+        expect(resolvedInput).toEqual({ authType: 'basic', filter: 'active' })
+        expect(elapsedMs).toBeLessThan(MAX_ACCEPTABLE_DURATION_MS)
+    }, 300_000)
+
+    it('still resolves loop items when the property input references the loop', async () => {
+        const { testExecutionContext } = await import('../../src/lib/handler/context/test-execution-context')
+        const { createPropsResolver } = await import('../../src/lib/variables/props-resolver')
+        const { generateMockEngineConstants } = await import('../handler/test-helper')
+
+        const flowVersion = buildFlowVersion()
+        const smallDocument = buildGoogleDocsLikeDocument({ paragraphCount: 3 })
+        const sampleData = {
+            trigger: { body: { filter: 'active' } },
+            [HUGE_STEP_NAME]: smallDocument,
+        }
+
+        const stepNames = ['trigger', HUGE_STEP_NAME, 'step_2', 'step_3', 'step_4']
+        const constants = generateMockEngineConstants({ stepNames })
+
+        // References the loop's item: guards that loop settings still resolve
+        // into the state used for property resolution.
+        const unresolvedInput = {
+            paragraphStart: '{{step_2[\'item\'][\'startIndex\']}}',
+        }
+
+        const executionState = await testExecutionContext.stateFromFlowVersion({
+            apiUrl: constants.internalApiUrl,
+            flowVersion,
+            projectId: constants.projectId,
+            engineToken: constants.engineToken,
+            sampleData,
+            engineConstants: constants,
+        })
+
+        const { resolvedInput } = await createPropsResolver({
+            apiUrl: constants.internalApiUrl,
+            projectId: constants.projectId,
+            engineToken: constants.engineToken,
+            contextVersion: undefined,
+            stepNames,
+        }).resolve<{ paragraphStart: number }>({
+            unresolvedInput,
+            executionState,
+        })
+
+        expect(resolvedInput).toEqual({ paragraphStart: 0 })
+    }, 60_000)
+})
+
+function buildFlowVersion(): FlowVersion {
+    return {
+        id: 'flowVersionId',
+        created: '2026-01-01T00:00:00.000Z',
+        updated: '2026-01-01T00:00:00.000Z',
+        flowId: 'flowId',
+        displayName: 'POST - Call back',
+        updatedBy: null,
+        valid: true,
+        schemaVersion: null,
+        agentIds: [],
+        connectionIds: [],
+        backupFiles: null,
+        notes: [],
+        state: FlowVersionState.DRAFT,
+        trigger: {
+            name: 'trigger',
+            displayName: 'Catch Webhook',
+            type: FlowTriggerType.EMPTY,
+            settings: {},
+            valid: true,
+            nextAction: {
+                name: HUGE_STEP_NAME,
+                displayName: 'Read Document',
+                type: FlowActionType.CODE,
+                skip: false,
+                valid: true,
+                settings: {
+                    input: {},
+                    sourceCode: { code: '', packageJson: '' },
+                },
+                nextAction: {
+                    name: 'step_2',
+                    displayName: 'Loop on Paragraphs',
+                    type: FlowActionType.LOOP_ON_ITEMS,
+                    skip: false,
+                    valid: true,
+                    settings: {
+                        items: `{{${HUGE_STEP_NAME}['body']['content']}}`,
+                    },
+                    nextAction: {
+                        name: 'step_3',
+                        displayName: 'Second Loop on Paragraphs',
+                        type: FlowActionType.LOOP_ON_ITEMS,
+                        skip: false,
+                        valid: true,
+                        settings: {
+                            items: `{{${HUGE_STEP_NAME}['body']['content']}}`,
+                        },
+                    },
+                },
+            },
+        },
+    }
+}
+
+/**
+ * Emulates the shape of a Google Docs `documents.get` response: a huge array
+ * of paragraphs where every textRun carries fully-expanded style objects.
+ * ~25k paragraphs ≈ 17 MB of JSON made of hundreds of thousands of small
+ * nested objects — the worst case for per-object copy costs.
+ */
+function buildGoogleDocsLikeDocument({ paragraphCount }: { paragraphCount: number }): Record<string, unknown> {
+    const content = []
+    for (let i = 0; i < paragraphCount; i++) {
+        const startIndex = i * 100
+        const endIndex = startIndex + 99
+        content.push({
+            startIndex,
+            endIndex,
+            paragraph: {
+                elements: [
+                    {
+                        startIndex,
+                        endIndex,
+                        textRun: {
+                            content: `Paragraph ${i} of the template with a placeholder value and trailing text.\n`,
+                            textStyle: {
+                                bold: false,
+                                italic: false,
+                                underline: false,
+                                strikethrough: false,
+                                smallCaps: false,
+                                backgroundColor: {},
+                                foregroundColor: { color: { rgbColor: { red: 0, green: 0, blue: 0 } } },
+                                fontSize: { magnitude: 11, unit: 'PT' },
+                                weightedFontFamily: { fontFamily: 'Arial', weight: 400 },
+                                baselineOffset: 'NONE',
+                            },
+                        },
+                    },
+                ],
+                paragraphStyle: {
+                    namedStyleType: 'NORMAL_TEXT',
+                    alignment: 'START',
+                    direction: 'LEFT_TO_RIGHT',
+                    lineSpacing: 100,
+                    spaceAbove: { magnitude: 0, unit: 'PT' },
+                    spaceBelow: { magnitude: 0, unit: 'PT' },
+                    borderBetween: emptyBorder(),
+                    borderTop: emptyBorder(),
+                    borderBottom: emptyBorder(),
+                    borderLeft: emptyBorder(),
+                    borderRight: emptyBorder(),
+                },
+            },
+        })
+    }
+    return {
+        documentId: 'template-document-id',
+        title: 'Template',
+        revisionId: 'revision-1',
+        body: { content },
+    }
+}
+
+function emptyBorder(): Record<string, unknown> {
+    return {
+        color: {},
+        width: { magnitude: 0, unit: 'PT' },
+        padding: { magnitude: 0, unit: 'PT' },
+        dashStyle: 'SOLID',
+    }
+}


### PR DESCRIPTION
## Incident

A customer on `0.79.4-rc.1` has flows that read whole Google Docs documents via Custom API Call (`documents.get`, no field mask) — ~17 MB of deeply-nested JSON stored as step sample data. Opening **any** step in the builder fired an `EXECUTE_PROPERTY` job that pinned a worker CPU for up to ~30 minutes, hit the sandbox timeout, got SIGKILLed and retried — saturating workers. The stuck job's `data` field was 16.9 MB (the sample data of all steps ships with the job). The stall happened even when the opened step never references the huge step's output.

## Root causes (reproduced, measured)

**Commit 1 — `utils.sizeof` is O(n²).** It deduplicates visited objects with `objectList.indexOf(value)`, a linear scan per object. A 17–30 MB Google-Docs-style response is hundreds of thousands of tiny nested objects → ~10¹¹ identity comparisons. `FlowExecutorContext.upsertStep` calls `loggingUtils.trimExecutionInput` → `sizeof(allSteps)` on **every** upsert, and `testExecutionContext.stateFromFlowVersion` upserts every step of the flow — so each `EXECUTE_PROPERTY` paid this quadratic cost several times (~160 s of the 164 s measured locally). Fix: track seen objects in a `Set`. Behavior-identical.

**Commit 2 — eager loop resolution bypasses reference narrowing** (port of #14047 from `main`). `stateFromFlowVersion` ran the full props resolver on every `LOOP_ON_ITEMS` step's settings, copying every referenced step output through `JSON.stringify`/`JSON.parse` + `ivm.ExternalCopy` into a fresh 128 MB isolate, twice (resolved + censored pass) — regardless of what the queried property references. Fix: compute which steps the input references **before** anything reaches `isolated-vm` (`computeRelevantStepNames` — textual refs of the input, expanded transitively through loop settings, reusing the existing `extractReferencedStepNames` heuristic) and skip unreferenced loops. The parameter is optional; the single-step test-run path (`flow.operation.ts`) is unchanged.

## Repro / verification

New engine test `execute-property-sample-data.test.ts` (runs under `AP_EXECUTION_MODE=SANDBOX_CODE_ONLY`, i.e. real `isolated-vm`): 31.6 MB Google-Docs-like sample output on `step_1`, referenced by two loop steps; the resolved property input references only the trigger.

- **Stock tag: 163,787 ms → sizeof fix alone: ~3,300 ms → both fixes: ~290 ms.**
- Second test guards the transitive case: an input referencing `{{step_2['item']}}` still resolves the loop item through the huge step.

Engine suite: 17 pre-existing failures on the pristine tag (unbuilt dev pieces in the local env) are unchanged; +2 new tests pass. `tsc --noEmit` (lib + spec) and eslint clean after each commit.

## Base branch note

`release/v0.79.5` was cut from tag `0.79.4-rc.1` — the exact revision the customer runs, and the tip of the 0.79 line (the existing `release/v0.79.4` branch has `main`/0.80.0 merged into it, so it no longer matches the shipped release).

Operational follow-up for the affected customer (independent of this fix): add `?fields=body&suggestionsViewMode=PREVIEW_WITHOUT_SUGGESTIONS` to the `documents.get` calls and re-test the steps to shrink stored samples.

https://claude.ai/code/session_01KfVKMzje19VGsRi7chahJL