### PR TITLE
fix(engine): retry 5xx on store read/write instead of failing the run

### DIFF
--- a/packages/server/engine/src/lib/piece-context/store.ts
+++ b/packages/server/engine/src/lib/piece-context/store.ts
@@ -2,7 +2,15 @@ import { URL } from 'node:url'
 import { FlowId, isNil } from '@activepieces/core-utils'
 import { Store, StoreScope } from '@activepieces/pieces-framework'
 import { DeleteStoreEntryRequest, ExecutionError, FetchError, PutStoreEntryRequest, StorageError, StorageInvalidKeyError, StorageLimitError, STORE_KEY_MAX_LENGTH, STORE_VALUE_MAX_SIZE, StoreEntry } from '@activepieces/shared'
+import fetchRetry from 'fetch-retry'
 import { utils } from '../utils'
+
+const fetchWithRetry = fetchRetry(global.fetch)
+const RETRY_CONFIG = {
+    retries: 3,
+    retryDelay: 3000,
+    retryOn: [408, 429, 500, 502, 503, 504],
+} as const
 
 export function createContextStore({ apiUrl, prefix, flowId, engineToken }: { apiUrl: string, prefix: string, flowId: FlowId, engineToken: string }): Store {
     return {
@@ -40,10 +48,11 @@ function createStoreClient({ engineToken, apiUrl }: CreateStoreClientParams): St
             const url = buildUrl(apiUrl, key)
 
             const { data: storeEntry, error: storeEntryError } = await utils.tryCatchAndThrowOnEngineError((async () => {
-                const response = await fetch(url, {
+                const response = await fetchWithRetry(url, {
                     headers: {
                         Authorization: `Bearer ${engineToken}`,
                     },
+                    ...RETRY_CONFIG,
                 })
                 if (!response.ok) {
                     return handleResponseError({
@@ -72,13 +81,14 @@ function createStoreClient({ engineToken, apiUrl }: CreateStoreClientParams): St
                 if (sizeOfValue > STORE_VALUE_MAX_SIZE) {
                     throw new StorageLimitError(request.key, STORE_VALUE_MAX_SIZE)
                 }
-                const response = await fetch(url, {
+                const response = await fetchWithRetry(url, {
                     method: 'POST',
                     headers: {
                         'Content-Type': 'application/json',
                         Authorization: `Bearer ${engineToken}`,
                     },
                     body: JSON.stringify(request),
+                    ...RETRY_CONFIG,
                 })
 
                 if (!response.ok) {
@@ -107,11 +117,12 @@ function createStoreClient({ engineToken, apiUrl }: CreateStoreClientParams): St
             const url = buildUrl(apiUrl, request.key)
 
             const { data: storeEntry, error: storeEntryError } = await utils.tryCatchAndThrowOnEngineError((async () => {
-                const response = await fetch(url, {
+                const response = await fetchWithRetry(url, {
                     method: 'DELETE',
                     headers: {
                         Authorization: `Bearer ${engineToken}`,
                     },
+                    ...RETRY_CONFIG,
                 })
 
                 if (!response.ok) {

--- a/packages/server/engine/src/lib/piece-context/store.ts
+++ b/packages/server/engine/src/lib/piece-context/store.ts
@@ -5,7 +5,7 @@ import { DeleteStoreEntryRequest, ExecutionError, FetchError, PutStoreEntryReque
 import fetchRetry from 'fetch-retry'
 import { utils } from '../utils'
 
-const fetchWithRetry = fetchRetry(global.fetch)
+const fetchWithRetry = fetchRetry((...args: Parameters<typeof fetch>) => global.fetch(...args))
 const RETRY_CONFIG = {
     retries: 3,
     retryDelay: 3000,


### PR DESCRIPTION
## Problem

The engine store client (`store.ts`) reads/writes flow store entries with **raw `fetch`** and **no retry** (3 sites: `get`/`put`/`delete`). A transient 5xx from the store API — e.g. a Cloudflare HTML error page during a blip — becomes a `StorageError` → `INTERNAL_ERROR`, which fails+retries the worker job and pages oncall.

Surfaced while categorizing the `INTERNAL_ERROR` backlog on cloud: `StorageError` jobs whose underlying cause was a Cloudflare 5xx error page.

## Fix

Wrap the three store fetches in `fetch-retry` with the same 5xx retry policy the file/callback clients use (`retryOn: [408, 429, 500, 502, 503, 504]`). Transient blips are absorbed; a persistent outage still surfaces as `StorageError` after retries.

4xx responses are unaffected — `handleResponseError` still short-circuits 404 (→ null), 413 (→ StorageLimitError), and other 4xx (→ StorageInvalidKeyError) without retry, since only 5xx/408/429 are in `retryOn`.

Part of the same "transient engine→API 5xx shouldn't nuke runs" theme as #14202 (file + progress/terminal callbacks); this covers the store client.

🤖 Generated with [Claude Code](https://claude.com/claude-code)