### PR TITLE
test(web): fix stale output-viewer label tests

### DIFF
--- a/packages/web/test/app/builder/data-selector/utils-schema.test.ts
+++ b/packages/web/test/app/builder/data-selector/utils-schema.test.ts
@@ -166,7 +166,7 @@ describe('schemaTreeUtils.buildTreeFromSchema — primitive arrays', () => {
 
     const idNode = firstItem?.children?.[0];
     expect(idNode?.data).toMatchObject({
-      displayName: 'Id',
+      displayName: 'id',
       value: 1,
       insertable: true,
     });
@@ -242,7 +242,7 @@ describe('schemaTreeUtils.buildTreeFromSchema — primitive arrays', () => {
 
     const nameNode = senderNode?.children?.[0];
     expect(nameNode?.data).toMatchObject({
-      displayName: 'Name',
+      displayName: 'name',
       value: 'Ada',
       insertable: true,
     });
@@ -250,7 +250,7 @@ describe('schemaTreeUtils.buildTreeFromSchema — primitive arrays', () => {
     const contactNode = senderNode?.children?.[1];
     const emailNode = contactNode?.children?.[0];
     expect(emailNode?.data).toMatchObject({
-      displayName: 'Email',
+      displayName: 'email',
       value: 'ada@acme.com',
       insertable: true,
     });
@@ -522,7 +522,7 @@ describe('schemaTreeUtils.buildTreeFromArray', () => {
     });
 
     const payloadNode = tree.children?.[0]?.children?.[0];
-    expect(payloadNode?.data).toMatchObject({ displayName: 'Payload' });
+    expect(payloadNode?.data).toMatchObject({ displayName: 'payload' });
     // container nodes carry the real object so they render the {} icon, not text
     expect(
       payloadNode?.data.type === 'value' &&
@@ -531,7 +531,7 @@ describe('schemaTreeUtils.buildTreeFromArray', () => {
     ).toBe(true);
 
     const customerNode = payloadNode?.children?.[0];
-    expect(customerNode?.data).toMatchObject({ displayName: 'Customer' });
+    expect(customerNode?.data).toMatchObject({ displayName: 'customer' });
 
     const addressNode = customerNode?.children?.[0];
     expect(addressNode?.children).toHaveLength(1);
@@ -539,7 +539,7 @@ describe('schemaTreeUtils.buildTreeFromArray', () => {
     const cityNode = addressNode?.children?.[0];
     expect(cityNode?.children).toBeUndefined();
     expect(cityNode?.data).toMatchObject({
-      displayName: 'City',
+      displayName: 'city',
       value: 'Amman',
       insertable: true,
     });
@@ -557,12 +557,12 @@ describe('schemaTreeUtils.buildTreeFromArray', () => {
 
     const tagsNode = tree.children?.[0]?.children?.[0];
     expect(tagsNode?.data).toMatchObject({
-      displayName: 'Tags',
+      displayName: 'tags',
       value: ['red', 'blue'],
     });
     expect(tagsNode?.children).toHaveLength(2);
     expect(tagsNode?.children?.[0]?.data).toMatchObject({
-      displayName: 'Tags 1',
+      displayName: 'tags 1',
       value: 'red',
       insertable: true,
     });
@@ -663,7 +663,7 @@ describe('schemaTreeUtils.buildTreeFromSchema — labelKey', () => {
     // The object entry drills into host/port instead of being a flat leaf.
     expect(db1?.children).toHaveLength(2);
     const hostNode = db1?.children?.find(
-      (c) => c.data.type === 'value' && c.data.displayName === 'Host',
+      (c) => c.data.type === 'value' && c.data.displayName === 'host',
     );
     expect(hostNode?.data).toMatchObject({ value: 'localhost' });
     expect(hostNode?.data.type === 'value' && hostNode.data.propertyPath).toBe(

--- a/packages/web/test/components/custom/smart-output-viewer/output-table-view.test.ts
+++ b/packages/web/test/components/custom/smart-output-viewer/output-table-view.test.ts
@@ -73,8 +73,8 @@ describe('buildColumns', () => {
   it('builds columns for flat records', () => {
     const cols = buildColumns({ id: 1, name: 'a' });
     expect(cols).toEqual([
-      { key: 'id', label: 'Id', path: ['id'] },
-      { key: 'name', label: 'Name', path: ['name'] },
+      { key: 'id', label: 'id', path: ['id'] },
+      { key: 'name', label: 'name', path: ['name'] },
     ]);
   });
 
@@ -84,7 +84,7 @@ describe('buildColumns', () => {
       address: { city: 'London', zip: 'EC1' },
     });
     expect(cols).toEqual([
-      { key: 'id', label: 'Id', path: ['id'] },
+      { key: 'id', label: 'id', path: ['id'] },
       { key: 'address.city', label: 'city', path: ['address', 'city'] },
       { key: 'address.zip', label: 'zip', path: ['address', 'zip'] },
     ]);
@@ -94,10 +94,10 @@ describe('buildColumns', () => {
     expect(buildColumns({ id: 1, items: [1, 2, 3] })).toBeNull();
   });
 
-  it('humanises camelCase and snake_case keys', () => {
+  it('keeps camelCase and snake_case keys verbatim', () => {
     const cols = buildColumns({ firstName: 'a', last_name: 'b' });
-    expect(cols?.[0].label).toBe('First Name');
-    expect(cols?.[1].label).toBe('Last Name');
+    expect(cols?.[0].label).toBe('firstName');
+    expect(cols?.[1].label).toBe('last_name');
   });
 
   it('returns null for an empty object', () => {


### PR DESCRIPTION
## What

Two web unit-test files (8 tests) were failing on `main`:
- `test/components/custom/smart-output-viewer/output-table-view.test.ts`
- `test/app/builder/data-selector/utils-schema.test.ts`

## Why

Commit c1910f8c9f (#14068, *"variable key names now display exactly as defined in the output viewer"*) intentionally stopped title-casing undescribed/drilled keys — it changed `displayName: stringUtils.titleCase(key)` → `displayName: key` in `utils-schema.ts` and dropped `formatKey`. `buildColumns` in `output-table-view.tsx` likewise uses `label: key`.

The source is correct; the tests were stale, still asserting the old humanized labels (`id`→`Id`, `firstName`→`First Name`). They weren't updated when #14068 landed.

## Fix (test-only)

Aligned the assertions with the shipped verbatim-key behavior. No product/source changes — re-adding `titleCase` would revert a deliberate decision. Described-schema labels and synthesized labels (`Item 1`, `Row 1`) were always correct and untouched.

`npx turbo run test --filter=web` → **359 passed (30 files)**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)