### PR TITLE
fix(pieces): image-helper and scrapeless updates never reach cloud because their bundles crash on load

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "activepieces",
@@ -404,7 +405,7 @@
     },
     "packages/core/shared": {
       "name": "@activepieces/shared",
-      "version": "0.113.1",
+      "version": "0.115.1",
       "dependencies": {
         "@activepieces/core-execution": "workspace:*",
         "@activepieces/core-formula": "workspace:*",
@@ -442,7 +443,7 @@
     },
     "packages/ee/embed-sdk": {
       "name": "ee-embed-sdk",
-      "version": "0.11.0",
+      "version": "0.12.0",
       "dependencies": {
         "tslib": "2.6.2",
       },
@@ -491,7 +492,7 @@
     },
     "packages/pieces/community/actualbudget": {
       "name": "@activepieces/piece-actualbudget",
-      "version": "0.1.6",
+      "version": "0.1.7",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -2084,7 +2085,7 @@
     },
     "packages/pieces/community/clarifai": {
       "name": "@activepieces/piece-clarifai",
-      "version": "0.3.6",
+      "version": "0.3.7",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -7222,7 +7223,7 @@
     },
     "packages/pieces/community/postgres": {
       "name": "@activepieces/piece-postgres",
-      "version": "0.2.5",
+      "version": "0.2.6",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -8037,13 +8038,15 @@
     },
     "packages/pieces/community/scrapeless": {
       "name": "@activepieces/piece-scrapeless",
-      "version": "0.1.6",
+      "version": "0.1.7",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
         "@activepieces/pieces-common": "workspace:*",
         "@activepieces/pieces-framework": "workspace:*",
         "@scrapeless-ai/sdk": "1.5.1",
+        "playwright-core": "^1.52.0",
+        "puppeteer-core": "^24.9.0",
       },
       "devDependencies": {
         "tslib": "2.6.2",
@@ -10293,7 +10296,7 @@
     },
     "packages/pieces/community/zoom": {
       "name": "@activepieces/piece-zoom",
-      "version": "0.6.5",
+      "version": "0.7.0",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -10503,7 +10506,7 @@
     },
     "packages/pieces/core/image-helper": {
       "name": "@activepieces/piece-image-helper",
-      "version": "0.1.14",
+      "version": "0.1.15",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",

--- a/packages/cli/src/lib/utils/bundle-piece-utils.ts
+++ b/packages/cli/src/lib/utils/bundle-piece-utils.ts
@@ -283,6 +283,7 @@ const NATIVE_EXTERNALS = new Set<string>([
     'pg-native', 'mongodb-client-encryption', 'kerberos',
     'snappy', 'aws4', 'bson-ext', '@mongodb-js/zstd',
     'playwright', 'playwright-core', 'puppeteer', 'puppeteer-core',
+    'sharp',
     // native-backed SDK (pulls better-sqlite3), and packages that load sibling files at runtime:
     // pg-format → require(__dirname + '/reserved.js'); clarifai-nodejs-grpc → loadSync('*.proto').
     '@actual-app/api', 'pg-format', 'clarifai-nodejs-grpc',

--- a/packages/pieces/community/scrapeless/package.json
+++ b/packages/pieces/community/scrapeless/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-scrapeless",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
@@ -9,7 +9,9 @@
     "@activepieces/pieces-framework": "workspace:*",
     "@scrapeless-ai/sdk": "1.5.1",
     "@activepieces/core-piece-types": "workspace:*",
-    "@activepieces/core-utils": "workspace:*"
+    "@activepieces/core-utils": "workspace:*",
+    "puppeteer-core": "^24.9.0",
+    "playwright-core": "^1.52.0"
   },
   "devDependencies": {
     "tslib": "2.6.2"

--- a/packages/pieces/core/image-helper/package.json
+++ b/packages/pieces/core/image-helper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-image-helper",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "dependencies": {

--- a/tools/scripts/pieces/update-pieces-metadata.ts
+++ b/tools/scripts/pieces/update-pieces-metadata.ts
@@ -60,8 +60,15 @@ const insertMetadata = async (piecesMetadata: PieceMetadata[]) => {
 const main = async () => {
   console.log('update pieces metadata: started')
 
-  const piecesMetadata = await findNewPieces()
-  await insertMetadata(piecesMetadata)
+  const { pieces, failures } = await findNewPieces()
+  await insertMetadata(pieces)
+
+  if (failures.length > 0) {
+    for (const failure of failures) {
+      console.error(`[updatePiecesMetadata] failed to load piece at ${failure.path}: ${failure.error}`)
+    }
+    process.exit(1)
+  }
 
   console.log('update pieces metadata: completed')
   process.exit()

--- a/tools/scripts/utils/piece-script-utils.ts
+++ b/tools/scripts/utils/piece-script-utils.ts
@@ -110,7 +110,8 @@ export async function findNewPieces(): Promise<FindNewPiecesResult> {
             }
             const result = await tryCatch(() => loadPieceFromFolder(folderPath))
             if (result.error !== null) {
-                const failure: PieceLoadFailure = { path: folderPath, error: result.error.message }
+                const message = result.error instanceof Error ? result.error.message : String(result.error)
+                const failure: PieceLoadFailure = { path: folderPath, error: message }
                 return failure
             }
             return result.data

--- a/tools/scripts/utils/piece-script-utils.ts
+++ b/tools/scripts/utils/piece-script-utils.ts
@@ -5,6 +5,7 @@ import { readdir, stat } from 'node:fs/promises'
 import { resolve, join, relative } from 'node:path'
 import { cwd } from 'node:process'
 import * as semver from 'semver'
+import { tryCatch } from '@activepieces/core-utils'
 import { readPackageJson } from './files'
 import { StatusCodes } from 'http-status-codes'
 import { pieceTranslation, PieceMetadata } from '@activepieces/pieces-framework'
@@ -51,12 +52,6 @@ const validateMetadata = (pieceMetadata: PieceMetadata): void => {
 }
 
 
-const byDisplayNameIgnoreCase = (a: PieceMetadata, b: PieceMetadata) => {
-    const aName = a.displayName.toUpperCase();
-    const bName = b.displayName.toUpperCase();
-    return aName.localeCompare(bName, 'en');
-};
-
 export function getCommunityPieceFolder(pieceName: string): string {
     return join(COMMUNITY_PIECE_FOLDER, pieceName)
 }
@@ -91,13 +86,14 @@ export const pieceMetadataExists = async (
     return pieceExist[cloudResponse.status];
 };
 
-export async function findNewPieces(): Promise<PieceMetadata[]> {
+export async function findNewPieces(): Promise<FindNewPiecesResult> {
     const changedDistPaths = getChangedPiecesDistPaths()
     const paths = changedDistPaths ?? await findAllDistPaths()
 
     console.info(`[findNewPieces] scanning ${paths.length} dist paths${changedDistPaths ? ' (scoped to changed)' : ' (all)'}`)
 
-    const changedPieces: PieceMetadata[] = []
+    const pieces: PieceMetadata[] = []
+    const failures: PieceLoadFailure[] = []
 
     // Adding batches because of memory limit when we have a lot of pieces
     const batchSize = 75
@@ -109,21 +105,31 @@ export async function findNewPieces(): Promise<PieceMetadata[]> {
                 return null;
             }
             const exists = await pieceMetadataExists(packageJson.name, packageJson.version)
-            if (!exists) {
-                try {
-                    return loadPieceFromFolder(folderPath);
-                } catch (ex) {
-                    return null;
-                }
+            if (exists) {
+                return null;
             }
-            return null;
+            const result = await tryCatch(() => loadPieceFromFolder(folderPath))
+            if (result.error !== null) {
+                const failure: PieceLoadFailure = { path: folderPath, error: result.error.message }
+                return failure
+            }
+            return result.data
         }))
 
-        const validResults = batchResults.filter((piece): piece is PieceMetadata => piece !== null)
-        changedPieces.push(...validResults)
+        for (const result of batchResults) {
+            if (result === null) {
+                continue
+            }
+            if ('error' in result) {
+                failures.push(result)
+            }
+            else {
+                pieces.push(result)
+            }
+        }
     }
 
-    return changedPieces;
+    return { pieces, failures };
 }
 
 function getChangedPiecesDistPaths(): string[] | null {
@@ -140,12 +146,6 @@ function getChangedPiecesDistPaths(): string[] | null {
         }
         return exists
     })
-}
-
-export async function findAllPieces(): Promise<PieceMetadata[]> {
-    const paths = await findAllDistPaths()
-    const pieces = await Promise.all(paths.map((p) => loadPieceFromFolder(p)))
-    return pieces.filter((p): p is PieceMetadata => p !== null).sort(byDisplayNameIgnoreCase)
 }
 
 async function findAllDistPaths(): Promise<string[]> {
@@ -183,29 +183,23 @@ async function traverseFolder(folderPath: string): Promise<string[]> {
     return paths
 }
 
-async function loadPieceFromFolder(folderPath: string): Promise<PieceMetadata | null> {
-    try {
-        const packageJson = await readPackageJson(folderPath);
-        const payload = loadPieceViaChildProcess(folderPath);
-        const i18n = await pieceTranslation.initializeI18n(folderPath)
-        const metadata: PieceMetadata = {
-            ...payload.metadata,
-            name: packageJson.name,
-            version: packageJson.version,
-            i18n,
-            authors: payload.authors,
-            directoryPath: folderPath,
-            minimumSupportedRelease: payload.minimumSupportedRelease ?? '0.0.0',
-            maximumSupportedRelease: payload.maximumSupportedRelease ?? '99999.99999.9999',
-        };
+async function loadPieceFromFolder(folderPath: string): Promise<PieceMetadata> {
+    const packageJson = await readPackageJson(folderPath);
+    const payload = loadPieceViaChildProcess(folderPath);
+    const i18n = await pieceTranslation.initializeI18n(folderPath)
+    const metadata: PieceMetadata = {
+        ...payload.metadata,
+        name: packageJson.name,
+        version: packageJson.version,
+        i18n,
+        authors: payload.authors,
+        directoryPath: folderPath,
+        minimumSupportedRelease: payload.minimumSupportedRelease ?? '0.0.0',
+        maximumSupportedRelease: payload.maximumSupportedRelease ?? '99999.99999.9999',
+    };
 
-        validateMetadata(metadata);
-        return metadata;
-    }
-    catch (ex) {
-        console.error(ex)
-    }
-    return null
+    validateMetadata(metadata);
+    return metadata;
 }
 
 function loadPieceViaChildProcess(folderPath: string): LoadedPieceChildPayload {
@@ -215,5 +209,15 @@ function loadPieceViaChildProcess(folderPath: string): LoadedPieceChildPayload {
         maxBuffer: 64 * 1024 * 1024,
     })
     return JSON.parse(stdout) as LoadedPieceChildPayload
+}
+
+export type PieceLoadFailure = {
+    path: string
+    error: string
+}
+
+export type FindNewPiecesResult = {
+    pieces: PieceMetadata[]
+    failures: PieceLoadFailure[]
 }
 


### PR DESCRIPTION
Fixes [GIT-1612](https://linear.app/activepieces/issue/GIT-1612)
Closes #14146

## Problem

1. image-helper 0.1.14 (#13705, adds `sharp`) shipped as a bundle that throws `createRequire(undefined)` at require time: `sharp` is native but missing from `NATIVE_EXTERNALS`, so esbuild inlined it and stubbed `import.meta` as `{}`. Neither gate can catch this class: sharp's `.node` require is runtime-computed, and esbuild suppresses `empty-import-meta` inside node_modules.
2. The `update pieces metadata` CI step crashed loading it, swallowed the error, and exited 0 — npm has 0.1.14, cloud still serves 0.1.13, workflow green since Jul 8. Ref: Pylon 5293.
3. scrapeless 0.1.6 is broken the same way: its externalized deps (`puppeteer-core`, `playwright-core`) are transitive via `@scrapeless-ai/sdk`, and `rewriteManifestForBundle` only writes direct deps into the dist manifest, so the published bundle requires packages it never declares.

## Fix

- `bundle-piece-utils.ts`: add `sharp` to `NATIVE_EXTERNALS`
- image-helper → 0.1.15, scrapeless → 0.1.7 (broken versions are immutable on npm)
- scrapeless: promote `puppeteer-core`/`playwright-core` to direct deps so they land in the dist manifest and resolve in the CI loader
- `piece-script-utils.ts` / `update-pieces-metadata.ts`: piece load failures are collected and the step exits 1 naming each failed piece (healthy pieces still insert first); removed dead `findAllPieces`

Follow-up (not this PR): have the bundler track actually-externalized transitive packages and write them into the dist manifest, so scrapeless-style promotion isn't needed per piece. The fail-loud step de-fangs that class to a named CI failure meanwhile.

## Verification

- Red-first: both pieces' bundles failed to load pre-fix in this worktree (same crash/offset as CI run 29011183584 and the published npm tarballs); post-fix both load via `load-piece-metadata-child.mjs` — image-helper `external=[sharp]`, 7 actions incl. `convert_image_format`; scrapeless `external=[puppeteer-core, playwright-core]`, dist deps pinned
- Fail-loud driven end to end: broken fixture piece → step exits 1 naming it; registered/no-op path still exits 0
- `npm run lint-dev` clean; `npm run test-unit` — only the 8 pre-existing web failures already on main (schema/output-viewer utils), untouched by this diff
- Regression test: not applicable — no test harness for `tools/scripts`; behavior verified by executing the real pipeline steps (red → green) as above
- Visual: n/a (no UI surface)
