### PR TITLE
fix(server): revert dev seed user name back to Dev User

### DIFF
--- a/packages/server/api/src/app/database/seeds/dev-seeds.ts
+++ b/packages/server/api/src/app/database/seeds/dev-seeds.ts
@@ -38,7 +38,7 @@ const seedDevUser = async (): Promise<void> => {
     const response = await authenticationService(log).signUp({
         email: DEV_EMAIL,
         password: DEV_PASSWORD,
-        firstName: 'Ash',
+        firstName: 'Dev',
         lastName: 'User',
         trackEvents: false,
         platformId: null,


### PR DESCRIPTION
## What
Reverts the seeded dev user's `firstName` from `Ash` back to `Dev`, so the dev-mode display name is "Dev User" again.

## Why
Commit e39058be45 (PR #13933, chat runtime server) accidentally changed the dev seed `firstName` from `Dev` to `Ash`. This is a local dev-only seed and had no reason to change.

Note: the seed only runs on a fresh DB (gated by the `DEV_DATA_SEEDED` flag), so existing local DBs are unaffected.