### PR TITLE
fix(ci): bound prepare-pieces bundle concurrency to avoid runner OOM

### DIFF
--- a/tools/scripts/pieces/prepare-pieces-for-publish.ts
+++ b/tools/scripts/pieces/prepare-pieces-for-publish.ts
@@ -1,5 +1,6 @@
 import { findAllPiecesDirectoryInSource } from '../utils/piece-script-utils'
 import { preparePieceDistForPublish } from '../../../packages/cli/src/lib/utils/prepare-piece-utils'
+import { chunk } from '@activepieces/core-utils'
 
 function getChangedPiecePaths(): string[] | null {
     const changedPieces = process.env['CHANGED_PIECES']
@@ -15,8 +16,11 @@ async function main(): Promise<void> {
 
     console.info(`[preparePieces] processing ${piecePaths.length} pieces${changedPaths ? ' (scoped to changed)' : ' (all)'}`)
 
-    for (const piecePath of piecePaths) {
-        preparePieceDistForPublish(piecePath)
+    // Bundling is memory-heavy; cap concurrent bundles so a large changeset (e.g. a mass version
+    // bump) can't OOM-kill the runner. Fire-and-forget over all pieces at once exhausts memory.
+    const batches = chunk(piecePaths, 30)
+    for (const batch of batches) {
+        await Promise.all(batch.map(preparePieceDistForPublish))
     }
 
     console.info(`[preparePieces] done, prepared ${piecePaths.length} pieces`)


### PR DESCRIPTION
## Problem

After a large piece version bump (~680 pieces), the **Release Pieces** workflow died mid-run with `The runner has received a shutdown signal / The operation was canceled` at ~18 min ([run 28875193427](https://github.com/activepieces/activepieces/actions/runs/28875193427/job/85648270415)). Every subsequent run failed identically, so **no piece was released since**.

### Root cause

`prepare-pieces-for-publish.ts` looped over all changed pieces and called the **async** `preparePieceDistForPublish` **without `await`** — firing all ~680 esbuild bundles concurrently. That exhausted the runner's memory → VM OOM-killed. Because the prepare step runs *before* publish, nothing ever reached npm/the registry, so each rerun recomputed the same full backlog and died the same way (zero forward progress).

It was **not** the job timeout (run was 18 min, not 6 h) and **not** the `concurrency` config (`cancel-in-progress: false` never cancels a running job).

## Fix

Batch the bundles 30-at-a-time with `await`, mirroring how `publish-pieces-to-npm.ts` and `update-pieces-metadata.ts` already loop with `chunk(..., 30)`. Bounds peak memory; output artifacts are unchanged.

## Notes

- Touches `tools/scripts/**` only, which is **not** in the workflow's path filter — merging won't auto-trigger a run. Unblock by manually running **Release Pieces** (`workflow_dispatch`) after merge; nothing was ever published, so it drains all 680 cleanly.
- Side-effect-free: per-piece bundling is independent (no shared state); only concurrency is capped. The one behavioral improvement is that a genuinely broken bundle now fails fast/loud via `await Promise.all` instead of becoming a swallowed unhandled rejection.