### PR TITLE
fix(triggers): forward context in polling triggers so republish preserves checkpoint

### DIFF
--- a/packages/pieces/community/agentx/package.json
+++ b/packages/pieces/community/agentx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-agentx",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/packages/pieces/community/agentx/src/lib/triggers/new-agent.ts
+++ b/packages/pieces/community/agentx/src/lib/triggers/new-agent.ts
@@ -51,13 +51,11 @@ export const newAgent = createTrigger({
   },
 
   async onEnable(context) {
-    const { store, auth, propsValue } = context;
-    await pollingHelper.onEnable(polling, { store, auth, propsValue });
+    await pollingHelper.onEnable(polling, context);
   },
 
   async onDisable(context) {
-    const { store, auth, propsValue } = context;
-    await pollingHelper.onDisable(polling, { store, auth, propsValue });
+    await pollingHelper.onDisable(polling, context);
   },
 
   async run(context) {

--- a/packages/pieces/community/amazon-s3/package.json
+++ b/packages/pieces/community/amazon-s3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-amazon-s3",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "dependencies": {

--- a/packages/pieces/community/amazon-s3/src/lib/triggers/new-file.ts
+++ b/packages/pieces/community/amazon-s3/src/lib/triggers/new-file.ts
@@ -44,18 +44,10 @@ export const newFile = createTrigger({
   },
   type: TriggerStrategy.POLLING,
   onEnable: async (context) => {
-    await pollingHelper.onEnable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onEnable(polling, context);
   },
   onDisable: async (context) => {
-    await pollingHelper.onDisable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onDisable(polling, context);
   },
   run: async (context) => {
     return pollingHelper.poll(polling, {

--- a/packages/pieces/community/apitable/package.json
+++ b/packages/pieces/community/apitable/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-apitable",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {

--- a/packages/pieces/community/apitable/src/lib/triggers/new-record.ts
+++ b/packages/pieces/community/apitable/src/lib/triggers/new-record.ts
@@ -71,18 +71,10 @@ export const newRecordTrigger = createTrigger({
     });
   },
   async onEnable(context) {
-    await pollingHelper.onEnable(polling, {
-      store: context.store,
-      auth: context.auth,
-      propsValue: { datasheet_id: context.propsValue.datasheet_id },
-    });
+    await pollingHelper.onEnable(polling, context);
   },
   async onDisable(context) {
-    await pollingHelper.onDisable(polling, {
-      store: context.store,
-      auth: context.auth,
-      propsValue: { datasheet_id: context.propsValue.datasheet_id },
-    });
+    await pollingHelper.onDisable(polling, context);
   },
   async run(context) {
     return await pollingHelper.poll(polling, {

--- a/packages/pieces/community/apitable/src/lib/triggers/new-record.ts
+++ b/packages/pieces/community/apitable/src/lib/triggers/new-record.ts
@@ -71,10 +71,19 @@ export const newRecordTrigger = createTrigger({
     });
   },
   async onEnable(context) {
-    await pollingHelper.onEnable(polling, context);
+    await pollingHelper.onEnable(polling, {
+      store: context.store,
+      auth: context.auth,
+      propsValue: { datasheet_id: context.propsValue.datasheet_id },
+      isRepublish: context.isRepublish,
+    });
   },
   async onDisable(context) {
-    await pollingHelper.onDisable(polling, context);
+    await pollingHelper.onDisable(polling, {
+      store: context.store,
+      auth: context.auth,
+      propsValue: { datasheet_id: context.propsValue.datasheet_id },
+    });
   },
   async run(context) {
     return await pollingHelper.poll(polling, {

--- a/packages/pieces/community/autocalls/package.json
+++ b/packages/pieces/community/autocalls/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-autocalls",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {

--- a/packages/pieces/community/autocalls/src/lib/triggers/get-assistants.ts
+++ b/packages/pieces/community/autocalls/src/lib/triggers/get-assistants.ts
@@ -100,12 +100,10 @@ async test(context) {
     return await pollingHelper.test(polling, context);
 },
 async onEnable(context) {
-    const { store, auth, propsValue } = context;
-    await pollingHelper.onEnable(polling, { store, auth, propsValue });
+    await pollingHelper.onEnable(polling, context);
 },
 async onDisable(context) {
-    const { store, auth, propsValue } = context;
-    await pollingHelper.onDisable(polling, { store, auth, propsValue });
+    await pollingHelper.onDisable(polling, context);
 },
 async run(context) {
     return await pollingHelper.poll(polling, context);

--- a/packages/pieces/community/azure-ad/package.json
+++ b/packages/pieces/community/azure-ad/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-azure-ad",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/packages/pieces/community/azure-ad/src/lib/triggers/new-group.ts
+++ b/packages/pieces/community/azure-ad/src/lib/triggers/new-group.ts
@@ -36,18 +36,10 @@ export const newGroupTrigger = createTrigger({
     id: '2ff8f722-0191-4c16-a378-a8fb4efec110',
   },
   async onEnable(context) {
-    await pollingHelper.onEnable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onEnable(polling, context);
   },
   async onDisable(context) {
-    await pollingHelper.onDisable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onDisable(polling, context);
     await context.store.delete(STORE_KEY);
   },
   async test(context) {

--- a/packages/pieces/community/azure-ad/src/lib/triggers/new-user.ts
+++ b/packages/pieces/community/azure-ad/src/lib/triggers/new-user.ts
@@ -35,18 +35,10 @@ export const newUserTrigger = createTrigger({
         createdDateTime: '2026-04-22T10:15:30Z',
     },
     async onEnable(context) {
-        await pollingHelper.onEnable(polling, {
-            auth: context.auth,
-            store: context.store,
-            propsValue: context.propsValue,
-        });
+        await pollingHelper.onEnable(polling, context);
     },
     async onDisable(context) {
-        await pollingHelper.onDisable(polling, {
-            auth: context.auth,
-            store: context.store,
-            propsValue: context.propsValue,
-        });
+        await pollingHelper.onDisable(polling, context);
         await context.store.delete(STORE_KEY);
     },
     async test(context) {

--- a/packages/pieces/community/backblaze/package.json
+++ b/packages/pieces/community/backblaze/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-backblaze",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {

--- a/packages/pieces/community/backblaze/src/lib/triggers/new-file.ts
+++ b/packages/pieces/community/backblaze/src/lib/triggers/new-file.ts
@@ -58,18 +58,10 @@ export const newBackBlazeFileTrigger = createTrigger({
   },
   type: TriggerStrategy.POLLING,
   onEnable: async (context) => {
-    await pollingHelper.onEnable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onEnable(polling, context);
   },
   onDisable: async (context) => {
-    await pollingHelper.onDisable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onDisable(polling, context);
   },
   run: async (context) => {
     return await pollingHelper.poll(polling, {

--- a/packages/pieces/community/base44/package.json
+++ b/packages/pieces/community/base44/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-base44",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/packages/pieces/community/base44/src/lib/triggers/entity-event.ts
+++ b/packages/pieces/community/base44/src/lib/triggers/entity-event.ts
@@ -117,18 +117,10 @@ export const entityEvent = createTrigger({
     });
   },
   async onEnable(ctx) {
-    await pollingHelper.onEnable(polling, {
-      auth: ctx.auth,
-      store: ctx.store,
-      propsValue: ctx.propsValue,
-    });
+    await pollingHelper.onEnable(polling, ctx);
   },
   async onDisable(ctx) {
-    await pollingHelper.onDisable(polling, {
-      auth: ctx.auth,
-      store: ctx.store,
-      propsValue: ctx.propsValue,
-    });
+    await pollingHelper.onDisable(polling, ctx);
   },
   async run(ctx) {
     return await pollingHelper.poll(polling, {

--- a/packages/pieces/community/bexio/package.json
+++ b/packages/pieces/community/bexio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-bexio",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/packages/pieces/community/bexio/src/lib/triggers/new-order.ts
+++ b/packages/pieces/community/bexio/src/lib/triggers/new-order.ts
@@ -151,18 +151,10 @@ export const newOrderTrigger = createTrigger({
     updated_at: '2019-04-08 13:17:32',
   },
   onEnable: async (context) => {
-    await pollingHelper.onEnable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onEnable(polling, context);
   },
   onDisable: async (context) => {
-    await pollingHelper.onDisable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onDisable(polling, context);
   },
   test: async (context) => {
     return await pollingHelper.test(polling, {

--- a/packages/pieces/community/bexio/src/lib/triggers/new-product.ts
+++ b/packages/pieces/community/bexio/src/lib/triggers/new-product.ts
@@ -121,18 +121,10 @@ export const newProductTrigger = createTrigger({
     expense_account_id: null,
   },
   onEnable: async (context) => {
-    await pollingHelper.onEnable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onEnable(polling, context);
   },
   onDisable: async (context) => {
-    await pollingHelper.onDisable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onDisable(polling, context);
   },
   test: async (context) => {
     return await pollingHelper.test(polling, {

--- a/packages/pieces/community/bexio/src/lib/triggers/new-project.ts
+++ b/packages/pieces/community/bexio/src/lib/triggers/new-project.ts
@@ -132,18 +132,10 @@ export const newProjectTrigger = createTrigger({
     user_id: 1,
   },
   onEnable: async (context) => {
-    await pollingHelper.onEnable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onEnable(polling, context);
   },
   onDisable: async (context) => {
-    await pollingHelper.onDisable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onDisable(polling, context);
   },
   test: async (context) => {
     return await pollingHelper.test(polling, {

--- a/packages/pieces/community/bexio/src/lib/triggers/new-quote.ts
+++ b/packages/pieces/community/bexio/src/lib/triggers/new-quote.ts
@@ -153,18 +153,10 @@ export const newQuoteTrigger = createTrigger({
     updated_at: '2019-04-08 13:17:32',
   },
   onEnable: async (context) => {
-    await pollingHelper.onEnable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onEnable(polling, context);
   },
   onDisable: async (context) => {
-    await pollingHelper.onDisable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onDisable(polling, context);
   },
   test: async (context) => {
     return await pollingHelper.test(polling, {

--- a/packages/pieces/community/bexio/src/lib/triggers/new-sales-invoice.ts
+++ b/packages/pieces/community/bexio/src/lib/triggers/new-sales-invoice.ts
@@ -153,18 +153,10 @@ export const newSalesInvoiceTrigger = createTrigger({
     updated_at: '2019-04-08 13:17:32',
   },
   onEnable: async (context) => {
-    await pollingHelper.onEnable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onEnable(polling, context);
   },
   onDisable: async (context) => {
-    await pollingHelper.onDisable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onDisable(polling, context);
   },
   test: async (context) => {
     return await pollingHelper.test(polling, {

--- a/packages/pieces/community/bexio/src/lib/triggers/new-updated-company.ts
+++ b/packages/pieces/community/bexio/src/lib/triggers/new-updated-company.ts
@@ -128,18 +128,10 @@ export const newUpdatedCompanyTrigger = createTrigger({
     updated_at: '2019-04-08 13:17:32',
   },
   onEnable: async (context) => {
-    await pollingHelper.onEnable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onEnable(polling, context);
   },
   onDisable: async (context) => {
-    await pollingHelper.onDisable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onDisable(polling, context);
   },
   test: async (context) => {
     return await pollingHelper.test(polling, {

--- a/packages/pieces/community/bexio/src/lib/triggers/new-updated-person.ts
+++ b/packages/pieces/community/bexio/src/lib/triggers/new-updated-person.ts
@@ -128,18 +128,10 @@ export const newUpdatedPersonTrigger = createTrigger({
     updated_at: '2019-04-08 13:17:32',
   },
   onEnable: async (context) => {
-    await pollingHelper.onEnable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onEnable(polling, context);
   },
   onDisable: async (context) => {
-    await pollingHelper.onDisable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onDisable(polling, context);
   },
   test: async (context) => {
     return await pollingHelper.test(polling, {

--- a/packages/pieces/community/bluesky/package.json
+++ b/packages/pieces/community/bluesky/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-bluesky",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/packages/pieces/community/bluesky/src/lib/triggers/new-follower-on-account.ts
+++ b/packages/pieces/community/bluesky/src/lib/triggers/new-follower-on-account.ts
@@ -97,13 +97,11 @@ export const newFollowerOnAccount = createTrigger({
   },
   
   async onEnable(context) {
-    const { store, auth, propsValue } = context;
-    await pollingHelper.onEnable(polling, { store, auth, propsValue });
+    await pollingHelper.onEnable(polling, context);
   },
 
   async onDisable(context) {
-    const { store, auth, propsValue } = context;
-    await pollingHelper.onDisable(polling, { store, auth, propsValue });
+    await pollingHelper.onDisable(polling, context);
   },
 
   async run(context) {

--- a/packages/pieces/community/bluesky/src/lib/triggers/new-post.ts
+++ b/packages/pieces/community/bluesky/src/lib/triggers/new-post.ts
@@ -210,13 +210,11 @@ export const newPost = createTrigger({
   },
   
   async onEnable(context) {
-    const { store, auth, propsValue } = context;
-    await pollingHelper.onEnable(polling, { store, auth, propsValue });
+    await pollingHelper.onEnable(polling, context);
   },
 
   async onDisable(context) {
-    const { store, auth, propsValue } = context;
-    await pollingHelper.onDisable(polling, { store, auth, propsValue });
+    await pollingHelper.onDisable(polling, context);
   },
 
   async run(context) {

--- a/packages/pieces/community/bluesky/src/lib/triggers/new-posts-by-author.ts
+++ b/packages/pieces/community/bluesky/src/lib/triggers/new-posts-by-author.ts
@@ -237,13 +237,11 @@ export const newPostsByAuthor = createTrigger({
   },
   
   async onEnable(context) {
-    const { store, auth, propsValue } = context;
-    await pollingHelper.onEnable(polling, { store, auth, propsValue });
+    await pollingHelper.onEnable(polling, context);
   },
 
   async onDisable(context) {
-    const { store, auth, propsValue } = context;
-    await pollingHelper.onDisable(polling, { store, auth, propsValue });
+    await pollingHelper.onDisable(polling, context);
   },
 
   async run(context) {

--- a/packages/pieces/community/bluesky/src/lib/triggers/new-timeline-posts.ts
+++ b/packages/pieces/community/bluesky/src/lib/triggers/new-timeline-posts.ts
@@ -126,13 +126,11 @@ export const newTimelinePosts = createTrigger({
   },
   
   async onEnable(context) {
-    const { store, auth, propsValue } = context;
-    await pollingHelper.onEnable(polling, { store, auth, propsValue });
+    await pollingHelper.onEnable(polling, context);
   },
 
   async onDisable(context) {
-    const { store, auth, propsValue } = context;
-    await pollingHelper.onDisable(polling, { store, auth, propsValue });
+    await pollingHelper.onDisable(polling, context);
   },
 
   async run(context) {

--- a/packages/pieces/community/buffer/package.json
+++ b/packages/pieces/community/buffer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-buffer",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/packages/pieces/community/buffer/src/lib/triggers/new-channel.ts
+++ b/packages/pieces/community/buffer/src/lib/triggers/new-channel.ts
@@ -51,18 +51,10 @@ export const newChannel = createTrigger({
     createdAt: '2026-05-25T10:00:00.000Z',
   } satisfies Channel,
   async onEnable(context) {
-    await pollingHelper.onEnable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onEnable(polling, context);
   },
   async onDisable(context) {
-    await pollingHelper.onDisable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onDisable(polling, context);
   },
   async test(context) {
     return await pollingHelper.test(polling, context);

--- a/packages/pieces/community/buffer/src/lib/triggers/new-queue-item.ts
+++ b/packages/pieces/community/buffer/src/lib/triggers/new-queue-item.ts
@@ -100,18 +100,10 @@ export const newQueueItem = createTrigger({
     tags: [],
   } satisfies BufferPost,
   async onEnable(context) {
-    await pollingHelper.onEnable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onEnable(polling, context);
   },
   async onDisable(context) {
-    await pollingHelper.onDisable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onDisable(polling, context);
   },
   async test(context) {
     return await pollingHelper.test(polling, context);

--- a/packages/pieces/community/buffer/src/lib/triggers/new-sent-item.ts
+++ b/packages/pieces/community/buffer/src/lib/triggers/new-sent-item.ts
@@ -99,18 +99,10 @@ export const newSentItem = createTrigger({
     tags: [],
   } satisfies BufferPost,
   async onEnable(context) {
-    await pollingHelper.onEnable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onEnable(polling, context);
   },
   async onDisable(context) {
-    await pollingHelper.onDisable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onDisable(polling, context);
   },
   async test(context) {
     return await pollingHelper.test(polling, context);

--- a/packages/pieces/community/chatling/package.json
+++ b/packages/pieces/community/chatling/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-chatling",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/packages/pieces/community/chatling/src/lib/triggers/new-contact.ts
+++ b/packages/pieces/community/chatling/src/lib/triggers/new-contact.ts
@@ -71,18 +71,10 @@ export const newContact = createTrigger({
   },
   type: TriggerStrategy.POLLING,
   async onEnable(context) {
-    await pollingHelper.onEnable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onEnable(polling, context);
   },
   async onDisable(context) {
-    await pollingHelper.onDisable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onDisable(polling, context);
   },
   async test(context) {
     return await pollingHelper.test(polling, context);

--- a/packages/pieces/community/chatling/src/lib/triggers/new-conversation.ts
+++ b/packages/pieces/community/chatling/src/lib/triggers/new-conversation.ts
@@ -70,18 +70,10 @@ export const newConversation = createTrigger({
   },
   type: TriggerStrategy.POLLING,
   async onEnable(context) {
-    await pollingHelper.onEnable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onEnable(polling, context);
   },
   async onDisable(context) {
-    await pollingHelper.onDisable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onDisable(polling, context);
   },
   async test(context) {
     return await pollingHelper.test(polling, context);

--- a/packages/pieces/community/circle/package.json
+++ b/packages/pieces/community/circle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-circle",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {

--- a/packages/pieces/community/circle/src/lib/triggers/new-member-added.ts
+++ b/packages/pieces/community/circle/src/lib/triggers/new-member-added.ts
@@ -80,18 +80,10 @@ export const newMemberAdded = createTrigger({
 	props: {},
 	type: TriggerStrategy.POLLING,
 	async onEnable(context) {
-		await pollingHelper.onEnable(polling, {
-			auth: context.auth,
-			store: context.store,
-			propsValue: context.propsValue,
-		});
+		await pollingHelper.onEnable(polling, context);
 	},
 	async onDisable(context) {
-		await pollingHelper.onDisable(polling, {
-			auth: context.auth,
-			store: context.store,
-			propsValue: context.propsValue,
-		});
+		await pollingHelper.onDisable(polling, context);
 	},
 	async test(context) {
 		return await pollingHelper.test(polling, context);

--- a/packages/pieces/community/circle/src/lib/triggers/new-post.ts
+++ b/packages/pieces/community/circle/src/lib/triggers/new-post.ts
@@ -84,18 +84,10 @@ export const newPostCreated = createTrigger({
 	},
 	type: TriggerStrategy.POLLING,
 	async onEnable(context) {
-		await pollingHelper.onEnable(polling, {
-			auth: context.auth,
-			store: context.store,
-			propsValue: context.propsValue,
-		});
+		await pollingHelper.onEnable(polling, context);
 	},
 	async onDisable(context) {
-		await pollingHelper.onDisable(polling, {
-			auth: context.auth,
-			store: context.store,
-			propsValue: context.propsValue,
-		});
+		await pollingHelper.onDisable(polling, context);
 	},
 	async test(context) {
 		return await pollingHelper.test(polling, context);

--- a/packages/pieces/community/clockodo/package.json
+++ b/packages/pieces/community/clockodo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-clockodo",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {

--- a/packages/pieces/community/clockodo/src/lib/triggers/new-absence-enquiry.ts
+++ b/packages/pieces/community/clockodo/src/lib/triggers/new-absence-enquiry.ts
@@ -40,18 +40,10 @@ export default createTrigger({
   props: {},
   sampleData: {},
   onEnable: async (context) => {
-    await pollingHelper.onEnable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onEnable(polling, context);
   },
   onDisable: async (context) => {
-    await pollingHelper.onDisable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onDisable(polling, context);
   },
   run: async (context) => {
     return await pollingHelper.poll(polling, {

--- a/packages/pieces/community/clockodo/src/lib/triggers/new-entry.ts
+++ b/packages/pieces/community/clockodo/src/lib/triggers/new-entry.ts
@@ -49,18 +49,10 @@ export default createTrigger({
   props: {},
   sampleData: {},
   onEnable: async (context) => {
-    await pollingHelper.onEnable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onEnable(polling, context);
   },
   onDisable: async (context) => {
-    await pollingHelper.onDisable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onDisable(polling, context);
   },
   run: async (context) => {
     return await pollingHelper.poll(polling, {

--- a/packages/pieces/community/cloudinary/package.json
+++ b/packages/pieces/community/cloudinary/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-cloudinary",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {

--- a/packages/pieces/community/cloudinary/src/lib/triggers/new-resource.ts
+++ b/packages/pieces/community/cloudinary/src/lib/triggers/new-resource.ts
@@ -70,18 +70,10 @@ export const newResourceInFolder = createTrigger({
   },
   type: TriggerStrategy.POLLING,
   async onEnable(context) {
-    await pollingHelper.onEnable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onEnable(polling, context);
   },
   async onDisable(context) {
-    await pollingHelper.onDisable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onDisable(polling, context);
   },
   async test(context) {
     return await pollingHelper.test(polling, context);

--- a/packages/pieces/community/cloudinary/src/lib/triggers/new-tag-added-to-asset.ts
+++ b/packages/pieces/community/cloudinary/src/lib/triggers/new-tag-added-to-asset.ts
@@ -108,18 +108,10 @@ export const newTagAddedToAsset = createTrigger({
     },
     type: TriggerStrategy.POLLING,
     async onEnable(context) {
-        await pollingHelper.onEnable(polling, {
-            auth: context.auth,
-            store: context.store,
-            propsValue: context.propsValue,
-        });
+        await pollingHelper.onEnable(polling, context);
     },
     async onDisable(context) {
-        await pollingHelper.onDisable(polling, {
-            auth: context.auth,
-            store: context.store,
-            propsValue: context.propsValue,
-        });
+        await pollingHelper.onDisable(polling, context);
     },
     async test(context) {
         return await pollingHelper.test(polling, context);

--- a/packages/pieces/community/coda/package.json
+++ b/packages/pieces/community/coda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-coda",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {

--- a/packages/pieces/community/coda/src/lib/triggers/new-row-created.ts
+++ b/packages/pieces/community/coda/src/lib/triggers/new-row-created.ts
@@ -66,18 +66,10 @@ export const newRowCreatedTrigger = createTrigger({
 	},
 	type: TriggerStrategy.POLLING,
 	async onEnable(context) {
-		await pollingHelper.onEnable(polling, {
-			auth: context.auth,
-			store: context.store,
-			propsValue: context.propsValue,
-		});
+		await pollingHelper.onEnable(polling, context);
 	},
 	async onDisable(context) {
-		await pollingHelper.onDisable(polling, {
-			auth: context.auth,
-			store: context.store,
-			propsValue: context.propsValue,
-		});
+		await pollingHelper.onDisable(polling, context);
 	},
 	async test(context) {
 		return await pollingHelper.test(polling, context);

--- a/packages/pieces/community/comfyicu/package.json
+++ b/packages/pieces/community/comfyicu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-comfyicu",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {

--- a/packages/pieces/community/comfyicu/src/lib/triggers/new-workflow-created.ts
+++ b/packages/pieces/community/comfyicu/src/lib/triggers/new-workflow-created.ts
@@ -25,18 +25,10 @@ export const newWorkflowCreatedTrigger = createTrigger({
   type: TriggerStrategy.POLLING,
   props: {},
   async onEnable(context) {
-    await pollingHelper.onEnable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onEnable(polling, context);
   },
   async onDisable(context) {
-    await pollingHelper.onDisable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onDisable(polling, context);
   },
   async test(context) {
     return await pollingHelper.test(polling, context);

--- a/packages/pieces/community/comfyicu/src/lib/triggers/run-completed.ts
+++ b/packages/pieces/community/comfyicu/src/lib/triggers/run-completed.ts
@@ -69,18 +69,10 @@ export const runCompletedTrigger = createTrigger({
   },
   type: TriggerStrategy.POLLING,
   async onEnable(context) {
-    await pollingHelper.onEnable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onEnable(polling, context);
   },
   async onDisable(context) {
-    await pollingHelper.onDisable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onDisable(polling, context);
   },
   async test(context) {
     return await pollingHelper.test(polling, context);

--- a/packages/pieces/community/comfyicu/src/lib/triggers/run-failed.ts
+++ b/packages/pieces/community/comfyicu/src/lib/triggers/run-failed.ts
@@ -71,18 +71,10 @@ export const runFailedTrigger = createTrigger({
   },
   type: TriggerStrategy.POLLING,
   async onEnable(context) {
-    await pollingHelper.onEnable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onEnable(polling, context);
   },
   async onDisable(context) {
-    await pollingHelper.onDisable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onDisable(polling, context);
   },
   async test(context) {
     return await pollingHelper.test(polling, context);

--- a/packages/pieces/community/contextual-ai/package.json
+++ b/packages/pieces/community/contextual-ai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-contextual-ai",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/packages/pieces/community/contextual-ai/src/lib/triggers/new-agent.ts
+++ b/packages/pieces/community/contextual-ai/src/lib/triggers/new-agent.ts
@@ -53,18 +53,10 @@ export const newAgentTrigger = createTrigger({
     description: 'A sample agent for testing',
   },
   async onEnable(context) {
-    await pollingHelper.onEnable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onEnable(polling, context);
   },
   async onDisable(context) {
-    await pollingHelper.onDisable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onDisable(polling, context);
   },
   async test(context) {
     return await pollingHelper.test(polling, context);

--- a/packages/pieces/community/copper/package.json
+++ b/packages/pieces/community/copper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-copper",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/packages/pieces/community/copper/src/lib/triggers/new-activity.ts
+++ b/packages/pieces/community/copper/src/lib/triggers/new-activity.ts
@@ -66,13 +66,11 @@ export const newActivity = createTrigger({
     return await pollingHelper.test(polling, context);
   },
   async onEnable(context) {
-    const { store, auth, propsValue } = context;
-    await pollingHelper.onEnable(polling, { store, auth, propsValue });
+    await pollingHelper.onEnable(polling, context);
   },
 
   async onDisable(context) {
-    const { store, auth, propsValue } = context;
-    await pollingHelper.onDisable(polling, { store, auth, propsValue });
+    await pollingHelper.onDisable(polling, context);
   },
 
   async run(context) {

--- a/packages/pieces/community/crisp/package.json
+++ b/packages/pieces/community/crisp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-crisp",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/packages/pieces/community/crisp/src/lib/triggers/new-contact.ts
+++ b/packages/pieces/community/crisp/src/lib/triggers/new-contact.ts
@@ -70,18 +70,10 @@ export const newContactTrigger = createTrigger({
 	type: TriggerStrategy.POLLING,
 	sampleData: {},
 	async onEnable(context) {
-		await pollingHelper.onEnable(polling, {
-			auth: context.auth,
-			store: context.store,
-			propsValue: context.propsValue,
-		});
+		await pollingHelper.onEnable(polling, context);
 	},
 	async onDisable(context) {
-		await pollingHelper.onDisable(polling, {
-			auth: context.auth,
-			store: context.store,
-			propsValue: context.propsValue,
-		});
+		await pollingHelper.onDisable(polling, context);
 	},
 	async test(context) {
 		return await pollingHelper.test(polling, context);

--- a/packages/pieces/community/crisp/src/lib/triggers/new-conversation.ts
+++ b/packages/pieces/community/crisp/src/lib/triggers/new-conversation.ts
@@ -68,18 +68,10 @@ export const newConversationTrigger = createTrigger({
 	type: TriggerStrategy.POLLING,
 	sampleData: {},
 	async onEnable(context) {
-		await pollingHelper.onEnable(polling, {
-			auth: context.auth,
-			store: context.store,
-			propsValue: context.propsValue,
-		});
+		await pollingHelper.onEnable(polling, context);
 	},
 	async onDisable(context) {
-		await pollingHelper.onDisable(polling, {
-			auth: context.auth,
-			store: context.store,
-			propsValue: context.propsValue,
-		});
+		await pollingHelper.onDisable(polling, context);
 	},
 	async test(context) {
 		return await pollingHelper.test(polling, context);

--- a/packages/pieces/community/cryptolens/package.json
+++ b/packages/pieces/community/cryptolens/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-cryptolens",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/packages/pieces/community/cryptolens/src/lib/triggers/new-api-event.ts
+++ b/packages/pieces/community/cryptolens/src/lib/triggers/new-api-event.ts
@@ -139,12 +139,10 @@ export const newApiEvent = createTrigger({
     return await pollingHelper.test(polling, context);
   },
   async onEnable(context) {
-    const { store, auth, propsValue } = context;
-    await pollingHelper.onEnable(polling, { store, auth, propsValue });
+    await pollingHelper.onEnable(polling, context);
   },
   async onDisable(context) {
-    const { store, auth, propsValue } = context;
-    await pollingHelper.onDisable(polling, { store, auth, propsValue });
+    await pollingHelper.onDisable(polling, context);
   },
   async run(context) {
     return await pollingHelper.poll(polling, context);

--- a/packages/pieces/community/cursor/package.json
+++ b/packages/pieces/community/cursor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-cursor",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/packages/pieces/community/cursor/src/lib/triggers/agent-pull-request-created.ts
+++ b/packages/pieces/community/cursor/src/lib/triggers/agent-pull-request-created.ts
@@ -115,12 +115,12 @@ export const agentPullRequestCreatedTrigger = createTrigger({
   async onEnable(context) {
     const { store, auth, propsValue } = context;
     await store.put('agents_with_prs', JSON.stringify([]));
-    await pollingHelper.onEnable(polling, { store, auth, propsValue });
+    await pollingHelper.onEnable(polling, context);
   },
   async onDisable(context) {
     const { store, auth, propsValue } = context;
     await store.delete('agents_with_prs');
-    await pollingHelper.onDisable(polling, { store, auth, propsValue });
+    await pollingHelper.onDisable(polling, context);
   },
   async test(context) {
     const { store, auth, propsValue, files } = context;

--- a/packages/pieces/community/cursor/src/lib/triggers/agent-status-equals.ts
+++ b/packages/pieces/community/cursor/src/lib/triggers/agent-status-equals.ts
@@ -125,7 +125,7 @@ export const agentStatusEqualsTrigger = createTrigger({
       await store.put(storeKey, null);
     }
 
-    await pollingHelper.onEnable(polling, { store, auth, propsValue });
+    await pollingHelper.onEnable(polling, context);
   },
   async onDisable(context) {
     const { store, auth, propsValue } = context;
@@ -133,7 +133,7 @@ export const agentStatusEqualsTrigger = createTrigger({
     const storeKey = `agent_status_${agentId}`;
 
     await store.delete(storeKey);
-    await pollingHelper.onDisable(polling, { store, auth, propsValue });
+    await pollingHelper.onDisable(polling, context);
   },
   async test(context) {
     const { store, auth, propsValue, files } = context;

--- a/packages/pieces/community/cursor/src/lib/triggers/new-agent-conversation-message.ts
+++ b/packages/pieces/community/cursor/src/lib/triggers/new-agent-conversation-message.ts
@@ -63,12 +63,10 @@ export const newAgentConversationMessageTrigger = createTrigger({
     text: 'Add a README.md file with installation instructions',
   },
   async onEnable(context) {
-    const { store, auth, propsValue } = context;
-    await pollingHelper.onEnable(polling, { store, auth, propsValue });
+    await pollingHelper.onEnable(polling, context);
   },
   async onDisable(context) {
-    const { store, auth, propsValue } = context;
-    await pollingHelper.onDisable(polling, { store, auth, propsValue });
+    await pollingHelper.onDisable(polling, context);
   },
   async test(context) {
     const { store, auth, propsValue, files } = context;

--- a/packages/pieces/community/cursor/src/lib/triggers/new-agent.ts
+++ b/packages/pieces/community/cursor/src/lib/triggers/new-agent.ts
@@ -95,18 +95,10 @@ export const newAgentTrigger = createTrigger({
     createdAt: '2024-01-15T10:30:00Z',
   },
   onEnable: async (context) => {
-    await pollingHelper.onEnable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onEnable(polling, context);
   },
   onDisable: async (context) => {
-    await pollingHelper.onDisable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onDisable(polling, context);
   },
   test: async (context) => {
     return await pollingHelper.test(polling, {

--- a/packages/pieces/community/discord/package.json
+++ b/packages/pieces/community/discord/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-discord",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {

--- a/packages/pieces/community/discord/src/lib/triggers/new-member.ts
+++ b/packages/pieces/community/discord/src/lib/triggers/new-member.ts
@@ -74,24 +74,10 @@ export const newMember = createTrigger({
   },
   sampleData: {},
   onEnable: async (context) => {
-    await pollingHelper.onEnable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: {
-        guildId: context.propsValue.guildId,
-        limit: context.propsValue.limit ?? 50,
-      },
-    });
+    await pollingHelper.onEnable(polling, context);
   },
   onDisable: async (context) => {
-    await pollingHelper.onDisable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: {
-        guildId: context.propsValue.guildId,
-        limit: context.propsValue.limit ?? 50,
-      },
-    });
+    await pollingHelper.onDisable(polling, context);
   },
   run: async (context) => {
     return await pollingHelper.poll(polling, {

--- a/packages/pieces/community/discord/src/lib/triggers/new-member.ts
+++ b/packages/pieces/community/discord/src/lib/triggers/new-member.ts
@@ -74,10 +74,25 @@ export const newMember = createTrigger({
   },
   sampleData: {},
   onEnable: async (context) => {
-    await pollingHelper.onEnable(polling, context);
+     await pollingHelper.onEnable(polling, {
+      auth: context.auth,
+      store: context.store,
+      propsValue: {
+        guildId: context.propsValue.guildId,
+        limit: context.propsValue.limit ?? 50,
+      },
+      isRepublish:context.isRepublish
+    })
   },
   onDisable: async (context) => {
-    await pollingHelper.onDisable(polling, context);
+    await pollingHelper.onDisable(polling, {
+      auth: context.auth,
+      store: context.store,
+      propsValue: {
+        guildId: context.propsValue.guildId,
+        limit: context.propsValue.limit ?? 50,
+      },
+    });
   },
   run: async (context) => {
     return await pollingHelper.poll(polling, {

--- a/packages/pieces/community/discord/src/lib/triggers/new-message.ts
+++ b/packages/pieces/community/discord/src/lib/triggers/new-message.ts
@@ -66,24 +66,10 @@ export const newMessage = createTrigger({
   },
   sampleData: {},
   onEnable: async (context) => {
-    await pollingHelper.onEnable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: {
-        channel: context.propsValue.channel,
-        limit: context.propsValue.limit ?? 50,
-      },
-    });
+    await pollingHelper.onEnable(polling, context);
   },
   onDisable: async (context) => {
-    await pollingHelper.onDisable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: {
-        channel: context.propsValue.channel,
-        limit: context.propsValue.limit ?? 50,
-      },
-    });
+    await pollingHelper.onDisable(polling, context);
   },
   run: async (context) => {
     return await pollingHelper.poll(polling, {

--- a/packages/pieces/community/discord/src/lib/triggers/new-message.ts
+++ b/packages/pieces/community/discord/src/lib/triggers/new-message.ts
@@ -66,10 +66,25 @@ export const newMessage = createTrigger({
   },
   sampleData: {},
   onEnable: async (context) => {
-    await pollingHelper.onEnable(polling, context);
+     await pollingHelper.onEnable(polling, {
+      auth: context.auth,
+      store: context.store,
+      propsValue: {
+        channel: context.propsValue.channel,
+        limit: context.propsValue.limit ?? 50,
+      },
+      isRepublish:context.isRepublish
+    });
   },
   onDisable: async (context) => {
-    await pollingHelper.onDisable(polling, context);
+     await pollingHelper.onDisable(polling, {
+      auth: context.auth,
+      store: context.store,
+      propsValue: {
+        channel: context.propsValue.channel,
+        limit: context.propsValue.limit ?? 50,
+      },
+    });
   },
   run: async (context) => {
     return await pollingHelper.poll(polling, {

--- a/packages/pieces/community/drupal/package.json
+++ b/packages/pieces/community/drupal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-drupal",
-  "version": "1.1.9",
+  "version": "1.1.10",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/packages/pieces/community/drupal/src/lib/triggers/polling-id.ts
+++ b/packages/pieces/community/drupal/src/lib/triggers/polling-id.ts
@@ -63,12 +63,10 @@ export const drupalPollingId = createTrigger({
     return await pollingHelper.test(polling, { store, auth, propsValue, files });
   },
   async onEnable(context) {
-    const { auth, propsValue, store } = context;
-    await pollingHelper.onEnable(polling, { store, auth, propsValue });
+    await pollingHelper.onEnable(polling, context);
   },
   async onDisable(context) {
-    const { auth, propsValue, store } = context;
-    await pollingHelper.onDisable(polling, { store, auth, propsValue });
+    await pollingHelper.onDisable(polling, context);
   },
   async run(context) {
     const { auth, propsValue, store, files } = context;

--- a/packages/pieces/community/drupal/src/lib/triggers/polling-timestamp.ts
+++ b/packages/pieces/community/drupal/src/lib/triggers/polling-timestamp.ts
@@ -63,12 +63,10 @@ export const drupalPollingTimestamp = createTrigger({
     return await pollingHelper.test(polling, { store, auth, propsValue, files });
   },
   async onEnable(context) {
-    const { auth, propsValue, store } = context;
-    await pollingHelper.onEnable(polling, { store, auth, propsValue });
+    await pollingHelper.onEnable(polling, context);
   },
   async onDisable(context) {
-    const { auth, propsValue, store } = context;
-    await pollingHelper.onDisable(polling, { store, auth, propsValue });
+    await pollingHelper.onDisable(polling, context);
   },
   async run(context) {
     const { auth, propsValue, store, files } = context;

--- a/packages/pieces/community/echowin/package.json
+++ b/packages/pieces/community/echowin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-echowin",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/packages/pieces/community/echowin/src/lib/triggers/new-contact.ts
+++ b/packages/pieces/community/echowin/src/lib/triggers/new-contact.ts
@@ -90,12 +90,10 @@ export const newContact = createTrigger({
     return await pollingHelper.test(polling, context);
   },
   async onEnable(context) {
-    const { store, auth, propsValue } = context;
-    await pollingHelper.onEnable(polling, { store, auth, propsValue });
+    await pollingHelper.onEnable(polling, context);
   },
   async onDisable(context) {
-    const { store, auth, propsValue } = context;
-    await pollingHelper.onDisable(polling, { store, auth, propsValue });
+    await pollingHelper.onDisable(polling, context);
   },
   async run(context) {
     return await pollingHelper.poll(polling, context);

--- a/packages/pieces/community/famulor/package.json
+++ b/packages/pieces/community/famulor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-famulor",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {

--- a/packages/pieces/community/famulor/src/lib/triggers/get-assistants.ts
+++ b/packages/pieces/community/famulor/src/lib/triggers/get-assistants.ts
@@ -101,12 +101,10 @@ async test(context) {
     return await pollingHelper.test(polling, context);
 },
 async onEnable(context) {
-    const { store, auth, propsValue } = context;
-    await pollingHelper.onEnable(polling, { store, auth, propsValue });
+    await pollingHelper.onEnable(polling, context);
 },
 async onDisable(context) {
-    const { store, auth, propsValue } = context;
-    await pollingHelper.onDisable(polling, { store, auth, propsValue });
+    await pollingHelper.onDisable(polling, context);
 },
 async run(context) {
     return await pollingHelper.poll(polling, context);

--- a/packages/pieces/community/fellow/package.json
+++ b/packages/pieces/community/fellow/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-fellow",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/packages/pieces/community/fellow/src/lib/triggers/new-recording.ts
+++ b/packages/pieces/community/fellow/src/lib/triggers/new-recording.ts
@@ -72,18 +72,10 @@ export const newRecordingTrigger = createTrigger({
     type: TriggerStrategy.POLLING,
     props: {},
     async onEnable(context) {
-        await pollingHelper.onEnable(polling, {
-            auth: context.auth,
-            store: context.store,
-            propsValue: context.propsValue,
-        });
+        await pollingHelper.onEnable(polling, context);
     },
     async onDisable(context) {
-        await pollingHelper.onDisable(polling, {
-            auth: context.auth,
-            store: context.store,
-            propsValue: context.propsValue,
-        });
+        await pollingHelper.onDisable(polling, context);
     },
     async test(context) {
         return await pollingHelper.test(polling, context);

--- a/packages/pieces/community/flow-parser/package.json
+++ b/packages/pieces/community/flow-parser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-flow-parser",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/packages/pieces/community/flow-parser/src/lib/triggers/new-parsed-document-by-template.ts
+++ b/packages/pieces/community/flow-parser/src/lib/triggers/new-parsed-document-by-template.ts
@@ -102,12 +102,10 @@ export const newParsedDocumentByTemplate = createTrigger({
     return await pollingHelper.test(polling, { store, auth, propsValue, files });
   },
   async onEnable(context) {
-    const { store, auth, propsValue } = context;
-    await pollingHelper.onEnable(polling, { store, auth, propsValue });
+    await pollingHelper.onEnable(polling, context);
   },
   async onDisable(context) {
-    const { store, auth, propsValue } = context;
-    await pollingHelper.onDisable(polling, { store, auth, propsValue });
+    await pollingHelper.onDisable(polling, context);
   },
   async run(context) {
     const { store, auth, propsValue, files } = context;

--- a/packages/pieces/community/flow-parser/src/lib/triggers/new-parsed-document-found.ts
+++ b/packages/pieces/community/flow-parser/src/lib/triggers/new-parsed-document-found.ts
@@ -86,12 +86,10 @@ export const newParsedDocumentFound = createTrigger({
     return await pollingHelper.test(polling, { store, auth, propsValue, files });
   },
   async onEnable(context) {
-    const { store, auth, propsValue } = context;
-    await pollingHelper.onEnable(polling, { store, auth, propsValue });
+    await pollingHelper.onEnable(polling, context);
   },
   async onDisable(context) {
-    const { store, auth, propsValue } = context;
-    await pollingHelper.onDisable(polling, { store, auth, propsValue });
+    await pollingHelper.onDisable(polling, context);
   },
   async run(context) {
     const { store, auth, propsValue, files } = context;

--- a/packages/pieces/community/foreplay-co/package.json
+++ b/packages/pieces/community/foreplay-co/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-foreplay-co",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/packages/pieces/community/foreplay-co/src/lib/triggers/new-ad-in-board.ts
+++ b/packages/pieces/community/foreplay-co/src/lib/triggers/new-ad-in-board.ts
@@ -131,19 +131,11 @@ export const newAdInBoard = createTrigger({
   },
 
   async onEnable(context) {
-    await pollingHelper.onEnable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onEnable(polling, context);
   },
 
   async onDisable(context) {
-    await pollingHelper.onDisable(polling, {
-      store: context.store,
-      propsValue: context.propsValue,
-      auth: context.auth,
-    });
+    await pollingHelper.onDisable(polling, context);
   },
 
   async run(context) {

--- a/packages/pieces/community/foreplay-co/src/lib/triggers/new-ad-in-spyder.ts
+++ b/packages/pieces/community/foreplay-co/src/lib/triggers/new-ad-in-spyder.ts
@@ -122,19 +122,11 @@ export const newAdInSpyder = createTrigger({
   },
 
   async onEnable(context) {
-    await pollingHelper.onEnable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onEnable(polling, context);
   },
 
   async onDisable(context) {
-    await pollingHelper.onDisable(polling, {
-      store: context.store,
-      propsValue: context.propsValue,
-      auth: context.auth,
-    });
+    await pollingHelper.onDisable(polling, context);
   },
 
   async run(context) {

--- a/packages/pieces/community/foreplay-co/src/lib/triggers/new-swipefile-ad.ts
+++ b/packages/pieces/community/foreplay-co/src/lib/triggers/new-swipefile-ad.ts
@@ -113,19 +113,11 @@ export const newSwipefileAd = createTrigger({
   },
 
   async onEnable(context) {
-    await pollingHelper.onEnable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onEnable(polling, context);
   },
 
   async onDisable(context) {
-    await pollingHelper.onDisable(polling, {
-      store: context.store,
-      propsValue: context.propsValue,
-      auth: context.auth,
-    });
+    await pollingHelper.onDisable(polling, context);
   },
 
   async run(context) {

--- a/packages/pieces/community/formstack/package.json
+++ b/packages/pieces/community/formstack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-formstack",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {

--- a/packages/pieces/community/formstack/src/lib/triggers/new-form.ts
+++ b/packages/pieces/community/formstack/src/lib/triggers/new-form.ts
@@ -152,12 +152,10 @@ export const newForm = createTrigger({
     }
   },
   async onEnable(context) {
-    const { store, auth, propsValue } = context;
-    await pollingHelper.onEnable(polling, { store, auth, propsValue });
+    await pollingHelper.onEnable(polling, context);
   },
   async onDisable(context) {
-    const { store, auth, propsValue } = context;
-    await pollingHelper.onDisable(polling, { store, auth, propsValue });
+    await pollingHelper.onDisable(polling, context);
   },
   async run(context) {
     return await pollingHelper.poll(polling, context);

--- a/packages/pieces/community/formstack/src/lib/triggers/new-submission.ts
+++ b/packages/pieces/community/formstack/src/lib/triggers/new-submission.ts
@@ -251,12 +251,10 @@ export const newSubmission = createTrigger({
     }
   },
   async onEnable(context) {
-    const { store, auth, propsValue } = context;
-    await pollingHelper.onEnable(polling, { store, auth, propsValue });
+    await pollingHelper.onEnable(polling, context);
   },
   async onDisable(context) {
-    const { store, auth, propsValue } = context;
-    await pollingHelper.onDisable(polling, { store, auth, propsValue });
+    await pollingHelper.onDisable(polling, context);
   },
   async run(context) {
     return await pollingHelper.poll(polling, context);

--- a/packages/pieces/community/fragment/package.json
+++ b/packages/pieces/community/fragment/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-fragment",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/packages/pieces/community/fragment/src/lib/triggers/new-task.ts
+++ b/packages/pieces/community/fragment/src/lib/triggers/new-task.ts
@@ -48,18 +48,10 @@ export const newTaskTrigger = createTrigger({
 	type: TriggerStrategy.POLLING,
 
 	async onEnable(context) {
-		await pollingHelper.onEnable(polling, {
-			auth: context.auth,
-			store: context.store,
-			propsValue: context.propsValue,
-		});
+		await pollingHelper.onEnable(polling, context);
 	},
 	async onDisable(context) {
-		await pollingHelper.onDisable(polling, {
-			auth: context.auth,
-			store: context.store,
-			propsValue: context.propsValue,
-		});
+		await pollingHelper.onDisable(polling, context);
 	},
 	async test(context) {
 		return await pollingHelper.test(polling, context);

--- a/packages/pieces/community/fragment/src/lib/triggers/task-updated.ts
+++ b/packages/pieces/community/fragment/src/lib/triggers/task-updated.ts
@@ -48,18 +48,10 @@ export const taskUpdatedTrigger = createTrigger({
 	type: TriggerStrategy.POLLING,
 
 	async onEnable(context) {
-		await pollingHelper.onEnable(polling, {
-			auth: context.auth,
-			store: context.store,
-			propsValue: context.propsValue,
-		});
+		await pollingHelper.onEnable(polling, context);
 	},
 	async onDisable(context) {
-		await pollingHelper.onDisable(polling, {
-			auth: context.auth,
-			store: context.store,
-			propsValue: context.propsValue,
-		});
+		await pollingHelper.onDisable(polling, context);
 	},
 	async test(context) {
 		return await pollingHelper.test(polling, context);

--- a/packages/pieces/community/free-agent/package.json
+++ b/packages/pieces/community/free-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-free-agent",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/packages/pieces/community/free-agent/src/lib/triggers/new-contact.ts
+++ b/packages/pieces/community/free-agent/src/lib/triggers/new-contact.ts
@@ -113,18 +113,10 @@ export const freeAgentNewContactTrigger = createTrigger({
     updated_at: '2011-09-16T09:34:41Z',
   },
   async onEnable(context) {
-    await pollingHelper.onEnable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onEnable(polling, context);
   },
   async onDisable(context) {
-    await pollingHelper.onDisable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onDisable(polling, context);
   },
   async run(context) {
     return await pollingHelper.poll(polling, {

--- a/packages/pieces/community/free-agent/src/lib/triggers/new-invoice.ts
+++ b/packages/pieces/community/free-agent/src/lib/triggers/new-invoice.ts
@@ -118,18 +118,10 @@ export const freeAgentNewInvoiceTrigger = createTrigger({
     updated_at: '2011-08-29T00:00:00Z',
   },
   async onEnable(context) {
-    await pollingHelper.onEnable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onEnable(polling, context);
   },
   async onDisable(context) {
-    await pollingHelper.onDisable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onDisable(polling, context);
   },
   async run(context) {
     return await pollingHelper.poll(polling, {

--- a/packages/pieces/community/free-agent/src/lib/triggers/new-task.ts
+++ b/packages/pieces/community/free-agent/src/lib/triggers/new-task.ts
@@ -98,18 +98,10 @@ export const freeAgentNewTaskTrigger = createTrigger({
     is_deletable: false,
   },
   async onEnable(context) {
-    await pollingHelper.onEnable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onEnable(polling, context);
   },
   async onDisable(context) {
-    await pollingHelper.onDisable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onDisable(polling, context);
   },
   async run(context) {
     return await pollingHelper.poll(polling, {

--- a/packages/pieces/community/free-agent/src/lib/triggers/new-user.ts
+++ b/packages/pieces/community/free-agent/src/lib/triggers/new-user.ts
@@ -99,18 +99,10 @@ export const freeAgentNewUserTrigger = createTrigger({
     updated_at: '2011-08-24T08:10:23Z',
   },
   async onEnable(context) {
-    await pollingHelper.onEnable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onEnable(polling, context);
   },
   async onDisable(context) {
-    await pollingHelper.onDisable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onDisable(polling, context);
   },
   async run(context) {
     return await pollingHelper.poll(polling, {

--- a/packages/pieces/community/freshservice/package.json
+++ b/packages/pieces/community/freshservice/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-freshservice",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {

--- a/packages/pieces/community/freshservice/src/lib/triggers/new-change-task.ts
+++ b/packages/pieces/community/freshservice/src/lib/triggers/new-change-task.ts
@@ -72,19 +72,11 @@ export const newChangeTask = createTrigger({
   },
 
   async onEnable(context) {
-    await pollingHelper.onEnable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onEnable(polling, context);
   },
 
   async onDisable(context) {
-    await pollingHelper.onDisable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onDisable(polling, context);
   },
 
   async run(context) {

--- a/packages/pieces/community/freshservice/src/lib/triggers/new-change.ts
+++ b/packages/pieces/community/freshservice/src/lib/triggers/new-change.ts
@@ -73,19 +73,11 @@ export const newChange = createTrigger({
   },
 
   async onEnable(context) {
-    await pollingHelper.onEnable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onEnable(polling, context);
   },
 
   async onDisable(context) {
-    await pollingHelper.onDisable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onDisable(polling, context);
   },
 
   async run(context) {

--- a/packages/pieces/community/freshservice/src/lib/triggers/new-requester.ts
+++ b/packages/pieces/community/freshservice/src/lib/triggers/new-requester.ts
@@ -77,19 +77,11 @@ export const newRequester = createTrigger({
   },
 
   async onEnable(context) {
-    await pollingHelper.onEnable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onEnable(polling, context);
   },
 
   async onDisable(context) {
-    await pollingHelper.onDisable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onDisable(polling, context);
   },
 
   async run(context) {

--- a/packages/pieces/community/freshservice/src/lib/triggers/new-ticket.ts
+++ b/packages/pieces/community/freshservice/src/lib/triggers/new-ticket.ts
@@ -85,19 +85,11 @@ export const newTicket = createTrigger({
   },
 
   async onEnable(context) {
-    await pollingHelper.onEnable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onEnable(polling, context);
   },
 
   async onDisable(context) {
-    await pollingHelper.onDisable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onDisable(polling, context);
   },
 
   async run(context) {

--- a/packages/pieces/community/freshservice/src/lib/triggers/updated-change-task.ts
+++ b/packages/pieces/community/freshservice/src/lib/triggers/updated-change-task.ts
@@ -72,19 +72,11 @@ export const updatedChangeTask = createTrigger({
   },
 
   async onEnable(context) {
-    await pollingHelper.onEnable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onEnable(polling, context);
   },
 
   async onDisable(context) {
-    await pollingHelper.onDisable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onDisable(polling, context);
   },
 
   async run(context) {

--- a/packages/pieces/community/freshservice/src/lib/triggers/updated-change.ts
+++ b/packages/pieces/community/freshservice/src/lib/triggers/updated-change.ts
@@ -73,19 +73,11 @@ export const updatedChange = createTrigger({
   },
 
   async onEnable(context) {
-    await pollingHelper.onEnable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onEnable(polling, context);
   },
 
   async onDisable(context) {
-    await pollingHelper.onDisable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onDisable(polling, context);
   },
 
   async run(context) {

--- a/packages/pieces/community/freshservice/src/lib/triggers/updated-requester.ts
+++ b/packages/pieces/community/freshservice/src/lib/triggers/updated-requester.ts
@@ -77,19 +77,11 @@ export const updatedRequester = createTrigger({
   },
 
   async onEnable(context) {
-    await pollingHelper.onEnable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onEnable(polling, context);
   },
 
   async onDisable(context) {
-    await pollingHelper.onDisable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onDisable(polling, context);
   },
 
   async run(context) {

--- a/packages/pieces/community/freshservice/src/lib/triggers/updated-ticket.ts
+++ b/packages/pieces/community/freshservice/src/lib/triggers/updated-ticket.ts
@@ -85,19 +85,11 @@ export const updatedTicket = createTrigger({
   },
 
   async onEnable(context) {
-    await pollingHelper.onEnable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onEnable(polling, context);
   },
 
   async onDisable(context) {
-    await pollingHelper.onDisable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onDisable(polling, context);
   },
 
   async run(context) {

--- a/packages/pieces/community/front/package.json
+++ b/packages/pieces/community/front/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-front",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/packages/pieces/community/front/src/lib/triggers/new-comment.ts
+++ b/packages/pieces/community/front/src/lib/triggers/new-comment.ts
@@ -255,12 +255,10 @@ export const newComment = createTrigger({
     return await pollingHelper.test(polling, context);
   },
   async onEnable(context) {
-    const { store, auth, propsValue } = context;
-    await pollingHelper.onEnable(polling, { store, auth, propsValue });
+    await pollingHelper.onEnable(polling, context);
   },
   async onDisable(context) {
-    const { store, auth, propsValue } = context;
-    await pollingHelper.onDisable(polling, { store, auth, propsValue });
+    await pollingHelper.onDisable(polling, context);
   },
   async run(context) {
     return await pollingHelper.poll(polling, context);

--- a/packages/pieces/community/front/src/lib/triggers/new-conversation-state-change.ts
+++ b/packages/pieces/community/front/src/lib/triggers/new-conversation-state-change.ts
@@ -224,13 +224,11 @@ export const newConversationStateChange = createTrigger({
     });
   },
   async onEnable(context) {
-    const { store, auth, propsValue } = context;
-    await pollingHelper.onEnable(polling, { store, auth, propsValue });
+    await pollingHelper.onEnable(polling, context);
   },
 
   async onDisable(context) {
-    const { store, auth, propsValue } = context;
-    await pollingHelper.onDisable(polling, { store, auth, propsValue });
+    await pollingHelper.onDisable(polling, context);
   },
 
   async run(context) {

--- a/packages/pieces/community/front/src/lib/triggers/new-inbound-message.ts
+++ b/packages/pieces/community/front/src/lib/triggers/new-inbound-message.ts
@@ -209,12 +209,10 @@ export const newInboundMessage = createTrigger({
     return await pollingHelper.test(polling, context);
   },
   async onEnable(context) {
-    const { store, auth, propsValue } = context;
-    await pollingHelper.onEnable(polling, { store, auth, propsValue });
+    await pollingHelper.onEnable(polling, context);
   },
   async onDisable(context) {
-    const { store, auth, propsValue } = context;
-    await pollingHelper.onDisable(polling, { store, auth, propsValue });
+    await pollingHelper.onDisable(polling, context);
   },
   async run(context) {
     return await pollingHelper.poll(polling, context);

--- a/packages/pieces/community/front/src/lib/triggers/new-outbound-message.ts
+++ b/packages/pieces/community/front/src/lib/triggers/new-outbound-message.ts
@@ -201,12 +201,10 @@ export const newOutboundMessage = createTrigger({
     return await pollingHelper.test(polling, context);
   },
   async onEnable(context) {
-    const { store, auth, propsValue } = context;
-    await pollingHelper.onEnable(polling, { store, auth, propsValue });
+    await pollingHelper.onEnable(polling, context);
   },
   async onDisable(context) {
-    const { store, auth, propsValue } = context;
-    await pollingHelper.onDisable(polling, { store, auth, propsValue });
+    await pollingHelper.onDisable(polling, context);
   },
   async run(context) {
     return await pollingHelper.poll(polling, context);

--- a/packages/pieces/community/front/src/lib/triggers/new-tag-added-to-message.ts
+++ b/packages/pieces/community/front/src/lib/triggers/new-tag-added-to-message.ts
@@ -241,12 +241,10 @@ export const newTagAddedToMessage = createTrigger({
     return await pollingHelper.test(polling, context);
   },
   async onEnable(context) {
-    const { store, auth, propsValue } = context;
-    await pollingHelper.onEnable(polling, { store, auth, propsValue });
+    await pollingHelper.onEnable(polling, context);
   },
   async onDisable(context) {
-    const { store, auth, propsValue } = context;
-    await pollingHelper.onDisable(polling, { store, auth, propsValue });
+    await pollingHelper.onDisable(polling, context);
   },
   async run(context) {
     return await pollingHelper.poll(polling, context);

--- a/packages/pieces/community/google-calendar/package.json
+++ b/packages/pieces/community/google-calendar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-google-calendar",
-  "version": "0.9.5",
+  "version": "0.9.6",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "dependencies": {

--- a/packages/pieces/community/google-calendar/src/lib/triggers/calendar-event.ts
+++ b/packages/pieces/community/google-calendar/src/lib/triggers/calendar-event.ts
@@ -110,7 +110,7 @@ export const calendarEventChanged = createTrigger({
 			files,
 		});
 	},
-	async onEnable({ store, auth, propsValue }) {
+	async onEnable({ store, auth, propsValue, isRepublish }) {
 		await pollingHelper.onEnable(polling, {
 			store,
 			auth,
@@ -118,6 +118,7 @@ export const calendarEventChanged = createTrigger({
 				calendarId: propsValue.calendar_id,
 				expandRecurringEvent: propsValue.expandRecurringEvent,
 			},
+			isRepublish,
 		});
 	},
 	async onDisable({ store, auth, propsValue }) {

--- a/packages/pieces/community/google-calendar/src/lib/triggers/event-cancelled.ts
+++ b/packages/pieces/community/google-calendar/src/lib/triggers/event-cancelled.ts
@@ -170,19 +170,11 @@ export const eventCancelled = createTrigger({
   },
 
   async onEnable(context) {
-    await pollingHelper.onEnable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onEnable(polling, context);
   },
 
   async onDisable(context) {
-    await pollingHelper.onDisable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onDisable(polling, context);
   },
 
   async run(context) {

--- a/packages/pieces/community/google-calendar/src/lib/triggers/event-ends.ts
+++ b/packages/pieces/community/google-calendar/src/lib/triggers/event-ends.ts
@@ -171,19 +171,11 @@ export const eventEnds = createTrigger({
   },
 
   async onEnable(context) {
-    await pollingHelper.onEnable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onEnable(polling, context);
   },
 
   async onDisable(context) {
-    await pollingHelper.onDisable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onDisable(polling, context);
   },
 
   async run(context) {

--- a/packages/pieces/community/google-calendar/src/lib/triggers/event-start-time-before.ts
+++ b/packages/pieces/community/google-calendar/src/lib/triggers/event-start-time-before.ts
@@ -171,19 +171,11 @@ export const eventStartTimeBefore = createTrigger({
   sampleData: {},
 
   async onEnable(context) {
-    await pollingHelper.onEnable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onEnable(polling, context);
   },
 
   async onDisable(context) {
-    await pollingHelper.onDisable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onDisable(polling, context);
   },
 
   async run(context) {

--- a/packages/pieces/community/google-calendar/src/lib/triggers/new-calendar.ts
+++ b/packages/pieces/community/google-calendar/src/lib/triggers/new-calendar.ts
@@ -164,19 +164,11 @@ export const newCalendar = createTrigger({
       filteredCalendars.map((cal) => cal.id)
     );
 
-    await pollingHelper.onEnable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onEnable(polling, context);
   },
 
   async onDisable(context) {
-    await pollingHelper.onDisable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onDisable(polling, context);
   },
 
   async run(context) {

--- a/packages/pieces/community/google-calendar/src/lib/triggers/new-event-matching-search.ts
+++ b/packages/pieces/community/google-calendar/src/lib/triggers/new-event-matching-search.ts
@@ -195,19 +195,11 @@ export const newEventMatchingSearch = createTrigger({
   },
 
   async onEnable(context) {
-    await pollingHelper.onEnable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onEnable(polling, context);
   },
 
   async onDisable(context) {
-    await pollingHelper.onDisable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onDisable(polling, context);
   },
 
   async run(context) {

--- a/packages/pieces/community/google-contacts/package.json
+++ b/packages/pieces/community/google-contacts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-google-contacts",
-  "version": "0.4.6",
+  "version": "0.4.7",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "dependencies": {

--- a/packages/pieces/community/google-contacts/src/lib/trigger/new-contact.ts
+++ b/packages/pieces/community/google-contacts/src/lib/trigger/new-contact.ts
@@ -152,18 +152,10 @@ export const googleContactNewOrUpdatedContact = createTrigger({
 
   type: TriggerStrategy.POLLING,
   async onEnable(ctx) {
-    return await pollingHelper.onEnable(polling, {
-      store: ctx.store,
-      auth: ctx.auth,
-      propsValue: {},
-    });
+    return await pollingHelper.onEnable(polling, ctx);
   },
   async onDisable(ctx) {
-    return await pollingHelper.onEnable(polling, {
-      store: ctx.store,
-      auth: ctx.auth,
-      propsValue: {},
-    });
+    return await pollingHelper.onEnable(polling, ctx);
   },
   async run(ctx) {
     return await pollingHelper.poll(polling, {

--- a/packages/pieces/community/google-contacts/src/lib/trigger/new-contact.ts
+++ b/packages/pieces/community/google-contacts/src/lib/trigger/new-contact.ts
@@ -152,10 +152,19 @@ export const googleContactNewOrUpdatedContact = createTrigger({
 
   type: TriggerStrategy.POLLING,
   async onEnable(ctx) {
-    return await pollingHelper.onEnable(polling, ctx);
+    return await pollingHelper.onEnable(polling, {
+      store: ctx.store,
+      auth: ctx.auth,
+      propsValue: {},
+      isRepublish: ctx.isRepublish,
+    });
   },
   async onDisable(ctx) {
-    return await pollingHelper.onEnable(polling, ctx);
+    return await pollingHelper.onDisable(polling, {
+      store: ctx.store,
+      auth: ctx.auth,
+      propsValue: {},
+    });
   },
   async run(ctx) {
     return await pollingHelper.poll(polling, {

--- a/packages/pieces/community/google-docs/package.json
+++ b/packages/pieces/community/google-docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-google-docs",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "dependencies": {

--- a/packages/pieces/community/google-docs/src/lib/triggers/new-document.ts
+++ b/packages/pieces/community/google-docs/src/lib/triggers/new-document.ts
@@ -78,18 +78,10 @@ export const newDocumentTrigger = createTrigger({
 	},
 	outputSchema: newDocumentTriggerOutputSchema,
 	async onEnable(context) {
-		await pollingHelper.onEnable(polling, {
-			auth: context.auth,
-			store: context.store,
-			propsValue: context.propsValue,
-		});
+		await pollingHelper.onEnable(polling, context);
 	},
 	async onDisable(context) {
-		await pollingHelper.onDisable(polling, {
-			auth: context.auth,
-			store: context.store,
-			propsValue: context.propsValue,
-		});
+		await pollingHelper.onDisable(polling, context);
 	},
 	async test(context) {
 		return await pollingHelper.test(polling, context);

--- a/packages/pieces/community/google-drive/package.json
+++ b/packages/pieces/community/google-drive/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-google-drive",
-  "version": "0.7.10",
+  "version": "0.7.11",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "dependencies": {

--- a/packages/pieces/community/google-drive/src/lib/triggers/new-file.ts
+++ b/packages/pieces/community/google-drive/src/lib/triggers/new-file.ts
@@ -57,18 +57,10 @@ export const newFile = createTrigger({
   outputSchema: newFileTriggerOutputSchema,
   type: TriggerStrategy.POLLING,
   onEnable: async (context) => {
-    await pollingHelper.onEnable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onEnable(polling, context);
   },
   onDisable: async (context) => {
-    await pollingHelper.onDisable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onDisable(polling, context);
   },
   run: async (context) => {
     const newFiles = await pollingHelper.poll(polling, {

--- a/packages/pieces/community/google-drive/src/lib/triggers/new-folder.ts
+++ b/packages/pieces/community/google-drive/src/lib/triggers/new-folder.ts
@@ -49,18 +49,10 @@ export const newFolder = createTrigger({
   outputSchema: newFolderTriggerOutputSchema,
   type: TriggerStrategy.POLLING,
   onEnable: async (context) => {
-    await pollingHelper.onEnable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onEnable(polling, context);
   },
   onDisable: async (context) => {
-    await pollingHelper.onDisable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onDisable(polling, context);
   },
   run: async (context) => {
     return await pollingHelper.poll(polling, context);

--- a/packages/pieces/community/google-forms/package.json
+++ b/packages/pieces/community/google-forms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-google-forms",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "dependencies": {

--- a/packages/pieces/community/google-forms/src/lib/triggers/new-form-response.ts
+++ b/packages/pieces/community/google-forms/src/lib/triggers/new-form-response.ts
@@ -69,18 +69,10 @@ export const newResponse = createTrigger({
     return await pollingHelper.test(polling, ctx);
   },
   async onEnable(ctx) {
-    await pollingHelper.onEnable(polling, {
-      auth: ctx.auth,
-      store: ctx.store,
-      propsValue: ctx.propsValue,
-    });
+    await pollingHelper.onEnable(polling, ctx);
   },
   async onDisable(ctx) {
-    await pollingHelper.onDisable(polling, {
-      auth: ctx.auth,
-      store: ctx.store,
-      propsValue: ctx.propsValue,
-    });
+    await pollingHelper.onDisable(polling, ctx);
   },
   async run(ctx) {
     return await pollingHelper.poll(polling, ctx);

--- a/packages/pieces/community/google-my-business/package.json
+++ b/packages/pieces/community/google-my-business/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-google-my-business",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {

--- a/packages/pieces/community/google-my-business/src/lib/triggers/new-review.ts
+++ b/packages/pieces/community/google-my-business/src/lib/triggers/new-review.ts
@@ -33,18 +33,10 @@ export const newReview = createTrigger({
     return await pollingHelper.test(polling, ctx);
   },
   async onEnable(ctx) {
-    await pollingHelper.onEnable(polling, {
-      auth: ctx.auth,
-      store: ctx.store,
-      propsValue: ctx.propsValue,
-    });
+    await pollingHelper.onEnable(polling, ctx);
   },
   async onDisable(ctx) {
-    await pollingHelper.onDisable(polling, {
-      auth: ctx.auth,
-      store: ctx.store,
-      propsValue: ctx.propsValue,
-    });
+    await pollingHelper.onDisable(polling, ctx);
   },
   async run(ctx) {
     return await pollingHelper.poll(polling, ctx);

--- a/packages/pieces/community/google-sheets/package.json
+++ b/packages/pieces/community/google-sheets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-google-sheets",
-  "version": "0.16.3",
+  "version": "0.16.4",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "dependencies": {

--- a/packages/pieces/community/google-sheets/src/lib/triggers/new-spreadsheet.ts
+++ b/packages/pieces/community/google-sheets/src/lib/triggers/new-spreadsheet.ts
@@ -66,18 +66,10 @@ export const newSpreadsheetTrigger = createTrigger({
 	},
 	outputSchema: newSpreadsheetTriggerOutputSchema,
 	async onEnable(context) {
-		await pollingHelper.onEnable(polling, {
-			auth: context.auth,
-			store: context.store,
-			propsValue: context.propsValue,
-		});
+		await pollingHelper.onEnable(polling, context);
 	},
 	async onDisable(context) {
-		await pollingHelper.onDisable(polling, {
-			auth: context.auth,
-			store: context.store,
-			propsValue: context.propsValue,
-		});
+		await pollingHelper.onDisable(polling, context);
 	},
 	async test(context) {
 		return await pollingHelper.test(polling, context);

--- a/packages/pieces/community/google-tasks/package.json
+++ b/packages/pieces/community/google-tasks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-google-tasks",
-  "version": "0.4.6",
+  "version": "0.4.7",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {

--- a/packages/pieces/community/google-tasks/src/lib/triggers/new-task.ts
+++ b/packages/pieces/community/google-tasks/src/lib/triggers/new-task.ts
@@ -59,13 +59,13 @@ export const newTaskTrigger = createTrigger({
     const store = context.store;
     const auth = context.auth;
     const propsValue = context.propsValue;
-    await pollingHelper.onEnable(polling, { store, auth, propsValue });
+    await pollingHelper.onEnable(polling, context);
   },
   async onDisable(context) {
     const store = context.store;
     const auth = context.auth;
     const propsValue = context.propsValue;
-    await pollingHelper.onEnable(polling, { store, auth, propsValue });
+    await pollingHelper.onEnable(polling, context);
   },
   async run(context) {
     const store = context.store;

--- a/packages/pieces/community/griptape/package.json
+++ b/packages/pieces/community/griptape/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-griptape",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/packages/pieces/community/griptape/src/lib/triggers/assistant-run-completes.ts
+++ b/packages/pieces/community/griptape/src/lib/triggers/assistant-run-completes.ts
@@ -74,12 +74,10 @@ export const assistantRunCompletes = createTrigger({
     return await pollingHelper.test(polling, context);
   },
   async onEnable(context) {
-    const { store, auth, propsValue } = context;
-    await pollingHelper.onEnable(polling, { store, auth, propsValue });
+    await pollingHelper.onEnable(polling, context);
   },
   async onDisable(context) {
-    const { store, auth, propsValue } = context;
-    await pollingHelper.onDisable(polling, { store, auth, propsValue });
+    await pollingHelper.onDisable(polling, context);
   },
   async run(context) {
     return await pollingHelper.poll(polling, context);

--- a/packages/pieces/community/griptape/src/lib/triggers/assistant-run-succeedes.ts
+++ b/packages/pieces/community/griptape/src/lib/triggers/assistant-run-succeedes.ts
@@ -74,12 +74,10 @@ export const assistantRunSucceedes = createTrigger({
     return await pollingHelper.test(polling, context);
   },
   async onEnable(context) {
-    const { store, auth, propsValue } = context;
-    await pollingHelper.onEnable(polling, { store, auth, propsValue });
+    await pollingHelper.onEnable(polling, context);
   },
   async onDisable(context) {
-    const { store, auth, propsValue } = context;
-    await pollingHelper.onDisable(polling, { store, auth, propsValue });
+    await pollingHelper.onDisable(polling, context);
   },
   async run(context) {
     return await pollingHelper.poll(polling, context);

--- a/packages/pieces/community/griptape/src/lib/triggers/structure-run-completes.ts
+++ b/packages/pieces/community/griptape/src/lib/triggers/structure-run-completes.ts
@@ -66,13 +66,11 @@ export const structureRunCompletes = createTrigger({
     return await pollingHelper.test(polling, context);
   },
   async onEnable(context) {
-    const { store, auth, propsValue } = context;
-    await pollingHelper.onEnable(polling, { store, auth, propsValue });
+    await pollingHelper.onEnable(polling, context);
   },
 
   async onDisable(context) {
-    const { store, auth, propsValue } = context;
-    await pollingHelper.onDisable(polling, { store, auth, propsValue });
+    await pollingHelper.onDisable(polling, context);
   },
 
   async run(context) {

--- a/packages/pieces/community/griptape/src/lib/triggers/structure-run-succeeds.ts
+++ b/packages/pieces/community/griptape/src/lib/triggers/structure-run-succeeds.ts
@@ -67,13 +67,11 @@ export const structureRunSucceeds = createTrigger({
     return await pollingHelper.test(polling, context);
   },
   async onEnable(context) {
-    const { store, auth, propsValue } = context;
-    await pollingHelper.onEnable(polling, { store, auth, propsValue });
+    await pollingHelper.onEnable(polling, context);
   },
 
   async onDisable(context) {
-    const { store, auth, propsValue } = context;
-    await pollingHelper.onDisable(polling, { store, auth, propsValue });
+    await pollingHelper.onDisable(polling, context);
   },
 
   async run(context) {

--- a/packages/pieces/community/guidelite/package.json
+++ b/packages/pieces/community/guidelite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-guidelite",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/packages/pieces/community/guidelite/src/lib/triggers/new-lead-submission.ts
+++ b/packages/pieces/community/guidelite/src/lib/triggers/new-lead-submission.ts
@@ -72,13 +72,11 @@ export const newLeadSubmission = createTrigger({
     return await pollingHelper.test(polling, context);
   },
   async onEnable(context) {
-    const { store, auth, propsValue } = context;
-    await pollingHelper.onEnable(polling, { store, auth, propsValue });
+    await pollingHelper.onEnable(polling, context);
   },
 
   async onDisable(context) {
-    const { store, auth, propsValue } = context;
-    await pollingHelper.onDisable(polling, { store, auth, propsValue });
+    await pollingHelper.onDisable(polling, context);
   },
 
   async run(context) {

--- a/packages/pieces/community/heymarket-sms/package.json
+++ b/packages/pieces/community/heymarket-sms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-heymarket-sms",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/packages/pieces/community/heymarket-sms/src/lib/triggers/new-or-updated-contact.ts
+++ b/packages/pieces/community/heymarket-sms/src/lib/triggers/new-or-updated-contact.ts
@@ -100,13 +100,11 @@ export const newOrUpdatedContact = createTrigger({
     return await pollingHelper.test(polling, context);
   },
   async onEnable(context) {
-    const { store, auth, propsValue } = context;
-    await pollingHelper.onEnable(polling, { store, auth, propsValue });
+    await pollingHelper.onEnable(polling, context);
   },
 
   async onDisable(context) {
-    const { store, auth, propsValue } = context;
-    await pollingHelper.onDisable(polling, { store, auth, propsValue });
+    await pollingHelper.onDisable(polling, context);
   },
 
   async run(context) {

--- a/packages/pieces/community/hubspot/package.json
+++ b/packages/pieces/community/hubspot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-hubspot",
-  "version": "0.8.7",
+  "version": "0.8.8",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "dependencies": {

--- a/packages/pieces/community/hubspot/src/lib/triggers/deal-stage-updated.ts
+++ b/packages/pieces/community/hubspot/src/lib/triggers/deal-stage-updated.ts
@@ -130,18 +130,10 @@ export const dealStageUpdatedTrigger = createTrigger({
 	},
 	type: TriggerStrategy.POLLING,
 	async onEnable(context) {
-		await pollingHelper.onEnable(polling, {
-			auth: context.auth,
-			store: context.store,
-			propsValue: context.propsValue,
-		});
+		await pollingHelper.onEnable(polling, context);
 	},
 	async onDisable(context) {
-		await pollingHelper.onDisable(polling, {
-			auth: context.auth,
-			store: context.store,
-			propsValue: context.propsValue,
-		});
+		await pollingHelper.onDisable(polling, context);
 	},
 	async test(context) {
 		return await pollingHelper.test(polling, context);

--- a/packages/pieces/community/hubspot/src/lib/triggers/email-subscriptions-timeline.ts
+++ b/packages/pieces/community/hubspot/src/lib/triggers/email-subscriptions-timeline.ts
@@ -67,18 +67,10 @@ export const newEmailSubscriptionsTimelineTrigger = createTrigger({
 	type: TriggerStrategy.POLLING,
 	props: {},
 	async onEnable(context) {
-		await pollingHelper.onEnable(polling, {
-			auth: context.auth,
-			store: context.store,
-			propsValue: context.propsValue,
-		});
+		await pollingHelper.onEnable(polling, context);
 	},
 	async onDisable(context) {
-		await pollingHelper.onDisable(polling, {
-			auth: context.auth,
-			store: context.store,
-			propsValue: context.propsValue,
-		});
+		await pollingHelper.onDisable(polling, context);
 	},
 	async test(context) {
 		return await pollingHelper.test(polling, context);

--- a/packages/pieces/community/hubspot/src/lib/triggers/new-blog-article.ts
+++ b/packages/pieces/community/hubspot/src/lib/triggers/new-blog-article.ts
@@ -115,18 +115,10 @@ export const newBlogArticleTrigger = createTrigger({
 		}),
 	},
 	async onEnable(context) {
-		await pollingHelper.onEnable(polling, {
-			auth: context.auth,
-			store: context.store,
-			propsValue: context.propsValue,
-		});
+		await pollingHelper.onEnable(polling, context);
 	},
 	async onDisable(context) {
-		await pollingHelper.onDisable(polling, {
-			auth: context.auth,
-			store: context.store,
-			propsValue: context.propsValue,
-		});
+		await pollingHelper.onDisable(polling, context);
 	},
 	async test(context) {
 		return await pollingHelper.test(polling, context);

--- a/packages/pieces/community/hubspot/src/lib/triggers/new-company-property-change.ts
+++ b/packages/pieces/community/hubspot/src/lib/triggers/new-company-property-change.ts
@@ -144,18 +144,10 @@ export const newCompanyPropertyChangeTrigger = createTrigger({
 	},
 	type: TriggerStrategy.POLLING,
 	async onEnable(context) {
-		await pollingHelper.onEnable(polling, {
-			auth: context.auth,
-			store: context.store,
-			propsValue: context.propsValue,
-		});
+		await pollingHelper.onEnable(polling, context);
 	},
 	async onDisable(context) {
-		await pollingHelper.onDisable(polling, {
-			auth: context.auth,
-			store: context.store,
-			propsValue: context.propsValue,
-		});
+		await pollingHelper.onDisable(polling, context);
 	},
 	async test(context) {
 		return await pollingHelper.test(polling, context);

--- a/packages/pieces/community/hubspot/src/lib/triggers/new-company.ts
+++ b/packages/pieces/community/hubspot/src/lib/triggers/new-company.ts
@@ -95,18 +95,10 @@ export const newCompanyTrigger = createTrigger({
 	},
 	type: TriggerStrategy.POLLING,
 	async onEnable(context) {
-		await pollingHelper.onEnable(polling, {
-			auth: context.auth,
-			store: context.store,
-			propsValue: context.propsValue,
-		});
+		await pollingHelper.onEnable(polling, context);
 	},
 	async onDisable(context) {
-		await pollingHelper.onDisable(polling, {
-			auth: context.auth,
-			store: context.store,
-			propsValue: context.propsValue,
-		});
+		await pollingHelper.onDisable(polling, context);
 	},
 	async test(context) {
 		return await pollingHelper.test(polling, context);

--- a/packages/pieces/community/hubspot/src/lib/triggers/new-contact-in-list.ts
+++ b/packages/pieces/community/hubspot/src/lib/triggers/new-contact-in-list.ts
@@ -151,18 +151,10 @@ export const newContactInListTrigger = createTrigger({
 		}),
 	},
 	async onEnable(context) {
-		await pollingHelper.onEnable(polling, {
-			auth: context.auth,
-			store: context.store,
-			propsValue: context.propsValue,
-		});
+		await pollingHelper.onEnable(polling, context);
 	},
 	async onDisable(context) {
-		await pollingHelper.onDisable(polling, {
-			auth: context.auth,
-			store: context.store,
-			propsValue: context.propsValue,
-		});
+		await pollingHelper.onDisable(polling, context);
 	},
 	async test(context) {
 		return await pollingHelper.test(polling, context);

--- a/packages/pieces/community/hubspot/src/lib/triggers/new-contact-property-change.ts
+++ b/packages/pieces/community/hubspot/src/lib/triggers/new-contact-property-change.ts
@@ -146,18 +146,10 @@ export const newContactPropertyChangeTrigger = createTrigger({
 	},
 	type: TriggerStrategy.POLLING,
 	async onEnable(context) {
-		await pollingHelper.onEnable(polling, {
-			auth: context.auth,
-			store: context.store,
-			propsValue: context.propsValue,
-		});
+		await pollingHelper.onEnable(polling, context);
 	},
 	async onDisable(context) {
-		await pollingHelper.onDisable(polling, {
-			auth: context.auth,
-			store: context.store,
-			propsValue: context.propsValue,
-		});
+		await pollingHelper.onDisable(polling, context);
 	},
 	async test(context) {
 		return await pollingHelper.test(polling, context);

--- a/packages/pieces/community/hubspot/src/lib/triggers/new-contact.ts
+++ b/packages/pieces/community/hubspot/src/lib/triggers/new-contact.ts
@@ -97,18 +97,10 @@ export const newContactTrigger = createTrigger({
 	},
 	type: TriggerStrategy.POLLING,
 	async onEnable(context) {
-		await pollingHelper.onEnable(polling, {
-			auth: context.auth,
-			store: context.store,
-			propsValue: context.propsValue,
-		});
+		await pollingHelper.onEnable(polling, context);
 	},
 	async onDisable(context) {
-		await pollingHelper.onDisable(polling, {
-			auth: context.auth,
-			store: context.store,
-			propsValue: context.propsValue,
-		});
+		await pollingHelper.onDisable(polling, context);
 	},
 	async test(context) {
 		return await pollingHelper.test(polling, context);

--- a/packages/pieces/community/hubspot/src/lib/triggers/new-custom-object-property-change.ts
+++ b/packages/pieces/community/hubspot/src/lib/triggers/new-custom-object-property-change.ts
@@ -144,18 +144,10 @@ export const newCustomObjectPropertyChangeTrigger = createTrigger({
 	},
 	type: TriggerStrategy.POLLING,
 	async onEnable(context) {
-		await pollingHelper.onEnable(polling, {
-			auth: context.auth,
-			store: context.store,
-			propsValue: context.propsValue,
-		});
+		await pollingHelper.onEnable(polling, context);
 	},
 	async onDisable(context) {
-		await pollingHelper.onDisable(polling, {
-			auth: context.auth,
-			store: context.store,
-			propsValue: context.propsValue,
-		});
+		await pollingHelper.onDisable(polling, context);
 	},
 	async test(context) {
 		return await pollingHelper.test(polling, context);

--- a/packages/pieces/community/hubspot/src/lib/triggers/new-custom-object.ts
+++ b/packages/pieces/community/hubspot/src/lib/triggers/new-custom-object.ts
@@ -113,18 +113,10 @@ export const newCustomObjectTrigger = createTrigger({
 	},
 	type: TriggerStrategy.POLLING,
 	async onEnable(context) {
-		await pollingHelper.onEnable(polling, {
-			auth: context.auth,
-			store: context.store,
-			propsValue: context.propsValue,
-		});
+		await pollingHelper.onEnable(polling, context);
 	},
 	async onDisable(context) {
-		await pollingHelper.onDisable(polling, {
-			auth: context.auth,
-			store: context.store,
-			propsValue: context.propsValue,
-		});
+		await pollingHelper.onDisable(polling, context);
 	},
 	async test(context) {
 		return await pollingHelper.test(polling, context);

--- a/packages/pieces/community/hubspot/src/lib/triggers/new-deal-property-change.ts
+++ b/packages/pieces/community/hubspot/src/lib/triggers/new-deal-property-change.ts
@@ -145,18 +145,10 @@ export const newDealPropertyChangeTrigger = createTrigger({
 	},
 	type: TriggerStrategy.POLLING,
 	async onEnable(context) {
-		await pollingHelper.onEnable(polling, {
-			auth: context.auth,
-			store: context.store,
-			propsValue: context.propsValue,
-		});
+		await pollingHelper.onEnable(polling, context);
 	},
 	async onDisable(context) {
-		await pollingHelper.onDisable(polling, {
-			auth: context.auth,
-			store: context.store,
-			propsValue: context.propsValue,
-		});
+		await pollingHelper.onDisable(polling, context);
 	},
 	async test(context) {
 		return await pollingHelper.test(polling, context);

--- a/packages/pieces/community/hubspot/src/lib/triggers/new-deal.ts
+++ b/packages/pieces/community/hubspot/src/lib/triggers/new-deal.ts
@@ -97,18 +97,10 @@ export const newDealTrigger = createTrigger({
 	},
 	type: TriggerStrategy.POLLING,
 	async onEnable(context) {
-		await pollingHelper.onEnable(polling, {
-			auth: context.auth,
-			store: context.store,
-			propsValue: context.propsValue,
-		});
+		await pollingHelper.onEnable(polling, context);
 	},
 	async onDisable(context) {
-		await pollingHelper.onDisable(polling, {
-			auth: context.auth,
-			store: context.store,
-			propsValue: context.propsValue,
-		});
+		await pollingHelper.onDisable(polling, context);
 	},
 	async test(context) {
 		return await pollingHelper.test(polling, context);

--- a/packages/pieces/community/hubspot/src/lib/triggers/new-email-event.ts
+++ b/packages/pieces/community/hubspot/src/lib/triggers/new-email-event.ts
@@ -129,18 +129,10 @@ export const newEmailEventTrigger = createTrigger({
 		}),
 	},
 	async onEnable(context) {
-		await pollingHelper.onEnable(polling, {
-			auth: context.auth,
-			store: context.store,
-			propsValue: context.propsValue,
-		});
+		await pollingHelper.onEnable(polling, context);
 	},
 	async onDisable(context) {
-		await pollingHelper.onDisable(polling, {
-			auth: context.auth,
-			store: context.store,
-			propsValue: context.propsValue,
-		});
+		await pollingHelper.onDisable(polling, context);
 	},
 	async test(context) {
 		return await pollingHelper.test(polling, context);

--- a/packages/pieces/community/hubspot/src/lib/triggers/new-engagement.ts
+++ b/packages/pieces/community/hubspot/src/lib/triggers/new-engagement.ts
@@ -104,18 +104,10 @@ export const newEngagementTrigger = createTrigger({
 		}),
 	},
 	async onEnable(context) {
-		await pollingHelper.onEnable(polling, {
-			auth: context.auth,
-			store: context.store,
-			propsValue: context.propsValue,
-		});
+		await pollingHelper.onEnable(polling, context);
 	},
 	async onDisable(context) {
-		await pollingHelper.onDisable(polling, {
-			auth: context.auth,
-			store: context.store,
-			propsValue: context.propsValue,
-		});
+		await pollingHelper.onDisable(polling, context);
 	},
 	async test(context) {
 		return await pollingHelper.test(polling, context);

--- a/packages/pieces/community/hubspot/src/lib/triggers/new-form-submission.ts
+++ b/packages/pieces/community/hubspot/src/lib/triggers/new-form-submission.ts
@@ -141,18 +141,10 @@ export const newFormSubmissionTrigger = createTrigger({
 		}),
 	},
 	async onEnable(context) {
-		await pollingHelper.onEnable(polling, {
-			auth: context.auth,
-			store: context.store,
-			propsValue: context.propsValue,
-		});
+		await pollingHelper.onEnable(polling, context);
 	},
 	async onDisable(context) {
-		await pollingHelper.onDisable(polling, {
-			auth: context.auth,
-			store: context.store,
-			propsValue: context.propsValue,
-		});
+		await pollingHelper.onDisable(polling, context);
 	},
 	async test(context) {
 		return await pollingHelper.test(polling, context);

--- a/packages/pieces/community/hubspot/src/lib/triggers/new-line-item.ts
+++ b/packages/pieces/community/hubspot/src/lib/triggers/new-line-item.ts
@@ -101,18 +101,10 @@ export const newLineItemTrigger = createTrigger({
 	},
 	type: TriggerStrategy.POLLING,
 	async onEnable(context) {
-		await pollingHelper.onEnable(polling, {
-			auth: context.auth,
-			store: context.store,
-			propsValue: context.propsValue,
-		});
+		await pollingHelper.onEnable(polling, context);
 	},
 	async onDisable(context) {
-		await pollingHelper.onDisable(polling, {
-			auth: context.auth,
-			store: context.store,
-			propsValue: context.propsValue,
-		});
+		await pollingHelper.onDisable(polling, context);
 	},
 	async test(context) {
 		return await pollingHelper.test(polling, context);

--- a/packages/pieces/community/hubspot/src/lib/triggers/new-or-updated-company.ts
+++ b/packages/pieces/community/hubspot/src/lib/triggers/new-or-updated-company.ts
@@ -97,18 +97,10 @@ export const newOrUpdatedCompanyTrigger = createTrigger({
 	},
 	type: TriggerStrategy.POLLING,
 	async onEnable(context) {
-		await pollingHelper.onEnable(polling, {
-			auth: context.auth,
-			store: context.store,
-			propsValue: context.propsValue,
-		});
+		await pollingHelper.onEnable(polling, context);
 	},
 	async onDisable(context) {
-		await pollingHelper.onDisable(polling, {
-			auth: context.auth,
-			store: context.store,
-			propsValue: context.propsValue,
-		});
+		await pollingHelper.onDisable(polling, context);
 	},
 	async test(context) {
 		return await pollingHelper.test(polling, context);

--- a/packages/pieces/community/hubspot/src/lib/triggers/new-or-updated-contact.ts
+++ b/packages/pieces/community/hubspot/src/lib/triggers/new-or-updated-contact.ts
@@ -97,18 +97,10 @@ export const newOrUpdatedContactTrigger = createTrigger({
 	},
 	type: TriggerStrategy.POLLING,
 	async onEnable(context) {
-		await pollingHelper.onEnable(polling, {
-			auth: context.auth,
-			store: context.store,
-			propsValue: context.propsValue,
-		});
+		await pollingHelper.onEnable(polling, context);
 	},
 	async onDisable(context) {
-		await pollingHelper.onDisable(polling, {
-			auth: context.auth,
-			store: context.store,
-			propsValue: context.propsValue,
-		});
+		await pollingHelper.onDisable(polling, context);
 	},
 	async test(context) {
 		return await pollingHelper.test(polling, context);

--- a/packages/pieces/community/hubspot/src/lib/triggers/new-or-updated-line-item.ts
+++ b/packages/pieces/community/hubspot/src/lib/triggers/new-or-updated-line-item.ts
@@ -97,18 +97,10 @@ export const newOrUpdatedLineItemTrigger = createTrigger({
 	},
 	type: TriggerStrategy.POLLING,
 	async onEnable(context) {
-		await pollingHelper.onEnable(polling, {
-			auth: context.auth,
-			store: context.store,
-			propsValue: context.propsValue,
-		});
+		await pollingHelper.onEnable(polling, context);
 	},
 	async onDisable(context) {
-		await pollingHelper.onDisable(polling, {
-			auth: context.auth,
-			store: context.store,
-			propsValue: context.propsValue,
-		});
+		await pollingHelper.onDisable(polling, context);
 	},
 	async test(context) {
 		return await pollingHelper.test(polling, context);

--- a/packages/pieces/community/hubspot/src/lib/triggers/new-or-updated-product.ts
+++ b/packages/pieces/community/hubspot/src/lib/triggers/new-or-updated-product.ts
@@ -97,18 +97,10 @@ export const newOrUpdatedProductTrigger = createTrigger({
 	},
 	type: TriggerStrategy.POLLING,
 	async onEnable(context) {
-		await pollingHelper.onEnable(polling, {
-			auth: context.auth,
-			store: context.store,
-			propsValue: context.propsValue,
-		});
+		await pollingHelper.onEnable(polling, context);
 	},
 	async onDisable(context) {
-		await pollingHelper.onDisable(polling, {
-			auth: context.auth,
-			store: context.store,
-			propsValue: context.propsValue,
-		});
+		await pollingHelper.onDisable(polling, context);
 	},
 	async test(context) {
 		return await pollingHelper.test(polling, context);

--- a/packages/pieces/community/hubspot/src/lib/triggers/new-product.ts
+++ b/packages/pieces/community/hubspot/src/lib/triggers/new-product.ts
@@ -101,18 +101,10 @@ export const newProductTrigger = createTrigger({
 	},
 	type: TriggerStrategy.POLLING,
 	async onEnable(context) {
-		await pollingHelper.onEnable(polling, {
-			auth: context.auth,
-			store: context.store,
-			propsValue: context.propsValue,
-		});
+		await pollingHelper.onEnable(polling, context);
 	},
 	async onDisable(context) {
-		await pollingHelper.onDisable(polling, {
-			auth: context.auth,
-			store: context.store,
-			propsValue: context.propsValue,
-		});
+		await pollingHelper.onDisable(polling, context);
 	},
 	async test(context) {
 		return await pollingHelper.test(polling, context);

--- a/packages/pieces/community/hubspot/src/lib/triggers/new-task.ts
+++ b/packages/pieces/community/hubspot/src/lib/triggers/new-task.ts
@@ -97,18 +97,10 @@ export const newTaskTrigger = createTrigger({
 	},
 	type: TriggerStrategy.POLLING,
 	async onEnable(context) {
-		await pollingHelper.onEnable(polling, {
-			auth: context.auth,
-			store: context.store,
-			propsValue: context.propsValue,
-		});
+		await pollingHelper.onEnable(polling, context);
 	},
 	async onDisable(context) {
-		await pollingHelper.onDisable(polling, {
-			auth: context.auth,
-			store: context.store,
-			propsValue: context.propsValue,
-		});
+		await pollingHelper.onDisable(polling, context);
 	},
 	async test(context) {
 		return await pollingHelper.test(polling, context);

--- a/packages/pieces/community/hubspot/src/lib/triggers/new-ticket-property-change.ts
+++ b/packages/pieces/community/hubspot/src/lib/triggers/new-ticket-property-change.ts
@@ -145,18 +145,10 @@ export const newTicketPropertyChangeTrigger = createTrigger({
 	},
 	type: TriggerStrategy.POLLING,
 	async onEnable(context) {
-		await pollingHelper.onEnable(polling, {
-			auth: context.auth,
-			store: context.store,
-			propsValue: context.propsValue,
-		});
+		await pollingHelper.onEnable(polling, context);
 	},
 	async onDisable(context) {
-		await pollingHelper.onDisable(polling, {
-			auth: context.auth,
-			store: context.store,
-			propsValue: context.propsValue,
-		});
+		await pollingHelper.onDisable(polling, context);
 	},
 	async test(context) {
 		return await pollingHelper.test(polling, context);

--- a/packages/pieces/community/hubspot/src/lib/triggers/new-ticket.ts
+++ b/packages/pieces/community/hubspot/src/lib/triggers/new-ticket.ts
@@ -97,18 +97,10 @@ export const newTicketTrigger = createTrigger({
 	},
 	type: TriggerStrategy.POLLING,
 	async onEnable(context) {
-		await pollingHelper.onEnable(polling, {
-			auth: context.auth,
-			store: context.store,
-			propsValue: context.propsValue,
-		});
+		await pollingHelper.onEnable(polling, context);
 	},
 	async onDisable(context) {
-		await pollingHelper.onDisable(polling, {
-			auth: context.auth,
-			store: context.store,
-			propsValue: context.propsValue,
-		});
+		await pollingHelper.onDisable(polling, context);
 	},
 	async test(context) {
 		return await pollingHelper.test(polling, context);

--- a/packages/pieces/community/hume-ai/package.json
+++ b/packages/pieces/community/hume-ai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-hume-ai",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/packages/pieces/community/hume-ai/src/lib/triggers/new-voice.ts
+++ b/packages/pieces/community/hume-ai/src/lib/triggers/new-voice.ts
@@ -56,18 +56,10 @@ export const newVoiceTrigger = createTrigger({
     compatibleOctaveModels: ['octave-2'],
   },
   async onEnable(context) {
-    await pollingHelper.onEnable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onEnable(polling, context);
   },
   async onDisable(context) {
-    await pollingHelper.onDisable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onDisable(polling, context);
   },
   async test(context) {
     return await pollingHelper.test(polling, context);

--- a/packages/pieces/community/hunter/package.json
+++ b/packages/pieces/community/hunter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-hunter",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/packages/pieces/community/hunter/src/lib/triggers/new-lead.ts
+++ b/packages/pieces/community/hunter/src/lib/triggers/new-lead.ts
@@ -15,18 +15,10 @@ export const newLeadTrigger = createTrigger({
     type: TriggerStrategy.POLLING,
     props: {},
     async onEnable(context) {
-        await pollingHelper.onEnable(polling, {
-            auth: context.auth,
-            store: context.store,
-            propsValue: context.propsValue
-        });
+        await pollingHelper.onEnable(polling, context);
     },
     async onDisable(context) {
-        await pollingHelper.onDisable(polling, {
-            auth: context.auth,
-            store: context.store,
-            propsValue: context.propsValue
-        });
+        await pollingHelper.onDisable(polling, context);
     },
     async test(context) {
         return await pollingHelper.test(polling, context);

--- a/packages/pieces/community/imap/package.json
+++ b/packages/pieces/community/imap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-imap",
-  "version": "0.4.6",
+  "version": "0.4.7",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "dependencies": {

--- a/packages/pieces/community/imap/src/lib/triggers/new-email.ts
+++ b/packages/pieces/community/imap/src/lib/triggers/new-email.ts
@@ -85,13 +85,11 @@ export const newEmail = createTrigger({
   },
 
   async onEnable(context) {
-    const { store, auth, propsValue } = context;
-    await pollingHelper.onEnable(polling, { store, auth, propsValue });
+    await pollingHelper.onEnable(polling, context);
   },
 
   async onDisable(context) {
-    const { store, auth, propsValue } = context;
-    await pollingHelper.onDisable(polling, { store, auth, propsValue });
+    await pollingHelper.onDisable(polling, context);
   },
 
   async run(context) {

--- a/packages/pieces/community/instabase/package.json
+++ b/packages/pieces/community/instabase/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-instabase",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/packages/pieces/community/instabase/src/lib/triggers/new-conversation.ts
+++ b/packages/pieces/community/instabase/src/lib/triggers/new-conversation.ts
@@ -45,18 +45,10 @@ export const newConversationTrigger = createTrigger({
     description: 'A sample conversation for testing',
   },
   async onEnable(context) {
-    await pollingHelper.onEnable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onEnable(polling, context);
   },
   async onDisable(context) {
-    await pollingHelper.onDisable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onDisable(polling, context);
   },
   async test(context) {
     return await pollingHelper.test(polling, context);

--- a/packages/pieces/community/instantly-ai/package.json
+++ b/packages/pieces/community/instantly-ai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-instantly-ai",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {

--- a/packages/pieces/community/instantly-ai/src/lib/triggers/new-lead-added.ts
+++ b/packages/pieces/community/instantly-ai/src/lib/triggers/new-lead-added.ts
@@ -69,18 +69,10 @@ export const newLeadAddedTrigger = createTrigger({
   props: {},
   type: TriggerStrategy.POLLING,
   async onEnable(context) {
-    await pollingHelper.onEnable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onEnable(polling, context);
   },
   async onDisable(context) {
-    await pollingHelper.onDisable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onDisable(polling, context);
   },
   async test(context) {
     return await pollingHelper.test(polling, context);

--- a/packages/pieces/community/klaviyo/package.json
+++ b/packages/pieces/community/klaviyo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-klaviyo",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {

--- a/packages/pieces/community/klaviyo/src/lib/triggers/new-profile.ts
+++ b/packages/pieces/community/klaviyo/src/lib/triggers/new-profile.ts
@@ -161,18 +161,10 @@ export const newProfileTrigger = createTrigger({
     });
   },
   async onEnable(context) {
-    await pollingHelper.onEnable(polling, {
-      store: context.store,
-      auth: context.auth as KlaviyoAuthValue,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onEnable(polling, context);
   },
   async onDisable(context) {
-    await pollingHelper.onDisable(polling, {
-      store: context.store,
-      auth: context.auth as KlaviyoAuthValue,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onDisable(polling, context);
   },
   async run(context) {
     return await pollingHelper.poll(polling, {

--- a/packages/pieces/community/klaviyo/src/lib/triggers/new-profile.ts
+++ b/packages/pieces/community/klaviyo/src/lib/triggers/new-profile.ts
@@ -161,10 +161,19 @@ export const newProfileTrigger = createTrigger({
     });
   },
   async onEnable(context) {
-    await pollingHelper.onEnable(polling, context);
+    await pollingHelper.onEnable(polling, {
+      store: context.store,
+      auth: context.auth as KlaviyoAuthValue,
+      propsValue: context.propsValue,
+      isRepublish: context.isRepublish,
+    });
   },
   async onDisable(context) {
-    await pollingHelper.onDisable(polling, context);
+    await pollingHelper.onDisable(polling, {
+      store: context.store,
+      auth: context.auth as KlaviyoAuthValue,
+      propsValue: context.propsValue,
+    });
   },
   async run(context) {
     return await pollingHelper.poll(polling, {

--- a/packages/pieces/community/klaviyo/src/lib/triggers/profile-added-to-list-segment.ts
+++ b/packages/pieces/community/klaviyo/src/lib/triggers/profile-added-to-list-segment.ts
@@ -254,18 +254,10 @@ export const profileAddedToListOrSegmentTrigger = createTrigger({
     });
   },
   async onEnable(context) {
-    await pollingHelper.onEnable(polling, {
-      store: context.store,
-      auth: context.auth as KlaviyoAuthValue,
-      propsValue: context.propsValue as StaticPropsValue<typeof props>,
-    });
+    await pollingHelper.onEnable(polling, context);
   },
   async onDisable(context) {
-    await pollingHelper.onDisable(polling, {
-      store: context.store,
-      auth: context.auth as KlaviyoAuthValue,
-      propsValue: context.propsValue as StaticPropsValue<typeof props>,
-    });
+    await pollingHelper.onDisable(polling, context);
   },
   async run(context) {
     return await pollingHelper.poll(polling, {

--- a/packages/pieces/community/klaviyo/src/lib/triggers/profile-added-to-list-segment.ts
+++ b/packages/pieces/community/klaviyo/src/lib/triggers/profile-added-to-list-segment.ts
@@ -254,10 +254,19 @@ export const profileAddedToListOrSegmentTrigger = createTrigger({
     });
   },
   async onEnable(context) {
-    await pollingHelper.onEnable(polling, context);
+    await pollingHelper.onEnable(polling, {
+      store: context.store,
+      auth: context.auth as KlaviyoAuthValue,
+      propsValue: context.propsValue as StaticPropsValue<typeof props>,
+      isRepublish: context.isRepublish,
+    });
   },
   async onDisable(context) {
-    await pollingHelper.onDisable(polling, context);
+    await pollingHelper.onDisable(polling, {
+      store: context.store,
+      auth: context.auth as KlaviyoAuthValue,
+      propsValue: context.propsValue as StaticPropsValue<typeof props>,
+    });
   },
   async run(context) {
     return await pollingHelper.poll(polling, {

--- a/packages/pieces/community/lead-connector/package.json
+++ b/packages/pieces/community/lead-connector/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-lead-connector",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {

--- a/packages/pieces/community/lead-connector/src/lib/triggers/contact-updated.ts
+++ b/packages/pieces/community/lead-connector/src/lib/triggers/contact-updated.ts
@@ -39,18 +39,10 @@ export const contactUpdated = createTrigger({
   sampleData: {},
 
   onEnable: async (context) => {
-    await pollingHelper.onEnable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onEnable(polling, context);
   },
   onDisable: async (context) => {
-    await pollingHelper.onDisable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onDisable(polling, context);
   },
   run: async (context) => {
     return await pollingHelper.poll(polling, {

--- a/packages/pieces/community/lead-connector/src/lib/triggers/new-contact.ts
+++ b/packages/pieces/community/lead-connector/src/lib/triggers/new-contact.ts
@@ -39,18 +39,10 @@ export const newContact = createTrigger({
   sampleData: {},
 
   onEnable: async (context) => {
-    await pollingHelper.onEnable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onEnable(polling, context);
   },
   onDisable: async (context) => {
-    await pollingHelper.onDisable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onDisable(polling, context);
   },
   run: async (context) => {
     return await pollingHelper.poll(polling, context);

--- a/packages/pieces/community/lead-connector/src/lib/triggers/new-form-submission.ts
+++ b/packages/pieces/community/lead-connector/src/lib/triggers/new-form-submission.ts
@@ -62,18 +62,10 @@ export const newFormSubmission = createTrigger({
   sampleData: {},
 
   onEnable: async (context) => {
-    await pollingHelper.onEnable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onEnable(polling, context);
   },
   onDisable: async (context) => {
-    await pollingHelper.onDisable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onDisable(polling, context);
   },
   run: async (context) => {
     return await pollingHelper.poll(polling, {

--- a/packages/pieces/community/lead-connector/src/lib/triggers/new-opportunity.ts
+++ b/packages/pieces/community/lead-connector/src/lib/triggers/new-opportunity.ts
@@ -64,18 +64,10 @@ export const newOpportunity = createTrigger({
   sampleData: {},
 
   onEnable: async (context) => {
-    await pollingHelper.onEnable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onEnable(polling, context);
   },
   onDisable: async (context) => {
-    await pollingHelper.onDisable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onDisable(polling, context);
   },
   run: async (context) => {
     return await pollingHelper.poll(polling, {

--- a/packages/pieces/community/leexi/package.json
+++ b/packages/pieces/community/leexi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-leexi",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/packages/pieces/community/leexi/src/lib/triggers/new-call-created.ts
+++ b/packages/pieces/community/leexi/src/lib/triggers/new-call-created.ts
@@ -66,18 +66,10 @@ export const newCallCreatedTrigger = createTrigger({
     type: TriggerStrategy.POLLING,
     props: {},
     async onEnable(context) {
-        await pollingHelper.onEnable(polling, {
-            auth: context.auth,
-            store: context.store,
-            propsValue: context.propsValue,
-        });
+        await pollingHelper.onEnable(polling, context);
     },
     async onDisable(context) {
-        await pollingHelper.onDisable(polling, {
-            auth: context.auth,
-            store: context.store,
-            propsValue: context.propsValue,
-        });
+        await pollingHelper.onDisable(polling, context);
     },
     async test(context) {
         return await pollingHelper.test(polling, context);

--- a/packages/pieces/community/lets-calendar/package.json
+++ b/packages/pieces/community/lets-calendar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-lets-calendar",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/packages/pieces/community/lets-calendar/src/lib/triggers/new-campaign.ts
+++ b/packages/pieces/community/lets-calendar/src/lib/triggers/new-campaign.ts
@@ -82,13 +82,11 @@ export const newCampaign = createTrigger({
     return await pollingHelper.test(polling, context);
   },
   async onEnable(context) {
-    const { store, auth, propsValue } = context;
-    await pollingHelper.onEnable(polling, { store, auth, propsValue });
+    await pollingHelper.onEnable(polling, context);
   },
 
   async onDisable(context) {
-    const { store, auth, propsValue } = context;
-    await pollingHelper.onDisable(polling, { store, auth, propsValue });
+    await pollingHelper.onDisable(polling, context);
   },
 
   async run(context) {

--- a/packages/pieces/community/microsoft-365-people/package.json
+++ b/packages/pieces/community/microsoft-365-people/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-microsoft-365-people",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/packages/pieces/community/microsoft-365-people/src/lib/triggers/new-or-updated-contact.ts
+++ b/packages/pieces/community/microsoft-365-people/src/lib/triggers/new-or-updated-contact.ts
@@ -48,13 +48,11 @@ export const newOrUpdatedContact = createTrigger({
     return await pollingHelper.test(polling, context);
   },
   async onEnable(context) {
-    const { store, auth, propsValue } = context;
-    await pollingHelper.onEnable(polling, { store, auth, propsValue });
+    await pollingHelper.onEnable(polling, context);
   },
 
   async onDisable(context) {
-    const { store, auth, propsValue } = context;
-    await pollingHelper.onDisable(polling, { store, auth, propsValue });
+    await pollingHelper.onDisable(polling, context);
   },
 
   async run(context) {

--- a/packages/pieces/community/microsoft-365-planner/package.json
+++ b/packages/pieces/community/microsoft-365-planner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-microsoft-365-planner",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/packages/pieces/community/microsoft-365-planner/src/lib/triggers/new-plan-created.ts
+++ b/packages/pieces/community/microsoft-365-planner/src/lib/triggers/new-plan-created.ts
@@ -43,13 +43,11 @@ export const newPlanCreated = createTrigger({
     return await pollingHelper.test(polling, context);
   },
   async onEnable(context) {
-    const { store, auth, propsValue } = context;
-    await pollingHelper.onEnable(polling, { store, auth, propsValue });
+    await pollingHelper.onEnable(polling, context);
   },
 
   async onDisable(context) {
-    const { store, auth, propsValue } = context;
-    await pollingHelper.onDisable(polling, { store, auth, propsValue });
+    await pollingHelper.onDisable(polling, context);
   },
 
   async run(context) {

--- a/packages/pieces/community/microsoft-365-planner/src/lib/triggers/new-task-assigned-to-user.ts
+++ b/packages/pieces/community/microsoft-365-planner/src/lib/triggers/new-task-assigned-to-user.ts
@@ -63,13 +63,11 @@ export const newTaskAssignedToUser = createTrigger({
     return await pollingHelper.test(polling, context);
   },
   async onEnable(context) {
-    const { store, auth, propsValue } = context;
-    await pollingHelper.onEnable(polling, { store, auth, propsValue });
+    await pollingHelper.onEnable(polling, context);
   },
 
   async onDisable(context) {
-    const { store, auth, propsValue } = context;
-    await pollingHelper.onDisable(polling, { store, auth, propsValue });
+    await pollingHelper.onDisable(polling, context);
   },
 
   async run(context) {

--- a/packages/pieces/community/microsoft-365-planner/src/lib/triggers/new-task-created.ts
+++ b/packages/pieces/community/microsoft-365-planner/src/lib/triggers/new-task-created.ts
@@ -86,13 +86,11 @@ export const newTaskCreated = createTrigger({
     return await pollingHelper.test(polling, context);
   },
   async onEnable(context) {
-    const { store, auth, propsValue } = context;
-    await pollingHelper.onEnable(polling, { store, auth, propsValue });
+    await pollingHelper.onEnable(polling, context);
   },
 
   async onDisable(context) {
-    const { store, auth, propsValue } = context;
-    await pollingHelper.onDisable(polling, { store, auth, propsValue });
+    await pollingHelper.onDisable(polling, context);
   },
 
   async run(context) {

--- a/packages/pieces/community/microsoft-dynamics-365-business-central/package.json
+++ b/packages/pieces/community/microsoft-dynamics-365-business-central/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-microsoft-dynamics-365-business-central",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {

--- a/packages/pieces/community/microsoft-dynamics-365-business-central/src/lib/triggers/new-or-updated-record.trigger.ts
+++ b/packages/pieces/community/microsoft-dynamics-365-business-central/src/lib/triggers/new-or-updated-record.trigger.ts
@@ -78,18 +78,10 @@ export const newOrUpdatedRecordTrigger = createTrigger({
     });
   },
   async onEnable(ctx) {
-    await pollingHelper.onEnable(polling, {
-      auth: ctx.auth,
-      store: ctx.store,
-      propsValue: ctx.propsValue,
-    });
+    await pollingHelper.onEnable(polling, ctx);
   },
   async onDisable(ctx) {
-    await pollingHelper.onDisable(polling, {
-      auth: ctx.auth,
-      store: ctx.store,
-      propsValue: ctx.propsValue,
-    });
+    await pollingHelper.onDisable(polling, ctx);
   },
   async run(ctx) {
     return await pollingHelper.poll(polling, {

--- a/packages/pieces/community/microsoft-excel-365/package.json
+++ b/packages/pieces/community/microsoft-excel-365/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-microsoft-excel-365",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "dependencies": {

--- a/packages/pieces/community/microsoft-excel-365/src/lib/trigger/new-row-added.ts
+++ b/packages/pieces/community/microsoft-excel-365/src/lib/trigger/new-row-added.ts
@@ -94,18 +94,10 @@ export const readNewRows = createTrigger({
     if (storageSource === 'sharepoint' && (!siteId || !documentId)) {
       throw new Error('please select SharePoint site and document library.');
     }
-    await pollingHelper.onEnable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onEnable(polling, context);
   },
   onDisable: async (context) => {
-    await pollingHelper.onDisable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onDisable(polling, context);
   },
   run: async (context) => {
     return await pollingHelper.poll(polling, {

--- a/packages/pieces/community/microsoft-excel-365/src/lib/trigger/new-row-in-table.ts
+++ b/packages/pieces/community/microsoft-excel-365/src/lib/trigger/new-row-in-table.ts
@@ -147,19 +147,11 @@ export const newRowInTableTrigger = createTrigger({
         if (storageSource === 'sharepoint' && (!siteId || !documentId)) {
             throw new Error('please select SharePoint site and document library.');
         }
-        await pollingHelper.onEnable(polling, {
-            auth: context.auth,
-            store: context.store,
-            propsValue: context.propsValue,
-        });
+        await pollingHelper.onEnable(polling, context);
     },
 
     onDisable: async (context) => {
-        await pollingHelper.onDisable(polling, {
-            auth: context.auth,
-            store: context.store,
-            propsValue: context.propsValue,
-        });
+        await pollingHelper.onDisable(polling, context);
     },
 
     run: async (context) => {

--- a/packages/pieces/community/microsoft-excel-365/src/lib/trigger/new-worksheet.ts
+++ b/packages/pieces/community/microsoft-excel-365/src/lib/trigger/new-worksheet.ts
@@ -92,19 +92,11 @@ export const newWorksheetTrigger = createTrigger({
     if (storageSource === 'sharepoint' && (!siteId || !documentId)) {
       throw new Error('please select SharePoint site and document library.');
     }
-    await pollingHelper.onEnable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue
-    });
+    await pollingHelper.onEnable(polling, context);
   },
 
   onDisable: async (context) => {
-    await pollingHelper.onDisable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue
-    });
+    await pollingHelper.onDisable(polling, context);
   },
 
   run: async (context) => {

--- a/packages/pieces/community/microsoft-excel-365/src/lib/trigger/updated-row.ts
+++ b/packages/pieces/community/microsoft-excel-365/src/lib/trigger/updated-row.ts
@@ -135,20 +135,12 @@ export const updatedRowTrigger = createTrigger({
         if (storageSource === 'sharepoint' && (!siteId || !documentId)) {
             throw new Error('please select SharePoint site and document library.');
         }
-        await pollingHelper.onEnable(polling, {
-            auth: context.auth,
-            store: context.store,
-            propsValue: context.propsValue,
-        });
+        await pollingHelper.onEnable(polling, context);
     },
 
     onDisable: async (context) => {
 
-        await pollingHelper.onDisable(polling, {
-            auth: context.auth,
-            store: context.store,
-            propsValue: context.propsValue,
-        });
+        await pollingHelper.onDisable(polling, context);
     },
 
     run: async (context) => {

--- a/packages/pieces/community/microsoft-onedrive/package.json
+++ b/packages/pieces/community/microsoft-onedrive/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-microsoft-onedrive",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "dependencies": {

--- a/packages/pieces/community/microsoft-onedrive/src/lib/triggers/new-file.ts
+++ b/packages/pieces/community/microsoft-onedrive/src/lib/triggers/new-file.ts
@@ -70,18 +70,10 @@ export const newFile = createTrigger({
 	},
 	type: TriggerStrategy.POLLING,
 	async onEnable(context) {
-		await pollingHelper.onEnable(polling, {
-			auth: context.auth,
-			store: context.store,
-			propsValue: context.propsValue,
-		});
+		await pollingHelper.onEnable(polling, context);
 	},
 	async onDisable(context) {
-		await pollingHelper.onDisable(polling, {
-			auth: context.auth,
-			store: context.store,
-			propsValue: context.propsValue,
-		});
+		await pollingHelper.onDisable(polling, context);
 	},
 	async test(context) {
 		return await pollingHelper.test(polling, context);

--- a/packages/pieces/community/microsoft-onenote/package.json
+++ b/packages/pieces/community/microsoft-onenote/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-microsoft-onenote",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/packages/pieces/community/microsoft-onenote/src/lib/triggers/new-note-in-section.ts
+++ b/packages/pieces/community/microsoft-onenote/src/lib/triggers/new-note-in-section.ts
@@ -129,18 +129,10 @@ export const newNoteInSectionTrigger = createTrigger({
 	},
 	type: TriggerStrategy.POLLING,
 	async onEnable(context) {
-		await pollingHelper.onEnable(polling, {
-			auth: context.auth,
-			store: context.store,
-			propsValue: context.propsValue,
-		});
+		await pollingHelper.onEnable(polling, context);
 	},
 	async onDisable(context) {
-		await pollingHelper.onDisable(polling, {
-			auth: context.auth,
-			store: context.store,
-			propsValue: context.propsValue,
-		});
+		await pollingHelper.onDisable(polling, context);
 	},
 	async test(context) {
 		return await pollingHelper.test(polling, context);

--- a/packages/pieces/community/microsoft-outlook/package.json
+++ b/packages/pieces/community/microsoft-outlook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-microsoft-outlook",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "dependencies": {

--- a/packages/pieces/community/microsoft-outlook/src/lib/triggers/new-email-in-folder.ts
+++ b/packages/pieces/community/microsoft-outlook/src/lib/triggers/new-email-in-folder.ts
@@ -73,18 +73,10 @@ export const newEmailInFolderTrigger = createTrigger({
 	sampleData: {},
 	type: TriggerStrategy.POLLING,
 	async onEnable(context) {
-		await pollingHelper.onEnable(polling, {
-			auth: context.auth,
-			store: context.store,
-			propsValue: context.propsValue,
-		});
+		await pollingHelper.onEnable(polling, context);
 	},
 	async onDisable(context) {
-		await pollingHelper.onDisable(polling, {
-			auth: context.auth,
-			store: context.store,
-			propsValue: context.propsValue,
-		});
+		await pollingHelper.onDisable(polling, context);
 	},
 	async test(context) {
 		return await pollingHelper.test(polling, context);

--- a/packages/pieces/community/microsoft-outlook/src/lib/triggers/new-email.ts
+++ b/packages/pieces/community/microsoft-outlook/src/lib/triggers/new-email.ts
@@ -104,18 +104,10 @@ export const newEmailTrigger = createTrigger({
 	sampleData: {},
 	type: TriggerStrategy.POLLING,
 	async onEnable(context) {
-		await pollingHelper.onEnable(polling, {
-			auth: context.auth,
-			store: context.store,
-			propsValue: context.propsValue,
-		});
+		await pollingHelper.onEnable(polling, context);
 	},
 	async onDisable(context) {
-		await pollingHelper.onDisable(polling, {
-			auth: context.auth,
-			store: context.store,
-			propsValue: context.propsValue,
-		});
+		await pollingHelper.onDisable(polling, context);
 	},
 	async test(context) {
 		return await pollingHelper.test(polling, context);

--- a/packages/pieces/community/microsoft-sharepoint/package.json
+++ b/packages/pieces/community/microsoft-sharepoint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-microsoft-sharepoint",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "dependencies": {

--- a/packages/pieces/community/microsoft-sharepoint/src/lib/triggers/new-list-item.ts
+++ b/packages/pieces/community/microsoft-sharepoint/src/lib/triggers/new-list-item.ts
@@ -88,18 +88,10 @@ export const newListItemTrigger = createTrigger({
 
 	sampleData: undefined,
 	async onEnable(context) {
-		await pollingHelper.onEnable(polling, {
-			auth: context.auth,
-			store: context.store,
-			propsValue: context.propsValue,
-		});
+		await pollingHelper.onEnable(polling, context);
 	},
 	async onDisable(context) {
-		await pollingHelper.onDisable(polling, {
-			auth: context.auth,
-			store: context.store,
-			propsValue: context.propsValue,
-		});
+		await pollingHelper.onDisable(polling, context);
 	},
 	async test(context) {
 		return await pollingHelper.test(polling, context);

--- a/packages/pieces/community/microsoft-sharepoint/src/lib/triggers/new-list.ts
+++ b/packages/pieces/community/microsoft-sharepoint/src/lib/triggers/new-list.ts
@@ -79,18 +79,10 @@ export const newListTrigger = createTrigger({
 
 	sampleData: undefined,
 	async onEnable(context) {
-		await pollingHelper.onEnable(polling, {
-			auth: context.auth,
-			store: context.store,
-			propsValue: context.propsValue,
-		});
+		await pollingHelper.onEnable(polling, context);
 	},
 	async onDisable(context) {
-		await pollingHelper.onDisable(polling, {
-			auth: context.auth,
-			store: context.store,
-			propsValue: context.propsValue,
-		});
+		await pollingHelper.onDisable(polling, context);
 	},
 	async test(context) {
 		return await pollingHelper.test(polling, context);

--- a/packages/pieces/community/microsoft-sharepoint/src/lib/triggers/new-or-updated-file.ts
+++ b/packages/pieces/community/microsoft-sharepoint/src/lib/triggers/new-or-updated-file.ts
@@ -156,18 +156,10 @@ export const newOrUpdatedFileTrigger = createTrigger({
 		parentReference: { id: 'PARENT_FOLDER_ID_HERE' },
 	},
 	async onEnable(context) {
-		await pollingHelper.onEnable(polling, {
-			auth: context.auth,
-			store: context.store,
-			propsValue: context.propsValue,
-		});
+		await pollingHelper.onEnable(polling, context);
 	},
 	async onDisable(context) {
-		await pollingHelper.onDisable(polling, {
-			auth: context.auth,
-			store: context.store,
-			propsValue: context.propsValue,
-		});
+		await pollingHelper.onDisable(polling, context);
 	},
 	async test(context) {
 		return await pollingHelper.test(polling, context);

--- a/packages/pieces/community/microsoft-sharepoint/src/lib/triggers/new-or-updated-folder.ts
+++ b/packages/pieces/community/microsoft-sharepoint/src/lib/triggers/new-or-updated-folder.ts
@@ -156,18 +156,10 @@ export const newOrUpdatedFolderTrigger = createTrigger({
 		parentReference: { id: 'PARENT_FOLDER_ID_HERE' },
 	},
 	async onEnable(context) {
-		await pollingHelper.onEnable(polling, {
-			auth: context.auth,
-			store: context.store,
-			propsValue: context.propsValue,
-		});
+		await pollingHelper.onEnable(polling, context);
 	},
 	async onDisable(context) {
-		await pollingHelper.onDisable(polling, {
-			auth: context.auth,
-			store: context.store,
-			propsValue: context.propsValue,
-		});
+		await pollingHelper.onDisable(polling, context);
 	},
 	async test(context) {
 		return await pollingHelper.test(polling, context);

--- a/packages/pieces/community/microsoft-sharepoint/src/lib/triggers/new-or-updated-list.ts
+++ b/packages/pieces/community/microsoft-sharepoint/src/lib/triggers/new-or-updated-list.ts
@@ -97,18 +97,10 @@ export const newOrUpdatedListTrigger = createTrigger({
 		webUrl: 'https://contoso.sharepoint.com/sites/MySite/Lists/Projects%20Tracker',
 	},
 	async onEnable(context) {
-		await pollingHelper.onEnable(polling, {
-			auth: context.auth,
-			store: context.store,
-			propsValue: context.propsValue,
-		});
+		await pollingHelper.onEnable(polling, context);
 	},
 	async onDisable(context) {
-		await pollingHelper.onDisable(polling, {
-			auth: context.auth,
-			store: context.store,
-			propsValue: context.propsValue,
-		});
+		await pollingHelper.onDisable(polling, context);
 	},
 	async test(context) {
 		return await pollingHelper.test(polling, context);

--- a/packages/pieces/community/microsoft-teams/package.json
+++ b/packages/pieces/community/microsoft-teams/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-microsoft-teams",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "dependencies": {

--- a/packages/pieces/community/microsoft-teams/src/lib/triggers/new-channel-message.ts
+++ b/packages/pieces/community/microsoft-teams/src/lib/triggers/new-channel-message.ts
@@ -31,18 +31,10 @@ export const newChannelMessageTrigger = createTrigger({
 	},
 	type: TriggerStrategy.POLLING,
 	async onEnable(context) {
-		await pollingHelper.onEnable(polling, {
-			auth: context.auth,
-			store: context.store,
-			propsValue: context.propsValue,
-		});
+		await pollingHelper.onEnable(polling, context);
 	},
 	async onDisable(context) {
-		await pollingHelper.onDisable(polling, {
-			auth: context.auth,
-			store: context.store,
-			propsValue: context.propsValue,
-		});
+		await pollingHelper.onDisable(polling, context);
 	},
 	async test(context) {
 		return await pollingHelper.test(polling, context);

--- a/packages/pieces/community/microsoft-teams/src/lib/triggers/new-channel.ts
+++ b/packages/pieces/community/microsoft-teams/src/lib/triggers/new-channel.ts
@@ -30,18 +30,10 @@ export const newChannelTrigger = createTrigger({
 	},
 	type: TriggerStrategy.POLLING,
 	async onEnable(context) {
-		await pollingHelper.onEnable(polling, {
-			auth: context.auth,
-			store: context.store,
-			propsValue: context.propsValue,
-		});
+		await pollingHelper.onEnable(polling, context);
 	},
 	async onDisable(context) {
-		await pollingHelper.onDisable(polling, {
-			auth: context.auth,
-			store: context.store,
-			propsValue: context.propsValue,
-		});
+		await pollingHelper.onDisable(polling, context);
 	},
 	async test(context) {
 		return await pollingHelper.test(polling, context);

--- a/packages/pieces/community/microsoft-teams/src/lib/triggers/new-chat-message.ts
+++ b/packages/pieces/community/microsoft-teams/src/lib/triggers/new-chat-message.ts
@@ -30,18 +30,10 @@ export const newChatMessageTrigger = createTrigger({
 	},
 	type: TriggerStrategy.POLLING,
 	async onEnable(context) {
-		await pollingHelper.onEnable(polling, {
-			auth: context.auth,
-			store: context.store,
-			propsValue: context.propsValue,
-		});
+		await pollingHelper.onEnable(polling, context);
 	},
 	async onDisable(context) {
-		await pollingHelper.onDisable(polling, {
-			auth: context.auth,
-			store: context.store,
-			propsValue: context.propsValue,
-		});
+		await pollingHelper.onDisable(polling, context);
 	},
 	async test(context) {
 		return await pollingHelper.test(polling, context);

--- a/packages/pieces/community/microsoft-teams/src/lib/triggers/new-chat.ts
+++ b/packages/pieces/community/microsoft-teams/src/lib/triggers/new-chat.ts
@@ -26,10 +26,19 @@ export const newChatTrigger = createTrigger({
 	props: {},
 	type: TriggerStrategy.POLLING,
 	async onEnable(context) {
-		await pollingHelper.onEnable(polling, context);
+		await pollingHelper.onEnable(polling, {
+			auth: context.auth,
+			store: context.store,
+			propsValue: context.propsValue as Props,
+			isRepublish: context.isRepublish,
+		});
 	},
 	async onDisable(context) {
-		await pollingHelper.onDisable(polling, context);
+		await pollingHelper.onDisable(polling, {
+			auth: context.auth,
+			store: context.store,
+			propsValue: context.propsValue as Props,
+		});
 	},
 	async test(context) {
 		return await pollingHelper.test(polling, context as any);

--- a/packages/pieces/community/microsoft-teams/src/lib/triggers/new-chat.ts
+++ b/packages/pieces/community/microsoft-teams/src/lib/triggers/new-chat.ts
@@ -26,18 +26,10 @@ export const newChatTrigger = createTrigger({
 	props: {},
 	type: TriggerStrategy.POLLING,
 	async onEnable(context) {
-		await pollingHelper.onEnable(polling, {
-			auth: context.auth,
-			store: context.store,
-			propsValue: context.propsValue as Props,
-		});
+		await pollingHelper.onEnable(polling, context);
 	},
 	async onDisable(context) {
-		await pollingHelper.onDisable(polling, {
-			auth: context.auth,
-			store: context.store,
-			propsValue: context.propsValue as Props,
-		});
+		await pollingHelper.onDisable(polling, context);
 	},
 	async test(context) {
 		return await pollingHelper.test(polling, context as any);

--- a/packages/pieces/community/microsoft-todo/package.json
+++ b/packages/pieces/community/microsoft-todo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-microsoft-todo",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "dependencies": {

--- a/packages/pieces/community/microsoft-todo/src/lib/triggers/new-task-created.ts
+++ b/packages/pieces/community/microsoft-todo/src/lib/triggers/new-task-created.ts
@@ -73,18 +73,10 @@ export const newTaskCreatedTrigger = createTrigger({
 	},
 	type: TriggerStrategy.POLLING,
 	async onEnable(context) {
-		await pollingHelper.onEnable(polling, {
-			auth: context.auth,
-			store: context.store,
-			propsValue: context.propsValue,
-		});
+		await pollingHelper.onEnable(polling, context);
 	},
 	async onDisable(context) {
-		await pollingHelper.onDisable(polling, {
-			auth: context.auth,
-			store: context.store,
-			propsValue: context.propsValue,
-		});
+		await pollingHelper.onDisable(polling, context);
 	},
 	async test(context) {
 		return await pollingHelper.test(polling, context);

--- a/packages/pieces/community/microsoft-todo/src/lib/triggers/task-updated.ts
+++ b/packages/pieces/community/microsoft-todo/src/lib/triggers/task-updated.ts
@@ -73,18 +73,10 @@ export const newOrUpdatedTaskTrigger = createTrigger({
 	},
 	type: TriggerStrategy.POLLING,
 	async onEnable(context) {
-		await pollingHelper.onEnable(polling, {
-			auth: context.auth,
-			store: context.store,
-			propsValue: context.propsValue,
-		});
+		await pollingHelper.onEnable(polling, context);
 	},
 	async onDisable(context) {
-		await pollingHelper.onDisable(polling, {
-			auth: context.auth,
-			store: context.store,
-			propsValue: context.propsValue,
-		});
+		await pollingHelper.onDisable(polling, context);
 	},
 	async test(context) {
 		return await pollingHelper.test(polling, context);

--- a/packages/pieces/community/mollie/package.json
+++ b/packages/pieces/community/mollie/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-mollie",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/packages/pieces/community/mollie/src/lib/triggers/new-chargeback.ts
+++ b/packages/pieces/community/mollie/src/lib/triggers/new-chargeback.ts
@@ -242,19 +242,11 @@ export const mollieNewChargeback = createTrigger({
   },
 
   async onEnable(context) {
-    await pollingHelper.onEnable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onEnable(polling, context);
   },
 
   async onDisable(context) {
-    await pollingHelper.onDisable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onDisable(polling, context);
   },
 
   async run(context) {

--- a/packages/pieces/community/mollie/src/lib/triggers/new-customer.ts
+++ b/packages/pieces/community/mollie/src/lib/triggers/new-customer.ts
@@ -156,19 +156,11 @@ export const mollieNewCustomer = createTrigger({
   },
 
   async onEnable(context) {
-    await pollingHelper.onEnable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onEnable(polling, context);
   },
 
   async onDisable(context) {
-    await pollingHelper.onDisable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onDisable(polling, context);
   },
 
   async run(context) {

--- a/packages/pieces/community/mollie/src/lib/triggers/new-order.ts
+++ b/packages/pieces/community/mollie/src/lib/triggers/new-order.ts
@@ -218,19 +218,11 @@ export const mollieNewOrder = createTrigger({
   },
 
   async onEnable(context) {
-    await pollingHelper.onEnable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onEnable(polling, context);
   },
 
   async onDisable(context) {
-    await pollingHelper.onDisable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onDisable(polling, context);
   },
 
   async run(context) {

--- a/packages/pieces/community/mollie/src/lib/triggers/new-payment.ts
+++ b/packages/pieces/community/mollie/src/lib/triggers/new-payment.ts
@@ -196,19 +196,11 @@ export const mollieNewPayment = createTrigger({
   },
 
   async onEnable(context) {
-    await pollingHelper.onEnable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onEnable(polling, context);
   },
 
   async onDisable(context) {
-    await pollingHelper.onDisable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onDisable(polling, context);
   },
 
   async run(context) {

--- a/packages/pieces/community/mollie/src/lib/triggers/new-refund.ts
+++ b/packages/pieces/community/mollie/src/lib/triggers/new-refund.ts
@@ -235,19 +235,11 @@ export const mollieNewRefund = createTrigger({
   },
 
   async onEnable(context) {
-    await pollingHelper.onEnable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onEnable(polling, context);
   },
 
   async onDisable(context) {
-    await pollingHelper.onDisable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onDisable(polling, context);
   },
 
   async run(context) {

--- a/packages/pieces/community/mollie/src/lib/triggers/new-settlement.ts
+++ b/packages/pieces/community/mollie/src/lib/triggers/new-settlement.ts
@@ -227,19 +227,11 @@ export const mollieNewSettlement = createTrigger({
   },
 
   async onEnable(context) {
-    await pollingHelper.onEnable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onEnable(polling, context);
   },
 
   async onDisable(context) {
-    await pollingHelper.onDisable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onDisable(polling, context);
   },
 
   async run(context) {

--- a/packages/pieces/community/motion/package.json
+++ b/packages/pieces/community/motion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-motion",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {

--- a/packages/pieces/community/motion/src/lib/triggers/task-created.ts
+++ b/packages/pieces/community/motion/src/lib/triggers/task-created.ts
@@ -76,18 +76,10 @@ export const taskCreated = createTrigger({
   },
 
   async onEnable(context) {
-    await pollingHelper.onEnable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onEnable(polling, context);
   },
   async onDisable(context) {
-    await pollingHelper.onDisable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onDisable(polling, context);
   },
   async test(context) {
     return await pollingHelper.test(polling, context);

--- a/packages/pieces/community/ninox/package.json
+++ b/packages/pieces/community/ninox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-ninox",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {

--- a/packages/pieces/community/ninox/src/lib/triggers/new-record.ts
+++ b/packages/pieces/community/ninox/src/lib/triggers/new-record.ts
@@ -75,18 +75,10 @@ export const newRecord = createTrigger({
 	},
 	type: TriggerStrategy.POLLING,
 	async onEnable(context) {
-		await pollingHelper.onEnable(polling, {
-			auth: context.auth,
-			store: context.store,
-			propsValue: context.propsValue,
-		});
+		await pollingHelper.onEnable(polling, context);
 	},
 	async onDisable(context) {
-		await pollingHelper.onDisable(polling, {
-			auth: context.auth,
-			store: context.store,
-			propsValue: context.propsValue,
-		});
+		await pollingHelper.onDisable(polling, context);
 	},
 	async test(context) {
 		return await pollingHelper.test(polling, context);

--- a/packages/pieces/community/notion/package.json
+++ b/packages/pieces/community/notion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-notion",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "dependencies": {

--- a/packages/pieces/community/notion/src/lib/triggers/new-comment.ts
+++ b/packages/pieces/community/notion/src/lib/triggers/new-comment.ts
@@ -76,18 +76,10 @@ export const newComment = createTrigger({
     });
   },
   async onEnable(ctx) {
-    await pollingHelper.onEnable(polling, {
-      auth: ctx.auth,
-      store: ctx.store,
-      propsValue: ctx.propsValue,
-    });
+    await pollingHelper.onEnable(polling, ctx);
   },
   async onDisable(ctx) {
-    await pollingHelper.onDisable(polling, {
-      auth: ctx.auth,
-      store: ctx.store,
-      propsValue: ctx.propsValue,
-    });
+    await pollingHelper.onDisable(polling, ctx);
   },
   async run(ctx) {
     return await pollingHelper.poll(polling, {

--- a/packages/pieces/community/notion/src/lib/triggers/new-database-item.ts
+++ b/packages/pieces/community/notion/src/lib/triggers/new-database-item.ts
@@ -102,18 +102,10 @@ export const newDatabaseItem = createTrigger({
     });
   },
   async onEnable(ctx) {
-    await pollingHelper.onEnable(polling, {
-      auth: ctx.auth,
-      store: ctx.store,
-      propsValue: ctx.propsValue,
-    });
+    await pollingHelper.onEnable(polling, ctx);
   },
   async onDisable(ctx) {
-    await pollingHelper.onDisable(polling, {
-      auth: ctx.auth,
-      store: ctx.store,
-      propsValue: ctx.propsValue,
-    });
+    await pollingHelper.onDisable(polling, ctx);
   },
   async run(ctx) {
     return await pollingHelper.poll(polling, {

--- a/packages/pieces/community/notion/src/lib/triggers/updated-database-item.ts
+++ b/packages/pieces/community/notion/src/lib/triggers/updated-database-item.ts
@@ -102,18 +102,10 @@ export const updatedDatabaseItem = createTrigger({
     });
   },
   async onEnable(ctx) {
-    await pollingHelper.onEnable(polling, {
-      auth: ctx.auth,
-      store: ctx.store,
-      propsValue: ctx.propsValue,
-    });
+    await pollingHelper.onEnable(polling, ctx);
   },
   async onDisable(ctx) {
-    await pollingHelper.onDisable(polling, {
-      auth: ctx.auth,
-      store: ctx.store,
-      propsValue: ctx.propsValue,
-    });
+    await pollingHelper.onDisable(polling, ctx);
   },
   async run(ctx) {
     return await pollingHelper.poll(polling, {

--- a/packages/pieces/community/notion/src/lib/triggers/updated-page.ts
+++ b/packages/pieces/community/notion/src/lib/triggers/updated-page.ts
@@ -87,18 +87,10 @@ export const updatedPage = createTrigger({
     });
   },
   async onEnable(ctx) {
-    await pollingHelper.onEnable(polling, {
-      auth: ctx.auth,
-      store: ctx.store,
-      propsValue: ctx.propsValue,
-    });
+    await pollingHelper.onEnable(polling, ctx);
   },
   async onDisable(ctx) {
-    await pollingHelper.onDisable(polling, {
-      auth: ctx.auth,
-      store: ctx.store,
-      propsValue: ctx.propsValue,
-    });
+    await pollingHelper.onDisable(polling, ctx);
   },
   async run(ctx) {
     return await pollingHelper.poll(polling, {

--- a/packages/pieces/community/oracle-database/package.json
+++ b/packages/pieces/community/oracle-database/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-oracle-database",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/packages/pieces/community/oracle-database/src/lib/triggers/new-row.ts
+++ b/packages/pieces/community/oracle-database/src/lib/triggers/new-row.ts
@@ -94,19 +94,11 @@ export const newRowTrigger = createTrigger({
   sampleData: {},
 
   async onEnable(context) {
-    await pollingHelper.onEnable(polling, {
-      store: context.store,
-      propsValue: context.propsValue,
-      auth: context.auth,
-    });
+    await pollingHelper.onEnable(polling, context);
   },
 
   async onDisable(context) {
-    await pollingHelper.onDisable(polling, {
-      store: context.store,
-      propsValue: context.propsValue,
-      auth: context.auth,
-    });
+    await pollingHelper.onDisable(polling, context);
   },
 
   async run(context) {

--- a/packages/pieces/community/parseur/package.json
+++ b/packages/pieces/community/parseur/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-parseur",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/packages/pieces/community/parseur/src/lib/triggers/new-mailbox.ts
+++ b/packages/pieces/community/parseur/src/lib/triggers/new-mailbox.ts
@@ -44,13 +44,11 @@ export const newMailbox = createTrigger({
     return await pollingHelper.test(polling, context);
   },
   async onEnable(context) {
-    const { store, auth, propsValue } = context;
-    await pollingHelper.onEnable(polling, { store, auth, propsValue });
+    await pollingHelper.onEnable(polling, context);
   },
 
   async onDisable(context) {
-    const { store, auth, propsValue } = context;
-    await pollingHelper.onDisable(polling, { store, auth, propsValue });
+    await pollingHelper.onDisable(polling, context);
   },
 
   async run(context) {

--- a/packages/pieces/community/pdfmonkey/package.json
+++ b/packages/pieces/community/pdfmonkey/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-pdfmonkey",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/packages/pieces/community/pdfmonkey/src/lib/triggers/document-generated.ts
+++ b/packages/pieces/community/pdfmonkey/src/lib/triggers/document-generated.ts
@@ -86,13 +86,11 @@ export const documentGeneratedTrigger = createTrigger({
 		return await pollingHelper.test(polling, context);
 	},
 	async onEnable(context) {
-		const { store, auth, propsValue } = context;
-		await pollingHelper.onEnable(polling, { store, auth, propsValue });
+		await pollingHelper.onEnable(polling, context);
 	},
 
 	async onDisable(context) {
-		const { store, auth, propsValue } = context;
-		await pollingHelper.onDisable(polling, { store, auth, propsValue });
+		await pollingHelper.onDisable(polling, context);
 	},
 
 	async run(context) {

--- a/packages/pieces/community/pinterest/package.json
+++ b/packages/pieces/community/pinterest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-pinterest",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {

--- a/packages/pieces/community/pinterest/src/lib/triggers/new-board.ts
+++ b/packages/pieces/community/pinterest/src/lib/triggers/new-board.ts
@@ -156,12 +156,10 @@ export const newBoard = createTrigger({
     return await pollingHelper.test(polling, context);
   },
   async onEnable(context) {
-    const { store, auth, propsValue } = context;
-    await pollingHelper.onEnable(polling, { store, auth, propsValue });
+    await pollingHelper.onEnable(polling, context);
   },
   async onDisable(context) {
-    const { store, auth, propsValue } = context;
-    await pollingHelper.onDisable(polling, { store, auth, propsValue });
+    await pollingHelper.onDisable(polling, context);
   },
   async run(context) {
     return await pollingHelper.poll(polling, context);

--- a/packages/pieces/community/pinterest/src/lib/triggers/new-follower.ts
+++ b/packages/pieces/community/pinterest/src/lib/triggers/new-follower.ts
@@ -88,12 +88,10 @@ export const newFollower = createTrigger({
     return await pollingHelper.test(polling, context);
   },
   async onEnable(context) {
-    const { store, auth, propsValue } = context;
-    await pollingHelper.onEnable(polling, { store, auth, propsValue });
+    await pollingHelper.onEnable(polling, context);
   },
   async onDisable(context) {
-    const { store, auth, propsValue } = context;
-    await pollingHelper.onDisable(polling, { store, auth, propsValue });
+    await pollingHelper.onDisable(polling, context);
   },
   async run(context) {
     return await pollingHelper.poll(polling, context);

--- a/packages/pieces/community/pinterest/src/lib/triggers/new-pin-on-board.ts
+++ b/packages/pieces/community/pinterest/src/lib/triggers/new-pin-on-board.ts
@@ -214,12 +214,10 @@ export const newPinOnBoard = createTrigger({
     return await pollingHelper.test(polling, context);
   },
   async onEnable(context) {
-    const { store, auth, propsValue } = context;
-    await pollingHelper.onEnable(polling, { store, auth, propsValue });
+    await pollingHelper.onEnable(polling, context);
   },
   async onDisable(context) {
-    const { store, auth, propsValue } = context;
-    await pollingHelper.onDisable(polling, { store, auth, propsValue });
+    await pollingHelper.onDisable(polling, context);
   },
   async run(context) {
     return await pollingHelper.poll(polling, context);

--- a/packages/pieces/community/postgres/package.json
+++ b/packages/pieces/community/postgres/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-postgres",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "dependencies": {

--- a/packages/pieces/community/postgres/src/lib/triggers/new-row.ts
+++ b/packages/pieces/community/postgres/src/lib/triggers/new-row.ts
@@ -188,13 +188,11 @@ export const newRow = createTrigger({
         return await pollingHelper.test(polling, context);
     },
     async onEnable(context) {
-        const { store, auth, propsValue } = context;
-        await pollingHelper.onEnable(polling, { store, propsValue, auth });
+        await pollingHelper.onEnable(polling, context);
     },
 
     async onDisable(context) {
-        const { store, auth, propsValue } = context;
-        await pollingHelper.onDisable(polling, { store, propsValue, auth });
+        await pollingHelper.onDisable(polling, context);
     },
 
     async run(context) {

--- a/packages/pieces/community/presentation/package.json
+++ b/packages/pieces/community/presentation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-presentation",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/packages/pieces/community/presentation/src/lib/triggers/new-presentation.ts
+++ b/packages/pieces/community/presentation/src/lib/triggers/new-presentation.ts
@@ -89,13 +89,11 @@ export const newPresentation = createTrigger({
     return await pollingHelper.test(polling, context);
   },
   async onEnable(context) {
-    const { store, auth, propsValue } = context;
-    await pollingHelper.onEnable(polling, { store, auth, propsValue });
+    await pollingHelper.onEnable(polling, context);
   },
 
   async onDisable(context) {
-    const { store, auth, propsValue } = context;
-    await pollingHelper.onDisable(polling, { store, auth, propsValue });
+    await pollingHelper.onDisable(polling, context);
   },
 
   async run(context) {

--- a/packages/pieces/community/quickbase/package.json
+++ b/packages/pieces/community/quickbase/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-quickbase",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/packages/pieces/community/quickbase/src/lib/triggers/new-or-updated-record.ts
+++ b/packages/pieces/community/quickbase/src/lib/triggers/new-or-updated-record.ts
@@ -80,12 +80,10 @@ export const newOrUpdatedRecord = createTrigger({
   sampleData: {
   },
   async onEnable(context) {
-    const { store, auth, propsValue } = context;
-    await pollingHelper.onEnable(polling, { store, auth, propsValue });
+    await pollingHelper.onEnable(polling, context);
   },
   async onDisable(context) {
-    const { store, auth, propsValue } = context;
-    await pollingHelper.onDisable(polling, { store, auth, propsValue });
+    await pollingHelper.onDisable(polling, context);
   },
   async run(context) {
     const { store, auth, propsValue, files } = context;

--- a/packages/pieces/community/quickbase/src/lib/triggers/new-record.ts
+++ b/packages/pieces/community/quickbase/src/lib/triggers/new-record.ts
@@ -82,12 +82,10 @@ export const newRecord = createTrigger({
   type: TriggerStrategy.POLLING,
   sampleData: {},
   async onEnable(context) {
-    const { store, auth, propsValue } = context;
-    await pollingHelper.onEnable(polling, { store, auth, propsValue });
+    await pollingHelper.onEnable(polling, context);
   },
   async onDisable(context) {
-    const { store, auth, propsValue } = context;
-    await pollingHelper.onDisable(polling, { store, auth, propsValue });
+    await pollingHelper.onDisable(polling, context);
   },
   async run(context) {
     const { store, auth, propsValue, files } = context;

--- a/packages/pieces/community/quickbooks/package.json
+++ b/packages/pieces/community/quickbooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-quickbooks",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {

--- a/packages/pieces/community/quickbooks/src/triggers/new-customer.ts
+++ b/packages/pieces/community/quickbooks/src/triggers/new-customer.ts
@@ -66,18 +66,10 @@ export const newCustomer = createTrigger({
   props: {},
   type: TriggerStrategy.POLLING,
   async onEnable(context) {
-    await pollingHelper.onEnable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onEnable(polling, context);
   },
   async onDisable(context) {
-    await pollingHelper.onDisable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onDisable(polling, context);
   },
   async test(context) {
     return await pollingHelper.test(polling, context);

--- a/packages/pieces/community/quickbooks/src/triggers/new-deposit.ts
+++ b/packages/pieces/community/quickbooks/src/triggers/new-deposit.ts
@@ -60,18 +60,10 @@ export const newDeposit = createTrigger({
     props: {},
     type: TriggerStrategy.POLLING,
   async onEnable(context) {
-    await pollingHelper.onEnable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onEnable(polling, context);
   },
   async onDisable(context) {
-    await pollingHelper.onDisable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onDisable(polling, context);
   },
   async test(context) {
     return await pollingHelper.test(polling, context);

--- a/packages/pieces/community/quickbooks/src/triggers/new-expense.ts
+++ b/packages/pieces/community/quickbooks/src/triggers/new-expense.ts
@@ -66,18 +66,10 @@ export const newExpense = createTrigger({
   props: {},
   type: TriggerStrategy.POLLING,
   async onEnable(context) {
-    await pollingHelper.onEnable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onEnable(polling, context);
   },
   async onDisable(context) {
-    await pollingHelper.onDisable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onDisable(polling, context);
   },
   async test(context) {
     return await pollingHelper.test(polling, context);

--- a/packages/pieces/community/quickbooks/src/triggers/new-invoice.ts
+++ b/packages/pieces/community/quickbooks/src/triggers/new-invoice.ts
@@ -66,18 +66,10 @@ export const newInvoice = createTrigger({
   props: {},
   type: TriggerStrategy.POLLING,
   async onEnable(context) {
-    await pollingHelper.onEnable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onEnable(polling, context);
   },
   async onDisable(context) {
-    await pollingHelper.onDisable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onDisable(polling, context);
   },
   async test(context) {
     return await pollingHelper.test(polling, context);

--- a/packages/pieces/community/quickbooks/src/triggers/new-transfer.ts
+++ b/packages/pieces/community/quickbooks/src/triggers/new-transfer.ts
@@ -67,18 +67,10 @@ export const newTransfer = createTrigger({
   props: {},
   type: TriggerStrategy.POLLING,
   async onEnable(context) {
-    await pollingHelper.onEnable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onEnable(polling, context);
   },
   async onDisable(context) {
-    await pollingHelper.onDisable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onDisable(polling, context);
   },
   async test(context) {
     return await pollingHelper.test(polling, context);

--- a/packages/pieces/community/rabbitmq/package.json
+++ b/packages/pieces/community/rabbitmq/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-rabbitmq",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "dependencies": {

--- a/packages/pieces/community/rabbitmq/src/lib/triggers/message-received.ts
+++ b/packages/pieces/community/rabbitmq/src/lib/triggers/message-received.ts
@@ -75,13 +75,11 @@ export const messageReceived = createTrigger({
     return await pollingHelper.test(polling, { store, auth, propsValue, files: context.files });
   },
   async onEnable(context) {
-    const { store, auth, propsValue } = context;
-    await pollingHelper.onEnable(polling, { store, auth, propsValue });
+    await pollingHelper.onEnable(polling, context);
   },
 
   async onDisable(context) {
-    const { store, auth, propsValue } = context;
-    await pollingHelper.onDisable(polling, { store, auth, propsValue });
+    await pollingHelper.onDisable(polling, context);
   },
 
   async run(context) {

--- a/packages/pieces/community/rss/package.json
+++ b/packages/pieces/community/rss/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-rss",
-  "version": "0.5.7",
+  "version": "0.5.8",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "dependencies": {

--- a/packages/pieces/community/rss/src/lib/triggers/new-item-list-triggers.ts
+++ b/packages/pieces/community/rss/src/lib/triggers/new-item-list-triggers.ts
@@ -46,11 +46,12 @@ export const rssNewItemListTrigger = createTrigger({
       files: files,
     });
   },
-  async onEnable({ auth, propsValue, store }): Promise<void> {
+  async onEnable({ auth, propsValue, store, isRepublish }): Promise<void> {
     await pollingHelper.onEnable(polling, {
       auth,
       store: store,
       propsValue: propsValue as PollingProps,
+      isRepublish,
     });
   },
 

--- a/packages/pieces/community/rss/src/lib/triggers/new-item-trigger.ts
+++ b/packages/pieces/community/rss/src/lib/triggers/new-item-trigger.ts
@@ -43,11 +43,12 @@ export const rssNewItemTrigger = createTrigger({
       files: files,
     });
   },
-  async onEnable({ auth, propsValue, store }): Promise<void> {
+  async onEnable({ auth, propsValue, store, isRepublish }): Promise<void> {
     await pollingHelper.onEnable(polling, {
       auth,
       store: store,
       propsValue: propsValue,
+      isRepublish,
     });
   },
 

--- a/packages/pieces/community/salesforce/package.json
+++ b/packages/pieces/community/salesforce/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-salesforce",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {

--- a/packages/pieces/community/salesforce/src/lib/trigger/new-record.ts
+++ b/packages/pieces/community/salesforce/src/lib/trigger/new-record.ts
@@ -42,18 +42,10 @@ export const newRecord = createTrigger({
     });
   },
   async onEnable(ctx) {
-    await pollingHelper.onEnable(polling, {
-      auth: ctx.auth,
-      store: ctx.store,
-      propsValue: ctx.propsValue,
-    });
+    await pollingHelper.onEnable(polling, ctx);
   },
   async onDisable(ctx) {
-    await pollingHelper.onDisable(polling, {
-      auth: ctx.auth,
-      store: ctx.store,
-      propsValue: ctx.propsValue,
-    });
+    await pollingHelper.onDisable(polling, ctx);
   },
   async run(ctx) {
     return await pollingHelper.poll(polling, {

--- a/packages/pieces/community/salesforce/src/lib/trigger/new-updated-record.ts
+++ b/packages/pieces/community/salesforce/src/lib/trigger/new-updated-record.ts
@@ -42,18 +42,10 @@ export const newOrUpdatedRecord = createTrigger({
     });
   },
   async onEnable(ctx) {
-    await pollingHelper.onEnable(polling, {
-      auth: ctx.auth,
-      store: ctx.store,
-      propsValue: ctx.propsValue,
-    });
+    await pollingHelper.onEnable(polling, ctx);
   },
   async onDisable(ctx) {
-    await pollingHelper.onDisable(polling, {
-      auth: ctx.auth,
-      store: ctx.store,
-      propsValue: ctx.propsValue,
-    });
+    await pollingHelper.onDisable(polling, ctx);
   },
   async run(ctx) {
     return await pollingHelper.poll(polling, ctx);

--- a/packages/pieces/community/service-now/package.json
+++ b/packages/pieces/community/service-now/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-service-now",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/packages/pieces/community/service-now/src/lib/triggers/new-comment.ts
+++ b/packages/pieces/community/service-now/src/lib/triggers/new-comment.ts
@@ -94,18 +94,10 @@ export const newCommentTrigger = createTrigger({
     sys_created_on: '2026-04-30 12:00:00',
   },
   async onEnable(context) {
-    await pollingHelper.onEnable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onEnable(polling, context);
   },
   async onDisable(context) {
-    await pollingHelper.onDisable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onDisable(polling, context);
   },
   async run(context) {
     return await pollingHelper.poll(polling, {

--- a/packages/pieces/community/service-now/src/lib/triggers/new-record.ts
+++ b/packages/pieces/community/service-now/src/lib/triggers/new-record.ts
@@ -66,18 +66,10 @@ export const newRecordTrigger = createTrigger({
     sys_updated_on: '2023-01-01 00:00:00',
   },
   async onEnable(context) {
-    await pollingHelper.onEnable(polling, {
-      auth: context.auth as any,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onEnable(polling, context);
   },
   async onDisable(context) {
-    await pollingHelper.onDisable(polling, {
-      auth: context.auth as any,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onDisable(polling, context);
   },
   async run(context) {
     return await pollingHelper.poll(polling, {

--- a/packages/pieces/community/service-now/src/lib/triggers/new-record.ts
+++ b/packages/pieces/community/service-now/src/lib/triggers/new-record.ts
@@ -66,10 +66,19 @@ export const newRecordTrigger = createTrigger({
     sys_updated_on: '2023-01-01 00:00:00',
   },
   async onEnable(context) {
-    await pollingHelper.onEnable(polling, context);
+    await pollingHelper.onEnable(polling, {
+      auth: context.auth as any,
+      store: context.store,
+      propsValue: context.propsValue,
+      isRepublish: context.isRepublish,
+    });
   },
   async onDisable(context) {
-    await pollingHelper.onDisable(polling, context);
+    await pollingHelper.onDisable(polling, {
+      auth: context.auth as any,
+      store: context.store,
+      propsValue: context.propsValue,
+    });
   },
   async run(context) {
     return await pollingHelper.poll(polling, {

--- a/packages/pieces/community/service-now/src/lib/triggers/updated-record.ts
+++ b/packages/pieces/community/service-now/src/lib/triggers/updated-record.ts
@@ -64,10 +64,19 @@ export const updatedRecordTrigger = createTrigger({
     sys_updated_on: '2023-01-01 01:00:00',
   },
   async onEnable(context) {
-    await pollingHelper.onEnable(polling, context);
+    await pollingHelper.onEnable(polling, {
+      auth: context.auth as any,
+      store: context.store,
+      propsValue: context.propsValue,
+      isRepublish: context.isRepublish,
+    });
   },
   async onDisable(context) {
-    await pollingHelper.onDisable(polling, context);
+    await pollingHelper.onDisable(polling, {
+      auth: context.auth as any,
+      store: context.store,
+      propsValue: context.propsValue,
+    });
   },
   async run(context) {
     return await pollingHelper.poll(polling, {

--- a/packages/pieces/community/service-now/src/lib/triggers/updated-record.ts
+++ b/packages/pieces/community/service-now/src/lib/triggers/updated-record.ts
@@ -64,18 +64,10 @@ export const updatedRecordTrigger = createTrigger({
     sys_updated_on: '2023-01-01 01:00:00',
   },
   async onEnable(context) {
-    await pollingHelper.onEnable(polling, {
-      auth: context.auth as any,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onEnable(polling, context);
   },
   async onDisable(context) {
-    await pollingHelper.onDisable(polling, {
-      auth: context.auth as any,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onDisable(polling, context);
   },
   async run(context) {
     return await pollingHelper.poll(polling, {

--- a/packages/pieces/community/shippo/package.json
+++ b/packages/pieces/community/shippo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-shippo",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/packages/pieces/community/shippo/src/lib/triggers/new-order.ts
+++ b/packages/pieces/community/shippo/src/lib/triggers/new-order.ts
@@ -114,18 +114,10 @@ export const newOrder = createTrigger({
     });
   },
   async onEnable(context) {
-    await pollingHelper.onEnable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onEnable(polling, context);
   },
   async onDisable(context) {
-    await pollingHelper.onDisable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onDisable(polling, context);
   },
   async run(context) {
     return await pollingHelper.poll(polling, {

--- a/packages/pieces/community/shippo/src/lib/triggers/new-shipping-label.ts
+++ b/packages/pieces/community/shippo/src/lib/triggers/new-shipping-label.ts
@@ -101,18 +101,10 @@ export const newShippingLabel = createTrigger({
     });
   },
   async onEnable(context) {
-    await pollingHelper.onEnable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onEnable(polling, context);
   },
   async onDisable(context) {
-    await pollingHelper.onDisable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onDisable(polling, context);
   },
   async run(context) {
     return await pollingHelper.poll(polling, {

--- a/packages/pieces/community/shopify/package.json
+++ b/packages/pieces/community/shopify/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-shopify",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {

--- a/packages/pieces/community/shopify/src/lib/triggers/new-abandoned-checkout.ts
+++ b/packages/pieces/community/shopify/src/lib/triggers/new-abandoned-checkout.ts
@@ -20,17 +20,17 @@ export const newAbandonedCheckout = createTrigger({
   props: {},
   sampleData: {},
   type: TriggerStrategy.POLLING,
-  async onEnable({ auth, propsValue, store, isRepublish }) {
-    await pollingHelper.onEnable(polling, { auth, propsValue, store, isRepublish });
+  async onEnable(context) {
+    await pollingHelper.onEnable(polling, context);
   },
-  async onDisable({ auth, propsValue, store }) {
-    await pollingHelper.onDisable(polling, { auth, propsValue, store });
+  async onDisable(context) {
+    await pollingHelper.onDisable(polling, context);
   },
-  async run({ auth, propsValue, store, files }) {
-    return await pollingHelper.poll(polling, { auth, propsValue, store, files });
+  async run(context) {
+    return await pollingHelper.poll(polling, context);
   },
-  async test({ auth, propsValue, store, files }) {
-    return await pollingHelper.test(polling, { auth, propsValue, store, files });
+  async test(context) {
+    return await pollingHelper.test(polling,context);
   },
 });
 

--- a/packages/pieces/community/shopify/src/lib/triggers/new-abandoned-checkout.ts
+++ b/packages/pieces/community/shopify/src/lib/triggers/new-abandoned-checkout.ts
@@ -20,11 +20,11 @@ export const newAbandonedCheckout = createTrigger({
   props: {},
   sampleData: {},
   type: TriggerStrategy.POLLING,
-  async onEnable({ auth, propsValue, store }) {
-    await pollingHelper.onEnable(polling, { auth, propsValue, store });
+  async onEnable({ auth, propsValue, store, isRepublish }) {
+    await pollingHelper.onEnable(polling, { auth, propsValue, store, isRepublish });
   },
   async onDisable({ auth, propsValue, store }) {
-    await pollingHelper.onEnable(polling, { auth, propsValue, store });
+    await pollingHelper.onDisable(polling, { auth, propsValue, store });
   },
   async run({ auth, propsValue, store, files }) {
     return await pollingHelper.poll(polling, { auth, propsValue, store, files });

--- a/packages/pieces/community/sitespeakai/package.json
+++ b/packages/pieces/community/sitespeakai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-sitespeakai",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/packages/pieces/community/sitespeakai/src/lib/triggers/new-lead.ts
+++ b/packages/pieces/community/sitespeakai/src/lib/triggers/new-lead.ts
@@ -63,13 +63,11 @@ export const newLead = createTrigger({
     },
 
     async onEnable(context) {
-        const { store, auth, propsValue } = context;
-        await pollingHelper.onEnable(polling, { store, auth, propsValue });
+        await pollingHelper.onEnable(polling, context);
     },
 
     async onDisable(context) {
-        const { store, auth, propsValue } = context;
-        await pollingHelper.onDisable(polling, { store, auth, propsValue });
+        await pollingHelper.onDisable(polling, context);
     },
 
     async run(context) {

--- a/packages/pieces/community/skyprep/package.json
+++ b/packages/pieces/community/skyprep/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-skyprep",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/packages/pieces/community/skyprep/src/lib/triggers/cource-failed.ts
+++ b/packages/pieces/community/skyprep/src/lib/triggers/cource-failed.ts
@@ -74,13 +74,11 @@ export const courceFailed = createTrigger({
     return await pollingHelper.test(polling, context);
   },
   async onEnable(context) {
-    const { store, auth, propsValue } = context;
-    await pollingHelper.onEnable(polling, { store, auth, propsValue });
+    await pollingHelper.onEnable(polling, context);
   },
 
   async onDisable(context) {
-    const { store, auth, propsValue } = context;
-    await pollingHelper.onDisable(polling, { store, auth, propsValue });
+    await pollingHelper.onDisable(polling, context);
   },
 
   async run(context) {

--- a/packages/pieces/community/skyprep/src/lib/triggers/cource-passed.ts
+++ b/packages/pieces/community/skyprep/src/lib/triggers/cource-passed.ts
@@ -74,13 +74,11 @@ export const courcePassed = createTrigger({
     return await pollingHelper.test(polling, context);
   },
   async onEnable(context) {
-    const { store, auth, propsValue } = context;
-    await pollingHelper.onEnable(polling, { store, auth, propsValue });
+    await pollingHelper.onEnable(polling, context);
   },
 
   async onDisable(context) {
-    const { store, auth, propsValue } = context;
-    await pollingHelper.onDisable(polling, { store, auth, propsValue });
+    await pollingHelper.onDisable(polling, context);
   },
 
   async run(context) {

--- a/packages/pieces/community/skyprep/src/lib/triggers/new-user.ts
+++ b/packages/pieces/community/skyprep/src/lib/triggers/new-user.ts
@@ -65,13 +65,11 @@ export const newUser = createTrigger({
     return await pollingHelper.test(polling, context);
   },
   async onEnable(context) {
-    const { store, auth, propsValue } = context;
-    await pollingHelper.onEnable(polling, { store, auth, propsValue });
+    await pollingHelper.onEnable(polling, context);
   },
 
   async onDisable(context) {
-    const { store, auth, propsValue } = context;
-    await pollingHelper.onDisable(polling, { store, auth, propsValue });
+    await pollingHelper.onDisable(polling, context);
   },
 
   async run(context) {

--- a/packages/pieces/community/smoove/package.json
+++ b/packages/pieces/community/smoove/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-smoove",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/packages/pieces/community/smoove/src/lib/triggers/new-form-created.ts
+++ b/packages/pieces/community/smoove/src/lib/triggers/new-form-created.ts
@@ -114,13 +114,11 @@ export const newFormCreated = createTrigger({
     },
     
     async onEnable(context) {
-        const { store, auth, propsValue } = context;
-        await pollingHelper.onEnable(polling, { store, auth, propsValue });
+        await pollingHelper.onEnable(polling, context);
     },
     
     async onDisable(context) {
-        const { store, auth, propsValue } = context;
-        await pollingHelper.onDisable(polling, { store, auth, propsValue });
+        await pollingHelper.onDisable(polling, context);
     },
     
     async run(context) {

--- a/packages/pieces/community/smoove/src/lib/triggers/new-lead-submitted.ts
+++ b/packages/pieces/community/smoove/src/lib/triggers/new-lead-submitted.ts
@@ -213,13 +213,11 @@ export const newLeadSubmitted = createTrigger({
     },
     
     async onEnable(context) {
-        const { store, auth, propsValue } = context;
-        await pollingHelper.onEnable(polling, { store, auth, propsValue });
+        await pollingHelper.onEnable(polling, context);
     },
     
     async onDisable(context) {
-        const { store, auth, propsValue } = context;
-        await pollingHelper.onDisable(polling, { store, auth, propsValue });
+        await pollingHelper.onDisable(polling, context);
     },
     
     async run(context) {

--- a/packages/pieces/community/smoove/src/lib/triggers/new-list-created.ts
+++ b/packages/pieces/community/smoove/src/lib/triggers/new-list-created.ts
@@ -130,13 +130,11 @@ export const newListCreated = createTrigger({
     },
     
     async onEnable(context) {
-        const { store, auth, propsValue } = context;
-        await pollingHelper.onEnable(polling, { store, auth, propsValue });
+        await pollingHelper.onEnable(polling, context);
     },
     
     async onDisable(context) {
-        const { store, auth, propsValue } = context;
-        await pollingHelper.onDisable(polling, { store, auth, propsValue });
+        await pollingHelper.onDisable(polling, context);
     },
     
     async run(context) {

--- a/packages/pieces/community/smoove/src/lib/triggers/new-subscriber.ts
+++ b/packages/pieces/community/smoove/src/lib/triggers/new-subscriber.ts
@@ -306,13 +306,11 @@ export const newSubscriber = createTrigger({
     },
     
     async onEnable(context) {
-        const { store, auth, propsValue } = context;
-        await pollingHelper.onEnable(polling, { store, auth, propsValue });
+        await pollingHelper.onEnable(polling, context);
     },
     
     async onDisable(context) {
-        const { store, auth, propsValue } = context;
-        await pollingHelper.onDisable(polling, { store, auth, propsValue });
+        await pollingHelper.onDisable(polling, context);
     },
     
     async run(context) {

--- a/packages/pieces/community/softr/package.json
+++ b/packages/pieces/community/softr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-softr",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/packages/pieces/community/softr/src/lib/triggers/new-database-record.ts
+++ b/packages/pieces/community/softr/src/lib/triggers/new-database-record.ts
@@ -91,12 +91,10 @@ export const newDatabaseRecord = createTrigger({
 		return await pollingHelper.test(polling, { store, auth, propsValue, files });
 	},
 	async onEnable(context) {
-		const { store, auth, propsValue } = context;
-		await pollingHelper.onEnable(polling, { store, auth, propsValue });
+		await pollingHelper.onEnable(polling, context);
 	},
 	async onDisable(context) {
-		const { store, auth, propsValue } = context;
-		await pollingHelper.onDisable(polling, { store, auth, propsValue });
+		await pollingHelper.onDisable(polling, context);
 	},
 	async run(context) {
 		const { store, auth, propsValue, files } = context;

--- a/packages/pieces/community/surrealdb/package.json
+++ b/packages/pieces/community/surrealdb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-surrealdb",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {

--- a/packages/pieces/community/surrealdb/src/lib/triggers/new-row.ts
+++ b/packages/pieces/community/surrealdb/src/lib/triggers/new-row.ts
@@ -180,13 +180,11 @@ export const newRow = createTrigger({
     return await pollingHelper.test(polling, context);
   },
   async onEnable(context) {
-    const { store, auth, propsValue } = context;
-    await pollingHelper.onEnable(polling, { store, propsValue, auth });
+    await pollingHelper.onEnable(polling, context);
   },
 
   async onDisable(context) {
-    const { store, auth, propsValue } = context;
-    await pollingHelper.onDisable(polling, { store, propsValue, auth });
+    await pollingHelper.onDisable(polling, context);
   },
 
   async run(context) {

--- a/packages/pieces/community/tableau/package.json
+++ b/packages/pieces/community/tableau/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-tableau",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/packages/pieces/community/tableau/src/lib/triggers/list-extract-refresh-tasks.ts
+++ b/packages/pieces/community/tableau/src/lib/triggers/list-extract-refresh-tasks.ts
@@ -130,18 +130,10 @@ export const listExtractRefreshTasksTrigger = createTrigger({
     datasourceId: null,
   },
   onEnable: async (context) => {
-    await pollingHelper.onEnable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onEnable(polling, context);
   },
   onDisable: async (context) => {
-    await pollingHelper.onDisable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onDisable(polling, context);
   },
   run: async (context) => {
     return await pollingHelper.poll(polling, context);

--- a/packages/pieces/community/tableau/src/lib/triggers/new-job.ts
+++ b/packages/pieces/community/tableau/src/lib/triggers/new-job.ts
@@ -129,18 +129,10 @@ export const newJobTrigger = createTrigger({
     jobType: 'refresh_extracts',
   },
   onEnable: async (context) => {
-    await pollingHelper.onEnable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onEnable(polling, context);
   },
   onDisable: async (context) => {
-    await pollingHelper.onDisable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onDisable(polling, context);
   },
   run: async (context) => {
     return await pollingHelper.poll(polling, context);

--- a/packages/pieces/community/tenzo/package.json
+++ b/packages/pieces/community/tenzo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-tenzo",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/packages/pieces/community/tenzo/src/lib/triggers/new-daily-forecast.trigger.ts
+++ b/packages/pieces/community/tenzo/src/lib/triggers/new-daily-forecast.trigger.ts
@@ -116,12 +116,10 @@ export const newDailyForecastTrigger = createTrigger({
     return await pollingHelper.test(polling, { store, auth, propsValue, files });
   },
   async onEnable(context) {
-    const { auth, propsValue, store } = context;
-    await pollingHelper.onEnable(polling, { store, auth, propsValue });
+    await pollingHelper.onEnable(polling, context);
   },
   async onDisable(context) {
-    const { auth, propsValue, store } = context;
-    await pollingHelper.onDisable(polling, { store, auth, propsValue });
+    await pollingHelper.onDisable(polling, context);
   },
   async run(context) {
     const { auth, propsValue, store, files } = context;

--- a/packages/pieces/community/tenzo/src/lib/triggers/new-summary-payments.trigger.ts
+++ b/packages/pieces/community/tenzo/src/lib/triggers/new-summary-payments.trigger.ts
@@ -140,12 +140,10 @@ export const newSummaryPaymentsTrigger = createTrigger({
     return await pollingHelper.test(polling, { store, auth, propsValue, files });
   },
   async onEnable(context) {
-    const { auth, propsValue, store } = context;
-    await pollingHelper.onEnable(polling, { store, auth, propsValue });
+    await pollingHelper.onEnable(polling, context);
   },
   async onDisable(context) {
-    const { auth, propsValue, store } = context;
-    await pollingHelper.onDisable(polling, { store, auth, propsValue });
+    await pollingHelper.onDisable(polling, context);
   },
   async run(context) {
     const { auth, propsValue, store, files } = context;

--- a/packages/pieces/community/tenzo/src/lib/triggers/new-summary-sales.trigger.ts
+++ b/packages/pieces/community/tenzo/src/lib/triggers/new-summary-sales.trigger.ts
@@ -129,12 +129,10 @@ export const newSummarySalesTrigger = createTrigger({
     return await pollingHelper.test(polling, { store, auth, propsValue, files });
   },
   async onEnable(context) {
-    const { auth, propsValue, store } = context;
-    await pollingHelper.onEnable(polling, { store, auth, propsValue });
+    await pollingHelper.onEnable(polling, context);
   },
   async onDisable(context) {
-    const { auth, propsValue, store } = context;
-    await pollingHelper.onDisable(polling, { store, auth, propsValue });
+    await pollingHelper.onDisable(polling, context);
   },
   async run(context) {
     const { auth, propsValue, store, files } = context;

--- a/packages/pieces/community/tidycal/package.json
+++ b/packages/pieces/community/tidycal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-tidycal",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {

--- a/packages/pieces/community/tidycal/src/lib/trigger/cancelled-booking.ts
+++ b/packages/pieces/community/tidycal/src/lib/trigger/cancelled-booking.ts
@@ -45,18 +45,10 @@ export const tidycalbookingcancelled = createTrigger({
   },
   type: TriggerStrategy.POLLING,
   onEnable: async (context) => {
-    await pollingHelper.onEnable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onEnable(polling, context);
   },
   onDisable: async (context) => {
-    await pollingHelper.onDisable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onDisable(polling, context);
   },
   run: async (context) => {
     return await pollingHelper.poll(polling, {

--- a/packages/pieces/community/tidycal/src/lib/trigger/new-booking.ts
+++ b/packages/pieces/community/tidycal/src/lib/trigger/new-booking.ts
@@ -45,18 +45,10 @@ export const tidycalnewbooking = createTrigger({
   },
   type: TriggerStrategy.POLLING,
   onEnable: async (context) => {
-    await pollingHelper.onEnable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onEnable(polling, context);
   },
   onDisable: async (context) => {
-    await pollingHelper.onDisable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onDisable(polling, context);
   },
   run: async (context) => {
     return await pollingHelper.poll(polling, {

--- a/packages/pieces/community/tidycal/src/lib/trigger/new-contacts.ts
+++ b/packages/pieces/community/tidycal/src/lib/trigger/new-contacts.ts
@@ -31,18 +31,10 @@ export const tidycalnewcontact = createTrigger({
   },
   type: TriggerStrategy.POLLING,
   onEnable: async (context) => {
-    await pollingHelper.onEnable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onEnable(polling, context);
   },
   onDisable: async (context) => {
-    await pollingHelper.onDisable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onDisable(polling, context);
   },
   run: async (context) => {
     return await pollingHelper.poll(polling, {

--- a/packages/pieces/community/time-ops/package.json
+++ b/packages/pieces/community/time-ops/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-time-ops",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/packages/pieces/community/time-ops/src/lib/triggers/new-customer.ts
+++ b/packages/pieces/community/time-ops/src/lib/triggers/new-customer.ts
@@ -59,18 +59,10 @@ export const newCustomer = createTrigger({
     defaultRate: 100,
   },
   async onEnable(context) {
-    await pollingHelper.onEnable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onEnable(polling, context);
   },
   async onDisable(context) {
-    await pollingHelper.onDisable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onDisable(polling, context);
   },
   async run(context) {
     return await pollingHelper.poll(polling, {

--- a/packages/pieces/community/time-ops/src/lib/triggers/new-project.ts
+++ b/packages/pieces/community/time-ops/src/lib/triggers/new-project.ts
@@ -63,18 +63,10 @@ export const newProject = createTrigger({
     rate: 100,
   },
   async onEnable(context) {
-    await pollingHelper.onEnable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onEnable(polling, context);
   },
   async onDisable(context) {
-    await pollingHelper.onDisable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onDisable(polling, context);
   },
   async run(context) {
     return await pollingHelper.poll(polling, {

--- a/packages/pieces/community/time-ops/src/lib/triggers/new-registration.ts
+++ b/packages/pieces/community/time-ops/src/lib/triggers/new-registration.ts
@@ -78,18 +78,10 @@ export const newRegistration = createTrigger({
     tags: [],
   },
   async onEnable(context) {
-    await pollingHelper.onEnable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onEnable(polling, context);
   },
   async onDisable(context) {
-    await pollingHelper.onDisable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onDisable(polling, context);
   },
   async run(context) {
     return await pollingHelper.poll(polling, {

--- a/packages/pieces/community/time-ops/src/lib/triggers/new-user.ts
+++ b/packages/pieces/community/time-ops/src/lib/triggers/new-user.ts
@@ -61,18 +61,10 @@ export const newUser = createTrigger({
     deactivatedAt: null,
   },
   async onEnable(context) {
-    await pollingHelper.onEnable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onEnable(polling, context);
   },
   async onDisable(context) {
-    await pollingHelper.onDisable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onDisable(polling, context);
   },
   async run(context) {
     return await pollingHelper.poll(polling, {

--- a/packages/pieces/community/timelines-ai/package.json
+++ b/packages/pieces/community/timelines-ai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-timelines-ai",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/packages/pieces/community/timelines-ai/src/lib/triggers/chat-closed.ts
+++ b/packages/pieces/community/timelines-ai/src/lib/triggers/chat-closed.ts
@@ -44,13 +44,11 @@ export const chatClosed = createTrigger({
     return await pollingHelper.test(polling, context);
   },
   async onEnable(context) {
-    const { store, auth, propsValue } = context;
-    await pollingHelper.onEnable(polling, { store, auth, propsValue });
+    await pollingHelper.onEnable(polling, context);
   },
 
   async onDisable(context) {
-    const { store, auth, propsValue } = context;
-    await pollingHelper.onDisable(polling, { store, auth, propsValue });
+    await pollingHelper.onDisable(polling, context);
   },
 
   async run(context) {

--- a/packages/pieces/community/timelines-ai/src/lib/triggers/new-uploaded-file.ts
+++ b/packages/pieces/community/timelines-ai/src/lib/triggers/new-uploaded-file.ts
@@ -43,13 +43,11 @@ export const newUploadedFile = createTrigger({
     return await pollingHelper.test(polling, context);
   },
   async onEnable(context) {
-    const { store, auth, propsValue } = context;
-    await pollingHelper.onEnable(polling, { store, auth, propsValue });
+    await pollingHelper.onEnable(polling, context);
   },
 
   async onDisable(context) {
-    const { store, auth, propsValue } = context;
-    await pollingHelper.onDisable(polling, { store, auth, propsValue });
+    await pollingHelper.onDisable(polling, context);
   },
 
   async run(context) {

--- a/packages/pieces/community/todoist/package.json
+++ b/packages/pieces/community/todoist/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-todoist",
-  "version": "0.4.8",
+  "version": "0.4.9",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {

--- a/packages/pieces/community/todoist/src/lib/triggers/task-completed-trigger.ts
+++ b/packages/pieces/community/todoist/src/lib/triggers/task-completed-trigger.ts
@@ -57,19 +57,11 @@ export const todoistTaskCompletedTrigger = createTrigger({
 	},
 
 	async onEnable(context) {
-		await pollingHelper.onEnable(polling, {
-			auth: context.auth,
-			store: context.store,
-			propsValue: context.propsValue,
-		});
+		await pollingHelper.onEnable(polling, context);
 	},
 
 	async onDisable(context) {
-		await pollingHelper.onDisable(polling, {
-			auth: context.auth,
-			store: context.store,
-			propsValue: context.propsValue,
-		});
+		await pollingHelper.onDisable(polling, context);
 	},
 	async test(context) {
 		return await pollingHelper.test(polling, context);

--- a/packages/pieces/community/toggl-track/package.json
+++ b/packages/pieces/community/toggl-track/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-toggl-track",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/packages/pieces/community/toggl-track/src/lib/triggers/new-time-entry-started.ts
+++ b/packages/pieces/community/toggl-track/src/lib/triggers/new-time-entry-started.ts
@@ -72,19 +72,11 @@ export const newTimeEntryStarted = createTrigger({
   type: TriggerStrategy.POLLING,
 
   async onEnable(context) {
-    await pollingHelper.onEnable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onEnable(polling, context);
   },
 
   async onDisable(context) {
-    await pollingHelper.onDisable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onDisable(polling, context);
   },
 
   async run(context) {

--- a/packages/pieces/community/toggl-track/src/lib/triggers/new-workspace.ts
+++ b/packages/pieces/community/toggl-track/src/lib/triggers/new-workspace.ts
@@ -78,19 +78,11 @@ export const newWorkspace = createTrigger({
   type: TriggerStrategy.POLLING,
 
   async onEnable(context) {
-    await pollingHelper.onEnable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onEnable(polling, context);
   },
 
   async onDisable(context) {
-    await pollingHelper.onDisable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onDisable(polling, context);
   },
 
   async run(context) {

--- a/packages/pieces/community/totalcms/package.json
+++ b/packages/pieces/community/totalcms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-totalcms",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {

--- a/packages/pieces/community/totalcms/src/lib/triggers/new-blog-post.ts
+++ b/packages/pieces/community/totalcms/src/lib/triggers/new-blog-post.ts
@@ -46,10 +46,19 @@ export const newBlogPost = createTrigger({
   },
   sampleData: {},
   onEnable: async (context) => {
-    await pollingHelper.onEnable(polling, context);
+    await pollingHelper.onEnable(polling, {
+      auth: context.auth as TotalCMSAuthType,
+      store: context.store,
+      propsValue: context.propsValue,
+      isRepublish: context.isRepublish,
+    });
   },
   onDisable: async (context) => {
-    await pollingHelper.onDisable(polling, context);
+    await pollingHelper.onDisable(polling, {
+      auth: context.auth as TotalCMSAuthType,
+      store: context.store,
+      propsValue: context.propsValue,
+    });
   },
   run: async (context) => {
     return await pollingHelper.poll(polling, {

--- a/packages/pieces/community/totalcms/src/lib/triggers/new-blog-post.ts
+++ b/packages/pieces/community/totalcms/src/lib/triggers/new-blog-post.ts
@@ -46,18 +46,10 @@ export const newBlogPost = createTrigger({
   },
   sampleData: {},
   onEnable: async (context) => {
-    await pollingHelper.onEnable(polling, {
-      auth: context.auth as TotalCMSAuthType,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onEnable(polling, context);
   },
   onDisable: async (context) => {
-    await pollingHelper.onDisable(polling, {
-      auth: context.auth as TotalCMSAuthType,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onDisable(polling, context);
   },
   run: async (context) => {
     return await pollingHelper.poll(polling, {

--- a/packages/pieces/community/twilio/package.json
+++ b/packages/pieces/community/twilio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-twilio",
-  "version": "0.4.7",
+  "version": "0.4.8",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {

--- a/packages/pieces/community/twilio/src/lib/trigger/new-call.ts
+++ b/packages/pieces/community/twilio/src/lib/trigger/new-call.ts
@@ -134,18 +134,10 @@ export const twilioNewCall = createTrigger({
 
 
   async onEnable(context) {
-    await pollingHelper.onEnable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onEnable(polling, context);
   },
   async onDisable(context) {
-    await pollingHelper.onDisable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onDisable(polling, context);
   },
   async test(context) {
     return await pollingHelper.test(polling, context);

--- a/packages/pieces/community/twilio/src/lib/trigger/new-phone-number.ts
+++ b/packages/pieces/community/twilio/src/lib/trigger/new-phone-number.ts
@@ -127,18 +127,10 @@ export const twilioNewPhoneNumber = createTrigger({
   type: TriggerStrategy.POLLING,
 
   async onEnable(context) {
-    await pollingHelper.onEnable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onEnable(polling, context);
   },
   async onDisable(context) {
-    await pollingHelper.onDisable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onDisable(polling, context);
   },
   async test(context) {
     return await pollingHelper.test(polling, context);

--- a/packages/pieces/community/twilio/src/lib/trigger/new-recording.ts
+++ b/packages/pieces/community/twilio/src/lib/trigger/new-recording.ts
@@ -118,18 +118,10 @@ export const twilioNewRecording = createTrigger({
     type: TriggerStrategy.POLLING,
 
   async onEnable(context) {
-    await pollingHelper.onEnable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onEnable(polling, context);
   },
   async onDisable(context) {
-    await pollingHelper.onDisable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onDisable(polling, context);
   },
   async test(context) {
     return await pollingHelper.test(polling, context);

--- a/packages/pieces/community/twilio/src/lib/trigger/new-transcription.ts
+++ b/packages/pieces/community/twilio/src/lib/trigger/new-transcription.ts
@@ -118,18 +118,10 @@ export const twilioNewTranscription = createTrigger({
 
 
   async onEnable(context) {
-    await pollingHelper.onEnable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onEnable(polling, context);
   },
   async onDisable(context) {
-    await pollingHelper.onDisable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onDisable(polling, context);
   },
   async test(context) {
     return await pollingHelper.test(polling, context);

--- a/packages/pieces/community/twitch/package.json
+++ b/packages/pieces/community/twitch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-twitch",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/packages/pieces/community/twitch/src/lib/triggers/stream-started.ts
+++ b/packages/pieces/community/twitch/src/lib/triggers/stream-started.ts
@@ -91,13 +91,11 @@ export const streamStarted = createTrigger({
     return await pollingHelper.test(polling, context);
   },
   async onEnable(context) {
-    const { store, auth, propsValue } = context;
-    await pollingHelper.onEnable(polling, { store, auth, propsValue });
+    await pollingHelper.onEnable(polling, context);
   },
 
   async onDisable(context) {
-    const { store, auth, propsValue } = context;
-    await pollingHelper.onDisable(polling, { store, auth, propsValue });
+    await pollingHelper.onDisable(polling, context);
   },
 
   async run(context) {

--- a/packages/pieces/community/vimeo/package.json
+++ b/packages/pieces/community/vimeo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-vimeo",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/packages/pieces/community/vimeo/src/lib/triggers/new-video-by-search.ts
+++ b/packages/pieces/community/vimeo/src/lib/triggers/new-video-by-search.ts
@@ -67,18 +67,10 @@ export const newVideoBySearch = createTrigger({
   },
   type: TriggerStrategy.POLLING,
   async onEnable(context) {
-    await pollingHelper.onEnable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onEnable(polling, context);
   },
   async onDisable(context) {
-    await pollingHelper.onDisable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onDisable(polling, context);
   },
   async test(context) {
     return await pollingHelper.test(polling, context);

--- a/packages/pieces/community/vimeo/src/lib/triggers/new-video-by-user.ts
+++ b/packages/pieces/community/vimeo/src/lib/triggers/new-video-by-user.ts
@@ -66,18 +66,10 @@ export const newVideoByUser = createTrigger({
   },
   type: TriggerStrategy.POLLING,
   async onEnable(context) {
-    await pollingHelper.onEnable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onEnable(polling, context);
   },
   async onDisable(context) {
-    await pollingHelper.onDisable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onDisable(polling, context);
   },
   async test(context) {
     return await pollingHelper.test(polling, context);

--- a/packages/pieces/community/vimeo/src/lib/triggers/new-video-liked.ts
+++ b/packages/pieces/community/vimeo/src/lib/triggers/new-video-liked.ts
@@ -46,18 +46,10 @@ export const newVideoLiked = createTrigger({
   },
   type: TriggerStrategy.POLLING,
   async onEnable(context) {
-    await pollingHelper.onEnable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onEnable(polling, context);
   },
   async onDisable(context) {
-    await pollingHelper.onDisable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onDisable(polling, context);
   },
   async test(context) {
     return await pollingHelper.test(polling, context);

--- a/packages/pieces/community/vimeo/src/lib/triggers/new-video-of-mine.ts
+++ b/packages/pieces/community/vimeo/src/lib/triggers/new-video-of-mine.ts
@@ -56,18 +56,10 @@ export const newVideoOfMine = createTrigger({
   },
   type: TriggerStrategy.POLLING,
   async onEnable(context) {
-    await pollingHelper.onEnable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onEnable(polling, context);
   },
   async onDisable(context) {
-    await pollingHelper.onDisable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onDisable(polling, context);
   },
   async test(context) {
     return await pollingHelper.test(polling, context);

--- a/packages/pieces/community/voipstudio/package.json
+++ b/packages/pieces/community/voipstudio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-voipstudio",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/packages/pieces/community/voipstudio/src/lib/triggers/call-tracking.ts
+++ b/packages/pieces/community/voipstudio/src/lib/triggers/call-tracking.ts
@@ -94,13 +94,11 @@ export const callTracking = createTrigger({
     return await pollingHelper.test(polling, context);
   },
   async onEnable(context) {
-    const { store, auth, propsValue } = context;
-    await pollingHelper.onEnable(polling, { store, auth, propsValue });
+    await pollingHelper.onEnable(polling, context);
   },
 
   async onDisable(context) {
-    const { store, auth, propsValue } = context;
-    await pollingHelper.onDisable(polling, { store, auth, propsValue });
+    await pollingHelper.onDisable(polling, context);
   },
 
   async run(context) {

--- a/packages/pieces/community/vtiger/package.json
+++ b/packages/pieces/community/vtiger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-vtiger",
-  "version": "1.3.7",
+  "version": "1.3.8",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "dependencies": {

--- a/packages/pieces/community/vtiger/src/lib/triggers/new-or-updated-record.ts
+++ b/packages/pieces/community/vtiger/src/lib/triggers/new-or-updated-record.ts
@@ -78,10 +78,10 @@ export const newOrUpdatedRecord = createTrigger({
     return await pollingHelper.test(polling, { ...ctx });
   },
   async onEnable(ctx) {
-    await pollingHelper.onEnable(polling, { ...ctx });
+    await pollingHelper.onEnable(polling, ctx);
   },
   async onDisable(ctx) {
-    await pollingHelper.onDisable(polling, { ...ctx });
+    await pollingHelper.onDisable(polling, ctx);
   },
   async run(ctx) {
     return await pollingHelper.poll(polling, { ...ctx });

--- a/packages/pieces/community/wealthbox/package.json
+++ b/packages/pieces/community/wealthbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-wealthbox",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/packages/pieces/community/wealthbox/src/lib/triggers/new-contact.ts
+++ b/packages/pieces/community/wealthbox/src/lib/triggers/new-contact.ts
@@ -301,19 +301,11 @@ export const newContact = createTrigger({
   },
 
   onEnable: async (context) => {
-    await pollingHelper.onEnable(polling, {
-      store: context.store,
-      propsValue: context.propsValue,
-      auth: context.auth
-    });
+    await pollingHelper.onEnable(polling, context);
   },
 
   onDisable: async (context) => {
-    await pollingHelper.onDisable(polling, {
-      store: context.store,
-      propsValue: context.propsValue,
-      auth: context.auth
-    });
+    await pollingHelper.onDisable(polling, context);
   },
 
   run: async (context) => {

--- a/packages/pieces/community/wealthbox/src/lib/triggers/new-event.ts
+++ b/packages/pieces/community/wealthbox/src/lib/triggers/new-event.ts
@@ -272,19 +272,11 @@ export const newEvent = createTrigger({
   },
 
   onEnable: async (context) => {
-    await pollingHelper.onEnable(polling, {
-      store: context.store,
-      propsValue: context.propsValue,
-      auth: context.auth
-    });
+    await pollingHelper.onEnable(polling, context);
   },
 
   onDisable: async (context) => {
-    await pollingHelper.onDisable(polling, {
-      store: context.store,
-      propsValue: context.propsValue,
-      auth: context.auth
-    });
+    await pollingHelper.onDisable(polling, context);
   },
 
   run: async (context) => {

--- a/packages/pieces/community/wealthbox/src/lib/triggers/new-opportunity.ts
+++ b/packages/pieces/community/wealthbox/src/lib/triggers/new-opportunity.ts
@@ -303,19 +303,11 @@ export const newOpportunity = createTrigger({
   },
 
   onEnable: async (context) => {
-    await pollingHelper.onEnable(polling, {
-      store: context.store,
-      propsValue: context.propsValue,
-      auth: context.auth
-    });
+    await pollingHelper.onEnable(polling, context);
   },
 
   onDisable: async (context) => {
-    await pollingHelper.onDisable(polling, {
-      store: context.store,
-      propsValue: context.propsValue,
-      auth: context.auth
-    });
+    await pollingHelper.onDisable(polling, context);
   },
 
   run: async (context) => {

--- a/packages/pieces/community/wealthbox/src/lib/triggers/new-task.ts
+++ b/packages/pieces/community/wealthbox/src/lib/triggers/new-task.ts
@@ -271,19 +271,11 @@ export const newTask = createTrigger({
   },
 
   onEnable: async (context) => {
-    await pollingHelper.onEnable(polling, {
-      store: context.store,
-      propsValue: context.propsValue,
-      auth: context.auth
-    });
+    await pollingHelper.onEnable(polling, context);
   },
 
   onDisable: async (context) => {
-    await pollingHelper.onDisable(polling, {
-      store: context.store,
-      propsValue: context.propsValue,
-      auth: context.auth
-    });
+    await pollingHelper.onDisable(polling, context);
   },
 
   run: async (context) => {

--- a/packages/pieces/community/webling/package.json
+++ b/packages/pieces/community/webling/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-webling",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {

--- a/packages/pieces/community/webling/src/lib/triggers/calendar-event.ts
+++ b/packages/pieces/community/webling/src/lib/triggers/calendar-event.ts
@@ -56,25 +56,11 @@ export const onEventChanged = createTrigger({
     });
   },
   async onEnable(context) {
-    const { store, auth, propsValue } = context;
-    await pollingHelper.onEnable(polling, {
-      store,
-      auth,
-      propsValue: {
-        calendarId: propsValue.calendarId,
-      },
-    });
+    await pollingHelper.onEnable(polling, context);
   },
 
   async onDisable(context) {
-    const { store, auth, propsValue } = context;
-    await pollingHelper.onDisable(polling, {
-      store,
-      auth,
-      propsValue: {
-        calendarId: propsValue.calendarId,
-      },
-    });
+    await pollingHelper.onDisable(polling, context);
   },
 
   async run(context) {

--- a/packages/pieces/community/webling/src/lib/triggers/calendar-event.ts
+++ b/packages/pieces/community/webling/src/lib/triggers/calendar-event.ts
@@ -56,11 +56,26 @@ export const onEventChanged = createTrigger({
     });
   },
   async onEnable(context) {
-    await pollingHelper.onEnable(polling, context);
+    const { store, auth, propsValue } = context;
+    await pollingHelper.onEnable(polling, {
+      store,
+      auth,
+      propsValue: {
+        calendarId: propsValue.calendarId,
+      },
+      isRepublish: context.isRepublish,
+    });
   },
 
   async onDisable(context) {
-    await pollingHelper.onDisable(polling, context);
+    const { store, auth, propsValue } = context;
+    await pollingHelper.onDisable(polling, {
+      store,
+      auth,
+      propsValue: {
+        calendarId: propsValue.calendarId,
+      },
+    });
   },
 
   async run(context) {

--- a/packages/pieces/community/webling/src/lib/triggers/on-changed-data.ts
+++ b/packages/pieces/community/webling/src/lib/triggers/on-changed-data.ts
@@ -94,21 +94,11 @@ export const onChangedData = createTrigger({
     });
   },
   async onEnable(context) {
-    const { store, auth, propsValue } = context;
-    await pollingHelper.onEnable(polling, {
-      store,
-      auth,
-      propsValue,
-    });
+    await pollingHelper.onEnable(polling, context);
   },
 
   async onDisable(context) {
-    const { store, auth, propsValue } = context;
-    await pollingHelper.onDisable(polling, {
-      store,
-      auth,
-      propsValue,
-    });
+    await pollingHelper.onDisable(polling, context);
   },
 
   async run(context) {

--- a/packages/pieces/community/wonderchat/package.json
+++ b/packages/pieces/community/wonderchat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-wonderchat",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/packages/pieces/community/wonderchat/src/lib/triggers/new-user-message.ts
+++ b/packages/pieces/community/wonderchat/src/lib/triggers/new-user-message.ts
@@ -80,13 +80,11 @@ export const newUserMessage = createTrigger({
   },
 
   async onEnable(context) {
-    const { store, auth, propsValue } = context;
-    await pollingHelper.onEnable(polling, { store, auth, propsValue });
+    await pollingHelper.onEnable(polling, context);
   },
 
   async onDisable(context) {
-    const { store, auth, propsValue } = context;
-    await pollingHelper.onEnable(polling, { store, auth, propsValue });
+    await pollingHelper.onEnable(polling, context);
   },
 
   async run(context) {

--- a/packages/pieces/community/wordpress/package.json
+++ b/packages/pieces/community/wordpress/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-wordpress",
-  "version": "0.4.6",
+  "version": "0.4.7",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {

--- a/packages/pieces/community/wordpress/src/lib/trigger/new-post.trigger.ts
+++ b/packages/pieces/community/wordpress/src/lib/trigger/new-post.trigger.ts
@@ -134,18 +134,10 @@ export const wordpressNewPost = createTrigger({
     });
   },
   async onEnable(ctx) {
-    await pollingHelper.onEnable(polling, {
-      auth: ctx.auth,
-      store: ctx.store,
-      propsValue: ctx.propsValue,
-    });
+    await pollingHelper.onEnable(polling, ctx);
   },
   async onDisable(ctx) {
-    await pollingHelper.onDisable(polling, {
-      auth: ctx.auth,
-      store: ctx.store,
-      propsValue: ctx.propsValue,
-    });
+    await pollingHelper.onDisable(polling, ctx);
   },
   async run(ctx) {
     return await pollingHelper.poll(polling, {

--- a/packages/pieces/community/workday/package.json
+++ b/packages/pieces/community/workday/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-workday",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/packages/pieces/community/workday/src/lib/trigger/business-process-completed.ts
+++ b/packages/pieces/community/workday/src/lib/trigger/business-process-completed.ts
@@ -32,7 +32,7 @@ export const businessProcessCompleted = createTrigger({
 	sampleData: { id: 'bp-001', descriptor: 'Hire: John Smith', completedDate: '2026-04-01T14:30:00Z' },
 	type: TriggerStrategy.POLLING,
 	async test(ctx) { return await pollingHelper.test(polling, { auth: ctx.auth, store: ctx.store, propsValue: ctx.propsValue, files: ctx.files }); },
-	async onEnable(ctx) { await pollingHelper.onEnable(polling, { auth: ctx.auth, store: ctx.store, propsValue: ctx.propsValue }); },
-	async onDisable(ctx) { await pollingHelper.onDisable(polling, { auth: ctx.auth, store: ctx.store, propsValue: ctx.propsValue }); },
+	async onEnable(ctx) { await pollingHelper.onEnable(polling, ctx); },
+	async onDisable(ctx) { await pollingHelper.onDisable(polling, ctx); },
 	async run(ctx) { return await pollingHelper.poll(polling, { auth: ctx.auth, store: ctx.store, propsValue: ctx.propsValue, files: ctx.files }); },
 });

--- a/packages/pieces/community/workday/src/lib/trigger/employee-terminated.ts
+++ b/packages/pieces/community/workday/src/lib/trigger/employee-terminated.ts
@@ -33,7 +33,7 @@ export const employeeTerminated = createTrigger({
 	sampleData: { id: '3aa5550b7fe348b98d7b5741afc65534', descriptor: 'Jane Doe', terminationDate: '2026-04-01' },
 	type: TriggerStrategy.POLLING,
 	async test(ctx) { return await pollingHelper.test(polling, { auth: ctx.auth, store: ctx.store, propsValue: ctx.propsValue, files: ctx.files }); },
-	async onEnable(ctx) { await pollingHelper.onEnable(polling, { auth: ctx.auth, store: ctx.store, propsValue: ctx.propsValue }); },
-	async onDisable(ctx) { await pollingHelper.onDisable(polling, { auth: ctx.auth, store: ctx.store, propsValue: ctx.propsValue }); },
+	async onEnable(ctx) { await pollingHelper.onEnable(polling, ctx); },
+	async onDisable(ctx) { await pollingHelper.onDisable(polling, ctx); },
 	async run(ctx) { return await pollingHelper.poll(polling, { auth: ctx.auth, store: ctx.store, propsValue: ctx.propsValue, files: ctx.files }); },
 });

--- a/packages/pieces/community/workday/src/lib/trigger/expense-report-submitted.ts
+++ b/packages/pieces/community/workday/src/lib/trigger/expense-report-submitted.ts
@@ -32,7 +32,7 @@ export const expenseReportSubmitted = createTrigger({
 	sampleData: { id: 'exp-001', descriptor: 'Q1 Travel Expenses', createdDate: '2026-04-01T09:00:00Z' },
 	type: TriggerStrategy.POLLING,
 	async test(ctx) { return await pollingHelper.test(polling, { auth: ctx.auth, store: ctx.store, propsValue: ctx.propsValue, files: ctx.files }); },
-	async onEnable(ctx) { await pollingHelper.onEnable(polling, { auth: ctx.auth, store: ctx.store, propsValue: ctx.propsValue }); },
-	async onDisable(ctx) { await pollingHelper.onDisable(polling, { auth: ctx.auth, store: ctx.store, propsValue: ctx.propsValue }); },
+	async onEnable(ctx) { await pollingHelper.onEnable(polling, ctx); },
+	async onDisable(ctx) { await pollingHelper.onDisable(polling, ctx); },
 	async run(ctx) { return await pollingHelper.poll(polling, { auth: ctx.auth, store: ctx.store, propsValue: ctx.propsValue, files: ctx.files }); },
 });

--- a/packages/pieces/community/workday/src/lib/trigger/leave-request-submitted.ts
+++ b/packages/pieces/community/workday/src/lib/trigger/leave-request-submitted.ts
@@ -32,7 +32,7 @@ export const leaveRequestSubmitted = createTrigger({
 	sampleData: { id: 'lr-001', descriptor: 'Vacation Request - John Smith', createdDate: '2026-04-01T11:00:00Z' },
 	type: TriggerStrategy.POLLING,
 	async test(ctx) { return await pollingHelper.test(polling, { auth: ctx.auth, store: ctx.store, propsValue: ctx.propsValue, files: ctx.files }); },
-	async onEnable(ctx) { await pollingHelper.onEnable(polling, { auth: ctx.auth, store: ctx.store, propsValue: ctx.propsValue }); },
-	async onDisable(ctx) { await pollingHelper.onDisable(polling, { auth: ctx.auth, store: ctx.store, propsValue: ctx.propsValue }); },
+	async onEnable(ctx) { await pollingHelper.onEnable(polling, ctx); },
+	async onDisable(ctx) { await pollingHelper.onDisable(polling, ctx); },
 	async run(ctx) { return await pollingHelper.poll(polling, { auth: ctx.auth, store: ctx.store, propsValue: ctx.propsValue, files: ctx.files }); },
 });

--- a/packages/pieces/community/workday/src/lib/trigger/new-hire-created.ts
+++ b/packages/pieces/community/workday/src/lib/trigger/new-hire-created.ts
@@ -49,10 +49,10 @@ export const newHireCreated = createTrigger({
 		return await pollingHelper.test(polling, { auth: ctx.auth, store: ctx.store, propsValue: ctx.propsValue, files: ctx.files });
 	},
 	async onEnable(ctx) {
-		await pollingHelper.onEnable(polling, { auth: ctx.auth, store: ctx.store, propsValue: ctx.propsValue });
+		await pollingHelper.onEnable(polling, ctx);
 	},
 	async onDisable(ctx) {
-		await pollingHelper.onDisable(polling, { auth: ctx.auth, store: ctx.store, propsValue: ctx.propsValue });
+		await pollingHelper.onDisable(polling, ctx);
 	},
 	async run(ctx) {
 		return await pollingHelper.poll(polling, { auth: ctx.auth, store: ctx.store, propsValue: ctx.propsValue, files: ctx.files });

--- a/packages/pieces/community/workday/src/lib/trigger/new-inbox-task.ts
+++ b/packages/pieces/community/workday/src/lib/trigger/new-inbox-task.ts
@@ -32,7 +32,7 @@ export const newInboxTask = createTrigger({
 	sampleData: { id: 'task-001', descriptor: 'Approve Time Off Request', assignedDate: '2026-04-01T08:00:00Z' },
 	type: TriggerStrategy.POLLING,
 	async test(ctx) { return await pollingHelper.test(polling, { auth: ctx.auth, store: ctx.store, propsValue: ctx.propsValue, files: ctx.files }); },
-	async onEnable(ctx) { await pollingHelper.onEnable(polling, { auth: ctx.auth, store: ctx.store, propsValue: ctx.propsValue }); },
-	async onDisable(ctx) { await pollingHelper.onDisable(polling, { auth: ctx.auth, store: ctx.store, propsValue: ctx.propsValue }); },
+	async onEnable(ctx) { await pollingHelper.onEnable(polling, ctx); },
+	async onDisable(ctx) { await pollingHelper.onDisable(polling, ctx); },
 	async run(ctx) { return await pollingHelper.poll(polling, { auth: ctx.auth, store: ctx.store, propsValue: ctx.propsValue, files: ctx.files }); },
 });

--- a/packages/pieces/community/workday/src/lib/trigger/new-or-updated-business-object-batch.ts
+++ b/packages/pieces/community/workday/src/lib/trigger/new-or-updated-business-object-batch.ts
@@ -126,18 +126,10 @@ export const newOrUpdatedBusinessObjectBatch = createTrigger({
 		});
 	},
 	async onEnable(ctx) {
-		await pollingHelper.onEnable(polling, {
-			auth: ctx.auth,
-			store: ctx.store,
-			propsValue: ctx.propsValue,
-		});
+		await pollingHelper.onEnable(polling, ctx);
 	},
 	async onDisable(ctx) {
-		await pollingHelper.onDisable(polling, {
-			auth: ctx.auth,
-			store: ctx.store,
-			propsValue: ctx.propsValue,
-		});
+		await pollingHelper.onDisable(polling, ctx);
 	},
 	async run(ctx) {
 		return await pollingHelper.poll(polling, {

--- a/packages/pieces/community/workday/src/lib/trigger/new-or-updated-business-object.ts
+++ b/packages/pieces/community/workday/src/lib/trigger/new-or-updated-business-object.ts
@@ -103,18 +103,10 @@ export const newOrUpdatedBusinessObject = createTrigger({
 		});
 	},
 	async onEnable(ctx) {
-		await pollingHelper.onEnable(polling, {
-			auth: ctx.auth,
-			store: ctx.store,
-			propsValue: ctx.propsValue,
-		});
+		await pollingHelper.onEnable(polling, ctx);
 	},
 	async onDisable(ctx) {
-		await pollingHelper.onDisable(polling, {
-			auth: ctx.auth,
-			store: ctx.store,
-			propsValue: ctx.propsValue,
-		});
+		await pollingHelper.onDisable(polling, ctx);
 	},
 	async run(ctx) {
 		return await pollingHelper.poll(polling, {

--- a/packages/pieces/community/workday/src/lib/trigger/new-supplier-invoice.ts
+++ b/packages/pieces/community/workday/src/lib/trigger/new-supplier-invoice.ts
@@ -32,7 +32,7 @@ export const newSupplierInvoice = createTrigger({
 	sampleData: { id: 'inv-001', descriptor: 'Invoice #12345 - Acme Corp', createdDate: '2026-04-01T12:00:00Z' },
 	type: TriggerStrategy.POLLING,
 	async test(ctx) { return await pollingHelper.test(polling, { auth: ctx.auth, store: ctx.store, propsValue: ctx.propsValue, files: ctx.files }); },
-	async onEnable(ctx) { await pollingHelper.onEnable(polling, { auth: ctx.auth, store: ctx.store, propsValue: ctx.propsValue }); },
-	async onDisable(ctx) { await pollingHelper.onDisable(polling, { auth: ctx.auth, store: ctx.store, propsValue: ctx.propsValue }); },
+	async onEnable(ctx) { await pollingHelper.onEnable(polling, ctx); },
+	async onDisable(ctx) { await pollingHelper.onDisable(polling, ctx); },
 	async run(ctx) { return await pollingHelper.poll(polling, { auth: ctx.auth, store: ctx.store, propsValue: ctx.propsValue, files: ctx.files }); },
 });

--- a/packages/pieces/community/workday/src/lib/trigger/new-supplier.ts
+++ b/packages/pieces/community/workday/src/lib/trigger/new-supplier.ts
@@ -32,7 +32,7 @@ export const newSupplier = createTrigger({
 	sampleData: { id: 'sup-001', descriptor: 'Acme Corp', createdDate: '2026-04-01T10:00:00Z' },
 	type: TriggerStrategy.POLLING,
 	async test(ctx) { return await pollingHelper.test(polling, { auth: ctx.auth, store: ctx.store, propsValue: ctx.propsValue, files: ctx.files }); },
-	async onEnable(ctx) { await pollingHelper.onEnable(polling, { auth: ctx.auth, store: ctx.store, propsValue: ctx.propsValue }); },
-	async onDisable(ctx) { await pollingHelper.onDisable(polling, { auth: ctx.auth, store: ctx.store, propsValue: ctx.propsValue }); },
+	async onEnable(ctx) { await pollingHelper.onEnable(polling, ctx); },
+	async onDisable(ctx) { await pollingHelper.onDisable(polling, ctx); },
 	async run(ctx) { return await pollingHelper.poll(polling, { auth: ctx.auth, store: ctx.store, propsValue: ctx.propsValue, files: ctx.files }); },
 });

--- a/packages/pieces/community/workday/src/lib/trigger/run-wql-query.ts
+++ b/packages/pieces/community/workday/src/lib/trigger/run-wql-query.ts
@@ -47,7 +47,7 @@ export const runWqlQuery = createTrigger({
 	sampleData: { id: 'record-001', createdDate: '2026-04-01T10:00:00Z', descriptor: 'Sample Record' },
 	type: TriggerStrategy.POLLING,
 	async test(ctx) { return await pollingHelper.test(polling, { auth: ctx.auth, store: ctx.store, propsValue: ctx.propsValue, files: ctx.files }); },
-	async onEnable(ctx) { await pollingHelper.onEnable(polling, { auth: ctx.auth, store: ctx.store, propsValue: ctx.propsValue }); },
-	async onDisable(ctx) { await pollingHelper.onDisable(polling, { auth: ctx.auth, store: ctx.store, propsValue: ctx.propsValue }); },
+	async onEnable(ctx) { await pollingHelper.onEnable(polling, ctx); },
+	async onDisable(ctx) { await pollingHelper.onDisable(polling, ctx); },
 	async run(ctx) { return await pollingHelper.poll(polling, { auth: ctx.auth, store: ctx.store, propsValue: ctx.propsValue, files: ctx.files }); },
 });

--- a/packages/pieces/community/workday/src/lib/trigger/scheduled-report-fetch-batch.ts
+++ b/packages/pieces/community/workday/src/lib/trigger/scheduled-report-fetch-batch.ts
@@ -86,18 +86,10 @@ export const scheduledReportFetchBatch = createTrigger({
 		});
 	},
 	async onEnable(ctx) {
-		await pollingHelper.onEnable(polling, {
-			auth: ctx.auth,
-			store: ctx.store,
-			propsValue: ctx.propsValue,
-		});
+		await pollingHelper.onEnable(polling, ctx);
 	},
 	async onDisable(ctx) {
-		await pollingHelper.onDisable(polling, {
-			auth: ctx.auth,
-			store: ctx.store,
-			propsValue: ctx.propsValue,
-		});
+		await pollingHelper.onDisable(polling, ctx);
 	},
 	async run(ctx) {
 		return await pollingHelper.poll(polling, {

--- a/packages/pieces/community/workday/src/lib/trigger/scheduled-report-fetch-wql-batch.ts
+++ b/packages/pieces/community/workday/src/lib/trigger/scheduled-report-fetch-wql-batch.ts
@@ -84,18 +84,10 @@ export const scheduledReportFetchWqlBatch = createTrigger({
 		});
 	},
 	async onEnable(ctx) {
-		await pollingHelper.onEnable(polling, {
-			auth: ctx.auth,
-			store: ctx.store,
-			propsValue: ctx.propsValue,
-		});
+		await pollingHelper.onEnable(polling, ctx);
 	},
 	async onDisable(ctx) {
-		await pollingHelper.onDisable(polling, {
-			auth: ctx.auth,
-			store: ctx.store,
-			propsValue: ctx.propsValue,
-		});
+		await pollingHelper.onDisable(polling, ctx);
 	},
 	async run(ctx) {
 		return await pollingHelper.poll(polling, {

--- a/packages/pieces/community/workday/src/lib/trigger/updated-supplier.ts
+++ b/packages/pieces/community/workday/src/lib/trigger/updated-supplier.ts
@@ -29,7 +29,7 @@ export const updatedSupplier = createTrigger({
 	sampleData: { id: 'sup-001', descriptor: 'Acme Corp', lastUpdated: '2026-04-01T10:00:00Z' },
 	type: TriggerStrategy.POLLING,
 	async test(ctx) { return await pollingHelper.test(polling, { auth: ctx.auth, store: ctx.store, propsValue: ctx.propsValue, files: ctx.files }); },
-	async onEnable(ctx) { await pollingHelper.onEnable(polling, { auth: ctx.auth, store: ctx.store, propsValue: ctx.propsValue }); },
-	async onDisable(ctx) { await pollingHelper.onDisable(polling, { auth: ctx.auth, store: ctx.store, propsValue: ctx.propsValue }); },
+	async onEnable(ctx) { await pollingHelper.onEnable(polling, ctx); },
+	async onDisable(ctx) { await pollingHelper.onDisable(polling, ctx); },
 	async run(ctx) { return await pollingHelper.poll(polling, { auth: ctx.auth, store: ctx.store, propsValue: ctx.propsValue, files: ctx.files }); },
 });

--- a/packages/pieces/community/xero/package.json
+++ b/packages/pieces/community/xero/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-xero",
-  "version": "0.6.7",
+  "version": "0.6.8",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {

--- a/packages/pieces/community/xero/src/lib/triggers/new-bank-transaction.ts
+++ b/packages/pieces/community/xero/src/lib/triggers/new-bank-transaction.ts
@@ -162,18 +162,10 @@ export const xeroNewBankTransaction = createTrigger({
   },
   type: TriggerStrategy.POLLING,
   async onEnable(context: any) {
-    await pollingHelper.onEnable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onEnable(polling, context);
   },
   async onDisable(context: any) {
-    await pollingHelper.onDisable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onDisable(polling, context);
   },
   async test(context: any) {
     return await pollingHelper.test(polling, context);

--- a/packages/pieces/community/xero/src/lib/triggers/new-bill.ts
+++ b/packages/pieces/community/xero/src/lib/triggers/new-bill.ts
@@ -139,18 +139,10 @@ export const xeroNewBill = createTrigger({
   },
   type: TriggerStrategy.POLLING,
   async onEnable(context: any) {
-    await pollingHelper.onEnable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onEnable(polling, context);
   },
   async onDisable(context: any) {
-    await pollingHelper.onDisable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onDisable(polling, context);
   },
   async test(context: any) {
     return await pollingHelper.test(polling, context);

--- a/packages/pieces/community/xero/src/lib/triggers/new-credit-note.ts
+++ b/packages/pieces/community/xero/src/lib/triggers/new-credit-note.ts
@@ -143,18 +143,10 @@ export const xeroNewCreditNote = createTrigger({
   },
   type: TriggerStrategy.POLLING,
   async onEnable(context: any) {
-    await pollingHelper.onEnable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onEnable(polling, context);
   },
   async onDisable(context: any) {
-    await pollingHelper.onDisable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onDisable(polling, context);
   },
   async test(context: any) {
     return await pollingHelper.test(polling, context);

--- a/packages/pieces/community/xero/src/lib/triggers/new-payment.ts
+++ b/packages/pieces/community/xero/src/lib/triggers/new-payment.ts
@@ -143,18 +143,10 @@ export const xeroNewPayment = createTrigger({
   },
   type: TriggerStrategy.POLLING,
   async onEnable(context: any) {
-    await pollingHelper.onEnable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onEnable(polling, context);
   },
   async onDisable(context: any) {
-    await pollingHelper.onDisable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onDisable(polling, context);
   },
   async test(context: any) {
     return await pollingHelper.test(polling, context);

--- a/packages/pieces/community/xero/src/lib/triggers/new-project.ts
+++ b/packages/pieces/community/xero/src/lib/triggers/new-project.ts
@@ -89,18 +89,10 @@ export const xeroNewProject = createTrigger({
   },
   type: TriggerStrategy.POLLING,
   async onEnable(context: any) {
-    await pollingHelper.onEnable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onEnable(polling, context);
   },
   async onDisable(context: any) {
-    await pollingHelper.onDisable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onDisable(polling, context);
   },
   async test(context: any) {
     return await pollingHelper.test(polling, context);

--- a/packages/pieces/community/xero/src/lib/triggers/new-purchase-order.ts
+++ b/packages/pieces/community/xero/src/lib/triggers/new-purchase-order.ts
@@ -147,18 +147,10 @@ export const xeroNewPurchaseOrder = createTrigger({
   },
   type: TriggerStrategy.POLLING,
   async onEnable(context: any) {
-    await pollingHelper.onEnable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onEnable(polling, context);
   },
   async onDisable(context: any) {
-    await pollingHelper.onDisable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onDisable(polling, context);
   },
   async test(context: any) {
     return await pollingHelper.test(polling, context);

--- a/packages/pieces/community/xero/src/lib/triggers/new-quote.ts
+++ b/packages/pieces/community/xero/src/lib/triggers/new-quote.ts
@@ -128,18 +128,10 @@ export const xeroNewQuote = createTrigger({
   },
   type: TriggerStrategy.POLLING,
   async onEnable(context: any) {
-    await pollingHelper.onEnable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onEnable(polling, context);
   },
   async onDisable(context: any) {
-    await pollingHelper.onDisable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onDisable(polling, context);
   },
   async test(context: any) {
     return await pollingHelper.test(polling, context);

--- a/packages/pieces/community/xero/src/lib/triggers/new-reconciled-payment.ts
+++ b/packages/pieces/community/xero/src/lib/triggers/new-reconciled-payment.ts
@@ -143,18 +143,10 @@ export const xeroNewReconciledPayment = createTrigger({
   },
   type: TriggerStrategy.POLLING,
   async onEnable(context: any) {
-    await pollingHelper.onEnable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onEnable(polling, context);
   },
   async onDisable(context: any) {
-    await pollingHelper.onDisable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onDisable(polling, context);
   },
   async test(context: any) {
     return await pollingHelper.test(polling, context);

--- a/packages/pieces/community/xero/src/lib/triggers/updated-quote.ts
+++ b/packages/pieces/community/xero/src/lib/triggers/updated-quote.ts
@@ -128,18 +128,10 @@ export const xeroUpdatedQuote = createTrigger({
   },
   type: TriggerStrategy.POLLING,
   async onEnable(context: any) {
-    await pollingHelper.onEnable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onEnable(polling, context);
   },
   async onDisable(context: any) {
-    await pollingHelper.onDisable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onDisable(polling, context);
   },
   async test(context: any) {
     return await pollingHelper.test(polling, context);

--- a/packages/pieces/community/zendesk-sell/package.json
+++ b/packages/pieces/community/zendesk-sell/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-zendesk-sell",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/packages/pieces/community/zendesk-sell/src/lib/triggers/deal_enters_stage.ts
+++ b/packages/pieces/community/zendesk-sell/src/lib/triggers/deal_enters_stage.ts
@@ -84,22 +84,14 @@ export const dealEntersStage = createTrigger({
     },
 
     async onEnable(context) {
-        await pollingHelper.onEnable(polling, {
-            auth: context.auth,
-            store: context.store,
-            propsValue: context.propsValue,
-        });
+        await pollingHelper.onEnable(polling, context);
         // Initialize custom state for stage tracking
         await context.store.put<PreviousDealStagesMap>(PREVIOUS_DEAL_STAGES_STORE_KEY, {});
         console.log(`Initialized store for dealEntersStage`);
     },
 
     async onDisable(context) {
-        await pollingHelper.onDisable(polling, {
-            auth: context.auth,
-            store: context.store,
-            propsValue: context.propsValue,
-        });
+        await pollingHelper.onDisable(polling, context);
         await context.store.delete(PREVIOUS_DEAL_STAGES_STORE_KEY);
         console.log(`Cleaned up store for dealEntersStage`);
     },

--- a/packages/pieces/community/zendesk-sell/src/lib/triggers/new_contact.ts
+++ b/packages/pieces/community/zendesk-sell/src/lib/triggers/new_contact.ts
@@ -71,19 +71,11 @@ export const newContact = createTrigger({
     type: TriggerStrategy.POLLING,
 
     async onEnable(context) {
-        await pollingHelper.onEnable(polling, {
-            auth: context.auth,
-            store: context.store,
-            propsValue: context.propsValue,
-        });
+        await pollingHelper.onEnable(polling, context);
     },
 
     async onDisable(context) {
-        await pollingHelper.onDisable(polling, {
-            auth: context.auth,
-            store: context.store,
-            propsValue: context.propsValue,
-        });
+        await pollingHelper.onDisable(polling, context);
     },
 
     async test(context) {

--- a/packages/pieces/community/zendesk-sell/src/lib/triggers/new_deal.ts
+++ b/packages/pieces/community/zendesk-sell/src/lib/triggers/new_deal.ts
@@ -67,19 +67,11 @@ export const newDeal = createTrigger({
     type: TriggerStrategy.POLLING,
 
     async onEnable(context) {
-        await pollingHelper.onEnable(polling, {
-            auth: context.auth,
-            store: context.store,
-            propsValue: context.propsValue,
-        });
+        await pollingHelper.onEnable(polling, context);
     },
 
     async onDisable(context) {
-        await pollingHelper.onDisable(polling, {
-            auth: context.auth,
-            store: context.store,
-            propsValue: context.propsValue,
-        });
+        await pollingHelper.onDisable(polling, context);
     },
 
     async test(context) {

--- a/packages/pieces/community/zendesk-sell/src/lib/triggers/new_lead.ts
+++ b/packages/pieces/community/zendesk-sell/src/lib/triggers/new_lead.ts
@@ -72,19 +72,11 @@ export const newLead = createTrigger({
     },
 
     async onEnable(context) {
-        await pollingHelper.onEnable(polling, {
-            auth: context.auth,
-            store: context.store,
-            propsValue: context.propsValue,
-        });
+        await pollingHelper.onEnable(polling, context);
     },
 
     async onDisable(context) {
-        await pollingHelper.onDisable(polling, {
-            auth: context.auth,
-            store: context.store,
-            propsValue: context.propsValue,
-        });
+        await pollingHelper.onDisable(polling, context);
     },
 
     async run(context) {

--- a/packages/pieces/community/zendesk-sell/src/lib/triggers/new_note.ts
+++ b/packages/pieces/community/zendesk-sell/src/lib/triggers/new_note.ts
@@ -68,19 +68,11 @@ export const newNote = createTrigger({
     },
 
     async onEnable(context) {
-        await pollingHelper.onEnable(polling, {
-            auth: context.auth,
-            store: context.store,
-            propsValue: context.propsValue,
-        });
+        await pollingHelper.onEnable(polling, context);
     },
 
     async onDisable(context) {
-        await pollingHelper.onDisable(polling, {
-            auth: context.auth,
-            store: context.store,
-            propsValue: context.propsValue,
-        });
+        await pollingHelper.onDisable(polling, context);
     },
 
     async run(context) {

--- a/packages/pieces/community/zendesk-sell/src/lib/triggers/updated_contact.ts
+++ b/packages/pieces/community/zendesk-sell/src/lib/triggers/updated_contact.ts
@@ -67,19 +67,11 @@ export const updatedContact = createTrigger({
     type: TriggerStrategy.POLLING,
 
     async onEnable(context) {
-        await pollingHelper.onEnable(polling, {
-            auth: context.auth,
-            store: context.store,
-            propsValue: context.propsValue,
-        });
+        await pollingHelper.onEnable(polling, context);
     },
 
     async onDisable(context) {
-        await pollingHelper.onDisable(polling, {
-            auth: context.auth,
-            store: context.store,
-            propsValue: context.propsValue,
-        });
+        await pollingHelper.onDisable(polling, context);
     },
 
     async test(context) {

--- a/packages/pieces/community/zendesk-sell/src/lib/triggers/updated_deal.ts
+++ b/packages/pieces/community/zendesk-sell/src/lib/triggers/updated_deal.ts
@@ -66,19 +66,11 @@ export const updatedDeal = createTrigger({
     type: TriggerStrategy.POLLING,
 
     async onEnable(context) {
-        await pollingHelper.onEnable(polling, {
-            auth: context.auth,
-            store: context.store,
-            propsValue: context.propsValue,
-        });
+        await pollingHelper.onEnable(polling, context);
     },
 
     async onDisable(context) {
-        await pollingHelper.onDisable(polling, {
-            auth: context.auth,
-            store: context.store,
-            propsValue: context.propsValue,
-        });
+        await pollingHelper.onDisable(polling, context);
     },
 
     async test(context) {

--- a/packages/pieces/community/zendesk-sell/src/lib/triggers/updated_lead.ts
+++ b/packages/pieces/community/zendesk-sell/src/lib/triggers/updated_lead.ts
@@ -76,19 +76,11 @@ export const updatedLead = createTrigger({
     },
 
     async onEnable(context) {
-        await pollingHelper.onEnable(polling, {
-            auth: context.auth,
-            store: context.store,
-            propsValue: context.propsValue,
-        });
+        await pollingHelper.onEnable(polling, context);
     },
 
     async onDisable(context) {
-        await pollingHelper.onDisable(polling, {
-            auth: context.auth,
-            store: context.store,
-            propsValue: context.propsValue,
-        });
+        await pollingHelper.onDisable(polling, context);
     },
 
     async run(context) {

--- a/packages/pieces/community/zendesk/package.json
+++ b/packages/pieces/community/zendesk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-zendesk",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {

--- a/packages/pieces/community/zendesk/src/lib/trigger/new-ticket-in-view.ts
+++ b/packages/pieces/community/zendesk/src/lib/trigger/new-ticket-in-view.ts
@@ -108,18 +108,10 @@ export const newTicketInView = createTrigger({
     from_messaging_channel: false,
   },
   onEnable: async (context) => {
-    await pollingHelper.onEnable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onEnable(polling, context);
   },
   onDisable: async (context) => {
-    await pollingHelper.onDisable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onDisable(polling, context);
   },
   run: async (context) => {
     return await pollingHelper.poll(polling, {

--- a/packages/pieces/community/zoho-campaigns/package.json
+++ b/packages/pieces/community/zoho-campaigns/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-zoho-campaigns",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/packages/pieces/community/zoho-campaigns/src/lib/triggers/new-campaign.ts
+++ b/packages/pieces/community/zoho-campaigns/src/lib/triggers/new-campaign.ts
@@ -54,13 +54,11 @@ export const newCampaign = createTrigger({
     return await pollingHelper.test(polling, context);
   },
   async onEnable(context) {
-    const { store, auth, propsValue } = context;
-    await pollingHelper.onEnable(polling, { store, auth, propsValue });
+    await pollingHelper.onEnable(polling, context);
   },
 
   async onDisable(context) {
-    const { store, auth, propsValue } = context;
-    await pollingHelper.onDisable(polling, { store, auth, propsValue });
+    await pollingHelper.onDisable(polling, context);
   },
 
   async run(context) {

--- a/packages/pieces/community/zoho-campaigns/src/lib/triggers/new-contact.ts
+++ b/packages/pieces/community/zoho-campaigns/src/lib/triggers/new-contact.ts
@@ -65,13 +65,11 @@ export const newContact = createTrigger({
     return await pollingHelper.test(polling, context);
   },
   async onEnable(context) {
-    const { store, auth, propsValue } = context;
-    await pollingHelper.onEnable(polling, { store, auth, propsValue });
+    await pollingHelper.onEnable(polling, context);
   },
 
   async onDisable(context) {
-    const { store, auth, propsValue } = context;
-    await pollingHelper.onDisable(polling, { store, auth, propsValue });
+    await pollingHelper.onDisable(polling, context);
   },
 
   async run(context) {

--- a/packages/pieces/community/zoho-campaigns/src/lib/triggers/unsubscribe.ts
+++ b/packages/pieces/community/zoho-campaigns/src/lib/triggers/unsubscribe.ts
@@ -67,13 +67,11 @@ export const unsubscribe = createTrigger({
     return await pollingHelper.test(polling, context);
   },
   async onEnable(context) {
-    const { store, auth, propsValue } = context;
-    await pollingHelper.onEnable(polling, { store, auth, propsValue });
+    await pollingHelper.onEnable(polling, context);
   },
 
   async onDisable(context) {
-    const { store, auth, propsValue } = context;
-    await pollingHelper.onDisable(polling, { store, auth, propsValue });
+    await pollingHelper.onDisable(polling, context);
   },
 
   async run(context) {

--- a/packages/pieces/community/zoho-crm/package.json
+++ b/packages/pieces/community/zoho-crm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-zoho-crm",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {

--- a/packages/pieces/community/zoho-crm/src/lib/triggers/new-contact.ts
+++ b/packages/pieces/community/zoho-crm/src/lib/triggers/new-contact.ts
@@ -110,11 +110,12 @@ export const newContact = createTrigger({
       files: files,
     });
   },
-  async onEnable({ auth, propsValue, store }): Promise<void> {
+  async onEnable({ auth, propsValue, store, isRepublish }): Promise<void> {
     await pollingHelper.onEnable(polling, {
       auth,
       store: store,
       propsValue: propsValue,
+      isRepublish,
     });
   },
   async onDisable({ auth, propsValue, store }): Promise<void> {

--- a/packages/pieces/community/zoho-invoice/package.json
+++ b/packages/pieces/community/zoho-invoice/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-zoho-invoice",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {

--- a/packages/pieces/community/zoho-invoice/src/lib/triggers/new-invoice.ts
+++ b/packages/pieces/community/zoho-invoice/src/lib/triggers/new-invoice.ts
@@ -47,18 +47,10 @@ export const newInvoice = createTrigger({
   props: {},
   type: TriggerStrategy.POLLING,
   onEnable: async (context) => {
-    await pollingHelper.onEnable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onEnable(polling, context);
   },
   onDisable: async (context) => {
-    await pollingHelper.onDisable(polling, {
-      auth: context.auth,
-      store: context.store,
-      propsValue: context.propsValue,
-    });
+    await pollingHelper.onDisable(polling, context);
   },
   run: async (context) => {
     return await pollingHelper.poll(polling, {

--- a/packages/pieces/community/zoho-mail/package.json
+++ b/packages/pieces/community/zoho-mail/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-zoho-mail",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "dependencies": {

--- a/packages/pieces/community/zoho-mail/src/lib/triggers/new-email-received-trigger.ts
+++ b/packages/pieces/community/zoho-mail/src/lib/triggers/new-email-received-trigger.ts
@@ -100,18 +100,10 @@ export const newEmailReceivedTrigger = createTrigger({
 	type: TriggerStrategy.POLLING,
 
 	async onEnable(context) {
-		await pollingHelper.onEnable(polling, {
-			auth: context.auth,
-			store: context.store,
-			propsValue: context.propsValue,
-		});
+		await pollingHelper.onEnable(polling, context);
 	},
 	async onDisable(context) {
-		await pollingHelper.onDisable(polling, {
-			auth: context.auth,
-			store: context.store,
-			propsValue: context.propsValue,
-		});
+		await pollingHelper.onDisable(polling, context);
 	},
 	async test(context) {
 		return await pollingHelper.test(polling, context);


### PR DESCRIPTION
## Context

Follow-up to #14147 (the core republish-checkpoint fix). **Stacked on that PR** — base is `fix/polling-republish-checkpoint-13311`, review/merge it first.

#14147 threads `context.isRepublish` to `pollingHelper.onEnable`, but ~76% of polling triggers destructure `{ store, auth, propsValue }` and drop `context`, so the flag never reaches `pollingHelper` for them. This PR makes every `pollingHelper`-based trigger forward it.

## Change

- **Codemod (275 triggers):** `pollingHelper.onEnable(polling, { store, auth, propsValue })` → `pollingHelper.onEnable(polling, context)` (removing any now-orphaned `const { … } = context` line). Same for `onDisable`.
- **Hand-edited (5 triggers)** with destructured params: `rss` (×2), `shopify`, `google-calendar`, `zoho-crm` — thread `isRepublish` through the destructured param + forwarded object (their `propsValue` is transformed/cast, so full-context forwarding isn't clean). Also fixes a latent `onDisable` calling `pollingHelper.onEnable` typo in `shopify`.
- Patch **version bump** for each of the 112 touched pieces.

No behavior change on its own — it's a safe superset refactor; the fix activates via the `isRepublish` logic from #14147.

## Out of scope

Custom-polling triggers that hand-roll `onEnable` without `pollingHelper` (e.g. Gmail — ~32 triggers) have the same bug but need tailored per-piece guards; separate follow-up.

## Verification

- AST parse-check: 0 errors across all 280 changed files.
- Lint/type-check: 0 errors on the hand-edited pieces (`google-calendar`, `rss`, `shopify`) and a sample of codemod pieces incl. the largest (`hubspot`, 24 triggers), `front`, `amazon-s3`.