### PR TITLE
fix(husky): use bun and local binaries in git hooks

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,5 +1,5 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
-
-npx --no -- commitlint --edit ${1}
+ROOT="$(cd "$(dirname -- "$0")/.." && pwd)"
+"$ROOT/node_modules/.bin/commitlint" --edit ${1}

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -35,7 +35,7 @@ case "$RUN_CHECKS" in
     ;;
   [lL][iI][nN][tT]|[lL])
     echo "Running lint-dev (with auto-fix)..."
-    npm run lint-dev || { echo ""; echo "Lint failed. Fix the remaining issues and try again."; exit 1; }
+    bun run lint-dev || { echo ""; echo "Lint failed. Fix the remaining issues and try again."; exit 1; }
     if [ -n "$(git status --porcelain)" ]; then
       echo ""
       echo "lint-dev auto-fixed files. Commit the changes before pushing:"
@@ -45,11 +45,11 @@ case "$RUN_CHECKS" in
     ;;
   *)
     echo "Running lint..."
-    npm run lint-core || { echo ""; echo "Lint failed. To auto-fix issues, run:"; echo "  npm run lint-dev"; echo "Or target a specific package:"; echo "  npx turbo run lint --filter=\"<packageName>\" --force -- --fix"; exit 1; }
-    npm run lint-affected || { echo ""; echo "Lint failed. To auto-fix issues, run:"; echo "  npm run lint-dev"; echo "Or target a specific package:"; echo "  npx turbo run lint --filter=\"<packageName>\" --force -- --fix"; exit 1; }
+    bun run lint-core || { echo ""; echo "Lint failed. To auto-fix issues, run:"; echo "  bun run lint-dev"; echo "Or target a specific package:"; echo "  bunx turbo run lint --filter=\"<packageName>\" --force -- --fix"; exit 1; }
+    bun run lint-affected || { echo ""; echo "Lint failed. To auto-fix issues, run:"; echo "  bun run lint-dev"; echo "Or target a specific package:"; echo "  bunx turbo run lint --filter=\"<packageName>\" --force -- --fix"; exit 1; }
     echo "Running tests..."
-    npm run test-unit || { echo ""; echo "Unit tests failed. Check the output above for details."; exit 1; }
-    npm run test-api || { echo ""; echo "API tests failed. Check the output above for details."; exit 1; }
+    bun run test-unit || { echo ""; echo "Unit tests failed. Check the output above for details."; exit 1; }
+    bun run test-api || { echo ""; echo "API tests failed. Check the output above for details."; exit 1; }
     ;;
 esac
 


### PR DESCRIPTION
## What does this PR do?
Fix broken `commit` and `pre-push` git hooks when developing with the repo's declared package manager.