### PR TITLE
fix(event-streaming): fix production flow run events not reaching configured event destinations

### DIFF
--- a/packages/core/shared/package.json
+++ b/packages/core/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/shared",
-  "version": "0.113.0",
+  "version": "0.113.1",
   "type": "commonjs",
   "sideEffects": false,
   "main": "./dist/src/index.js",

--- a/packages/core/shared/src/lib/ee/audit-events/index.ts
+++ b/packages/core/shared/src/lib/ee/audit-events/index.ts
@@ -193,7 +193,7 @@ const FlowRunEventData = z.object({
         environment: z.string(),
         flowId: z.string(),
         flowVersionId: z.string(),
-        stepNameToTest: z.string().optional(),
+        stepNameToTest: z.string().nullish(),
         flowDisplayName: z.string().optional(),
         status: z.string(),
     }),

--- a/packages/core/shared/test/ee/audit-events.test.ts
+++ b/packages/core/shared/test/ee/audit-events.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest'
+import { ApplicationEventName, FlowRunEvent } from '../../src/lib/ee/audit-events'
+
+const basePayload = {
+    id: 'audit-event-id',
+    created: '2026-01-01T00:00:00.000Z',
+    updated: '2026-01-01T00:00:00.000Z',
+    platformId: 'platform-id',
+    action: ApplicationEventName.FLOW_RUN_FINISHED,
+}
+
+describe('FlowRunEvent', () => {
+    it('parses a real production flow run where stepNameToTest is null', () => {
+        const payload = {
+            ...basePayload,
+            data: {
+                flowRun: {
+                    id: 'flow-run-id',
+                    environment: 'production',
+                    flowId: 'flow-id',
+                    flowVersionId: 'flow-version-id',
+                    status: 'SUCCEEDED',
+                    stepNameToTest: null,
+                },
+            },
+        }
+
+        expect(FlowRunEvent.safeParse(payload).success).toBe(true)
+    })
+
+    it('parses a test-destination flow run where stepNameToTest is undefined', () => {
+        const payload = {
+            ...basePayload,
+            data: {
+                flowRun: {
+                    id: 'flow-run-id',
+                    environment: 'production',
+                    flowId: 'flow-id',
+                    flowVersionId: 'flow-version-id',
+                    status: 'SUCCEEDED',
+                },
+            },
+        }
+
+        expect(FlowRunEvent.safeParse(payload).success).toBe(true)
+    })
+})


### PR DESCRIPTION
## Problem

Event Streaming never triggers the handler flow for real (production) flow runs. When a real flow finishes, the `flow.run.finished` event is enqueued as an `EVENT_DESTINATION` job, but it's dropped at dequeue with `Failing job with invalid schema as unrecoverable` before the worker ever runs it.

The Test-destination button appears to work because it sends a mock event that omits the offending field, it doesn't exercise this bug. Only real flow runs hit it.

## Root cause

`packages/core/shared/src/lib/ee/audit-events/index.ts` defines `stepNameToTest: z.string().optional()` on `FlowRunEventData`. This accepts `string | undefined` but rejects `null`. Every real `FlowRun` carries `stepNameToTest: null` (it's only ever a string for test-step runs), so `JobData.safeParse(...)` in `packages/server/api/src/app/workers/job-queue/job-broker.ts` fails and the job is killed as unrecoverable at dequeue, never reaching the worker.

Sibling fields `startTime` / `finishTime` on the same object already use `.nullish()` correctly; `stepNameToTest` was the one field missed.

## Fix

- Widen `stepNameToTest` to `.nullish()` to match its siblings.
- Patch version bump on `packages/core/shared/package.json` (0.110.0 -> 0.110.1) per this repo's `AGENTS.md` convention for any change to `packages/core/shared`.
- Added `packages/core/shared/test/ee/audit-events.test.ts` covering both the real-run case (`stepNameToTest: null`) and the existing test-destination case (`stepNameToTest: undefined`), so both paths are asserted going forward.

## Testing

- `npx vitest run test/ee/audit-events.test.ts` - 2/2 passing
- `eslint` on changed/added files - clean, no new issues

Closes #13632
