### PR TITLE
chore(release): bump version to 0.86.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activepieces",
-  "version": "0.86.2",
+  "version": "0.86.3",
   "packageManager": "bun@1.3.3",
   "trustedDependencies": [
     "sqlite3",


### PR DESCRIPTION
Bumps root `package.json` to `0.86.3` so the Release Self-Hosted workflow can cut `0.86.3-rc.1` (contains the benchmark deployment-diagnostics feature #14162). Version-only change.