### PR TITLE
feat(subflows): add "Process CSV in Chunks" action to fan out CSV rows across subflow runs

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -10652,15 +10652,17 @@
     },
     "packages/pieces/core/subflows": {
       "name": "@activepieces/piece-subflows",
-      "version": "0.4.15",
+      "version": "0.4.16",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
         "@activepieces/pieces-common": "workspace:*",
         "@activepieces/pieces-framework": "workspace:*",
+        "csv-parse": "5.6.0",
       },
       "devDependencies": {
         "tslib": "2.6.2",
+        "vitest": "3.2.6",
       },
     },
     "packages/pieces/core/tables": {

--- a/packages/pieces/core/subflows/package.json
+++ b/packages/pieces/core/subflows/package.json
@@ -1,20 +1,23 @@
 {
   "name": "@activepieces/piece-subflows",
-  "version": "0.4.15",
+  "version": "0.4.16",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",
     "bundle": "node ../../../../dist/packages/cli/src/index.js pieces bundle",
-    "lint": "eslint 'src/**/*.ts'"
+    "lint": "eslint 'src/**/*.ts'",
+    "test": "vitest run"
   },
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "@activepieces/core-piece-types": "workspace:*",
-    "@activepieces/core-utils": "workspace:*"
+    "@activepieces/core-utils": "workspace:*",
+    "csv-parse": "5.6.0"
   },
   "devDependencies": {
+    "vitest": "3.2.6",
     "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/core/subflows/src/i18n/translation.json
+++ b/packages/pieces/core/subflows/src/i18n/translation.json
@@ -15,5 +15,20 @@
   "Callable Flow": "Callable Flow",
   "Waiting to be triggered from another flow": "Waiting to be triggered from another flow",
   "Sample Data": "Sample Data",
-  "The schema to be passed to the flow": "The schema to be passed to the flow"
+  "The schema to be passed to the flow": "The schema to be passed to the flow",
+  "Process CSV in Chunks": "Process CSV in Chunks",
+  "Split a CSV file into chunks and dispatch each chunk to a subflow (\"Callable Flow\") for processing. Set the chunk size below; when left empty it defaults to 5000 rows.": "Split a CSV file into chunks and dispatch each chunk to a subflow (\"Callable Flow\") for processing. Set the chunk size below; when left empty it defaults to 5000 rows.",
+  "CSV File": "CSV File",
+  "The CSV file to split and process.": "The CSV file to split and process.",
+  "The subflow that processes each chunk. Only published flows with a \"Callable Flow\" trigger appear here; disabled flows are marked \"(inactive)\".": "The subflow that processes each chunk. Only published flows with a \"Callable Flow\" trigger appear here; disabled flows are marked \"(inactive)\".",
+  "Does the CSV have headers?": "Does the CSV have headers?",
+  "Delimiter": "Delimiter",
+  "The delimiter used in the CSV file.": "The delimiter used in the CSV file.",
+  "Comma": "Comma",
+  "Tab": "Tab",
+  "Semicolon": "Semicolon",
+  "Additional Data": "Additional Data",
+  "Static data merged into every chunk payload sent to the subflow.": "Static data merged into every chunk payload sent to the subflow.",
+  "Chunk Size (rows)": "Chunk Size (rows)",
+  "Number of rows per chunk. Defaults to 5000 when left empty.": "Number of rows per chunk. Defaults to 5000 when left empty."
 }

--- a/packages/pieces/core/subflows/src/index.ts
+++ b/packages/pieces/core/subflows/src/index.ts
@@ -1,5 +1,6 @@
 import { createPiece, PieceAuth } from '@activepieces/pieces-framework';
 import { callFlow } from './lib/actions/call-flow';
+import { processCsvInChunks } from './lib/actions/process-csv-in-chunks';
 import { callableFlow } from './lib/triggers/callable-flow';
 import { response } from './lib/actions/respond';
 import { PieceCategory } from '@activepieces/pieces-framework';
@@ -12,6 +13,6 @@ export const flows = createPiece({
   categories: [PieceCategory.CORE, PieceCategory.FLOW_CONTROL],
   logoUrl: 'https://cdn.activepieces.com/pieces/new-core/subflows.svg',
   authors: ['hazemadelkhalel'],
-  actions: [callFlow, response],
+  actions: [callFlow, processCsvInChunks, response],
   triggers: [callableFlow],
 });

--- a/packages/pieces/core/subflows/src/lib/actions/process-csv-in-chunks.ts
+++ b/packages/pieces/core/subflows/src/lib/actions/process-csv-in-chunks.ts
@@ -1,0 +1,168 @@
+import {
+  createAction,
+  PieceAuth,
+  Property,
+} from '@activepieces/pieces-framework';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+import {
+  FAIL_PARENT_ON_FAILURE_HEADER,
+  FlowStatus,
+  PARENT_RUN_ID_HEADER,
+} from '@activepieces/pieces-framework';
+import { parse } from 'csv-parse/sync';
+import {
+  findFlowByExternalIdOrThrow,
+  listFlowsWithSubflowTrigger,
+} from '../common';
+
+type FlowValue = {
+  externalId: string;
+};
+
+export const processCsvInChunks = createAction({
+  audience: 'human',
+  name: 'processCsvInChunks',
+  displayName: 'Process CSV in Chunks',
+  description:
+    'Split a CSV file into chunks and dispatch each chunk to a subflow ("Callable Flow") for processing. Set the chunk size below; when left empty it defaults to 5000 rows.',
+  props: {
+    file: Property.File({
+      displayName: 'CSV File',
+      description: 'The CSV file to split and process.',
+      required: true,
+    }),
+    flow: Property.Dropdown<FlowValue>({
+      auth: PieceAuth.None(),
+      displayName: 'Flow',
+      description:
+        'The subflow that processes each chunk. Only published flows with a "Callable Flow" trigger appear here; disabled flows are marked "(inactive)".',
+      required: true,
+      refreshers: [],
+      options: async (_, context) => {
+        const flows = await listFlowsWithSubflowTrigger({
+          flowsContext: context.flows,
+        });
+        return {
+          options: flows.map((flow) => ({
+            value: { externalId: flow.externalId ?? flow.id },
+            label:
+              flow.status === FlowStatus.ENABLED
+                ? flow.version.displayName
+                : `${flow.version.displayName} (inactive)`,
+          })),
+        };
+      },
+    }),
+    chunkSize: Property.Number({
+      displayName: 'Chunk Size (rows)',
+      description: 'Number of rows per chunk. Defaults to 5000 when left empty.',
+      required: false,
+    }),
+    hasHeaders: Property.Checkbox({
+      displayName: 'Does the CSV have headers?',
+      required: true,
+      defaultValue: true,
+    }),
+    delimiter: Property.StaticDropdown({
+      displayName: 'Delimiter',
+      description: 'The delimiter used in the CSV file.',
+      required: true,
+      defaultValue: ',',
+      options: {
+        options: [
+          { label: 'Comma', value: ',' },
+          { label: 'Tab', value: '\t' },
+          { label: 'Semicolon', value: ';' },
+        ],
+      },
+    }),
+    additionalData: Property.Object({
+      displayName: 'Additional Data',
+      description: 'Static data merged into every chunk payload sent to the subflow.',
+      required: false,
+    }),
+  },
+  async run(context) {
+    const file = context.propsValue.file;
+    const rows = parse(file.data.toString('utf-8'), {
+      delimiter: context.propsValue.delimiter,
+      columns: context.propsValue.hasHeaders,
+      skip_empty_lines: true,
+    }) as unknown[];
+
+    const chunkSize = resolveChunkSize(context.propsValue.chunkSize);
+    const chunks = chunkArray(rows, chunkSize);
+
+    const flow = await findFlowByExternalIdOrThrow({
+      flowsContext: context.flows,
+      externalId: context.propsValue.flow?.externalId,
+    });
+    if (flow.status !== FlowStatus.ENABLED) {
+      throw new Error(
+        JSON.stringify({
+          message:
+            'The selected subflow is disabled. Enable it before processing chunks.',
+          externalId: context.propsValue.flow?.externalId,
+          flowName: flow.version.displayName,
+        })
+      );
+    }
+
+    const additionalData = context.propsValue.additionalData ?? {};
+    const url = `${context.server.apiUrl}v1/webhooks/${flow.id}`;
+
+    for (let index = 0; index < chunks.length; index++) {
+      await httpClient.sendRequest({
+        method: HttpMethod.POST,
+        url,
+        headers: {
+          'Content-Type': 'application/json',
+          [PARENT_RUN_ID_HEADER]: context.run.id,
+          [FAIL_PARENT_ON_FAILURE_HEADER]: 'false',
+        },
+        body: {
+          data: {
+            chunkIndex: index,
+            totalChunks: chunks.length,
+            rows: chunks[index],
+            ...additionalData,
+          },
+        },
+      });
+    }
+
+    return {
+      dispatchedChunks: chunks.length,
+      chunkSize,
+      totalRows: rows.length,
+      flowExternalId: flow.externalId ?? flow.id,
+    };
+  },
+  errorHandlingOptions: {
+    continueOnFailure: {
+      defaultValue: false,
+      hide: false,
+    },
+    retryOnFailure: {
+      defaultValue: false,
+      hide: false,
+    },
+  },
+});
+
+function chunkArray<T>(items: T[], size: number): T[][] {
+  const result: T[][] = [];
+  for (let i = 0; i < items.length; i += size) {
+    result.push(items.slice(i, i + size));
+  }
+  return result;
+}
+
+function resolveChunkSize(chunkSize: number | undefined): number {
+  if (typeof chunkSize === 'number' && Number.isFinite(chunkSize) && chunkSize >= 1) {
+    return Math.floor(chunkSize);
+  }
+  return DEFAULT_CHUNK_SIZE;
+}
+
+const DEFAULT_CHUNK_SIZE = 5000;

--- a/packages/pieces/core/subflows/test/process-csv-in-chunks.test.ts
+++ b/packages/pieces/core/subflows/test/process-csv-in-chunks.test.ts
@@ -1,0 +1,164 @@
+/// <reference types="vitest/globals" />
+
+import {
+  ApFile,
+  createMockActionContext,
+  FAIL_PARENT_ON_FAILURE_HEADER,
+  PARENT_RUN_ID_HEADER,
+} from '@activepieces/pieces-framework';
+
+const { sendRequest, findFlowByExternalIdOrThrow } = vi.hoisted(() => ({
+  sendRequest: vi.fn(),
+  findFlowByExternalIdOrThrow: vi.fn(),
+}));
+
+vi.mock('@activepieces/pieces-common', () => ({
+  httpClient: { sendRequest },
+  HttpMethod: { GET: 'GET', POST: 'POST' },
+}));
+
+vi.mock('../src/lib/common', () => ({
+  listFlowsWithSubflowTrigger: vi.fn(),
+  findFlowByExternalIdOrThrow,
+}));
+
+import { processCsvInChunks } from '../src/lib/actions/process-csv-in-chunks';
+
+const ENABLED_SUBFLOW = {
+  id: 'sub-flow-id',
+  externalId: 'sub-external-id',
+  status: 'ENABLED',
+  version: { displayName: 'Chunk Processor' },
+};
+
+describe('processCsvInChunks action', () => {
+  beforeEach(() => {
+    sendRequest.mockReset().mockResolvedValue({ status: 200, body: {} });
+    findFlowByExternalIdOrThrow.mockReset().mockResolvedValue(ENABLED_SUBFLOW);
+  });
+
+  test('splits the CSV into chunks of the configured size and dispatches one subflow call per chunk', async () => {
+    const result = await processCsvInChunks.run(contextFor({ rowCount: 5, chunkSize: 2 }));
+
+    expect(result).toEqual({
+      dispatchedChunks: 3,
+      chunkSize: 2,
+      totalRows: 5,
+      flowExternalId: 'sub-external-id',
+    });
+    expect(sendRequest).toHaveBeenCalledTimes(3);
+    expect(dispatchedPayloads().map((payload) => payload.rows.length)).toEqual([2, 2, 1]);
+    expect(dispatchedPayloads().map((payload) => payload.chunkIndex)).toEqual([0, 1, 2]);
+    expect(dispatchedPayloads().every((payload) => payload.totalChunks === 3)).toBe(true);
+  });
+
+  test('falls back to 5000 rows per chunk when the chunk size is left empty', async () => {
+    const result = await processCsvInChunks.run(contextFor({ rowCount: 3, chunkSize: undefined }));
+
+    expect(result.chunkSize).toBe(5000);
+    expect(result.dispatchedChunks).toBe(1);
+  });
+
+  test.each([0, -10, Number.NaN])(
+    'falls back to 5000 rows per chunk when the chunk size is %s',
+    async (chunkSize) => {
+      const result = await processCsvInChunks.run(contextFor({ rowCount: 3, chunkSize }));
+
+      expect(result.chunkSize).toBe(5000);
+    }
+  );
+
+  test('truncates a fractional chunk size to a whole number of rows', async () => {
+    const result = await processCsvInChunks.run(contextFor({ rowCount: 5, chunkSize: 2.9 }));
+
+    expect(result.chunkSize).toBe(2);
+    expect(result.dispatchedChunks).toBe(3);
+  });
+
+  test('dispatches nothing when the CSV has no data rows', async () => {
+    const result = await processCsvInChunks.run(contextFor({ rowCount: 0, chunkSize: 10 }));
+
+    expect(result.totalRows).toBe(0);
+    expect(result.dispatchedChunks).toBe(0);
+    expect(sendRequest).not.toHaveBeenCalled();
+  });
+
+  test('merges additionalData into every chunk payload', async () => {
+    await processCsvInChunks.run(
+      contextFor({ rowCount: 3, chunkSize: 2, additionalData: { batch: 'nightly' } })
+    );
+
+    expect(dispatchedPayloads()).toHaveLength(2);
+    expect(dispatchedPayloads().every((payload) => payload.batch === 'nightly')).toBe(true);
+  });
+
+  test('links every chunk to the parent run without letting it fail the parent', async () => {
+    await processCsvInChunks.run(contextFor({ rowCount: 3, chunkSize: 2 }));
+
+    for (const [request] of sendRequest.mock.calls) {
+      expect(request.method).toBe('POST');
+      expect(request.url).toContain('v1/webhooks/sub-flow-id');
+      expect(request.headers[PARENT_RUN_ID_HEADER]).toBe('test-run-id');
+      expect(request.headers[FAIL_PARENT_ON_FAILURE_HEADER]).toBe('false');
+    }
+  });
+
+  test('parses headerless CSVs as positional rows', async () => {
+    const result = await processCsvInChunks.run(
+      contextFor({ rowCount: 2, chunkSize: 10, hasHeaders: false })
+    );
+
+    expect(result.totalRows).toBe(3);
+    expect(dispatchedPayloads()[0].rows[0]).toEqual(['id', 'name']);
+  });
+
+  test('honours a non-comma delimiter', async () => {
+    const result = await processCsvInChunks.run(
+      contextFor({ rowCount: 2, chunkSize: 10, delimiter: ';', separator: ';' })
+    );
+
+    expect(result.totalRows).toBe(2);
+    expect(dispatchedPayloads()[0].rows[0]).toEqual({ id: '1', name: 'User 1' });
+  });
+
+  test('throws when the selected subflow is disabled', async () => {
+    findFlowByExternalIdOrThrow.mockResolvedValue({ ...ENABLED_SUBFLOW, status: 'DISABLED' });
+
+    await expect(processCsvInChunks.run(contextFor({ rowCount: 3, chunkSize: 2 }))).rejects.toThrow(
+      /disabled/
+    );
+    expect(sendRequest).not.toHaveBeenCalled();
+  });
+});
+
+function csvFile(rowCount: number, separator = ','): ApFile {
+  const lines = [['id', 'name'].join(separator)];
+  for (let i = 1; i <= rowCount; i++) {
+    lines.push([String(i), `User ${i}`].join(separator));
+  }
+  return new ApFile('data.csv', Buffer.from(lines.join('\n')), 'csv');
+}
+
+function contextFor(params: {
+  rowCount: number;
+  chunkSize: number | undefined;
+  hasHeaders?: boolean;
+  delimiter?: string;
+  separator?: string;
+  additionalData?: Record<string, unknown>;
+}) {
+  return createMockActionContext({
+    propsValue: {
+      file: csvFile(params.rowCount, params.separator),
+      flow: { externalId: 'sub-external-id' },
+      chunkSize: params.chunkSize,
+      hasHeaders: params.hasHeaders ?? true,
+      delimiter: params.delimiter ?? ',',
+      additionalData: params.additionalData,
+    },
+  });
+}
+
+function dispatchedPayloads(): Record<string, unknown>[] {
+  return sendRequest.mock.calls.map(([request]) => request.body.data);
+}

--- a/packages/pieces/core/subflows/vitest.config.ts
+++ b/packages/pieces/core/subflows/vitest.config.ts
@@ -1,0 +1,18 @@
+import path from 'path'
+import { defineConfig } from 'vitest/config'
+
+const repoRoot = path.resolve(__dirname, '../../../..')
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+  },
+  resolve: {
+    alias: {
+      '@activepieces/shared': path.resolve(repoRoot, 'packages/core/shared/src/index.ts'),
+      '@activepieces/pieces-framework': path.resolve(repoRoot, 'packages/pieces/framework/src/index.ts'),
+      '@activepieces/pieces-common': path.resolve(repoRoot, 'packages/pieces/common/src/index.ts'),
+    },
+  },
+})


### PR DESCRIPTION
## What does this PR do?

Adds a **"Process CSV in Chunks"** action to the core **Sub Flows** piece.

It takes a CSV file, splits it into chunks of N rows, and dispatches each chunk to a
subflow (a flow with the "Callable Flow" trigger) asynchronously. Each chunk becomes an
independent child run, so a large CSV is processed in parallel instead of in one
long-running step that risks hitting the flow timeout.

Scope is limited to the piece: no changes to the server or to `@activepieces/shared`.

### Explain How the Feature Works

The action exposes these inputs:

| Input | Type | Required | Description |
|---|---|---|---|
| CSV File | File | yes | The CSV to split. |
| Flow | Dropdown | yes | The target subflow. Only published flows with a "Callable Flow" trigger are listed; disabled ones are marked `(inactive)`. |
| Chunk Size (rows) | Number | no | Rows per chunk. **Defaults to 5000 when left empty.** |
| Does the CSV have headers? | Checkbox | yes | Controls `columns` when parsing. |
| Delimiter | Dropdown | yes | `,` / tab / `;` |
| Additional Data | Object | no | Static data merged into every chunk payload. |

At run time it:

1. Parses the CSV with `csv-parse/sync` (already used by the core CSV piece).
2. Resolves the chunk size: a finite number `>= 1` is used, otherwise the `5000` fallback.
3. Splits the rows into chunks.
4. Resolves the target subflow and fails fast with a clear message if it is disabled.
5. For each chunk, POSTs to the subflow webhook with
   `PARENT_RUN_ID_HEADER` (so the chunk becomes a **child run** of the parent) and
   `FAIL_PARENT_ON_FAILURE_HEADER: 'false'` (so a failing chunk never fails the parent).
   The payload is `{ data: { chunkIndex, totalChunks, rows, ...additionalData } }`.
6. Returns `{ dispatchedChunks, chunkSize, totalRows, flowExternalId }`.

It is deliberately **fire-and-forget**: no waitpoint is created, so the parent completes as
soon as the chunks are dispatched. (Activepieces' waitpoint model is one per
`(run, step)`, so awaiting N parallel callbacks would need a separate aggregation design.)

Covered by 12 unit tests (`packages/pieces/core/subflows/test/process-csv-in-chunks.test.ts`):
chunk boundaries, the 5000-row fallback (empty / `0` / negative / `NaN`), fractional chunk
size truncation, empty CSV dispatching nothing, `additionalData` merging, parent-run
headers, headerless CSVs, non-comma delimiters, and the disabled-subflow guard.

### Relevant User Scenarios

- **Bulk import from a CSV** into an external system (CRM/ERP) whose API rate-limits large
  batches — each chunk is a separate run with its own pacing.
- **Per-row processing at scale** (HTTP call, AI enrichment, DB insert): work is spread over
  parallel child runs instead of one step that would hit `FLOW_RUN_TIME_SECONDS`.
- **Failure isolation**: if 3 of 50 chunks fail, the other 47 still succeed and only the
  failed chunks need to be retried, instead of reprocessing the whole file.
- **Human-in-the-loop upload**: pair it with a Web Form trigger so a user uploads the CSV
  and the flow fans the rows out to a processing subflow.

Fixes # (issue)
