### PR TITLE
feat(ai): add Requesty as an AI provider

### DIFF
--- a/packages/core/piece-types/src/lib/ai-providers.ts
+++ b/packages/core/piece-types/src/lib/ai-providers.ts
@@ -22,6 +22,7 @@ const AzureProviderAuthConfig = BaseAIProviderAuthConfig
 const GoogleProviderAuthConfig = BaseAIProviderAuthConfig
 const OpenAIProviderAuthConfig = BaseAIProviderAuthConfig
 const OpenRouterProviderAuthConfig = BaseAIProviderAuthConfig
+const RequestyProviderAuthConfig = BaseAIProviderAuthConfig
 const MistralProviderAuthConfig = BaseAIProviderAuthConfig
 
 export const BedrockProviderAuthConfig = z.object({
@@ -35,6 +36,7 @@ const ActivePiecesProviderConfig = z.object({})
 const GoogleProviderConfig = z.object({})
 const OpenAIProviderConfig = z.object({})
 const OpenRouterProviderConfig = z.object({})
+const RequestyProviderConfig = z.object({})
 const MistralProviderConfig = z.object({})
 
 export const ProviderModelConfig = z.object({
@@ -81,6 +83,7 @@ export const AIProviderAuthConfig = z.union([
     GoogleProviderAuthConfig,
     OpenAIProviderAuthConfig,
     OpenRouterProviderAuthConfig,
+    RequestyProviderAuthConfig,
     CloudflareGatewayProviderAuthConfig,
     OpenAICompatibleProviderAuthConfig,
     ActivePiecesProviderAuthConfig,
@@ -99,6 +102,7 @@ export const AIProviderConfig = z.union([
     GoogleProviderConfig,
     OpenAIProviderConfig,
     OpenRouterProviderConfig,
+    RequestyProviderConfig,
     ActivePiecesProviderConfig,
     MistralProviderConfig,
 ])

--- a/packages/core/shared/package.json
+++ b/packages/core/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/shared",
-  "version": "0.117.0",
+  "version": "0.118.0",
   "type": "commonjs",
   "sideEffects": false,
   "main": "./dist/src/index.js",

--- a/packages/core/shared/src/lib/management/ai-providers/index.ts
+++ b/packages/core/shared/src/lib/management/ai-providers/index.ts
@@ -37,6 +37,9 @@ export type OpenAIProviderAuthConfig = z.infer<typeof OpenAIProviderAuthConfig>
 export const OpenRouterProviderAuthConfig = BaseAIProviderAuthConfig
 export type OpenRouterProviderAuthConfig = z.infer<typeof OpenRouterProviderAuthConfig>
 
+export const RequestyProviderAuthConfig = BaseAIProviderAuthConfig
+export type RequestyProviderAuthConfig = z.infer<typeof RequestyProviderAuthConfig>
+
 export const BedrockProviderAuthConfig = z.object({
     accessKeyId: z.string().min(1),
     secretAccessKey: z.string().min(1),
@@ -97,6 +100,9 @@ export type OpenAIProviderConfig = z.infer<typeof OpenAIProviderConfig>
 export const OpenRouterProviderConfig = z.object({})
 export type OpenRouterProviderConfig = z.infer<typeof OpenRouterProviderConfig>
 
+export const RequestyProviderConfig = z.object({})
+export type RequestyProviderConfig = z.infer<typeof RequestyProviderConfig>
+
 export const BedrockProviderConfig = z.object({
     region: z.string().min(1),
 })
@@ -111,6 +117,7 @@ export const AIProviderAuthConfig = z.union([
     GoogleProviderAuthConfig,
     OpenAIProviderAuthConfig,
     OpenRouterProviderAuthConfig,
+    RequestyProviderAuthConfig,
     CloudflareGatewayProviderAuthConfig,
     OpenAICompatibleProviderAuthConfig,
     ActivePiecesProviderAuthConfig,
@@ -128,6 +135,7 @@ export const AIProviderConfig = z.union([
     GoogleProviderConfig,
     OpenAIProviderConfig,
     OpenRouterProviderConfig,
+    RequestyProviderConfig,
     ActivePiecesProviderConfig,
     MistralProviderConfig,
 ])
@@ -145,6 +153,12 @@ const ProviderConfigUnion = z.discriminatedUnion('provider', [
         provider: z.literal(AIProviderName.OPENROUTER),
         config: OpenRouterProviderConfig,
         auth: OpenRouterProviderAuthConfig,
+    }),
+    z.object({
+        displayName: z.string().min(1),
+        provider: z.literal(AIProviderName.REQUESTY),
+        config: RequestyProviderConfig,
+        auth: RequestyProviderAuthConfig,
     }),
     z.object({
         displayName: z.string().min(1),
@@ -371,6 +385,7 @@ const PROVIDER_MAX_CONTEXT_TOKENS: Partial<Record<AIProviderName, number>> = {
     [AIProviderName.BEDROCK]: 200_000,
     [AIProviderName.AZURE]: 128_000,
     [AIProviderName.OPENROUTER]: 128_000,
+    [AIProviderName.REQUESTY]: 128_000,
     [AIProviderName.ACTIVEPIECES]: 200_000,
     [AIProviderName.MISTRAL]: 128_000,
 }

--- a/packages/core/utils/src/lib/permission.ts
+++ b/packages/core/utils/src/lib/permission.ts
@@ -45,6 +45,7 @@ export const STEP_NAME_REGEX = /^[a-zA-Z_][a-zA-Z0-9_]*$/
 export enum AIProviderName {
     OPENAI = 'openai',
     OPENROUTER = 'openrouter',
+    REQUESTY = 'requesty',
     ANTHROPIC = 'anthropic',
     AZURE = 'azure',
     GOOGLE = 'google',

--- a/packages/pieces/community/ai/src/lib/common/ai-sdk.ts
+++ b/packages/pieces/community/ai/src/lib/common/ai-sdk.ts
@@ -202,6 +202,22 @@ export async function createAIModel({
             })
             return provider.chatModel(modelId)
         }
+        case AIProviderName.REQUESTY: {
+            const { apiKey } = auth as BaseAIProviderAuthConfig
+            if (isImage) {
+                throw new Error(`Provider ${AIProviderName.REQUESTY} does not support image models`)
+            }
+            const provider = createOpenAICompatible({
+                name: 'requesty',
+                baseURL: 'https://router.requesty.ai/v1',
+                apiKey,
+                headers: {
+                    'HTTP-Referer': 'https://www.activepieces.com',
+                    'X-Title': 'Activepieces',
+                },
+            })
+            return provider.chatModel(modelId)
+        }
         case AIProviderName.ACTIVEPIECES:
         case AIProviderName.OPENROUTER: {
             const { apiKey } = auth as BaseAIProviderAuthConfig
@@ -227,6 +243,7 @@ const DEFAULT_EMBEDDING_MODELS: Partial<Record<AIProviderName, string>> = {
     [AIProviderName.AZURE]: 'text-embedding-3-small',
     [AIProviderName.ACTIVEPIECES]: 'text-embedding-3-small',
     [AIProviderName.OPENROUTER]: 'openai/text-embedding-3-small',
+    [AIProviderName.REQUESTY]: 'openai/text-embedding-3-small',
 }
 
 const OPENAI_EMBEDDING_PROVIDER_OPTIONS = {
@@ -271,6 +288,14 @@ export async function createEmbeddingModel({
         case AIProviderName.OPENROUTER: {
             const openRouterProvider = createOpenRouter({ apiKey })
             return { model: openRouterProvider.textEmbeddingModel(embeddingModelId), embeddingModelId, providerOptions: OPENAI_EMBEDDING_PROVIDER_OPTIONS }
+        }
+        case AIProviderName.REQUESTY: {
+            const p = createOpenAICompatible({
+                name: 'requesty',
+                baseURL: 'https://router.requesty.ai/v1',
+                apiKey,
+            })
+            return { model: p.textEmbeddingModel(embeddingModelId), embeddingModelId, providerOptions: OPENAI_EMBEDDING_PROVIDER_OPTIONS }
         }
         default:
             throw new Error(`Provider ${provider} does not support embedding models`)

--- a/packages/server/api/src/app/ai/providers/index.ts
+++ b/packages/server/api/src/app/ai/providers/index.ts
@@ -10,11 +10,13 @@ import { mistralProvider } from './mistral-provider'
 import { openAICompatibleProvider } from './openai-compatible-gateway-provider'
 import { openaiProvider } from './openai-provider'
 import { openRouterProvider } from './openrouter-provider'
+import { requestyProvider } from './requesty-provider'
 
 export const aiProviders: Record<AIProviderName, AIProviderStrategy<AIProviderAuthConfig, AIProviderConfig>> = {
     [AIProviderName.OPENAI]: openaiProvider,
     [AIProviderName.ANTHROPIC]: anthropicProvider,
     [AIProviderName.OPENROUTER]: openRouterProvider,
+    [AIProviderName.REQUESTY]: requestyProvider,
     [AIProviderName.AZURE]: azureProvider,
     [AIProviderName.GOOGLE]: googleProvider,
     [AIProviderName.CLOUDFLARE_GATEWAY]: cloudflareGatewayProvider,

--- a/packages/server/api/src/app/ai/providers/requesty-provider.ts
+++ b/packages/server/api/src/app/ai/providers/requesty-provider.ts
@@ -1,0 +1,41 @@
+import { httpClient, HttpMethod } from '@activepieces/pieces-common'
+import { AIProviderModel, AIProviderModelType, RequestyProviderAuthConfig, RequestyProviderConfig } from '@activepieces/shared'
+import { FastifyBaseLogger } from 'fastify'
+import { AIProviderStrategy } from './ai-provider'
+
+export const requestyProvider: AIProviderStrategy<RequestyProviderAuthConfig, RequestyProviderConfig> = {
+    name: 'Requesty',
+    async validateConnection(authConfig: RequestyProviderAuthConfig, _config: RequestyProviderConfig, _log: FastifyBaseLogger): Promise<void> {
+        await httpClient.sendRequest({
+            url: 'https://router.requesty.ai/v1/models',
+            method: HttpMethod.GET,
+            headers: {
+                'Authorization': `Bearer ${authConfig.apiKey}`,
+                'Content-Type': 'application/json',
+            },
+        })
+    },
+    async listModels(authConfig: RequestyProviderAuthConfig, _config: RequestyProviderConfig): Promise<AIProviderModel[]> {
+        const res = await httpClient.sendRequest<{ data: RequestyModel[] }>({
+            url: 'https://router.requesty.ai/v1/models',
+            method: HttpMethod.GET,
+            headers: {
+                'Authorization': `Bearer ${authConfig.apiKey}`,
+                'Content-Type': 'application/json',
+            },
+        })
+
+        const { data } = res.body
+
+        return data.map((model: RequestyModel) => ({
+            id: model.id,
+            name: model.id,
+            type: model.supports_image_generation ? AIProviderModelType.IMAGE : AIProviderModelType.TEXT,
+        }))
+    },
+}
+
+type RequestyModel = {
+    id: string
+    supports_image_generation?: boolean
+}

--- a/packages/server/utils/src/chat-ai-utils.ts
+++ b/packages/server/utils/src/chat-ai-utils.ts
@@ -106,6 +106,18 @@ function createChatModel({ provider, auth, config, modelId, webSearchEnabled = f
                 },
             }).chatModel(modelId)
         }
+        case AIProviderName.REQUESTY: {
+            const { apiKey } = auth as BaseAIProviderAuthConfig
+            return createOpenAICompatible({
+                name: 'requesty',
+                baseURL: 'https://router.requesty.ai/v1',
+                headers: {
+                    'Authorization': `Bearer ${apiKey}`,
+                    'HTTP-Referer': 'https://www.activepieces.com',
+                    'X-Title': 'Activepieces',
+                },
+            }).chatModel(modelId)
+        }
         case AIProviderName.MISTRAL:
         case AIProviderName.ACTIVEPIECES:
         case AIProviderName.OPENROUTER: {

--- a/packages/web/src/features/agents/ai-model/index.tsx
+++ b/packages/web/src/features/agents/ai-model/index.tsx
@@ -29,6 +29,7 @@ export const PROVIDER_EMBEDDING_MODELS: Partial<
   [AIProviderName.AZURE]: 'text-embedding-3-small',
   [AIProviderName.ACTIVEPIECES]: 'text-embedding-3-small',
   [AIProviderName.OPENROUTER]: 'openai/text-embedding-3-small',
+  [AIProviderName.REQUESTY]: 'openai/text-embedding-3-small',
 };
 
 type AIModelSelectorProps = {

--- a/packages/web/src/features/agents/ai-providers.ts
+++ b/packages/web/src/features/agents/ai-providers.ts
@@ -85,6 +85,14 @@ It is strongly recommended that you add your credit card information to your Ope
 2. Once on the website, locate and click on the option to obtain your OpenRouter API Key.`),
   },
   {
+    provider: AIProviderName.REQUESTY,
+    name: 'Requesty',
+    logoUrl: 'https://cdn.activepieces.com/pieces/new-core/text-ai.svg',
+    markdown: t(`Follow these instructions to get your Requesty API Key:
+1. Go to https://app.requesty.ai/api-keys.
+2. Once on the website, locate and click on the option to obtain your Requesty API Key.`),
+  },
+  {
     provider: AIProviderName.CUSTOM,
     name: 'Other (OpenAI Compatible)',
     logoUrl: 'https://cdn.activepieces.com/pieces/new-core/text-ai.svg',


### PR DESCRIPTION
## Summary

Adds [Requesty](https://requesty.ai) — an OpenAI-compatible LLM router — as a community AI provider, mirroring the existing OpenRouter provider. Requesty exposes 400+ models through one endpoint, addressed as `provider/model`.

This mirrors only the community `ai/providers/openrouter-provider.ts`; the EE platform-plan key-provisioning path is intentionally left untouched.

## Changes

- `packages/server/api/src/app/ai/providers/requesty-provider.ts` — `validateConnection` + `listModels` against `https://router.requesty.ai/v1/models` (uses `httpClient`, maps Requesty's `supports_image_generation` and `model.id` fields), registered in `providers/index.ts`
- `packages/core/utils/.../permission.ts` — `AIProviderName.REQUESTY`
- `packages/core/shared/.../ai-providers/index.ts` + `packages/core/piece-types/.../ai-providers.ts` — Requesty auth/config zod schemas + discriminated-union entries + max-context entry
- `packages/pieces/community/ai/.../ai-sdk.ts` + `packages/server/utils/.../chat-ai-utils.ts` — REQUESTY chat/embedding wired via `createOpenAICompatible` (base URL `https://router.requesty.ai/v1`, `HTTP-Referer`/`X-Title` headers); the exhaustive `createChatModel` switch is handled so the build stays type-complete
- `packages/web/.../ai-providers.ts` + `ai-model/index.tsx` — Requesty in the `SUPPORTED_AI_PROVIDERS` dropdown + embedding default
- `packages/core/shared/package.json` — version bump (required for new shared exports)

## Testing

Verified the provider's exact request + response-mapping logic (`validateConnection` GET + `listModels` `.map()`) against the live `https://router.requesty.ai/v1/models` endpoint: 200, 605 models mapped correctly (562 text / 43 image). Requesty is OpenAI-compatible, so the chat/embedding path reuses `createOpenAICompatible`.

I work at Requesty. This mirrors the existing OpenRouter provider as closely as possible. Happy to adjust or close it if it's not a fit.
