### PR TITLE
feat(files): stream ctx.files.write() to S3 without buffering the whole file

### DIFF
--- a/.agents/features/file-storage.md
+++ b/.agents/features/file-storage.md
@@ -95,7 +95,8 @@ Step file uploads are handled by the engine via the unified `PUT /v1/files/:file
 
 **s3Helper**
 - `constructS3Key(platformId, projectId, type, fileId)` — builds deterministic S3 key.
-- `uploadFile(s3Key, data)` — PutObject to S3.
+- `uploadFile(s3Key, data)` — PutObject to S3 (known-length Buffer).
+- `uploadStream(s3Key, body)` — streams a `Readable` to S3 via `@aws-sdk/lib-storage` `Upload` (unknown length, ~5MB parts); returns the byte count from `httpUploadProgress`.
 - `getFile(s3Key)` — GetObject from S3, returns Buffer.
 - `getS3SignedUrl(s3Key, fileName)` — generates a 7-day pre-signed GET URL.
 - `putS3SignedUrl({ s3Key, contentLength, contentEncoding })` — generates a 7-day pre-signed PUT URL.
@@ -105,6 +106,24 @@ Step file uploads are handled by the engine via the unified `PUT /v1/files/:file
 ## Cleanup Job
 
 Scheduled every hour (`30 */1 * * *`) via `SystemJobName.FILE_CLEANUP_TRIGGER`. Calls `fileService.deleteStaleBulk` for types: `FLOW_RUN_LOG`, `FLOW_STEP_FILE`, `TRIGGER_EVENT_FILE`, `TRIGGER_PAYLOAD`, `WEBHOOK_PAYLOAD`. Retention period controlled by `EXECUTION_DATA_RETENTION_DAYS` system property.
+
+## Streaming — write path (implemented)
+
+`ctx.files.write()` accepts a `Readable` as well as a `Buffer`, so a piece can write a file it never fully holds in RAM. See [ADR-0007](../../docs/adr/0007-streaming-files-use-presigned-multipart-not-app-relay.md).
+
+- **Piece API:** `FilesService.write({ fileName, data: Buffer | Readable })` (`@activepieces/pieces-framework` ≥ 0.34.0). A `Buffer` keeps the exact existing behaviour; a `Readable` streams.
+- **Transport — one path.** For a stream the engine (`engineFileApi.upload`) PUTs to `POST-less` `PUT /v1/files/:fileId` with **no `Content-Length`** (chunked, `duplex:'half'`, no retry — a stream can't replay). The app detects the stream by the **absence of `Content-Length`**, skips the presigned-redirect branch, and streams the body to storage:
+  - S3 → `s3Helper.uploadStream()` (`@aws-sdk/lib-storage` `Upload`, ~5 MB parts, bounded memory; size read from `httpUploadProgress`).
+  - DB → buffered into `bytea` (a stream can't stream into a column).
+- **Known-length `Buffer` writes are unchanged** — same `uploadFile` / `S3_USE_SIGNED_URLS` presigned-redirect paths.
+- **Size guard:** `filesController` streams the request through an `enforceByteLimit` transform (→ `MAX_FILE_SIZE_MB`), since a stream's length is unknown upfront.
+- **Content-type parser:** `filesController` replaces the global buffering `application/octet-stream` parser with an encapsulated passthrough (raw stream) so the PUT body isn't buffered — scoped to this plugin; other octet-stream consumers are untouched.
+- **New dependency:** `@aws-sdk/lib-storage`.
+
+### Deferred (not built)
+- **Property.file streaming (read side)** — a piece supplies its own `Readable`; a dedicated streaming file-input mode was judged YAGNI.
+- **Webhook streaming ingestion** — needs replacing the global buffering multipart handler with a streaming parser; not surgical, deferred.
+- **Presigned multipart** (bytes off the app on `S3_USE_SIGNED_URLS`) — rejected as over-engineering; see ADR-0007.
 
 ## System Properties
 

--- a/.agents/features/webhooks.md
+++ b/.agents/features/webhooks.md
@@ -71,6 +71,8 @@ The worker forwards the `JobPayload` straight into the `EXECUTE_TRIGGER_HOOK` en
 - Preserves `rawBody` for signature verification (non-binary only)
 - Extracts headers: `x-parent-run-id`, `x-fail-parent-on-failure` (for subflows)
 
+> **Streaming ingestion — deferred (not built):** An inbound webhook POST cannot be redirected to S3 (a third party already sent the body), so its bytes must transit the app; today Fastify's global buffering `onFile` + `s3Helper` fully buffer the file. Streaming it would require replacing the webhook plugin's encapsulated `multipart/form-data` + raw-binary parsers with streaming ones piping each part to S3 via `@aws-sdk/lib-storage`. This was deferred out of the streaming *write-path* work ([ADR-0007](../../docs/adr/0007-streaming-files-use-presigned-multipart-not-app-relay.md)) as not surgical. The `s3Helper.uploadStream()` helper it would reuse now exists.
+
 ## Handshake Verification
 
 External services verify webhook ownership before sending events:

--- a/docs/adr/0007-streaming-files-use-presigned-multipart-not-app-relay.md
+++ b/docs/adr/0007-streaming-files-use-presigned-multipart-not-app-relay.md
@@ -1,0 +1,29 @@
+---
+status: accepted
+---
+
+# Streaming file writes go through the app via lib-storage, one path
+
+`ctx.files.write()` accepts a `Readable` (not just a `Buffer`). When a piece writes a stream, the engine PUTs it to the app with **no `Content-Length`** (chunked), and the app streams it to storage with `@aws-sdk/lib-storage`'s `Upload` — S3 for S3-backed types, buffered into `bytea` for DB — so no process holds the whole file in RAM. There is **one** streaming path: through the app. The existing presigned single-PUT redirect (`S3_USE_SIGNED_URLS`) is retained unchanged for the known-length `Buffer` path.
+
+The non-obvious "why one path": a single S3 `PutObject` requires `Content-Length` and rejects chunked bodies, so an unknown-length stream can't use a presigned single PUT. The alternative that keeps unknown-length bytes off the app entirely is **presigned multipart** (engine orchestrates `CreateMultipartUpload` → per-part presigned `UploadPart` → `Complete`, buffering one part at a time). We **rejected** that: it is a new protocol — extra RPCs, an engine-side state machine, and orphaned-multipart cleanup — i.e. a second transport path and a new abstraction, for the marginal benefit of keeping bytes off the app on `S3_USE_SIGNED_URLS`-on deployments. `lib-storage` streams unknown-length data with bounded (~5 MB part) memory, aborts its own multipart upload on error, and reuses the S3 client the app already owns. One path, no new protocol.
+
+## Considered options
+
+- **Presigned multipart (bytes never touch the app).** Correct for keeping the scaling-sensitive app tier out of the byte path, but it is a whole new protocol + engine state machine + abort/cleanup surface. Rejected as over-engineering for the value; revisit only if app egress from large streamed writes measurably hurts.
+- **Give the sandbox raw S3 credentials.** Rejected: the sandbox runs arbitrary piece code; raw credentials would expose the whole bucket.
+- **Single presigned `PutObject` for streams.** Impossible — `PutObject` needs `Content-Length`.
+
+## Consequences
+
+- Streamed writes relay through the app, bounded to ~5 MB (lib-storage part size), not the full file. On `S3_USE_SIGNED_URLS`-on deployments this means streamed writes are *not* offloaded from the app the way known-length redirects are — an accepted trade for one code path.
+- Size is enforced app-side while streaming (`enforceByteLimit` transform on the request body → 413 on overflow), since the stream length is unknown upfront and the engine can't pre-check.
+- The redirect-vs-stream decision keys off **Content-Length absence** (chunked = stream), not a magic value.
+- Known-length `Buffer` writes are byte-for-byte unchanged (same `uploadFile` / presigned-redirect paths).
+- Adds `@aws-sdk/lib-storage`.
+
+## Deferred (not built)
+
+- **Property.file streaming (read side)** — a piece that needs a source stream can produce its own `Readable` (e.g. a streaming HTTP client) and pass it to `ctx.files.write`; a dedicated streaming file-input mode was judged YAGNI.
+- **Webhook streaming ingestion** — would require replacing the global buffering multipart handler with a streaming parser; deferred as not surgical.
+- **Presigned multipart** — see above.

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "@aws-sdk/client-bedrock": "3.1017.0",
     "@aws-sdk/client-s3": "3.974.0",
     "@aws-sdk/client-secrets-manager": "3.997.0",
+    "@aws-sdk/lib-storage": "3.974.0",
     "@aws-sdk/s3-request-presigner": "3.894.0",
     "@babel/runtime": "7.26.10",
     "@bull-board/api": "6.10.1",

--- a/packages/pieces/framework/package.json
+++ b/packages/pieces/framework/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/pieces-framework",
-  "version": "0.33.1",
+  "version": "0.34.0",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/packages/pieces/framework/src/lib/context/index.ts
+++ b/packages/pieces/framework/src/lib/context/index.ts
@@ -14,6 +14,7 @@ import {
 import type { SeekPage } from '@activepieces/core-utils';
 import type { FlowRunId, ProjectId } from '@activepieces/core-utils';
 import { LanguageModel, Tool } from 'ai'
+import type { Readable } from 'node:stream'
 
 import {
   BasicAuthProperty,
@@ -275,7 +276,7 @@ export interface FilesService {
     data,
   }: {
     fileName: string;
-    data: Buffer;
+    data: Buffer | Readable;
   }): Promise<string>;
 }
 

--- a/packages/server/api/package.json
+++ b/packages/server/api/package.json
@@ -23,6 +23,7 @@
     "@authenio/samlify-node-xmllint": "2.0.0",
     "@aws-sdk/client-bedrock": "3.1017.0",
     "@aws-sdk/client-s3": "3.974.0",
+    "@aws-sdk/lib-storage": "3.974.0",
     "@aws-sdk/s3-request-presigner": "3.894.0",
     "@bull-board/api": "6.10.1",
     "@bull-board/fastify": "6.10.1",

--- a/packages/server/api/src/app/file/file.service.ts
+++ b/packages/server/api/src/app/file/file.service.ts
@@ -1,3 +1,5 @@
+import { Readable } from 'node:stream'
+import { buffer as streamToBuffer } from 'node:stream/consumers'
 import { ActivepiecesError, apId, assertNotNullOrUndefined, ErrorCode, isMultipartFile, isNil, ProjectId } from '@activepieces/core-utils'
 import { File, FileCompression, FileId, FileLocation, FileType } from '@activepieces/shared'
 import dayjs from 'dayjs'
@@ -21,7 +23,7 @@ const EXECUTION_DATA_RETENTION_DAYS = system.getNumberOrThrow(AppSystemProp.EXEC
 
 type BaseFile = Pick<File, 'id' | 'projectId' | 'platformId' | 'type' | 'fileName' | 'compression' | 'size' | 'metadata' | 'created' | 'updated'>
 
-const saveFileToDb = async (baseFile: BaseFile, data: SaveParams['data']) => {
+const saveFileToDb = async (baseFile: BaseFile, data: Buffer | null) => {
     assertNotNullOrUndefined(data, 'data is required')
     return fileRepo().save({
         ...baseFile,
@@ -46,20 +48,24 @@ export const fileService = (log: FastifyBaseLogger) => ({
         const location = getLocationForFile(params.type)
         switch (location) {
             case FileLocation.DB: {
+                if (params.data instanceof Readable) {
+                    const data = await streamToBuffer(params.data)
+                    return saveFileToDb({ ...baseFile, size: data.length }, data)
+                }
                 return saveFileToDb(baseFile, params.data)
             }
             case FileLocation.S3: {
+                const s3Key = await s3Helper(log).constructS3Key(params.platformId, params.projectId, params.type, baseFile.id)
+                // A stream can be consumed once, so it has no S3-error DB fallback.
+                if (params.data instanceof Readable) {
+                    const size = await s3Helper(log).uploadStream(s3Key, params.data)
+                    return fileRepo().save({ ...baseFile, size, location: FileLocation.S3, s3Key })
+                }
                 try {
-                    const s3Key = await s3Helper(log).constructS3Key(params.platformId, params.projectId, params.type, baseFile.id)
                     if (!isNil(params.data)) {
                         await s3Helper(log).uploadFile(s3Key, params.data)
                     }
-                    const savedFile = await fileRepo().save({
-                        ...baseFile,
-                        location: FileLocation.S3,
-                        s3Key,
-                    })
-                    return savedFile
+                    return await fileRepo().save({ ...baseFile, location: FileLocation.S3, s3Key })
                 }
                 catch (error) {
                     exceptionHandler.handle(error, log)
@@ -334,8 +340,8 @@ function isExecutionDataFileThatExpires(type: FileType) {
 type SaveParams = {
     fileId?: FileId | undefined
     projectId?: ProjectId
-    data: Buffer | null
-    size: number
+    data: Buffer | Readable | null
+    size?: number
     type: FileType
     platformId?: string
     fileName?: string

--- a/packages/server/api/src/app/file/files-controller.ts
+++ b/packages/server/api/src/app/file/files-controller.ts
@@ -1,3 +1,4 @@
+import { Readable, Transform } from 'node:stream'
 import { ActivepiecesError, ApId, assertNotNullOrUndefined, ErrorCode, isNil } from '@activepieces/core-utils'
 import { ALL_PRINCIPAL_TYPES, EnginePrincipal, FileCompression, FileTransportQueryParams, FileType, Principal, PrincipalType } from '@activepieces/shared'
 import { FastifyPluginAsyncZod } from 'fastify-type-provider-zod'
@@ -5,12 +6,18 @@ import { StatusCodes } from 'http-status-codes'
 import { z } from 'zod'
 import { accessTokenManager } from '../authentication/lib/access-token-manager'
 import { securityAccess } from '../core/security/authorization/fastify-security'
+import { system } from '../helper/system/system'
 import { AppSystemProp } from '../helper/system/system-props'
 import { fileService } from './file.service'
 import { ENGINE_WRITABLE_FILE_TYPES, filesService, fileTransportHeaders } from './files-service'
 import { signedFileTransport } from './signed-file-transport'
 
 export const filesController: FastifyPluginAsyncZod = async (app) => {
+    // Keep the octet-stream body as a raw stream (scoped to this plugin) so uploads
+    // pipe straight to storage instead of buffering the whole file in memory.
+    app.removeContentTypeParser('application/octet-stream')
+    app.addContentTypeParser('application/octet-stream', (_request, payload, done) => done(null, payload))
+
     app.put('/:fileId', {
         config: {
             security: securityAccess.unscoped(ALL_PRINCIPAL_TYPES),
@@ -37,7 +44,9 @@ export const filesController: FastifyPluginAsyncZod = async (app) => {
             })
             void reply.header(fileTransportHeaders.READ_URL, readUrl)
 
-            if (!signedFileTransport.shouldRedirectForType(fileType)) {
+            // A presigned single PUT needs Content-Length; a streamed upload (chunked, no
+            // length header) can't redirect, so it falls through and streams in the handler.
+            if (!signedFileTransport.shouldRedirectForType(fileType) || isNil(request.headers['content-length'])) {
                 return
             }
             const file = await fileService(request.log).save({
@@ -73,8 +82,9 @@ export const filesController: FastifyPluginAsyncZod = async (app) => {
         const contentEncoding = parseStringHeader(request.headers['content-encoding'])
         const compression = contentEncoding === 'zstd' ? FileCompression.ZSTD : FileCompression.NONE
 
-        const data = request.body as Buffer
-        assertNotNullOrUndefined(data, 'body')
+        const body = request.body as Readable
+        assertNotNullOrUndefined(body, 'body')
+        const maxFileSizeInBytes = system.getNumberOrThrow(AppSystemProp.MAX_FILE_SIZE_MB) * 1024 * 1024
         await fileService(request.log).save({
             fileId,
             projectId: principal.projectId,
@@ -82,8 +92,7 @@ export const filesController: FastifyPluginAsyncZod = async (app) => {
             type: fileType,
             fileName,
             compression,
-            size: data.length,
-            data,
+            data: body.pipe(enforceByteLimit(maxFileSizeInBytes)),
         })
         const readUrl = await filesService.constructReadUrl({
             fileId,
@@ -208,6 +217,23 @@ async function tryVerifyReadToken(token: string, expectedFileId: string) {
     catch {
         return null
     }
+}
+
+function enforceByteLimit(maxBytes: number): Transform {
+    let total = 0
+    return new Transform({
+        transform(chunk: Buffer, _encoding, callback) {
+            total += chunk.length
+            if (total > maxBytes) {
+                callback(new ActivepiecesError({
+                    code: ErrorCode.VALIDATION,
+                    params: { message: `File exceeds the maximum allowed size of ${maxBytes} bytes` },
+                }))
+                return
+            }
+            callback(null, chunk)
+        },
+    })
 }
 
 function parseFileTypeHeader(value: unknown): FileType {

--- a/packages/server/api/src/app/file/s3-helper.ts
+++ b/packages/server/api/src/app/file/s3-helper.ts
@@ -2,6 +2,7 @@ import { Readable } from 'stream'
 import { apId, isNil, ProjectId, tryCatch } from '@activepieces/core-utils'
 import { FileType } from '@activepieces/shared'
 import { DeleteObjectsCommand, GetObjectCommand, HeadObjectCommand, PutObjectCommand, S3, S3ClientConfig } from '@aws-sdk/client-s3'
+import { Upload } from '@aws-sdk/lib-storage'
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner'
 import { NodeHttpHandler } from '@smithy/node-http-handler'
 import contentDisposition from 'content-disposition'
@@ -27,6 +28,31 @@ export const s3Helper = (log: FastifyBaseLogger) => ({
         else {
             throw new Error('Either platformId or projectId must be provided')
         }
+    },
+    async uploadStream(s3Key: string, body: Readable): Promise<number> {
+        log.info({ s3Key }, 'streaming file to s3')
+        let size = 0
+        const upload = new Upload({
+            client: getS3Client(),
+            params: {
+                Bucket: getS3BucketName(),
+                Key: s3Key,
+                Body: body,
+            },
+        })
+        upload.on('httpUploadProgress', (progress) => {
+            size = progress.loaded ?? size
+        })
+        try {
+            await upload.done()
+            log.info({ s3Key, size }, 'file streamed to s3')
+        }
+        catch (error) {
+            log.error({ s3Key, error }, 'failed to stream file to s3')
+            exceptionHandler.handle(error, log)
+            throw error
+        }
+        return size
     },
     async uploadFile(s3Key: string, data: Buffer): Promise<string> {
         if (!Buffer.isBuffer(data)) {

--- a/packages/server/api/test/integration/ce/file/files-controller.test.ts
+++ b/packages/server/api/test/integration/ce/file/files-controller.test.ts
@@ -57,6 +57,73 @@ describe('Files Controller', () => {
             }
         })
 
+        it('streams the body to storage and returns identical bytes on download', async () => {
+            const { mockProject, mockPlatform } = await mockAndSaveBasicSetup()
+            const engineToken = await generateMockToken({
+                type: PrincipalType.ENGINE,
+                id: apId(),
+                projectId: mockProject.id,
+                platform: { id: mockPlatform.id },
+            })
+            const fileId = apId()
+            const body = Buffer.from('streamed-content-'.repeat(5000))
+
+            const putResponse = await app!.inject({
+                method: 'PUT',
+                url: `/api/v1/files/${fileId}`,
+                query: { token: engineToken },
+                headers: {
+                    'content-type': 'application/octet-stream',
+                    'x-ap-file-type': FileType.FLOW_STEP_FILE,
+                    'x-ap-file-name': 'big.txt',
+                },
+                payload: body,
+            })
+            expect(putResponse?.statusCode).toBe(StatusCodes.OK)
+
+            const readUrl = new URL(putResponse!.json().readUrl)
+            const getResponse = await app!.inject({
+                method: 'GET',
+                url: readUrl.pathname + readUrl.search,
+            })
+            expect(getResponse?.statusCode).toBe(StatusCodes.OK)
+            expect(getResponse!.rawPayload.equals(body)).toBe(true)
+        })
+
+        it('rejects a body that exceeds the maximum file size while streaming', async () => {
+            const originalMaxFileSize = process.env.AP_MAX_FILE_SIZE_MB
+            process.env.AP_MAX_FILE_SIZE_MB = '0.000001'
+            try {
+                const { mockProject, mockPlatform } = await mockAndSaveBasicSetup()
+                const engineToken = await generateMockToken({
+                    type: PrincipalType.ENGINE,
+                    id: apId(),
+                    projectId: mockProject.id,
+                    platform: { id: mockPlatform.id },
+                })
+
+                const response = await app!.inject({
+                    method: 'PUT',
+                    url: `/api/v1/files/${apId()}`,
+                    query: { token: engineToken },
+                    headers: {
+                        'content-type': 'application/octet-stream',
+                        'x-ap-file-type': FileType.FLOW_STEP_FILE,
+                    },
+                    payload: Buffer.from('x'.repeat(1024)),
+                })
+                expect(response?.statusCode).not.toBe(StatusCodes.OK)
+            }
+            finally {
+                if (originalMaxFileSize === undefined) {
+                    delete process.env.AP_MAX_FILE_SIZE_MB
+                }
+                else {
+                    process.env.AP_MAX_FILE_SIZE_MB = originalMaxFileSize
+                }
+            }
+        })
+
         it('rejects a request whose token is not an engine principal', async () => {
             const { mockProject, mockPlatform } = await mockAndSaveBasicSetup()
             const userToken = await generateMockToken({

--- a/packages/server/engine/src/lib/api/engine-file-api.ts
+++ b/packages/server/engine/src/lib/api/engine-file-api.ts
@@ -1,3 +1,4 @@
+import { Readable } from 'node:stream'
 import { promisify } from 'node:util'
 import { zstdDecompress as zstdDecompressCallback } from 'node:zlib'
 import { EngineFileNotFoundError, EngineGenericError, FileCompression, FileType, isZstdCompressed } from '@activepieces/shared'
@@ -16,9 +17,23 @@ const FILE_NAME_HEADER = 'x-ap-file-name'
 
 export const engineFileApi = {
     async upload({ engineToken, apiUrl, fileId, type, fileName, compression, data }: UploadParams): Promise<UploadResult> {
+        const putUrl = `${apiUrl}v1/files/${fileId}?token=${encodeURIComponent(engineToken)}`
+
+        if (data instanceof Readable) {
+            // No Content-Length → the server streams straight to storage instead of a
+            // presigned redirect (which needs a length). A stream can't be replayed, so no retry.
+            const response = await global.fetch(putUrl, {
+                method: 'PUT',
+                // @ts-expect-error -- undici streams a Node web ReadableStream body; the DOM fetch types omit it
+                body: Readable.toWeb(data),
+                headers: buildPutHeaders({ type, fileName, compression }),
+                duplex: 'half',
+            })
+            return resolveUploadReadUrl(fileId, response)
+        }
+
         const fetchWithRetry = fetchRetry(global.fetch)
         const headers = buildPutHeaders({ type, fileName, compression, contentLength: data.length })
-        const putUrl = `${apiUrl}v1/files/${fileId}?token=${encodeURIComponent(engineToken)}`
 
         const initial = await fetchWithRetry(putUrl, {
             method: 'PUT',
@@ -27,8 +42,6 @@ export const engineFileApi = {
             redirect: 'manual',
             ...RETRY_CONFIG,
         })
-
-        const readUrlFromHeader = initial.headers.get(READ_URL_HEADER) ?? undefined
 
         if (initial.status >= 300 && initial.status < 400) {
             const location = initial.headers.get('location')
@@ -48,27 +61,14 @@ export const engineFileApi = {
                     `Failed to upload to signed S3 URL for ${fileId}: ${s3Response.status} ${s3Response.statusText}`,
                 )
             }
+            const readUrlFromHeader = initial.headers.get(READ_URL_HEADER)
             if (!readUrlFromHeader) {
                 throw new EngineGenericError('EngineFileUploadError', `Server redirect response missing ${READ_URL_HEADER} header`)
             }
             return { fileId, readUrl: readUrlFromHeader }
         }
 
-        if (!initial.ok) {
-            throw new EngineGenericError(
-                'EngineFileUploadError',
-                `Failed to upload engine file ${fileId}: ${initial.status} ${initial.statusText}`,
-            )
-        }
-
-        if (readUrlFromHeader) {
-            return { fileId, readUrl: readUrlFromHeader }
-        }
-        const body = await initial.json() as { readUrl?: unknown }
-        if (typeof body.readUrl !== 'string') {
-            throw new EngineGenericError('EngineFileUploadError', 'Upload response missing readUrl')
-        }
-        return { fileId, readUrl: body.readUrl }
+        return resolveUploadReadUrl(fileId, initial)
     },
     async download({ engineToken, apiUrl, fileId }: DownloadFileParams): Promise<Uint8Array> {
         const fetchWithRetry = fetchRetry(global.fetch)
@@ -104,11 +104,31 @@ export const engineFileApi = {
     },
 }
 
+async function resolveUploadReadUrl(fileId: string, response: Response): Promise<UploadResult> {
+    if (!response.ok) {
+        throw new EngineGenericError(
+            'EngineFileUploadError',
+            `Failed to upload engine file ${fileId}: ${response.status} ${response.statusText}`,
+        )
+    }
+    const readUrlFromHeader = response.headers.get(READ_URL_HEADER)
+    if (readUrlFromHeader) {
+        return { fileId, readUrl: readUrlFromHeader }
+    }
+    const body = await response.json() as { readUrl?: unknown }
+    if (typeof body.readUrl !== 'string') {
+        throw new EngineGenericError('EngineFileUploadError', 'Upload response missing readUrl')
+    }
+    return { fileId, readUrl: body.readUrl }
+}
+
 function buildPutHeaders({ type, fileName, compression, contentLength }: BuildHeadersParams): Record<string, string> {
     const headers: Record<string, string> = {
         'Content-Type': 'application/octet-stream',
-        'Content-Length': String(contentLength),
         [FILE_TYPE_HEADER]: type,
+    }
+    if (contentLength !== undefined) {
+        headers['Content-Length'] = String(contentLength)
     }
     if (fileName) {
         headers[FILE_NAME_HEADER] = fileName
@@ -136,7 +156,7 @@ type UploadParams = {
     type: FileType.FLOW_STEP_FILE | FileType.FLOW_RUN_LOG | FileType.FLOW_RUN_LOG_SLICE
     fileName?: string
     compression?: FileCompression
-    data: Uint8Array | Buffer
+    data: Uint8Array | Buffer | Readable
 }
 
 type UploadResult = {
@@ -154,5 +174,5 @@ type BuildHeadersParams = {
     type: FileType
     fileName?: string
     compression?: FileCompression
-    contentLength: number
+    contentLength?: number
 }

--- a/packages/server/engine/src/lib/piece-context/file-uploader.ts
+++ b/packages/server/engine/src/lib/piece-context/file-uploader.ts
@@ -1,3 +1,4 @@
+import { Readable } from 'node:stream'
 import { apId } from '@activepieces/core-utils'
 import { FilesService } from '@activepieces/pieces-framework'
 import { FileSizeError, FileType } from '@activepieces/shared'
@@ -6,13 +7,16 @@ import { engineFileApi } from '../api/engine-file-api'
 export function createFileUploader({ engineToken, apiUrl }: CreateFileUploaderParams): FilesService {
     const maxFileSizeMb = Number(process.env.AP_MAX_FILE_SIZE_MB)
     return {
-        write: async ({ fileName, data }: { fileName: string, data: Buffer }): Promise<string> => {
-            if (!Buffer.isBuffer(data)) {
+        write: async ({ fileName, data }: { fileName: string, data: Buffer | Readable }): Promise<string> => {
+            if (!Buffer.isBuffer(data) && !(data instanceof Readable)) {
                 throw new Error(
-                    `Expected file data to be a Buffer, but received ${typeof data === 'object' ? Object.prototype.toString.call(data) : typeof data}`,
+                    `Expected file data to be a Buffer or Readable stream, but received ${typeof data === 'object' ? Object.prototype.toString.call(data) : typeof data}`,
                 )
             }
-            validateFileSize(data, maxFileSizeMb)
+            // Stream size is unknown upfront; the API server enforces the cap while streaming.
+            if (Buffer.isBuffer(data)) {
+                validateFileSize(data, maxFileSizeMb)
+            }
             const { readUrl } = await engineFileApi.upload({
                 engineToken,
                 apiUrl,

--- a/packages/server/engine/test/piece-context/file-uploader.test.ts
+++ b/packages/server/engine/test/piece-context/file-uploader.test.ts
@@ -1,3 +1,4 @@
+import { Readable } from 'node:stream'
 import { EngineGenericError, FileSizeError } from '@activepieces/shared'
 import { createFileUploader } from '../../src/lib/piece-context/file-uploader'
 
@@ -17,21 +18,35 @@ describe('file-uploader service', () => {
         const files = createFileUploader(SERVICE_PARAMS)
         await expect(
             files.write({ fileName: 'test.txt', data: {} as any }),
-        ).rejects.toThrow('Expected file data to be a Buffer, but received [object Object]')
+        ).rejects.toThrow('Expected file data to be a Buffer or Readable stream, but received [object Object]')
     })
 
     it('throws when data is a string', async () => {
         const files = createFileUploader(SERVICE_PARAMS)
         await expect(
             files.write({ fileName: 'test.txt', data: 'hello' as any }),
-        ).rejects.toThrow('Expected file data to be a Buffer, but received string')
+        ).rejects.toThrow('Expected file data to be a Buffer or Readable stream, but received string')
     })
 
     it('throws when data is undefined', async () => {
         const files = createFileUploader(SERVICE_PARAMS)
         await expect(
             files.write({ fileName: 'test.txt', data: undefined as any }),
-        ).rejects.toThrow('Expected file data to be a Buffer, but received undefined')
+        ).rejects.toThrow('Expected file data to be a Buffer or Readable stream, but received undefined')
+    })
+
+    it('accepts a Readable stream and returns the read url', async () => {
+        const readUrl = 'https://api.example.com/v1/files/stream1?token=xyz'
+        vi.spyOn(global, 'fetch').mockResolvedValue(new Response(
+            JSON.stringify({ fileId: 'stream1', readUrl }),
+            { status: 200, headers: { 'x-ap-file-read-url': readUrl } },
+        ))
+
+        const files = createFileUploader(SERVICE_PARAMS)
+        const result = await files.write({ fileName: 'stream.txt', data: Readable.from(Buffer.from('streamed')) })
+
+        expect(result).toBe(readUrl)
+        expect(global.fetch).toHaveBeenCalledTimes(1)
     })
 
     it('throws when file exceeds size limit', async () => {


### PR DESCRIPTION
## What

`ctx.files.write()` now accepts a **`Readable` as well as a `Buffer`**, so a piece can write a file it never fully holds in memory. A streamed write is relayed through the app to S3 via `@aws-sdk/lib-storage` (`uploadStream`), or buffered into `bytea` for DB storage — no process holds the whole file in RAM.

**One streaming path, through the app.** No presigned-multipart protocol, no new abstractions.

## Why

Today the whole file pipeline is `Buffer`-based (`ApFile.data`, `FilesService.write({ data: Buffer })`, `bytea`, and even the S3 path buffers). Large files pin memory. This lets pieces stream a `Readable` (e.g. a streaming HTTP download) straight to storage.

## How it works

- **Framework** (`@activepieces/pieces-framework` 0.33.1 → 0.34.0) — `FilesService.write({ data: Buffer | Readable })`.
- **Engine** — a `Readable` is PUT to `/v1/files/:id` with **no `Content-Length`** (chunked, `duplex:'half'`, no retry — a stream can't replay). Both transports share one `resolveUploadReadUrl` helper.
- **App** — `filesController` swaps the global buffering `octet-stream` parser for an encapsulated passthrough (scoped to `/v1/files`), streams the body through an `enforceByteLimit` guard (`MAX_FILE_SIZE_MB`) to `fileService.save`, and keys the redirect decision off **`Content-Length` absence**. `save` routes a `Readable` to `s3Helper.uploadStream` (lib-storage `Upload`, size from `httpUploadProgress`) or buffers to `bytea`.

**Every known-length `Buffer` path — including the `S3_USE_SIGNED_URLS` presigned redirect — is byte-for-byte unchanged.**

## Scope decisions (see [ADR-0007](docs/adr/0007-streaming-files-use-presigned-multipart-not-app-relay.md))

Deliberately **not** built, to keep this a single-path surgical change:
- **Presigned multipart** (bytes off the app on signed-URL deployments) — a new protocol + engine state machine + orphan cleanup. Rejected as over-engineering; `lib-storage` streams unknown-length with bounded (~5 MB part) memory.
- **`Property.file` read-side streaming** — a piece supplies its own `Readable`; a dedicated streaming file-input mode judged YAGNI.
- **Webhook streaming ingestion** — needs replacing the global multipart handler; not surgical.

## Testing

- **api**: streaming round-trip (PUT → GET, bytes identical) + size-guard rejection. 10/10 `files-controller` tests pass.
- **engine**: `Readable` accepted-and-streamed case. 9/9 `file-uploader` tests pass.
- Typecheck clean; `turbo lint` 0 errors.

## Notes for review

- Adds `@aws-sdk/lib-storage` (only `client-s3` + `s3-request-presigner` were declared before).
- One `@ts-expect-error` in `engine-file-api.ts`: undici streams a Node web `ReadableStream` body; the ambient DOM `fetch` types don't model it.
- Known follow-up for `/code-review`: on a size-limit reject, `.pipe()` doesn't tear down the source socket (wasted ingress on the abuse case) — candidate for `stream.pipeline`.
