### PR TITLE
fix: user deletion no longer trips fk_project_owner_id on first attempt

### DIFF
--- a/packages/server/api/src/app/ee/projects/platform-project-service.ts
+++ b/packages/server/api/src/app/ee/projects/platform-project-service.ts
@@ -2,7 +2,7 @@ import { ActivepiecesError, apId, Cursor, ErrorCode, isNil, Metadata, PlatformId
 import { apDayjs } from '@activepieces/server-utils'
 import { AppConnectionScope, PiecesFilterType, PrincipalType, Project, ProjectType, ProjectWithLimits, TeamProjectsLimit, UpdateProjectPlatformRequest } from '@activepieces/shared'
 import { FastifyBaseLogger } from 'fastify'
-import { ArrayContains, Equal, ILike, In, IsNull } from 'typeorm'
+import { ArrayContains, Equal, ILike, In, IsNull, Not } from 'typeorm'
 import { appConnectionsRepo } from '../../app-connection/app-connection-service/app-connection-service'
 import { repoFactory } from '../../core/db/repo-factory'
 import { transaction } from '../../core/db/transaction'
@@ -217,6 +217,17 @@ export const platformProjectService = (log: FastifyBaseLogger) => ({
         }
     },
 
+    async reassignSoftDeletedPersonalProjects({ fromUserId, toUserId, platformId }: ReassignSoftDeletedPersonalProjectsParams): Promise<void> {
+        await projectRepo().update({
+            ownerId: fromUserId,
+            platformId,
+            type: ProjectType.PERSONAL,
+            deleted: Not(IsNull()),
+        }, {
+            ownerId: toUserId,
+        })
+    },
+
     async markForDeletion({ id, platformId }: DeleteProjectParams): Promise<void> {
         const result = await projectRepo().softDelete({ id, platformId })
         if (result.affected === 0) {
@@ -347,6 +358,12 @@ type GetAllForParamsAndUser = {
     types?: ProjectType[]
     isPrivileged: boolean
     principalType?: PrincipalType
+}
+
+type ReassignSoftDeletedPersonalProjectsParams = {
+    fromUserId: UserId
+    toUserId: UserId
+    platformId: PlatformId
 }
 
 type DeletePersonalProjectForUserParams = {

--- a/packages/server/api/src/app/user/user-service.ts
+++ b/packages/server/api/src/app/user/user-service.ts
@@ -157,6 +157,17 @@ export const userService = (log: FastifyBaseLogger) => ({
             userId: id,
             platformId,
         })
+        // The personal project is soft deleted above and hard deleted later by an
+        // async system job. Until that job runs, the project row still references
+        // the user through fk_project_owner_id (ON DELETE NO ACTION), which makes
+        // the user hard delete below fail with a foreign key violation. Reassign
+        // the soft-deleted row to the platform owner so the user row can go now.
+        const platform = await platformService(log).getOneOrThrow(platformId)
+        await platformProjectService(log).reassignSoftDeletedPersonalProjects({
+            fromUserId: id,
+            toUserId: platform.ownerId,
+            platformId,
+        })
         await userRepo().delete({
             id,
             platformId,


### PR DESCRIPTION
## What does this PR do?

Fixes the self-hosted "delete user fails on first attempt, succeeds on retry" bug (#14020).

As diagnosed in the issue: `userService.delete` soft-deletes the personal project and queues the **async** `HARD_DELETE_PROJECT` job, then immediately hard-deletes the user row. Because the soft-deleted project row still exists and `fk_project_owner_id` is `ON DELETE NO ACTION`, Postgres rejects the user delete with `23503` → generic 500. The retry succeeds only because the async job has removed the project row by then.

### Explain How the Feature Works

The fix keeps the async hard-delete architecture untouched and just removes the FK obstacle at delete time:

1. New `platformProjectService.reassignSoftDeletedPersonalProjects` reassigns the user's **soft-deleted** personal project rows (`type = PERSONAL`, `deleted IS NOT NULL` — live rows are never touched) to the platform owner.
2. `userService.delete` calls it after `deletePersonalProjectForUser` and before `userRepo().delete`, so the user row no longer blocks on the FK.

Why this shape:

- Running the hard-delete synchronously was rejected: the `HARD_DELETE_PROJECT` handler does flow side-effect cleanup with retries (25 attempts) and is intentionally async — not something to run inside the HTTP request.
- The reassigned row is invisible (soft-deleted) and already queued for hard deletion by `jobId: hard-delete-project-{id}`; the job deletes by `{ id, platformId }`, so the owner change does not affect it.
- The platform owner is guaranteed to exist and can never be deleted (`assertNotPlatformOwner`), so the FK target is always safe. `idx_project_owner_id` is non-unique, so the owner temporarily "owning" a second (deleted) personal project row violates nothing.
- Cloud is unaffected: it routes to `removeFromPlatform`, which never deletes the user row.

### Relevant User Scenarios

- Platform Admin → Users → Delete on self-hosted EE (customer-reported on 0.85.0, reproduced on current build per the issue): first attempt now succeeds instead of returning "Something went wrong".

Fixes #14020
