### PR TITLE
fix(web): guard MCP tool test dialog against non-array inputSchema

### DIFF
--- a/packages/web/src/app/builder/test-step/custom-test-step/mcp-tool-testing-dialog.tsx
+++ b/packages/web/src/app/builder/test-step/custom-test-step/mcp-tool-testing-dialog.tsx
@@ -53,6 +53,12 @@ function mapMcpTypeToPropertyType(mcpType: McpPropertyType): PropertyType {
   }
 }
 
+// toggling the dynamic (f(x)) input mode on the inputSchema array property
+// replaces its form value with `{}`, so this must not assume the raw value is still an array
+function toMcpFormFields(rawInputSchema: unknown): McpFormField[] {
+  return Array.isArray(rawInputSchema) ? rawInputSchema : [];
+}
+
 function McpToolTestingDialog({
   open,
   onOpenChange,
@@ -60,8 +66,7 @@ function McpToolTestingDialog({
 }: McpToolTestingDialogProps) {
   const form = useFormContext<FlowTrigger>();
   const formValues = form.getValues();
-  const formProps = (formValues.settings.input.inputSchema ??
-    []) as McpFormField[];
+  const formProps = toMcpFormFields(formValues.settings.input.inputSchema);
   const { mutate: saveMockAsSampleData, isPending: isSavingMockdata } =
     testStepHooks.useSaveMockData({
       onSuccess: () => {
@@ -205,4 +210,4 @@ function McpToolTestingDialog({
   );
 }
 
-export { McpToolTestingDialog };
+export { McpToolTestingDialog, toMcpFormFields };

--- a/packages/web/test/app/builder/test-step/custom-test-step/mcp-tool-testing-dialog.test.ts
+++ b/packages/web/test/app/builder/test-step/custom-test-step/mcp-tool-testing-dialog.test.ts
@@ -1,0 +1,28 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Regression test: toggling the dynamic (f(x)) input mode on the MCP tool
+ * trigger's inputSchema property replaces its form value with `{}` (see
+ * ARRAY case in form-utils.tsx's getDefaultPropertyValue). Reading that raw
+ * value and calling .filter() on it without checking it's still an array
+ * threw "TypeError: i.filter is not a function" in the test-trigger dialog.
+ */
+import { describe, expect, it } from 'vitest';
+
+import { toMcpFormFields } from '@/app/builder/test-step/custom-test-step/mcp-tool-testing-dialog';
+
+describe('toMcpFormFields', () => {
+  it('returns the array unchanged when inputSchema is a valid array', () => {
+    const fields = [{ name: 'foo', required: true, type: 'TEXT' }];
+    expect(toMcpFormFields(fields)).toBe(fields);
+  });
+
+  it('falls back to an empty array when inputSchema is {} (dynamic mode toggled on)', () => {
+    expect(toMcpFormFields({})).toEqual([]);
+  });
+
+  it('falls back to an empty array when inputSchema is null or undefined', () => {
+    expect(toMcpFormFields(null)).toEqual([]);
+    expect(toMcpFormFields(undefined)).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- Toggling dynamic f(x) mode on the MCP tool trigger's `inputSchema` (Parameters) property replaces the field's form value with a plain object `{}` instead of an array (shared, generic behavior for any Array property with a `.properties` sub-schema).
- `McpToolTestingDialog` read that raw value with only a `?? []` fallback (which doesn't catch non-array objects) and then called `.filter()` on it, throwing `TypeError: i.filter is not a function` and crashing the "Test trigger" dialog.
- Extracted the coercion into `toMcpFormFields()`, which now guards with `Array.isArray(...)` so a non-array value safely falls back to `[]`.

Closes #14022
Fixes [GIT-1598](https://linear.app/activepieces/issue/GIT-1598)

## Test plan
- [x] Added `mcp-tool-testing-dialog.test.ts` covering: valid array passthrough, `{}` (dynamic-mode shape) → `[]`, `null`/`undefined` → `[]`
- [x] `npm test` — 368/368 passing
- [x] `npm run lint-dev` — 0 errors (pre-existing warnings only)
- [x] Manually verify in the builder: toggle dynamic f(x) on MCP tool trigger's Parameters, then open "Test trigger" — dialog opens without crashing