### PR TITLE
fix(router): use form.watch so Second value field hides immediately on operator change

### DIFF
--- a/packages/web/src/app/builder/step-settings/branch-settings/branch-single-condition.tsx
+++ b/packages/web/src/app/builder/step-settings/branch-settings/branch-single-condition.tsx
@@ -74,7 +74,7 @@ const BranchSingleCondition = ({
 }: BranchSingleConditionProps) => {
   const form = useFormContext<RouterAction>();
 
-  const condition = form.getValues(
+  const condition = form.watch(
     `settings.branches.${branchIndex}.conditions.${groupIndex}.${conditionIndex}`,
   );
 


### PR DESCRIPTION
## Summary

Fixes #13900 — Router "Second value" field stayed visible after selecting `Exists` / `Does not exist` until page refresh.

- `form.getValues()` returns a one-time snapshot that does not subscribe to form changes, so `isSingleValueCondition` was stale after an operator change
- Replace with `form.watch()` so the component re-renders on every operator change and `isSingleValueCondition` is always current
- Matches the pattern already mandated in CLAUDE.md: "Use `form.watch()` for conditional rendering"

## Test plan

- [ ] Add a Router step and open its condition editor
- [ ] Set an operator that shows a Second value field (e.g. "Exactly matches")
- [ ] Change the operator to `Exists` or `Does not exist`
- [ ] Verify the Second value field disappears immediately without a page refresh
- [ ] Change back to a two-value operator and verify Second value reappears
- [ ] Existing flow saves and runs correctly