### PR TITLE
fix(pieces): file uploads no longer send empty or corrupted files

### DIFF
--- a/packages/pieces/common/package.json
+++ b/packages/pieces/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/pieces-common",
-  "version": "0.12.5",
+  "version": "0.12.6",
   "type": "commonjs",
   "sideEffects": false,
   "main": "./dist/src/index.js",

--- a/packages/pieces/common/src/lib/http/core/fetch-http-client.ts
+++ b/packages/pieces/common/src/lib/http/core/fetch-http-client.ts
@@ -193,7 +193,8 @@ function isNodeFormData(body: unknown): body is NodeFormData {
     typeof body === 'object' &&
     body !== null &&
     typeof (body as NodeFormData).getHeaders === 'function' &&
-    typeof (body as NodeFormData).pipe === 'function'
+    typeof (body as NodeFormData).pipe === 'function' &&
+    typeof (body as NodeFormData).on === 'function'
   );
 }
 

--- a/packages/pieces/common/src/lib/http/core/fetch-http-client.ts
+++ b/packages/pieces/common/src/lib/http/core/fetch-http-client.ts
@@ -1,3 +1,4 @@
+import { PassThrough } from 'node:stream';
 import { BaseHttpClient } from './base-http-client';
 import { DelegatingAuthenticationConverter } from './delegating-authentication-converter';
 import { HttpError } from './http-error';
@@ -94,9 +95,11 @@ function serializeBody(
   if (isNil(body)) {
     return { body: undefined, extraHeaders: {}, isStream: false };
   }
-  // node `form-data` instance: a Readable stream that owns its multipart boundary.
   if (isNodeFormData(body)) {
-    return { body: body as unknown as BodyInit, extraHeaders: body.getHeaders(), isStream: true };
+    const stream = new PassThrough();
+    body.on('error', (error) => stream.destroy(error));
+    body.pipe(stream);
+    return { body: stream as unknown as BodyInit, extraHeaders: body.getHeaders(), isStream: true };
   }
   // Already a wire-ready body — pass through untouched.
   if (
@@ -172,7 +175,7 @@ function normalizeHeaders(headers: HttpHeaders): Record<string, string> {
     if (value === undefined) {
       continue;
     }
-    result[key] = Array.isArray(value) ? value.join(', ') : value;
+    result[key.toLowerCase()] = Array.isArray(value) ? value.join(', ') : value;
   }
   return result;
 }
@@ -201,6 +204,7 @@ function isNil(value: unknown): value is null | undefined {
 type NodeFormData = {
   getHeaders: () => Record<string, string>;
   pipe: (...args: unknown[]) => unknown;
+  on: (event: 'error', listener: (error: Error) => void) => unknown;
 };
 
 type ResponseType = NonNullable<HttpRequest['responseType']>;

--- a/packages/server/engine/test/http/formdata-multipart-claim-verify.test.ts
+++ b/packages/server/engine/test/http/formdata-multipart-claim-verify.test.ts
@@ -1,0 +1,64 @@
+import http from 'node:http'
+import { FetchHttpClient, HttpMethod } from '@activepieces/pieces-common'
+import FormData from 'form-data'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+const FIELD_MARKER = 'AP-FORENSICS-MULTIPART-9f2c1a'
+
+type CapturedRequest = {
+    contentType: string
+    rawBody: string
+}
+
+describe('claim: FetchHttpClient sends a node form-data body as multipart, not a stringified object', () => {
+    let server: http.Server
+    let capturePromise: Promise<CapturedRequest>
+
+    beforeEach(async () => {
+        capturePromise = new Promise<CapturedRequest>((resolve) => {
+            server = http.createServer((req, res) => {
+                const chunks: Buffer[] = []
+                req.on('data', (chunk) => chunks.push(chunk))
+                req.on('end', () => {
+                    res.writeHead(200, { 'content-type': 'application/json' })
+                    res.end(JSON.stringify({ ok: true }))
+                    resolve({
+                        contentType: req.headers['content-type'] ?? '',
+                        rawBody: Buffer.concat(chunks).toString('utf8'),
+                    })
+                })
+            })
+        })
+        await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', () => resolve()))
+    })
+
+    afterEach(async () => {
+        await new Promise<void>((resolve) => server.close(() => resolve()))
+    })
+
+    it('delivers the appended field content over the wire', async () => {
+        const address = server.address()
+        if (address === null || typeof address === 'string') {
+            throw new Error('expected a TCP address')
+        }
+        const port = address.port
+
+        const form = new FormData()
+        form.append('file', Buffer.from(FIELD_MARKER), {
+            filename: 'synthetic-upload.txt',
+            contentType: 'text/plain',
+        })
+
+        const client = new FetchHttpClient()
+        await client.sendRequest({
+            method: HttpMethod.POST,
+            url: `http://127.0.0.1:${port}/upload`,
+            body: form,
+        })
+
+        const received = await capturePromise
+        expect(received.rawBody).not.toContain('[object FormData]')
+        expect(received.rawBody).toContain(FIELD_MARKER)
+        expect(received.contentType).toMatch(/^multipart\/form-data;\s*boundary=/)
+    })
+})


### PR DESCRIPTION
Fixes activepieces/activepieces#14225  <br>Closes activepieces/activepieces#14225

## Problem

1. Since 0.86.0 (fetch client replaced axios), node `form-data` bodies sent through pieces-common `httpClient` are delivered as the literal string `[object FormData]`. undici stringifies the form object (a `CombinedStream` with no `Symbol.asyncIterator`) via `String(body)`. Lenient APIs (e.g. Google Drive) store a junk file; strict APIs return 400 "file is required". \~40 pieces plus customer custom pieces are affected.
2. The base client's default `Content-Type: application/json` and the form's lowercase `content-type` both survived the header merge, so fetch combined them into `application/json, multipart/form-data; boundary=...`, which strict multipart parsers reject.

## Fix

* `fetch-http-client.ts` `serializeBody`: pipe the form through a `PassThrough` so undici streams a real Node Readable (source errors propagated via `stream.destroy`).
* `fetch-http-client.ts` `normalizeHeaders`: lowercase header keys, so the form's multipart `content-type` (spread last, last wins) replaces the default `application/json` instead of colliding with it.
* Bump `@activepieces/pieces-common` 0.12.5 to 0.12.6.

## Verification

* Regression test `packages/server/engine/test/http/formdata-multipart-claim-verify.test.ts` drives `FetchHttpClient` against a local echo server. RED-FIRST at HEAD (received body was `[object FormData]`), GREEN after the fix; each run twice, deterministic.
* Full engine unit suite: 353/353 pass (no regression from the header change).
* lint clean on touched files; `/simplify`, `/code-review`, `/security-review` left no unresolved findings.
* Visual: none - backend-only HTTP client serialization, no user-visible change.