### PR TITLE
fix(pieces): surface real npm error on custom piece install failure

### DIFF
--- a/packages/server/api/src/app/pieces/piece-install-service.ts
+++ b/packages/server/api/src/app/pieces/piece-install-service.ts
@@ -54,7 +54,7 @@ export const pieceInstallService = (log: FastifyBaseLogger) => ({
             throw new ActivepiecesError({
                 code: ErrorCode.ENGINE_OPERATION_FAILURE,
                 params: {
-                    message: JSON.stringify(error),
+                    message: error instanceof Error ? error.message : String(error),
                 },
             })
         }

--- a/packages/web/src/features/pieces/components/install-piece-dialog.tsx
+++ b/packages/web/src/features/pieces/components/install-piece-dialog.tsx
@@ -1,3 +1,4 @@
+`import { ApErrorParams, ErrorCode } from '@activepieces/core-utils';
 import {
   AddPieceRequestBody,
   ApFlagId,
@@ -143,20 +144,27 @@ const InstallPieceDialog = ({
     },
     onError: (error) => {
       if (api.isError(error)) {
-        switch (error.response?.status) {
-          case HttpStatusCode.Conflict:
-            form.setError('root.serverError', {
-              message: t(
-                'A piece with this name and version is already installed. Please update the version number in package.json and try again.',
-              ),
-            });
-            break;
-          default:
-            form.setError('root.serverError', {
-              message: t('Something went wrong, please try again later'),
-            });
-            break;
+        if (error.response?.status === HttpStatusCode.Conflict) {
+          form.setError('root.serverError', {
+            message: t(
+              'A piece with this name and version is already installed. Please update the version number in package.json and try again.',
+            ),
+          });
+          return;
         }
+        const responseData = error.response?.data as ApErrorParams | undefined;
+        if (
+          responseData?.code === ErrorCode.ENGINE_OPERATION_FAILURE &&
+          responseData.params.message
+        ) {
+          form.setError('root.serverError', {
+            message: responseData.params.message,
+          });
+          return;
+        }
+        form.setError('root.serverError', {
+          message: t('Something went wrong, please try again later'),
+        });
       }
     },
   });

--- a/packages/web/src/features/pieces/components/install-piece-dialog.tsx
+++ b/packages/web/src/features/pieces/components/install-piece-dialog.tsx
@@ -1,4 +1,4 @@
-`import { ApErrorParams, ErrorCode } from '@activepieces/core-utils';
+import { ApErrorParams, ErrorCode } from '@activepieces/core-utils';
 import {
   AddPieceRequestBody,
   ApFlagId,


### PR DESCRIPTION
## Problem

When installing a custom piece (npm or tgz) via **Platform Admin → Pieces** and the underlying package install fails (e.g. pinning a dependency version that doesn't exist on npm → 404), the UI only shows a generic *"Something went wrong, please try again later"* banner. The real npm error is captured server-side but never reaches the user, leaving piece developers with zero actionable detail.

Fixes [GIT-1549](https://linear.app/activepieces/issue/GIT-1549) (branch `fix/GIT-1567`).

## Root cause

The error detail survived most of the pipeline and was dropped at the last two hops:

1. **Backend** — `piece-install-service.ts` rethrew non-VALIDATION errors as `ENGINE_OPERATION_FAILURE` with `params: { message: JSON.stringify(error) }`. `JSON.stringify` on an `Error` yields `{}` (non-enumerable props), so the wrapped message was lost.
2. **Frontend** — `install-piece-dialog.tsx` special-cased only HTTP 409 (version conflict); every other status fell through to the generic banner.

## Fix

- **API** (`piece-install-service.ts`): propagate the real message via `error instanceof Error ? error.message : String(error)` so the offending package/version and full stderr survive to the client.
- **UI** (`install-piece-dialog.tsx`): render the server-provided message for `ENGINE_OPERATION_FAILURE` responses, keeping the existing 409 version-conflict special case and generic fallback.

The engine-failure message is rendered as raw `children` in `FormMessage` (outside a `FormField`), so it bypasses i18next/ICU parsing — npm stderr containing `{}` characters displays safely.

## Testing

- `npx turbo run lint --filter=web --filter=api` → 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)