### PR TITLE
feat(embed-sdk): add embedding.hideGlobalSearch flag to disable the CMD+K global search palette

### DIFF
--- a/docs/embedding/embed-builder.mdx
+++ b/docs/embedding/embed-builder.mdx
@@ -21,7 +21,7 @@ These steps assume you have already generated a JWT token from the backend. If n
 </Tip>
 
 ```html
-<script src="https://cdn.activepieces.com/sdk/embed/0.9.0.js">
+<script src="https://cdn.activepieces.com/sdk/embed/0.13.0.js">
 </script>
 <script>
 const instanceUrl = 'YOUR_INSTANCE_URL';
@@ -78,6 +78,7 @@ Please check the [navigation](./navigation) section, as it's very important to u
 | embedding.hideFolders | ❌ | boolean | Hides all things related to folders in both the flows table and builder by default it is false. |
 | embedding.hideTables | ❌ | boolean | Hides the Tables UI in the dashboard (tree, filters, create/import buttons) and blocks direct access to the table editor route. The Tables piece used inside flows is unaffected. By default it is false. (added in [0.9.0](./sdk-changelog#04%2F21%2F2026-0-9-0)) |
 | embedding.hideActiveUsers | ❌ | boolean | Hides the active users (presence) avatars in the builder's header and the table editor's header. When hidden, the embedded user also stops appearing in other collaborators' active-users list. By default it is false. (added in [0.12.0](./sdk-changelog#07%2F09%2F2026-0-12-0)) |
+| embedding.hideGlobalSearch | ❌ | boolean | Hides the global search button in the dashboard sidebar and disables the `CMD+K` / `Ctrl+K` command palette, by default it is false. (added in [0.13.0](./sdk-changelog#07%2F09%2F2026-0-13-0)) |
 | embedding.styling.fontUrl | ❌ | string | The url of the font to be used in the embedding, by default it is `https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500;700&display=swap`. |
 | embedding.styling.fontFamily | ❌ | string | The font family to be used in the embedding, by default it is `Roboto`. |
 | embedding.styling.mode | ❌ | `light` \| `dark` | Controls light/dark mode (added in [0.5.0](./sdk-changelog#03%2F07%2F2025-0-5-0))|

--- a/docs/embedding/sdk-changelog.mdx
+++ b/docs/embedding/sdk-changelog.mdx
@@ -20,7 +20,7 @@ Change log format: MM/DD/YYYY (version)
 
 ### 07/09/2026 (0.13.0)
 - SDK URL: https://cdn.activepieces.com/sdk/embed/0.13.0.js
-- Added `embedding.hideGlobalSearch` parameter to the [configure](./embed-builder#configure-parameters) method **(value: true | false)**. When `true`, hides the global search button in the dashboard sidebar and disables the `CMD+K` / `Ctrl+K` command palette, so embedded users can't navigate to pages, flows, or tables through search. This version requires an Activepieces release that includes the fix for [#13555](https://github.com/activepieces/activepieces/issues/13555).
+- Added `embedding.hideGlobalSearch` parameter to the [configure](./embed-builder#configure-parameters) method **(value: true | false)**. When `true`, hides the global search button in the dashboard sidebar and disables the `CMD+K` / `Ctrl+K` command palette, so embedded users can't navigate to pages, flows, or tables through search. This version requires an Activepieces release that includes [#14135](https://github.com/activepieces/activepieces/pull/14135).
 
 ### 07/09/2026 (0.12.0)
 - SDK URL: https://cdn.activepieces.com/sdk/embed/0.12.0.js

--- a/docs/embedding/sdk-changelog.mdx
+++ b/docs/embedding/sdk-changelog.mdx
@@ -18,6 +18,10 @@ Change log format: MM/DD/YYYY (version)
 
 
 
+### 07/09/2026 (0.13.0)
+- SDK URL: https://cdn.activepieces.com/sdk/embed/0.13.0.js
+- Added `embedding.hideGlobalSearch` parameter to the [configure](./embed-builder#configure-parameters) method **(value: true | false)**. When `true`, hides the global search button in the dashboard sidebar and disables the `CMD+K` / `Ctrl+K` command palette, so embedded users can't navigate to pages, flows, or tables through search. This version requires an Activepieces release that includes the fix for [#13555](https://github.com/activepieces/activepieces/issues/13555).
+
 ### 07/09/2026 (0.12.0)
 - SDK URL: https://cdn.activepieces.com/sdk/embed/0.12.0.js
 - Added `embedding.hideActiveUsers` parameter to the [configure](./embed-builder#configure-parameters) method **(value: true | false)**. When `true`, hides the active users (presence) avatars in the builder's header and the table editor's header. The embedded user will also not appear in other collaborators' active-users list. This version requires an Activepieces release that includes [#13630](https://github.com/activepieces/activepieces/pull/13630).

--- a/packages/ee/embed-sdk/package.json
+++ b/packages/ee/embed-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ee-embed-sdk",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "type": "commonjs",
   "main": "./src/index.js",
   "typings": "./src/index.d.ts",

--- a/packages/ee/embed-sdk/src/index.ts
+++ b/packages/ee/embed-sdk/src/index.ts
@@ -136,6 +136,7 @@ export interface ActivepiecesVendorInit {
     hideFlowsPageNavbar?: boolean;
     hidePageHeader?: boolean;
     hideActiveUsers?: boolean;
+    hideGlobalSearch?: boolean;
   };
 }
 
@@ -173,6 +174,7 @@ type EmbeddingParam = {
   hideFolders?: boolean;
   hideTables?: boolean;
   hideActiveUsers?: boolean;
+  hideGlobalSearch?: boolean;
   navigation?: {
     handler?: (data: { route: string }) => void;
   }
@@ -195,7 +197,7 @@ export type McpCredentials = {
 
 type RequestMethod = Required<Parameters<typeof fetch>>[1]['method'];
 class ActivepiecesEmbedded {
-  readonly _sdkVersion = "0.11.0";
+  readonly _sdkVersion = "0.13.0";
   //used for  Automatically Sync URL feature i.e /org/1234
   _prefix = '/';
   _instanceUrl = '';
@@ -309,6 +311,7 @@ class ActivepiecesEmbedded {
                 mode: this._embeddingState?.styling?.mode,
                 hidePageHeader: this._embeddingState?.dashboard?.hidePageHeader ?? false,
                 hideActiveUsers: this._embeddingState?.hideActiveUsers ?? false,
+                hideGlobalSearch: this._embeddingState?.hideGlobalSearch ?? false,
               },
             };
             targetWindow.postMessage(apEvent, '*');

--- a/packages/web/src/app/components/global-search/global-search-command.tsx
+++ b/packages/web/src/app/components/global-search/global-search-command.tsx
@@ -1,6 +1,7 @@
 import { t } from 'i18next';
 import { Search } from 'lucide-react';
 
+import { useEmbedding } from '@/components/providers/embed-provider';
 import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
 
@@ -8,8 +9,13 @@ import { useGlobalSearch } from './global-search-context';
 
 export function GlobalSearchCommand() {
   const { setOpen } = useGlobalSearch();
+  const { embedState } = useEmbedding();
   const isMac =
     typeof navigator !== 'undefined' && /(Mac)/i.test(navigator.userAgent);
+
+  if (embedState.hideGlobalSearch) {
+    return null;
+  }
 
   return (
     <Button

--- a/packages/web/src/app/components/global-search/global-search-context.tsx
+++ b/packages/web/src/app/components/global-search/global-search-context.tsx
@@ -10,6 +10,7 @@ import React, {
 import { useNavigate } from 'react-router-dom';
 import { useDebounce } from 'use-debounce';
 
+import { useEmbedding } from '@/components/providers/embed-provider';
 import {
   CommandDialog,
   CommandGroup,
@@ -225,8 +226,13 @@ export function GlobalSearchProvider({
   children: React.ReactNode;
 }) {
   const [open, setOpen] = useState(false);
+  const { embedState } = useEmbedding();
+  const { hideGlobalSearch } = embedState;
 
   useEffect(() => {
+    if (hideGlobalSearch) {
+      return;
+    }
     const handleKeyDown = (e: KeyboardEvent) => {
       if (e.key === 'k' && (e.metaKey || e.ctrlKey)) {
         e.preventDefault();
@@ -235,12 +241,14 @@ export function GlobalSearchProvider({
     };
     document.addEventListener('keydown', handleKeyDown);
     return () => document.removeEventListener('keydown', handleKeyDown);
-  }, []);
+  }, [hideGlobalSearch]);
 
   return (
     <GlobalSearchContext.Provider value={{ open, setOpen }}>
       {children}
-      <GlobalSearchDialogContent open={open} onOpenChange={setOpen} />
+      {!hideGlobalSearch && (
+        <GlobalSearchDialogContent open={open} onOpenChange={setOpen} />
+      )}
     </GlobalSearchContext.Provider>
   );
 }

--- a/packages/web/src/app/routes/embed/index.tsx
+++ b/packages/web/src/app/routes/embed/index.tsx
@@ -160,6 +160,7 @@ const EmbedPage = React.memo(() => {
                     event.data.data.hideFlowsPageNavbar ?? false,
                   hidePageHeader: event.data.data.hidePageHeader ?? false,
                   hideActiveUsers: event.data.data.hideActiveUsers ?? false,
+                  hideGlobalSearch: event.data.data.hideGlobalSearch ?? false,
                 });
               });
               memoryRouter.navigate(initialRoute);

--- a/packages/web/src/components/providers/embed-provider.tsx
+++ b/packages/web/src/components/providers/embed-provider.tsx
@@ -22,6 +22,7 @@ type EmbeddingState = {
   hideDuplicateFlow: boolean;
   hidePageHeader: boolean;
   hideActiveUsers: boolean;
+  hideGlobalSearch: boolean;
 };
 
 const defaultState: EmbeddingState = {
@@ -40,6 +41,7 @@ const defaultState: EmbeddingState = {
   hideDuplicateFlow: false,
   hidePageHeader: false,
   hideActiveUsers: false,
+  hideGlobalSearch: false,
 };
 
 const EmbeddingContext = createContext<{

--- a/packages/web/test/app/components/global-search/global-search-command.test.tsx
+++ b/packages/web/test/app/components/global-search/global-search-command.test.tsx
@@ -1,0 +1,106 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Regression test for https://github.com/activepieces/activepieces/issues/13555
+ * (GIT-1530): the global search trigger button must not render when the
+ * embedding state sets `hideGlobalSearch`.
+ *
+ * This file uses raw `react-dom` + React's `act` rather than
+ * @testing-library/react (which is not a dependency of this package), so the
+ * testing-library lint rules that assume that library do not apply.
+ */
+/* eslint-disable testing-library/no-unnecessary-act */
+import * as React from 'react';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('i18next', () => ({ t: (key: string) => key }));
+
+vi.mock('lucide-react', () => ({
+  Search: () => null,
+}));
+
+vi.mock('@/components/ui/button', () => ({
+  Button: ({
+    children,
+    ...props
+  }: React.PropsWithChildren<React.ComponentProps<'button'>>) => (
+    <button {...props}>{children}</button>
+  ),
+}));
+
+vi.mock('@/app/components/global-search/global-search-context', () => ({
+  useGlobalSearch: () => ({ open: false, setOpen: vi.fn() }),
+}));
+
+import { GlobalSearchCommand } from '@/app/components/global-search/global-search-command';
+import {
+  EmbeddingProvider,
+  useEmbedding,
+} from '@/components/providers/embed-provider';
+
+declare global {
+  // Tells React the test wraps updates in act(); see React's act() docs.
+  // eslint-disable-next-line no-var
+  var IS_REACT_ACT_ENVIRONMENT: boolean;
+}
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+function SetEmbedState({ hideGlobalSearch }: { hideGlobalSearch: boolean }) {
+  const { setEmbedState } = useEmbedding();
+  React.useEffect(() => {
+    setEmbedState((prev) => ({
+      ...prev,
+      isEmbedded: true,
+      hideGlobalSearch,
+    }));
+  }, [hideGlobalSearch, setEmbedState]);
+  return null;
+}
+
+let root: Root | null = null;
+let container: HTMLDivElement | null = null;
+
+function renderCommand({
+  hideGlobalSearch,
+}: { hideGlobalSearch?: boolean } = {}) {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+  act(() => {
+    root?.render(
+      <EmbeddingProvider>
+        {hideGlobalSearch !== undefined && (
+          <SetEmbedState hideGlobalSearch={hideGlobalSearch} />
+        )}
+        <GlobalSearchCommand />
+      </EmbeddingProvider>,
+    );
+  });
+}
+
+afterEach(() => {
+  act(() => root?.unmount());
+  container?.remove();
+  root = null;
+  container = null;
+});
+
+describe('GlobalSearchCommand', () => {
+  it('renders the search trigger outside embed mode', () => {
+    renderCommand();
+    expect(container?.querySelector('button')).not.toBeNull();
+  });
+
+  it('renders the search trigger in embed mode when hideGlobalSearch is off', () => {
+    renderCommand({ hideGlobalSearch: false });
+    expect(container?.querySelector('button')).not.toBeNull();
+  });
+
+  it('renders nothing when hideGlobalSearch is set', () => {
+    renderCommand({ hideGlobalSearch: true });
+    expect(container?.querySelector('button')).toBeNull();
+  });
+});

--- a/packages/web/test/app/components/global-search/global-search-context.test.tsx
+++ b/packages/web/test/app/components/global-search/global-search-context.test.tsx
@@ -1,0 +1,164 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Regression test for https://github.com/activepieces/activepieces/issues/13555
+ * (GIT-1530): in embed mode, hosts can hide every navigation surface, but the
+ * global search palette still opened via CMD+K / Ctrl+K and let users navigate
+ * to any page, flow, or table on their own. When the embedding state sets
+ * `hideGlobalSearch`, the provider must neither register the keyboard shortcut
+ * nor render the palette dialog at all.
+ *
+ * This file uses raw `react-dom` + React's `act` rather than
+ * @testing-library/react (which is not a dependency of this package), so the
+ * testing-library lint rules that assume that library do not apply.
+ */
+/* eslint-disable testing-library/no-unnecessary-act */
+import * as React from 'react';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('i18next', () => ({ t: (key: string) => key }));
+
+vi.mock('lucide-react', () => ({
+  CornerDownLeft: () => null,
+  X: () => null,
+}));
+
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => vi.fn(),
+}));
+
+vi.mock('@/components/ui/command', () => ({
+  CommandDialog: ({
+    open,
+    children,
+  }: React.PropsWithChildren<{ open: boolean }>) =>
+    open ? <div data-testid="global-search-dialog">{children}</div> : null,
+  CommandGroup: ({ children }: React.PropsWithChildren) => (
+    <div>{children}</div>
+  ),
+  CommandInput: () => <input />,
+  CommandItem: ({ children }: React.PropsWithChildren) => <div>{children}</div>,
+  CommandList: ({ children }: React.PropsWithChildren) => <div>{children}</div>,
+  CommandSeparator: () => null,
+}));
+
+vi.mock('@/features/projects', () => ({
+  projectCollectionUtils: { setCurrentProject: vi.fn() },
+}));
+
+vi.mock('@/app/components/global-search/use-global-search-results', () => ({
+  useGlobalSearchResults: () => ({ groups: [], isLoading: false }),
+}));
+
+vi.mock('@/app/components/global-search/search-result-item', () => ({
+  SearchResultRow: () => null,
+}));
+
+vi.mock('@/app/components/global-search/access-history', () => ({
+  recordAccess: vi.fn(),
+}));
+
+import { GlobalSearchProvider } from '@/app/components/global-search/global-search-context';
+import {
+  EmbeddingProvider,
+  useEmbedding,
+} from '@/components/providers/embed-provider';
+
+declare global {
+  // Tells React the test wraps updates in act(); see React's act() docs.
+  // eslint-disable-next-line no-var
+  var IS_REACT_ACT_ENVIRONMENT: boolean;
+}
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+function SetEmbedState({ hideGlobalSearch }: { hideGlobalSearch: boolean }) {
+  const { setEmbedState } = useEmbedding();
+  React.useEffect(() => {
+    setEmbedState((prev) => ({
+      ...prev,
+      isEmbedded: true,
+      hideGlobalSearch,
+    }));
+  }, [hideGlobalSearch, setEmbedState]);
+  return null;
+}
+
+let root: Root | null = null;
+let container: HTMLDivElement | null = null;
+
+function renderProvider({
+  hideGlobalSearch,
+}: { hideGlobalSearch?: boolean } = {}) {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+  act(() => {
+    root?.render(
+      <EmbeddingProvider>
+        {hideGlobalSearch !== undefined && (
+          <SetEmbedState hideGlobalSearch={hideGlobalSearch} />
+        )}
+        <GlobalSearchProvider>
+          <div />
+        </GlobalSearchProvider>
+      </EmbeddingProvider>,
+    );
+  });
+}
+
+function pressSearchShortcut(modifier: 'metaKey' | 'ctrlKey') {
+  act(() => {
+    document.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'k', [modifier]: true }),
+    );
+  });
+}
+
+function findDialog() {
+  return document.querySelector('[data-testid="global-search-dialog"]');
+}
+
+afterEach(() => {
+  act(() => root?.unmount());
+  container?.remove();
+  root = null;
+  container = null;
+});
+
+describe('GlobalSearchProvider', () => {
+  it('opens the palette on CMD+K outside embed mode', () => {
+    renderProvider();
+    expect(findDialog()).toBeNull();
+
+    pressSearchShortcut('metaKey');
+
+    expect(findDialog()).not.toBeNull();
+  });
+
+  it('keeps the palette available in embed mode when hideGlobalSearch is off', () => {
+    renderProvider({ hideGlobalSearch: false });
+
+    pressSearchShortcut('metaKey');
+
+    expect(findDialog()).not.toBeNull();
+  });
+
+  it('ignores CMD+K when hideGlobalSearch is set', () => {
+    renderProvider({ hideGlobalSearch: true });
+
+    pressSearchShortcut('metaKey');
+
+    expect(findDialog()).toBeNull();
+  });
+
+  it('ignores Ctrl+K when hideGlobalSearch is set', () => {
+    renderProvider({ hideGlobalSearch: true });
+
+    pressSearchShortcut('ctrlKey');
+
+    expect(findDialog()).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

In embed mode, hosts can hide navigation surfaces (sidebar, folders, page header, builder navigation) to fully control navigation — but the global search command palette still opened via `CMD+K` / `Ctrl+K`, letting embedded users navigate to any page, flow, or table on their own.

This adds an `embedding.hideGlobalSearch` parameter to the embed SDK's `configure` method (default `false`), wired through `VENDOR_INIT` into the frontend `EmbeddingState`, following the existing `[Embed] Hide X` pattern. When set:

- `GlobalSearchProvider` does not register the `CMD+K` / `Ctrl+K` keydown listener and does not mount the palette dialog at all
- the `GlobalSearchCommand` trigger button in the dashboard sidebar is hidden

## Changes

- `packages/ee/embed-sdk`: `hideGlobalSearch` on `EmbeddingParam` (top level — the palette works in both dashboard and builder, like `hideFolders`/`hideTables`) and `ActivepiecesVendorInit`; version `0.12.0` → `0.13.0`
- `packages/web`: flag on `EmbeddingState` (default `false`) + `VENDOR_INIT` wiring; gating in `global-search-context.tsx` and `global-search-command.tsx`
- `docs/embedding`: SDK changelog entry (0.13.0), configure-parameters table row, and bumped the quickstart snippet SDK URL (was still `0.9.0.js`, which silently ignores newer params)

## Test plan

- [x] 7 new vitest component tests (`packages/web/test/app/components/global-search/`): CMD+K/Ctrl+K ignored + dialog not mounted when the flag is set, palette unaffected outside embed mode and when the flag is off; trigger button hidden only when the flag is set
- [x] `ee-embed-sdk`: tsc build, webpack bundle, eslint — clean
- [x] `web`: eslint clean; full vitest suite — only pre-existing failures (reproduced on pristine `origin/main`)
- [x] Old SDK ↔ new frontend: missing param defaults to `false` (no behavior change); new SDK ↔ old frontend: unknown field ignored

Closes #13555