### PR TITLE
fix(worker): version flow bundles so stale piece lists self-heal

### DIFF
--- a/packages/server/sandbox/src/lib/cache/flow/flow-bundle-store.ts
+++ b/packages/server/sandbox/src/lib/cache/flow/flow-bundle-store.ts
@@ -9,6 +9,10 @@ import { codeCache } from './code/code-cache'
 import { flowSteps } from './flow-steps'
 
 const MISS = ''
+// Bump when the SET of pieces we resolve into a bundle changes for a reason the flow's schemaVersion does
+// not capture (e.g. #13798 started including agent-tool pieces). Bundles built before the bump lack the
+// field, so parseManifest rejects them and they rebuild on next run — schemaVersion alone can't catch this.
+const FLOW_BUNDLE_FORMAT_VERSION = 2
 
 export const flowBundleStore = (log: ApLogger, apiClient: WorkerToApiContract, basePath: string) => ({
     async tryFetch({ flowVersionId, projectId }: TryFetchParams): Promise<MaterializedFlowBundle | null> {
@@ -55,7 +59,7 @@ export const flowBundleStore = (log: ApLogger, apiClient: WorkerToApiContract, b
             stepName,
             compiledJs: await codes.readCompiledStep({ flowVersionId: flowVersion.id, stepName }),
         })))
-        const manifest: FlowBundleManifest = { flowVersion, pieces, codes: compiledSteps }
+        const manifest: FlowBundleManifest = { flowVersion, pieces, codes: compiledSteps, bundleFormatVersion: FLOW_BUNDLE_FORMAT_VERSION }
         const data = Buffer.from(JSON.stringify(manifest), 'utf8')
         const prepared = await apiClient.prepareFlowBundleUpload({
             flowVersionId: flowVersion.id,
@@ -98,7 +102,7 @@ function parseManifest(value: string | null): FlowBundleManifest | null {
         return null
     }
     const { data: manifest } = tryCatchSync(() => JSON.parse(value) as FlowBundleManifest)
-    if (isNil(manifest) || manifest.flowVersion?.schemaVersion !== LATEST_FLOW_SCHEMA_VERSION) {
+    if (isNil(manifest) || manifest.flowVersion?.schemaVersion !== LATEST_FLOW_SCHEMA_VERSION || manifest.bundleFormatVersion !== FLOW_BUNDLE_FORMAT_VERSION) {
         return null
     }
     return manifest
@@ -130,6 +134,7 @@ type FlowBundleManifest = {
     flowVersion: FlowVersion
     pieces: PiecePackage[]
     codes: CompiledCodeStep[]
+    bundleFormatVersion: number
 }
 
 type CompiledCodeStep = {

--- a/packages/server/sandbox/test/lib/cache/flow/flow-bundle-store.test.ts
+++ b/packages/server/sandbox/test/lib/cache/flow/flow-bundle-store.test.ts
@@ -172,7 +172,7 @@ describe('flowBundleStore', () => {
     it('tryFetch downloads from a signed URL and materializes compiled code', async () => {
         const basePath = uniqueBasePath()
         const flowVersion = buildFlowVersion()
-        const manifest = { flowVersion, pieces: [piece], codes: [{ stepName: 'step_1', compiledJs: 'exports.code = () => 1' }] }
+        const manifest = { flowVersion, pieces: [piece], codes: [{ stepName: 'step_1', compiledJs: 'exports.code = () => 1' }], bundleFormatVersion: 2 }
         vi.mocked(bundleHttp.getBuffer).mockResolvedValue(Buffer.from(JSON.stringify(manifest), 'utf8'))
         const apiClient = {
             getFlowBundle: vi.fn(async () => ({ kind: 'url', url: 'https://s3/get' })),
@@ -184,6 +184,22 @@ describe('flowBundleStore', () => {
         expect(bundleHttp.getBuffer).toHaveBeenCalledWith('https://s3/get')
         const fetchedCodes = codeCache(cacheUtils(basePath).getGlobalCodeCachePath())
         expect(await fetchedCodes.readCompiledStep({ flowVersionId: flowVersion.id, stepName: 'step_1' })).toBe('exports.code = () => 1')
+    })
+
+    it('tryFetch ignores a bundle with an outdated bundleFormatVersion (self-heals via rebuild)', async () => {
+        const basePath = uniqueBasePath()
+        const flowVersion = buildFlowVersion()
+        // Pre-#13798-era manifest: current schemaVersion but no bundleFormatVersion (its piece list may omit
+        // agent-tool pieces). Must be rejected so the run falls back to a fresh resolve.
+        const staleManifest = { flowVersion, pieces: [piece], codes: [{ stepName: 'step_1', compiledJs: 'exports.code = () => 1' }] }
+        vi.mocked(bundleHttp.getBuffer).mockResolvedValue(Buffer.from(JSON.stringify(staleManifest), 'utf8'))
+        const apiClient = {
+            getFlowBundle: vi.fn(async () => ({ kind: 'url', url: 'https://s3/get' })),
+        } as unknown as WorkerToApiContract
+
+        const fetched = await flowBundleStore(fakeLog, apiClient, basePath).tryFetch({ flowVersionId: flowVersion.id, projectId: 'p1' })
+
+        expect(fetched).toBeNull()
     })
 
     it('tryFetch returns null and does not cache when the signed-URL download fails (retries next run)', async () => {


### PR DESCRIPTION
## Problem

Flow bundles (the materialized `flowVersion` + `pieces` + compiled code cached per flow version) are invalidated **only** when the flow's `schemaVersion` changes (`parseManifest` in `flow-bundle-store.ts`). But the *set of pieces* resolved into a bundle can change for reasons `schemaVersion` doesn't capture — most notably #13798, which started provisioning **agent-tool pieces** (`extractAgentToolPieceRefs`).

A bundle published *before* such a change keeps serving its stale piece list indefinitely: the fast path returns it and skips `resolvePieces` entirely, so the newly-required piece is never installed. At runtime the engine can't find it → `PieceNotFoundError` → `INTERNAL_ERROR` (pages oncall).

This actually happened: a flow's bundle published **2026-06-26** (4 days before #13798) omitted its `@activepieces/piece-brave-search` agent tool; every scheduled run failed until the flow was manually re-published. The bundle was still considered valid because `schemaVersion` hadn't changed.

## Fix

Add a `bundleFormatVersion` to the manifest and validate it in `parseManifest` alongside `schemaVersion`. Bumping the constant invalidates every previously-published bundle (they lack the field → rejected → `MISS` → rebuilt from a fresh resolve on next run, which now includes agent-tool pieces). Set to `2` to flush the agent-tool-less bundles.

This is the general lever the cache was missing: **whenever piece-resolution logic changes, bump `FLOW_BUNDLE_FORMAT_VERSION`** and all stale bundles self-heal — no per-flow intervention.

## Tests

- Existing signed-URL fetch test updated to a current-format manifest.
- New test: a manifest with current `schemaVersion` but **no** `bundleFormatVersion` (pre-#13798 shape) is ignored → `tryFetch` returns null → rebuild.

Found while categorizing the `INTERNAL_ERROR` backlog on cloud (the brave-search agent-tool `PieceNotFoundError`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)