### PR TITLE
fix(engine): fail RESUME cleanly on gone payload/log file instead of INTERNAL_ERROR

### DIFF
--- a/packages/server/engine/src/lib/operations/flow.operation.ts
+++ b/packages/server/engine/src/lib/operations/flow.operation.ts
@@ -1,5 +1,5 @@
 import { isNil, tryCatch } from '@activepieces/core-utils'
-import { BeginExecuteFlowOperation, EngineGenericError, EngineResponse, EngineResponseStatus, ExecuteFlowOperation, ExecuteTriggerResponse, ExecutionError, ExecutionErrorType, ExecutionState, ExecutionType, FlowActionType, FlowRunStatus, flowStructureUtil, GenericStepOutput, LoopStepOutput, ResumePayload, ResumeReason, StepOutput, StepOutputStatus, TriggerHookType, TriggerPayload } from '@activepieces/shared'
+import { EngineGenericError, EngineResponse, EngineResponseStatus, ExecuteFlowOperation, ExecuteTriggerResponse, ExecutionError, ExecutionErrorType, ExecutionState, ExecutionType, FlowActionType, FlowRunStatus, flowStructureUtil, GenericStepOutput, LoopStepOutput, ResumePayload, ResumeReason, StepOutput, StepOutputStatus, TriggerHookType, TriggerPayload } from '@activepieces/shared'
 import { engineFileApi } from '../api/engine-file-api'
 import { EngineConstants, ResolvedBeginExecuteFlowOperation, ResolvedExecuteFlowOperation } from '../handler/context/engine-constants'
 import { FlowExecutorContext } from '../handler/context/flow-execution-context'
@@ -58,7 +58,12 @@ function isEngineExecutionError(error: unknown): boolean {
 }
 
 async function reportFailedTriggerRun({ operation, error }: ReportFailedTriggerRunParams): Promise<EngineResponse<undefined>> {
-    const input: ResolvedBeginExecuteFlowOperation = { ...operation, triggerPayload: undefined }
+    // Inputs were never resolved (that is why we are here), so build a minimal resolved shape purely to report
+    // a FAILED run. buildFailedTriggerContext only reads flowVersion + executionType, so the resume
+    // placeholders below are never actually consumed — they exist solely to satisfy ResolvedExecuteFlowOperation.
+    const input: ResolvedExecuteFlowOperation = operation.executionType === ExecutionType.BEGIN
+        ? { ...operation, triggerPayload: undefined }
+        : { ...operation, resumePayload: { body: undefined, headers: {}, queryParams: {} }, executionState: { steps: {}, tags: [] } }
     return reportFailedRun({ input, constants: EngineConstants.fromExecuteFlowInput(input), error })
 }
 
@@ -274,7 +279,7 @@ type BuildFailedTriggerContextParams = {
 }
 
 type ReportFailedTriggerRunParams = {
-    operation: BeginExecuteFlowOperation
+    operation: ExecuteFlowOperation
     error: Error
 }
 

--- a/packages/server/engine/src/lib/operations/flow.operation.ts
+++ b/packages/server/engine/src/lib/operations/flow.operation.ts
@@ -14,11 +14,13 @@ export const flowOperation = {
     execute: async (operation: ExecuteFlowOperation): Promise<EngineResponse<undefined>> => {
         const { data: input, error: resolveError } = await tryCatch(() => resolveExecuteFlowOperation(operation))
         if (resolveError) {
-            // Resolving the trigger payload (downloading its file) happens before flow execution. If the
-            // payload file was deleted/expired (404), that is a user/data error, not an engine bug — report a
-            // FAILED run instead of letting it escape as INTERNAL_ERROR, which fails+retries the worker job
-            // and pages oncall. Only genuine ENGINE errors (e.g. a transient 5xx download) keep that path.
-            if (operation.executionType === ExecutionType.BEGIN && !isEngineExecutionError(resolveError)) {
+            // Resolving inputs before execution downloads files: the trigger payload (BEGIN) or the resume
+            // log/payload (RESUME). If one was deleted/expired (404), that is a user/data-lifecycle error, not
+            // an engine bug — report a FAILED run instead of letting it escape as INTERNAL_ERROR, which
+            // fails+retries the worker job and pages oncall (and can never recover an expired file).
+            // EngineFileNotFoundError is USER-typed precisely for this; a BEGIN-only gate defeated it on
+            // RESUME. Only genuine ENGINE errors (e.g. a transient 5xx download) keep the throw path.
+            if (!isEngineExecutionError(resolveError)) {
                 return reportFailedTriggerRun({ operation, error: resolveError })
             }
             throw resolveError

--- a/packages/server/engine/test/operations/flow-operation-invariants.test.ts
+++ b/packages/server/engine/test/operations/flow-operation-invariants.test.ts
@@ -209,6 +209,21 @@ describe('flow operation invariants', () => {
             await expect(flowOperation.execute(operation)).rejects.toThrow('executionState is missing in logs file')
         })
 
+        it('surfaces a gone resume log file as a FAILED run + OK engine response (instead of INTERNAL_ERROR)', async () => {
+            mockDownload.mockReset()
+            mockSendUpdate.mockClear()
+            mockBackup.mockClear()
+            mockDownload.mockRejectedValue(new EngineFileNotFoundError('logs-file-gone'))
+            const operation = makeResumeOperation({ logsFileId: 'logs-file-gone' })
+
+            const response = await flowOperation.execute(operation)
+
+            expect(response.status).toBe(EngineResponseStatus.OK)
+            const finalCtx = mockSendUpdate.mock.calls[mockSendUpdate.mock.calls.length - 1][0].flowExecutorContext
+            expect(finalCtx.verdict.status).toBe(FlowRunStatus.FAILED)
+            expect(mockBackup).toHaveBeenCalled()
+        })
+
         it('proceeds past hydration when logs file has non-empty execution state', async () => {
             mockDownload.mockReset()
             mockDownload.mockResolvedValue(
@@ -557,7 +572,7 @@ describe('flow operation invariants', () => {
         it('surfaces a plain TypeError thrown by the trigger run() hook as a FAILED run + OK engine response (instead of INTERNAL_ERROR)', async () => {
             mockSendUpdate.mockClear()
             mockBackup.mockClear()
-            mockExecuteTrigger.mockRejectedValue(new TypeError("Cannot read 'toLowerCase' of undefined"))
+            mockExecuteTrigger.mockRejectedValue(new TypeError('Cannot read \'toLowerCase\' of undefined'))
             const operation = makeBeginOperation({
                 triggerPayload: { type: 'inline', value: {} },
                 executeTrigger: true,


### PR DESCRIPTION
## Problem

When the engine resolves a flow's inputs before execution, it downloads files: the **trigger payload** on `BEGIN`, or the **run-log / resume payload** on `RESUME`. If such a file was deleted or expired, `engine-file-api.ts` deliberately throws a **USER-typed** `EngineFileNotFoundError` (see its comment: *"a gone file … is a data-lifecycle issue, not an engine bug — surface it as a USER error so callers can fail the run cleanly"*).

But `flowOperation.execute()` only honored that on `BEGIN`:

```ts
if (operation.executionType === ExecutionType.BEGIN && !isEngineExecutionError(resolveError)) {
    return reportFailedTriggerRun({ operation, error: resolveError })
}
throw resolveError
```

On `RESUME`, the `=== BEGIN` gate is false, so the USER-level `EngineFileNotFoundError` (a resume whose log/payload file expired out of retention) is **rethrown → `INTERNAL_ERROR`**, which fails + retries the worker job and **pages oncall** — and retrying can never recover an already-expired file.

## Fix

Drop the `BEGIN`-only restriction so *any* non-ENGINE resolve error reports a FAILED run, regardless of execution type. Genuine ENGINE errors (e.g. a transient 5xx download) still take the `throw` path and keep paging/retrying.

## Scope / notes

- This handles the **retention** case (file genuinely gone → 404/410 → `EngineFileNotFoundError`, USER).
- It intentionally does **not** touch `EmptyResumeStateError` / `ResumeLogsFileMissing` / `ExecutionStateMissing` — those fire when the file is *present but empty/malformed*, which is not retention and stays ENGINE (loud) on purpose.

Found while categorizing the `INTERNAL_ERROR` backlog on cloud (RESUME jobs failing on gone payload/log files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)