### PR TITLE
feat(event-streaming): enrich real flow-run events with flow + project display name

### DIFF
--- a/packages/server/api/src/app/event-destinations/event-destinations.service.ts
+++ b/packages/server/api/src/app/event-destinations/event-destinations.service.ts
@@ -4,10 +4,12 @@ import { FastifyBaseLogger } from 'fastify'
 import { StatusCodes } from 'http-status-codes'
 import { ArrayContains, FindOptionsWhere } from 'typeorm'
 import { repoFactory } from '../core/db/repo-factory'
+import { flowVersionService } from '../flows/flow-version/flow-version.service'
 import { applicationEvents } from '../helper/application-events'
 import { domainHelper } from '../helper/domain-helper'
 import { buildPaginator } from '../helper/pagination/build-paginator'
 import { paginationHelper } from '../helper/pagination/pagination-utils'
+import { projectService } from '../project/project-service'
 import { triggerSourceService } from '../trigger/trigger-source/trigger-source-service'
 import { WebhookFlowVersionToRun, webhookService } from '../webhooks/webhook.service'
 import { jobQueue, JobType } from '../workers/job-queue/job-queue'
@@ -116,6 +118,7 @@ export const eventDestinationService = (log: FastifyBaseLogger) => ({
         if (destinations.length === 0) {
             return
         }
+        const enrichedEvent = await enrichFlowRunEvent({ event, log })
         const webhookUrlPrefix = await domainHelper.getPublicApiUrl({
             path: 'v1/webhooks',
         })
@@ -123,7 +126,7 @@ export const eventDestinationService = (log: FastifyBaseLogger) => ({
             classifyDestination({ destination, webhookUrlPrefix }))
         const destinationsToDispatch = skipInternalDestinationsOnFlowCycle({
             classifiedDestinations,
-            event,
+            event: enrichedEvent,
             log,
         })
         await Promise.all(destinationsToDispatch.map(({ destination, internalFlowId }) =>
@@ -134,7 +137,7 @@ export const eventDestinationService = (log: FastifyBaseLogger) => ({
                 destinationId: destination.id,
                 destinationUrl: destination.url,
                 internalFlowId,
-                event,
+                event: enrichedEvent,
             }),
         ))
     },
@@ -283,6 +286,28 @@ const isFlowRunEvent = (
     event: Pick<ApplicationEvent, 'action' | 'data'>,
 ): event is Pick<FlowRunEvent, 'action' | 'data'> => FLOW_RUN_EVENT_ACTIONS.has(event.action)
 
+const enrichFlowRunEvent = async ({ event, log }: EnrichFlowRunEventParams): Promise<ApplicationEvent> => {
+    const projectId = event.projectId
+    if (!isFlowRunEvent(event)) {
+        return event
+    }
+    const [flowVersion, project] = await Promise.all([
+        flowVersionService(log).getOne(event.data.flowRun.flowVersionId),
+        isNil(projectId) ? Promise.resolve(null) : projectService(log).getOne(projectId),
+    ])
+    return {
+        ...event,
+        data: {
+            ...event.data,
+            flowRun: {
+                ...event.data.flowRun,
+                flowDisplayName: flowVersion?.displayName ?? event.data.flowRun.flowDisplayName,
+            },
+            ...(isNil(project) ? {} : { project: { displayName: project.displayName } }),
+        },
+    }
+}
+
 const matchInternalWebhookFlowId = ({
     destinationUrl,
     webhookUrlPrefix,
@@ -338,6 +363,11 @@ type TestParams = {
     projectId?: ProjectId
     url: string
     event?: ApplicationEventName
+}
+
+type EnrichFlowRunEventParams = {
+    event: ApplicationEvent
+    log: FastifyBaseLogger
 }
 
 type ClassifiedDestination = {


### PR DESCRIPTION
## Problem

Real `flow.run.*` event-streaming payloads carried only IDs (`flowId`, `flowVersionId`, `projectId`, …) — no flow name, no project name. The **Test** button, however, sent a sample including `flowDisplayName: "Sample flow"` and `project.displayName`, so consumers built handlers against fields real events never delivered, then couldn't tell which workflow a real event belonged to without extra API calls.

Closes SRE-193 · [#13707](https://github.com/activepieces/activepieces/issues/13707)

## Change

Enrich `flow.run.*` events before dispatch with:
- `data.flowRun.flowDisplayName` — from the run's flow version
- `data.project.displayName`

Enrichment (`enrichFlowRunEvent`) runs inside `eventDestinationService.trigger()` **after** at least one destination is confirmed, so the two lookups never hit the hot start/finish path when nobody is subscribed. Non-flow-run events pass through untouched (reuses the existing `isFlowRunEvent` guard); the lookups run in parallel.

The `test` path already dispatches the fully-populated mock directly (bypassing `trigger`), so test and real payloads now match with no mock change.

## Notes

- Fields were already `.optional()` in the `FlowRunEventData` schema, so **existing consumers are unaffected** — this only populates them.
- No `@activepieces/shared` change → no version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)