### PR TITLE
ci: add nightly ZAP DAST scan

### DIFF
--- a/.github/workflows/dast.yml
+++ b/.github/workflows/dast.yml
@@ -1,0 +1,170 @@
+name: DAST (ZAP) — Staging
+
+# Dynamic Application Security Testing. Runs OWASP ZAP against the STAGING deployment
+# (https://stg.activepieces.com) — never production. Authenticated as a dedicated throwaway
+# account whose USER-scoped JWT confines any data mutation to that account's own project.
+# Non-blocking: findings surface in the GitHub Security tab, the job does not fail the build.
+#
+# Requires two repository secrets: DAST_STG_EMAIL and DAST_STG_PASSWORD (a throwaway
+# staging account). See .zap/README.md.
+
+on:
+  schedule:
+    # 03:00 UTC — inside the staging deploy freeze window (17:00–09:00 UTC), so no deploy
+    # races the scan and the target is stable. See continuous-delivery-stg.yml.
+    - cron: '0 3 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  security-events: write
+
+env:
+  STAGING_URL: https://stg.activepieces.com
+
+jobs:
+  zap-dast:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 180
+    steps:
+      - name: Checkout
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+
+      - name: Acquire staging JWT
+        id: auth
+        env:
+          DAST_STG_EMAIL: ${{ secrets.DAST_STG_EMAIL }}
+          DAST_STG_PASSWORD: ${{ secrets.DAST_STG_PASSWORD }}
+        run: |
+          set -euo pipefail
+          if [ -z "${DAST_STG_EMAIL:-}" ] || [ -z "${DAST_STG_PASSWORD:-}" ]; then
+            echo "::error::DAST_STG_EMAIL / DAST_STG_PASSWORD secrets are not set."
+            exit 1
+          fi
+          BASE_URL="${STAGING_URL}/api/v1"
+
+          # Sign in with the throwaway account. On cloud, an already-onboarded account
+          # returns a USER token with a projectId; a fresh account returns an ONBOARDING
+          # token (projectId null) which we complete by creating a platform. Mirrors
+          # benchmark/setup.sh.
+          SIGNIN=$(curl -s "${BASE_URL}/authentication/sign-in" \
+            -H "Content-Type: application/json" \
+            -d "{\"email\":\"${DAST_STG_EMAIL}\",\"password\":\"${DAST_STG_PASSWORD}\"}")
+          # jq made non-fatal: a non-JSON response (502 HTML, WAF, timeout) would parse-error and,
+          # under `pipefail`, abort the step before the guards below. Empty token -> guard fires.
+          TOKEN=$(echo "$SIGNIN" | jq -r '.token // empty' 2>/dev/null || true)
+          PROJECT_ID=$(echo "$SIGNIN" | jq -r '.projectId // empty' 2>/dev/null || true)
+
+          if [ -z "$TOKEN" ]; then
+            echo "::error::Sign-in to staging failed (no token returned)."
+            exit 1
+          fi
+
+          if [ "$PROJECT_ID" = "null" ] || [ -z "$PROJECT_ID" ]; then
+            echo "Completing onboarding (creating platform + project)..."
+            PLATFORM=$(curl -s "${BASE_URL}/platforms" \
+              -H "Content-Type: application/json" \
+              -H "Authorization: Bearer $TOKEN" \
+              -d '{"name":"DAST"}')
+            TOKEN=$(echo "$PLATFORM" | jq -r '.token // empty' 2>/dev/null || true)
+            if [ -z "$TOKEN" ]; then
+              echo "::error::Failed to complete onboarding for the DAST account: ${PLATFORM}"
+              exit 1
+            fi
+          fi
+
+          echo "::add-mask::$TOKEN"
+          echo "jwt=$TOKEN" >> "$GITHUB_OUTPUT"
+
+      - name: Prepare reports directory
+        run: |
+          mkdir -p "${GITHUB_WORKSPACE}/.zap/reports"
+          # The stable ZAP image runs as uid 1000 ("zap"); make the mounted dir writable.
+          sudo chmod -R a+rwx "${GITHUB_WORKSPACE}/.zap"
+
+      - name: Run ZAP full + API scan
+        id: zap
+        continue-on-error: true
+        env:
+          JWT: ${{ steps.auth.outputs.jwt }}
+        run: |
+          set -euo pipefail
+          # The auth bearer must NOT go on the command line: process args are world-readable
+          # via /proc/<pid>/cmdline. Write the ZAP replacer config (incl. the token) to a
+          # properties file in $RUNNER_TEMP, bind-mount it read-only, and load it with
+          # -configfile. It lives outside the mounted .zap dir so it is never uploaded as an
+          # artifact, and is deleted immediately after the run.
+          #   replacer(0): inject the auth bearer on every request.
+          #   replacer(1): tag traffic with a marker User-Agent so staging logs/monitors
+          #                (BetterStack/Checkly) can tell DAST from real users or an attacker.
+          CONF="${RUNNER_TEMP}/zap-auth.prop"
+          {
+            printf 'replacer.full_list(0).description=auth\n'
+            printf 'replacer.full_list(0).enabled=true\n'
+            printf 'replacer.full_list(0).matchtype=REQ_HEADER\n'
+            printf 'replacer.full_list(0).matchstr=Authorization\n'
+            printf 'replacer.full_list(0).regex=false\n'
+            printf 'replacer.full_list(0).replacement=Bearer %s\n' "${JWT}"
+            printf 'replacer.full_list(1).description=dast-marker\n'
+            printf 'replacer.full_list(1).enabled=true\n'
+            printf 'replacer.full_list(1).matchtype=REQ_HEADER\n'
+            printf 'replacer.full_list(1).matchstr=User-Agent\n'
+            printf 'replacer.full_list(1).regex=false\n'
+            printf 'replacer.full_list(1).replacement=Activepieces-DAST-ZAP\n'
+          } > "$CONF"
+          # Readable by the container's zap user (uid 1000); host runner is single-tenant + ephemeral.
+          chmod 644 "$CONF"
+          rc=0
+          docker run --rm \
+            -v "${GITHUB_WORKSPACE}/.zap:/zap/wrk:rw" \
+            -v "${CONF}:/zap/auth.prop:ro" \
+            ghcr.io/zaproxy/zaproxy@sha256:8d387b1a63e3425beef4846e39719f5af2a787753af2d8b6558c6257d7a577a2 \
+            zap.sh -cmd -silent -configfile /zap/auth.prop -autorun /zap/wrk/dast-plan.yaml || rc=$?
+          rm -f "$CONF"
+          exit $rc
+
+      - name: Locate SARIF report
+        id: sarif
+        if: always()
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          found=""
+          for f in "${GITHUB_WORKSPACE}"/.zap/reports/*; do
+            # SARIF files carry a top-level "$schema" key and a sarif schema URL. The literal
+            # $schema must not be shell-expanded, hence the single quotes.
+            # shellcheck disable=SC2016
+            if grep -qlF '"$schema"' "$f" 2>/dev/null && grep -qil 'sarif' "$f" 2>/dev/null; then
+              found="$f"; break
+            fi
+          done
+          if [ -n "$found" ]; then
+            cp "$found" "${GITHUB_WORKSPACE}/.zap/reports/zap-dast.sarif"
+            echo "found=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "found=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::No SARIF report produced by ZAP; skipping Security-tab upload."
+          fi
+
+      - name: Upload SARIF to GitHub Security tab
+        if: always() && steps.sarif.outputs.found == 'true'
+        uses: github/codeql-action/upload-sarif@1521896cd211af95be3f02edf6f436e10b819c27 # v3.35.4
+        with:
+          sarif_file: .zap/reports/zap-dast.sarif
+          category: zap-dast
+
+      - name: Upload ZAP reports artifact
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: zap-dast-reports-${{ github.run_id }}-${{ github.run_attempt }}
+          path: .zap/reports/
+          retention-days: 30
+          if-no-files-found: warn
+
+      - name: Report ZAP outcome
+        if: always()
+        run: |
+          if [ "${{ steps.zap.outcome }}" != "success" ]; then
+            echo "::warning::ZAP run reported a non-success outcome. Findings (if any) are in the Security tab / artifact. Not failing the build (non-blocking DAST)."
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@
 # Claude Code worktrees
 .claude/worktrees/
 
+# ZAP DAST scan output (generated at runtime, see .zap/README.md)
+.zap/reports/
+
 pieces-cache-db-*.sqlite
 
 # local debug logs (evlog filesystem drain)

--- a/.zap/README.md
+++ b/.zap/README.md
@@ -1,0 +1,52 @@
+# DAST (Dynamic Application Security Testing)
+
+OWASP ZAP scans the running **staging** deployment for runtime vulnerabilities (injection,
+XSS, header/TLS misconfig, exposed surfaces, auth gaps). It complements the static container
+scan (Grype, `.github/actions/sbom/`).
+
+- Workflow: [`.github/workflows/dast.yml`](../.github/workflows/dast.yml)
+- Scan plan: [`dast-plan.yaml`](./dast-plan.yaml) (ZAP Automation Framework)
+
+## What it does
+
+1. Signs in to `https://stg.activepieces.com` with a dedicated throwaway account and obtains a
+   USER JWT.
+2. Runs ZAP via the official `ghcr.io/zaproxy/zaproxy:stable` image, injecting
+   `Authorization: Bearer <jwt>` on every request through a global `replacer` rule.
+3. The Automation Framework plan imports the public OpenAPI spec (`/api/v1/docs`), spiders the
+   SPA + API (traditional + AJAX), then runs a **full active** injection scan.
+4. Emits a SARIF report → GitHub **Security → Code scanning**, and an HTML report kept as a
+   30-day workflow artifact.
+
+Runs nightly at **03:00 UTC** (inside the staging deploy freeze window, so no deploy races the
+scan) and on demand via `workflow_dispatch`. **Non-blocking** for now — findings are surfaced,
+the build is never failed.
+
+## Blast radius & the safety denylist
+
+Active scanning sends real attack payloads. Two things keep the damage contained:
+
+1. **USER-scoped JWT** — authorization limits any created/modified/deleted data to the throwaway
+   account's own project.
+2. **`excludePaths` in `dast-plan.yaml`** — a safety denylist for endpoints whose side effects
+   reach *other people or external services*, excluded even under full-active:
+   - `/api/v1/otp`, `/api/v1/authn/local` — password-reset / verification **emails**
+   - `/api/v1/user-invitations` — invitation **emails**
+   - `/api/v1/stripe-billing` — payment provider **webhook**
+   - `/ingest` — PostHog reverse-proxy (open passthrough)
+   - `/api/v1/admin` — platform-admin surface (separate admin secret; unreachable with a USER JWT)
+
+   To scan these anyway, remove the corresponding line — but understand the side effect first.
+
+## Setup (one-time)
+
+1. Create a throwaway account on staging (its own platform/project → natural containment).
+2. Add repository secrets `DAST_STG_EMAIL` and `DAST_STG_PASSWORD` for that account.
+3. Trigger the workflow via **Actions → DAST (ZAP) — Staging → Run workflow** to validate before
+   relying on the nightly schedule.
+
+## Tuning false positives
+
+Add `alertFilter` entries in `dast-plan.yaml` (by ZAP `ruleId`) to downgrade or hide known
+non-issues as the findings baseline is triaged.
+

--- a/.zap/dast-plan.yaml
+++ b/.zap/dast-plan.yaml
@@ -1,0 +1,114 @@
+# OWASP ZAP Automation Framework plan for Activepieces DAST.
+# Run by .github/workflows/dast.yml against staging (https://stg.activepieces.com).
+# Auth is injected as a global `replacer` rule on the ZAP command line by the workflow
+# (Authorization: Bearer <jwt>), so it applies to every job below.
+#
+# Scope note: excludePaths below are a deliberate SAFETY denylist. Even though we run a
+# FULL ACTIVE scan, these endpoints have side effects that reach *other people or external
+# services* (emails, payment webhooks, an open proxy) and must never receive attack traffic.
+env:
+  contexts:
+    - name: activepieces-staging
+      urls:
+        - https://stg.activepieces.com
+      includePaths:
+        - https://stg.activepieces.com.*
+      excludePaths:
+        - https://stg.activepieces.com/api/v1/otp.*
+        - https://stg.activepieces.com/api/v1/authn/local.*
+        - https://stg.activepieces.com/api/v1/user-invitations.*
+        - https://stg.activepieces.com/api/v1/stripe-billing.*
+        - https://stg.activepieces.com/ingest.*
+        - https://stg.activepieces.com/api/v1/admin.*
+  parameters:
+    failOnError: true
+    failOnWarning: false
+    progressToStdout: true
+
+jobs:
+  # Import the public OpenAPI spec so the active scanner knows every tagged endpoint,
+  # its methods, and body schemas. Untagged internal routes are absent (hideUntagged:true)
+  # and are reached via the spider jobs below instead.
+  - type: openapi
+    parameters:
+      apiUrl: https://stg.activepieces.com/api/v1/docs
+      targetUrl: https://stg.activepieces.com
+      context: activepieces-staging
+
+  # Traditional spider for server-rendered links + the imported API tree.
+  - type: spider
+    parameters:
+      context: activepieces-staging
+      url: https://stg.activepieces.com
+      maxDuration: 5
+
+  # AJAX spider crawls the React SPA (needs the headless Firefox bundled in the stable image).
+  - type: spiderAjax
+    parameters:
+      context: activepieces-staging
+      url: https://stg.activepieces.com
+      maxDuration: 5
+      maxCrawlDepth: 10
+
+  - type: passiveScan-wait
+    parameters:
+      maxDuration: 5
+
+  # Full active injection (SQLi, XSS, path traversal, etc.) against everything discovered
+  # and in scope. The excludePaths in the context keep the safety denylist out of this.
+  # Time caps bound the run so it always emits a report: the smoke run discovered ~2,000 URLs,
+  # and an uncapped active scan over that many nodes can run for hours. Keep these below the
+  # workflow's timeout-minutes.
+  - type: activeScan
+    parameters:
+      context: activepieces-staging
+      maxScanDurationInMins: 120
+      maxRuleDurationInMins: 20
+
+  # False-positive tuning, triaged from the first full run. Rules that are noise everywhere
+  # are filtered globally; rules that are useful elsewhere are scoped by url so a real hit
+  # still surfaces. Re-verify before adding to this list — do not blanket-ignore.
+  - type: alertFilter
+    parameters:
+      deleteGlobalAlerts: false
+    alertFilters:
+      # Informational timestamp disclosure — noise for a JSON API.
+      - ruleId: 10096
+        newRisk: "False Positive"
+        context: activepieces-staging
+      # Format String Error: heuristic targets a C/Microsoft crash class that does not exist
+      # in Node/Fastify. Verified non-reproducible (malformed cursor -> clean 200).
+      - ruleId: 30002
+        newRisk: "False Positive"
+        context: activepieces-staging
+      # "Sensitive info in URL" fires on query-PARAMETER NAMES (e.g. externalUserId), not values.
+      - ruleId: 10024
+        newRisk: "False Positive"
+        context: activepieces-staging
+      # App-error / debug-message disclosure on the static i18n bundle: matches UI strings
+      # containing the word "error", not a real stack/path leak. Scoped to /locales only so
+      # a genuine error-disclosure on an API route still reports.
+      - ruleId: 90022
+        newRisk: "False Positive"
+        url: "https://stg\\.activepieces\\.com/locales/.*"
+        context: activepieces-staging
+      - ruleId: 10023
+        newRisk: "False Positive"
+        url: "https://stg\\.activepieces\\.com/locales/.*"
+        context: activepieces-staging
+
+  # SARIF report for the GitHub Security tab (Security -> Code scanning).
+  - type: report
+    parameters:
+      template: sarif-json
+      reportDir: /zap/wrk/reports
+      reportFile: zap-dast
+      reportTitle: Activepieces DAST (ZAP)
+
+  # Human-readable HTML report, kept as a workflow artifact.
+  - type: report
+    parameters:
+      template: traditional-html
+      reportDir: /zap/wrk/reports
+      reportFile: zap-dast
+      reportTitle: Activepieces DAST (ZAP)


### PR DESCRIPTION
## What

Adds an automated security scan (OWASP ZAP) that runs against staging.

## How it works

- Runs nightly at 03:00 UTC, plus on-demand from the Actions tab
- Scans staging only, never production
- Signs in with a dedicated throwaway account
- Results show up in the Security tab; full report saved as a build artifact

## Setup

Details in `.zap/README.md`.
