### PR TITLE
fix: avoid chrome password breach warning for variables

### DIFF
--- a/packages/web/src/app/variables/variable-dialog.tsx
+++ b/packages/web/src/app/variables/variable-dialog.tsx
@@ -36,6 +36,7 @@ import { internalErrorToast } from '@/components/ui/sonner';
 import { variablesApi } from '@/features/variables/api/variables';
 import { api } from '@/lib/api';
 import { authenticationSession } from '@/lib/authentication-session';
+import { cn } from '@/lib/utils';
 
 const FormSchema = z.object({
   name: z
@@ -171,9 +172,10 @@ function VariableForm(props: VariableFormProps) {
                   <div className="relative">
                     <Input
                       {...field}
-                      type={valueVisible ? 'text' : 'password'}
-                      autoComplete="new-password"
-                      className="pr-10"
+                      type={'text'}
+                      spellCheck={false}
+                      autoComplete="off"
+                      className={cn('pr-10', !valueVisible && '[webkit-text-security:disc]')}
                       placeholder={
                         isEdit ? t('Enter new value') : t('Enter the value')
                       }


### PR DESCRIPTION
Changes the variable value input from type="password" to type="text" while using -webkit-text-security: disc to keep the value masked.

This prevents Chrome from treating the field as a password input, avoiding the native "Change your password" warning that could appear when creating or editing variables.

Fixes #14198 
