### PR TITLE
perf(canvas): precompute step node derivation

### DIFF
--- a/packages/web/src/app/builder/flow-canvas/index.tsx
+++ b/packages/web/src/app/builder/flow-canvas/index.tsx
@@ -315,7 +315,7 @@ const createGraphKey = (
       const childrenKey = getChildrenKey(step);
       return `${acc}-${step.displayName}-${step.type}-${
         step.nextAction ? step.nextAction.name : ''
-      }-${
+      }-${'skip' in step && !!step.skip}-${
         step.type === FlowActionType.PIECE ||
         step.type === FlowTriggerType.PIECE
           ? `${step.settings.pieceName}-${step.settings.pieceVersion}`

--- a/packages/web/src/app/builder/flow-canvas/nodes/step-node/index.tsx
+++ b/packages/web/src/app/builder/flow-canvas/nodes/step-node/index.tsx
@@ -6,7 +6,7 @@ import {
 } from '@activepieces/shared';
 import { useDraggable } from '@dnd-kit/core';
 import { Handle, NodeProps, Position } from '@xyflow/react';
-import React, { useMemo } from 'react';
+import React from 'react';
 
 import { useBuilderStateContext } from '@/app/builder/builder-hooks';
 import { PieceSelector } from '@/app/builder/pieces-selector';
@@ -16,7 +16,6 @@ import { stepsHooks } from '@/features/pieces';
 import { cn } from '@/lib/utils';
 
 import { flowCanvasConsts } from '../../utils/consts';
-import { flowCanvasUtils } from '../../utils/flow-canvas-utils';
 import { ApStepNode } from '../../utils/types';
 
 import { StepNodeChevron } from './step-node-chevron';
@@ -28,13 +27,14 @@ import { ApStepNodeStatusInRun } from './step-node-status-in-run';
 import { TriggerWidget } from './trigger-widget';
 
 const ApStepCanvasNode = React.memo(
-  ({ data: { step } }: NodeProps & Omit<ApStepNode, 'position'>) => {
+  ({
+    data: { step, stepIndex, isSkipped },
+  }: NodeProps & Omit<ApStepNode, 'position'>) => {
     const [
       selectStepByName,
       isSelected,
       isDragging,
       readonly,
-      flowVersion,
       setSelectedBranchIndex,
       isPieceSelectorOpened,
       setOpenedPieceSelectorStepNameOrAddButtonId,
@@ -45,7 +45,6 @@ const ApStepCanvasNode = React.memo(
       state.selectedStep === step.name,
       state.activeDraggingStep === step.name,
       state.readonly,
-      state.flowVersion,
       state.setSelectedBranchIndex,
       state.openedPieceSelectorStepNameOrAddButtonId === step.name,
       state.setOpenedPieceSelectorStepNameOrAddButtonId,
@@ -56,12 +55,7 @@ const ApStepCanvasNode = React.memo(
     const { stepMetadata } = stepsHooks.useStepMetadata({
       step,
     });
-    const stepIndex = useMemo(
-      () => flowStructureUtil.getStepNumber(flowVersion.trigger, step.name),
-      [step, flowVersion],
-    );
     const isTrigger = flowStructureUtil.isTrigger(step.type);
-    const isSkipped = flowCanvasUtils.isSkipped(step.name, flowVersion.trigger);
 
     const { attributes, listeners, setNodeRef } = useDraggable({
       id: step.name,
@@ -152,8 +146,8 @@ const ApStepCanvasNode = React.memo(
         {isTrigger && <TriggerWidget isSelected={isSelected} />}
         <LoopIterationInput stepName={step.name} />
         <ApStepNodeStatusInRun stepName={step.name} />
-        <ApStepNodeSkippedStatus stepName={step.name} />
-        <ApStepNodeStatusInDraft stepName={step.name} />
+        <ApStepNodeSkippedStatus stepName={step.name} isSkipped={isSkipped} />
+        <ApStepNodeStatusInDraft stepName={step.name} isSkipped={isSkipped} />
         <div
           className={cn('h-full w-full', {
             'px-3 overflow-hidden': !isHorizontal,

--- a/packages/web/src/app/builder/flow-canvas/nodes/step-node/step-node-skipped-status.tsx
+++ b/packages/web/src/app/builder/flow-canvas/nodes/step-node/step-node-skipped-status.tsx
@@ -10,19 +10,21 @@ import { RouteOff } from 'lucide-react';
 import { flowRunUtils } from '@/features/flow-runs';
 
 import { useBuilderStateContext } from '../../../builder-hooks';
-import { flowCanvasUtils } from '../../utils/flow-canvas-utils';
 
 import { StepNodeBadgeContainer } from './step-node-badge-container';
 
-const ApStepNodeSkippedStatus = ({ stepName }: { stepName: string }) => {
-  const [run, stepType, isInDraft, isSkipped] = useBuilderStateContext(
-    (state) => [
-      state.run,
-      flowStructureUtil.getStep(stepName, state.flowVersion.trigger)?.type,
-      state.flowVersion.state === FlowVersionState.DRAFT,
-      flowCanvasUtils.isSkipped(stepName, state.flowVersion.trigger),
-    ],
-  );
+const ApStepNodeSkippedStatus = ({
+  stepName,
+  isSkipped,
+}: {
+  stepName: string;
+  isSkipped: boolean;
+}) => {
+  const [run, stepType, isInDraft] = useBuilderStateContext((state) => [
+    state.run,
+    flowStructureUtil.getStep(stepName, state.flowVersion.trigger)?.type,
+    state.flowVersion.state === FlowVersionState.DRAFT,
+  ]);
 
   const hasRun = !isNil(run);
   const shouldShowSkippedStatus =

--- a/packages/web/src/app/builder/flow-canvas/nodes/step-node/step-node-status-in-draft.tsx
+++ b/packages/web/src/app/builder/flow-canvas/nodes/step-node/step-node-status-in-draft.tsx
@@ -19,9 +19,9 @@ import { StepStatusIcon, flowRunUtils } from '@/features/flow-runs';
 import { pieceSelectorUtils } from '@/features/pieces';
 
 import { useBuilderStateContext } from '../../../builder-hooks';
-import { flowCanvasUtils } from '../../utils/flow-canvas-utils';
 
 import { StepNodeBadgeContainer } from './step-node-badge-container';
+
 type DraftStepStatus =
   | 'invalid'
   | 'testing'
@@ -30,7 +30,13 @@ type DraftStepStatus =
   | 'tested'
   | 'untested';
 
-const ApStepNodeStatusInDraft = ({ stepName }: { stepName: string }) => {
+const ApStepNodeStatusInDraft = ({
+  stepName,
+  isSkipped,
+}: {
+  stepName: string;
+  isSkipped: boolean;
+}) => {
   const [
     run,
     isBeingTested,
@@ -41,7 +47,6 @@ const ApStepNodeStatusInDraft = ({ stepName }: { stepName: string }) => {
     isInDraft,
     isStepValid,
     isManualTrigger,
-    isSkipped,
   ] = useBuilderStateContext((state) => {
     const step = flowStructureUtil.getStep(stepName, state.flowVersion.trigger);
     const isManualTrigger =
@@ -60,7 +65,6 @@ const ApStepNodeStatusInDraft = ({ stepName }: { stepName: string }) => {
       state.flowVersion.state === FlowVersionState.DRAFT,
       !!step?.valid,
       isManualTrigger,
-      flowCanvasUtils.isSkipped(stepName, state.flowVersion.trigger),
     ];
   });
 

--- a/packages/web/src/app/builder/flow-canvas/utils/flow-canvas-utils.ts
+++ b/packages/web/src/app/builder/flow-canvas/utils/flow-canvas-utils.ts
@@ -714,9 +714,8 @@ function deriveStepNodeData(trigger: FlowTrigger): Map<string, StepNodeData> {
     derivedData.set(step.name, {
       stepIndex,
       isSkipped:
-        step.type !== FlowTriggerType.EMPTY &&
-        step.type !== FlowTriggerType.PIECE &&
-        (isSkippedByParent || !!step.skip),
+        !flowStructureUtil.isTrigger(step.type) &&
+        (isSkippedByParent || ('skip' in step && !!step.skip)),
     });
 
     const isSkippedByStep =

--- a/packages/web/src/app/builder/flow-canvas/utils/flow-canvas-utils.ts
+++ b/packages/web/src/app/builder/flow-canvas/utils/flow-canvas-utils.ts
@@ -103,6 +103,8 @@ const createStepGraph: (params: {
     position: { x: 0, y: 0 },
     data: {
       step,
+      stepIndex: 0,
+      isSkipped: false,
     },
     selectable: step.name !== 'trigger',
     draggable: true,
@@ -694,6 +696,54 @@ function buildNotesGraph(notes: Note[]): ApGraph {
   };
 }
 
+function deriveStepNodeData(trigger: FlowTrigger): Map<string, StepNodeData> {
+  const derivedData = new Map<string, StepNodeData>();
+  let stepIndex = 0;
+
+  function visit({
+    step,
+    isSkippedByParent,
+  }: {
+    step: FlowAction | FlowTrigger | null | undefined;
+    isSkippedByParent: boolean;
+  }): void {
+    if (isNil(step)) {
+      return;
+    }
+    stepIndex += 1;
+    derivedData.set(step.name, {
+      stepIndex,
+      isSkipped:
+        step.type !== FlowTriggerType.EMPTY &&
+        step.type !== FlowTriggerType.PIECE &&
+        (isSkippedByParent || !!step.skip),
+    });
+
+    const isSkippedByStep =
+      isSkippedByParent || ('skip' in step && !!step.skip);
+    if (step.type === FlowActionType.LOOP_ON_ITEMS) {
+      visit({ step: step.firstLoopAction, isSkippedByParent: isSkippedByStep });
+    } else if (step.type === FlowActionType.ROUTER) {
+      step.children.forEach((child) =>
+        visit({ step: child, isSkippedByParent: isSkippedByStep }),
+      );
+    } else if (
+      step.type === FlowActionType.CODE ||
+      step.type === FlowActionType.PIECE
+    ) {
+      sharedFlowCanvasUtils
+        .getContinueOnFailureBranchPair(step)
+        .forEach((child) =>
+          visit({ step: child, isSkippedByParent: isSkippedByStep }),
+        );
+    }
+    visit({ step: step.nextAction, isSkippedByParent });
+  }
+
+  visit({ step: trigger, isSkippedByParent: false });
+  return derivedData;
+}
+
 function determineInitiallySelectedStep(
   failedStepNameInRun: string | null,
   flowVersion: FlowVersion,
@@ -727,6 +777,7 @@ export const flowCanvasUtils = {
     notes: Note[];
     orientation: CanvasOrientation;
   }): ApGraph {
+    const stepNodeData = deriveStepNodeData(version.trigger);
     const stepsGraph = buildFlowGraph({
       step: version.trigger,
       orientation,
@@ -740,10 +791,23 @@ export const flowCanvasUtils = {
     } else {
       console.warn('Flow end widget not found');
     }
+    const graphWithStepNodeData: ApGraph = {
+      ...stepsGraph,
+      nodes: stepsGraph.nodes.map((node) => {
+        if (node.type !== ApNodeType.STEP) {
+          return node;
+        }
+        const derivedData = stepNodeData.get(node.id);
+        if (isNil(derivedData)) {
+          throw new Error(`Missing derived data for step node ${node.id}`);
+        }
+        return { ...node, data: { ...node.data, ...derivedData } };
+      }),
+    };
     const orientedGraph =
       orientation === 'horizontal'
-        ? transposeGraphPositions(stepsGraph)
-        : stepsGraph;
+        ? transposeGraphPositions(graphWithStepNodeData)
+        : graphWithStepNodeData;
     return mergeGraph(orientedGraph, notesGraph);
   },
   createFocusStepInGraphParams,
@@ -754,3 +818,5 @@ export const flowCanvasUtils = {
   determineInitiallySelectedStep,
   doesSelectionRectangleExist,
 };
+
+type StepNodeData = Pick<ApStepNode['data'], 'stepIndex' | 'isSkipped'>;

--- a/packages/web/src/app/builder/flow-canvas/utils/types.ts
+++ b/packages/web/src/app/builder/flow-canvas/utils/types.ts
@@ -32,6 +32,8 @@ export type ApStepNode = {
   };
   data: {
     step: FlowAction | FlowTrigger;
+    stepIndex: number;
+    isSkipped: boolean;
   };
   selectable?: boolean;
   style?: React.CSSProperties;

--- a/packages/web/test/app/builder/flow-canvas/utils/flow-canvas-utils.test.ts
+++ b/packages/web/test/app/builder/flow-canvas/utils/flow-canvas-utils.test.ts
@@ -1,11 +1,13 @@
 // @vitest-environment jsdom
 import {
   CodeAction,
+  FlowAction,
   EmptyTrigger,
   FlowActionType,
   FlowTriggerType,
   FlowVersion,
   FlowVersionState,
+  PieceAction,
 } from '@activepieces/shared';
 import { describe, expect, it, vi } from 'vitest';
 
@@ -41,7 +43,23 @@ const createCodeAction = (
   nextAction,
 });
 
-const createFlowVersion = (firstAction?: CodeAction): FlowVersion => {
+const createPieceAction = (name: string, skip = false): PieceAction => ({
+  name,
+  skip,
+  valid: true,
+  displayName: name,
+  lastUpdatedDate: '2026-01-01T00:00:00.000Z',
+  type: FlowActionType.PIECE,
+  settings: {
+    pieceName: '@activepieces/piece-test',
+    pieceVersion: '0.0.1',
+    actionName: 'test',
+    input: {},
+    errorHandlingOptions: {},
+  },
+});
+
+const createFlowVersion = (firstAction?: FlowAction): FlowVersion => {
   const trigger: EmptyTrigger = {
     name: 'trigger',
     valid: false,
@@ -138,6 +156,16 @@ describe('flowCanvasUtils.createFlowGraph', () => {
       stepIndex: 3,
       isSkipped: false,
     });
+  });
+
+  it('keeps skipped piece actions distinct from piece triggers', () => {
+    const graph = flowCanvasUtils.createFlowGraph({
+      version: createFlowVersion(createPieceAction('piece_action', true)),
+      notes: [],
+      orientation: 'vertical',
+    });
+
+    expect(getStepNode(graph, 'piece_action').data.isSkipped).toBe(true);
   });
 
   it('counts stored continue-on-failure branches when numbering visible steps', () => {

--- a/packages/web/test/app/builder/flow-canvas/utils/flow-canvas-utils.test.ts
+++ b/packages/web/test/app/builder/flow-canvas/utils/flow-canvas-utils.test.ts
@@ -22,8 +22,10 @@ vi.mock('@/features/flow-runs', () => ({
 const createCodeAction = (
   name: string,
   nextAction?: CodeAction,
+  skip = false,
 ): CodeAction => ({
   name,
+  skip,
   valid: true,
   displayName: name,
   lastUpdatedDate: '2026-01-01T00:00:00.000Z',
@@ -113,5 +115,85 @@ describe('flowCanvasUtils.createFlowGraph', () => {
     expect(triggerEdge?.target).toEqual('trigger-subgraph-end');
     const lastEdge = graph.edges.find((edge) => edge.source === 'step_1');
     expect(lastEdge?.target).toEqual('step_1-subgraph-end');
+  });
+
+  it('derives stable step indexes and skip state for canvas nodes', () => {
+    const graph = flowCanvasUtils.createFlowGraph({
+      version: createFlowVersion(
+        createCodeAction('step_1', createCodeAction('step_2'), true),
+      ),
+      notes: [],
+      orientation: 'vertical',
+    });
+
+    expect(getStepNode(graph, 'trigger').data).toMatchObject({
+      stepIndex: 1,
+      isSkipped: false,
+    });
+    expect(getStepNode(graph, 'step_1').data).toMatchObject({
+      stepIndex: 2,
+      isSkipped: true,
+    });
+    expect(getStepNode(graph, 'step_2').data).toMatchObject({
+      stepIndex: 3,
+      isSkipped: false,
+    });
+  });
+
+  it('counts stored continue-on-failure branches when numbering visible steps', () => {
+    const parent = createCodeAction('parent', createCodeAction('tail'));
+    parent.settings.errorHandlingOptions = {
+      continueOnFailure: { value: false },
+      retryOnFailure: { value: false },
+    };
+    parent.continueOnFailureBranches = {
+      onSuccess: createCodeAction('hidden_success'),
+      onFailure: createCodeAction('hidden_failure'),
+    };
+
+    const graph = flowCanvasUtils.createFlowGraph({
+      version: createFlowVersion(parent),
+      notes: [],
+      orientation: 'vertical',
+    });
+
+    expect(getStepNode(graph, 'tail').data.stepIndex).toBe(5);
+    expect(graph.nodes.some((node) => node.id === 'hidden_success')).toBe(
+      false,
+    );
+    expect(graph.nodes.some((node) => node.id === 'hidden_failure')).toBe(
+      false,
+    );
+  });
+
+  it('derives branch order and inherited skip state before the next action', () => {
+    const parent = createCodeAction('parent', createCodeAction('tail'), true);
+    parent.settings.errorHandlingOptions = {
+      continueOnFailure: { value: true },
+      retryOnFailure: { value: false },
+    };
+    parent.continueOnFailureBranches = {
+      onSuccess: createCodeAction('success', createCodeAction('success_next')),
+      onFailure: createCodeAction('failure'),
+    };
+
+    const graph = flowCanvasUtils.createFlowGraph({
+      version: createFlowVersion(parent),
+      notes: [],
+      orientation: 'vertical',
+    });
+
+    expect(
+      ['parent', 'success', 'success_next', 'failure', 'tail'].map((name) => {
+        const { stepIndex, isSkipped } = getStepNode(graph, name).data;
+        return { name, stepIndex, isSkipped };
+      }),
+    ).toEqual([
+      { name: 'parent', stepIndex: 2, isSkipped: true },
+      { name: 'success', stepIndex: 3, isSkipped: true },
+      { name: 'success_next', stepIndex: 4, isSkipped: true },
+      { name: 'failure', stepIndex: 5, isSkipped: true },
+      { name: 'tail', stepIndex: 6, isSkipped: false },
+    ]);
   });
 });


### PR DESCRIPTION
## What does this PR do?

Large flow canvases currently derive each step's display index once and inherited skip state three times inside every step node. Each lookup walks the flow tree again, so this work grows quadratically with the number of steps.

This PR derives both values in one traversal while the canvas graph is built, stores them in the step node data, and passes them to the status components. Skip changes are included in the graph cache key so toggling a step still updates affected descendants.

### Explain How the Feature Works

The derivation traversal follows the same ordering as `getAllSteps`, including stored continue-on-failure branches, and only propagates skip state through structural children. A missing step-node derivation is treated as an invariant failure instead of silently falling back.

### Relevant User Scenarios

This reduces synchronous canvas work for large automation flows. It is related to #11256, but intentionally does not claim to solve the issue's network, schema-loading, React rendering, or virtualization costs.

PR #10567 addresses broad canvas rerenders in the previous frontend tree. This change is narrower: it removes repeated step-number and skip-state traversals in the current `packages/web` canvas.

### Performance

The strict harness alternates 21 current-main and candidate samples in the same process and verifies exact step indexes, inherited skip state, graph structure in both orientations, input immutability, and benchmark checksums.

| Flow size | Current main | Candidate | Speedup |
| --- | ---: | ---: | ---: |
| 101 steps | 67.12 ms | 1.44 ms | 46.47x |
| 201 steps | 535.87 ms | 5.28 ms | 101.48x |

Geometric mean: **68.67x faster** for the isolated canvas step-derivation path.

Supplementary autoresearch: [public dashboard](https://dashboard.weco.ai/share/CCYAThQndDtdJ3-mtg6tZjtBQ0pK-4wL)

### Validation

- `bun run --cwd packages/web test test/app/builder/flow-canvas/utils/flow-canvas-utils.test.ts` (7 passed)
- `bun run --cwd packages/web typecheck`
- ESLint on all changed TypeScript files (0 errors; 4 pre-existing hook warnings)
- `git diff --check`

Related to #11256
