### PR TITLE
fix(tables): neq filter returns rows with empty/unset cells

### DIFF
--- a/.agents/features/tables.md
+++ b/.agents/features/tables.md
@@ -81,7 +81,7 @@ A built-in relational database feature that lets users store structured data dir
 - `table.exportTable()` — returns fields + rows as JSON
 - `table.createWebhook()` / `table.deleteWebhook()` — link table events to flows
 - `record.create()` — bulk insert (max 50 per batch, transactional), validates field count
-- `record.list()` — with filters (EQ, NEQ, GT, GTE, LT, LTE, CO, EXISTS, NOT_EXISTS)
+- `record.list()` — with filters (EQ, NEQ, GT, GTE, LT, LTE, CO, EXISTS, NOT_EXISTS); filtering is in-memory and a missing cell is treated as an empty value (`''`), so NEQ/NOT_EXISTS match unset columns
 - `record.update()` — update cells (empty fields unchanged)
 - `record.delete()` / `record.deleteAll()` — bulk delete
 

--- a/packages/server/api/src/app/tables/record/record.service.ts
+++ b/packages/server/api/src/app/tables/record/record.service.ts
@@ -113,9 +113,7 @@ export const recordService = {
             }
             return filters.every((filter) => {
                 const cell = record.cells.find(c => c.fieldId === filter.fieldId)
-                if (!cell) {
-                    return filter.operator === FilterOperator.NOT_EXISTS
-                }
+                    ?? { fieldId: filter.fieldId, value: '' }
                 return doesCellValueMatchFilters(cell, [filter])
             })
         })
@@ -486,7 +484,7 @@ function formatRecords(records: RecordSchema[], fields: Field[]): PopulatedRecor
     })
 }
 
-function doesCellValueMatchFilters(cell: Cell, filters: Filter[]): boolean {
+function doesCellValueMatchFilters(cell: Pick<Cell, 'fieldId' | 'value'>, filters: Filter[]): boolean {
     if (filters.length === 0) {
         return true
     }

--- a/packages/server/api/test/integration/ce/tables/record.test.ts
+++ b/packages/server/api/test/integration/ce/tables/record.test.ts
@@ -375,6 +375,47 @@ describe('Record API', () => {
             expect(body.data.length).toBe(1)
             expect(body.data[0].id).toBe(record1.id)
         })
+
+        it('NEQ: should match record without a cell for the field', async () => {
+            const ctx = await setup()
+            const { table, field } = await createTableWithField(ctx)
+            const record1 = createMockRecord({ tableId: table.id, projectId: ctx.project.id })
+            const record2 = createMockRecord({ tableId: table.id, projectId: ctx.project.id })
+            await db.save('record', [record1, record2])
+            const cell2 = createMockCell({ recordId: record2.id, fieldId: field.id, projectId: ctx.project.id })
+            cell2.value = 'true'
+            await db.save('cell', cell2)
+
+            const response = await ctx.inject({
+                method: 'GET',
+                url: `/api/v1/records?${qs.stringify({ tableId: table.id, filters: [{ fieldId: field.id, operator: FilterOperator.NEQ, value: 'true' }] })}`,
+            })
+
+            expect(response?.statusCode).toBe(StatusCodes.OK)
+            const body = response?.json()
+            expect(body.data.length).toBe(1)
+            expect(body.data[0].id).toBe(record1.id)
+        })
+
+        it('NEQ: should match record with empty string cell', async () => {
+            const ctx = await setup()
+            const { table, field } = await createTableWithField(ctx)
+            const record1 = createMockRecord({ tableId: table.id, projectId: ctx.project.id })
+            await db.save('record', record1)
+            const cell1 = createMockCell({ recordId: record1.id, fieldId: field.id, projectId: ctx.project.id })
+            cell1.value = ''
+            await db.save('cell', cell1)
+
+            const response = await ctx.inject({
+                method: 'GET',
+                url: `/api/v1/records?${qs.stringify({ tableId: table.id, filters: [{ fieldId: field.id, operator: FilterOperator.NEQ, value: 'true' }] })}`,
+            })
+
+            expect(response?.statusCode).toBe(StatusCodes.OK)
+            const body = response?.json()
+            expect(body.data.length).toBe(1)
+            expect(body.data[0].id).toBe(record1.id)
+        })
     })
 
     describeWithAuth('DELETE /v1/records (Delete)', () => app!, (setup) => {


### PR DESCRIPTION
## Problem

The Tables `neq` filter silently drops rows where the target column is empty or was never filled. Reported case: filtering `converted neq "true"` returned an empty result even though rows existed where `converted` was empty — and empty ≠ `"true"`, so those rows should match.

## Root cause

Record filtering runs in-memory in `record.service.ts`. A record with **no cell** for the filtered field was special-cased to match only `NOT_EXISTS`:

```ts
const cell = record.cells.find(c => c.fieldId === filter.fieldId)
if (!cell) {
    return filter.operator === FilterOperator.NOT_EXISTS
}
```

So for a never-filled column, `neq` (and `eq`, `co`, …) always returned `false` and the row was excluded — regardless of the actual comparison.

## Fix

Treat a missing cell as an empty value (`''`, the same sentinel `update` writes via `value: cellData.value ?? ''`) and route it through the normal operator logic. All operators now handle empty/unset columns consistently — `neq "true"` returns the empty rows, while `exists` / `not_exists` still behave correctly since `''` is the empty sentinel.

## Tests

Added two integration cases to `record.test.ts`:
- `NEQ: should match record without a cell for the field`
- `NEQ: should match record with empty string cell`

Both pass on CE (`AP_EDITION=ce`); logic is edition-agnostic.