### PR TITLE
fix(engine): coerce checkbox string literals before validation

### DIFF
--- a/packages/server/engine/src/lib/variables/processors/checkbox.ts
+++ b/packages/server/engine/src/lib/variables/processors/checkbox.ts
@@ -1,0 +1,14 @@
+import { ProcessorFn } from './types'
+
+export const checkboxProcessor: ProcessorFn = async (_property, value) => {
+    if (typeof value === 'boolean') {
+        return value
+    }
+    if (value === 'true') {
+        return true
+    }
+    if (value === 'false') {
+        return false
+    }
+    return value
+}

--- a/packages/server/engine/src/lib/variables/processors/index.ts
+++ b/packages/server/engine/src/lib/variables/processors/index.ts
@@ -1,4 +1,5 @@
 import { PropertyType } from '@activepieces/pieces-framework'
+import { checkboxProcessor } from './checkbox'
 import { dateTimeProcessor } from './date-time'
 import { fileProcessor } from './file'
 import { jsonProcessor } from './json'
@@ -8,6 +9,7 @@ import { textProcessor } from './text'
 import { ProcessorFn } from './types'
 
 export const processors: Partial<Record<PropertyType, ProcessorFn>> = {
+    CHECKBOX: checkboxProcessor,
     JSON: jsonProcessor,
     OBJECT: objectProcessor,
     NUMBER: numberProcessor,

--- a/packages/server/engine/test/variables/props-validator.test.ts
+++ b/packages/server/engine/test/variables/props-validator.test.ts
@@ -419,4 +419,25 @@ describe('Property Validation', () => {
             })
         })
     })
+
+    it('coerces checkbox string literals before validation', async () => {
+        const props = {
+            enabled: Property.Checkbox({
+                displayName: 'Enabled',
+                required: false,
+                defaultValue: false,
+            }),
+        }
+
+        const { processedInput, errors } = await propsProcessor.applyProcessorsAndValidators(
+            { enabled: 'false' },
+            props,
+            PieceAuth.None(),
+            false,
+            {},
+        )
+
+        expect(errors).toEqual({})
+        expect(processedInput.enabled).toBe(false)
+    })
 })


### PR DESCRIPTION
## Summary
- Add CHECKBOX processor for true/false string coercion
- Add regression test for enabled: 'false'

Fixes #13711

## Test plan
- [x] props-validator checkbox coercion test

Made with [Cursor](https://cursor.com)