### PR TITLE
ci: enforce breaking-change & security declaration on PRs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,17 +1,29 @@
-## What does this PR do?
+## Description
 
-<!-- We need a clear description of what the PR does, as this will be used for the marketing team to generate the release notes. -->
+<!-- A clear description of what this PR does — this is used by the marketing team to generate release notes. -->
+<!-- Add sub-sections as needed, e.g. the issue it solves, how it works, relevant user scenarios, or a short screen recording. -->
 
 
-### Explain How the Feature Works
-<!-- Adding a video demonstration is optional but encourged! It helps reviewers / marketing team understand your implementation better. -->
-<!-- [Insert the video link here] -->
 
-### Relevant User Scenarios
+## How was this tested?
 
-<!-- List specific use cases where this feature would be valuable. -->
-<!-- [Insert Pylon tickets or community posts here if possible] -->
+<!-- How did you verify the change: manual steps, automated tests, and which edition paths (CE / EE / Cloud) you checked. -->
 
 
 
 Fixes # (issue)
+
+### Breaking change?  (required — CI fails if this is left unedited)
+
+<!-- Tick exactly one box. If either "yes", apply the "⛓️‍💥 breaking-change" label AND add an entry to docs/install/reference/breaking-changes.mdx (what changed + the action self-hosters must take). -->
+
+- [ ] no — reviewed, not breaking
+- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
+- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)
+
+### Security impact?  (required — CI fails if this is left unedited)
+
+<!-- Tick exactly one box. "Security-sensitive" = touches authentication, secrets, permissions/roles, cryptography, SSRF / outbound HTTP, or file handling. -->
+
+- [ ] no — reviewed, no security impact
+- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -33,5 +33,7 @@ template: |
 
   $CHANGES
 
+  > 📌 **Upgrading a self-hosted instance?** Review the [Breaking Changes](https://www.activepieces.com/docs/install/reference/breaking-changes) page for any actions required before you upgrade.
+
   ## Thanks ❤️
   $CONTRIBUTORS

--- a/.github/workflows/breaking-change-check.yml
+++ b/.github/workflows/breaking-change-check.yml
@@ -1,0 +1,29 @@
+name: Breaking change check
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, labeled, unlabeled]
+
+permissions:
+  contents: read
+
+jobs:
+  breaking-change-check:
+    name: Breaking change check
+    runs-on: ubuntu-latest
+    if: github.repository == 'activepieces/activepieces'
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Check breaking-change declaration
+        env:
+          GITHUB_BASE_REF: ${{ github.event.pull_request.base.ref }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+          PR_LABELS: ${{ toJSON(github.event.pull_request.labels.*.name) }}
+        run: bun tools/scripts/breaking-change-check.ts

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,6 +95,10 @@ When running in `--mode=cloud`, do not use OAuth2 connections — the OAuth prov
 - If the PR includes any contributions to pieces (integrations under `packages/pieces`), also add the appropriate pieces label (in addition to the primary label above):
   - **`🧩 area/third-party-pieces`** — for third-party integrations (most pieces under `packages/pieces/community/`)
   - **`🧩 area/core-pieces`** — for core pieces (under `packages/pieces/core/`)
+- **Always fill the "Breaking change?" section of the PR template** — tick exactly one box (the `breaking-change-check` CI job fails if it is left unedited). A change is breaking if a self-hoster or API consumer must take action: removed/renamed API fields or endpoints, dropped columns, new required fields, removed/required env vars, or default/limit/behaviour changes. If it is breaking:
+  - also apply the **`⛓️‍💥 breaking-change`** label (in addition to the primary label above), and
+  - add an entry to `docs/install/reference/breaking-changes.mdx` describing what changed and the action required. CI enforces that the label and the docs entry travel together.
+- **Non-rollbackable migrations are a separate axis** from customer-facing breaking changes: a migration that runs destructive DDL (`DROP TABLE`/`DROP COLUMN`, `ADD ... NOT NULL` without `DEFAULT`, etc.) must set `breaking = true` on the migration class — this is the rollback-safety flag (used by `rollback-migrations.ts` and the release rollback note), enforced by `check-migration-rollback.ts`. It does **not** by itself require the `⛓️‍💥 breaking-change` label; decide that from the upgrade-impact question above.
 
 ## Database Migrations
 

--- a/tools/scripts/breaking-change-check.ts
+++ b/tools/scripts/breaking-change-check.ts
@@ -28,16 +28,19 @@ function sectionChoice({ body, heading }: { body: string, heading: RegExp }): Te
     return checked[0] === 'yes' ? 'yes' : 'no'
 }
 
-function addedLinesFor({ baseRef, file }: { baseRef: string, file: string }): number {
-    const output = execSync(
-        `git diff --numstat origin/${baseRef}...HEAD -- ${file}`,
+// Counts added lines with real content — a blank line or an HTML comment must not
+// satisfy the "documented the breaking change" requirement.
+function addedContentLines({ baseRef, file }: { baseRef: string, file: string }): number {
+    const diff = execSync(
+        `git diff origin/${baseRef}...HEAD -- ${file}`,
         { encoding: 'utf-8' },
-    ).trim()
-    if (!output) {
-        return 0
-    }
-    const added = parseInt(output.split('\n')[0].split('\t')[0], 10)
-    return Number.isNaN(added) ? 0 : added
+    )
+    return diff
+        .split('\n')
+        .filter((line) => line.startsWith('+') && !line.startsWith('+++'))
+        .map((line) => line.slice(1).trim())
+        .filter((line) => line.length > 0 && !line.startsWith('<!--'))
+        .length
 }
 
 function main(): void {
@@ -48,7 +51,7 @@ function main(): void {
     const hasBreakingLabel = labels.includes(BREAKING_LABEL)
     const templateChoice = sectionChoice({ body, heading: /^#{2,3}\s*Breaking change\?/im })
     const securityChoice = sectionChoice({ body, heading: /^#{2,3}\s*Security impact\?/im })
-    const docAdded = addedLinesFor({ baseRef, file: BREAKING_CHANGES_DOC }) > 0
+    const docAdded = addedContentLines({ baseRef, file: BREAKING_CHANGES_DOC }) > 0
 
     const errors: string[] = []
 

--- a/tools/scripts/breaking-change-check.ts
+++ b/tools/scripts/breaking-change-check.ts
@@ -1,3 +1,4 @@
+import assert from 'assert'
 import { execSync } from 'child_process'
 
 const BREAKING_LABEL = '⛓️‍💥 breaking-change'
@@ -28,9 +29,9 @@ function sectionChoice({ body, heading }: { body: string, heading: RegExp }): Te
     return checked[0] === 'yes' ? 'yes' : 'no'
 }
 
-// Counts added lines with real content — a blank line or an HTML comment must not
-// satisfy the "documented the breaking change" requirement.
-function addedContentLines({ baseRef, file }: { baseRef: string, file: string }): number {
+// The PR's added lines in `file`, stripped and cleared of blanks and HTML comments —
+// neither may satisfy the "documented the breaking change" requirement.
+function addedDocLines({ baseRef, file }: { baseRef: string, file: string }): string[] {
     const diff = execSync(
         `git diff origin/${baseRef}...HEAD -- ${file}`,
         { encoding: 'utf-8' },
@@ -40,7 +41,16 @@ function addedContentLines({ baseRef, file }: { baseRef: string, file: string })
         .filter((line) => line.startsWith('+') && !line.startsWith('+++'))
         .map((line) => line.slice(1).trim())
         .filter((line) => line.length > 0 && !line.startsWith('<!--'))
-        .length
+}
+
+// A real entry has the shape the doc uses: a `####` heading naming what changed, plus
+// at least one line of description/action beneath it. A bare heading, a `---` separator,
+// a version bump, or a stray sentence on its own is not an entry — so a labelled PR
+// cannot pass the docs gate by adding generic content.
+function hasBreakingEntry(added: string[]): boolean {
+    const hasTitle = added.some((line) => /^#{4}\s+\S/.test(line))
+    const hasBody = added.some((line) => !/^#{1,6}\s/.test(line) && !/^[-*_]{3,}$/.test(line))
+    return hasTitle && hasBody
 }
 
 function main(): void {
@@ -51,7 +61,7 @@ function main(): void {
     const hasBreakingLabel = labels.includes(BREAKING_LABEL)
     const templateChoice = sectionChoice({ body, heading: /^#{2,3}\s*Breaking change\?/im })
     const securityChoice = sectionChoice({ body, heading: /^#{2,3}\s*Security impact\?/im })
-    const docAdded = addedContentLines({ baseRef, file: BREAKING_CHANGES_DOC }) > 0
+    const docAdded = hasBreakingEntry(addedDocLines({ baseRef, file: BREAKING_CHANGES_DOC }))
 
     const errors: string[] = []
 
@@ -97,4 +107,18 @@ function main(): void {
     console.log('✅ Breaking-change check passed.')
 }
 
-main()
+function runSelfCheck(): void {
+    assert(hasBreakingEntry(['#### AP_FOO removed', 'It is gone — remove it from your env.']) === true, 'titled entry with a body is a real entry')
+    assert(hasBreakingEntry(['#### AP_FOO removed']) === false, 'a bare heading with no body is not an entry')
+    assert(hasBreakingEntry(['---']) === false, 'a separator is not an entry')
+    assert(hasBreakingEntry(['## 0.87.0', 'Set AP_FOO is gone.']) === false, 'a version bump without a #### title is not an entry')
+    assert(hasBreakingEntry(['Just a stray sentence.']) === false, 'placeholder prose without a title is not an entry')
+    console.log('breaking-change-check self-check passed')
+}
+
+if (process.argv.includes('--self-check')) {
+    runSelfCheck()
+}
+else {
+    main()
+}

--- a/tools/scripts/breaking-change-check.ts
+++ b/tools/scripts/breaking-change-check.ts
@@ -1,0 +1,97 @@
+import { execSync } from 'child_process'
+
+const BREAKING_LABEL = '⛓️‍💥 breaking-change'
+const BREAKING_CHANGES_DOC = 'docs/install/reference/breaking-changes.mdx'
+
+type TemplateChoice = 'yes' | 'no' | 'unset' | 'multiple'
+
+// Both the "Breaking change?" and "Security impact?" sections use no/yes checkboxes,
+// so each section is parsed in isolation — a global scan would conflate the two.
+function sectionChoice({ body, heading }: { body: string, heading: RegExp }): TemplateChoice {
+    const match = heading.exec(body)
+    if (!match) {
+        return 'unset'
+    }
+    const rest = body.slice(match.index + match[0].length)
+    const nextHeading = rest.search(/^\s{0,3}#{2,3}\s/m)
+    const section = nextHeading === -1 ? rest : rest.slice(0, nextHeading)
+
+    const checked = [...section.matchAll(/^\s*-\s*\[([ xX])\]\s*(no|yes)\b/gim)]
+        .filter((box) => box[1].toLowerCase() === 'x')
+        .map((box) => box[2].toLowerCase())
+    if (checked.length === 0) {
+        return 'unset'
+    }
+    if (checked.length > 1) {
+        return 'multiple'
+    }
+    return checked[0] === 'yes' ? 'yes' : 'no'
+}
+
+function addedLinesFor({ baseRef, file }: { baseRef: string, file: string }): number {
+    const output = execSync(
+        `git diff --numstat origin/${baseRef}...HEAD -- ${file}`,
+        { encoding: 'utf-8' },
+    ).trim()
+    if (!output) {
+        return 0
+    }
+    const added = parseInt(output.split('\n')[0].split('\t')[0], 10)
+    return Number.isNaN(added) ? 0 : added
+}
+
+function main(): void {
+    const baseRef = process.env.BASE_REF ?? process.env.GITHUB_BASE_REF ?? 'main'
+    const body = process.env.PR_BODY ?? ''
+    const labels: string[] = JSON.parse(process.env.PR_LABELS ?? '[]')
+
+    const hasBreakingLabel = labels.includes(BREAKING_LABEL)
+    const templateChoice = sectionChoice({ body, heading: /^#{2,3}\s*Breaking change\?/im })
+    const securityChoice = sectionChoice({ body, heading: /^#{2,3}\s*Security impact\?/im })
+    const docAdded = addedLinesFor({ baseRef, file: BREAKING_CHANGES_DOC }) > 0
+
+    const errors: string[] = []
+
+    // R1 — the author must make an explicit breaking-change choice in the PR template.
+    if (templateChoice === 'unset') {
+        errors.push('The "Breaking change?" section in the PR description is not filled in — tick exactly one box (no / yes-technical / yes-functional).')
+    }
+    else if (templateChoice === 'multiple') {
+        errors.push('The "Breaking change?" section has more than one box ticked — tick exactly one.')
+    }
+
+    // R2 — the author must explicitly declare security impact (declaration only, no label coupling).
+    if (securityChoice === 'unset') {
+        errors.push('The "Security impact?" section in the PR description is not filled in — tick exactly one box (no / yes-security-sensitive).')
+    }
+    else if (securityChoice === 'multiple') {
+        errors.push('The "Security impact?" section has more than one box ticked — tick exactly one.')
+    }
+
+    // R3 — the breaking label, the template answer, and the docs entry must agree.
+    if (hasBreakingLabel && !docAdded) {
+        errors.push(`PR carries the "${BREAKING_LABEL}" label but adds no entry to ${BREAKING_CHANGES_DOC}. Document the change (what changed + required action) so it reaches self-hosters.`)
+    }
+    if (docAdded && !hasBreakingLabel) {
+        errors.push(`PR adds an entry to ${BREAKING_CHANGES_DOC} but is missing the "${BREAKING_LABEL}" label. Apply the label so it lands in the release notes.`)
+    }
+    if (templateChoice === 'yes' && !hasBreakingLabel) {
+        errors.push(`The PR template declares a breaking change but the "${BREAKING_LABEL}" label is missing. Apply it.`)
+    }
+    if (templateChoice === 'no' && hasBreakingLabel) {
+        errors.push(`The PR template declares "not breaking" but carries the "${BREAKING_LABEL}" label — reconcile the two.`)
+    }
+
+    if (errors.length > 0) {
+        console.error('❌ Breaking-change check failed:\n')
+        for (const error of errors) {
+            console.error(`   - ${error}`)
+        }
+        console.error('\nSee docs/install/reference/breaking-changes.mdx and the PR template for guidance.')
+        process.exit(1)
+    }
+
+    console.log('✅ Breaking-change check passed.')
+}
+
+main()

--- a/tools/scripts/breaking-change-scanners/migration-ddl.ts
+++ b/tools/scripts/breaking-change-scanners/migration-ddl.ts
@@ -1,6 +1,18 @@
 import assert from 'assert'
 import { readFileSync } from 'fs'
 
+// A single ALTER TABLE literal can add several columns, each with its own NOT NULL /
+// DEFAULT. Check each `ADD ...` clause on its own — a DEFAULT on one column must not
+// mask a NOT-NULL-without-DEFAULT on another (`ADD "a" bool NOT NULL DEFAULT false,
+// ADD "b" text NOT NULL` is unsafe because of "b").
+function hasUnsafeNotNullAdd(sql: string): boolean {
+    return sql
+        .split(/\bADD\b/i)
+        .slice(1)
+        .map((clause) => clause.split(';')[0])
+        .some((clause) => /\bNOT\s+NULL\b/i.test(clause) && !/\bDEFAULT\b/i.test(clause))
+}
+
 // Rules run against the up() SQL only. down() commonly contains the inverse of a
 // safe change (a DROP INDEX undoing a CREATE INDEX, a CREATE TABLE undoing a DROP)
 // which is not itself a breaking change — scanning it would produce false positives.
@@ -11,7 +23,7 @@ const DESTRUCTIVE_RULES: { label: string, test: (sql: string) => boolean }[] = [
     { label: 'DROP COLUMN', test: (sql) => /\bDROP\s+COLUMN\b/i.test(sql) },
     { label: 'DROP CONSTRAINT', test: (sql) => /\bDROP\s+CONSTRAINT\b/i.test(sql) },
     { label: 'ALTER COLUMN ... TYPE', test: (sql) => /\bALTER\s+COLUMN\b[\s\S]*?\bTYPE\b/i.test(sql) },
-    { label: 'ADD ... NOT NULL without DEFAULT', test: (sql) => /\bADD\b[\s\S]*?\bNOT\s+NULL\b/i.test(sql) && !/\bDEFAULT\b/i.test(sql) },
+    { label: 'ADD ... NOT NULL without DEFAULT', test: hasUnsafeNotNullAdd },
 ]
 
 function extractSqlLiterals(source: string): string[] {
@@ -48,6 +60,11 @@ function runSelfCheck(): void {
     assert(destructive.breaking === true, 'expected DropBadges to declare breaking = true')
     assert(additive.destructive === false, `expected additive index migration to be non-destructive, got ${JSON.stringify(additive.ddl)}`)
     assert(additive.breaking === false, 'expected additive index migration to declare breaking = false')
+
+    assert(hasUnsafeNotNullAdd('ADD COLUMN "a" text NOT NULL') === true, 'single NOT NULL without DEFAULT is unsafe')
+    assert(hasUnsafeNotNullAdd('ADD COLUMN "a" boolean NOT NULL DEFAULT false') === false, 'NOT NULL with DEFAULT is safe')
+    assert(hasUnsafeNotNullAdd('ADD COLUMN "a" boolean NOT NULL DEFAULT false, ADD COLUMN "b" text NOT NULL') === true, 'multi-column: a DEFAULT on one column must not mask NOT-NULL-without-DEFAULT on another')
+    assert(hasUnsafeNotNullAdd('ADD COLUMN "a" text') === false, 'nullable ADD is safe')
 
     console.log('migration-ddl self-check passed')
 }

--- a/tools/scripts/breaking-change-scanners/migration-ddl.ts
+++ b/tools/scripts/breaking-change-scanners/migration-ddl.ts
@@ -1,0 +1,80 @@
+import assert from 'assert'
+import { readFileSync } from 'fs'
+
+// Rules run against the up() SQL only. down() commonly contains the inverse of a
+// safe change (a DROP INDEX undoing a CREATE INDEX, a CREATE TABLE undoing a DROP)
+// which is not itself a breaking change — scanning it would produce false positives.
+// Dropping an index is intentionally NOT listed: it is a performance concern, not a
+// data/schema-contract break.
+const DESTRUCTIVE_RULES: { label: string, test: (sql: string) => boolean }[] = [
+    { label: 'DROP TABLE', test: (sql) => /\bDROP\s+TABLE\b/i.test(sql) },
+    { label: 'DROP COLUMN', test: (sql) => /\bDROP\s+COLUMN\b/i.test(sql) },
+    { label: 'DROP CONSTRAINT', test: (sql) => /\bDROP\s+CONSTRAINT\b/i.test(sql) },
+    { label: 'ALTER COLUMN ... TYPE', test: (sql) => /\bALTER\s+COLUMN\b[\s\S]*?\bTYPE\b/i.test(sql) },
+    { label: 'ADD ... NOT NULL without DEFAULT', test: (sql) => /\bADD\b[\s\S]*?\bNOT\s+NULL\b/i.test(sql) && !/\bDEFAULT\b/i.test(sql) },
+]
+
+function extractSqlLiterals(source: string): string[] {
+    const backtick = source.match(/`[\s\S]*?`/g) ?? []
+    const single = source.match(/'(?:[^'\\]|\\.)*'/g) ?? []
+    return [...backtick, ...single]
+}
+
+function extractUpSql(source: string): string[] {
+    const upStart = source.search(/\b(public\s+)?async\s+up\s*\(/)
+    if (upStart === -1) {
+        return []
+    }
+    const rest = source.slice(upStart)
+    const downRel = rest.search(/\b(public\s+)?async\s+down\s*\(/)
+    const upBody = downRel === -1 ? rest : rest.slice(0, downRel)
+    return extractSqlLiterals(upBody)
+}
+
+function readBreakingFlag(source: string): boolean | undefined {
+    const match = source.match(/\bbreaking\s*=\s*(true|false)\b/)
+    if (!match) {
+        return undefined
+    }
+    return match[1] === 'true'
+}
+
+function runSelfCheck(): void {
+    const destructiveFile = 'packages/server/api/src/app/database/migration/postgres/1804000000000-DropBadges.ts'
+    const additiveFile = 'packages/server/api/src/app/database/migration/postgres/1807000000000-AddChatConversationStreamingUpdatedIndex.ts'
+    const [destructive, additive] = scanMigrations({ files: [destructiveFile, additiveFile] })
+
+    assert(destructive.destructive === true, `expected DropBadges up() to be destructive, got ${JSON.stringify(destructive.ddl)}`)
+    assert(destructive.breaking === true, 'expected DropBadges to declare breaking = true')
+    assert(additive.destructive === false, `expected additive index migration to be non-destructive, got ${JSON.stringify(additive.ddl)}`)
+    assert(additive.breaking === false, 'expected additive index migration to declare breaking = false')
+
+    console.log('migration-ddl self-check passed')
+}
+
+export function scanMigrations({ files }: { files: string[] }): MigrationScanResult[] {
+    return files.map((file) => {
+        const source = readFileSync(file, 'utf-8')
+        const sqlStatements = extractUpSql(source)
+        const ddl = DESTRUCTIVE_RULES
+            .filter((rule) => sqlStatements.some((sql) => rule.test(sql)))
+            .map((rule) => rule.label)
+        return {
+            file,
+            breaking: readBreakingFlag(source),
+            destructive: ddl.length > 0,
+            ddl,
+        }
+    })
+}
+
+if (process.argv[1]?.endsWith('migration-ddl.ts')) {
+    runSelfCheck()
+}
+
+export type MigrationScanResult = {
+    file: string
+    breaking: boolean | undefined
+    destructive: boolean
+    ddl: string[]
+}

--- a/tools/scripts/check-migration-rollback.ts
+++ b/tools/scripts/check-migration-rollback.ts
@@ -1,6 +1,7 @@
 import { execSync } from 'child_process'
 import semver from 'semver'
 import { Migration } from '../../packages/server/api/src/app/database/migration'
+import { scanMigrations } from './breaking-change-scanners/migration-ddl'
 
 const MIGRATION_DIRS = [
     'packages/server/api/src/app/database/migration/postgres',
@@ -55,6 +56,11 @@ async function checkMigrationFile(filePath: string): Promise<string[]> {
         }
     }
 
+    const [scan] = scanMigrations({ files: [filePath] })
+    if (scan.destructive && instance.breaking !== true) {
+        errors.push(`Runs destructive DDL (${scan.ddl.join(', ')}) but "breaking" is not true. Destructive migrations must set breaking = true.`)
+    }
+
     return errors
 }
 
@@ -91,6 +97,7 @@ async function main(): Promise<void> {
         console.error('  1. Set breaking = true or breaking = false')
         console.error("  2. Set release = '<semver>' (e.g. '0.78.0')")
         console.error('  3. Have a down() method (unless breaking = true)')
+        console.error('  4. Set breaking = true if they run destructive DDL (DROP TABLE/COLUMN, ADD NOT NULL without DEFAULT, etc.)')
         process.exit(1)
     }
 


### PR DESCRIPTION
## Description

Prevents unannounced breaking changes from merging without a signal, without burdening authors.

Two independent axes, each with its own check:

- **Customer-facing breaking change** (upgrade impact) — new `breaking-change-check` CI job + a required PR-template declaration. Enforces that the `⛓️‍💥 breaking-change` label, the template answer, and a `docs/install/reference/breaking-changes.mdx` entry all agree. Also adds a required, declaration-only **Security impact?** box.
- **Non-rollbackable migration** (downgrade safety) — `check-migration-rollback.ts` now also fails a new migration that runs destructive DDL (`DROP TABLE`/`DROP COLUMN`, `ADD ... NOT NULL` without `DEFAULT`, ...) without `breaking = true`.

The two axes are deliberately separate: `breaking = true` is the rollback-safety flag (e.g. `DropBadges` in 0.85.7 — non-rollbackable but not customer-breaking), which does **not** by itself require the customer label.

`tools/scripts/breaking-change-scanners/migration-ddl.ts` is the single source of truth for "is this migration destructive" (scans `up()` only). Also reworks the PR template with general **Description** / **How was this tested?** sections.

Linear: SRE-176

## How was this tested?

All scripts have zero external deps and run under `bun` (the CI runtime).

- **Scanner self-check** (`bun tools/scripts/breaking-change-scanners/migration-ddl.ts`): asserts `DropBadges` (`DROP TABLE`, `breaking=true`) is flagged destructive and an additive `CREATE INDEX` migration is not — scans `up()` only, so a `DROP INDEX` in `down()` does not false-positive.
- **breaking-change-check** driven with fixture env vars: unedited template → both declaration rules fail; >1 box ticked → fail; label without docs entry → fail; docs entry without label → fail; template/label mismatch → fail; both "no" with no label/docs → pass. Verified the two no/yes sections are parsed in isolation (breaking=yes + security=no read independently).
- **check-migration-rollback** run against real history: correctly flags `DropDataManipulationEnabledFromPlatformPlan` (`DROP COLUMN`, `breaking=false`) as destructive-without-breaking; runs clean on this branch (no added migrations).
- Actual PR template: unedited fails; one box ticked passes.
- `eslint --no-ignore` clean on all three scripts; workflow YAML validated.

Fully exercising the GitHub workflow end-to-end requires a live PR (this one).

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
