### PR TITLE
fix(shopify): preserve product images on partial update

### DIFF
--- a/packages/pieces/community/shopify/package.json
+++ b/packages/pieces/community/shopify/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-shopify",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {

--- a/packages/pieces/community/shopify/src/lib/actions/update-product.ts
+++ b/packages/pieces/community/shopify/src/lib/actions/update-product.ts
@@ -1,7 +1,7 @@
-import { Property, createAction } from '@activepieces/pieces-framework';
+import { Property, createAction, spreadIfDefined } from '@activepieces/pieces-framework';
 import { shopifyAuth } from '../..';
 import { updateProduct } from '../common';
-import { ShopifyImage, ShopifyProductStatuses } from '../common/types';
+import { ShopifyImage, ShopifyProduct, ShopifyProductStatuses } from '../common/types';
 
 export const updateProductAction = createAction({
   auth: shopifyAuth,
@@ -71,24 +71,19 @@ export const updateProductAction = createAction({
     const { id, title, bodyHtml, vendor, productType, tags, productImage } =
       propsValue;
 
-    const images: Partial<ShopifyImage>[] = [];
-    if (productImage) {
-      images.push({
-        attachment: productImage.base64,
-      });
-    }
+    const images: Partial<ShopifyImage>[] | undefined = productImage
+      ? [{ attachment: productImage.base64 }]
+      : undefined;
 
-    return await updateProduct(
-      +id,
-      {
-        title,
-        body_html: bodyHtml,
-        vendor,
-        product_type: productType,
-        tags,
-        images,
-      },
-      auth
-    );
+    const product: Partial<ShopifyProduct> = {
+      ...spreadIfDefined('title', title),
+      ...spreadIfDefined('body_html', bodyHtml),
+      ...spreadIfDefined('vendor', vendor),
+      ...spreadIfDefined('product_type', productType),
+      ...spreadIfDefined('tags', tags),
+      ...spreadIfDefined('images', images),
+    };
+
+    return await updateProduct(+id, product, auth);
   },
 });


### PR DESCRIPTION
## What does this PR do?
- Fixes #6939 
- The Shopify **Update Product** action always sent `images: []` on every request, even when no new image was provided. Shopify's `PUT /products/{id}` treat that as replacing the product with no images, which delete existing product images when updating fields like description.
- This change only includes fields the user actually set in the request payload, and omit `images` unless a new product image is provided.

<img width="857" height="877" alt="image" src="https://github.com/user-attachments/assets/4489dad6-6f54-4d08-ac24-ac6586195c9b" />
