### PR TITLE
fix: prevent Safari project menu overlap

### DIFF
--- a/packages/web/src/components/ui/virtualized-scroll-area.tsx
+++ b/packages/web/src/components/ui/virtualized-scroll-area.tsx
@@ -94,11 +94,10 @@ const VirtualizedScrollArea = <T,>({
             data-virtual-index={virtualItem.index}
             style={{
               position: 'absolute',
-              top: 0,
+              top: `${virtualItem.start}px`,
               left: 0,
               width: '100%',
               height: `${virtualItem.size}px`,
-              transform: `translateY(${virtualItem.start}px)`,
             }}
           >
             {renderItem(items[virtualItem.index], virtualItem.index)}


### PR DESCRIPTION
Fixes #14167

Virtualized rows now use their computed `top` offset instead of `transform: translateY(...)`. Row sizing and scroll calculations are unchanged. This avoids WebKit's transformed, absolutely positioned row rendering path that causes project names to overlap.

Validation:

- `git diff --check`
- `npx --yes prettier@3.8.1 --check packages/web/src/components/ui/virtualized-scroll-area.tsx`
- `npx --yes esbuild@0.25.0 packages/web/src/components/ui/virtualized-scroll-area.tsx --bundle --platform=browser --format=esm '--external:*' --outfile=/tmp/activepieces-virtualized-scroll-area.js`

Not run:

- Safari end-to-end reproduction; no configured Activepieces test environment was available locally.
- `npm run lint-dev`; the isolated partial clone has no installed monorepo dependencies and exits with `turbo: command not found`.
