### PR TITLE
feat(pieces): connect DaoXE multi-model AI gateway for chat completions

### DIFF
--- a/packages/pieces/community/daoxe/.eslintrc.json
+++ b/packages/pieces/community/daoxe/.eslintrc.json
@@ -1,0 +1,47 @@
+{
+  "extends": [
+    "../../../../.eslintrc.base.json"
+  ],
+  "ignorePatterns": [
+    "!**/*"
+  ],
+  "overrides": [
+    {
+      "files": [
+        "*.ts",
+        "*.tsx",
+        "*.js",
+        "*.jsx"
+      ],
+      "rules": {}
+    },
+    {
+      "files": [
+        "*.ts",
+        "*.tsx"
+      ],
+      "rules": {
+        "no-restricted-imports": [
+          "error",
+          {
+            "patterns": [
+              "lodash",
+              "lodash/*",
+              "@activepieces/core-*",
+              "@activepieces/server*",
+              "@activepieces/engine",
+              "@activepieces/shared"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "files": [
+        "*.js",
+        "*.jsx"
+      ],
+      "rules": {}
+    }
+  ]
+}

--- a/packages/pieces/community/daoxe/README.md
+++ b/packages/pieces/community/daoxe/README.md
@@ -1,0 +1,9 @@
+# DaoXE piece
+
+OpenAI-compatible multi-model gateway for Activepieces.
+
+- Default base URL: `https://daoxe.com/v1`
+- Auth: API key (+ optional base URL override)
+- Action: Ask DaoXE (chat completions)
+
+Model IDs are account-scoped. DaoXE is not available in mainland China.

--- a/packages/pieces/community/daoxe/package.json
+++ b/packages/pieces/community/daoxe/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@activepieces/piece-daoxe",
+  "version": "0.0.1",
+  "main": "./dist/src/index.js",
+  "types": "./dist/src/index.d.ts",
+  "dependencies": {
+    "@activepieces/pieces-common": "workspace:*",
+    "@activepieces/pieces-framework": "workspace:*",
+    "openai": "4.67.1",
+    "zod": "4.3.6",
+    "@activepieces/core-piece-types": "workspace:*",
+    "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.lib.json && cp package.json dist/",
+    "bundle": "node ../../../../dist/packages/cli/src/index.js pieces bundle",
+    "lint": "eslint 'src/**/*.ts'"
+  }
+}

--- a/packages/pieces/community/daoxe/src/index.ts
+++ b/packages/pieces/community/daoxe/src/index.ts
@@ -1,0 +1,16 @@
+import { createPiece, PieceCategory } from '@activepieces/pieces-framework';
+import { daoxeAuth } from './lib/auth';
+import { askDaoxe } from './lib/actions/ask-daoxe';
+
+export const daoxe = createPiece({
+  displayName: 'DaoXE',
+  description:
+    'Multi-model multi-protocol AI API gateway (OpenAI-compatible Chat Completions).',
+  auth: daoxeAuth,
+  categories: [PieceCategory.ARTIFICIAL_INTELLIGENCE],
+  minimumSupportedRelease: '0.36.1',
+  logoUrl: 'https://cdn.activepieces.com/pieces/openai.png',
+  authors: ['seven7763'],
+  actions: [askDaoxe],
+  triggers: [],
+});

--- a/packages/pieces/community/daoxe/src/index.ts
+++ b/packages/pieces/community/daoxe/src/index.ts
@@ -9,7 +9,7 @@ export const daoxe = createPiece({
   auth: daoxeAuth,
   categories: [PieceCategory.ARTIFICIAL_INTELLIGENCE],
   minimumSupportedRelease: '0.36.1',
-  logoUrl: 'https://cdn.activepieces.com/pieces/openai.png',
+  logoUrl: 'https://daoxe.com/logo.png',
   authors: ['seven7763'],
   actions: [askDaoxe],
   triggers: [],

--- a/packages/pieces/community/daoxe/src/lib/actions/ask-daoxe.ts
+++ b/packages/pieces/community/daoxe/src/lib/actions/ask-daoxe.ts
@@ -1,0 +1,134 @@
+import {
+  createAction,
+  Property,
+  StoreScope,
+} from '@activepieces/pieces-framework';
+import OpenAI from 'openai';
+import * as z from 'zod/mini';
+import { propsValidation } from '@activepieces/pieces-common';
+import { daoxeAuth } from '../auth';
+import { DEFAULT_BASE_URL } from '../common/common';
+
+export const askDaoxe = createAction({
+  audience: 'human',
+  auth: daoxeAuth,
+  name: 'ask_daoxe',
+  displayName: 'Ask DaoXE',
+  description:
+    'Send a chat completion request via DaoXE OpenAI-compatible gateway.',
+  props: {
+    model: Property.Dropdown({
+      auth: daoxeAuth,
+      displayName: 'Model',
+      required: true,
+      description:
+        'Exact model ID available to your DaoXE account (from GET /v1/models).',
+      refreshers: [],
+      options: async ({ auth }) => {
+        if (!auth) {
+          return {
+            disabled: true,
+            placeholder: 'Enter your API key first',
+            options: [],
+          };
+        }
+        try {
+          const props = auth as { props: { apiKey: string; baseUrl?: string } };
+          const baseURL = (props.props.baseUrl || DEFAULT_BASE_URL).replace(
+            /\/$/,
+            '',
+          );
+          const openai = new OpenAI({
+            baseURL,
+            apiKey: props.props.apiKey,
+          });
+          const response = await openai.models.list();
+          return {
+            disabled: false,
+            options: response.data.map((model) => ({
+              label: model.id,
+              value: model.id,
+            })),
+          };
+        } catch (error) {
+          return {
+            disabled: true,
+            options: [],
+            placeholder: "Couldn't load models; check API key and base URL",
+          };
+        }
+      },
+    }),
+    prompt: Property.LongText({
+      displayName: 'Question',
+      required: true,
+    }),
+    temperature: Property.Number({
+      displayName: 'Temperature',
+      required: false,
+      defaultValue: 1,
+    }),
+    maxTokens: Property.Number({
+      displayName: 'Maximum Tokens',
+      required: false,
+      defaultValue: 1024,
+    }),
+    memoryKey: Property.ShortText({
+      displayName: 'Memory Key',
+      description:
+        'Optional memory key to keep chat history across runs. Leave empty for stateless calls.',
+      required: false,
+    }),
+  },
+  async run({ auth, propsValue, store }) {
+    await propsValidation.validateZod(propsValue, {
+      temperature: z.optional(z.number().check(z.minimum(0), z.maximum(2))),
+      memoryKey: z.optional(z.string().check(z.maxLength(128))),
+    });
+
+    const baseURL = (auth.props.baseUrl || DEFAULT_BASE_URL).replace(
+      /\/$/,
+      '',
+    );
+    const openai = new OpenAI({
+      baseURL,
+      apiKey: auth.props.apiKey,
+    });
+
+    const { model, prompt, temperature, maxTokens, memoryKey } = propsValue;
+
+    let messageHistory: { role: string; content: string }[] = [];
+    if (memoryKey) {
+      messageHistory =
+        (await store.get(memoryKey, StoreScope.PROJECT)) ?? [];
+    }
+
+    messageHistory.push({
+      role: 'user',
+      content: prompt,
+    });
+
+    const completion = await openai.chat.completions.create({
+      model,
+      messages: messageHistory as OpenAI.Chat.ChatCompletionMessageParam[],
+      temperature: temperature ?? undefined,
+      max_tokens: maxTokens ?? undefined,
+    });
+
+    const assistant = completion.choices[0]?.message?.content ?? '';
+    messageHistory.push({
+      role: 'assistant',
+      content: assistant,
+    });
+
+    if (memoryKey) {
+      await store.put(memoryKey, messageHistory, StoreScope.PROJECT);
+    }
+
+    return {
+      result: assistant,
+      usage: completion.usage,
+      model: completion.model,
+    };
+  },
+});

--- a/packages/pieces/community/daoxe/src/lib/auth.ts
+++ b/packages/pieces/community/daoxe/src/lib/auth.ts
@@ -1,0 +1,47 @@
+import { PieceAuth, Property } from '@activepieces/pieces-framework';
+import OpenAI from 'openai';
+import { DEFAULT_BASE_URL, unauthorizedMessage } from './common/common';
+
+export const daoxeAuth = PieceAuth.CustomAuth({
+  description: `DaoXE is a multi-model API gateway with an OpenAI-compatible Chat Completions API.
+
+1. Create an API key at https://daoxe.com
+2. Base URL defaults to https://daoxe.com/v1
+3. Model IDs are account-scoped — use exact IDs from your dashboard or GET /v1/models
+
+DaoXE is not available in mainland China.`,
+  required: true,
+  props: {
+    apiKey: PieceAuth.SecretText({
+      displayName: 'API Key',
+      description: 'Your DaoXE API key',
+      required: true,
+    }),
+    baseUrl: Property.ShortText({
+      displayName: 'Base URL',
+      description:
+        'OpenAI-compatible base URL. Default: https://daoxe.com/v1',
+      required: false,
+      defaultValue: DEFAULT_BASE_URL,
+    }),
+  },
+  validate: async ({ auth }) => {
+    try {
+      const baseURL = (auth.props.baseUrl || DEFAULT_BASE_URL).replace(
+        /\/$/,
+        '',
+      );
+      const openai = new OpenAI({
+        baseURL,
+        apiKey: auth.props.apiKey,
+      });
+      const models = await openai.models.list();
+      if (models.data.length > 0) {
+        return { valid: true };
+      }
+      return { valid: false, error: unauthorizedMessage };
+    } catch (e) {
+      return { valid: false, error: unauthorizedMessage };
+    }
+  },
+});

--- a/packages/pieces/community/daoxe/src/lib/auth.ts
+++ b/packages/pieces/community/daoxe/src/lib/auth.ts
@@ -1,6 +1,6 @@
 import { PieceAuth, Property } from '@activepieces/pieces-framework';
 import OpenAI from 'openai';
-import { DEFAULT_BASE_URL, unauthorizedMessage } from './common/common';
+import { DEFAULT_BASE_URL, getUnauthorizedMessage } from './common/common';
 
 export const daoxeAuth = PieceAuth.CustomAuth({
   description: `DaoXE is a multi-model API gateway with an OpenAI-compatible Chat Completions API.
@@ -26,22 +26,24 @@ DaoXE is not available in mainland China.`,
     }),
   },
   validate: async ({ auth }) => {
+    const baseURL = (auth.props.baseUrl || DEFAULT_BASE_URL).replace(
+      /\/$/,
+      '',
+    );
     try {
-      const baseURL = (auth.props.baseUrl || DEFAULT_BASE_URL).replace(
-        /\/$/,
-        '',
-      );
       const openai = new OpenAI({
         baseURL,
         apiKey: auth.props.apiKey,
       });
-      const models = await openai.models.list();
-      if (models.data.length > 0) {
-        return { valid: true };
-      }
-      return { valid: false, error: unauthorizedMessage };
+      // Successfully listing models proves the key/base URL pair is accepted.
+      // An empty model list is still a valid authenticated response (e.g. new account).
+      await openai.models.list();
+      return { valid: true };
     } catch (e) {
-      return { valid: false, error: unauthorizedMessage };
+      return {
+        valid: false,
+        error: getUnauthorizedMessage(baseURL),
+      };
     }
   },
 });

--- a/packages/pieces/community/daoxe/src/lib/common/common.ts
+++ b/packages/pieces/community/daoxe/src/lib/common/common.ts
@@ -1,5 +1,9 @@
 export const DEFAULT_BASE_URL = 'https://daoxe.com/v1';
 
-export const unauthorizedMessage = `Error Occurred: 401
-Ensure that your DaoXE API key is valid and that the base URL is https://daoxe.com/v1 (or your gateway URL).
+export const getUnauthorizedMessage = (baseUrl: string) =>
+  `Error Occurred: 401
+Ensure that your DaoXE API key is valid and that the base URL is ${baseUrl} (or your gateway URL).
 `;
+
+/** @deprecated Prefer getUnauthorizedMessage(baseUrl) so custom base URLs appear correctly. */
+export const unauthorizedMessage = getUnauthorizedMessage(DEFAULT_BASE_URL);

--- a/packages/pieces/community/daoxe/src/lib/common/common.ts
+++ b/packages/pieces/community/daoxe/src/lib/common/common.ts
@@ -1,0 +1,5 @@
+export const DEFAULT_BASE_URL = 'https://daoxe.com/v1';
+
+export const unauthorizedMessage = `Error Occurred: 401
+Ensure that your DaoXE API key is valid and that the base URL is https://daoxe.com/v1 (or your gateway URL).
+`;

--- a/packages/pieces/community/daoxe/tsconfig.json
+++ b/packages/pieces/community/daoxe/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "noPropertyAccessFromIndexSignature": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/packages/pieces/community/daoxe/tsconfig.lib.json
+++ b/packages/pieces/community/daoxe/tsconfig.lib.json
@@ -1,0 +1,15 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "rootDir": ".",
+    "baseUrl": ".",
+    "paths": {},
+    "outDir": "./dist",
+    "declaration": true,
+    "declarationMap": true,
+    "types": ["node"]
+  },
+  "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"],
+  "include": ["src/**/*.ts"]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -389,6 +389,9 @@
       "@activepieces/piece-deepl": [
         "packages/pieces/community/deepl/src/index.ts"
       ],
+      "@activepieces/piece-daoxe": [
+        "packages/pieces/community/daoxe/src/index.ts"
+      ],
       "@activepieces/piece-deepseek": [
         "packages/pieces/community/deepseek/src/index.ts"
       ],


### PR DESCRIPTION
## Summary

Adds a community **DaoXE** piece for Activepieces:

- **Auth (CustomAuth):** API key + optional Base URL (default \`https://daoxe.com/v1\`)
- **Action:** Ask DaoXE — chat completions with model dropdown from \`GET /v1/models\`
- Registers \`@activepieces/piece-daoxe\` in \`tsconfig.base.json\`

DaoXE is a multi-model multi-protocol AI API gateway. This piece uses the **OpenAI-compatible Chat Completions** path only. Model IDs are account-scoped.

### Notes

- Logo temporarily reuses OpenAI CDN asset (same pattern as some placeholders); happy to supply a dedicated logo URL.
- Not available in mainland China
- Contributor is affiliated with DaoXE

## Test plan

- [ ] Piece builds (\`nx\` / piece package build if required by CI)
- [ ] Auth validate lists models against DaoXE with a real key
- [ ] Ask DaoXE returns a completion for an account model ID