### PR TITLE
fix(ai-providers): restrict provider changes to platform admins

### DIFF
--- a/.agents/features/ai-providers.md
+++ b/.agents/features/ai-providers.md
@@ -71,12 +71,14 @@ Models listed per provider are cached in memory. Cache cleared daily at midnight
 
 ## Endpoints
 
+Reads are open to any platform member (`GET /` / `/:provider/models` allow USER + ENGINE; `/:provider/config` is engine-only). Mutations are **platform-admin only**.
+
 - `GET /` — list providers (auto-creates ACTIVEPIECES if credits enabled)
 - `GET /:provider/config` — get provider config + decrypted auth (engine-only access)
 - `GET /:provider/models` — list available models (cached)
-- `POST /` — create provider (validates credentials first)
-- `POST /:id` — update provider (re-validates if auth changed, cannot update ACTIVEPIECES)
-- `DELETE /:id` — delete provider (cannot delete ACTIVEPIECES)
+- `POST /` — create provider (platform-admin only; validates credentials first)
+- `POST /:id` — update provider (platform-admin only; re-validates if auth changed, cannot update ACTIVEPIECES)
+- `DELETE /:id` — delete provider (platform-admin only; cannot delete ACTIVEPIECES)
 
 ## Engine Integration
 

--- a/packages/server/api/src/app/ai/ai-provider-controller.ts
+++ b/packages/server/api/src/app/ai/ai-provider-controller.ts
@@ -67,7 +67,7 @@ const ListModels = {
 
 const CreateAIProvider = {
     config: {
-        security: securityAccess.publicPlatform([PrincipalType.USER]),
+        security: securityAccess.platformAdminOnly([PrincipalType.USER]),
     },
     schema: {
         body: CreateAIProviderRequest,
@@ -76,7 +76,7 @@ const CreateAIProvider = {
 
 const UpdateAIProvider = {
     config: {
-        security: securityAccess.publicPlatform([PrincipalType.USER]),
+        security: securityAccess.platformAdminOnly([PrincipalType.USER]),
     },
     schema: {
         params: z.object({
@@ -88,7 +88,7 @@ const UpdateAIProvider = {
 
 const DeleteAIProvider = {
     config: {
-        security: securityAccess.publicPlatform([PrincipalType.USER]),
+        security: securityAccess.platformAdminOnly([PrincipalType.USER]),
     },
     schema: {
         params: z.object({

--- a/packages/server/api/test/integration/ce/ai-provider/ai-provider.test.ts
+++ b/packages/server/api/test/integration/ce/ai-provider/ai-provider.test.ts
@@ -1,11 +1,11 @@
 import { AIProviderName, apId } from '@activepieces/core-utils'
-import { PrincipalType } from '@activepieces/shared'
+import { DefaultProjectRole, PrincipalType } from '@activepieces/shared'
 import { FastifyInstance } from 'fastify'
 import { StatusCodes } from 'http-status-codes'
 import { generateMockToken } from '../../../helpers/auth'
 import { db } from '../../../helpers/db'
 import { mockAndSaveAIProvider } from '../../../helpers/mocks'
-import { createTestContext, TestContext } from '../../../helpers/test-context'
+import { createMemberContext, createTestContext, TestContext } from '../../../helpers/test-context'
 import { setupTestEnvironment, teardownTestEnvironment } from '../../../helpers/test-setup'
 
 let app: FastifyInstance | null = null
@@ -177,6 +177,96 @@ describe('AI Providers API', () => {
             )
             expect(customProvider).toBeDefined()
             expect(customProvider.config.defaultHeaders).toEqual({ 'X-Test': 'test' })
+        })
+    })
+
+    describe('authorization: mutations require platform admin', () => {
+        const createBody = {
+            provider: AIProviderName.CUSTOM,
+            displayName: 'Attacker Provider',
+            config: {
+                baseUrl: 'https://attacker.example.com/v1',
+                apiKeyHeader: 'Authorization',
+                models: [],
+            },
+            auth: { apiKey: 'attacker-key' },
+        }
+
+        it('forbids a non-admin platform member from creating a provider', async () => {
+            const memberCtx = await createMemberContext(app!, ctx, {
+                projectRole: DefaultProjectRole.VIEWER,
+            })
+
+            const response = await memberCtx.post('/v1/ai-providers', createBody)
+
+            expect(response?.statusCode).toBe(StatusCodes.FORBIDDEN)
+        })
+
+        it('forbids a non-admin platform member from updating a provider', async () => {
+            const provider = await mockAndSaveAIProvider({
+                platformId: ctx.platform.id,
+                provider: AIProviderName.CUSTOM,
+                displayName: 'Victim Provider',
+                config: {
+                    baseUrl: 'https://api.example.com/v1',
+                    apiKeyHeader: 'Authorization',
+                    models: [],
+                },
+            })
+            const memberCtx = await createMemberContext(app!, ctx, {
+                projectRole: DefaultProjectRole.VIEWER,
+            })
+
+            const response = await memberCtx.post(`/v1/ai-providers/${provider.id}`, createBody)
+
+            expect(response?.statusCode).toBe(StatusCodes.FORBIDDEN)
+        })
+
+        it('forbids a non-admin platform member from deleting a provider', async () => {
+            const provider = await mockAndSaveAIProvider({
+                platformId: ctx.platform.id,
+                provider: AIProviderName.CUSTOM,
+                displayName: 'Victim Provider',
+                config: {
+                    baseUrl: 'https://api.example.com/v1',
+                    apiKeyHeader: 'Authorization',
+                    models: [],
+                },
+            })
+            const memberCtx = await createMemberContext(app!, ctx, {
+                projectRole: DefaultProjectRole.VIEWER,
+            })
+
+            const response = await memberCtx.delete(`/v1/ai-providers/${provider.id}`)
+
+            expect(response?.statusCode).toBe(StatusCodes.FORBIDDEN)
+        })
+
+        it('allows a platform admin to delete a provider', async () => {
+            const provider = await mockAndSaveAIProvider({
+                platformId: ctx.platform.id,
+                provider: AIProviderName.CUSTOM,
+                displayName: 'Admin Provider',
+                config: {
+                    baseUrl: 'https://api.example.com/v1',
+                    apiKeyHeader: 'Authorization',
+                    models: [],
+                },
+            })
+
+            const response = await ctx.delete(`/v1/ai-providers/${provider.id}`)
+
+            expect(response?.statusCode).toBe(StatusCodes.NO_CONTENT)
+        })
+
+        it('still allows a non-admin platform member to list providers', async () => {
+            const memberCtx = await createMemberContext(app!, ctx, {
+                projectRole: DefaultProjectRole.VIEWER,
+            })
+
+            const response = await memberCtx.get('/v1/ai-providers')
+
+            expect(response?.statusCode).toBe(StatusCodes.OK)
         })
     })
 })


### PR DESCRIPTION
## Summary
Only platform admins can now add, edit, or remove AI providers. Viewing the list of providers and models is unchanged.

## Testing
- Added tests: non-admins are blocked from adding/editing/removing providers, admins can, and everyone can still view the list.
- AI provider test suite passing.
