### PR TITLE
feat(gmail): add label/archive/delete write-actions + starred & conversation triggers

### DIFF
--- a/packages/pieces/community/gmail/package.json
+++ b/packages/pieces/community/gmail/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-gmail",
-  "version": "0.12.8",
+  "version": "0.13.0",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "dependencies": {

--- a/packages/pieces/community/gmail/src/index.ts
+++ b/packages/pieces/community/gmail/src/index.ts
@@ -11,6 +11,12 @@ import { gmailNewAttachmentTrigger } from './lib/triggers/new-attachment';
 import { gmailNewLabelTrigger } from './lib/triggers/new-label';
 import { gmailSearchMailAction } from './lib/actions/search-email-action';
 import { gmailGetEmailAction } from './lib/actions/get-mail-action';
+import { gmailAddLabelToEmailAction } from './lib/actions/add-label-to-email-action';
+import { gmailRemoveLabelFromEmailAction } from './lib/actions/remove-label-from-email-action';
+import { gmailCreateLabelAction } from './lib/actions/create-label-action';
+import { gmailArchiveEmailAction } from './lib/actions/archive-email-action';
+import { gmailDeleteEmailAction } from './lib/actions/delete-email-action';
+import { gmailRemoveLabelFromThreadAction } from './lib/actions/remove-label-from-thread-action';
 import { gmailAuth, getAccessToken, GmailAuthValue } from './lib/auth';
 
 export {
@@ -34,6 +40,12 @@ export const gmail = createPiece({
     gmailCreateDraftReplyAction,
     gmailGetEmailAction,
     gmailSearchMailAction,
+    gmailAddLabelToEmailAction,
+    gmailRemoveLabelFromEmailAction,
+    gmailCreateLabelAction,
+    gmailArchiveEmailAction,
+    gmailDeleteEmailAction,
+    gmailRemoveLabelFromThreadAction,
     createCustomApiCallAction({
       baseUrl: () => 'https://gmail.googleapis.com/gmail/v1',
       auth: gmailAuth,

--- a/packages/pieces/community/gmail/src/index.ts
+++ b/packages/pieces/community/gmail/src/index.ts
@@ -17,6 +17,8 @@ import { gmailCreateLabelAction } from './lib/actions/create-label-action';
 import { gmailArchiveEmailAction } from './lib/actions/archive-email-action';
 import { gmailDeleteEmailAction } from './lib/actions/delete-email-action';
 import { gmailRemoveLabelFromThreadAction } from './lib/actions/remove-label-from-thread-action';
+import { gmailNewStarredEmailTrigger } from './lib/triggers/new-starred-email';
+import { gmailNewConversationTrigger } from './lib/triggers/new-conversation';
 import { gmailAuth, getAccessToken, GmailAuthValue } from './lib/auth';
 
 export {
@@ -76,6 +78,8 @@ export const gmail = createPiece({
     gmailNewLabeledEmailTrigger,
     gmailNewAttachmentTrigger,
     gmailNewLabelTrigger,
+    gmailNewStarredEmailTrigger,
+    gmailNewConversationTrigger,
   ],
   auth: gmailAuth,
 });

--- a/packages/pieces/community/gmail/src/lib/actions/add-label-to-email-action.ts
+++ b/packages/pieces/community/gmail/src/lib/actions/add-label-to-email-action.ts
@@ -1,0 +1,39 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { gmailAuth, createGoogleClient } from '../auth';
+import { gmail as googleGmail } from '@googleapis/gmail';
+import { GmailProps } from '../common/props';
+
+export const gmailAddLabelToEmailAction = createAction({
+  auth: gmailAuth,
+  name: 'add_label_to_email',
+  displayName: 'Add Label to Email',
+  description: 'Add a label to a specific email.',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Applies a Gmail label to a single message identified by its message ID. Use this to categorize or tag an email (for example mark it Important or file it under a user label). Idempotent: applying a label the message already has is a no-op.',
+    idempotent: true,
+  },
+  props: {
+    message_id: GmailProps.message,
+    label: GmailProps.label({
+      displayName: 'Label',
+      description: 'The label to add to the email.',
+      required: true,
+    }),
+  },
+  async run(context) {
+    const authClient = await createGoogleClient(context.auth);
+    const gmail = googleGmail({ version: 'v1', auth: authClient });
+
+    const response = await gmail.users.messages.modify({
+      userId: 'me',
+      id: context.propsValue.message_id,
+      requestBody: {
+        addLabelIds: [context.propsValue.label.id],
+      },
+    });
+
+    return response.data;
+  },
+});

--- a/packages/pieces/community/gmail/src/lib/actions/add-label-to-email-action.ts
+++ b/packages/pieces/community/gmail/src/lib/actions/add-label-to-email-action.ts
@@ -22,6 +22,13 @@ export const gmailAddLabelToEmailAction = createAction({
       required: true,
     }),
   },
+  outputSchema: {
+    fields: [
+      { key: 'id', label: 'Message ID' },
+      { key: 'threadId', label: 'Thread ID' },
+      { key: 'labelIds', label: 'Labels' },
+    ],
+  },
   async run(context) {
     const authClient = await createGoogleClient(context.auth);
     const gmail = googleGmail({ version: 'v1', auth: authClient });

--- a/packages/pieces/community/gmail/src/lib/actions/archive-email-action.ts
+++ b/packages/pieces/community/gmail/src/lib/actions/archive-email-action.ts
@@ -1,0 +1,34 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { gmailAuth, createGoogleClient } from '../auth';
+import { gmail as googleGmail } from '@googleapis/gmail';
+import { GmailProps } from '../common/props';
+
+export const gmailArchiveEmailAction = createAction({
+  auth: gmailAuth,
+  name: 'archive_email',
+  displayName: 'Archive Email',
+  description: 'Archive an email by removing it from the inbox.',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Archives a message by removing the INBOX label, moving it to All Mail without deleting it. Use this to clear an email from the inbox while keeping it searchable. Idempotent: archiving an already-archived message is a no-op.',
+    idempotent: true,
+  },
+  props: {
+    message_id: GmailProps.message,
+  },
+  async run(context) {
+    const authClient = await createGoogleClient(context.auth);
+    const gmail = googleGmail({ version: 'v1', auth: authClient });
+
+    const response = await gmail.users.messages.modify({
+      userId: 'me',
+      id: context.propsValue.message_id,
+      requestBody: {
+        removeLabelIds: ['INBOX'],
+      },
+    });
+
+    return response.data;
+  },
+});

--- a/packages/pieces/community/gmail/src/lib/actions/archive-email-action.ts
+++ b/packages/pieces/community/gmail/src/lib/actions/archive-email-action.ts
@@ -17,6 +17,13 @@ export const gmailArchiveEmailAction = createAction({
   props: {
     message_id: GmailProps.message,
   },
+  outputSchema: {
+    fields: [
+      { key: 'id', label: 'Message ID' },
+      { key: 'threadId', label: 'Thread ID' },
+      { key: 'labelIds', label: 'Labels' },
+    ],
+  },
   async run(context) {
     const authClient = await createGoogleClient(context.auth);
     const gmail = googleGmail({ version: 'v1', auth: authClient });

--- a/packages/pieces/community/gmail/src/lib/actions/create-label-action.ts
+++ b/packages/pieces/community/gmail/src/lib/actions/create-label-action.ts
@@ -1,0 +1,66 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { gmailAuth, createGoogleClient } from '../auth';
+import { gmail as googleGmail } from '@googleapis/gmail';
+
+export const gmailCreateLabelAction = createAction({
+  auth: gmailAuth,
+  name: 'create_label',
+  displayName: 'Create Label',
+  description: 'Create a new label in Gmail.',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Creates a new user label in Gmail with the given name and optional visibility settings. Use this before applying a label that does not yet exist. Not idempotent: creating a label whose name already exists fails with a conflict error.',
+    idempotent: false,
+  },
+  props: {
+    name: Property.ShortText({
+      displayName: 'Label Name',
+      description: 'The name of the new label to create.',
+      required: true,
+    }),
+    label_list_visibility: Property.StaticDropdown({
+      displayName: 'Label List Visibility',
+      description: 'Whether the label is shown in the label list.',
+      required: false,
+      defaultValue: 'labelShow',
+      options: {
+        disabled: false,
+        options: [
+          { label: 'Show', value: 'labelShow' },
+          { label: 'Show if unread', value: 'labelShowIfUnread' },
+          { label: 'Hide', value: 'labelHide' },
+        ],
+      },
+    }),
+    message_list_visibility: Property.StaticDropdown({
+      displayName: 'Message List Visibility',
+      description:
+        'Whether messages with this label are shown in the message list.',
+      required: false,
+      defaultValue: 'show',
+      options: {
+        disabled: false,
+        options: [
+          { label: 'Show', value: 'show' },
+          { label: 'Hide', value: 'hide' },
+        ],
+      },
+    }),
+  },
+  async run(context) {
+    const authClient = await createGoogleClient(context.auth);
+    const gmail = googleGmail({ version: 'v1', auth: authClient });
+
+    const response = await gmail.users.labels.create({
+      userId: 'me',
+      requestBody: {
+        name: context.propsValue.name,
+        labelListVisibility: context.propsValue.label_list_visibility,
+        messageListVisibility: context.propsValue.message_list_visibility,
+      },
+    });
+
+    return response.data;
+  },
+});

--- a/packages/pieces/community/gmail/src/lib/actions/create-label-action.ts
+++ b/packages/pieces/community/gmail/src/lib/actions/create-label-action.ts
@@ -48,6 +48,15 @@ export const gmailCreateLabelAction = createAction({
       },
     }),
   },
+  outputSchema: {
+    fields: [
+      { key: 'id', label: 'Label ID' },
+      { key: 'name', label: 'Name' },
+      { key: 'type', label: 'Type' },
+      { key: 'labelListVisibility', label: 'Label List Visibility' },
+      { key: 'messageListVisibility', label: 'Message List Visibility' },
+    ],
+  },
   async run(context) {
     const authClient = await createGoogleClient(context.auth);
     const gmail = googleGmail({ version: 'v1', auth: authClient });

--- a/packages/pieces/community/gmail/src/lib/actions/delete-email-action.ts
+++ b/packages/pieces/community/gmail/src/lib/actions/delete-email-action.ts
@@ -17,6 +17,13 @@ export const gmailDeleteEmailAction = createAction({
   props: {
     message_id: GmailProps.message,
   },
+  outputSchema: {
+    fields: [
+      { key: 'id', label: 'Message ID' },
+      { key: 'threadId', label: 'Thread ID' },
+      { key: 'labelIds', label: 'Labels' },
+    ],
+  },
   async run(context) {
     const authClient = await createGoogleClient(context.auth);
     const gmail = googleGmail({ version: 'v1', auth: authClient });

--- a/packages/pieces/community/gmail/src/lib/actions/delete-email-action.ts
+++ b/packages/pieces/community/gmail/src/lib/actions/delete-email-action.ts
@@ -1,0 +1,31 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { gmailAuth, createGoogleClient } from '../auth';
+import { gmail as googleGmail } from '@googleapis/gmail';
+import { GmailProps } from '../common/props';
+
+export const gmailDeleteEmailAction = createAction({
+  auth: gmailAuth,
+  name: 'delete_email',
+  displayName: 'Delete Email',
+  description: 'Move an email to the trash.',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Moves a message to the Trash by its message ID. This is recoverable for 30 days rather than a permanent deletion. Idempotent: trashing an already-trashed message is a no-op.',
+    idempotent: true,
+  },
+  props: {
+    message_id: GmailProps.message,
+  },
+  async run(context) {
+    const authClient = await createGoogleClient(context.auth);
+    const gmail = googleGmail({ version: 'v1', auth: authClient });
+
+    const response = await gmail.users.messages.trash({
+      userId: 'me',
+      id: context.propsValue.message_id,
+    });
+
+    return response.data;
+  },
+});

--- a/packages/pieces/community/gmail/src/lib/actions/remove-label-from-email-action.ts
+++ b/packages/pieces/community/gmail/src/lib/actions/remove-label-from-email-action.ts
@@ -22,6 +22,13 @@ export const gmailRemoveLabelFromEmailAction = createAction({
       required: true,
     }),
   },
+  outputSchema: {
+    fields: [
+      { key: 'id', label: 'Message ID' },
+      { key: 'threadId', label: 'Thread ID' },
+      { key: 'labelIds', label: 'Labels' },
+    ],
+  },
   async run(context) {
     const authClient = await createGoogleClient(context.auth);
     const gmail = googleGmail({ version: 'v1', auth: authClient });

--- a/packages/pieces/community/gmail/src/lib/actions/remove-label-from-email-action.ts
+++ b/packages/pieces/community/gmail/src/lib/actions/remove-label-from-email-action.ts
@@ -1,0 +1,39 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { gmailAuth, createGoogleClient } from '../auth';
+import { gmail as googleGmail } from '@googleapis/gmail';
+import { GmailProps } from '../common/props';
+
+export const gmailRemoveLabelFromEmailAction = createAction({
+  auth: gmailAuth,
+  name: 'remove_label_from_email',
+  displayName: 'Remove Label from Email',
+  description: 'Remove a label from a specific email.',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Removes a Gmail label from a single message identified by its message ID. Idempotent: removing a label the message does not have is a no-op.',
+    idempotent: true,
+  },
+  props: {
+    message_id: GmailProps.message,
+    label: GmailProps.label({
+      displayName: 'Label',
+      description: 'The label to remove from the email.',
+      required: true,
+    }),
+  },
+  async run(context) {
+    const authClient = await createGoogleClient(context.auth);
+    const gmail = googleGmail({ version: 'v1', auth: authClient });
+
+    const response = await gmail.users.messages.modify({
+      userId: 'me',
+      id: context.propsValue.message_id,
+      requestBody: {
+        removeLabelIds: [context.propsValue.label.id],
+      },
+    });
+
+    return response.data;
+  },
+});

--- a/packages/pieces/community/gmail/src/lib/actions/remove-label-from-thread-action.ts
+++ b/packages/pieces/community/gmail/src/lib/actions/remove-label-from-thread-action.ts
@@ -22,6 +22,13 @@ export const gmailRemoveLabelFromThreadAction = createAction({
       required: true,
     }),
   },
+  outputSchema: {
+    fields: [
+      { key: 'id', label: 'Thread ID' },
+      { key: 'historyId', label: 'History ID' },
+      { key: 'messages', label: 'Messages' },
+    ],
+  },
   async run(context) {
     const authClient = await createGoogleClient(context.auth);
     const gmail = googleGmail({ version: 'v1', auth: authClient });

--- a/packages/pieces/community/gmail/src/lib/actions/remove-label-from-thread-action.ts
+++ b/packages/pieces/community/gmail/src/lib/actions/remove-label-from-thread-action.ts
@@ -1,0 +1,39 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { gmailAuth, createGoogleClient } from '../auth';
+import { gmail as googleGmail } from '@googleapis/gmail';
+import { GmailProps } from '../common/props';
+
+export const gmailRemoveLabelFromThreadAction = createAction({
+  auth: gmailAuth,
+  name: 'remove_label_from_thread',
+  displayName: 'Remove Label from Thread',
+  description: 'Remove a label from all emails in a thread.',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Removes a Gmail label from an entire conversation thread by its thread ID, stripping the label from every message in the thread. Idempotent: removing a label the thread does not have is a no-op.',
+    idempotent: true,
+  },
+  props: {
+    thread_id: GmailProps.thread,
+    label: GmailProps.label({
+      displayName: 'Label',
+      description: 'The label to remove from the thread.',
+      required: true,
+    }),
+  },
+  async run(context) {
+    const authClient = await createGoogleClient(context.auth);
+    const gmail = googleGmail({ version: 'v1', auth: authClient });
+
+    const response = await gmail.users.threads.modify({
+      userId: 'me',
+      id: context.propsValue.thread_id,
+      requestBody: {
+        removeLabelIds: [context.propsValue.label.id],
+      },
+    });
+
+    return response.data;
+  },
+});

--- a/packages/pieces/community/gmail/src/lib/auth.ts
+++ b/packages/pieces/community/gmail/src/lib/auth.ts
@@ -11,6 +11,7 @@ const gmailServiceAccountScopes = [
   'https://www.googleapis.com/auth/gmail.send',
   'https://www.googleapis.com/auth/gmail.readonly',
   'https://www.googleapis.com/auth/gmail.compose',
+  'https://www.googleapis.com/auth/gmail.modify',
 ];
 
 export const gmailScopes = [...gmailServiceAccountScopes, 'email'];

--- a/packages/pieces/community/gmail/src/lib/triggers/new-starred-email.ts
+++ b/packages/pieces/community/gmail/src/lib/triggers/new-starred-email.ts
@@ -1,0 +1,157 @@
+import {
+  createTrigger,
+  TriggerStrategy,
+  FilesService,
+} from '@activepieces/pieces-framework';
+import { gmailAuth, createGoogleClient } from '../auth';
+import { gmail as googleGmail } from '@googleapis/gmail';
+import { parseStream, convertAttachment } from '../common/data';
+
+const STARRED_LABEL = 'STARRED';
+
+async function enrichStarredMessage({
+  gmail,
+  messageId,
+  files,
+}: {
+  gmail: any;
+  messageId: string;
+  files: FilesService;
+}) {
+  const rawMailResponse = await gmail.users.messages.get({
+    userId: 'me',
+    id: messageId,
+    format: 'raw',
+  });
+
+  const parsedMailResponse = await parseStream(
+    Buffer.from(rawMailResponse.data.raw as string, 'base64').toString('utf-8')
+  );
+
+  return {
+    id: messageId,
+    ...parsedMailResponse,
+    attachments: await convertAttachment(parsedMailResponse.attachments, files),
+  };
+}
+
+export const gmailNewStarredEmailTrigger = createTrigger({
+  auth: gmailAuth,
+  name: 'new_starred_email',
+  displayName: 'New Starred Email',
+  description: 'Triggers when an email is starred',
+  aiMetadata: {
+    description:
+      'Fires when a message is starred in the connected Gmail account (the STARRED label is added to it). Each event represents one message that was just starred, with its parsed contents.',
+  },
+  props: {},
+  outputSchema: {
+    fields: [
+      { key: 'id', label: 'Message ID' },
+      { key: 'subject', label: 'Subject' },
+      { key: 'from', label: 'From', value: 'from.text' },
+      { key: 'to', label: 'To', value: 'to.text' },
+      { key: 'date', label: 'Date', format: 'datetime' },
+      { key: 'text', label: 'Text Body' },
+      { key: 'html', label: 'HTML Body', format: 'html' },
+      { key: 'messageId', label: 'Internet Message ID' },
+    ],
+  },
+  sampleData: {},
+  type: TriggerStrategy.POLLING,
+  onEnable: async (context) => {
+    const authClient = await createGoogleClient(context.auth);
+    const gmail = googleGmail({ version: 'v1', auth: authClient });
+
+    const profile = await gmail.users.getProfile({ userId: 'me' });
+    await context.store.put('lastHistoryId', profile.data.historyId);
+  },
+  onDisable: async (context) => {
+    await context.store.delete('lastHistoryId');
+  },
+  run: async (context) => {
+    const authClient = await createGoogleClient(context.auth);
+    const gmail = googleGmail({ version: 'v1', auth: authClient });
+
+    const lastHistoryId = await context.store.get('lastHistoryId');
+
+    const historyResponse = await gmail.users.history.list({
+      userId: 'me',
+      startHistoryId: lastHistoryId as string,
+      labelId: STARRED_LABEL,
+      historyTypes: ['labelAdded'],
+    });
+
+    const starredMessages = new Map<string, string>();
+
+    if (historyResponse.data.history) {
+      for (const history of historyResponse.data.history) {
+        if (history.labelsAdded) {
+          for (const labelAdded of history.labelsAdded) {
+            if (
+              labelAdded.labelIds?.includes(STARRED_LABEL) &&
+              labelAdded.message?.id
+            ) {
+              starredMessages.set(
+                labelAdded.message.id,
+                history.id?.toString() || ''
+              );
+            }
+          }
+        }
+      }
+    }
+
+    const results = [];
+    for (const [messageId, historyId] of starredMessages) {
+      const enriched = await enrichStarredMessage({
+        gmail,
+        messageId,
+        files: context.files,
+      });
+
+      if (lastHistoryId !== historyId) {
+        results.push({
+          id: historyId,
+          data: enriched,
+        });
+      }
+    }
+
+    if (historyResponse.data.historyId) {
+      await context.store.put('lastHistoryId', historyResponse.data.historyId);
+    }
+
+    return results;
+  },
+  test: async (context) => {
+    const authClient = await createGoogleClient(context.auth);
+    const gmail = googleGmail({ version: 'v1', auth: authClient });
+
+    const messagesResponse = await gmail.users.messages.list({
+      userId: 'me',
+      labelIds: [STARRED_LABEL],
+      maxResults: 5,
+    });
+
+    const results = [];
+    if (messagesResponse.data.messages) {
+      for (const message of messagesResponse.data.messages) {
+        if (!message.id) {
+          continue;
+        }
+        const enriched = await enrichStarredMessage({
+          gmail,
+          messageId: message.id,
+          files: context.files,
+        });
+        results.push({
+          id: message.id,
+          data: enriched,
+        });
+      }
+    }
+
+    return results;
+  },
+});


### PR DESCRIPTION
Draft — reference implementation for #8072. I'm aware #8083 is finalized and pending App Review and that the issue asks contributors to hold off, so I'm opening this as a draft alternative for the team's reference, not to merge over #8083.

Completes the Gmail piece against the full issue scope:

**Write actions** (on main's current `createGoogleClient` auth — works for both OAuth2 and service-account connections):
- Add Label / Remove Label (email), Create Label
- Archive (removes `INBOX`), Delete (moves to Trash via `messages.trash`)
- Remove Label from Thread

**Triggers:**
- New Starred Email (Gmail History API, `STARRED` label-add)
- New Conversation (a complete trigger already in the piece but never registered — wired it in)

**Scope:** adds only `gmail.modify` (covers modify / trash / threads.modify / labels.create), on both the OAuth2 and service-account paths. Version `0.12.8` → `0.13.0`. Builds + lints clean against `main`.

Caveats for reviewers: existing Gmail connections will need to re-consent before the new write actions work, and `gmail.modify` needs the same Google App Review #8083 is waiting on. Happy to adjust or close if #8083 is on track.