### PR TITLE
fix(user): delete personal project synchronously to avoid FK race on user delete

### DIFF
--- a/packages/server/api/src/app/ee/projects/platform-project-jobs.ts
+++ b/packages/server/api/src/app/ee/projects/platform-project-jobs.ts
@@ -15,50 +15,62 @@ import { ProjectEntity } from '../../project/project-entity'
 
 const projectRepo = repoFactory(ProjectEntity)
 
+export const hardDeleteProject = async (
+    projectId: string,
+    platformId: string,
+    preDeletedFlowIds: string[],
+    log: FastifyBaseLogger,
+    onFlowPreDeleted?: (flowId: string) => Promise<void>,
+): Promise<void> => {
+    const allFlows = await flowRepo().find({
+        where: { projectId },
+    })
+
+    for (const flow of allFlows) {
+        if (preDeletedFlowIds.includes(flow.id)) {
+            continue
+        }
+        const flowExists = await flowRepo().existsBy({ id: flow.id })
+        if (!flowExists) {
+            log.info({ flow: { id: flow.id } }, '[hardDeleteProject] Flow already deleted, skipping preDelete')
+            continue
+        }
+        await flowSideEffects(log).preDelete({ flowToDelete: flow })
+        await onFlowPreDeleted?.(flow.id)
+    }
+
+    const flowIds = allFlows.map(flow => flow.id)
+
+    for (const flowId of flowIds) {
+        await batchDeleteByFlowId(flowId)
+        await flowRepo().delete({ id: flowId })
+    }
+
+    await transaction(async (entityManager) => {
+        await appConnectionsRepo(entityManager).delete({
+            scope: AppConnectionScope.PROJECT,
+            projectIds: ArrayContains([projectId]),
+        })
+        await projectRepo(entityManager).delete({
+            id: projectId,
+            platformId,
+        })
+    })
+
+    await flowExecutionCache(log).invalidate(...flowIds)
+}
+
 export const platformProjectBackgroundJobs = (log: FastifyBaseLogger) => ({
     hardDeleteProjectHandler: async (data: SystemJobData<SystemJobName.HARD_DELETE_PROJECT>) => {
         const { projectId, platformId, preDeletedFlowIds } = data
         const job = await systemJobsSchedule(log).getJob(`hard-delete-project-${projectId}`)
         assertNotNullOrUndefined(job, 'job is required')
 
-        const allFlows = await flowRepo().find({
-            where: { projectId },
-        })
-
-        for (const flow of allFlows) {
-            if (preDeletedFlowIds.includes(flow.id)) {
-                continue
-            }
-            const flowExists = await flowRepo().existsBy({ id: flow.id })
-            if (!flowExists) {
-                log.info({ flow: { id: flow.id } }, '[hardDeleteProjectHandler] Flow already deleted, skipping preDelete')
-                continue
-            }
-            await flowSideEffects(log).preDelete({ flowToDelete: flow })
+        await hardDeleteProject(projectId, platformId, preDeletedFlowIds, log, async (flowId) => {
             await job.updateData({
                 ...data,
-                preDeletedFlowIds: [...preDeletedFlowIds, flow.id],
-            })
-        }
-
-        const flowIds = allFlows.map(flow => flow.id)
-
-        for (const flowId of flowIds) {
-            await batchDeleteByFlowId(flowId)
-            await flowRepo().delete({ id: flowId })
-        }
-
-        await transaction(async (entityManager) => {
-            await appConnectionsRepo(entityManager).delete({
-                scope: AppConnectionScope.PROJECT,
-                projectIds: ArrayContains([projectId]),
-            })
-            await projectRepo(entityManager).delete({
-                id: projectId,
-                platformId,
+                preDeletedFlowIds: [...preDeletedFlowIds, flowId],
             })
         })
-
-        await flowExecutionCache(log).invalidate(...flowIds)
     },
 })

--- a/packages/server/api/src/app/user/user-service.ts
+++ b/packages/server/api/src/app/user/user-service.ts
@@ -6,14 +6,18 @@ import { nanoid } from 'nanoid'
 import { In, IsNull } from 'typeorm'
 import { userIdentityRepository, userIdentityService } from '../authentication/user-identity/user-identity-service'
 import { repoFactory } from '../core/db/repo-factory'
+import { hardDeleteProject } from '../ee/projects/platform-project-jobs'
 import { platformProjectService } from '../ee/projects/platform-project-service'
 import { projectMemberRepo } from '../ee/projects/project-role/project-role.service'
 import { buildPaginator } from '../helper/pagination/build-paginator'
 import { paginationHelper } from '../helper/pagination/pagination-utils'
 import { system } from '../helper/system/system'
 import { platformService } from '../platform/platform.service'
+import { ProjectEntity } from '../project/project-entity'
 import { projectService } from '../project/project-service'
 import { UserEntity, UserSchema } from './user-entity'
+
+const projectRepo = repoFactory(ProjectEntity)
 
 
 export const userRepo = repoFactory(UserEntity)
@@ -153,10 +157,14 @@ export const userService = (log: FastifyBaseLogger) => ({
     },
     async delete({ id, platformId }: DeleteParams): Promise<void> {
         await assertNotPlatformOwner({ id, platformId, log })
-        await platformProjectService(log).deletePersonalProjectForUser({
-            userId: id,
+        const personalProject = await projectRepo().findOneBy({
             platformId,
+            ownerId: id,
+            type: ProjectType.PERSONAL,
         })
+        if (!isNil(personalProject)) {
+            await hardDeleteProject(personalProject.id, platformId, [], log)
+        }
         await userRepo().delete({
             id,
             platformId,

--- a/packages/web/src/features/platform-admin/hooks/platform-user-hooks.ts
+++ b/packages/web/src/features/platform-admin/hooks/platform-user-hooks.ts
@@ -11,9 +11,11 @@ import { t } from 'i18next';
 import { toast } from 'sonner';
 
 import { platformUserApi } from '@/api/platform-user-api';
+import { internalErrorToast } from '@/components/ui/sonner';
 import { userInvitationApi } from '@/features/members/api/user-invitation';
 import { useAuthorization } from '@/hooks/authorization-hooks';
 import { userHooks } from '@/hooks/user-hooks';
+import { api } from '@/lib/api';
 
 export const platformUserKeys = {
   users: ['users'] as const,
@@ -67,6 +69,28 @@ export const platformUserMutations = {
       onSuccess: () => {
         onSuccess();
         toast.success(t('User deleted successfully'), { duration: 3000 });
+      },
+      onError: (error) => {
+        const data = api.isError(error) ? error.response?.data : undefined;
+        const message =
+          typeof data === 'object' &&
+          data !== null &&
+          'params' in data &&
+          typeof data.params === 'object' &&
+          data.params !== null &&
+          'message' in data.params
+            ? String(data.params.message)
+            : typeof data === 'object' && data !== null && 'message' in data
+            ? String(data.message)
+            : undefined;
+        if (message) {
+          toast.error(t('Failed to delete user'), {
+            description: message,
+            duration: 5000,
+          });
+        } else {
+          internalErrorToast();
+        }
       },
     });
   },


### PR DESCRIPTION
## What does this PR do?

Fixes a bug where deleting a user from Platform Admin on self-hosted always failed on the first attempt with a generic "Something went wrong" error, then succeeded on retry.

Root cause: `userService.delete` soft-deleted the user's personal project and queued its hard-delete as an async background job, then immediately hard-deleted the user row. Since the project row still physically existed at that point, the `fk_project_owner_id` foreign key (`ON DELETE NO ACTION`) rejected the user delete with a Postgres `23503` error. The retry only worked because by then the queued job had removed the project.

Fix: the personal project is now deleted synchronously (flows, connections, and the project row) before the user row is deleted, closing the race entirely. Also added an `onError` handler to the frontend delete-user mutation so real server errors surface to the user instead of a generic toast.

### Explain How the Feature Works

- `userService.delete` (packages/server/api/src/app/user/user-service.ts) now looks up the user's personal project and calls a new `hardDeleteProject` helper synchronously, instead of `deletePersonalProjectForUser` (soft-delete + async queue).
- `hardDeleteProject` (packages/server/api/src/app/ee/projects/platform-project-jobs.ts) is the same deletion logic the queued `HARD_DELETE_PROJECT` job already used (deletes flows, connections, then the project row in a transaction), extracted so it can run inline. The queued job path is unaffected — same behavior, same signature, still resumable via `preDeletedFlowIds`.
- `useDeleteUser` (packages/web/src/features/platform-admin/hooks/platform-user-hooks.ts) now has an `onError` handler that reads the actual server error message and shows it in the toast, falling back to the generic error only when no message is available.

Verified locally: invited a second user, accepted the invite (provisions personal project), deleted via Platform Admin — succeeds on the **first** attempt (204), not the second. Confirmed via API too (`DELETE /api/v1/users/:id` → 204, follow-up `GET` → 404).

### Relevant User Scenarios

Any self-hosted admin removing a user with a personal project (the common case — every user gets one on invite acceptance) hit this on every single delete. Confirmed present from v0.74.4 through current main; Cloud was unaffected since it detaches instead of hard-deleting.

Fixes #14051
