### PR TITLE
fix(release): align PR labels with release-drafter categories

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -14,9 +14,11 @@ categories:
   - title: "✨ Exciting New Features"
     labels:
       - "🌟 feature"
+      - "feature"
   - title: "🐞 Bug Fixes"
     labels:
       - "🐛 bug"
+      - "bug"
   - title: "🎨 Enhancements & Polish"
     labels:
       - "✨ polishing"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,12 +89,12 @@ When running in `--mode=cloud`, do not use OAuth2 connections — the OAuth prov
 ## Pull Requests
 
 - When creating a PR with `gh pr create`, always apply exactly one of these labels based on the nature of the change:
-  - **`feature`** — new functionality
-  - **`bug`** — bug fix
+  - **`🌟 feature`** — new functionality
+  - **`🐛 bug`** — bug fix
   - **`skip-changelog`** — changes that should not appear in the changelog (docs, CI tweaks, internal refactors, etc.)
 - If the PR includes any contributions to pieces (integrations under `packages/pieces`), also add the appropriate pieces label (in addition to the primary label above):
-  - **`area/third-party-pieces`** — for third-party integrations (most pieces under `packages/pieces/community/`)
-  - **`area/core-pieces`** — for core pieces (under `packages/pieces/core/`)
+  - **`🧩 area/third-party-pieces`** — for third-party integrations (most pieces under `packages/pieces/community/`)
+  - **`🧩 area/core-pieces`** — for core pieces (under `packages/pieces/core/`)
 
 ## Database Migrations
 


### PR DESCRIPTION
## Problem

Release notes are drafted by [release-drafter.yml](.github/release-drafter.yml) from the **emoji** labels (\`🌟 feature\`, \`🐛 bug\`). But \`AGENTS.md\`/\`CLAUDE.md\` instructed contributors and the ticket-to-PR bot to apply the **plain** \`feature\` / \`bug\` labels — so those PRs fell through and never showed up in the changelog. The same drift existed on the area labels (\`area/third-party-pieces\` vs the real \`🧩 area/third-party-pieces\`).

## Fix

- Point the AGENTS.md PR-label guidance at the canonical emoji labels (\`🌟 feature\`, \`🐛 bug\`, \`🧩 area/*\`).
- As a bridge for PRs already tagged with the plain labels, also accept \`bug\`/\`feature\` in release-drafter categories.

## Follow-up (not in this PR)

Once the already-plain-labeled PRs age out of the release notes, revert the release-drafter bridge and \`gh label delete bug feature\` to remove the duplicates for good.

## Testing

release-drafter runs on push to the default branch and updates the draft release. It can't be exercised from a feature branch directly — verify after merge by confirming the next draft release picks up emoji-labeled PRs. This PR is docs/config only (\`skip-changelog\`), so it won't itself appear in the notes.