### PR TITLE
feat(engine): add batch mode to Loop on Items

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -360,7 +360,7 @@
     },
     "packages/core/execution": {
       "name": "@activepieces/core-execution",
-      "version": "0.8.0",
+      "version": "0.9.0",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -405,7 +405,7 @@
     },
     "packages/core/shared": {
       "name": "@activepieces/shared",
-      "version": "0.117.0",
+      "version": "0.118.0",
       "dependencies": {
         "@activepieces/core-execution": "workspace:*",
         "@activepieces/core-formula": "workspace:*",

--- a/packages/core/execution/package.json
+++ b/packages/core/execution/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/core-execution",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "scripts": {

--- a/packages/core/execution/src/lib/flows/actions/action.ts
+++ b/packages/core/execution/src/lib/flows/actions/action.ts
@@ -99,6 +99,7 @@ export const PieceActionSchema = z.object({
 export const LoopOnItemsActionSettings = z.object({
     ...commonActionSettings,
     items: z.string(),
+    batchSize: z.number().optional(),
 })
 export type LoopOnItemsActionSettings = z.infer<
   typeof LoopOnItemsActionSettings

--- a/packages/core/shared/package.json
+++ b/packages/core/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/shared",
-  "version": "0.117.0",
+  "version": "0.118.0",
   "type": "commonjs",
   "sideEffects": false,
   "main": "./dist/src/index.js",

--- a/packages/server/engine/src/lib/handler/loop-executor.ts
+++ b/packages/server/engine/src/lib/handler/loop-executor.ts
@@ -1,4 +1,4 @@
-import { isNil } from '@activepieces/core-utils'
+import { chunk, isNil } from '@activepieces/core-utils'
 import { LATEST_CONTEXT_VERSION } from '@activepieces/pieces-framework'
 import { FlowRunStatus, LoopOnItemsAction, LoopStepOutput, StepOutputStatus } from '@activepieces/shared'
 import { utils } from '../utils'
@@ -7,6 +7,14 @@ import { flowExecutor } from './flow-executor'
 
 type LoopOnActionResolvedSettings = {
     items: readonly unknown[]
+    batchSize?: number
+}
+
+function resolveBatchSize(batchSize: number | undefined): number {
+    if (isNil(batchSize) || !Number.isFinite(batchSize) || batchSize < 1) {
+        return 1
+    }
+    return Math.floor(batchSize)
 }
 
 export const loopExecutor: BaseExecutor<LoopOnItemsAction> = {
@@ -20,6 +28,7 @@ export const loopExecutor: BaseExecutor<LoopOnItemsAction> = {
             constants.getPropsResolver(LATEST_CONTEXT_VERSION).resolve<LoopOnActionResolvedSettings>({
                 unresolvedInput: {
                     items: action.settings.items,
+                    batchSize: action.settings.batchSize,
                 },
                 executionState,
             }),
@@ -63,12 +72,16 @@ export const loopExecutor: BaseExecutor<LoopOnItemsAction> = {
 
         const firstLoopAction = action.firstLoopAction
 
+        const batchSize = resolveBatchSize(resolvedInput.batchSize)
+        const units: readonly unknown[] = batchSize <= 1
+            ? resolvedInput.items
+            : chunk([...resolvedInput.items], batchSize)
 
-        for (let i = 0; i < resolvedInput.items.length; ++i) {
+        for (let i = 0; i < units.length; ++i) {
             const newCurrentPath = newExecutionContext.currentPath.loopIteration({ loopName: action.name, iteration: i })
 
             const testSingleStepMode = !isNil(constants.stepNameToTest)
-            stepOutput = stepOutput.setItemAndIndex({ item: resolvedInput.items[i], index: i + 1 })
+            stepOutput = stepOutput.setItemAndIndex({ item: units[i], index: i + 1 })
             const addEmptyIteration = !stepOutput.hasIteration(i)
             if (addEmptyIteration) {
                 stepOutput = stepOutput.addIteration()

--- a/packages/server/engine/test/handler/flow-looping.test.ts
+++ b/packages/server/engine/test/handler/flow-looping.test.ts
@@ -58,6 +58,90 @@ describe('flow with looping', () => {
         expect(loopOut.output?.item).toBe(4)
     })
 
+    it('should group items into batches when batchSize > 1', async () => {
+        const result = await flowExecutor.execute({
+            action: buildSimpleLoopAction({
+                name: 'loop',
+                loopItems: '{{ [1,2,3,4,5] }}',
+                batchSize: 2,
+                firstLoopAction: buildCodeAction({
+                    name: 'echo_step',
+                    input: { 'item': '{{loop.output.item}}' },
+                }),
+            }),
+            executionState: FlowExecutorContext.empty(),
+            constants: generateMockEngineConstants({ stepNames: ['loop'] }),
+        })
+
+        const loopOut = result.steps.loop as LoopStepOutput
+        expect(result.verdict.status).toBe(FlowRunStatus.RUNNING)
+        // 5 items, batch of 2 -> 3 iterations, last batch is partial
+        expect(loopOut.output?.iterations.length).toBe(3)
+        expect(loopOut.output?.index).toBe(3)
+        expect(loopOut.output?.item).toEqual([5])
+    })
+
+    it('should iterate item-by-item when batchSize is 1 (unchanged behavior)', async () => {
+        const result = await flowExecutor.execute({
+            action: buildSimpleLoopAction({ name: 'loop', loopItems: '{{ [1,2,3] }}', batchSize: 1 }),
+            executionState: FlowExecutorContext.empty(),
+            constants: generateMockEngineConstants({ stepNames: ['loop'] }),
+        })
+
+        const loopOut = result.steps.loop as LoopStepOutput
+        expect(loopOut.output?.iterations.length).toBe(3)
+        expect(loopOut.output?.item).toBe(3)
+    })
+
+    it.each([0, -3, Number.NaN])('should fall back to item-by-item when batchSize is %s', async (batchSize) => {
+        const result = await flowExecutor.execute({
+            action: buildSimpleLoopAction({ name: 'loop', loopItems: '{{ [1,2,3] }}', batchSize }),
+            executionState: FlowExecutorContext.empty(),
+            constants: generateMockEngineConstants({ stepNames: ['loop'] }),
+        })
+
+        const loopOut = result.steps.loop as LoopStepOutput
+        expect(loopOut.output?.iterations.length).toBe(3)
+        expect(loopOut.output?.item).toBe(3)
+    })
+
+    it('should truncate a fractional batchSize', async () => {
+        const result = await flowExecutor.execute({
+            action: buildSimpleLoopAction({ name: 'loop', loopItems: '{{ [1,2,3,4,5] }}', batchSize: 2.9 }),
+            executionState: FlowExecutorContext.empty(),
+            constants: generateMockEngineConstants({ stepNames: ['loop'] }),
+        })
+
+        const loopOut = result.steps.loop as LoopStepOutput
+        expect(loopOut.output?.iterations.length).toBe(3)
+        expect(loopOut.output?.item).toEqual([5])
+    })
+
+    it('should produce a single batch when batchSize exceeds the item count', async () => {
+        const result = await flowExecutor.execute({
+            action: buildSimpleLoopAction({ name: 'loop', loopItems: '{{ [1,2,3] }}', batchSize: 100 }),
+            executionState: FlowExecutorContext.empty(),
+            constants: generateMockEngineConstants({ stepNames: ['loop'] }),
+        })
+
+        const loopOut = result.steps.loop as LoopStepOutput
+        expect(loopOut.output?.iterations.length).toBe(1)
+        expect(loopOut.output?.index).toBe(1)
+        expect(loopOut.output?.item).toEqual([1, 2, 3])
+    })
+
+    it('should run zero iterations for an empty list with a batchSize', async () => {
+        const result = await flowExecutor.execute({
+            action: buildSimpleLoopAction({ name: 'loop', loopItems: '{{ [] }}', batchSize: 10 }),
+            executionState: FlowExecutorContext.empty(),
+            constants: generateMockEngineConstants({ stepNames: ['loop'] }),
+        })
+
+        const loopOut = result.steps.loop as LoopStepOutput
+        expect(result.verdict.status).toBe(FlowRunStatus.RUNNING)
+        expect(loopOut.output?.iterations.length).toBe(0)
+    })
+
     it('should skip loop', async () => {
         const result = await flowExecutor.execute({
             action: buildSimpleLoopAction({ name: 'loop', loopItems: '{{ [4,5,6] }}', skip: true }), executionState: FlowExecutorContext.empty(), constants: generateMockEngineConstants(),

--- a/packages/server/engine/test/handler/test-helper.ts
+++ b/packages/server/engine/test/handler/test-helper.ts
@@ -36,11 +36,13 @@ export function buildSimpleLoopAction({
     loopItems,
     firstLoopAction,
     skip,
+    batchSize,
 }: {
     name: string
     loopItems: string
     firstLoopAction?: FlowAction
     skip?: boolean
+    batchSize?: number
 }): LoopOnItemsAction {
     return {
         name,
@@ -49,6 +51,7 @@ export function buildSimpleLoopAction({
         skip: skip ?? false,
         settings: {
             items: loopItems,
+            ...(batchSize !== undefined ? { batchSize } : {}),
         },
         firstLoopAction,
         valid: true,

--- a/packages/web/public/locales/en/translation.json
+++ b/packages/web/public/locales/en/translation.json
@@ -286,6 +286,8 @@
   "Edit Step Name": "Edit Step Name",
   "Select the items to iterate over from the previous step by clicking on the **Items** input, which should be a **list** of items.\n\nThe loop will iterate over each item in the list and execute the next step for every item.": "Select the items to iterate over from the previous step by clicking on the **Items** input, which should be a **list** of items.\n\nThe loop will iterate over each item in the list and execute the next step for every item.",
   "Items": "Items",
+  "Batch Size": "Batch Size",
+  "Optional. When set to more than 1, each iteration receives a list of that many items instead of a single item.": "Optional. When set to more than 1, each iteration receives a list of that many items instead of a single item.",
   "Select an array of items": "Select an array of items",
   "Select a connection": "Select a connection",
   "Permission needed": "Permission needed",

--- a/packages/web/src/app/builder/step-settings/loops-settings.tsx
+++ b/packages/web/src/app/builder/step-settings/loops-settings.tsx
@@ -4,7 +4,15 @@ import React from 'react';
 import { useFormContext } from 'react-hook-form';
 
 import { ApMarkdown } from '@/components/custom/markdown';
-import { FormField, FormItem, FormLabel } from '@/components/ui/form';
+import {
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/ui/form';
+import { Input } from '@/components/ui/input';
 
 import { TextInputWithMentions } from '../piece-properties/text-input-with-mentions';
 
@@ -20,22 +28,53 @@ const LoopsSettings = React.memo(({ readonly }: LoopsSettingsProps) => {
   const form = useFormContext<LoopOnItemsAction>();
 
   return (
-    <FormField
-      control={form.control}
-      name="settings.items"
-      render={({ field }) => (
-        <FormItem className="flex flex-col gap-2">
-          <ApMarkdown markdown={markdown} />
-          <FormLabel showRequiredIndicator>{t('Items')}</FormLabel>
-          <TextInputWithMentions
-            disabled={readonly}
-            onChange={field.onChange}
-            initialValue={field.value}
-            placeholder={t('Select an array of items')}
-          ></TextInputWithMentions>
-        </FormItem>
-      )}
-    />
+    <div className="flex flex-col gap-4">
+      <FormField
+        control={form.control}
+        name="settings.items"
+        render={({ field }) => (
+          <FormItem className="flex flex-col gap-2">
+            <ApMarkdown markdown={markdown} />
+            <FormLabel showRequiredIndicator>{t('Items')}</FormLabel>
+            <TextInputWithMentions
+              disabled={readonly}
+              onChange={field.onChange}
+              initialValue={field.value}
+              placeholder={t('Select an array of items')}
+            ></TextInputWithMentions>
+          </FormItem>
+        )}
+      />
+      <FormField
+        control={form.control}
+        name="settings.batchSize"
+        render={({ field }) => (
+          <FormItem className="flex flex-col gap-2">
+            <FormLabel>{t('Batch Size')}</FormLabel>
+            <FormControl>
+              <Input
+                type="number"
+                min={1}
+                step={1}
+                disabled={readonly}
+                placeholder="1"
+                value={field.value ?? ''}
+                onChange={(e) => {
+                  const raw = e.target.value;
+                  field.onChange(raw === '' ? undefined : Number(raw));
+                }}
+              />
+            </FormControl>
+            <FormDescription>
+              {t(
+                'Optional. When set to more than 1, each iteration receives a list of that many items instead of a single item.',
+              )}
+            </FormDescription>
+            <FormMessage />
+          </FormItem>
+        )}
+      />
+    </div>
   );
 });
 


### PR DESCRIPTION
## What does this PR do?

Adds an optional **Batch Size** to the **Loop on Items** step.

When Batch Size is set to `N > 1`, each iteration receives a **list of N items** instead of a
single item, so a downstream step can process the whole batch in one call — e.g. Tables →
Create Record(s), or an HTTP request whose body is a JSON array.

Today, "iterate an array in groups of N" requires dropping in a Code step to chunk the array
first. This makes chunking a native, reusable loop primitive. It also reduces the number of
per-item iteration records the loop writes into the run's execution state from `N` to
`ceil(N / batchSize)`, which matters on large lists against `MAX_FLOW_RUN_LOG_SIZE_MB`.

Fully backwards compatible: when Batch Size is empty or `<= 1`, the loop iterates item-by-item
exactly as before. The item mention (`{{loop.output.item}}`) is unchanged — in batch mode it
simply resolves to the batch array.

### Explain How the Feature Works

- **Schema** (`LoopOnItemsActionSettings`): a new optional `batchSize: number`. Being optional,
  existing flows stay valid and no flow-schema migration is needed.
- **Engine** (`loop-executor.ts`): after resolving `items` (and `batchSize`) through the props
  resolver — inside the existing `tryCatchAndThrowOnEngineError` wrapper — it derives the units
  to iterate over: the raw items when `batchSize <= 1` (unchanged path), or `chunk(items, batchSize)`
  when `> 1`, using `chunk()` from `@activepieces/core-utils` (already bundled in the engine).
  `resolveBatchSize` normalizes empty / `<= 0` / `NaN` to 1 and truncates fractional values.
  Nothing else in the loop (iteration records, current path, verdict handling, single-step test
  mode) changes.
- **Builder**: the Loop step settings gain an optional numeric **Batch Size** input, stored as a
  number.

Covered by unit tests in `packages/server/engine/test/handler/flow-looping.test.ts`:
- 5 items with `batchSize: 2` → 3 iterations, last batch partial (`[5]`);
- `batchSize` of `1` / `0` / negative / `NaN` → item-by-item (unchanged behavior);
- fractional `batchSize` truncated;
- `batchSize` greater than the list → a single batch with all items;
- empty list with a batch size → zero iterations.

### Relevant User Scenarios

- **Bulk insert into a Table**: `Loop (batchSize: 50) → Tables Create Record(s)` inserts 50 rows
  per call instead of one row per iteration.
- **Batched API calls**: send an array of N records per HTTP request to a rate-limited endpoint.
- **Large lists**: fewer, larger iterations keep the run's execution log smaller and the loop
  faster than one iteration per item.
