### PR TITLE
feat(benchmark): api-key-only auth for the benchmark CLI

### DIFF
--- a/.agents/features/benchmark-cli.md
+++ b/.agents/features/benchmark-cli.md
@@ -12,7 +12,7 @@
 - `benchmark/run-gke.sh` — GKE harness used to produce the published reference numbers
 
 ## Edition Availability
-Community, Enterprise, Cloud. Setup discovery + infra diagnostics require a **platform-admin** token (`worker-machines` and `health/*` are `platformAdminOnly` USER); without it the CLI still runs the load test and per-run latency attribution, but skips specs/split validation and the infra round-trip block.
+Community, Enterprise, Cloud. The CLI authenticates with a **platform API key only** (`AP_API_KEY` / `--api-key` + `--project-id`), same as the other CLI commands — email/password login was removed. The diagnostic endpoints (`GET /v1/worker-machines`, `/v1/health/system`, `/v1/health/diagnostics`) accept a platform API key (`PrincipalType.SERVICE`), so a single API key gets the full bundle. The infra-diagnostics block is still self-hosted only (`FEATURE_DISABLED` on `AP_EDITION=cloud`).
 
 ## Reproduction basis
 To compare our reference deployment against a customer deployment apples-to-apples, the invariant is **concurrency = each deployment's own execution slots** (the CLI default), so neither side queues. The comparable numbers are then the server/worker-measured RUN/service-time and the infra round-trip — not a fixed concurrency (which would make a smaller deployment queue and reproduce the original "over-drove their slots" confusion). Edition note: the infra round-trip block is **self-hosted only** — `GET /v1/health/diagnostics` returns `FEATURE_DISABLED` on `AP_EDITION=cloud` (a Cloud platform-admin is a tenant, not the infra operator), and the CLI degrades gracefully to the rest of the report.

--- a/docs/install/architecture/benchmark.mdx
+++ b/docs/install/architecture/benchmark.mdx
@@ -114,13 +114,9 @@ To load-test and **diagnose** your own deployment — no cluster scripts require
 
 Because the CLI runs from a **different host and region** than your API and workers, every client-side number it sees (autocannon latency, round-trip time) is polluted by that network distance. So the authoritative numbers come from the **server and workers themselves**: the per-run QUEUE/PROVISION/BOOT/RUN split is timed *inside the worker*, and the DB/Redis/S3 round-trip latency is measured *in-region* by a platform-admin diagnostics endpoint. Client-side numbers are shown but clearly marked observational.
 
-Authenticate with an API key or user token, **or** with email + password. A **platform-admin** login unlocks the full bundle (setup validation, infra round-trip, worker fleet); a plain API key still runs the load test and per-run latency attribution.
+Authenticate with your **platform API key** — the same credential the other CLI commands use (`AP_API_KEY`). It gets the **full** bundle: setup validation, the in-region infra round-trip, and the worker + app fleet.
 
 ```bash
-# platform-admin login (full diagnostics)
-npx @activepieces/cli@latest benchmark --url https://your-instance.example.com --email admin@company.com --password '...'
-
-# or API key + project (load test + latency attribution; admin-only sections skipped)
 AP_API_KEY=<key> npx @activepieces/cli@latest benchmark --url https://your-instance.example.com --project-id <id>
 ```
 
@@ -131,9 +127,8 @@ By default the load runs at **concurrency = your deployment's execution slots** 
 | `--url` | `http://localhost:3000` | Base URL of your Activepieces instance |
 | `--concurrency` | auto = execution slots | Concurrent connections; omit to match your fleet's slot count |
 | `--requests` | `40 × concurrency` | Total requests to fire |
-| `--api-key` | `AP_API_KEY` env var | Platform API key or user token (Bearer); requires `--project-id` |
-| `--project-id` | | Project to create the benchmark flow in (required with `--api-key`) |
-| `--email` / `--password` | | Login instead of an API key; a platform-admin unlocks the full diagnostics |
+| `--api-key` | `AP_API_KEY` env var | Platform API key (Bearer) — gets the full bundle; required |
+| `--project-id` | | Project to create the benchmark flow in (required) |
 | `--body` | `{"test":true}` | JSON body sent to the webhook |
 | `--json` | | Emit the full machine-readable bundle (share this with support) |
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/cli",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "bin": {
     "pieces-cli": "../../dist/packages/cli/src/index.js"
   },

--- a/packages/cli/src/lib/commands/benchmark.spec.ts
+++ b/packages/cli/src/lib/commands/benchmark.spec.ts
@@ -17,7 +17,7 @@ describe('benchmarkUtils.normalizeOptions', () => {
     it('leaves auth and load fields undefined when not provided', () => {
         const config = benchmarkUtils.normalizeOptions({ url: 'http://x', body: '{}' });
         expect(config.apiKey).toBeUndefined();
-        expect(config.email).toBeUndefined();
+        expect(config.projectId).toBeUndefined();
         expect(config.requests).toBeUndefined();
         expect(config.concurrency).toBeUndefined();
     });

--- a/packages/cli/src/lib/commands/benchmark.ts
+++ b/packages/cli/src/lib/commands/benchmark.ts
@@ -11,10 +11,8 @@ export const benchmarkCommand = new Command('benchmark')
     .option('--url <url>', 'Activepieces base URL (dev env API port)', 'http://localhost:3000')
     .option('--requests <n>', 'Total requests to fire (default: 40 x concurrency)')
     .option('--concurrency <c>', 'Concurrent connections (default: auto = sum of worker execution slots)')
-    .option('--api-key <key>', 'Platform API key or user token (Bearer). Or set AP_API_KEY. Requires --project-id.')
-    .option('--project-id <id>', 'Project to create the benchmark flow in (required with --api-key)')
-    .option('--email <email>', 'Login email (alternative to --api-key; resolves the project automatically)')
-    .option('--password <password>', 'Login password')
+    .option('--api-key <key>', 'Platform API key (Bearer). Or set AP_API_KEY. Requires --project-id.')
+    .option('--project-id <id>', 'Project to create the benchmark flow in (required)')
     .option('--body <json>', 'JSON request body sent to the webhook', '{"test":true}')
     .option('--json', 'Emit machine-readable JSON output')
     .action(async (opts) => {
@@ -22,7 +20,7 @@ export const benchmarkCommand = new Command('benchmark')
         try {
             const client = axios.create({ baseURL: config.url, validateStatus: () => true });
             await waitForReady(client);
-            const auth = await authenticate({ client, config });
+            const auth = authenticate({ config });
             const authed = axios.create({
                 baseURL: config.url,
                 headers: { Authorization: `Bearer ${auth.token}` },
@@ -102,8 +100,6 @@ function normalizeOptions(opts: Record<string, string | boolean | undefined>): B
         concurrency,
         apiKey: typeof opts.apiKey === 'string' ? opts.apiKey : undefined,
         projectId: typeof opts.projectId === 'string' ? opts.projectId : undefined,
-        email: typeof opts.email === 'string' ? opts.email : undefined,
-        password: typeof opts.password === 'string' ? opts.password : undefined,
         body,
         json: opts.json === true,
     };
@@ -317,29 +313,15 @@ async function waitForReady(client: AxiosInstance): Promise<void> {
     throw new Error('Server did not become ready in time (checked /api/v1/flags)');
 }
 
-async function authenticate({ client, config }: { client: AxiosInstance; config: BenchmarkConfig }): Promise<AuthResult> {
+function authenticate({ config }: { config: BenchmarkConfig }): AuthResult {
     const apiKey = config.apiKey ?? process.env.AP_API_KEY;
-    if (apiKey) {
-        if (!config.projectId) {
-            throw new Error('When using --api-key (or AP_API_KEY), also pass --project-id.');
-        }
-        return { token: apiKey, projectId: config.projectId };
+    if (!apiKey) {
+        throw new Error('Provide a platform API key via --api-key or the AP_API_KEY env var.');
     }
-
-    if (config.email && config.password) {
-        const signIn = await client.post('/api/v1/authentication/sign-in', { email: config.email, password: config.password });
-        const token: string | undefined = signIn.data?.token;
-        if (!token) {
-            throw new Error(`Login failed: ${JSON.stringify(signIn.data)}`);
-        }
-        const projectId: string | undefined = config.projectId ?? signIn.data?.projectId ?? undefined;
-        if (!projectId) {
-            throw new Error('Login succeeded but returned no project; pass --project-id.');
-        }
-        return { token, projectId };
+    if (!config.projectId) {
+        throw new Error('Pass --project-id (the project to create the benchmark flow in).');
     }
-
-    throw new Error('Provide credentials: --api-key (or AP_API_KEY) with --project-id, or --email and --password.');
+    return { token: apiKey, projectId: config.projectId };
 }
 
 async function createBenchmarkFlow({ client, projectId }: { client: AxiosInstance; projectId: string }): Promise<string> {
@@ -660,8 +642,6 @@ type BenchmarkConfig = {
     concurrency?: number;
     apiKey?: string;
     projectId?: string;
-    email?: string;
-    password?: string;
     body: string;
     json: boolean;
 };

--- a/packages/server/api/src/app/health/health.module.ts
+++ b/packages/server/api/src/app/health/health.module.ts
@@ -54,7 +54,7 @@ const healthController: FastifyPluginAsyncZod = async (app) => {
 
 const GetSystemHealthChecks = {
     config: {
-        security: securityAccess.platformAdminOnly([PrincipalType.USER]),
+        security: securityAccess.platformAdminOnly([PrincipalType.USER, PrincipalType.SERVICE]),
     },
     response: {
         200: {
@@ -104,7 +104,7 @@ const GetHealthHistoryRequest = {
 
 const GetDiagnosticsRequest = {
     config: {
-        security: securityAccess.platformAdminOnly([PrincipalType.USER]),
+        security: securityAccess.platformAdminOnly([PrincipalType.USER, PrincipalType.SERVICE]),
     },
     schema: {
         tags: ['health'],

--- a/packages/server/api/src/app/workers/machine/machine-controller.ts
+++ b/packages/server/api/src/app/workers/machine/machine-controller.ts
@@ -53,7 +53,7 @@ export const workerMachineController: FastifyPluginAsyncZod = async (app) => {
 
 const ListWorkersParams = {
     config: {
-        security: securityAccess.platformAdminOnly([PrincipalType.USER]),
+        security: securityAccess.platformAdminOnly([PrincipalType.USER, PrincipalType.SERVICE]),
     },
 }
 


### PR DESCRIPTION
Makes the benchmark CLI authenticate with a **platform API key only** (`AP_API_KEY` / `--api-key` + `--project-id`), consistent with every other CLI command — removes the email/password login path.

To make one API key sufficient for the full diagnostic bundle, allows `PrincipalType.SERVICE` on the three admin endpoints the benchmark reads: `GET /v1/worker-machines`, `/v1/health/system`, `/v1/health/diagnostics`. (`/v1/worker-machines/queue-metrics` already allowed SERVICE.) A platform API key is already far more privileged than reading diagnostics, so this exposes nothing new; `/flows` and `/flow-runs` already accept SERVICE.

- cli: drop `--email`/`--password`; `authenticate()` requires an API key; version → 1.2.0 (triggers npm publish)
- server: add SERVICE to the three diagnostic endpoints' security
- docs: api-key is the only documented auth

Verified: cli build+lint+tests (13) green; api build clean; MDX compiles.