### PR TITLE
feat(security): migrate encryption at rest from AES-256-CBC to AES-256-GCM

### DIFF
--- a/.agents/features/secret-encryption.md
+++ b/.agents/features/secret-encryption.md
@@ -1,0 +1,41 @@
+# Secret Encryption at Rest
+
+## Summary
+All secrets stored in the database — app-connection credentials, project variables, AI
+provider/tool keys, EE OAuth-app secrets, secret-manager configs, and the OIDC signing key — are
+encrypted through a single chokepoint, `encryptUtils`. As of the CBC→GCM migration, secrets are
+written with **AES-256-GCM** (authenticated encryption: ciphertext + 12-byte IV + auth tag). Blobs
+written before the migration use **AES-256-CBC** (`{ iv, data }`, no auth tag) and are still
+readable; a background sweep (`reencryptSecretsJob`) re-encrypts them to GCM in place.
+
+The stored shape is `EncryptedObject = { iv, data, authTag? }`. **The presence of `authTag` is the
+format discriminator**: absent ⇒ legacy CBC, present ⇒ GCM. The 32-character `AP_ENCRYPTION_KEY` is
+the AES-256 key for both algorithms (`Buffer.from(secret, 'binary')` → 32 bytes) — the migration is
+algorithm-only, no key rotation and no new env var.
+
+The sweep is a one-shot system job (`SystemJobName.REENCRYPT_SECRETS`), single-runner via
+`distributedLock`, keyset-paginated over each table's primary key, paced, restart-safe, and
+idempotent. Its write-back is conditional on the exact CBC blob it read, so a concurrent re-auth is
+never clobbered. It re-enqueues on every boot (dedup by `jobId`) and converges as legacy rows drain
+to zero; it is removed in the Release-3 "contract" step once counts hit zero fleet-wide.
+
+## Key Files
+- `packages/server/api/src/app/helper/encryption.ts` — `encryptUtils` chokepoint: GCM write, dual-format read.
+- `packages/server/api/src/app/helper/reencrypt-secrets.job.ts` — the migration sweep + blob registry.
+- `packages/server/api/src/app/helper/system-jobs/common.ts` — `SystemJobName.REENCRYPT_SECRETS`.
+- `packages/server/api/src/app/app.ts` — boot-time `register()` + fire-and-forget `enqueue()`.
+- `packages/server/api/src/app/helper/system-validator.ts` — asserts `AP_ENCRYPTION_KEY` at startup.
+
+### Encrypted-blob locations (what the sweep covers)
+- `app_connection.value` (jsonb, highest volume), `variable.value` (jsonb), `ai_provider.auth`
+  (json), `ai_tool_config.auth` (json) — all editions.
+- `oauth_app.clientSecret` (jsonb), `secret_manager_connection.auth` (jsonb, nullable) — EE.
+- `flag.value` (jsonb) — EE; **only** the row `id = 'OIDC_RSA_PRIVATE_KEY'` is encrypted (all other
+  flag rows are plaintext, so the sweep restricts to that id).
+
+## Edition Availability
+All editions (Community, Enterprise, Cloud). The four core tables exist everywhere; the three EE
+tables are swept when present and skipped (`42P01`) when absent.
+
+## Domain Terms
+Encrypted blob, auth tag, IV — see [Authentication & Security](../contexts/authentication/CONTEXT.md).

--- a/docs/adr/0007-encryption-at-rest-migrated-cbc-to-gcm.md
+++ b/docs/adr/0007-encryption-at-rest-migrated-cbc-to-gcm.md
@@ -1,0 +1,57 @@
+# Encryption at rest migrated from AES-256-CBC to AES-256-GCM
+
+## Status
+
+accepted
+
+## Context
+
+Every secret Activepieces stores at rest — app-connection credentials, project variables, AI
+provider/tool keys, EE OAuth-app secrets, secret-manager configs, and the OIDC signing key — is
+encrypted through one chokepoint, `encryptUtils` in `encryption.ts`, historically with
+**AES-256-CBC** and the stored shape `{ iv, data }`. CBC provides confidentiality only: it has no
+authentication tag, so tampering with a stored ciphertext is undetectable. We wanted authenticated
+encryption (**AES-256-GCM**) and to retire CBC entirely, not merely stop writing it.
+
+Two properties constrained the design. First, there is **no plaintext fallback**: if a running
+process cannot decrypt a blob, that secret is unrecoverable. Second, the change is at cloud scale —
+`app_connection` alone can hold millions of rows — so any re-encryption must trickle, not spike the
+database, and must survive restarts and concurrent writes.
+
+The 32-character `AP_ENCRYPTION_KEY` is already a valid 32-byte AES-256 key for GCM
+(`Buffer.from(secret, 'binary')`), so no key rotation and no new env var were needed; self-hosting
+stays zero-setup. Key rotation is a separate concern and was explicitly deferred.
+
+## Decision
+
+**Discriminate formats by the presence of `authTag`.** `EncryptedObject` became
+`{ iv, data, authTag? }`: `authTag` absent ⇒ legacy CBC, present ⇒ GCM. No version field, no
+`keyId`, no keyring — if key rotation is ever needed, an optional `keyId` can be added later with no
+further format migration.
+
+**Roll out as expand → migrate → contract, three releases.** Because there is no plaintext fallback
+and a process on the *previous* release has no GCM reader, GCM writes must not begin until the reader
+is fleet-wide:
+1. **Expand** — add the GCM read branch; keep writing CBC. Dormant everywhere, fully rollback-safe.
+2. **Migrate** — flip `encryptString` to GCM (12-byte IV + auth tag) and run a background sweep
+   (`reencryptSecretsJob`) that re-encrypts legacy blobs in place. Keyset-paginated on the primary
+   key, paced, single-runner via `distributedLock`, restart-safe, idempotent, re-enqueued each boot.
+   Write-back is conditional on the **exact CBC blob read** (not merely `authTag IS NULL`), so a
+   concurrent re-auth — including a CBC write from a not-yet-upgraded instance during the rollout —
+   is never clobbered; such a row is simply left for a later sweep.
+3. **Contract** (later) — once legacy counts are zero fleet-wide for a full release cycle, delete the
+   CBC read branch, make `authTag` required, and remove the sweep job.
+
+## Consequences
+
+- Stored secrets are tamper-evident under GCM; CBC is read-only and time-boxed to removal in the
+  contract release.
+- Two formats coexist during migration — intentional and readable via the `authTag` discriminator.
+- Rollout safety is load-bearing on ordering: Release 1 must reach 100% of instances before Release 2
+  ships. The reward is that every step is independently rollback-safe.
+- A dual-column (`iv2`/`data2`) scheme was rejected: it doubles storage on the largest table, forces
+  a second full rewrite (or permanent awkward field names) at cleanup, and keeps minting fresh CBC
+  for newly created rows — trading a cheap sequencing discipline for a heavier, longer-lived one.
+- Key entropy is unchanged (`openssl rand -hex 16` seeds ~128-bit into the 32-byte key). 128-bit is
+  cryptographically secure; raising it would require a longer key and thus key rotation, which is out
+  of scope here.

--- a/packages/server/api/src/app/app.ts
+++ b/packages/server/api/src/app/app.ts
@@ -80,6 +80,7 @@ import { exceptionHandler } from './helper/exception-handler'
 import { clientLogsModule } from './helper/logs/client-logs.module'
 import { openapiModule } from './helper/openapi/openapi.module'
 import { rejectedPromiseHandler } from './helper/promise-handler'
+import { reencryptSecretsJob } from './helper/reencrypt-secrets.job'
 import { system } from './helper/system/system'
 import { AppSystemProp } from './helper/system/system-props'
 import { SystemJobName } from './helper/system-jobs/common'
@@ -221,6 +222,10 @@ export const setupApp = async (app: FastifyInstance): Promise<FastifyInstance> =
     // built (existing deployment whose piece_metadata is already populated, so no sync delta fires).
     // Fire-and-forget — a no-op once the index has rows, and must never block or fail boot.
     rejectedPromiseHandler(toolSearchReindexJob(app.log).backfillIfEmpty(), app.log)
+    // Migration sweep (CBC → GCM): re-encrypts any legacy blobs left over from before the GCM write
+    // flip. Fire-and-forget, paced, idempotent, and a cheap no-op once every blob is already GCM.
+    reencryptSecretsJob(app.log).register()
+    rejectedPromiseHandler(reencryptSecretsJob(app.log).enqueue(), app.log)
     await pieceMetadataService(app.log).setup()
     await app.register(pieceModule)
     await app.register(collaborativeModule)

--- a/packages/server/api/src/app/helper/encryption.ts
+++ b/packages/server/api/src/app/helper/encryption.ts
@@ -11,13 +11,15 @@ import { localFileStore } from './local-store'
 import { system } from './system/system'
 import { AppSystemProp } from './system/system-props'
 
-const algorithm = 'aes-256-cbc'
-const ivLength = 16
+const cbcAlgorithm = 'aes-256-cbc'
+const gcmAlgorithm = 'aes-256-gcm'
+const gcmIvLength = 12
 const mutexLock = new Mutex()
 
 export const EncryptedObject = z.object({
     iv: z.string(),
     data: z.string(),
+    authTag: z.string().optional(),
 })
 export type EncryptedObject = z.infer<typeof EncryptedObject>
 const redisType = redisConnections.getRedisType()
@@ -26,21 +28,19 @@ const redisType = redisConnections.getRedisType()
 export const encryptUtils = {
     decryptString: async (encryptedObject: EncryptedObject): Promise<string> => {
         const secret = await encryptUtils.getEncryptionKey()
+        assertNotNullOrUndefined(secret, 'secret')
         const iv = Buffer.from(encryptedObject.iv, 'hex')
-        const key = Buffer.from(secret!, 'binary')
-        const decipher = crypto.createDecipheriv(algorithm, key, iv)
+        const key = Buffer.from(secret, 'binary')
+        const { authTag } = encryptedObject
+        const decipher = isNil(authTag)
+            ? crypto.createDecipheriv(cbcAlgorithm, key, iv)
+            : createGcmDecipher({ key, iv, authTag })
         let decrypted = decipher.update(encryptedObject.data, 'hex', 'utf8')
         decrypted += decipher.final('utf8')
         return decrypted
     },
     decryptObject: async <T>(encryptedObject: EncryptedObject): Promise<T> => {
-        const secret = await encryptUtils.getEncryptionKey()
-        const iv = Buffer.from(encryptedObject.iv, 'hex')
-        const key = Buffer.from(secret!, 'binary')
-        const decipher = crypto.createDecipheriv(algorithm, key, iv)
-        let decrypted = decipher.update(encryptedObject.data, 'hex', 'utf8')
-        decrypted += decipher.final('utf8')
-        return JSON.parse(decrypted)
+        return JSON.parse(await encryptUtils.decryptString(encryptedObject))
     },
     encryptObject: async (object: unknown): Promise<EncryptedObject> => {
         const objectString = JSON.stringify(object)
@@ -48,15 +48,16 @@ export const encryptUtils = {
     },
     encryptString: async (inputString: string): Promise<EncryptedObject> => {
         const secret = await encryptUtils.getEncryptionKey()
-        const iv = crypto.randomBytes(ivLength)
         assertNotNullOrUndefined(secret, 'secret')
+        const iv = crypto.randomBytes(gcmIvLength)
         const key = Buffer.from(secret, 'binary')
-        const cipher = crypto.createCipheriv(algorithm, key, iv)
+        const cipher = crypto.createCipheriv(gcmAlgorithm, key, iv)
         let encrypted = cipher.update(inputString, 'utf8', 'hex')
         encrypted += cipher.final('hex')
         return {
             iv: iv.toString('hex'),
             data: encrypted,
+            authTag: cipher.getAuthTag().toString('hex'),
         }
     },
     getEncryptionKey: async (): Promise<string | null> => {
@@ -71,6 +72,12 @@ export const encryptUtils = {
     },
 }
 
+
+function createGcmDecipher({ key, iv, authTag }: { key: Buffer, iv: Buffer, authTag: string }): crypto.DecipherGCM {
+    const decipher = crypto.createDecipheriv(gcmAlgorithm, key, iv)
+    decipher.setAuthTag(Buffer.from(authTag, 'hex'))
+    return decipher
+}
 
 function generateAndStoreSecret(): Promise<string> {
     return mutexLock.runExclusive(async () => {

--- a/packages/server/api/src/app/helper/reencrypt-secrets.job.ts
+++ b/packages/server/api/src/app/helper/reencrypt-secrets.job.ts
@@ -1,0 +1,140 @@
+import { isNil, tryCatch } from '@activepieces/core-utils'
+import { apDayjs } from '@activepieces/server-utils'
+import { FastifyBaseLogger } from 'fastify'
+import { databaseConnection } from '../database/database-connection'
+import { distributedLock } from '../database/redis-connections'
+import { EncryptedObject, encryptUtils } from './encryption'
+import { sleep } from './sleep'
+import { SystemJobName } from './system-jobs/common'
+import { systemJobHandlers } from './system-jobs/job-handlers'
+import { systemJobsSchedule } from './system-jobs/system-job'
+
+export const reencryptSecretsJob = (log: FastifyBaseLogger) => ({
+    register(): void {
+        systemJobHandlers.registerJobHandler(SystemJobName.REENCRYPT_SECRETS, async () => {
+            await distributedLock(log).runExclusive({
+                key: REENCRYPT_LOCK_KEY,
+                timeoutInSeconds: REENCRYPT_LOCK_TIMEOUT_SECONDS,
+                fn: async () => reencryptAllSecrets(log),
+            })
+        })
+    },
+
+    async enqueue(): Promise<void> {
+        await systemJobsSchedule(log).upsertJob({
+            job: {
+                name: SystemJobName.REENCRYPT_SECRETS,
+                data: {},
+                jobId: REENCRYPT_JOB_ID,
+            },
+            schedule: {
+                type: 'one-time',
+                date: apDayjs(),
+            },
+        })
+    },
+})
+
+export async function reencryptAllSecrets(log: FastifyBaseLogger): Promise<void> {
+    log.info('[reencryptSecretsJob] Starting legacy CBC → GCM re-encryption sweep')
+    for (const target of SWEEP_TARGETS) {
+        const { error } = await tryCatch(() => reencryptTable(target, log))
+        if (isNil(error)) {
+            continue
+        }
+        if (pgErrorCode(error) === UNDEFINED_TABLE_ERROR) {
+            log.info({ table: target.table }, '[reencryptSecretsJob] Table not present in this edition — skipping')
+            continue
+        }
+        log.error({ error, table: target.table }, '[reencryptSecretsJob] Table sweep failed — continuing with remaining tables')
+    }
+    log.info('[reencryptSecretsJob] Legacy CBC → GCM re-encryption sweep finished')
+}
+
+async function reencryptTable(target: SweepTarget, log: FastifyBaseLogger): Promise<void> {
+    const table = `"${target.table}"`
+    const column = `"${target.blobColumn}"`
+    const conditions = ['"id" > $1', `${column} IS NOT NULL`, `${column}->>'authTag' IS NULL`]
+    if (!isNil(target.extraWhere)) {
+        conditions.push(target.extraWhere)
+    }
+    const selectSql = `SELECT "id", ${column} AS blob FROM ${table} WHERE ${conditions.join(' AND ')} ORDER BY "id" LIMIT $2`
+    const updateSql = `UPDATE ${table} SET ${column} = $1::${target.jsonType} WHERE "id" = $2 AND ${column}::jsonb = $3::jsonb`
+
+    let lastId = ''
+    let reencrypted = 0
+    let failed = 0
+    for (;;) {
+        const rows: CbcRow[] = await databaseConnection().query(selectSql, [lastId, BATCH_SIZE])
+        if (rows.length === 0) {
+            break
+        }
+        for (const row of rows) {
+            const { error } = await tryCatch(() => reencryptRow({ updateSql, row }))
+            if (isNil(error)) {
+                reencrypted++
+                continue
+            }
+            failed++
+            log.error({ error, table: target.table, id: row.id }, '[reencryptSecretsJob] Failed to re-encrypt row — leaving it as legacy CBC')
+        }
+        lastId = rows[rows.length - 1].id
+        await sleep(PACING_DELAY_MS)
+    }
+    log.info({ table: target.table, reencrypted, failed }, '[reencryptSecretsJob] Table sweep complete')
+}
+
+// Conditional on the exact CBC blob we read (`${column}::jsonb = $3::jsonb`), not just `authTag IS NULL`:
+// during the R1→R2 rollout a still-running R1 instance may write a fresh CBC value for the same row,
+// and an `authTag IS NULL`-only guard would clobber it with our stale plaintext. The exact-match no-ops
+// on any concurrent change; the straggler stays CBC and is caught by a later sweep once R1 is gone.
+async function reencryptRow({ updateSql, row }: { updateSql: string, row: CbcRow }): Promise<void> {
+    const plaintext = await encryptUtils.decryptString(row.blob)
+    const reencrypted = await encryptUtils.encryptString(plaintext)
+    await databaseConnection().query(updateSql, [JSON.stringify(reencrypted), row.id, JSON.stringify(row.blob)])
+}
+
+function pgErrorCode(error: unknown): string | undefined {
+    if (typeof error !== 'object' || isNil(error)) {
+        return undefined
+    }
+    if ('code' in error && typeof error.code === 'string') {
+        return error.code
+    }
+    if ('driverError' in error && typeof error.driverError === 'object' && !isNil(error.driverError) && 'code' in error.driverError && typeof error.driverError.code === 'string') {
+        return error.driverError.code
+    }
+    return undefined
+}
+
+const OIDC_PRIVATE_KEY_FLAG_ID = 'OIDC_RSA_PRIVATE_KEY'
+const REENCRYPT_JOB_ID = 'reencrypt-secrets'
+const REENCRYPT_LOCK_KEY = 'reencrypt-secrets'
+const REENCRYPT_LOCK_TIMEOUT_SECONDS = 300
+const BATCH_SIZE = 200
+const PACING_DELAY_MS = 200
+const UNDEFINED_TABLE_ERROR = '42P01'
+
+// ponytail: full index scan per table on every boot until Release 3 removes this job — acceptable
+// for a temporary migration; upgrade path is the R3 contract that deletes the sweep entirely.
+const SWEEP_TARGETS: SweepTarget[] = [
+    { table: 'app_connection', blobColumn: 'value', jsonType: 'jsonb' },
+    { table: 'variable', blobColumn: 'value', jsonType: 'jsonb' },
+    { table: 'ai_provider', blobColumn: 'auth', jsonType: 'json' },
+    { table: 'ai_tool_config', blobColumn: 'auth', jsonType: 'json' },
+    { table: 'oauth_app', blobColumn: 'clientSecret', jsonType: 'jsonb' },
+    { table: 'secret_manager_connection', blobColumn: 'auth', jsonType: 'jsonb' },
+    { table: 'flag', blobColumn: 'value', jsonType: 'jsonb', extraWhere: `"id" = '${OIDC_PRIVATE_KEY_FLAG_ID}'` },
+]
+
+type CbcRow = {
+    id: string
+    blob: EncryptedObject
+}
+
+type SweepTarget = {
+    table: string
+    blobColumn: string
+    jsonType: 'json' | 'jsonb'
+    extraWhere?: string
+}

--- a/packages/server/api/src/app/helper/system-jobs/common.ts
+++ b/packages/server/api/src/app/helper/system-jobs/common.ts
@@ -17,6 +17,7 @@ export enum SystemJobName {
     RESUME_DELAY_WAITPOINT = 'resume-delay-waitpoint',
     TOOL_SEARCH_REINDEX = 'tool-search-reindex',
     BUNDLE_PIECE = 'bundle-piece',
+    REENCRYPT_SECRETS = 'reencrypt-secrets',
 }
 
 type BundlePieceSystemJobData = {
@@ -72,6 +73,7 @@ type SystemJobDataMap = {
     [SystemJobName.RESUME_DELAY_WAITPOINT]: ResumeDelayWaitpointSystemJobData
     [SystemJobName.TOOL_SEARCH_REINDEX]: ToolSearchReindexSystemJobData
     [SystemJobName.BUNDLE_PIECE]: BundlePieceSystemJobData
+    [SystemJobName.REENCRYPT_SECRETS]: Record<string, never>
 }
 
 export type SystemJobData<T extends SystemJobName = SystemJobName> = T extends SystemJobName ? SystemJobDataMap[T] : never

--- a/packages/server/api/test/integration/ce/encryption/reencrypt-secrets.test.ts
+++ b/packages/server/api/test/integration/ce/encryption/reencrypt-secrets.test.ts
@@ -1,0 +1,72 @@
+import * as crypto from 'crypto'
+import { assertNotNullOrUndefined } from '@activepieces/core-utils'
+import { FastifyBaseLogger, FastifyInstance } from 'fastify'
+import { EncryptedObject, encryptUtils } from '../../../../src/app/helper/encryption'
+import { reencryptAllSecrets } from '../../../../src/app/helper/reencrypt-secrets.job'
+import { db } from '../../../helpers/db'
+import { createMockConnection, mockAndSaveBasicSetup } from '../../../helpers/mocks'
+import { setupTestEnvironment, teardownTestEnvironment } from '../../../helpers/test-setup'
+
+let app: FastifyInstance | null = null
+let mockLog: FastifyBaseLogger
+
+beforeAll(async () => {
+    app = await setupTestEnvironment()
+    mockLog = app!.log!
+})
+
+afterAll(async () => {
+    await teardownTestEnvironment()
+})
+
+async function encryptCbc(plaintext: string): Promise<EncryptedObject> {
+    const secret = await encryptUtils.getEncryptionKey()
+    assertNotNullOrUndefined(secret, 'secret')
+    const key = Buffer.from(secret, 'binary')
+    const iv = crypto.randomBytes(16)
+    const cipher = crypto.createCipheriv('aes-256-cbc', key, iv)
+    let data = cipher.update(plaintext, 'utf8', 'hex')
+    data += cipher.final('hex')
+    return { iv: iv.toString('hex'), data }
+}
+
+async function seedConnection({ platformId, projectId, ownerId, value }: { platformId: string, projectId: string, ownerId: string, value: EncryptedObject }): Promise<string> {
+    const base = createMockConnection({ platformId, projectIds: [projectId] }, ownerId)
+    const row = { ...base, value }
+    await db.save('app_connection', row)
+    return base.id
+}
+
+describe('reencryptAllSecrets sweep (CBC → GCM)', () => {
+    it('re-encrypts legacy CBC blobs to GCM and preserves the plaintext', async () => {
+        const { mockPlatform, mockProject, mockOwner } = await mockAndSaveBasicSetup()
+
+        const secretA = 'super-secret-token-A'
+        const secretB = 'super-secret-token-B'
+        const idA = await seedConnection({ platformId: mockPlatform.id, projectId: mockProject.id, ownerId: mockOwner.id, value: await encryptCbc(secretA) })
+        const idB = await seedConnection({ platformId: mockPlatform.id, projectId: mockProject.id, ownerId: mockOwner.id, value: await encryptCbc(secretB) })
+
+        await reencryptAllSecrets(mockLog)
+
+        const rowA = await db.findOneByOrFail<{ value: EncryptedObject }>('app_connection', { id: idA })
+        const rowB = await db.findOneByOrFail<{ value: EncryptedObject }>('app_connection', { id: idB })
+
+        expect(rowA.value.authTag).toBeDefined()
+        expect(rowB.value.authTag).toBeDefined()
+        expect(Buffer.from(rowA.value.iv, 'hex')).toHaveLength(12)
+        expect(await encryptUtils.decryptString(rowA.value)).toBe(secretA)
+        expect(await encryptUtils.decryptString(rowB.value)).toBe(secretB)
+    })
+
+    it('leaves already-GCM blobs untouched (conditional predicate skips them)', async () => {
+        const { mockPlatform, mockProject, mockOwner } = await mockAndSaveBasicSetup()
+
+        const gcmValue = await encryptUtils.encryptString('already-gcm-secret')
+        const id = await seedConnection({ platformId: mockPlatform.id, projectId: mockProject.id, ownerId: mockOwner.id, value: gcmValue })
+
+        await reencryptAllSecrets(mockLog)
+
+        const row = await db.findOneByOrFail<{ value: EncryptedObject }>('app_connection', { id })
+        expect(row.value).toEqual(gcmValue)
+    })
+})

--- a/packages/server/api/test/unit/app/helper/encryption.test.ts
+++ b/packages/server/api/test/unit/app/helper/encryption.test.ts
@@ -1,0 +1,61 @@
+import * as crypto from 'crypto'
+import { encryptUtils, EncryptedObject } from '../../../../src/app/helper/encryption'
+
+process.env.AP_ENCRYPTION_KEY = '0123456789abcdef0123456789abcdef'
+
+const KEY = Buffer.from(process.env.AP_ENCRYPTION_KEY, 'binary')
+
+function encryptGcm(plaintext: string): EncryptedObject {
+    const iv = crypto.randomBytes(12)
+    const cipher = crypto.createCipheriv('aes-256-gcm', KEY, iv)
+    let data = cipher.update(plaintext, 'utf8', 'hex')
+    data += cipher.final('hex')
+    return { iv: iv.toString('hex'), data, authTag: cipher.getAuthTag().toString('hex') }
+}
+
+describe('encryptUtils', () => {
+    it('accepts an optional authTag in the schema', () => {
+        expect(EncryptedObject.safeParse({ iv: 'aa', data: 'bb' }).success).toBe(true)
+        expect(EncryptedObject.safeParse({ iv: 'aa', data: 'bb', authTag: 'cc' }).success).toBe(true)
+    })
+
+    it('writes GCM (string) and round-trips it', async () => {
+        const encrypted = await encryptUtils.encryptString('hello world')
+        expect(encrypted.authTag).toBeDefined()
+        expect(Buffer.from(encrypted.iv, 'hex')).toHaveLength(12)
+        expect(await encryptUtils.decryptString(encrypted)).toBe('hello world')
+    })
+
+    it('writes GCM (object) and round-trips it', async () => {
+        const value = { token: 'secret', nested: { n: 1 } }
+        const encrypted = await encryptUtils.encryptObject(value)
+        expect(encrypted.authTag).toBeDefined()
+        expect(await encryptUtils.decryptObject(encrypted)).toEqual(value)
+    })
+
+    it('decrypts a GCM blob (string)', async () => {
+        const encrypted = encryptGcm('gcm-secret')
+        expect(await encryptUtils.decryptString(encrypted)).toBe('gcm-secret')
+    })
+
+    it('decrypts a GCM blob (object)', async () => {
+        const value = { apiKey: 'k', scopes: ['a', 'b'] }
+        const encrypted = encryptGcm(JSON.stringify(value))
+        expect(await encryptUtils.decryptObject(encrypted)).toEqual(value)
+    })
+
+    it('rejects a tampered GCM ciphertext (auth tag mismatch)', async () => {
+        const encrypted = encryptGcm('gcm-secret')
+        const tampered = { ...encrypted, data: encrypted.data.replace(/.$/, (c) => (c === '0' ? '1' : '0')) }
+        await expect(encryptUtils.decryptString(tampered)).rejects.toThrow()
+    })
+
+    it('decrypts a legacy CBC blob (no authTag)', async () => {
+        const iv = crypto.randomBytes(16)
+        const cipher = crypto.createCipheriv('aes-256-cbc', KEY, iv)
+        let data = cipher.update('legacy-cbc', 'utf8', 'hex')
+        data += cipher.final('hex')
+        const fixture: EncryptedObject = { iv: iv.toString('hex'), data }
+        expect(await encryptUtils.decryptString(fixture)).toBe('legacy-cbc')
+    })
+})


### PR DESCRIPTION
## What

Moves at-rest secret encryption from **AES-256-CBC** (confidentiality only, no auth tag) to authenticated **AES-256-GCM**, through the single `encryptUtils` chokepoint. Algorithm-only migration — the 32-char `AP_ENCRYPTION_KEY` is unchanged, no new env var, self-hosting stays zero-setup.

Secrets covered: app-connection credentials, project variables, AI provider/tool keys, EE OAuth-app secrets, secret-manager configs, and the OIDC signing key.

## How

`EncryptedObject` becomes `{ iv, data, authTag? }`. **Presence of `authTag` is the format discriminator** — absent ⇒ legacy CBC, present ⇒ GCM. No version field, no keyId, no keyring.

This PR combines the first two of a three-release rollout:

- **Release 1 (expand)** — `decrypt*` gains a GCM read branch (`isNil(authTag)`); `encryptString` still writes CBC. Dormant reader, fully rollback-safe.
- **Release 2 (migrate)** — `encryptString` flips to GCM (12-byte IV + auth tag). A new `SystemJobName.REENCRYPT_SECRETS` background job re-encrypts legacy CBC blobs in place: keyset-paginated on the PK, paced (200 rows / 200 ms), single-runner via `distributedLock`, restart-safe, idempotent (re-enqueued each boot, dedup by `jobId`). It covers all seven blob locations across every edition (EE tables skipped via `42P01` when absent); `flag` is restricted to the OIDC key row.

**Migration safety:** write-back is conditional on the **exact CBC blob read** (`col::jsonb = $3::jsonb`), not merely `authTag IS NULL` — so a concurrent re-auth (including a CBC write from a not-yet-upgraded instance during rollout) is never clobbered; such a row is simply swept later.

## ⚠️ Deploy ordering (load-bearing)

There is **no plaintext fallback** — an instance that can't read a blob loses that secret. So **Release 1's reader must reach 100% of the fleet before Release 2's GCM writes begin**. Since this PR contains both, sequence the deploy accordingly (or a not-yet-upgraded instance will hit an unreadable GCM blob, and the write-flip becomes irreversible). Rationale in [ADR 0007](docs/adr/0007-encryption-at-rest-migrated-cbc-to-gcm.md).

**Release 3 (contract, later):** delete the CBC branch, make `authTag` required, remove the sweep — once `authTag IS NULL` counts are zero fleet-wide for a full release cycle.

## Verification

- `tsc` (production source): 0 errors · `turbo lint --filter=api`: 0 errors
- Unit `encryption.test.ts`: 7/7 — GCM round-trip, tamper rejection, legacy CBC read
- Integration `reencrypt-secrets.test.ts` (real Postgres): 2/2 — CBC→GCM preserves plaintext (12-byte IV), already-GCM rows untouched

Docs: [ADR 0007](docs/adr/0007-encryption-at-rest-migrated-cbc-to-gcm.md) + feature registry `.agents/features/secret-encryption.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)