### PR TITLE
fix(user): deleting a platform user fails on first attempt when they …

### DIFF
--- a/.agents/features/ee-projects.md
+++ b/.agents/features/ee-projects.md
@@ -109,6 +109,8 @@ The EE Projects module adds team collaboration, role-based access control (RBAC)
 - Operators: see all projects except others' personal
 - Regular users: see own personal + team projects where member
 
+`platformProjectService.deletePersonalProjectForUser()` — called when a user is removed. Reassigns the user's personal project to the platform owner and soft-deletes it in one transaction (then schedules the async `HARD_DELETE_PROJECT` job), so the `fk_project_owner_id` FK no longer blocks hard-deleting the user. `markForDeletion()` remains the generic soft-delete + schedule path used for ordinary project deletion.
+
 **Endpoints** (`platform-project-controller.ts`):
 - `POST /v1/projects/:id` — update; body `UpdateProjectPlatformRequest` accepts `workerGroupId` (validated against `^[a-z0-9_-]+$`, applied in `platformProjectService.update()` only when `platform_plan.workerGroupsEnabled` is on).
 - `GET /v1/projects/worker-groups` — platform-admin only; returns `{ groups: [{ label, slots }], sharedSlots }` from online project-scope workers (those started with `AP_PROJECT_WORKER=true`) via `machineService.listProjectWorkerGroups()` for the assignment UI; returns 402 `FEATURE_DISABLED` when `workerGroupsEnabled` is off.

--- a/packages/server/api/src/app/ee/projects/platform-project-service.ts
+++ b/packages/server/api/src/app/ee/projects/platform-project-service.ts
@@ -212,9 +212,13 @@ export const platformProjectService = (log: FastifyBaseLogger) => ({
             ownerId: userId,
             type: ProjectType.PERSONAL,
         })
-        if (!isNil(personalProject)) {
-            await this.markForDeletion({ id: personalProject.id, platformId })
+        if (isNil(personalProject)) {
+            return
         }
+        
+        const platform = await platformService(log).getOneOrThrow(platformId)
+        await projectRepo().update({ id: personalProject.id, platformId }, { ownerId: platform.ownerId })
+        await this.markForDeletion({ id: personalProject.id, platformId })
     },
 
     async markForDeletion({ id, platformId }: DeleteProjectParams): Promise<void> {

--- a/packages/server/api/src/app/ee/projects/platform-project-service.ts
+++ b/packages/server/api/src/app/ee/projects/platform-project-service.ts
@@ -217,8 +217,11 @@ export const platformProjectService = (log: FastifyBaseLogger) => ({
         }
         
         const platform = await platformService(log).getOneOrThrow(platformId)
-        await projectRepo().update({ id: personalProject.id, platformId }, { ownerId: platform.ownerId })
-        await this.markForDeletion({ id: personalProject.id, platformId })
+        await transaction(async (entityManager) => {
+            await projectRepo(entityManager).update({ id: personalProject.id, platformId }, { ownerId: platform.ownerId })
+            await projectRepo(entityManager).softDelete({ id: personalProject.id, platformId })
+        })
+        await scheduleHardDeleteProjectJob({ id: personalProject.id, platformId, log })
     },
 
     async markForDeletion({ id, platformId }: DeleteProjectParams): Promise<void> {
@@ -232,30 +235,34 @@ export const platformProjectService = (log: FastifyBaseLogger) => ({
                 },
             })
         }
-        await systemJobsSchedule(log).upsertJob({
-            job: {
-                name: SystemJobName.HARD_DELETE_PROJECT,
-                data: {
-                    projectId: id,
-                    platformId,
-                    preDeletedFlowIds: [],
-                },
-                jobId: `hard-delete-project-${id}`,
-            },
-            schedule: {
-                type: 'one-time',
-                date: apDayjs(),
-            },
-            customConfig: {
-                attempts: 25,
-                backoff: {
-                    type: 'fixed',
-                    delay: 60000,
-                },
-            },
-        })
+        await scheduleHardDeleteProjectJob({ id, platformId, log })
     },
 })
+
+async function scheduleHardDeleteProjectJob({ id, platformId, log }: ScheduleHardDeleteProjectJobParams): Promise<void> {
+    await systemJobsSchedule(log).upsertJob({
+        job: {
+            name: SystemJobName.HARD_DELETE_PROJECT,
+            data: {
+                projectId: id,
+                platformId,
+                preDeletedFlowIds: [],
+            },
+            jobId: `hard-delete-project-${id}`,
+        },
+        schedule: {
+            type: 'one-time',
+            date: apDayjs(),
+        },
+        customConfig: {
+            attempts: 25,
+            backoff: {
+                type: 'fixed',
+                delay: 60000,
+            },
+        },
+    })
+}
 
 async function enrichProjects(
     projects: Project[],
@@ -377,4 +384,10 @@ type CreateProjectParams = {
 type DeleteProjectParams = {
     id: ProjectId
     platformId: PlatformId
+}
+
+type ScheduleHardDeleteProjectJobParams = {
+    id: ProjectId
+    platformId: PlatformId
+    log: FastifyBaseLogger
 }

--- a/packages/server/api/test/integration/ce/user/platform-user-community.test.ts
+++ b/packages/server/api/test/integration/ce/user/platform-user-community.test.ts
@@ -1,9 +1,11 @@
 import { apId } from '@activepieces/core-utils'
-import { PlatformRole, PrincipalType, UserStatus } from '@activepieces/shared'
+import { PlatformRole, PrincipalType, ProjectType, UserStatus } from '@activepieces/shared'
 import { FastifyInstance } from 'fastify'
 import { StatusCodes } from 'http-status-codes'
+import { databaseConnection } from '../../../../src/app/database/database-connection'
 import { generateMockToken } from '../../../helpers/auth'
 import {
+    createMockProject,
     mockAndSaveBasicSetup,
     mockBasicUser,
 } from '../../../helpers/mocks'
@@ -228,6 +230,43 @@ describe('User API', () => {
             const response = await app?.inject({
                 method: 'DELETE',
                 url: `/api/v1/users/${mockEditor.id}`,
+                headers: {
+                    authorization: `Bearer ${mockOwnerToken}`,
+                },
+            })
+
+            // assert
+            expect(response?.statusCode).toBe(StatusCodes.NO_CONTENT)
+        })
+
+        it('Removes a user who owns a personal project on the first attempt', async () => {
+            // arrange
+            const { mockOwner, mockPlatform } = await mockAndSaveBasicSetup()
+            const { mockUser: mockMember } = await mockBasicUser({
+                user: {
+                    platformId: mockPlatform.id,
+                    platformRole: PlatformRole.MEMBER,
+                },
+            })
+            const personalProject = createMockProject({
+                ownerId: mockMember.id,
+                platformId: mockPlatform.id,
+                type: ProjectType.PERSONAL,
+            })
+            await databaseConnection().getRepository('project').save(personalProject)
+
+            const mockOwnerToken = await generateMockToken({
+                id: mockOwner.id,
+                type: PrincipalType.USER,
+                platform: {
+                    id: mockPlatform.id,
+                },
+            })
+
+            // act
+            const response = await app?.inject({
+                method: 'DELETE',
+                url: `/api/v1/users/${mockMember.id}`,
                 headers: {
                     authorization: `Bearer ${mockOwnerToken}`,
                 },


### PR DESCRIPTION
## Problem

Deleting a user from **Platform Admin → Users** fails on the first attempt with a generic "Something went wrong" toast, then succeeds when the same delete is repeated. Reported by a customer on 0.85.0 and reproduced locally on the current build.

## Root cause

The community-edition delete path is `userService.delete()`:

1. `deletePersonalProjectForUser()` → `markForDeletion()` **soft-deletes** the user's personal project (the row and its `ownerId` FK remain in place) and schedules an **async** `HARD_DELETE_PROJECT` job to do the real removal later.
2. `userRepo().delete()` then **hard-deletes** the user row immediately.

The soft-deleted project still references the user via `fk_project_owner_id` (which has no `ON DELETE` rule), so Postgres rejects the user delete with error `23503`:

```
update or delete on table "user" violates foreign key constraint "fk_project_owner_id" on table "project"
```

This surfaces as HTTP 500 → the frontend's generic "Something went wrong" toast (the delete dialog passes no `onError`, so it falls back to the global handler). On retry, the async `HARD_DELETE_PROJECT` job has already removed the project row, so the FK is clear and the delete succeeds — hence the fail-first / succeed-on-retry behaviour.

## Fix

`packages/server/api/src/app/ee/projects/platform-project-service.ts` — `deletePersonalProjectForUser()` now reassigns the personal project to the platform owner **and** soft-deletes it in a single transaction before the user is removed:

```ts
const platform = await platformService(log).getOneOrThrow(platformId)
await transaction(async (entityManager) => {
    await projectRepo(entityManager).update({ id: personalProject.id, platformId }, { ownerId: platform.ownerId })
    await projectRepo(entityManager).softDelete({ id: personalProject.id, platformId })
})
await scheduleHardDeleteProjectJob({ id: personalProject.id, platformId, log })
```

- **Clears the FK synchronously** so the user deletes on the **first** attempt.
- **Atomic**: the reassign and the soft-delete commit together — there is no active-and-reassigned state, and a rolled-back attempt is still findable by the member's `ownerId` on retry.
- The async `HARD_DELETE_PROJECT` job still performs the full flow-side-effect and connection cleanup — nothing heavy is done synchronously, and nothing is orphaned.
- The platform owner is guaranteed to exist and to differ from the deleted user (`assertNotPlatformOwner` runs first).
- `markForDeletion()` is unchanged (the generic soft-delete + schedule path used for ordinary project deletion); the job scheduling is shared via a `scheduleHardDeleteProjectJob` helper.

### Why not `ON DELETE CASCADE`

Cascading on `fk_project_owner_id` would delete **every** project the user owns when the user is deleted — including team projects — causing data loss. The fix is scoped to the personal project that is already being torn down.

### Why reassign instead of a synchronous hard-delete

Hard-deleting the project inline would run all the flow/trigger/connection teardown inside the delete-user request (slow, and would duplicate the async job's logic). Reassign + soft-delete is cheap and instantly clears the FK, while the heavy teardown stays in the background job.

## Testing

- **Regression test** in `packages/server/api/test/integration/ce/user/platform-user-community.test.ts`: `Removes a user who owns a personal project on the first attempt` — fails before the fix (500), passes after (204). The pre-existing `Removes a user` test (a member without a personal project) never exercised this path, which is why the bug slipped through.
- Full CE user suite: 8/8 passing; `turbo run lint --filter=api` clean.
- Verified live in a running dev instance — a member with a personal project deletes cleanly on the first attempt (`DELETE /api/v1/users/:id 204`), with the `hard-delete-project` job firing afterward for the async cleanup.

## Docs

Added a `deletePersonalProjectForUser()` note under *Platform Project Service* in `.agents/features/ee-projects.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
