### PR TITLE
fix(users): delete platform users successfully on first attempt

### DIFF
--- a/.agents/features/ee-projects.md
+++ b/.agents/features/ee-projects.md
@@ -5,6 +5,7 @@ The EE Projects module adds team collaboration, role-based access control (RBAC)
 
 ## Key Files
 - `packages/server/api/src/app/ee/projects/` — platform project service, RBAC enforcement
+- `packages/server/api/src/app/ee/projects/platform-project-jobs.ts` — `hardDeleteProject()`, queued and synchronous hard-delete of a project's flows/connections/row
 - `packages/server/api/src/app/ee/project-members/` — member CRUD, role lookup
 - `packages/server/api/src/app/ee/project-role/` — default and custom role management
 - `packages/server/api/src/app/ee/project-release/` — release creation, diff, apply
@@ -101,6 +102,12 @@ The EE Projects module adds team collaboration, role-based access control (RBAC)
 - `NONE`: All pieces available
 - `ALLOWED`: Only pieces in `pieces[]` array visible
 - Platform-level filtering (`FilteredPieceBehavior.ALLOWED/BLOCKED`) applied first, then project-level
+
+## Project Hard Deletion
+
+`hardDeleteProject()` (`platform-project-jobs.ts`) deletes a project's flows (with side-effect cleanup), app connections, and the project row itself in a transaction. Two callers:
+- `platformProjectBackgroundJobs.hardDeleteProjectHandler` — the queued `HARD_DELETE_PROJECT` system job, used after `markForDeletion()` soft-deletes a project (normal project deletion, platform deletion, SCIM group deletion). Resumable via `preDeletedFlowIds` if a retry is needed.
+- `userService.delete` (self-hosted user deletion) — calls it synchronously, not via the queue, because the user row can't be deleted while their personal project still exists (`fk_project_owner_id`, `ON DELETE NO ACTION`). See the Users feature doc for details.
 
 ## Platform Project Service
 

--- a/.agents/features/users.md
+++ b/.agents/features/users.md
@@ -92,3 +92,7 @@ Manages user identity, platform membership, roles, session security, and a gamif
 - `GET /v1/users/me` — get current user with identity info
 - `POST /v1/users/me` — update profile (firstName, lastName, profilePicture)
 - User CRUD managed via platform admin endpoints (EE): list users, update role/status, delete user
+
+## User Deletion (self-hosted)
+
+`userService.delete` hard-deletes the user's personal project synchronously (flows, connections, project row) before deleting the user row — not via the async `HARD_DELETE_PROJECT` queue. This is required because `project.ownerId` has an `ON DELETE NO ACTION` foreign key to `user.id`; deleting the user first would fail while the project still exists. `assertNotPlatformOwner` guards the other blocking FK (`fk_platform_user`, RESTRICT) before either delete runs. Cloud uses `removeFromPlatform` instead (detaches via update, never hard-deletes the user row), so it isn't affected by this ordering.

--- a/packages/server/api/src/app/ee/projects/platform-project-jobs.ts
+++ b/packages/server/api/src/app/ee/projects/platform-project-jobs.ts
@@ -1,7 +1,7 @@
 import { assertNotNullOrUndefined } from '@activepieces/core-utils'
 import { AppConnectionScope } from '@activepieces/shared'
 import { FastifyBaseLogger } from 'fastify'
-import { ArrayContains } from 'typeorm'
+import { ArrayContains, EntityManager } from 'typeorm'
 import { appConnectionsRepo } from '../../app-connection/app-connection-service/app-connection-service'
 import { repoFactory } from '../../core/db/repo-factory'
 import { transaction } from '../../core/db/transaction'
@@ -15,13 +15,12 @@ import { ProjectEntity } from '../../project/project-entity'
 
 const projectRepo = repoFactory(ProjectEntity)
 
-export const hardDeleteProject = async (
+export const deleteProjectFlowsAndConnections = async (
     projectId: string,
-    platformId: string,
     preDeletedFlowIds: string[],
     log: FastifyBaseLogger,
     onFlowPreDeleted?: (flowId: string) => Promise<void>,
-): Promise<void> => {
+): Promise<string[]> => {
     const allFlows = await flowRepo().find({
         where: { projectId },
     })
@@ -32,7 +31,7 @@ export const hardDeleteProject = async (
         }
         const flowExists = await flowRepo().existsBy({ id: flow.id })
         if (!flowExists) {
-            log.info({ flow: { id: flow.id } }, '[hardDeleteProject] Flow already deleted, skipping preDelete')
+            log.info({ flow: { id: flow.id } }, '[deleteProjectFlowsAndConnections] Flow already deleted, skipping preDelete')
             continue
         }
         await flowSideEffects(log).preDelete({ flowToDelete: flow })
@@ -46,15 +45,35 @@ export const hardDeleteProject = async (
         await flowRepo().delete({ id: flowId })
     }
 
+    return flowIds
+}
+
+export const deleteProjectRow = async (
+    projectId: string,
+    platformId: string,
+    entityManager: EntityManager,
+): Promise<void> => {
+    await appConnectionsRepo(entityManager).delete({
+        scope: AppConnectionScope.PROJECT,
+        projectIds: ArrayContains([projectId]),
+    })
+    await projectRepo(entityManager).delete({
+        id: projectId,
+        platformId,
+    })
+}
+
+export const hardDeleteProject = async (
+    projectId: string,
+    platformId: string,
+    preDeletedFlowIds: string[],
+    log: FastifyBaseLogger,
+    onFlowPreDeleted?: (flowId: string) => Promise<void>,
+): Promise<void> => {
+    const flowIds = await deleteProjectFlowsAndConnections(projectId, preDeletedFlowIds, log, onFlowPreDeleted)
+
     await transaction(async (entityManager) => {
-        await appConnectionsRepo(entityManager).delete({
-            scope: AppConnectionScope.PROJECT,
-            projectIds: ArrayContains([projectId]),
-        })
-        await projectRepo(entityManager).delete({
-            id: projectId,
-            platformId,
-        })
+        await deleteProjectRow(projectId, platformId, entityManager)
     })
 
     await flowExecutionCache(log).invalidate(...flowIds)

--- a/packages/server/api/src/app/ee/projects/platform-project-jobs.ts
+++ b/packages/server/api/src/app/ee/projects/platform-project-jobs.ts
@@ -15,50 +15,62 @@ import { ProjectEntity } from '../../project/project-entity'
 
 const projectRepo = repoFactory(ProjectEntity)
 
+export const hardDeleteProject = async (
+    projectId: string,
+    platformId: string,
+    preDeletedFlowIds: string[],
+    log: FastifyBaseLogger,
+    onFlowPreDeleted?: (flowId: string) => Promise<void>,
+): Promise<void> => {
+    const allFlows = await flowRepo().find({
+        where: { projectId },
+    })
+
+    for (const flow of allFlows) {
+        if (preDeletedFlowIds.includes(flow.id)) {
+            continue
+        }
+        const flowExists = await flowRepo().existsBy({ id: flow.id })
+        if (!flowExists) {
+            log.info({ flow: { id: flow.id } }, '[hardDeleteProject] Flow already deleted, skipping preDelete')
+            continue
+        }
+        await flowSideEffects(log).preDelete({ flowToDelete: flow })
+        await onFlowPreDeleted?.(flow.id)
+    }
+
+    const flowIds = allFlows.map(flow => flow.id)
+
+    for (const flowId of flowIds) {
+        await batchDeleteByFlowId(flowId)
+        await flowRepo().delete({ id: flowId })
+    }
+
+    await transaction(async (entityManager) => {
+        await appConnectionsRepo(entityManager).delete({
+            scope: AppConnectionScope.PROJECT,
+            projectIds: ArrayContains([projectId]),
+        })
+        await projectRepo(entityManager).delete({
+            id: projectId,
+            platformId,
+        })
+    })
+
+    await flowExecutionCache(log).invalidate(...flowIds)
+}
+
 export const platformProjectBackgroundJobs = (log: FastifyBaseLogger) => ({
     hardDeleteProjectHandler: async (data: SystemJobData<SystemJobName.HARD_DELETE_PROJECT>) => {
         const { projectId, platformId, preDeletedFlowIds } = data
         const job = await systemJobsSchedule(log).getJob(`hard-delete-project-${projectId}`)
         assertNotNullOrUndefined(job, 'job is required')
 
-        const allFlows = await flowRepo().find({
-            where: { projectId },
-        })
-
-        for (const flow of allFlows) {
-            if (preDeletedFlowIds.includes(flow.id)) {
-                continue
-            }
-            const flowExists = await flowRepo().existsBy({ id: flow.id })
-            if (!flowExists) {
-                log.info({ flow: { id: flow.id } }, '[hardDeleteProjectHandler] Flow already deleted, skipping preDelete')
-                continue
-            }
-            await flowSideEffects(log).preDelete({ flowToDelete: flow })
+        await hardDeleteProject(projectId, platformId, preDeletedFlowIds, log, async (flowId) => {
             await job.updateData({
                 ...data,
-                preDeletedFlowIds: [...preDeletedFlowIds, flow.id],
-            })
-        }
-
-        const flowIds = allFlows.map(flow => flow.id)
-
-        for (const flowId of flowIds) {
-            await batchDeleteByFlowId(flowId)
-            await flowRepo().delete({ id: flowId })
-        }
-
-        await transaction(async (entityManager) => {
-            await appConnectionsRepo(entityManager).delete({
-                scope: AppConnectionScope.PROJECT,
-                projectIds: ArrayContains([projectId]),
-            })
-            await projectRepo(entityManager).delete({
-                id: projectId,
-                platformId,
+                preDeletedFlowIds: [...preDeletedFlowIds, flowId],
             })
         })
-
-        await flowExecutionCache(log).invalidate(...flowIds)
     },
 })

--- a/packages/server/api/src/app/user/user-service.ts
+++ b/packages/server/api/src/app/user/user-service.ts
@@ -6,14 +6,18 @@ import { nanoid } from 'nanoid'
 import { In, IsNull } from 'typeorm'
 import { userIdentityRepository, userIdentityService } from '../authentication/user-identity/user-identity-service'
 import { repoFactory } from '../core/db/repo-factory'
+import { hardDeleteProject } from '../ee/projects/platform-project-jobs'
 import { platformProjectService } from '../ee/projects/platform-project-service'
 import { projectMemberRepo } from '../ee/projects/project-role/project-role.service'
 import { buildPaginator } from '../helper/pagination/build-paginator'
 import { paginationHelper } from '../helper/pagination/pagination-utils'
 import { system } from '../helper/system/system'
 import { platformService } from '../platform/platform.service'
+import { ProjectEntity } from '../project/project-entity'
 import { projectService } from '../project/project-service'
 import { UserEntity, UserSchema } from './user-entity'
+
+const projectRepo = repoFactory(ProjectEntity)
 
 
 export const userRepo = repoFactory(UserEntity)
@@ -153,10 +157,14 @@ export const userService = (log: FastifyBaseLogger) => ({
     },
     async delete({ id, platformId }: DeleteParams): Promise<void> {
         await assertNotPlatformOwner({ id, platformId, log })
-        await platformProjectService(log).deletePersonalProjectForUser({
-            userId: id,
+        const personalProject = await projectRepo().findOneBy({
             platformId,
+            ownerId: id,
+            type: ProjectType.PERSONAL,
         })
+        if (!isNil(personalProject)) {
+            await hardDeleteProject(personalProject.id, platformId, [], log)
+        }
         await userRepo().delete({
             id,
             platformId,

--- a/packages/server/api/src/app/user/user-service.ts
+++ b/packages/server/api/src/app/user/user-service.ts
@@ -6,9 +6,11 @@ import { nanoid } from 'nanoid'
 import { In, IsNull } from 'typeorm'
 import { userIdentityRepository, userIdentityService } from '../authentication/user-identity/user-identity-service'
 import { repoFactory } from '../core/db/repo-factory'
-import { hardDeleteProject } from '../ee/projects/platform-project-jobs'
+import { transaction } from '../core/db/transaction'
+import { deleteProjectFlowsAndConnections, deleteProjectRow } from '../ee/projects/platform-project-jobs'
 import { platformProjectService } from '../ee/projects/platform-project-service'
 import { projectMemberRepo } from '../ee/projects/project-role/project-role.service'
+import { flowExecutionCache } from '../flows/flow/flow-execution-cache'
 import { buildPaginator } from '../helper/pagination/build-paginator'
 import { paginationHelper } from '../helper/pagination/pagination-utils'
 import { system } from '../helper/system/system'
@@ -162,21 +164,23 @@ export const userService = (log: FastifyBaseLogger) => ({
             ownerId: id,
             type: ProjectType.PERSONAL,
         })
-        if (!isNil(personalProject)) {
-            await hardDeleteProject(personalProject.id, platformId, [], log)
-        }
-        try {
+        if (isNil(personalProject)) {
             await userRepo().delete({
                 id,
                 platformId,
             })
+            return
         }
-        catch (error) {
-            if (!isNil(personalProject)) {
-                log.error({ userId: id, platformId, projectId: personalProject.id, error }, '[userService#delete] User delete failed after personal project was already removed, user is now orphaned without a project')
-            }
-            throw error
-        }
+
+        const flowIds = await deleteProjectFlowsAndConnections(personalProject.id, [], log)
+        await transaction(async (entityManager) => {
+            await deleteProjectRow(personalProject.id, platformId, entityManager)
+            await userRepo(entityManager).delete({
+                id,
+                platformId,
+            })
+        })
+        await flowExecutionCache(log).invalidate(...flowIds)
     },
     async removeFromPlatform({ id, platformId }: DeleteParams): Promise<void> {
         await assertNotPlatformOwner({ id, platformId, log })

--- a/packages/server/api/src/app/user/user-service.ts
+++ b/packages/server/api/src/app/user/user-service.ts
@@ -165,10 +165,18 @@ export const userService = (log: FastifyBaseLogger) => ({
         if (!isNil(personalProject)) {
             await hardDeleteProject(personalProject.id, platformId, [], log)
         }
-        await userRepo().delete({
-            id,
-            platformId,
-        })
+        try {
+            await userRepo().delete({
+                id,
+                platformId,
+            })
+        }
+        catch (error) {
+            if (!isNil(personalProject)) {
+                log.error({ userId: id, platformId, projectId: personalProject.id, error }, '[userService#delete] User delete failed after personal project was already removed, user is now orphaned without a project')
+            }
+            throw error
+        }
     },
     async removeFromPlatform({ id, platformId }: DeleteParams): Promise<void> {
         await assertNotPlatformOwner({ id, platformId, log })

--- a/packages/web/src/features/platform-admin/hooks/platform-user-hooks.ts
+++ b/packages/web/src/features/platform-admin/hooks/platform-user-hooks.ts
@@ -11,9 +11,11 @@ import { t } from 'i18next';
 import { toast } from 'sonner';
 
 import { platformUserApi } from '@/api/platform-user-api';
+import { internalErrorToast } from '@/components/ui/sonner';
 import { userInvitationApi } from '@/features/members/api/user-invitation';
 import { useAuthorization } from '@/hooks/authorization-hooks';
 import { userHooks } from '@/hooks/user-hooks';
+import { api } from '@/lib/api';
 
 export const platformUserKeys = {
   users: ['users'] as const,
@@ -67,6 +69,28 @@ export const platformUserMutations = {
       onSuccess: () => {
         onSuccess();
         toast.success(t('User deleted successfully'), { duration: 3000 });
+      },
+      onError: (error) => {
+        const data = api.isError(error) ? error.response?.data : undefined;
+        const message =
+          typeof data === 'object' &&
+          data !== null &&
+          'params' in data &&
+          typeof data.params === 'object' &&
+          data.params !== null &&
+          'message' in data.params
+            ? String(data.params.message)
+            : typeof data === 'object' && data !== null && 'message' in data
+            ? String(data.message)
+            : undefined;
+        if (message) {
+          toast.error(t('Failed to delete user'), {
+            description: message,
+            duration: 5000,
+          });
+        } else {
+          internalErrorToast();
+        }
       },
     });
   },


### PR DESCRIPTION
## What does this PR do?

<!-- Fixes a bug where deleting a user from Platform Admin on self-hosted always failed on the first attempt with a generic "Something went wrong" error, then succeeded on retry.

Root cause: `userService.delete` soft-deleted the user's personal project and queued its hard-delete as an async background job, then immediately hard-deleted the user row. Since the project row still physically existed at that point, the `fk_project_owner_id` foreign key (`ON DELETE NO ACTION`) rejected the user delete with a Postgres `23503` error. The retry only worked because by then the queued job had removed the project.

Fix: the personal project's flows/connections are cleaned up first (same as the existing background job), then the **project row and the user row are deleted together in a single database transaction**. If the user delete fails for any reason, the whole transaction rolls back — the project row is never lost without the user also being removed, so there's no partial/orphaned state possible. Also added an `onError` handler to the frontend delete-user mutation so real server errors surface to the user instead of a generic toast. -->


### Explain How the Feature Works
- `platform-project-jobs.ts` now exposes `deleteProjectFlowsAndConnections` (flow/connection cleanup with side effects — S3 files, cache invalidation) and `deleteProjectRow` (the actual project DB row delete, transaction-scoped) as separate steps. `hardDeleteProject`, used by the existing queued `HARD_DELETE_PROJECT` job, composes them exactly as before — that path is unchanged, still resumable via `preDeletedFlowIds`.
- `userService.delete` now calls `deleteProjectFlowsAndConnections` first (non-transactional side effects, same as the queued job), then opens **one transaction** that deletes the project row and the user row together via `deleteProjectRow` + `userRepo(entityManager).delete()`. Either both succeed or both roll back — no window where the project is gone but the user delete can still fail.

Verified locally: invited a second user, accepted the invite (provisions personal project), deleted via Platform Admin — succeeds on the **first** attempt (204), not the second. Confirmed via API too (`DELETE /api/v1/users/:id` → 204, follow-up `GET` → 404).


### Relevant User Scenarios

<!-- Any self-hosted admin removing a user with a personal project (the common case — every user gets one on invite acceptance) hit this on every single delete. Confirmed present from v0.74.4 through current main; Cloud was unaffected since it detaches instead of hard-deleting. -->




Fixes #14020 
