### PR TITLE
chore(security): add advisory triage skills

### DIFF
--- a/.agents/skills/triage-dependabot-alerts/SKILL.md
+++ b/.agents/skills/triage-dependabot-alerts/SKILL.md
@@ -1,0 +1,194 @@
+---
+name: triage-dependabot-alerts
+description: Triage Dependabot dependency vulnerability alerts for the Activepieces repo — pull open alerts, dedupe to distinct (package, advisory), confirm the vulnerable package + API is actually used, and propose version-bump fixes proven non-breaking (build + tests) before any PR. Use when the user asks to triage Dependabot alerts, work the dependency-vulnerability backlog, or bump vulnerable dependencies. For human-reported vulnerabilities, use the triage-security-advisories skill instead.
+---
+
+# Triage Dependabot Alerts (dependency vulnerabilities)
+
+On-demand triage of Dependabot dependency alerts for `activepieces/activepieces`. Produces a
+**review-ready** report per affected package, and proposes version-bump fixes that are **proven
+non-breaking** before any PR. The user reviews and decides per package: approve the bump /
+dismiss / escalate.
+
+For human-reported vulnerabilities (Security tab advisories), use the
+**triage-security-advisories** skill. The two share the `.security-triage/` workspace. Dependency
+CVEs are already public, so there is no scope-check against SECURITY.md and fixes may use normal
+PRs (not the private-fork flow).
+
+## Privacy note
+
+Write all artifacts to `.security-triage/` (gitignored). Dependabot data is less sensitive than
+private reports, but keep the workspace consistent and never commit triage artifacts.
+
+## Step 1 — Fetch (deterministic)
+
+```
+mkdir -p .security-triage
+gh api -H "Accept: application/vnd.github+json" "/repos/activepieces/activepieces/dependabot/alerts?state=open" --paginate > .security-triage/dependabot.json
+```
+
+`gh api --paginate` emits one concatenated array per page — **always** merge:
+
+```
+jq -s 'add' .security-triage/dependabot.json > .tmp && mv .tmp .security-triage/dependabot.json
+```
+
+Then **validate** the result is real data, not an error object. A 404/403 body is
+`{message,documentation_url,status}`, and `jq 'length'` on it returns `3` — which looks like
+"3 alerts". Guard explicitly:
+
+```
+jq -e 'type=="array"' .security-triage/dependabot.json >/dev/null \
+  || echo "Not an array — Dependabot fetch failed (likely token scope). Stopping."
+```
+
+If it is not an array, the fetch failed — almost always token scope. **Don't pre-gate on a scope
+check:** `repo` scope alone returned the full backlog in practice, so just try the fetch first.
+Only if it 403/404s or returns a non-array does the token likely need `security_events` — add it
+with `gh auth refresh -s security_events` (web-OAuth `gho_` login) or mint a new classic token with
+`repo` + `security_events` and `gh auth login --with-token` (PAT, since refresh can't add scopes to
+a PAT) — then retry. Stop until the fetch returns an array.
+
+## Step 2 — Dedupe, then validate usage
+
+A large backlog (100s of alerts) collapses to a small set of distinct vulnerabilities — the same
+CVE is reported once per manifest that declares the package, and a monorepo with a single hoisted
+lockfile installs one copy. **Triage the distinct set, not the raw alerts.** Dedupe first:
+
+```
+# distinct (package, advisory) — the real triage unit
+jq -r 'group_by(.security_advisory.ghsa_id + "|" + .dependency.package.name)
+  | map({pkg:.[0].dependency.package.name, sev:.[0].security_advisory.severity,
+         ghsa:.[0].security_advisory.ghsa_id, n:length}) | .[]
+  | "\(.sev)\t\(.pkg)\t\(.ghsa)\tx\(.n)"' .security-triage/dependabot.json | sort
+```
+
+By default focus on **critical + high** (ask the user if they want medium/low too — a big backlog
+is rarely worth triaging end-to-end). Then **group by package** for the rest of the workflow: one
+bump usually clears every alert for a package across all manifests.
+
+**Read the full vulnerable-range set per advisory, not just the first.** Each advisory's
+`security_advisory.vulnerabilities[]` has one entry **per affected major line** (e.g. `form-data`
+patches `<2.5.6` *and* `>=4.0.0,<4.0.6`; `undici` patches separate 6.x / 7.x / 8.x lines; a `<6.27`
+range has no lower bound and also covers 5.x). A table built from `vulnerabilities[0]` silently
+understates exposure — pull them all:
+
+```
+jq -r '.[] | select(.security_advisory.ghsa_id=="<GHSA>")
+  | .security_advisory.vulnerabilities[]
+  | "  range=\(.vulnerable_version_range)  patched=\(.first_patched_version.identifier // "none")"' \
+  .security-triage/dependabot.json | sort -u
+```
+
+**Census the lockfile in the main thread — do not trust subagent recall.** Before spawning
+subagents, list every installed copy of each package straight from the lockfile. This is
+authoritative; subagents routinely under-count duplicate transitive copies (in practice two
+subagents reported a single copy where the lockfile held three):
+
+```
+grep -oE '"<pkg>@[0-9][^"]*"' bun.lock | sort -u   # every installed version, incl. transitive dupes
+```
+
+Spawn one subagent **per package (or per distinct advisory)** — never one per raw alert. Each
+confirms the alert is real for THIS repo:
+
+- Confirm the package is actually a dependency (direct or transitive) and which manifest(s)
+  declare it. **Ignore `node_modules/**` paths** when grepping manifests.
+- Confirm the **specific vulnerable API / code path** is actually imported and exercised — not a
+  transitive-only or dead-code path.
+- **Ground "is it vulnerable" in the lockfile, not recall.** Read the installed version from the
+  lockfile and compare to the advisory's vulnerable range. A version inside the range is
+  vulnerable even if it looks recent. For packages with **multiple advisories**, being ≥ one
+  advisory's first-patched version does NOT mean safe — another advisory may patch higher (e.g.
+  `form-data` 4.0.4 clears `<4.0.4` but is still vulnerable to the `<4.0.6` advisory). LLM guesses
+  about installed versions are unreliable; always check the lockfile.
+- Note the **first patched version** and whether a fixed version exists at all.
+- Assess real exposure (reachable with attacker input vs dev/build-time only).
+
+Detect the package manager from the repo (`packageManager` field + which lockfile exists:
+`bun.lock` → bun, `package-lock.json` → npm, `pnpm-lock.yaml` → pnpm, `yarn.lock` → yarn). This
+repo is **bun**. Use the matching tooling in Step 4.
+
+Emit a verdict per package/advisory: `AFFECTED` (vulnerable path used) / `NOT_AFFECTED` (dep
+present but vulnerable API unused) / `NO_FIX_YET` (no patched version anywhere) / `DEV_ONLY`
+(build/test-time only).
+
+## Step 3 — Report
+
+Write a review-ready markdown file **per affected package** under
+`.security-triage/reports/dependabot-<package>.md` (not one per alert — that does not scale).
+Each lists: the package's advisories + vulnerable ranges, installed version(s) from the lockfile,
+first patched version(s), usage verdict + the call sites, severity, the constituent alert IDs,
+and a recommendation.
+
+Then write the consolidated **`.security-triage/DEPENDABOT-TRIAGE-SUMMARY.md`** (the review
+artifact — a distinct name from the advisories skill's `TRIAGE-SUMMARY.md`, which shares this
+workspace; do not clobber it):
+verdict tally (AFFECTED / NOT_AFFECTED / NO_FIX_YET / DEV_ONLY), a table grouped by severity +
+verdict (package, severity, installed → fix, verdict, reachability, alert count), and any
+**shared-dependency patterns** (one bump resolves several alerts, or several alerts share a
+manifest).
+
+Present the headline verdicts in chat, **most attacker-reachable first**. Surface `DEV_ONLY`
+findings in a separate group — a critical CVSS in a dev-only test runner should not bury an
+attacker-reachable high in production code.
+
+## Step 4 — Fix on approval (bump must be PROVEN non-breaking)
+
+After the user picks which packages to fix:
+
+**Single lockfile → one batched PR.** In a monorepo with one shared lockfile (bun/npm/pnpm),
+per-package branches all conflict on the lockfile. Bump **all** approved packages in **one**
+isolated worktree and open **one** PR — never a worktree/PR per package.
+
+1. Create one isolated git worktree for the whole batch so the main tree is untouched.
+2. Bump each dependency to the first patched version that clears **all** of its advisories
+   (bun: edit the pinned range + `bun install`). Direct deps here are usually **exact-pinned**, so
+   bump them in every manifest that declares them — a `find … -not -path '*/node_modules/*' -exec
+   sed -i 's/"<pkg>": "<old>"/"<pkg>": "<new>"/'` sweep is appropriate for an exact pin.
+3. **Dedupe the leftover copies carefully — this is where bumps go wrong.** Re-run the Step 2
+   census after the bump. For each still-vulnerable copy:
+   - **Same major line, our own tree** → pin it with a flat `resolutions`/`overrides` entry
+     (e.g. `"axios": "1.16.0"`). **bun honours only FLAT keys — scoped keys like
+     `"superagent/form-data": "x"` are silently ignored**, so a flat pin forces *every* copy.
+   - **Crossing a major line inside a third-party SDK** (e.g. `form-data` 2.x in `superagent`,
+     `undici` 5.x in a vendor client) → **do NOT force it.** The repo's tests don't exercise that
+     SDK's code path, so a forced cross-major bump **cannot be proven non-breaking**. Leave it and
+     **document it as a residual** in the package report + PR body (which copy, which advisory, why
+     not forced). Fixing the attacker-reachable *direct* deps is the bar; transitive SDK-internal
+     copies wait for the SDK to update.
+   Confirm the final tree with the census grep.
+4. Classify the semver jump. **A minor/patch bump is NOT automatically safe** — libraries tighten
+   TypeScript types in minor releases and break the build (in practice `samlify` 2.10→2.13, a
+   minor, broke `tsc` by narrowing a parameter type). Flag majors as highest-risk, but never skip
+   the build on a "low-risk" bump.
+5. Read the dependency's changelog / release notes between current and target for breaking changes.
+6. Grep every usage of the dependency's API across the repo and check each call against the new
+   version. Any required code change (e.g. adapting to a tightened type) goes in the **same** PR.
+7. Run typecheck + **build** + lint + the affected packages' tests:
+   `npx turbo run build lint test --filter=<pkg> …` (one `--filter` per affected package).
+8. **Triage failures — don't assume the bump caused them.** If a test fails, re-run it on the base
+   (HEAD) tree before blaming the bump: stale tests and network-dependent integration tests fail
+   regardless of the dependency version. Only a test that is green on base and red after the bump
+   is yours to fix.
+9. A dep bump inside a **versioned internal package** (`packages/core/shared`,
+   `packages/server/utils`) trips the repo's version-bump rule — patch-bump those packages too
+   (once per branch, not per edit).
+10. Propose the PR **only if build/lint/tests pass** (or the only failures are proven
+    pre-existing/environmental, per step 8). Otherwise report the exact breakage and options (pin,
+    patch-only bump, or required code change). Discard the worktree on failure.
+
+**NO_FIX_YET packages get no bump PR.** Instead produce a risk-acceptance / mitigation writeup in
+the package report: where it's reachable, any existing sandboxing, and the options (accept
+residual risk with justification, patch locally via `patch-package`/bun patch, or swap the
+library). If the only available fix is an external source (e.g. SheetJS off npm → CDN tarball),
+flag the **self-hosting rule** — an install that depends on a third-party CDN at build time may
+break zero-setup self-hosting; call it out for a maintainer decision.
+
+Dependency CVEs are public, so a normal PR is fine (no private-fork flow). Patch-bump scope — do
+not bundle unrelated upgrades.
+
+## Output recap
+
+Everything lands in `.security-triage/` (gitignored): `dependabot.json`, `DEPENDABOT-TRIAGE-SUMMARY.md`, and
+one report per affected package under `reports/`.

--- a/.agents/skills/triage-image-cves/SKILL.md
+++ b/.agents/skills/triage-image-cves/SKILL.md
@@ -1,0 +1,242 @@
+---
+name: triage-image-cves
+description: Scan an Activepieces Docker image with grype for OS/base-image (deb) and application (npm) CVEs of High/Critical severity. Lists the 3 most-recent published tags and lets the user pick which to scan, validates each finding is real and reachable, and proves candidate fixes in an isolated git worktree (rebuild image + re-scan + tests + container smoke-run + codebase diff) before proposing anything — fixes are NEVER auto-applied; the user decides per finding. Use when the user asks to grype-scan the image, triage container/image vulnerabilities, or check a shipped Docker image for CVEs.
+---
+
+# Triage Image CVEs (grype container scan)
+
+On-demand triage of vulnerabilities in a **published Activepieces Docker image** on Docker Hub
+(`activepieces/activepieces`) using [grype](https://github.com/anchore/grype). The skill lists the
+**3 most-recent tags** and lets the user pick which to scan. Produces a **review-ready** report
+per affected package and proposes fixes that are **proven non-breaking in an isolated worktree** —
+image rebuilds, the target CVE clears with no new High/Critical introduced, tests pass, the
+container boots, and the codebase diff is scoped. **Nothing is ever applied to the working tree or
+committed.** The user decides per finding: approve / dismiss / escalate.
+
+Scope (decided with the user; defaults below — re-confirm if they want different):
+- **Image source:** Docker Hub `activepieces/activepieces`, one of the **3 most-recent tags**,
+  chosen by the user at the start of the run.
+- **Findings:** both OS/base-image packages (`deb`, fix = Dockerfile base/apt change) **and** app
+  npm deps (fix = lockfile bump).
+- **Severity:** **High + Critical only** (above medium).
+- **Validation:** full gate, always in a throwaway git worktree.
+
+Artifacts go in the `.security-triage/` workspace (gitignored).
+
+## Privacy note
+
+Write all artifacts to `.security-triage/` (gitignored — confirm with `git status` after a run
+that nothing new appears under tracked paths). Image CVEs are public, so fixes may use normal PRs
+(no private-fork flow) — but still never commit triage artifacts.
+
+## Prerequisites
+
+- `grype` on PATH (`grype version`). If missing, install it yourself first — **do not pipe a
+  remote installer into a shell**. Prefer a package manager (`brew install grype`) or download the
+  pinned release binary from https://github.com/anchore/grype/releases and verify its published
+  checksum before use. If grype is absent, this skill stops and asks you to install it rather than
+  fetch-and-exec an installer in the security workspace.
+- `docker` running.
+- First scan downloads/updates the grype vuln DB (needs network). Force it once with
+  `grype db update` if a run reports a stale DB.
+
+## Step 1 — Pick the tag, then scan (deterministic)
+
+List the **3 most-recent tags** from Docker Hub and let the user choose which to scan (use
+`AskUserQuestion`, one option per tag, newest first, showing the push date):
+
+```
+mkdir -p .security-triage
+curl -s "https://hub.docker.com/v2/repositories/activepieces/activepieces/tags?page_size=50&ordering=last_updated" \
+  | jq -r '[.results[] | select(.name|test("^[0-9]+\\.[0-9]+\\.[0-9]+$"))][0:3][]
+           | "\(.name)\t\(.last_updated)"'
+```
+
+The `select(... test ...)` keeps only semver release tags and drops the floating `latest` pointer
+(it just aliases one of them). If the API call fails or returns nothing, fall back to
+`docker search` / ask the user for a tag explicitly. Set `TAG` to the user's choice, then scan:
+
+```
+docker pull activepieces/activepieces:$TAG
+# scan EVERYTHING (do not pass --only-fixed here — we still want to surface no-fix CVEs for a
+# risk writeup). Pin the platform so the result is reproducible.
+grype activepieces/activepieces:$TAG --platform linux/amd64 -o json \
+  > .security-triage/grype.json
+```
+
+**Validate it is a real scan, not an error.** A failed scan can still write a small JSON object;
+guard on the `matches` array explicitly:
+
+```
+jq -e '.matches | type=="array"' .security-triage/grype.json >/dev/null \
+  || echo "No matches array — grype scan failed (pull/DB/network). Stopping."
+```
+
+Filter to **High + Critical**, dedupe to the real triage unit `(CVE, package, version)` — the same
+CVE recurs once per install location — and split OS vs app by `artifact.type`:
+
+```
+# the deduped High/Critical set, tagged class=os|app
+jq -r '
+  .matches[]
+  | select(.vulnerability.severity=="High" or .vulnerability.severity=="Critical")
+  | { id:.vulnerability.id, sev:.vulnerability.severity,
+      pkg:.artifact.name, ver:.artifact.version, type:.artifact.type,
+      fixState:.vulnerability.fix.state,
+      fixedIn:((.vulnerability.fix.versions // []) | join(",")),
+      class:(if (.artifact.type|test("^(deb|apk|rpm)$")) then "os" else "app" end) }
+' .security-triage/grype.json \
+  | jq -s 'unique_by(.id + "|" + .pkg + "|" + .ver)' \
+  > .security-triage/grype-filtered.json
+
+# headline table, OS first then app, critical first
+jq -r 'sort_by(.class!="os", (.sev=="Critical"|not), .pkg)[]
+  | "\(.class)\t\(.sev)\t\(.pkg) \(.ver)\t\(.id)\tfix=\(.fixState):\(.fixedIn)"' \
+  .security-triage/grype-filtered.json
+```
+
+`fixState` is `fixed` / `not-fixed` / `wont-fix` / `unknown`. Only `fixed` findings have a fix to
+test; the rest go to the risk-writeup path (Step 4, NO_FIX_YET).
+
+**Reachability caveat for OS findings:** the shipped image's `run` stage is `FROM base`, so the
+build toolchain in the Dockerfile (`g++`, `build-essential`, `git`, `python3`, `poppler-utils`,
+`curl`, …) is **present in the final image**, not stripped. "Present" therefore does not mean
+"reachable" — a CVE in `g++` only matters if a runtime path invokes it. Decide reachability in
+Step 2, do not assume.
+
+## Step 2 — Validate each finding (one focused subagent per package)
+
+Spawn one read-only subagent **per package** (not per match). Each returns a verdict backed by
+evidence. Keep subagents read-only; they write `reports/image-<pkg>.md` and return a compact
+verdict line.
+
+For **every** finding, ground the version in the scan, not recall: the installed version is
+`artifact.version` from `grype.json`; compare it to the advisory's fixed version
+(`vulnerability.fix.versions`). Pull the advisory link from `vulnerability.dataSource`.
+
+**OS / base-image (`deb`) findings:**
+- Confirm the package is in the **shipped** image (it is, if grype found it on the scanned tag) and
+  whether it sits on a **runtime-reachable** path or is a build-tool leftover. Map it to how AP
+  uses it: `git` → git-sync; `python3`/`poppler-utils` → PDF/AI pieces; `ca-certificates`/`curl`
+  → outbound HTTP; `g++`/`build-essential`/`node-gyp` → native-module rebuild at install (build-
+  time, but the binary still ships). State which.
+- Determine the fix path and its blast radius:
+  - **apt patch available in bullseye** → `apt-get install -y --only-upgrade <pkg>` or pin the
+    fixed version. Low risk.
+  - **fixed only in a newer base tag** → bump `FROM node:<x>-bullseye-slim` to the latest patch
+    digest. Medium risk (Node minor/patch).
+  - **fixed only in a newer Debian release** → bullseye(11)→bookworm(12). **High risk** —
+    glibc/openssl bumps can break native modules (`isolated-vm`, sandboxes). Must be proven by the
+    full gate, never proposed on paper.
+  - **no fix** → `not-fixed`/`wont-fix` → NO_FIX_YET.
+- **Self-hosting rule:** any base/apt change must keep zero-setup self-hosting working — no new
+  env var, no build-time dependency on a third-party CDN, no manual step. Flag violations.
+
+**App (`npm`) findings:**
+- Confirm the package is a real dependency and the **vulnerable API is actually exercised** (not
+  transitive dead code). Read the installed version from `bun.lock` (this repo is **bun**), not
+  from recall. For a package with multiple advisories, being ≥ one fix version does not mean safe.
+- **Confirm it on the built image, not just the lockfile.** The shipped image runs a trimmed
+  `bun install --production` over a regenerated lockfile (pieces are stripped in the build), so the
+  set of installed npm packages in the image can differ from the dev `bun.lock`. The version grype
+  reports is the one actually shipped — treat that as ground truth.
+
+Emit one verdict per package:
+
+| Verdict | Meaning |
+| --- | --- |
+| `FIXABLE` | Reachable, a patched version exists, fix path is in-distro / minor bump. |
+| `FIX_VIA_BASE_BUMP` | Only fixed by a base-image tag/release bump (higher risk; must pass full gate). |
+| `NOT_REACHABLE` | Package present in image but the vulnerable component is not invoked by AP. |
+| `NO_FIX_YET` | No upstream fix (`not-fixed` / `wont-fix`). Risk writeup, no build. |
+
+## Step 3 — Report
+
+Write `.security-triage/reports/image-<pkg>.md` per affected package: class (os/app), the CVEs +
+severities, installed version (from the scan), fixed version(s), `fixState`, reachability verdict
+with the runtime path, the proposed fix path + risk class, and any self-hosting concern.
+
+Then the consolidated **`.security-triage/IMAGE-CVE-TRIAGE-SUMMARY.md`** (distinct filename so it
+never collides with other tools' artifacts in the shared gitignored `.security-triage/` workspace):
+- Image digest scanned + grype DB date (`jq '.descriptor' grype.json`), so the run is reproducible.
+- Verdict tally and a table grouped by class then severity (pkg, severity, installed → fix,
+  verdict, reachability, CVE count).
+- Findings clearable by a **single base-image bump** grouped together (one Dockerfile change
+  resolves many deb CVEs).
+
+Present headline verdicts in chat, **runtime-reachable first**; surface `NOT_REACHABLE` /
+build-only separately so a scary-looking CVE in a build tool doesn't bury a reachable one. Then
+**ask the user which findings to fix** before doing anything.
+
+## Step 4 — Fix on approval (PROVEN in an isolated worktree, never applied)
+
+Only after the user picks findings. **All build/test/scan work happens in a throwaway git
+worktree so the working tree is never touched.**
+
+```
+# <short> MUST be unique per run (e.g. $(date +%s)-$RANDOM) so paths never collide across runs;
+# `git worktree add` also aborts if the path already exists, so a collision fails here.
+git worktree add ../ap-cve-fix-<short> HEAD     # isolated copy; main tree stays clean
+```
+
+Group approved fixes sensibly: **all approved OS findings → one Dockerfile change set**; **all
+approved npm bumps → one lockfile change set** (the repo has a single shared `bun.lock`, so per-
+package branches would all conflict on it — bump all approved npm packages in one batch, never one
+worktree/PR per package). Then, inside the worktree:
+
+1. **Apply the candidate fix.**
+   - OS: edit `Dockerfile` (and `Dockerfile.worker` if affected) — pin the upgraded apt package,
+     bump the `FROM` digest, or change the Debian release. Keep it minimal and self-hosting-safe.
+   - npm: bump the pinned range(s) to the first version clearing all advisories + `bun install`;
+     patch-bump any versioned internal package touched (`packages/core/shared`,
+     `packages/server/utils`) per the repo rule (once per branch).
+2. **Rebuild the image** from the worktree: `docker build -t ap-cve-test:<short> .`
+   (plus `-f Dockerfile.worker` if it was changed). A failed build = fix rejected; report the
+   build error.
+3. **Re-scan the rebuilt image and diff against baseline** — the fix must clear the target CVE(s)
+   **and introduce no new High/Critical**:
+   ```
+   grype ap-cve-test:<short> --platform linux/amd64 -o json > .security-triage/grype-after.json
+   # target CVE(s) gone?
+   jq -r '[.matches[].vulnerability.id] | unique' .security-triage/grype-after.json   # must NOT contain the target ids
+   # no NEW high/critical vs baseline?
+   comm -13 \
+     <(jq -r '.matches[]|select(.vulnerability.severity|test("High|Critical"))|.vulnerability.id' .security-triage/grype.json | sort -u) \
+     <(jq -r '.matches[]|select(.vulnerability.severity|test("High|Critical"))|.vulnerability.id' .security-triage/grype-after.json | sort -u)
+   ```
+   The `comm` output must be empty (no High/Critical present after that wasn't there before).
+4. **Run tests** for code/dep changes: `npx turbo run build lint test --filter=<pkg> …` (one
+   `--filter` per affected package). **Triage failures against base** — re-run a failing test on
+   HEAD before blaming the fix; only green-on-base / red-after is yours. For a pure base-image bump
+   with no code change, the build + smoke run below is the proof; still run a representative
+   package's tests to catch a glibc/native-module regression.
+5. **Smoke-run the container** — prove it actually boots (entrypoint, migrations):
+   ```
+   docker run --rm -d --name ap-cve-smoke -p 8080:80 ap-cve-test:<short>
+   # poll the health/entrypoint for boot, then:
+   docker logs ap-cve-smoke; docker rm -f ap-cve-smoke
+   ```
+   Container must come up clean (no crash loop, migrations run). Tear it down.
+6. **Scan the codebase diff** — `git -C ../ap-cve-fix-<short> status` + `git diff`. Confirm the
+   change is **scoped to the intended files** (Dockerfile / lockfile / the one adapted call site)
+   with no stray churn or unrelated edits. Report the diff stat.
+7. **Propose only if every gate passes.** Report: build ✓/✗, target CVE cleared ✓/✗, no-new-
+   High/Critical ✓/✗, tests ✓/✗, smoke-run ✓/✗, diff scope ✓/✗ — with the exact evidence. If
+   anything fails, report the precise breakage and options (pin instead of bump, patch-only, base
+   tag instead of release jump, or a required code change). **Do not apply, commit, merge, or open
+   a PR** unless the user explicitly approves after seeing the gate results.
+8. **Always discard the worktree** when done — safe because `<short>` is unique to this run, so the
+   path is provably this run's: `git worktree remove ../ap-cve-fix-<short> --force`
+   (and `docker rmi ap-cve-test:<short>`).
+
+**NO_FIX_YET** findings get no build — produce a risk-acceptance writeup in the package report:
+where it's reachable in the image, any sandboxing that mitigates it, and the options (accept with
+justification, pin/patch locally, swap the component, or wait for upstream).
+
+## Output recap
+
+Everything lands in `.security-triage/` (gitignored): `grype.json` (baseline scan),
+`grype-filtered.json` (High/Critical deduped), `grype-after.json` (post-fix re-scan),
+`IMAGE-CVE-TRIAGE-SUMMARY.md`, and one report per affected package under `reports/image-*.md`.
+The working tree and git history are never modified; all fix validation happens in a discarded
+worktree.

--- a/.agents/skills/triage-security-advisories/SKILL.md
+++ b/.agents/skills/triage-security-advisories/SKILL.md
@@ -1,0 +1,253 @@
+---
+name: triage-security-advisories
+description: Triage the GitHub privately-reported vulnerability backlog for Activepieces — pull repository security advisories from the Security tab, scope-check against SECURITY.md, deeply validate each, compute SLA status, and propose fix plans for review. Use when the user asks to triage security advisories, work the reported-vulnerability backlog, or check SLA on reported vulns. For Dependabot dependency alerts, use the triage-dependabot-alerts skill instead.
+---
+
+# Triage Security Advisories (reported vulnerabilities)
+
+On-demand triage of privately-reported vulnerabilities in the Activepieces GitHub repo
+(`activepieces/activepieces`) — the **repository security advisories** from the Security tab.
+Produces a **review-ready** report per advisory + an SLA dashboard, and proposes fix plans.
+The user reviews and decides per advisory: approve the fix / dismiss as out-of-scope / escalate.
+
+For Dependabot dependency alerts, use the **triage-dependabot-alerts** skill. The two share the
+`.security-triage/` workspace, the privacy rule, and the SLA script.
+
+Follow the manual process this automates: `docs/handbook/engineering/playbooks/security-advisory-response.mdx`.
+
+## HARD PRIVACY RULE — read first
+
+This is a **public** repo. Private/embargoed advisory content MUST NOT be committed.
+- Write all artifacts (fetched JSON, per-advisory reports, dashboard) to `.security-triage/`,
+  which is gitignored. Never write advisory content into any tracked file.
+- After a run, confirm `git status` shows nothing new under tracked paths.
+- Fixes go to a **private-fork `security/<ghsa-id>` branch** per the playbook — never a public
+  pre-embargo PR.
+
+## One-time setup
+
+The `gh` token needs security scopes or the advisory API returns 403. If step 1 returns 403,
+tell the user to run:
+
+```
+gh auth refresh -s security_events,repo
+```
+
+## Step 1 — Fetch (deterministic)
+
+```
+mkdir -p .security-triage
+gh api /repos/activepieces/activepieces/security-advisories --paginate > .security-triage/advisories.json
+```
+
+`gh api --paginate` may emit concatenated arrays (you'll see `jq` parse multiple top-level
+values, e.g. lengths `100` then `5`); if so merge into one array (`jq -s 'add'`).
+On 403, surface the setup command above and stop.
+
+**zsh JSON footgun (hit this every run):** never pipe advisory rows through `echo`/`printf` into
+`jq` — `echo "$row" | jq …` corrupts embedded control chars/backslashes and fails with
+`Invalid string: control characters … must be escaped`. To split the merged array into one
+input file per advisory, loop the ids and let `jq` read the source file directly each time
+(no shell string round-trip):
+
+```
+mkdir -p .security-triage/input .security-triage/reports
+for id in $(jq -r '.[] | select(.state=="triage" or .state=="draft") | .ghsa_id' .security-triage/advisories.json); do
+  jq --arg id "$id" '.[] | select(.ghsa_id==$id) | {ghsa_id, cve_id, summary, severity, state, created_at, cvss: .cvss_severities, cwes: .cwe_ids, description}' \
+    .security-triage/advisories.json > ".security-triage/input/${id}.json"
+done
+```
+
+Then hand each subagent its `input/<ghsa>.json` path to read — keeps the (private, embargoed)
+advisory body out of the orchestrator's context and out of subagent prompts.
+
+No manual state filtering needed — the SLA script (step 4) excludes resolved advisories
+(`closed`/`published`/`withdrawn`) by default. The actionable backlog is state `triage`
+(newly reported, un-assessed → full pipeline) and `draft` (accepted, fix in flight → SLA-track
+only). Use `--state triage` to focus on un-assessed only, or `--state all` to include resolved.
+When the user asks for "triage state only", pass `--state triage` AND filter the input-file loop
+above to `select(.state=="triage")`.
+
+## Step 2 — Filter + scope-check
+
+For each advisory, check it against the out-of-scope list in `SECURITY.md`: clickjacking on
+non-sensitive pages, unauthenticated/logout/login CSRF, MITM/physical-access attacks, DoS,
+content/text injection without an attack vector, email spoofing, missing DNSSEC/CAA/CSP,
+non-sensitive cookie flags, deadlinks, `UNSANDBOXED` execution mode, special-char inputs with
+no exploitable sink, capability-token guessing without a disclosure path, and pure
+high-entropy-identifier (e.g. nanoid) guessing.
+
+If a report matches an out-of-scope item, mark it `OUT_OF_SCOPE` with the exact SECURITY.md
+clause and reasoning.
+
+## Step 3 — Deep validate (one focused subagent per advisory)
+
+Do NOT stop at "the report mentions X." For each in-scope advisory, trace the **full path from
+entry point to sink** and gather evidence the user can agree with or overrule:
+
+- **Treat the reporter's `file:line` AND stated mechanism as a hint, not ground truth.** Nearly
+  every advisory this codebase produces has drifted citations — refactors move code
+  (`packages/shared`→`packages/core/shared`), rewrites swap the sink (axios→native `fetch`,
+  worker→sandbox), line numbers shift. Re-locate the sink on current `main` by symbol/string
+  search. The vuln can be real while the cited location is stale, and the reported **root cause
+  can be wrong** even when a bug exists nearby (e.g. a reported bypass mechanism turns out to be
+  irrelevant and the real flaw is elsewhere on the path). Verify the *mechanism*, not just that
+  "something looks off near there."
+- Locate the actual sink (`file:line`) and every reachable route/caller that reaches it.
+- Inspect the guards in between and decide if the vuln is truly **reachable for an attacker**,
+  not merely present in source:
+  - Auth: `securityAccess` config on the endpoint (every endpoint must have one).
+  - Tenant isolation: queries must filter by `projectId` / `platformId`
+    (`.claude/rules/data-isolation.md`); connections use `ArrayContains([projectId])`.
+  - Input validation (zod schemas), and edition gating (`platformMustHaveFeatureEnabled`,
+    EE-only paths) — `.claude/rules/edition-safety.md`.
+  - SSRF: outbound HTTP should use `safeHttp` (`.claude/rules/safe-http.md`); a raw
+    `fetch`/`axios.create` on user input is a real reachable sink.
+- **Default-on vs opt-in, and which edition — this flips real severity.** Check: (a) which edition
+  registers the module (the `app.ts` edition switch — many sinks are Cloud-only or EE-only); (b)
+  whether the vulnerable path is default-enabled or behind an env flag (admin/debug UIs often are);
+  (c) whether the *protective* mode is opt-in (e.g. an SSRF guard that only runs in a non-default
+  network mode). A real bug reachable only in a
+  non-default/opt-in or single-edition config is materially lower severity — say so.
+- Confirm the affected **version range** against current `main` — already patched? did a
+  refactor remove the sink? Use `git log -S'<sink string>'` / `git blame` to find the fix commit.
+  If `ALREADY_MITIGATED`, record the **fix commit SHA + date** and compare it to the advisory's
+  `created_at`: reports filed *after* the fix landed are common here (one critical was fixed ~5
+  weeks before it was reported). The fix date drives the close-out message and proves "BREACHED"
+  on the dashboard is stale.
+- Cross-check CVSS 4.0 scoring inputs from the playbook (attack vector, privileges, user
+  interaction, scope, CIA impact). Buckets: 0.1–3.9 low, 4.0–6.9 medium, 7.0–8.9 high,
+  9.0–10 critical.
+- Produce a concrete **PoC sketch / failing-test outline**, or state precisely why it cannot
+  be triggered.
+
+Emit exactly one **verdict** per advisory, each backed by `file:line` evidence:
+
+| Verdict | Meaning |
+| --- | --- |
+| `CONFIRMED_EXPLOITABLE` | Reachable and exploitable as described. |
+| `THEORETICAL` | Sink present but not reachable (guarded / not wired up). |
+| `ALREADY_MITIGATED` | A guard or prior fix already blocks it. |
+| `FALSE_POSITIVE` | Not a real vulnerability. |
+| `OUT_OF_SCOPE` | Excluded by SECURITY.md. |
+
+Also flag **duplicates** (same sink/root cause) and **systemic patterns** (one fix covers
+several). For a large backlog, fan out one subagent per advisory in parallel, then synthesize.
+Subagents stay read-only; they write a report file (`reports/<ghsa>.md`) and return a compact
+verdict line; they never edit code. Only use the Workflow tool if the user explicitly opts into
+multi-agent orchestration — otherwise use parallel `Agent` calls.
+
+Fan-out tips that paid off:
+- **Group advisories into root-cause clusters and give each subagent its sibling list** ("likely
+  same sink as X; cross-check, validate only yours"). This is what surfaces duplicates and the
+  systemic patterns — a subagent blind to its siblings can't dedupe.
+- **Runtimes are very uneven** (single deep history-trace took ~30 min vs ~3 min typical, and a
+  subagent may spawn its own sub-agent for git archaeology). Tell agents to prioritize the
+  **current-`main` verdict** and treat exhaustive history as secondary.
+- **Don't poll with `sleep`** (the harness blocks it). To wait for all reports, arm a background
+  `until [ "$(ls .security-triage/reports/*.md | wc -l)" -ge N ]; do sleep 3; done` and let it
+  notify on completion; collect the streamed verdict notifications meanwhile.
+
+## Activepieces sink patterns — "looks guarded but isn't" (grep these first)
+
+High-yield recurring footguns in this codebase. Each surfaced as a confirmed advisory; a repo-wide
+grep for them catches the systemic cluster, not just the reported instance:
+
+- **`securityAccess.project(..., undefined, ...)`** — passing `undefined` as the required
+  permission. `grantAccess()` returns `true` on a nil permission (`rbac-service.ts`), so the route
+  collapses to **membership-only** — any project member (incl. VIEWER) passes. Confirm a dedicated
+  permission *exists and is deliberately withheld* (the route is a bug) vs. genuinely membership-
+  only by design (e.g. piece-metadata reads). Compare against a sibling module that wires the
+  permission correctly (git-sync does).
+- **`securityAccess.publicPlatform([PrincipalType.USER])`** on a state-changing or platform-wide
+  route where `platformAdminOnly` is required — `publicPlatform` sets `adminOnly:false`, so the
+  admin assertion never runs; any authenticated member reaches it. Compare to audit-events /
+  api-keys / signing-keys / global-connections, which all use `platformAdminOnly`.
+- **TypeORM `.where()` called twice** — the second `.where()` **replaces** the first (use
+  `.andWhere`). A `projectId` filter followed by `.where({ appName })` silently drops tenant
+  isolation.
+- **`projectIds @> '[]'::jsonb`** — empty-array JSONB containment is **TRUE for every row** in
+  Postgres, so an absent/empty `projectIds` collapses the tenant filter to match everything.
+- **`request.projectId` trusted under PLATFORM auth** — it is only populated for
+  `AuthorizationType.PROJECT`; under `publicPlatform`/PLATFORM it is `undefined`, and downstream
+  code that reads it as a scope key then "fails open".
+- **Websocket handlers with no per-event RBAC** — the dispatcher validates only the *handshake*
+  `projectId`; individual `addListener` handlers trust client-supplied `resourceId`/`flowVersionId`
+  with no per-event permission or resource→project ownership check.
+- **Egress not via `safeHttp`** — AI-provider/piece outbound calls using `pieces-common`
+  `httpClient` (native `fetch`/undici) instead of `safeHttp`; user-controlled `baseUrl`/host/
+  `resourceName` interpolated into a URL = SSRF. The in-process dns/socket guards are opt-in
+  (non-default network mode) and best-effort — verify they actually classify the transport in use.
+- **`NODE_TLS_REJECT_UNAUTHORIZED='0'`** set anywhere — a process-wide, persistent TLS-verification
+  kill (its own CWE-295 defect regardless of the reported vuln).
+- **`window.opener.postMessage(payload, '*')`** — wildcard targetOrigin leaks the payload (OAuth
+  code) to any opener origin; receive-side origin checks do NOT mitigate the send side.
+- **Identity matched by email alone** — federated login (`getIdentityByEmail`) / a global
+  `user_identity` keyed only on email, with no provider/`sub`/NameID binding = cross-tenant
+  account takeover surface.
+
+## Step 4 — Score + SLA (deterministic)
+
+```
+npm run security:sla -- --source advisory                # excludes resolved by default
+npm run security:sla -- --source advisory --state triage  # un-assessed backlog only
+npm run security:sla -- --source advisory --state all     # include closed/published
+```
+
+Reads `.security-triage/advisories.json`, computes deadlines + status, writes
+`.security-triage/sla.json` + `.security-triage/dashboard.md`. By default it drops
+`closed`/`published`/`withdrawn` advisories; `--state <csv>` overrides. SLA clock starts at the
+advisory **creation date**:
+
+| Severity | Remediate within | DUE_SOON threshold |
+| --- | --- | --- |
+| Critical | 7 days | ≤ 2 days left |
+| High | 30 days | ≤ 7 days left |
+| Medium | 90 days | ≤ 14 days left |
+| Low | best-effort (no hard deadline) | — |
+
+Status buckets: `BREACHED` → `DUE_SOON` → `ON_TRACK` → `BEST_EFFORT` → `NEEDS_TRIAGE`
+(unscored). Sorted most-urgent-first.
+
+## Step 5 — Report
+
+Write a per-advisory review-ready markdown file under `.security-triage/reports/<ghsa>.md`:
+scope verdict, validity verdict + `file:line` evidence, the sink, PoC sketch, **reported vs
+assessed severity** (note when deep-validation changes it; the SLA dashboard buckets by the
+GitHub-reported severity), SLA deadline + status, recommendation.
+
+Then write the consolidated **`.security-triage/TRIAGE-SUMMARY.md`** — this is the artifact the
+user actually reviews. It must include:
+- Verdict tally (how many CONFIRMED_EXPLOITABLE / THEORETICAL / ALREADY_MITIGATED /
+  FALSE_POSITIVE / OUT_OF_SCOPE).
+- A table grouped by severity/SLA status: GHSA, SLA status, verdict, sink `file:line`, one-line note.
+- **Duplicates** called out (same sink/root cause → fix once).
+- **Systemic patterns** — where one fix covers several advisories (e.g. a shared broken guard).
+- Severity downgrades/upgrades from deep-validation.
+
+Present the SLA dashboard + the summary's headline verdicts in chat. **Lead with the count of
+`CONFIRMED_EXPLOITABLE & unpatched-on-main`, NOT the raw BREACHED count** — the dashboard buckets
+by GitHub-reported severity and lumps in already-fixed advisories, so "24 BREACHED" badly
+overstates the real backlog (a run can have 24 BREACHED but only ~15 actually actionable). State
+explicitly that BREACHED is reported-severity-based and includes mitigated items, then give the
+actionable list sorted by urgency.
+
+## Step 6 — Fix on approval (never before the user approves)
+
+After the user picks which advisories to fix, follow the playbook's private flow:
+- Draft the patch + a **regression test** that fails before / passes after.
+- Stage it on a `security/<ghsa-id>` branch (private fork), patch-bump only — never bundle
+  features. Do not open a public PR before the embargo.
+
+## Closing / responding to a reporter
+
+The repository-security-advisory REST API exposes `state` (closeable via
+`PATCH /repos/activepieces/activepieces/security-advisories/<ghsa-id> -f state=closed`) but
+**no comments endpoint** — the conversation thread is UI-only. To respond with a reason, draft
+the message, have the user paste it into the advisory page, THEN close (so the reporter sees
+the reason, not a bare close notification).
+
+## Output recap
+
+Everything lands in `.security-triage/` (gitignored): `advisories.json`, `sla.json`,
+`dashboard.md`, and one report per advisory. Nothing private is ever committed.

--- a/.gitignore
+++ b/.gitignore
@@ -81,6 +81,9 @@ scratch.md
 # chat-eval CLI cache + decision log
 .chat-eval/
 
+# security advisory triage artifacts (PRIVATE/embargoed advisory content — never commit)
+.security-triage/
+
 .cursor/rules/nx-rules.mdc
 .github/instructions/nx.instructions.md
 

--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
     "push-i18n": "crowdin upload sources",
     "i18n:extract": "i18next --config packages/web/i18next-parser.config.js",
     "bump-translated-pieces": "npx ts-node --project tools/tsconfig.tools.json tools/scripts/pieces/bump-translated-pieces.ts",
-    "bump-all-pieces-patch-version": "npx ts-node --project tools/tsconfig.tools.json tools/scripts/pieces/bump-all-pieces-patch-version.ts"
+    "bump-all-pieces-patch-version": "npx ts-node --project tools/tsconfig.tools.json tools/scripts/pieces/bump-all-pieces-patch-version.ts",
+    "security:sla": "npx ts-node --project tools/tsconfig.tools.json tools/scripts/security/sla-report.ts"
   },
   "private": true,
   "dependencies": {

--- a/tools/scripts/security/sla-report.ts
+++ b/tools/scripts/security/sla-report.ts
@@ -1,0 +1,367 @@
+import * as fs from 'fs'
+import * as path from 'path'
+
+const SLA_DAYS: Record<Severity, number | null> = {
+    critical: 7,
+    high: 30,
+    medium: 90,
+    low: null,
+}
+
+const DUE_SOON_DAYS: Record<Severity, number> = {
+    critical: 2,
+    high: 7,
+    medium: 14,
+    low: 0,
+}
+
+const STATUS_ORDER: Record<SlaStatus, number> = {
+    BREACHED: 0,
+    DUE_SOON: 1,
+    ON_TRACK: 2,
+    BEST_EFFORT: 3,
+    NEEDS_TRIAGE: 4,
+}
+
+const RESOLVED_STATES = new Set(['closed', 'published', 'withdrawn', 'fixed', 'dismissed', 'auto_dismissed'])
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000
+
+function main(): void {
+    const args = parseArgs(process.argv.slice(2))
+    const now = args.now ? new Date(args.now) : new Date()
+    if (Number.isNaN(now.getTime())) {
+        fail(`Invalid --now value: ${args.now}`)
+    }
+
+    const advisories = args.source === 'dependabot'
+        ? []
+        : readSourceFile({ file: args.advisories, label: 'advisories' }).map((raw) => normalizeAdvisory(raw))
+    const dependabot = args.source === 'advisory'
+        ? []
+        : readSourceFile({ file: args.dependabot, label: 'dependabot' }).map((raw) => normalizeDependabot(raw))
+
+    const allItems = [...advisories, ...dependabot]
+    const items = filterByState({ items: allItems, stateFilter: args.state })
+    const dropped = allItems.length - items.length
+    if (dropped > 0) {
+        console.warn(`[info] excluded ${dropped} resolved/filtered item(s) by state; ${items.length} remaining.`)
+    }
+    if (items.length === 0) {
+        console.log('No advisories or Dependabot alerts found (after state filter). Nothing to report.')
+        return
+    }
+
+    const rows = items
+        .map((item) => buildRow({ item, now }))
+        .sort(compareRows)
+
+    fs.mkdirSync(args.out, { recursive: true })
+    const jsonPath = path.join(args.out, 'sla.json')
+    const dashboardPath = path.join(args.out, 'dashboard.md')
+    const dashboard = renderDashboard({ rows, now })
+
+    fs.writeFileSync(jsonPath, JSON.stringify(rows, null, 2))
+    fs.writeFileSync(dashboardPath, dashboard)
+
+    console.log(dashboard)
+    console.log(`\nWrote ${rows.length} row(s) to ${jsonPath} and ${dashboardPath}`)
+}
+
+function parseArgs(argv: string[]): CliArgs {
+    const out: CliArgs = {
+        advisories: '.security-triage/advisories.json',
+        dependabot: '.security-triage/dependabot.json',
+        out: '.security-triage',
+        now: undefined,
+        source: 'all',
+        state: undefined,
+    }
+    for (let i = 0; i < argv.length; i += 2) {
+        const flag = argv[i]
+        const value = argv[i + 1]
+        if (value === undefined) {
+            fail(`Missing value for ${flag}`)
+        }
+        switch (flag) {
+            case '--advisories':
+                out.advisories = value
+                break
+            case '--dependabot':
+                out.dependabot = value
+                break
+            case '--out':
+                out.out = value
+                break
+            case '--now':
+                out.now = value
+                break
+            case '--source':
+                out.source = toSourceFilter(value)
+                break
+            case '--state':
+                out.state = value
+                break
+            default:
+                fail(`Unknown flag: ${flag}`)
+        }
+    }
+    return out
+}
+
+function readSourceFile({ file, label }: { file: string, label: string }): Record<string, unknown>[] {
+    if (!fs.existsSync(file)) {
+        console.warn(`[warn] ${label} file not found at ${file} — skipping that source.`)
+        return []
+    }
+    // `gh api --paginate` concatenates one JSON array per page (`[...]\n[...]`), which is not itself
+    // valid JSON. Scan out each top-level value (string-aware so brackets in text don't fool us).
+    const raw = fs.readFileSync(file, 'utf-8')
+    const pages: unknown[] = []
+    let depth = 0, inString = false, escaped = false, start = -1
+    for (let i = 0; i < raw.length; i++) {
+        const ch = raw[i]
+        if (inString) {
+            if (escaped) escaped = false
+            else if (ch === '\\') escaped = true
+            else if (ch === '"') inString = false
+        }
+        else if (ch === '"') inString = true
+        else if (ch === '[' || ch === '{') { if (depth++ === 0) start = i }
+        else if ((ch === ']' || ch === '}') && --depth === 0 && start >= 0) {
+            pages.push(JSON.parse(raw.slice(start, i + 1)))
+            start = -1
+        }
+    }
+    if (depth !== 0 || pages.length === 0) {
+        fail(`${label} file ${file} must contain JSON array(s) from 'gh api ... --paginate'.`)
+    }
+    return pages.flatMap((page) => {
+        if (!Array.isArray(page)) {
+            fail(`${label} file ${file} has a non-array top-level JSON value.`)
+        }
+        return page
+    }).map((entry) => asRecord(entry))
+}
+
+function filterByState({ items, stateFilter }: { items: TriageItem[], stateFilter: string | undefined }): TriageItem[] {
+    if (stateFilter === undefined) {
+        return items.filter((item) => item.state === null || !RESOLVED_STATES.has(item.state))
+    }
+    if (stateFilter === 'all') {
+        return items
+    }
+    const allowed = new Set(stateFilter.split(',').map((s) => s.trim()).filter((s) => s.length > 0))
+    return items.filter((item) => item.state !== null && allowed.has(item.state))
+}
+
+function normalizeAdvisory(raw: Record<string, unknown>): TriageItem {
+    const cvss = raw.cvss !== undefined && raw.cvss !== null ? asRecord(raw.cvss) : undefined
+    return {
+        source: 'advisory',
+        id: asStringOrNull(raw.ghsa_id) ?? asStringOrNull(raw.cve_id) ?? 'unknown',
+        ghsaId: asStringOrNull(raw.ghsa_id),
+        cveId: asStringOrNull(raw.cve_id),
+        severity: toSeverity(raw.severity),
+        summary: asStringOrNull(raw.summary) ?? '(no summary)',
+        createdAt: asStringOrNull(raw.created_at),
+        htmlUrl: asStringOrNull(raw.html_url) ?? '',
+        cvssScore: cvss ? asNumberOrNull(cvss.score) : null,
+        state: asStringOrNull(raw.state),
+    }
+}
+
+function normalizeDependabot(raw: Record<string, unknown>): TriageItem {
+    const advisory = raw.security_advisory !== undefined && raw.security_advisory !== null
+        ? asRecord(raw.security_advisory)
+        : undefined
+    const vuln = raw.security_vulnerability !== undefined && raw.security_vulnerability !== null
+        ? asRecord(raw.security_vulnerability)
+        : undefined
+    const pkg = vuln?.package !== undefined && vuln.package !== null ? asRecord(vuln.package) : undefined
+    const packageName = pkg ? asStringOrNull(pkg.name) : null
+    const number = asNumberOrNull(raw.number)
+    const summary = advisory ? asStringOrNull(advisory.summary) : null
+    return {
+        source: 'dependabot',
+        id: number !== null ? `dependabot-${number}` : (advisory ? asStringOrNull(advisory.ghsa_id) ?? 'unknown' : 'unknown'),
+        ghsaId: advisory ? asStringOrNull(advisory.ghsa_id) : null,
+        cveId: advisory ? asStringOrNull(advisory.cve_id) : null,
+        severity: toSeverity(vuln?.severity ?? advisory?.severity),
+        summary: packageName ? `${packageName}: ${summary ?? '(no summary)'}` : (summary ?? '(no summary)'),
+        createdAt: asStringOrNull(raw.created_at),
+        htmlUrl: asStringOrNull(raw.html_url) ?? '',
+        cvssScore: null,
+        state: asStringOrNull(raw.state),
+    }
+}
+
+function buildRow({ item, now }: { item: TriageItem, now: Date }): SlaRow {
+    const created = item.createdAt ? new Date(item.createdAt) : null
+    const createdValid = created !== null && !Number.isNaN(created.getTime())
+
+    if (item.severity === null) {
+        return { ...item, deadline: null, daysLeft: null, status: 'NEEDS_TRIAGE' }
+    }
+
+    const slaDays = SLA_DAYS[item.severity]
+    if (slaDays === null) {
+        return { ...item, deadline: null, daysLeft: null, status: 'BEST_EFFORT' }
+    }
+
+    if (!createdValid) {
+        return { ...item, deadline: null, daysLeft: null, status: 'NEEDS_TRIAGE' }
+    }
+
+    const deadline = new Date(created.getTime() + slaDays * MS_PER_DAY)
+    const daysLeft = Math.floor((deadline.getTime() - now.getTime()) / MS_PER_DAY)
+    const status = computeStatus({ severity: item.severity, daysLeft })
+    return { ...item, deadline: deadline.toISOString(), daysLeft, status }
+}
+
+function computeStatus({ severity, daysLeft }: { severity: Severity, daysLeft: number }): SlaStatus {
+    if (daysLeft < 0) {
+        return 'BREACHED'
+    }
+    if (daysLeft <= DUE_SOON_DAYS[severity]) {
+        return 'DUE_SOON'
+    }
+    return 'ON_TRACK'
+}
+
+function compareRows(a: SlaRow, b: SlaRow): number {
+    const byStatus = STATUS_ORDER[a.status] - STATUS_ORDER[b.status]
+    if (byStatus !== 0) {
+        return byStatus
+    }
+    const aLeft = a.daysLeft ?? Number.MAX_SAFE_INTEGER
+    const bLeft = b.daysLeft ?? Number.MAX_SAFE_INTEGER
+    return aLeft - bLeft
+}
+
+function renderDashboard({ rows, now }: { rows: SlaRow[], now: Date }): string {
+    const counts = countByStatus(rows)
+    const summary = (Object.keys(STATUS_ORDER) as SlaStatus[])
+        .filter((status) => (counts[status] ?? 0) > 0)
+        .map((status) => `${status}: ${counts[status]}`)
+        .join(' | ')
+
+    const header = '| Status | Severity | Source | ID | Summary | Created | Deadline | Days left | Link |'
+    const divider = '| --- | --- | --- | --- | --- | --- | --- | --- | --- |'
+    const lines = rows.map((row) => {
+        const cells = [
+            row.status,
+            row.severity ?? 'unscored',
+            row.source,
+            row.cveId ?? row.ghsaId ?? row.id,
+            truncate(row.summary.replace(/\|/g, '\\|'), 70),
+            formatDate(row.createdAt),
+            formatDate(row.deadline),
+            row.daysLeft === null ? '—' : String(row.daysLeft),
+            row.htmlUrl ? `[link](${row.htmlUrl})` : '',
+        ]
+        return `| ${cells.join(' | ')} |`
+    })
+
+    return [
+        `# Security Advisory SLA Dashboard`,
+        ``,
+        `Generated: ${now.toISOString()}`,
+        `Total: ${rows.length} — ${summary}`,
+        ``,
+        `SLA: Critical 7d, High 30d, Medium 90d (from report/alert creation date). Low = best-effort.`,
+        ``,
+        header,
+        divider,
+        ...lines,
+    ].join('\n')
+}
+
+function countByStatus(rows: SlaRow[]): Partial<Record<SlaStatus, number>> {
+    return rows.reduce<Partial<Record<SlaStatus, number>>>((acc, row) => {
+        acc[row.status] = (acc[row.status] ?? 0) + 1
+        return acc
+    }, {})
+}
+
+function toSourceFilter(value: string): SourceFilter {
+    if (value === 'advisory' || value === 'dependabot' || value === 'all') {
+        return value
+    }
+    fail(`Invalid --source value: ${value} (expected advisory | dependabot | all)`)
+}
+
+function toSeverity(value: unknown): Severity | null {
+    if (value === 'critical' || value === 'high' || value === 'medium' || value === 'low') {
+        return value
+    }
+    return null
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+    if (!isRecord(value)) {
+        fail(`Expected an object but got: ${JSON.stringify(value)}`)
+    }
+    return value
+}
+
+function asStringOrNull(value: unknown): string | null {
+    return typeof value === 'string' ? value : null
+}
+
+function asNumberOrNull(value: unknown): number | null {
+    return typeof value === 'number' ? value : null
+}
+
+function formatDate(iso: string | null): string {
+    return iso ? iso.slice(0, 10) : '—'
+}
+
+function truncate(value: string, max: number): string {
+    return value.length > max ? `${value.slice(0, max - 1)}…` : value
+}
+
+function fail(message: string): never {
+    console.error(`[sla-report] ${message}`)
+    process.exit(1)
+}
+
+main()
+
+type Severity = 'critical' | 'high' | 'medium' | 'low'
+
+type SlaStatus = 'BREACHED' | 'DUE_SOON' | 'ON_TRACK' | 'BEST_EFFORT' | 'NEEDS_TRIAGE'
+
+type SourceFilter = 'advisory' | 'dependabot' | 'all'
+
+type CliArgs = {
+    advisories: string
+    dependabot: string
+    out: string
+    now: string | undefined
+    source: SourceFilter
+    state: string | undefined
+}
+
+type TriageItem = {
+    source: 'advisory' | 'dependabot'
+    id: string
+    ghsaId: string | null
+    cveId: string | null
+    severity: Severity | null
+    summary: string
+    createdAt: string | null
+    htmlUrl: string
+    cvssScore: number | null
+    state: string | null
+}
+
+type SlaRow = TriageItem & {
+    deadline: string | null
+    daysLeft: number | null
+    status: SlaStatus
+}


### PR DESCRIPTION
## Summary
Adds internal tooling for working the security backlog:
- Three triage skills: reported security advisories, Dependabot alerts, and Docker image CVEs.
- A `security:sla` script that reports remediation deadlines and status.
- Gitignores the local `.security-triage/` workspace so private advisory content is never committed.


## Testing
- Ran `security:sla` against the current backlog; deadlines and status render correctly.
- Confirmed `.security-triage/` is gitignored (nothing private staged).
