### PR TITLE
feat(pieces): add Tunova (Suno music generation)

### DIFF
--- a/packages/pieces/community/tunova/.eslintrc.json
+++ b/packages/pieces/community/tunova/.eslintrc.json
@@ -1,0 +1,14 @@
+{
+  "extends": ["../../../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*"],
+  "overrides": [
+    { "files": ["*.ts", "*.tsx", "*.js", "*.jsx"], "rules": {} },
+    {
+      "files": ["*.ts", "*.tsx"],
+      "rules": {
+        "no-restricted-imports": ["error", { "patterns": ["lodash", "lodash/*", "@activepieces/core-*", "@activepieces/server*", "@activepieces/engine", "@activepieces/shared"] }]
+      }
+    },
+    { "files": ["*.js", "*.jsx"], "rules": {} }
+  ]
+}

--- a/packages/pieces/community/tunova/README.md
+++ b/packages/pieces/community/tunova/README.md
@@ -1,0 +1,18 @@
+# Tunova (Activepieces piece)
+
+Generate music with **Suno (v5.5)** from your Activepieces flows via the [Tunova](https://tunova.ai)
+API — async, and **billed only on a successful render** (a failed render auto-refunds).
+
+## Authentication
+
+Create a **Tunova** connection with your API key (`sk_live_…`). Get one free — 50 tokens, no card —
+at <https://tunova.ai>. The key is sent as the `X-API-Key` header.
+
+## Actions
+
+- **Generate Song** — submit a job from a text prompt (`prompt`, `model` default `v5.5`, optional instrumental). Async: returns a `job_id`.
+- **Get Job** — poll a `job_id`; once `status` is `complete`, `clips[].audio_url` is set.
+- **Generate Lyrics** — generate song lyrics from a theme/brief.
+- **Custom API Call** — call any Tunova endpoint directly.
+
+Docs: <https://api.tunova.ai/docs>. Tunova is an independent service, not affiliated with Suno.

--- a/packages/pieces/community/tunova/package.json
+++ b/packages/pieces/community/tunova/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@activepieces/piece-tunova",
+  "version": "0.1.0",
+  "type": "commonjs",
+  "main": "./dist/src/index.js",
+  "types": "./dist/src/index.d.ts",
+  "dependencies": {
+    "@activepieces/pieces-common": "workspace:*",
+    "@activepieces/pieces-framework": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.lib.json && cp package.json dist/",
+    "bundle": "node ../../../../dist/packages/cli/src/index.js pieces bundle",
+    "lint": "eslint 'src/**/*.ts'"
+  }
+}

--- a/packages/pieces/community/tunova/src/i18n/translation.json
+++ b/packages/pieces/community/tunova/src/i18n/translation.json
@@ -1,0 +1,20 @@
+{
+  "API Key": "API Key",
+  "Your Tunova API key (sk_live_…).": "Your Tunova API key (sk_live_…).",
+  "\nYour Tunova API key (sk_live_…). Get one free — 50 tokens, no card — at https://tunova.ai\n": "\nYour Tunova API key (sk_live_…). Get one free — 50 tokens, no card — at https://tunova.ai\n",
+  "Generate Song": "Generate Song",
+  "Submit a song generation job from a text prompt. Async — returns a job_id; use \"Get Job\" to poll for the finished track. Billed only on a successful render.": "Submit a song generation job from a text prompt. Async — returns a job_id; use \"Get Job\" to poll for the finished track. Billed only on a successful render.",
+  "Prompt": "Prompt",
+  "A text description of the song, e.g. \"calm rainy-night lofi\".": "A text description of the song, e.g. \"calm rainy-night lofi\".",
+  "Model": "Model",
+  "Suno model to use.": "Suno model to use.",
+  "Instrumental": "Instrumental",
+  "Generate an instrumental (no vocals).": "Generate an instrumental (no vocals).",
+  "Get Job": "Get Job",
+  "Poll a generation job. Once status is \"complete\", clips[].audio_url is set; a failed render is auto-refunded.": "Poll a generation job. Once status is \"complete\", clips[].audio_url is set; a failed render is auto-refunded.",
+  "Job ID": "Job ID",
+  "The job_id returned by \"Generate Song\".": "The job_id returned by \"Generate Song\".",
+  "Generate Lyrics": "Generate Lyrics",
+  "Generate song lyrics from a theme or brief. Synchronous.": "Generate song lyrics from a theme or brief. Synchronous.",
+  "The theme or brief for the lyrics.": "The theme or brief for the lyrics."
+}

--- a/packages/pieces/community/tunova/src/index.ts
+++ b/packages/pieces/community/tunova/src/index.ts
@@ -1,0 +1,32 @@
+import { createPiece, PieceCategory } from '@activepieces/pieces-framework';
+import { createCustomApiCallAction } from '@activepieces/pieces-common';
+import { tunovaAuth } from './lib/common/auth';
+import { generateSong } from './lib/actions/generate-song';
+import { getJob } from './lib/actions/get-job';
+import { generateLyrics } from './lib/actions/generate-lyrics';
+
+export { tunovaAuth };
+
+export const tunova = createPiece({
+  displayName: 'Tunova',
+  description:
+    'Generate music with Suno (v5.5) via the Tunova API — REST + MCP, async, billed only on successful renders (a failed render auto-refunds).',
+  auth: tunovaAuth,
+  minimumSupportedRelease: '0.36.1',
+  logoUrl: 'https://tunova.ai/icon.svg',
+  categories: [PieceCategory.ARTIFICIAL_INTELLIGENCE, PieceCategory.CONTENT_AND_FILES],
+  authors: ['erliona'],
+  actions: [
+    generateSong,
+    getJob,
+    generateLyrics,
+    createCustomApiCallAction({
+      auth: tunovaAuth,
+      baseUrl: () => 'https://api.tunova.ai',
+      authMapping: async (auth) => ({
+        'X-API-Key': auth.props.apiKey,
+      }),
+    }),
+  ],
+  triggers: [],
+});

--- a/packages/pieces/community/tunova/src/lib/actions/generate-lyrics.ts
+++ b/packages/pieces/community/tunova/src/lib/actions/generate-lyrics.ts
@@ -1,0 +1,23 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { tunovaAuth } from '../common/auth';
+import { tunovaRequest } from '../common/client';
+
+export const generateLyrics = createAction({
+  auth: tunovaAuth,
+  name: 'generate_lyrics',
+  displayName: 'Generate Lyrics',
+  description: 'Generate song lyrics from a theme or brief. Synchronous.',
+  props: {
+    prompt: Property.LongText({
+      displayName: 'Prompt',
+      description: 'The theme or brief for the lyrics.',
+      required: true,
+    }),
+  },
+  async run(context) {
+    return tunovaRequest(context.auth.props.apiKey, HttpMethod.POST, '/api/lyrics', {
+      prompt: context.propsValue.prompt,
+    });
+  },
+});

--- a/packages/pieces/community/tunova/src/lib/actions/generate-song.ts
+++ b/packages/pieces/community/tunova/src/lib/actions/generate-song.ts
@@ -1,0 +1,38 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { tunovaAuth } from '../common/auth';
+import { tunovaRequest } from '../common/client';
+
+export const generateSong = createAction({
+  auth: tunovaAuth,
+  name: 'generate_song',
+  displayName: 'Generate Song',
+  description:
+    'Submit a song generation job from a text prompt. Async — returns a job_id; use "Get Job" to poll for the finished track. Billed only on a successful render.',
+  props: {
+    prompt: Property.LongText({
+      displayName: 'Prompt',
+      description: 'A text description of the song, e.g. "calm rainy-night lofi".',
+      required: true,
+    }),
+    model: Property.ShortText({
+      displayName: 'Model',
+      description: 'Suno model to use.',
+      required: false,
+      defaultValue: 'v5.5',
+    }),
+    makeInstrumental: Property.Checkbox({
+      displayName: 'Instrumental',
+      description: 'Generate an instrumental (no vocals).',
+      required: false,
+      defaultValue: false,
+    }),
+  },
+  async run(context) {
+    return tunovaRequest(context.auth.props.apiKey, HttpMethod.POST, '/api/generate', {
+      prompt: context.propsValue.prompt,
+      model: context.propsValue.model,
+      make_instrumental: context.propsValue.makeInstrumental,
+    });
+  },
+});

--- a/packages/pieces/community/tunova/src/lib/actions/get-job.ts
+++ b/packages/pieces/community/tunova/src/lib/actions/get-job.ts
@@ -1,0 +1,26 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { tunovaAuth } from '../common/auth';
+import { tunovaRequest } from '../common/client';
+
+export const getJob = createAction({
+  auth: tunovaAuth,
+  name: 'get_job',
+  displayName: 'Get Job',
+  description:
+    'Poll a generation job. Once status is "complete", clips[].audio_url is set; a failed render is auto-refunded.',
+  props: {
+    jobId: Property.ShortText({
+      displayName: 'Job ID',
+      description: 'The job_id returned by "Generate Song".',
+      required: true,
+    }),
+  },
+  async run(context) {
+    return tunovaRequest(
+      context.auth.props.apiKey,
+      HttpMethod.GET,
+      `/api/jobs/${encodeURIComponent(context.propsValue.jobId)}`,
+    );
+  },
+});

--- a/packages/pieces/community/tunova/src/lib/common/auth.ts
+++ b/packages/pieces/community/tunova/src/lib/common/auth.ts
@@ -1,0 +1,15 @@
+import { PieceAuth } from '@activepieces/pieces-framework';
+
+export const tunovaAuth = PieceAuth.CustomAuth({
+  description:
+    'Your Tunova API key (sk_live_…). Get one free — 50 tokens, no card — at https://tunova.ai',
+  props: {
+    // SecretText → the key is masked in the UI and never displayed as a plain text prop.
+    apiKey: PieceAuth.SecretText({
+      displayName: 'API Key',
+      description: 'Your Tunova API key (sk_live_…).',
+      required: true,
+    }),
+  },
+  required: true,
+});

--- a/packages/pieces/community/tunova/src/lib/common/client.ts
+++ b/packages/pieces/community/tunova/src/lib/common/client.ts
@@ -1,0 +1,22 @@
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+
+const BASE_URL = 'https://api.tunova.ai';
+
+/** Thin wrapper around the public Tunova REST API. The API key is sent as the `X-API-Key` header. */
+export async function tunovaRequest(
+  apiKey: string,
+  method: HttpMethod,
+  path: string,
+  body?: unknown,
+): Promise<unknown> {
+  const response = await httpClient.sendRequest({
+    method,
+    url: `${BASE_URL}${path}`,
+    headers: {
+      'X-API-Key': apiKey,
+      'Content-Type': 'application/json',
+    },
+    body,
+  });
+  return response.body;
+}

--- a/packages/pieces/community/tunova/tsconfig.json
+++ b/packages/pieces/community/tunova/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": false,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "files": [],
+  "include": [],
+  "references": [{ "path": "./tsconfig.lib.json" }]
+}

--- a/packages/pieces/community/tunova/tsconfig.lib.json
+++ b/packages/pieces/community/tunova/tsconfig.lib.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "baseUrl": ".",
+    "paths": {},
+    "outDir": "./dist",
+    "declaration": true,
+    "declarationMap": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
Adds a **Tunova** piece — generate music with **Suno (v5.5)** from Activepieces flows via the public [Tunova](https://tunova.ai) REST API. Async, and **billed only on a successful render** (a failed render auto-refunds).

### Auth
CustomAuth with an API Key field → sent as the `X-API-Key` header. Free key (50 tokens, no card) at https://tunova.ai.

### Actions
- **Generate Song** — `POST /api/generate` (prompt, model default `v5.5`, optional instrumental) → returns a `job_id`
- **Get Job** — `GET /api/jobs/{id}` → poll for status + `clips[].audio_url`
- **Generate Lyrics** — `POST /api/lyrics`
- **Custom API Call**

### Notes
- Follows the `apitemplate-io`/`deepl` piece structure; the action/auth/`createCustomApiCallAction` usage typechecks against `@activepieces/pieces-framework`.
- `logoUrl` points at our hosted `https://tunova.ai/icon.svg` for now — happy to provide a PNG / have it moved to the AP CDN.
- Included `src/i18n/translation.json` with the source strings; can regenerate via the i18n tooling if preferred.
- I couldn't run the full monorepo build locally — glad to iterate on anything CI flags.

Tunova is an independent service, not affiliated with or endorsed by Suno.