### PR TITLE
fix(chat): enforce project role on ap_execute_action and ap_run_code

### DIFF
--- a/.agents/features/chat.md
+++ b/.agents/features/chat.md
@@ -133,10 +133,11 @@ A platform-level AI chat assistant that lets users interact with an LLM to manag
 ## Local Tools
 - `ap_set_session_title` — auto-names the conversation after the first exchange
 - `ap_select_project` — switches project context (scopes MCP tools to that project)
-- `ap_execute_action` — executes a single piece action ad-hoc (e.g. "check my inbox"); connections are managed server-side (the LLM never sees externalIds); write/destructive actions trigger an action preview gate before execution; emits `ACTION_RECEIPT` events after completion
+- `ap_execute_action` — executes a single piece action ad-hoc (e.g. "check my inbox"); connections are managed server-side (the LLM never sees externalIds); write/destructive actions trigger an action preview gate before execution; emits `ACTION_RECEIPT` events after completion. Requires the caller's project role to have `Permission.WRITE_RUN` (enforced via `checkWriteRunPermission` → `resolvePermissionChecker`; no-op in Community, denies on missing role)
+- `ap_run_code` — runs ad-hoc TypeScript in the flow-engine sandbox (`executeAdhocCode`); used to post-process large offloaded tool results or produce files. Same `Permission.WRITE_RUN` requirement as `ap_execute_action`
 - `ap_list_across_projects` — lists flows, tables, runs, or connections across all user-accessible projects
 - `ap_deselect_project` — clears the selected project context
-- `ap_explore_data` — read-only exploration of the user's data (sheets, channels, columns) to build understanding during discovery; never configures the automation
+- `ap_explore_data` — read-only exploration of the user's data (sheets, channels, columns) to build understanding during discovery; never configures the automation. Read-only, so no `WRITE_RUN` gate (Viewers may use it)
 - `ap_load_guide` — loads an on-demand prompt guide (`build_flow`, `one_time_task`, `error_handling`, `http_fallback`, `control_flow`, `state`, `tables`, `ai`) so guidance is only in context when needed
 - `ap_fetch_url` — SSRF-safe read-only GET of any public http(s) URL (`safeHttp.axios`); HTML is stripped to text via `string-strip-html` and large results are truncated. Available in both phases on every provider (disabled in dry runs); built in `createWebTools` (`chat-worker-tools.ts`)
 - `ap_set_phase` — flips the agent between the `discovery` and `build` tool phases

--- a/packages/server/api/src/app/ee/chat/tools/chat-tools.ts
+++ b/packages/server/api/src/app/ee/chat/tools/chat-tools.ts
@@ -1,4 +1,4 @@
-import { isNil, isObject, parseToJsonIfPossible, spreadIfDefined, tryCatch } from '@activepieces/core-utils'
+import { isNil, isObject, parseToJsonIfPossible, Permission, spreadIfDefined, tryCatch } from '@activepieces/core-utils'
 import { chatAiUtils } from '@activepieces/server-utils'
 import { AppConnectionStatus, AppConnectionType, chatToolClassification, FileCompression, FileType, FlowRunStatus, FlowStatus, Project, RunEnvironment } from '@activepieces/shared'
 import { FastifyBaseLogger } from 'fastify'
@@ -7,6 +7,7 @@ import { fileService } from '../../../file/file.service'
 import { filesService } from '../../../file/files-service'
 import { flowService } from '../../../flows/flow/flow.service'
 import { flowRunService } from '../../../flows/flow-run/flow-run-service'
+import { resolvePermissionChecker } from '../../../mcp/mcp-permissions'
 import { formatFlowLine } from '../../../mcp/tools/ap-list-flows'
 import { AdhocOffload, executeAdhocAction, executeAdhocCode, formatRunSummary } from '../../../mcp/tools/flow-run-utils'
 import { mcpUtils } from '../../../mcp/tools/mcp-utils'
@@ -209,6 +210,17 @@ async function listResourceForProject({ resource, projectId, status, log }: {
     }
 }
 
+async function checkWriteRunPermission({ userId, projectId, toolName, log }: {
+    userId: string
+    projectId: string
+    toolName: string
+    log: FastifyBaseLogger
+}): Promise<string | null> {
+    const checker = await resolvePermissionChecker({ userId, projectId, log })
+    const denial = checker.check(Permission.WRITE_RUN, toolName)
+    return isNil(denial) ? null : denial.content.map((part) => part.text).join(' ')
+}
+
 async function executeCrossProjectTool({ toolName, toolInput, platformId, userId, conversationId, log }: {
     toolName: string
     toolInput: Record<string, unknown>
@@ -256,7 +268,7 @@ async function executeCrossProjectTool({ toolName, toolInput, platformId, userId
             return discoveryResult
         }
         case 'ap_execute_action': {
-            return runChatAdhocAction({ toolInput, projects, availableProjectIds, conversationId, platformId, log })
+            return runChatAdhocAction({ toolInput, projects, availableProjectIds, conversationId, platformId, userId, requireWritePermission: true, log })
         }
         case 'ap_run_code': {
             return runChatCode({ toolInput, projects, platformId, userId, conversationId, log })
@@ -267,7 +279,7 @@ async function executeCrossProjectTool({ toolName, toolInput, platformId, userId
             if (!chatToolClassification.isReadOnlyActionCall({ actionName, input: exploreInput })) {
                 return chatToolClassification.readOnlyRejection(actionName)
             }
-            return runChatAdhocAction({ toolInput, projects, availableProjectIds, conversationId, platformId, log })
+            return runChatAdhocAction({ toolInput, projects, availableProjectIds, conversationId, platformId, userId, log })
         }
         case 'ap_list_across_projects': {
             const resource = toolInput.resource as string
@@ -336,12 +348,14 @@ function buildAdhocOffload({ projectId, platformId, pieceName, actionName, log }
     }
 }
 
-async function runChatAdhocAction({ toolInput, projects, availableProjectIds, conversationId, platformId, log }: {
+async function runChatAdhocAction({ toolInput, projects, availableProjectIds, conversationId, platformId, userId, requireWritePermission, log }: {
     toolInput: Record<string, unknown>
     projects: Project[]
     availableProjectIds: string[]
     conversationId?: string
     platformId?: string
+    userId: string
+    requireWritePermission?: boolean
     log: FastifyBaseLogger
 }): Promise<unknown> {
     const pieceName = toolInput.pieceName as string
@@ -366,6 +380,12 @@ async function runChatAdhocAction({ toolInput, projects, availableProjectIds, co
     }
     if (connectionProjectId && !availableProjectIds.includes(connectionProjectId)) {
         return { success: false, error: `Project ${connectionProjectId} is not accessible.` }
+    }
+    if (requireWritePermission) {
+        const denial = await checkWriteRunPermission({ userId, projectId: resolvedProjectId, toolName: 'ap_execute_action', log })
+        if (denial) {
+            return { success: false, error: denial }
+        }
     }
 
     let parsedInput = toolInput.input
@@ -427,6 +447,10 @@ async function runChatCode({ toolInput, projects, platformId, userId, conversati
     }
     if (isNil(projectId)) {
         return { text: '❌ No projects available. Create a project first.', producedFiles: [] }
+    }
+    const denial = await checkWriteRunPermission({ userId, projectId, toolName: 'ap_run_code', log })
+    if (denial) {
+        return { text: `❌ ${denial}`, producedFiles: [] }
     }
 
     const baseInput = isObject(toolInput.input) ? toolInput.input as Record<string, unknown> : {}

--- a/packages/server/api/test/integration/cloud/chat/chat.test.ts
+++ b/packages/server/api/test/integration/cloud/chat/chat.test.ts
@@ -2,6 +2,7 @@ import { DefaultProjectRole } from '@activepieces/shared'
 import { FastifyInstance } from 'fastify'
 import { StatusCodes } from 'http-status-codes'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { executeCrossProjectTool } from '../../../../src/app/ee/chat/tools/chat-tools'
 import { createMemberContext, createTestContext } from '../../../helpers/test-context'
 import { setupTestEnvironment, teardownTestEnvironment } from '../../../helpers/test-setup'
 
@@ -250,6 +251,26 @@ describe('Chat Conversations API', () => {
 
             const deleteResponse = await ctx.delete(`${CONVERSATIONS_URL}/non-existent-id`)
             expect(deleteResponse.statusCode).toBe(StatusCodes.NOT_FOUND)
+        })
+    })
+
+    describe('Tool permission parity', () => {
+        it.each([
+            { toolName: 'ap_execute_action', toolInput: { pieceName: '@activepieces/piece-slack', actionName: 'send_channel_message', input: {} } },
+            { toolName: 'ap_run_code', toolInput: { code: 'export const code = async () => 1' } },
+        ])('blocks a VIEWER from $toolName (needs WRITE_RUN)', async ({ toolName, toolInput }) => {
+            const ctx = await createTestContext(app, { plan: { chatEnabled: true } })
+            const viewerCtx = await createMemberContext(app, ctx, { projectRole: DefaultProjectRole.VIEWER })
+
+            const result = await executeCrossProjectTool({
+                toolName,
+                toolInput,
+                platformId: viewerCtx.platform.id,
+                userId: viewerCtx.user.id,
+                log: app.log,
+            })
+
+            expect(JSON.stringify(result)).toMatch(/permission denied/i)
         })
     })
 


### PR DESCRIPTION
## What

Chat's native cross-project tools `ap_execute_action` (run any piece action) and `ap_run_code` (run ad-hoc code) executed with **no project-role check**. On EE/Cloud, a project **Viewer** could run arbitrary actions and code that the builder denies them — a privilege-escalation gap.

## Why it was only these two tools

Tables writes, flow build/publish, and run-flow already enforce the caller's project role, because chat connects to the platform MCP server (`/mcp/platform`) with a `userId`-bearing token and `registerPlatformTools` wraps every write tool with `resolvePermissionChecker` per selected project. The only unguarded write paths were the two chat-native tools that run outside MCP, in `executeCrossProjectTool`.

## Change

- Add `checkWriteRunPermission` in `chat-tools.ts`, reusing `resolvePermissionChecker` from `mcp/mcp-permissions.ts` — no new permission machinery.
- Gate `ap_execute_action` and `ap_run_code` on `Permission.WRITE_RUN`, checked against the resolved target project.
- `ap_explore_data` stays open (read-only; Viewers should keep it).

Because `resolvePermissionChecker` is already edition-gated, this is a no-op in Community (everyone is effectively admin there) and only enforces on Cloud/Enterprise — matching how the builder behaves. A missing role denies, consistent with MCP.

## Tests

Two parameterized Viewer-denial cases in `test/integration/cloud/chat/chat.test.ts` (`ap_execute_action`, `ap_run_code`). Full file passes 20/20; `lint` reports 0 errors.
