### PR TITLE
perf(flows): batch sample-data fetch to remove N+1 requests

### DIFF
--- a/.agents/features/flows.md
+++ b/.agents/features/flows.md
@@ -112,6 +112,7 @@ When CHANGE_STATUS to DISABLED:
 - Captures test data per step (input + output)
 - Stored as File entities (SAMPLE_DATA / SAMPLE_DATA_INPUT types)
 - Per flow version — each version has its own test data
+- `GET /v1/sample-data/all` — returns a `{ [stepName]: data }` map for every step in a flow version in a single batched request; used by the builder to load all sample data in one request instead of one per step
 
 ## Frontend Builder Architecture
 

--- a/packages/core/execution/src/lib/flows/sample-data/index.ts
+++ b/packages/core/execution/src/lib/flows/sample-data/index.ts
@@ -30,6 +30,14 @@ export const GetSampleDataRequest = z.object({
 })
 export type GetSampleDataRequest = z.infer<typeof GetSampleDataRequest>
 
+export const GetSampleDataForFlowRequest = z.object({
+    flowId: z.string(),
+    flowVersionId: z.string(),
+    projectId: z.string(),
+    type: z.enum(SampleDataFileType),
+})
+export type GetSampleDataForFlowRequest = z.infer<typeof GetSampleDataForFlowRequest>
+
 export const CreateStepRunRequestBody = z.object({
     projectId: z.string(),
     flowVersionId: z.string(),

--- a/packages/server/api/src/app/flows/step-run/sample-data.controller.ts
+++ b/packages/server/api/src/app/flows/step-run/sample-data.controller.ts
@@ -1,4 +1,4 @@
-import { CreateStepRunRequestBody, GetSampleDataRequest, PrincipalType, SERVICE_KEY_SECURITY_OPENAPI } from '@activepieces/shared'
+import { CreateStepRunRequestBody, GetSampleDataForFlowRequest, GetSampleDataRequest, PrincipalType, SERVICE_KEY_SECURITY_OPENAPI } from '@activepieces/shared'
 import { FastifyPluginAsyncZod } from 'fastify-type-provider-zod'
 import { ProjectResourceType } from '../../core/security/authorization/common'
 import { securityAccess } from '../../core/security/authorization/fastify-security'
@@ -31,6 +31,34 @@ export const sampleDataController: FastifyPluginAsyncZod = async (fastify) => {
         })
         return sampleData
     })
+
+    fastify.get('/all', GetSampleDataForFlowRequestParams, async (request) => {
+        const flow = await flowService(request.log).getOnePopulatedOrThrow({
+            id: request.query.flowId,
+            projectId: request.projectId,
+            versionId: request.query.flowVersionId,
+        })
+        return sampleDataService(request.log).getSampleDataForFlow(
+            request.projectId,
+            flow.version,
+            request.query.type,
+        )
+    })
+}
+
+const GetSampleDataForFlowRequestParams = {
+    config: {
+        security: securityAccess.project(
+            [PrincipalType.USER, PrincipalType.SERVICE],
+            undefined, {
+                type: ProjectResourceType.QUERY,
+            }),
+    },
+    schema: {
+        tags: ['sample-data'],
+        querystring: GetSampleDataForFlowRequest,
+        security: [SERVICE_KEY_SECURITY_OPENAPI],
+    },
 }
 
 const GetSampleDataRequestParams = {

--- a/packages/web/src/features/flows/api/sample-data-api.ts
+++ b/packages/web/src/features/flows/api/sample-data-api.ts
@@ -1,9 +1,15 @@
-import { GetSampleDataRequest } from '@activepieces/shared';
+import {
+  GetSampleDataForFlowRequest,
+  GetSampleDataRequest,
+} from '@activepieces/shared';
 
 import { api } from '@/lib/api';
 
 export const sampleDataApi = {
   get(request: GetSampleDataRequest) {
     return api.get<unknown>(`/v1/sample-data`, request);
+  },
+  getForFlow(request: GetSampleDataForFlowRequest) {
+    return api.get<Record<string, unknown>>(`/v1/sample-data/all`, request);
   },
 };

--- a/packages/web/src/features/flows/hooks/sample-data-hooks.ts
+++ b/packages/web/src/features/flows/hooks/sample-data-hooks.ts
@@ -44,11 +44,9 @@ export const sampleDataHooks = {
         );
         const stepsWithoutInput = flowStructureUtil
           .getAllSteps(flowVersion!.trigger)
-          .filter((step) => !step.settings.sampleData?.sampleDataInputFileId);
-        stepsWithoutInput.forEach((step) => {
-          sampleDataInput[step.name] = undefined;
-        });
-        return sampleDataInput;
+          .filter((step) => !step.settings.sampleData?.sampleDataInputFileId)
+          .map((step) => [step.name, undefined] as const);
+        return { ...sampleDataInput, ...Object.fromEntries(stepsWithoutInput) };
       },
     });
   },
@@ -65,15 +63,10 @@ async function getSampleDataForFlow(
   projectId: string,
   type: SampleDataFileType,
 ): Promise<Record<string, unknown>> {
-  return sampleDataApi
-    .getForFlow({
-      flowId: flowVersion.flowId,
-      flowVersionId: flowVersion.id,
-      projectId,
-      type,
-    })
-    .catch((error) => {
-      console.error(error);
-      return {};
-    });
+  return sampleDataApi.getForFlow({
+    flowId: flowVersion.flowId,
+    flowVersionId: flowVersion.id,
+    projectId,
+    type,
+  });
 }

--- a/packages/web/src/features/flows/hooks/sample-data-hooks.ts
+++ b/packages/web/src/features/flows/hooks/sample-data-hooks.ts
@@ -18,26 +18,12 @@ export const sampleDataHooks = {
       staleTime: 0,
       retry: 4,
       refetchOnWindowFocus: false,
-      queryFn: async () => {
-        const steps = flowStructureUtil.getAllSteps(flowVersion!.trigger);
-        const singleStepSampleData = await Promise.all(
-          steps.map(async (step) => {
-            return {
-              [step.name]: await getSampleData(
-                flowVersion!,
-                step.name,
-                projectId!,
-                SampleDataFileType.OUTPUT,
-              ),
-            };
-          }),
-        );
-        const sampleData: Record<string, unknown> = {};
-        singleStepSampleData.forEach((stepData) => {
-          Object.assign(sampleData, stepData);
-        });
-        return sampleData;
-      },
+      queryFn: () =>
+        getSampleDataForFlow(
+          flowVersion!,
+          projectId!,
+          SampleDataFileType.OUTPUT,
+        ),
     });
   },
   useSampleDataInputForFlow: (
@@ -51,24 +37,16 @@ export const sampleDataHooks = {
       retry: 4,
       refetchOnWindowFocus: false,
       queryFn: async () => {
-        const steps = flowStructureUtil.getAllSteps(flowVersion!.trigger);
-        const singleStepSampleDataInput = await Promise.all(
-          steps.map(async (step) => {
-            return {
-              [step.name]: step.settings.sampleData?.sampleDataInputFileId
-                ? await getSampleData(
-                    flowVersion!,
-                    step.name,
-                    projectId!,
-                    SampleDataFileType.INPUT,
-                  )
-                : undefined,
-            };
-          }),
+        const sampleDataInput = await getSampleDataForFlow(
+          flowVersion!,
+          projectId!,
+          SampleDataFileType.INPUT,
         );
-        const sampleDataInput: Record<string, unknown> = {};
-        singleStepSampleDataInput.forEach((stepData) => {
-          Object.assign(sampleDataInput, stepData);
+        const stepsWithoutInput = flowStructureUtil
+          .getAllSteps(flowVersion!.trigger)
+          .filter((step) => !step.settings.sampleData?.sampleDataInputFileId);
+        stepsWithoutInput.forEach((step) => {
+          sampleDataInput[step.name] = undefined;
         });
         return sampleDataInput;
       },
@@ -82,22 +60,20 @@ export const sampleDataHooks = {
   },
 };
 
-async function getSampleData(
+async function getSampleDataForFlow(
   flowVersion: FlowVersion,
-  stepName: string,
   projectId: string,
   type: SampleDataFileType,
-): Promise<unknown> {
+): Promise<Record<string, unknown>> {
   return sampleDataApi
-    .get({
+    .getForFlow({
       flowId: flowVersion.flowId,
       flowVersionId: flowVersion.id,
-      stepName,
       projectId,
       type,
     })
     .catch((error) => {
       console.error(error);
-      return undefined;
+      return {};
     });
 }


### PR DESCRIPTION

## What does this PR do?

The flow builder fetched step sample data one HTTP request per step (useSampleDataForFlow / useSampleDataInputForFlow fanned out over getAllSteps), so opening a flow with N steps issued ~2N GET /v1/sample-data requests. The server already had a batched sampleDataService.getSampleDataForFlow used by other callers but no HTTP route exposed it.

Add GET /v1/sample-data/all (GetSampleDataForFlowRequest) that returns the whole per-step map in one call, and collapse the two builder hooks to a single request each. A flow of any size now loads sample data in 2 requests. Input parity is preserved: steps without an input file stay undefined (not {}) so the Input tab visibility is unchanged.


### Relevant User Scenarios


Fixes # (issue)
