### PR TITLE
feat(pieces/eden-ai): migrate LLM chat to Eden AI v3 (OpenAI-compatible) + EU data residency

### DIFF
--- a/packages/pieces/community/eden-ai/README.md
+++ b/packages/pieces/community/eden-ai/README.md
@@ -1,4 +1,35 @@
-# pieces-eden-ai
+# Eden AI — Activepieces piece
+
+[Eden AI](https://www.edenai.co/) is a unified AI API: one key, one endpoint, **500+ models** from every major provider (OpenAI, Anthropic, Google, Mistral, Meta, Cohere, xAI, Amazon, DeepSeek, Groq…), plus native features for OCR, document parsing, translation, speech and moderation. Eden AI is **EU-based and GDPR-focused**, and offers **EU data-residency model variants** for privacy-sensitive workloads.
+
+This piece lets you use Eden AI's LLM and AI features inside your Activepieces flows.
+
+## Authentication
+
+Create an API key in your [Eden AI dashboard](https://app.edenai.run/admin/api-settings/features-preferences) and paste it into the connection. The key is validated against `GET https://api.edenai.run/v3/models`.
+
+> Your API key is stored as an Activepieces secret and sent only as a `Bearer` token to `api.edenai.run`. It is never logged or embedded in flow data.
+
+## LLM chat — Generate Text
+
+The **Generate Text** action calls Eden AI's **v3 OpenAI-compatible** endpoint (`POST /v3/chat/completions`). Optionally filter by **Provider**, pick a **Model** from the live catalogue (the exact `provider/model` id), and send your prompt. Supports system prompts, temperature, max tokens, reasoning effort, image input (vision models) and fallback models. The Provider and Model dropdowns are populated live from `GET /v3/models`, so you always see exactly what your account can call.
+
+### 🇪🇺 EU Data Residency (GDPR)
+
+Eden AI hosts a large share of its catalogue (≈270 of 760+ models) in the **European Union**. Enable the **EU Data Residency** checkbox and the Provider/Model dropdowns are **filtered to EU-hosted models only**, so inference is processed within the EU. EU-hosted models are flagged with **🇪🇺** in the dropdown, and the value sent is the exact model id — no manual suffix handling.
+
+Use it when:
+
+- You process personal data and need processing to stay in the EU (GDPR Art. 44+ data-transfer constraints).
+- Your organization has a data-residency or sovereignty requirement.
+
+**How EU hosting is expressed:** each model in `GET /v3/models` carries a `regions` list. A model is EU-hosted when its regions include `{ "code": "eu" }`. Some providers also publish explicit regional variants whose id ends in `@eu` / `@us` (e.g. `amazon/amazon.nova-2-lite-v1:0@eu`); most EU-hosted models simply use their plain id (e.g. `amazon/amazon.nova-lite-v1:0`). Either way, the EU filter selects the correct ids for you.
+
+> EU coverage evolves; the live catalogue (`GET /v3/models`, `regions`) is the source of truth, which is exactly what the dropdown reflects.
+
+## Other AI features
+
+The piece also ships actions for **Summarize Text, Extract Keywords, Detect Language, Extract Entities, Moderate Text, Spell Check, Translate Text, Invoice Parser, Receipt Parser, OCR Image, Image Generation and Text to Speech**, backed by Eden AI's feature API.
 
 ## Building
 

--- a/packages/pieces/community/eden-ai/package.json
+++ b/packages/pieces/community/eden-ai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-eden-ai",
-  "version": "0.2.3",
+  "version": "0.3.0",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {

--- a/packages/pieces/community/eden-ai/src/index.ts
+++ b/packages/pieces/community/eden-ai/src/index.ts
@@ -25,9 +25,10 @@ import { PieceCategory } from '@activepieces/pieces-framework';
           return { valid: false, error: 'Invalid API key format.' };
         }
         try {
+          // Validate against the v3 OpenAI-compatible model catalogue (lightweight, semantically correct).
           const response = await httpClient.sendRequest({
             method: HttpMethod.GET,
-            url: 'https://api.edenai.run/v2/video/explicit_content_detection_async',
+            url: 'https://api.edenai.run/v3/models',
             headers: {
               'Authorization': `Bearer ${auth}`,
               'Content-Type': 'application/json',

--- a/packages/pieces/community/eden-ai/src/lib/actions/generate-text.ts
+++ b/packages/pieces/community/eden-ai/src/lib/actions/generate-text.ts
@@ -1,23 +1,9 @@
 import { createAction, Property } from '@activepieces/pieces-framework';
 import { HttpMethod, propsValidation } from '@activepieces/pieces-common';
-import { edenAiApiCall } from '../common/client';
-import { createStaticDropdown } from '../common/providers';
+import { edenAiApiCall, EDENAI_V3_BASE_URL } from '../common/client';
+import { createStaticDropdown, modelDropdownOptions, providerDropdownOptions } from '../common/providers';
 import * as z from 'zod/mini'
 import { edenAiAuth } from '../..';
-
-const CHAT_PROVIDERS = [
-  { label: 'OpenAI GPT-4o', value: 'openai' },
-  { label: 'Anthropic Claude', value: 'anthropic' },
-  { label: 'Google Gemini', value: 'google' },
-  { label: 'Meta Llama', value: 'meta' },
-  { label: 'Mistral', value: 'mistral' },
-  { label: 'Cohere', value: 'cohere' },
-  { label: 'XAI Grok', value: 'xai' },
-  { label: 'Amazon Nova', value: 'amazon' },
-  { label: 'Microsoft', value: 'microsoft' },
-  { label: 'DeepSeek', value: 'deepseek' },
-  { label: 'Groq', value: 'groq' }
-];
 
 const REASONING_EFFORT_OPTIONS = [
   { label: 'Low - Quick responses', value: 'low' },
@@ -25,23 +11,17 @@ const REASONING_EFFORT_OPTIONS = [
   { label: 'High - In-depth reasoning', value: 'high' }
 ];
 
-function normalizeChatResponse(provider: string, response: any) {
-  const providerResult = response[provider];
-  if (!providerResult) {
-    return { provider, content: '', usage: null, raw: response };
-  }
-
-  const choices = providerResult.choices || [];
-  const firstChoice = choices[0];
+// v3 /chat/completions returns a standard OpenAI-shaped response (not provider-keyed like v2 /llm/chat).
+function normalizeChatResponse(response: any) {
+  const firstChoice = response?.choices?.[0];
   const message = firstChoice?.message;
 
   return {
-    provider,
     content: message?.content || '',
     role: message?.role || 'assistant',
     finish_reason: firstChoice?.finish_reason || '',
-    usage: providerResult.usage || null,
-    model: providerResult.model || '',
+    usage: response?.usage || null,
+    model: response?.model || '',
     raw: response
   };
 }
@@ -51,21 +31,44 @@ export const generateTextAction = createAction({
   name: 'generate_text',
   displayName: 'Generate Text',
   description:
-    'Generate text completions using various AI providers through Eden AI chat endpoint.',
+    'Generate text completions across 500+ models from every major provider through Eden AI\'s single OpenAI-compatible endpoint. Optionally restrict to EU-hosted models for GDPR data residency.',
   audience: 'both',
   aiMetadata: {
     description:
-      'Generate a chat/LLM completion from a prompt through Eden AI, routing to a chosen provider (OpenAI, Anthropic, Google, Meta, Mistral, and others) with optional system prompt, model override, temperature, and fallback providers. Choose it for one-shot text generation when you want provider flexibility behind a single call rather than calling a specific LLM piece directly. Requires a provider and prompt; optionally pass an image URL for vision-capable models. Generative and non-deterministic, but stateless — repeating the call creates no extra side effect.',
+      'Generate a chat/LLM completion from a prompt through Eden AI, routing to any of 500+ models across providers (OpenAI, Anthropic, Google, Mistral, and others) behind one API key, with optional system prompt, temperature, and fallback models. For GDPR-sensitive data, enable "EU Data Residency" to restrict the model list to Eden AI\'s EU-hosted models (processing stays within the EU). Choose it for one-shot text generation when you want provider flexibility behind a single call rather than calling a specific LLM piece directly. Requires a model and prompt; optionally pass an image URL for vision-capable models. Generative and non-deterministic, but stateless — repeating the call creates no extra side effect.',
     idempotent: true,
   },
   props: {
+    eu_residency: Property.Checkbox({
+      displayName: 'EU Data Residency (GDPR)',
+      description:
+        'Restrict the Provider and Model lists to Eden AI\'s EU-hosted models, so inference is processed within the European Union. EU-hosted models are flagged with 🇪🇺.',
+      required: false,
+      defaultValue: false,
+    }),
     provider: Property.Dropdown({
-      auth: edenAiAuth,   
+      auth: edenAiAuth,
       displayName: 'Provider',
-      description: 'The AI provider to use for text generation.',
+      description: 'Optionally filter the Model list to a single provider. Leave empty to browse all providers.',
+      required: false,
+      refreshers: ['eu_residency'],
+      options: async ({ auth, eu_residency }) => {
+        const opts = await providerDropdownOptions(auth);
+        // eu_residency is applied at the model level; providers with no EU model still list here,
+        // but the Model dropdown will show "no EU-hosted models" for those.
+        void eu_residency;
+        return opts;
+      },
+    }),
+    model: Property.Dropdown({
+      auth: edenAiAuth,
+      displayName: 'Model',
+      description:
+        'The model to use, as the exact Eden AI `provider/model` id. When "EU Data Residency" is on, only EU-hosted models (🇪🇺) are listed.',
       required: true,
-      refreshers: [],
-      options: createStaticDropdown(CHAT_PROVIDERS)
+      refreshers: ['provider', 'eu_residency'],
+      options: async ({ auth, provider, eu_residency }) =>
+        modelDropdownOptions(auth, provider as string | undefined, eu_residency as boolean | undefined),
     }),
     prompt: Property.LongText({
       displayName: 'Prompt',
@@ -76,12 +79,6 @@ export const generateTextAction = createAction({
       displayName: 'System Prompt',
       description:
         'System message to set the behavior and context for the AI assistant (e.g., "You are a helpful coding assistant").',
-      required: false
-    }),
-    model: Property.ShortText({
-      displayName: 'Model',
-      description:
-        'Specific model to use (e.g., gpt-4o, claude-3-sonnet-latest, gemini-2.0-flash). Leave empty for provider-specific defaults.',
       required: false
     }),
     temperature: Property.Number({
@@ -100,34 +97,35 @@ export const generateTextAction = createAction({
     reasoning_effort: Property.Dropdown({
       auth: edenAiAuth,
       displayName: 'Reasoning Effort',
-      description: 'Level of reasoning depth for the response.',
+      description: 'Level of reasoning depth for the response (only used by reasoning-capable models).',
       required: false,
       refreshers: [],
       options: createStaticDropdown(REASONING_EFFORT_OPTIONS)
     }),
-    fallback_providers: Property.MultiSelectDropdown({
+    fallback_models: Property.MultiSelectDropdown({
       auth: edenAiAuth,
-      displayName: 'Fallback Providers',
-      description: 'Alternative providers to try if the main provider fails.',
+      displayName: 'Fallback Models',
+      description: 'Alternative models (exact `provider/model` ids) to try if the primary model fails.',
       required: false,
-      refreshers: [],
-      options: createStaticDropdown(CHAT_PROVIDERS)
+      refreshers: ['eu_residency'],
+      options: async ({ auth, eu_residency }) =>
+        modelDropdownOptions(auth, undefined, eu_residency as boolean | undefined),
     }),
-         include_image: Property.Checkbox({
-       displayName: 'Include Image',
-       description: 'Include an image in your prompt (for vision-capable models).',
-       required: false,
-       defaultValue: false,
-     }),
-     image_url: Property.ShortText({
-       displayName: 'Image URL',
-       description: 'URL of the image to include in the prompt (only used if "Include Image" is enabled).',
-       required: false,
-     }),
+    include_image: Property.Checkbox({
+      displayName: 'Include Image',
+      description: 'Include an image in your prompt (for vision-capable models).',
+      required: false,
+      defaultValue: false,
+    }),
+    image_url: Property.ShortText({
+      displayName: 'Image URL',
+      description: 'URL of the image to include in the prompt (only used if "Include Image" is enabled).',
+      required: false,
+    }),
   },
   async run({ auth, propsValue }) {
     await propsValidation.validateZod(propsValue, {
-      provider: z.string().check(z.minLength(1, 'Provider is required')),
+      model: z.string().check(z.minLength(1, 'Model is required')),
       prompt: z.string().check(z.minLength(1, 'Prompt is required')),
       temperature: z.nullish(z.number().check(z.minimum(0), z.maximum(2))),
       max_completion_tokens: z.nullish(z.number().check(z.minimum(1))),
@@ -135,14 +133,13 @@ export const generateTextAction = createAction({
     });
 
     const {
-      provider,
+      model,
       prompt,
       system_prompt,
-      model,
       temperature,
       max_completion_tokens,
       reasoning_effort,
-      fallback_providers,
+      fallback_models,
       include_image,
       image_url
     } = propsValue;
@@ -157,52 +154,40 @@ export const generateTextAction = createAction({
     }
 
     const userContent: any[] = [{ type: 'text', text: prompt }];
-    
-     if (include_image && image_url) {
-       userContent.push({
-         type: 'image_url',
-         image_url: { url: image_url }
-       });
-     }
+
+    if (include_image && image_url) {
+      userContent.push({
+        type: 'image_url',
+        image_url: { url: image_url }
+      });
+    }
 
     messages.push({
       role: 'user',
       content: userContent
     });
 
+    // v3 /chat/completions takes the exact "provider/model" id (EU-hosted models are chosen via the
+    // Model dropdown when EU Data Residency is enabled — there is no suffix to append).
     const body: Record<string, any> = {
-      providers: provider,
+      model,
       messages
     };
 
-    const defaultModels: Record<string, string> = {
-      'openai': 'gpt-4o',
-      'anthropic': 'claude-3-sonnet-latest',
-      'google': 'gemini-2.0-flash',
-      'meta': 'llama-3.1-70b-instruct',
-      'mistral': 'mistral-large-latest',
-      'cohere': 'command-r-plus',
-      'xai': 'grok-2-latest',
-      'amazon': 'nova-pro-v1:0',
-      'microsoft': 'gpt-4o',
-      'deepseek': 'deepseek-chat',
-      'groq': 'llama-3.1-70b-versatile'
-    };
-    
-    body['model'] = model || defaultModels[provider] || 'gpt-4o';
-
     if (temperature !== undefined) body['temperature'] = temperature;
-    if (max_completion_tokens !== undefined) body['max_completion_tokens'] = max_completion_tokens;
+    if (max_completion_tokens !== undefined) body['max_tokens'] = max_completion_tokens;
     if (reasoning_effort) body['reasoning_effort'] = reasoning_effort;
-    if (fallback_providers && fallback_providers.length > 0) {
-      body['fallback_providers'] = fallback_providers;
+    if (fallback_models && fallback_models.length > 0) {
+      // Eden AI extension to the OpenAI-compatible endpoint: models tried on failure.
+      body['fallback_providers'] = fallback_models;
     }
 
     try {
       const response = await edenAiApiCall({
         apiKey: auth.secret_text,
         method: HttpMethod.POST,
-        resourceUri: '/llm/chat',
+        baseUrl: EDENAI_V3_BASE_URL,
+        resourceUri: '/chat/completions',
         body
       });
 
@@ -210,7 +195,7 @@ export const generateTextAction = createAction({
         throw new Error('Invalid response from Eden AI API.');
       }
 
-      return normalizeChatResponse(provider, response);
+      return normalizeChatResponse(response);
     } catch (err: any) {
       if (err.response?.body?.error) {
         throw new Error(`Eden AI API error: ${err.response.body.error}`);

--- a/packages/pieces/community/eden-ai/src/lib/common/client.ts
+++ b/packages/pieces/community/eden-ai/src/lib/common/client.ts
@@ -1,6 +1,10 @@
 import { HttpMethod, httpClient } from '@activepieces/pieces-common';
 
-const BASE_URL = 'https://api.edenai.run/v2';
+// Eden AI exposes two surfaces:
+//  - v2: native per-feature endpoints (OCR, parsers, TTS, translation, moderation…) — used by most actions here.
+//  - v3: unified, OpenAI-compatible endpoint (/v3/chat/completions, /v3/models) — used by LLM chat.
+export const EDENAI_V2_BASE_URL = 'https://api.edenai.run/v2';
+export const EDENAI_V3_BASE_URL = 'https://api.edenai.run/v3';
 const DEFAULT_TIMEOUT = 20000;
 const MAX_RETRIES = 3;
 const RETRY_BACKOFF = 1000;
@@ -33,6 +37,7 @@ export async function edenAiApiCall<T = any>({
   headers: customHeaders = {},
   timeout = DEFAULT_TIMEOUT,
   maxRetries = MAX_RETRIES,
+  baseUrl = EDENAI_V2_BASE_URL,
 }: {
   apiKey: string;
   method: HttpMethod;
@@ -42,6 +47,8 @@ export async function edenAiApiCall<T = any>({
   headers?: Record<string, string>;
   timeout?: number;
   maxRetries?: number;
+  // Defaults to the v2 feature API; pass EDENAI_V3_BASE_URL for the OpenAI-compatible LLM endpoint.
+  baseUrl?: string;
 }): Promise<T> {
   if (!apiKey || typeof apiKey !== 'string' || apiKey.trim().length < 10) {
     throw new Error('Missing or invalid Eden AI API key. Please check your credentials.');
@@ -52,7 +59,7 @@ export async function edenAiApiCall<T = any>({
     ...customHeaders,
   };
 
-  const url = `${BASE_URL}${resourceUri}`;
+  const url = `${baseUrl}${resourceUri}`;
   let lastError;
   const stringQueryParams = query
     ? Object.fromEntries(Object.entries(query).map(([k, v]) => [k, String(v)]))

--- a/packages/pieces/community/eden-ai/src/lib/common/providers.ts
+++ b/packages/pieces/community/eden-ai/src/lib/common/providers.ts
@@ -1,5 +1,72 @@
+import { HttpMethod } from '@activepieces/pieces-common';
+import { edenAiApiCall, EDENAI_V3_BASE_URL } from './client';
+
 type Option = { label: string; value: string };
 
 export function createStaticDropdown(options: Option[]) {
   return async () => ({ options });
-} 
+}
+
+type EdenModel = { id: string; regions?: { code: string }[] };
+
+function isEuModel(model: EdenModel): boolean {
+  return (model.regions ?? []).some((r) => r.code === 'eu');
+}
+
+async function fetchEdenModels(auth: unknown): Promise<EdenModel[]> {
+  const apiKey = (auth as { secret_text?: string })?.secret_text ?? (auth as string);
+  const res = await edenAiApiCall<{ data?: EdenModel[] } | EdenModel[]>({
+    apiKey,
+    method: HttpMethod.GET,
+    baseUrl: EDENAI_V3_BASE_URL,
+    resourceUri: '/models',
+  });
+  return Array.isArray(res) ? res : res?.data ?? [];
+}
+
+/** Dropdown of the distinct provider prefixes available on the account (openai, anthropic, mistral, …). */
+export async function providerDropdownOptions(auth: unknown) {
+  if (!auth) {
+    return { disabled: true, placeholder: 'Connect your Eden AI account first', options: [] as Option[] };
+  }
+  try {
+    const models = await fetchEdenModels(auth);
+    const providers = Array.from(new Set(models.map((m) => m.id.split('/')[0]))).sort();
+    return { disabled: false, options: providers.map((p) => ({ label: p, value: p })) };
+  } catch {
+    return { disabled: true, placeholder: 'Failed to load providers — check your API key', options: [] as Option[] };
+  }
+}
+
+/**
+ * Dropdown of chat models from GET /v3/models. Optionally filter by provider and/or to
+ * EU-hosted models only. EU-hosted models are flagged with 🇪🇺 so residency is visible at a glance.
+ * The value is the exact Eden AI model id (e.g. "openai/gpt-4o", "amazon/amazon.nova-2-lite-v1:0@eu").
+ */
+export async function modelDropdownOptions(auth: unknown, provider?: string, euOnly?: boolean) {
+  if (!auth) {
+    return { disabled: true, placeholder: 'Connect your Eden AI account first', options: [] as Option[] };
+  }
+  try {
+    let models = await fetchEdenModels(auth);
+    if (provider) {
+      models = models.filter((m) => m.id.startsWith(`${provider}/`));
+    }
+    if (euOnly) {
+      models = models.filter(isEuModel);
+    }
+    const options = models
+      .map((m) => ({ label: isEuModel(m) ? `🇪🇺 ${m.id}` : m.id, value: m.id }))
+      .sort((a, b) => a.value.localeCompare(b.value));
+    if (options.length === 0) {
+      return {
+        disabled: true,
+        placeholder: euOnly ? 'No EU-hosted models match this provider' : 'No models found',
+        options: [] as Option[],
+      };
+    }
+    return { disabled: false, options };
+  } catch {
+    return { disabled: true, placeholder: 'Failed to load models — check your API key', options: [] as Option[] };
+  }
+}


### PR DESCRIPTION
## What & why

Modernizes the existing **`@activepieces/piece-eden-ai`** to Eden AI's **v3 OpenAI-compatible** API.

[Eden AI](https://www.edenai.co/) is a unified, **EU-based** AI gateway: one key reaches **500+ models** across every major provider (OpenAI, Anthropic, Google, Mistral, Amazon, xAI, DeepSeek, Groq…), with built-in fallback. The **Generate Text** action was still on the legacy `/v2/llm/chat` surface with a hardcoded provider list; this PR moves it to the standard `POST /v3/chat/completions` endpoint, drives Provider/Model from the live catalogue, and adds an EU data-residency filter.

## Changes

- **LLM chat → v3 OpenAI-compatible** (`POST /v3/chat/completions`): standard OpenAI response parsing (`choices[0].message.content`), replacing the provider-keyed v2 shape.
- **Live Provider & Model dropdowns** sourced from `GET /v3/models` (replaces the stale hardcoded 11-provider list — e.g. `meta` had no models and defaults pointed at ids that don't exist). Values are the exact `provider/model` ids.
- **🇪🇺 EU Data Residency (GDPR)**: a checkbox that filters the Provider/Model lists to Eden AI's EU-hosted models (those whose `regions` include `eu` — ~270 of 760+). EU models are flagged with 🇪🇺 in the dropdown. No manual model-id munging.
- **Connection validation → `GET /v3/models`**, replacing the previous `/v2/video/explicit_content_detection_async` probe.
- **README** rewritten with usage + an EU residency section.
- Version bump `0.2.3 → 0.3.0`.

## Out of scope (intentionally)

- The 12 feature actions (Summarize, Keywords, Language Detect, Entities, Moderation, Spell Check, Translate, Invoice/Receipt Parser, OCR, Image Generation, Text-to-Speech) stay on their working `/v2` endpoints — **no rewrite, no removed behavior**.
- Streaming and tool-calling for chat — noted as a follow-up.
- Registering Eden AI as a first-class provider in the native AI-providers registry (would cover the OpenAI-compatible-gateway asks in #8954 / #7987) — happy to do as a separate PR if maintainers want it, since it touches core.

## Behavior changes to note for reviewers

- `Model` is now a required dropdown (was optional free-text). Existing flows that relied on the empty-means-default behavior will need a model selected. The dropdown makes valid ids discoverable and prevents typos.
- `Fallback Providers` → **`Fallback Models`**: now takes exact `provider/model` ids from the catalogue (the endpoint's `fallback_providers` extension accepts model ids).
- `edenAiApiCall` gained an optional `baseUrl` (defaults to v2) so LLM chat targets v3 without disturbing the feature actions.

## Testing

Tested end-to-end against the live Eden AI API with a real key (supplied via environment variable only — **no credentials in code or in this diff**):

- `GET /v3/models` → **200** (760 models; 269 expose an `eu` region).
- `POST /v3/chat/completions` → **200** for: a standard model (`openai/gpt-4o`), an EU-hosted model (`amazon/amazon.nova-lite-v1:0`), an explicit `@eu` variant (`amazon/amazon.nova-2-lite-v1:0@eu`), and a request with `fallback_providers` — using the exact multimodal message shape the action builds.
- `turbo run lint --filter=@activepieces/piece-eden-ai` → **0 errors**.
- `turbo run build --filter=@activepieces/piece-eden-ai` → **success**.

---

**Checklist**
- [x] Piece builds and lints (turbo, 0 errors)
- [x] Tested against the live API with a real key (env var only)
- [x] No breaking changes to the 12 feature actions
- [x] README updated
