### PR TITLE
fix(file): S3 uploads and file cleanup failing on OCI and other S3-compatible storage

### DIFF
--- a/.agents/features/file-storage.md
+++ b/.agents/features/file-storage.md
@@ -99,7 +99,7 @@ Step file uploads are handled by the engine via the unified `PUT /v1/files/:file
 - `getFile(s3Key)` — GetObject from S3, returns Buffer.
 - `getS3SignedUrl(s3Key, fileName)` — generates a 7-day pre-signed GET URL.
 - `putS3SignedUrl({ s3Key, contentLength, contentEncoding })` — generates a 7-day pre-signed PUT URL.
-- `deleteFiles(s3Keys)` — DeleteObjects in batches of 100 (Cloudflare R2 limit).
+- `deleteFiles(s3Keys)` — DeleteObjects in batches of 100 (Cloudflare R2 limit); sends the CRC32C checksum algorithm (OCI Object Storage rejects the SDK-default CRC32).
 - `validateS3Configuration()` — smoke test: puts, heads, and deletes a test object.
 
 ## Cleanup Job
@@ -116,6 +116,6 @@ Scheduled every hour (`30 */1 * * *`) via `SystemJobName.FILE_CLEANUP_TRIGGER`. 
 | `S3_SECRET_ACCESS_KEY` | S3 credentials (not needed if `S3_USE_IRSA=true`) |
 | `S3_BUCKET` | S3 bucket name |
 | `S3_REGION` | S3 region |
-| `S3_ENDPOINT` | Custom S3 endpoint URL (for Cloudflare R2, MinIO, etc.) |
+| `S3_ENDPOINT` | Custom S3 endpoint URL (for Cloudflare R2, MinIO, OCI Object Storage, etc.). When set, the SDK checksum defaults and aws-chunked upload encoding are disabled (`WHEN_REQUIRED`) for S3-compatible providers; plain AWS keeps SDK defaults |
 | `S3_USE_IRSA` | Use IAM Roles for Service Accounts instead of static credentials |
 | `S3_USE_SIGNED_URLS` | When true, redirect step file downloads to pre-signed S3 URLs |

--- a/packages/server/api/src/app/file/s3-helper.ts
+++ b/packages/server/api/src/app/file/s3-helper.ts
@@ -119,8 +119,6 @@ export const s3Helper = (log: FastifyBaseLogger) => ({
                         Objects: deleteObjects,
                         Quiet: true,
                     },
-                    // DeleteObjects requires a checksum; the SDK default (CRC32) is rejected by
-                    // OCI Object Storage, which accepts only MD5 / SHA256 / CRC32C
                     ChecksumAlgorithm: 'CRC32C',
                 }))
                 log.info({ count: chunk.length }, 'files deleted from s3')
@@ -179,9 +177,6 @@ const getS3Client = (): S3 => {
         maxAttempts: 3,
     }
     if (!isNil(endpoint)) {
-        // SDK defaults (WHEN_SUPPORTED) force CRC32 checksums and aws-chunked upload
-        // encoding, which S3-compatible providers like OCI Object Storage reject.
-        // A custom endpoint means a non-AWS provider; plain AWS keeps the SDK defaults
         options.requestChecksumCalculation = 'WHEN_REQUIRED'
         options.responseChecksumValidation = 'WHEN_REQUIRED'
     }

--- a/packages/server/api/src/app/file/s3-helper.ts
+++ b/packages/server/api/src/app/file/s3-helper.ts
@@ -119,6 +119,9 @@ export const s3Helper = (log: FastifyBaseLogger) => ({
                         Objects: deleteObjects,
                         Quiet: true,
                     },
+                    // DeleteObjects requires a checksum; the SDK default (CRC32) is rejected by
+                    // OCI Object Storage, which accepts only MD5 / SHA256 / CRC32C
+                    ChecksumAlgorithm: 'CRC32C',
                 }))
                 log.info({ count: chunk.length }, 'files deleted from s3')
             }
@@ -174,6 +177,13 @@ const getS3Client = (): S3 => {
             requestTimeout: 120_000,
         }),
         maxAttempts: 3,
+    }
+    if (!isNil(endpoint)) {
+        // SDK defaults (WHEN_SUPPORTED) force CRC32 checksums and aws-chunked upload
+        // encoding, which S3-compatible providers like OCI Object Storage reject.
+        // A custom endpoint means a non-AWS provider; plain AWS keeps the SDK defaults
+        options.requestChecksumCalculation = 'WHEN_REQUIRED'
+        options.responseChecksumValidation = 'WHEN_REQUIRED'
     }
     if (!useIRSA) {
         const accessKeyId = system.getOrThrow<string>(AppSystemProp.S3_ACCESS_KEY_ID)

--- a/packages/server/api/test/unit/app/file/s3-helper-checksum.test.ts
+++ b/packages/server/api/test/unit/app/file/s3-helper-checksum.test.ts
@@ -1,0 +1,102 @@
+import { createServer, IncomingMessage, Server } from 'http'
+import { AddressInfo } from 'net'
+import { FastifyBaseLogger } from 'fastify'
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import { s3Helper } from '../../../../src/app/file/s3-helper'
+
+let endpoint: string
+
+vi.mock('../../../../src/app/file/file.service', () => ({
+    fileRepo: vi.fn(),
+}))
+
+vi.mock('../../../../src/app/helper/exception-handler', () => ({
+    exceptionHandler: { handle: vi.fn() },
+}))
+
+vi.mock('../../../../src/app/helper/system/system', () => ({
+    system: {
+        get: vi.fn((prop: string) => {
+            if (prop === 'S3_ENDPOINT') {
+                return endpoint
+            }
+            if (prop === 'S3_REGION') {
+                return 'us-east-1'
+            }
+            return undefined
+        }),
+        getOrThrow: vi.fn((prop: string) => {
+            if (prop === 'S3_BUCKET') {
+                return 'test-bucket'
+            }
+            return 'test-credential'
+        }),
+        getBoolean: vi.fn().mockReturnValue(false),
+    },
+}))
+
+type CapturedRequest = {
+    method: string
+    headers: IncomingMessage['headers']
+    body: string
+}
+
+const captured: CapturedRequest[] = []
+let server: Server
+
+const log = {
+    info: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+} as unknown as FastifyBaseLogger
+
+describe('s3Helper checksum behavior on S3-compatible providers', () => {
+    beforeAll(async () => {
+        server = createServer((req, res) => {
+            const chunks: Buffer[] = []
+            req.on('data', (chunk) => chunks.push(chunk))
+            req.on('end', () => {
+                captured.push({
+                    method: req.method ?? '',
+                    headers: req.headers,
+                    body: Buffer.concat(chunks).toString('utf8'),
+                })
+                res.writeHead(200, { 'content-type': 'application/xml' })
+                res.end('<?xml version="1.0"?><DeleteResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"></DeleteResult>')
+            })
+        })
+        await new Promise<void>((resolve) => server.listen(0, resolve))
+        endpoint = `http://127.0.0.1:${(server.address() as AddressInfo).port}`
+    })
+
+    afterAll(async () => {
+        await new Promise<void>((resolve, reject) => server.close((error) => error ? reject(error) : resolve()))
+    })
+
+    beforeEach(() => {
+        captured.length = 0
+    })
+
+    it('uploads without aws-chunked encoding or checksum headers', async () => {
+        const payload = Buffer.from('regression-test-payload')
+
+        await s3Helper(log).uploadFile('project/p1/FLOW_RUN_LOG/f1', payload)
+
+        const putRequest = captured.find((request) => request.method === 'PUT')
+        expect(putRequest).toBeDefined()
+        expect(putRequest?.headers['content-encoding'] ?? '').not.toContain('aws-chunked')
+        expect(putRequest?.headers['content-md5']).toBeUndefined()
+        const checksumHeaders = Object.keys(putRequest?.headers ?? {}).filter((header) => header.startsWith('x-amz-checksum-'))
+        expect(checksumHeaders).toEqual([])
+        expect(putRequest?.body).toBe('regression-test-payload')
+    })
+
+    it('deletes objects with the CRC32C checksum accepted by OCI', async () => {
+        await s3Helper(log).deleteFiles(['project/p1/FLOW_RUN_LOG/f1'])
+
+        const deleteRequest = captured.find((request) => request.method === 'POST')
+        expect(deleteRequest).toBeDefined()
+        expect(deleteRequest?.headers['x-amz-checksum-crc32c']).toBeDefined()
+        expect(deleteRequest?.headers['x-amz-checksum-crc32']).toBeUndefined()
+    })
+})


### PR DESCRIPTION
Fixes [GIT-1604](https://linear.app/activepieces/issue/GIT-1604)
Closes #14110

## Problem

`AP_S3_*` on OCI Object Storage, since AWS SDK 3.729.0 defaults:

1. Every upload: `NotImplemented: AWS chunked encoding not supported`
2. Hourly file-cleanup (`DeleteObjects`): `InvalidRequest: Missing required header: Content-MD5 or x-amz-checksum-sha256 or x-amz-checksum-crc32c` (SDK sends crc32)

## Fix

`s3-helper.ts`:

- Custom `AP_S3_ENDPOINT` set → `requestChecksumCalculation/responseChecksumValidation: WHEN_REQUIRED`. No endpoint (plain AWS) → SDK defaults unchanged
- `DeleteObjectsCommand` → `ChecksumAlgorithm: CRC32C` (checksum-required op; explicit algorithm overrides crc32 default; AWS + OCI accept crc32c)

## Verification

- Regression test (wire-captures SDK requests against local stub), mutation-checked
- Real server boot against stub: S3 validation PUT sent plain body, no checksum headers
- lint clean; security review clean
- Unverified: CRC32C on `DeleteObjects` vs Cloudflare R2
- Unrelated pre-existing on main: 8 web `buildColumns` test failures


