### PR TITLE
fix(pieces): stop leaking payloads and PII via console.debug

### DIFF
--- a/packages/pieces/community/appfollow/package.json
+++ b/packages/pieces/community/appfollow/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-appfollow",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/packages/pieces/community/appfollow/src/lib/common/props.ts
+++ b/packages/pieces/community/appfollow/src/lib/common/props.ts
@@ -76,7 +76,6 @@ export const application_ext_idDropdown = Property.Dropdown({
         HttpMethod.GET,
         `/account/apps/app?apps_id=${collection_id}`
       );
-      console.debug("dsdsdsdsdsdsdssdss",response);
       const apps = response.apps_app;
       return {
         disabled:false,

--- a/packages/pieces/community/bannerbear/package.json
+++ b/packages/pieces/community/bannerbear/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-bannerbear",
-  "version": "0.4.6",
+  "version": "0.4.7",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {

--- a/packages/pieces/community/bannerbear/src/lib/actions/create-image.ts
+++ b/packages/pieces/community/bannerbear/src/lib/actions/create-image.ts
@@ -164,7 +164,6 @@ export const bannerbearCreateImageAction = createAction({
     };
 
     const result = await httpClient.sendRequest<BannerbearTemplate>(request);
-    console.debug('Image creation complete', result);
 
     if (result.status === 200 || result.status === 202) {
       return result.body;

--- a/packages/pieces/community/cal-com/package.json
+++ b/packages/pieces/community/cal-com/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-cal-com",
-  "version": "0.4.6",
+  "version": "0.4.7",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {

--- a/packages/pieces/community/cal-com/src/lib/triggers/register-webhook.ts
+++ b/packages/pieces/community/cal-com/src/lib/triggers/register-webhook.ts
@@ -53,7 +53,6 @@ export const registerWebhooks = ({
       );
 
       if (response.status === 200 || response.status === 201) {
-        console.debug('trigger.onEnable', response.body.data, context);
         await context.store?.put(
           `cal_com_trigger_${name}`,
           response.body.data
@@ -75,21 +74,16 @@ export const registerWebhooks = ({
         };
 
         try {
-          const response = await httpClient.sendRequest(request);
-          console.debug('trigger.onDisable', response);
+          await httpClient.sendRequest(request);
         } catch (e: any) {
           // 404 means the webhook was registered under the old v1 API and no
           // longer exists in v2 — safe to ignore, re-enabling will create a
           // fresh v2 webhook.
           if (e?.response?.status !== 404) throw e;
-          console.debug('trigger.onDisable: webhook not found in v2 (was v1), ignoring');
         }
-      } else {
-        console.debug(`trigger 'cal_com_trigger_${name}' not found`);
       }
     },
     async run(context) {
-      console.debug('trigger running', context);
       return [context.payload.body];
     },
   });

--- a/packages/pieces/community/clickup/package.json
+++ b/packages/pieces/community/clickup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-clickup",
-  "version": "0.7.7",
+  "version": "0.7.8",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {

--- a/packages/pieces/community/clickup/src/lib/triggers/register-trigger.ts
+++ b/packages/pieces/community/clickup/src/lib/triggers/register-trigger.ts
@@ -70,7 +70,6 @@ export const clickupRegisterTrigger = ({
       const response = await httpClient.sendRequest<WebhookInformation>(
         request
       );
-      console.debug(`clickup.${eventType}.onEnable`, response);
 
       await context.store.put<WebhookInformation>(
         `clickup_${name}_trigger`,
@@ -90,8 +89,7 @@ export const clickupRegisterTrigger = ({
             token: context.auth['access_token'],
           },
         };
-        const response = await httpClient.sendRequest(request);
-        console.debug(`clickup.${eventType}.onDisable`, response);
+        await httpClient.sendRequest(request);
       }
     },
     async run(context) {
@@ -115,7 +113,6 @@ export const clickupRegisterTrigger = ({
           },
         ];
 
-        console.debug('payload enriched', enriched);
         return enriched;
       }
 

--- a/packages/pieces/community/clickup/src/lib/triggers/task-tag-updated.ts
+++ b/packages/pieces/community/clickup/src/lib/triggers/task-tag-updated.ts
@@ -80,7 +80,6 @@ export const triggerTaskTagUpdated = createTrigger({
     }
 
     const response = await httpClient.sendRequest<WebhookInformation>(request);
-    console.debug(`clickup.${ClickupEventType.TASK_TAG_UPDATED}.onEnable`, response)
 
     await context.store.put<WebhookInformation>(`clickup_task_tag_updated_trigger`, response.body);
   },
@@ -95,8 +94,7 @@ export const triggerTaskTagUpdated = createTrigger({
           token: context.auth['access_token'],
         },
       };
-      const response = await httpClient.sendRequest(request);
-      console.debug(`clickup.${ClickupEventType.TASK_TAG_UPDATED}.onDisable`, response)
+      await httpClient.sendRequest(request);
     }
   },
   async run(context) {

--- a/packages/pieces/community/contentful/package.json
+++ b/packages/pieces/community/contentful/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-contentful",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "dependencies": {

--- a/packages/pieces/community/contentful/src/lib/actions/records/create-record.ts
+++ b/packages/pieces/community/contentful/src/lib/actions/records/create-record.ts
@@ -62,7 +62,6 @@ export const ContentfulCreateRecordAction = createAction({
         ),
       };
     }
-    console.debug('Creating record with values', values);
     const record = await client.entry.create(
       { contentTypeId: model.sys.id },
       { fields: values }

--- a/packages/pieces/community/dropbox/package.json
+++ b/packages/pieces/community/dropbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-dropbox",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {

--- a/packages/pieces/community/dropbox/src/lib/actions/create-new-folder.ts
+++ b/packages/pieces/community/dropbox/src/lib/actions/create-new-folder.ts
@@ -44,7 +44,6 @@ export const dropboxCreateNewFolder = createAction({
     };
 
     const result = await httpClient.sendRequest(request);
-    console.debug('Folder creation response', result);
 
     if (result.status == 200) {
       return result.body;

--- a/packages/pieces/community/dropbox/src/lib/actions/create-new-text-file.ts
+++ b/packages/pieces/community/dropbox/src/lib/actions/create-new-text-file.ts
@@ -68,7 +68,6 @@ export const dropboxCreateNewTextFile = createAction({
     };
 
     const result = await httpClient.sendRequest(request);
-    console.debug('Folder creation response', result);
 
     if (result.status == 200) {
       return result.body;

--- a/packages/pieces/community/drupal/package.json
+++ b/packages/pieces/community/drupal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-drupal",
-  "version": "1.1.8",
+  "version": "1.1.9",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/packages/pieces/community/drupal/src/lib/actions/services.ts
+++ b/packages/pieces/community/drupal/src/lib/actions/services.ts
@@ -43,7 +43,6 @@ export const drupalCallServiceAction = createAction({
               'Accept': 'application/vnd.api+json',
             },
           });
-          console.debug('Service response', response);
           if (response.status === 200) {
             return {
               disabled: false,
@@ -72,7 +71,6 @@ export const drupalCallServiceAction = createAction({
       required: true,
       auth: drupalAuth,
       props: async ({ service }) => {
-        console.debug('Service config input', service);
         const fields: Record<string, any> = {};
         const items = (service as { config: DrupalServiceConfig[] }).config;
         items.forEach((config: any) => {
@@ -120,7 +118,6 @@ export const drupalCallServiceAction = createAction({
             });
           }
         });
-        console.debug('Field for this service', fields);
         return fields;
       },
     }),
@@ -141,7 +138,6 @@ export const drupalCallServiceAction = createAction({
     };
 
     const result = await httpClient.sendRequest<DrupalService>(request);
-    console.debug('Service call completed', result);
 
     if (result.status === 200 || result.status === 202) {
       return result.body;

--- a/packages/pieces/community/drupal/src/lib/auth.ts
+++ b/packages/pieces/community/drupal/src/lib/auth.ts
@@ -57,7 +57,6 @@ export const drupalAuth = PieceAuth.CustomAuth({
           'Accept': 'application/vnd.api+json',
         },
       });
-      console.debug('Auth validation response', response);
       if (response.status === 200) {
         const data = (response.body as any).data;
         return {

--- a/packages/pieces/community/drupal/src/lib/triggers/polling-id.ts
+++ b/packages/pieces/community/drupal/src/lib/triggers/polling-id.ts
@@ -34,8 +34,6 @@ const polling: Polling<DrupalAuthType, { name: string }> = {
         'Accept': 'application/vnd.api+json',
       },
     });
-    console.debug('Poll response', response);
-    console.debug('Poll response', JSON.stringify(response.body));
     return response.body.reverse().map((item) => ({
       id: item.id,
       data: item.data,

--- a/packages/pieces/community/drupal/src/lib/triggers/polling-timestamp.ts
+++ b/packages/pieces/community/drupal/src/lib/triggers/polling-timestamp.ts
@@ -34,8 +34,6 @@ const polling: Polling<DrupalAuthType, { name: string }> = {
         'Accept': 'application/vnd.api+json',
       },
     });
-    console.debug('Poll response', response);
-    console.debug('Poll response', JSON.stringify(response.body));
     return response.body.map((item) => ({
       epochMilliSeconds: item.timestamp * 1000,
       data: item.data,

--- a/packages/pieces/community/drupal/src/lib/triggers/webhook.ts
+++ b/packages/pieces/community/drupal/src/lib/triggers/webhook.ts
@@ -43,14 +43,13 @@ export const drupalWebhook = createTrigger({
         'Accept': 'application/vnd.api+json',
       },
     });
-    console.debug('Webhook register response', response);
     await context.store.put(webhookStoreKey(context.propsValue.id), response.body);
   },
   async onDisable(context) {
     const { website_url, username, password } = context.auth.props;
     const webhook = await context.store.get(webhookStoreKey(context.propsValue.id));
     if (webhook) {
-      const response = await httpClient.sendRequest({
+      await httpClient.sendRequest({
         method: HttpMethod.POST,
         url: website_url + `/orchestration/webhook/unregister`,
         body: webhook,
@@ -59,7 +58,6 @@ export const drupalWebhook = createTrigger({
           'Accept': 'application/vnd.api+json',
         },
       });
-      console.debug('Webhook unregister response', response);
     }
   },
   async run(context) {

--- a/packages/pieces/community/freshsales/package.json
+++ b/packages/pieces/community/freshsales/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-freshsales",
-  "version": "0.4.6",
+  "version": "0.4.7",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {

--- a/packages/pieces/community/freshsales/src/lib/actions/create-contact.ts
+++ b/packages/pieces/community/freshsales/src/lib/actions/create-contact.ts
@@ -149,7 +149,6 @@ export const freshSalesCreateContact = createAction({
     };
 
     const result = await httpClient.sendRequest(request);
-    console.debug('Create contact response', result);
 
     if (result.status == 200) {
       return result.body;

--- a/packages/pieces/community/gcloud-pubsub/package.json
+++ b/packages/pieces/community/gcloud-pubsub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-gcloud-pubsub",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "dependencies": {

--- a/packages/pieces/community/gcloud-pubsub/src/lib/action/publish-to-topic.ts
+++ b/packages/pieces/community/gcloud-pubsub/src/lib/action/publish-to-topic.ts
@@ -42,15 +42,12 @@ export const publishToTopic = createAction({
       messages: [{ data: Buffer.from(json).toString('base64') }],
     });
 
-    const { data } = await client.request<{ messageIds: string[] }>({
+    await client.request<{ messageIds: string[] }>({
       url,
       method: 'POST',
       body,
     });
 
-    console.debug(
-      `Message sended to topic[${topic}]: ${json}, ack: ${data.messageIds[0]}`
-    );
     return json;
   },
 });

--- a/packages/pieces/community/gcloud-pubsub/src/lib/trigger/new-message-in-topic.ts
+++ b/packages/pieces/community/gcloud-pubsub/src/lib/trigger/new-message-in-topic.ts
@@ -85,7 +85,6 @@ export const newMessageInTopic = createTrigger({
     }
   },
   async run(context) {
-    console.debug('payload received', context.payload.body);
     const payloadBody = context.payload.body as PayloadBody;
     const { data } = payloadBody.message;
     const object = data

--- a/packages/pieces/community/github/package.json
+++ b/packages/pieces/community/github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-github",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {

--- a/packages/pieces/community/github/src/lib/trigger/register-trigger.ts
+++ b/packages/pieces/community/github/src/lib/trigger/register-trigger.ts
@@ -66,8 +66,6 @@ export const githubRegisterTrigger = ({
       }
     },
     async run(context) {
-      console.debug('payload received', context.payload.body);
-
       if (isVerificationCall(context.payload.body as Record<string, unknown>)) {
         return [];
       }

--- a/packages/pieces/community/sendinblue/package.json
+++ b/packages/pieces/community/sendinblue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-sendinblue",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {

--- a/packages/pieces/community/sendinblue/src/lib/actions/create-or-update-contact.ts
+++ b/packages/pieces/community/sendinblue/src/lib/actions/create-or-update-contact.ts
@@ -90,7 +90,6 @@ export const createOrUpdateContact = createAction({
       Object.entries(contact).filter(([_, value]) => Boolean(value))
     );
 
-    console.log('Contact update request ' + identifier);
     await httpClient.sendRequest({
       method: HttpMethod.POST,
       url: `https://api.sendinblue.com/v3/contacts`,

--- a/packages/pieces/community/sendinblue/src/lib/actions/create-or-update-contact.ts
+++ b/packages/pieces/community/sendinblue/src/lib/actions/create-or-update-contact.ts
@@ -91,7 +91,7 @@ export const createOrUpdateContact = createAction({
     );
 
     console.log('Contact update request ' + identifier);
-    const updateResponse = await httpClient.sendRequest({
+    await httpClient.sendRequest({
       method: HttpMethod.POST,
       url: `https://api.sendinblue.com/v3/contacts`,
       body,
@@ -99,7 +99,6 @@ export const createOrUpdateContact = createAction({
         'api-key': context.auth.secret_text,
       },
     });
-    console.debug('Contact update response', updateResponse);
 
     const contactREsponse = await httpClient.sendRequest({
       method: HttpMethod.GET,

--- a/packages/pieces/community/shopify/package.json
+++ b/packages/pieces/community/shopify/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-shopify",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {

--- a/packages/pieces/community/shopify/src/lib/common/register-webhook.ts
+++ b/packages/pieces/community/shopify/src/lib/common/register-webhook.ts
@@ -70,7 +70,6 @@ export const createShopifyWebhookTrigger = ({
       await context.store?.put(`shopify_webhook_id`, null);
     },
     async run(context) {
-      console.debug('trigger running', context);
       return [context.payload.body];
     },
   });

--- a/packages/pieces/community/vtiger/package.json
+++ b/packages/pieces/community/vtiger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-vtiger",
-  "version": "1.3.6",
+  "version": "1.3.7",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "dependencies": {

--- a/packages/pieces/community/vtiger/src/lib/actions/create-record.ts
+++ b/packages/pieces/community/vtiger/src/lib/actions/create-record.ts
@@ -40,13 +40,6 @@ export const createRecord = createAction({
         },
       });
 
-      console.debug({
-        operation: 'create',
-        sessionName: instance.sessionId ?? instance.sessionName,
-        elementType: elementType,
-        element: JSON.stringify(record),
-      });
-
       return response.body;
     }
 

--- a/packages/pieces/community/vtiger/src/lib/actions/query-records.ts
+++ b/packages/pieces/community/vtiger/src/lib/actions/query-records.ts
@@ -49,8 +49,6 @@ export const queryRecords = createAction({
     if (response.body.success) {
       return response.body.result;
     } else {
-      console.debug(response);
-
       return {
         error: 'Unexpected outcome!',
       };

--- a/packages/pieces/community/vtiger/src/lib/actions/update-record.ts
+++ b/packages/pieces/community/vtiger/src/lib/actions/update-record.ts
@@ -300,16 +300,6 @@ export const updateRecord = createAction({
         },
       });
 
-      console.debug({
-        operation: 'update',
-        sessionName: instance.sessionId ?? instance.sessionName,
-        elementType: elementType,
-        element: JSON.stringify({
-          id: id,
-          ...record,
-        }),
-      });
-
       return response.body;
     }
 

--- a/packages/pieces/community/xero/package.json
+++ b/packages/pieces/community/xero/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-xero",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {

--- a/packages/pieces/community/xero/src/lib/actions/create-contact.ts
+++ b/packages/pieces/community/xero/src/lib/actions/create-contact.ts
@@ -51,7 +51,6 @@ export const xeroCreateContact = createAction({
     };
 
     const result = await httpClient.sendRequest(request);
-    console.debug('Contact creation response', result);
 
     if (result.status === 200) {
       return result.body;

--- a/packages/pieces/community/xero/src/lib/actions/create-invoice.ts
+++ b/packages/pieces/community/xero/src/lib/actions/create-invoice.ts
@@ -108,7 +108,6 @@ export const xeroCreateInvoice = createAction({
     };
 
     const result = await httpClient.sendRequest(request);
-    console.debug('Invoice creation response', result);
 
     if (result.status === 200) {
       return result.body;

--- a/packages/pieces/community/zoom/package.json
+++ b/packages/pieces/community/zoom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-zoom",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {

--- a/packages/pieces/community/zoom/src/lib/actions/create-meeting-registrant.ts
+++ b/packages/pieces/community/zoom/src/lib/actions/create-meeting-registrant.ts
@@ -58,7 +58,6 @@ export const zoomCreateMeetingRegistrant = createAction({
     };
 
     const result = await httpClient.sendRequest<RegistrationResponse>(request);
-    console.debug('Meeting registration response', result);
 
     if (result.status === 201) {
       return result.body;


### PR DESCRIPTION
## Summary
- `console.debug` bypasses the engine's `console.log` patch (`worker-socket.ts`), so any call to it writes straight to raw host stdout instead of the structured, per-run log sink.
- Removed all such calls across 15 pieces where they dumped full webhook payloads, API responses, or in some cases webhook secrets/session tokens (clickup, vtiger) to that unstructured stream.
- Fixes #13938 (GitHub piece) and extends the same fix to gcloud-pubsub, cal-com, shopify, clickup, drupal, sendinblue, zoom, freshsales, xero, dropbox, contentful, bannerbear, vtiger, and appfollow.
- Bumped the patch version of every touched piece's `package.json`.

## Test plan
- [ ] Trigger the GitHub "New Pull Request" webhook trigger and confirm no payload appears in raw container stdout, only in the structured run log
- [ ] Spot-check one clickup trigger enable/disable cycle to confirm the webhook secret no longer appears in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)