### PR TITLE
fix(tool-search): fix reindex crash, self-heal partial index, add coverage logs

### DIFF
--- a/packages/server/api/src/app/app.ts
+++ b/packages/server/api/src/app/app.ts
@@ -217,10 +217,10 @@ export const setupApp = async (app: FastifyInstance): Promise<FastifyInstance> =
     await app.register(folderModule)
     await pieceSyncService(app.log).setup()
     toolSearchReindexJob(app.log).register()
-    // Cold-start backfill: build the tool-search index once if the flag is on but it has never been
-    // built (existing deployment whose piece_metadata is already populated, so no sync delta fires).
-    // Fire-and-forget — a no-op once the index has rows, and must never block or fail boot.
-    rejectedPromiseHandler(toolSearchReindexJob(app.log).backfillIfEmpty(), app.log)
+    // Boot backfill: build the tool-search index if the flag is on but it is empty or only partially
+    // embedded (a populated deployment fires no sync delta, and a build that failed midway leaves rows
+    // unembedded). Fire-and-forget — a no-op once fully built, and must never block or fail boot.
+    rejectedPromiseHandler(toolSearchReindexJob(app.log).backfillIfNeeded(), app.log)
     await pieceMetadataService(app.log).setup()
     await app.register(pieceModule)
     await app.register(collaborativeModule)

--- a/packages/server/api/src/app/tool-search/tool-search-reindex.job.ts
+++ b/packages/server/api/src/app/tool-search/tool-search-reindex.job.ts
@@ -1,7 +1,6 @@
 import { apDayjs } from '@activepieces/server-utils'
 import { ApEdition, isNil } from '@activepieces/shared'
 import { FastifyBaseLogger } from 'fastify'
-import { databaseConnection } from '../database/database-connection'
 import { distributedLock } from '../database/redis-connections'
 import { system } from '../helper/system/system'
 import { AppSystemProp } from '../helper/system/system-props'
@@ -10,7 +9,7 @@ import { systemJobHandlers } from '../helper/system-jobs/job-handlers'
 import { systemJobsSchedule } from '../helper/system-jobs/system-job'
 import { platformService } from '../platform/platform.service'
 import { isToolSearchEnabled } from './tool-search-flag'
-import { ReindexScope, toolSearchReindexService, toolSearchTableExists } from './tool-search-reindex.service'
+import { ReindexScope, toolSearchIndexCoverage, toolSearchReindexService, toolSearchTableExists } from './tool-search-reindex.service'
 
 // One global lock TTL; RedLock auto-extends it while the reconcile runs, so this only needs to be
 // comfortably larger than a single embed round-trip — a full re-embed (model swap) keeps extending.
@@ -62,7 +61,7 @@ export const toolSearchReindexJob = (log: FastifyBaseLogger) => ({
                 timeoutInSeconds: REINDEX_LOCK_TIMEOUT_SECONDS,
                 fn: async () => {
                     if (shouldSkipReindexOnCloud()) {
-                        log.info('[toolSearchReindexJob] Cloud edition without AP_OPENAI_API_KEY — skipping reindex; on cloud we never fall back to the oldest platform (keyword floor serves).')
+                        log.warn('[toolSearchReindexJob] Cloud edition without AP_OPENAI_API_KEY — a reconcile was requested but cannot run; set AP_OPENAI_API_KEY to fund embedding (keyword floor serves meanwhile).')
                         return
                     }
                     // Embedding is funded by AP_OPENAI_API_KEY when set; otherwise (self-host only) by
@@ -98,34 +97,40 @@ export const toolSearchReindexJob = (log: FastifyBaseLogger) => ({
     },
 
     /**
-     * Cold-start path: schedule the first global reconcile if the index has never been built. The
-     * steady-state hook (piece-sync) only fires on a catalog delta, so on a deployment whose
-     * piece_metadata is already populated, flipping AP_TOOL_SEARCH_ENABLED on would otherwise leave
-     * the index empty until the next upstream piece add/delete. Covers both the fresh-deploy and the
-     * already-populated-deploy cases.
+     * Boot reconcile: (re)build the index when it is empty OR only partially embedded. The steady-state
+     * hook (piece-sync) only fires on a catalog delta, so without this a deployment whose piece_metadata
+     * is already populated would leave the index unbuilt after AP_TOOL_SEARCH_ENABLED is flipped on — and
+     * a build that failed midway (embedder rate-limited, leaving rows with NULL embeddings) would never
+     * retry until the next piece add/delete. Covers fresh-deploy, already-populated-deploy, and
+     * partial-build recovery.
      *
-     * No-op unless the flag is on AND the index is empty: once any row exists the index is considered
-     * built and the sync hook owns deltas from there — so a re-run at every boot is a cheap single
-     * SELECT … LIMIT 1 with no side effects. Called fire-and-forget at boot (after register()); it
-     * must never throw fatally, so any DB error surfaces through rejectedPromiseHandler, not boot.
+     * No-op once the index is fully embedded: the coverage read is a single cheap aggregate, so re-running
+     * at every boot has no side effects. Called fire-and-forget at boot (after register()); it must never
+     * throw fatally, so any DB error surfaces through rejectedPromiseHandler, not boot.
      */
-    async backfillIfEmpty(): Promise<void> {
+    async backfillIfNeeded(): Promise<void> {
         if (!isToolSearchEnabled()) {
             return
         }
         if (shouldSkipReindexOnCloud()) {
-            log.info('[toolSearchReindexJob#backfillIfEmpty] Cloud edition without AP_OPENAI_API_KEY — skipping cold-start backfill; on cloud we never fall back to the oldest platform (keyword floor serves).')
+            log.warn('[toolSearchReindexJob#backfillIfNeeded] Cloud edition without AP_OPENAI_API_KEY — tool-search is enabled but cannot build its index; set AP_OPENAI_API_KEY to fund embedding (keyword floor serves meanwhile).')
             return
         }
         if (!await toolSearchTableExists()) {
-            log.info('[toolSearchReindexJob#backfillIfEmpty] tool_search_index is absent (pgvector not installed) — skipping backfill; keyword floor serves.')
+            log.info('[toolSearchReindexJob#backfillIfNeeded] tool_search_index is absent (pgvector not installed) — skipping backfill; keyword floor serves.')
             return
         }
-        const existing = await databaseConnection().query('SELECT 1 FROM "tool_search_index" LIMIT 1')
-        if (!isNil(existing) && existing.length > 0) {
+        const coverage = await toolSearchIndexCoverage()
+        if (coverage.total > 0 && coverage.pending === 0) {
+            log.info(coverage, '[toolSearchReindexJob#backfillIfNeeded] Tool-search index fully built — nothing to reconcile.')
             return
         }
-        log.info('[toolSearchReindexJob#backfillIfEmpty] Tool-search enabled with an empty index — scheduling a one-time global reconcile (cold-start backfill).')
+        if (coverage.total === 0) {
+            log.info(coverage, '[toolSearchReindexJob#backfillIfNeeded] Tool-search enabled with an empty index — scheduling the initial global reconcile (cold-start backfill).')
+        }
+        else {
+            log.warn(coverage, '[toolSearchReindexJob#backfillIfNeeded] Tool-search index partially embedded (a prior build left rows unembedded) — scheduling a global reconcile to finish it.')
+        }
         await this.enqueue({ type: 'all' })
     },
 })

--- a/packages/server/api/src/app/tool-search/tool-search-reindex.job.ts
+++ b/packages/server/api/src/app/tool-search/tool-search-reindex.job.ts
@@ -8,6 +8,7 @@ import { SystemJobName } from '../helper/system-jobs/common'
 import { systemJobHandlers } from '../helper/system-jobs/job-handlers'
 import { systemJobsSchedule } from '../helper/system-jobs/system-job'
 import { platformService } from '../platform/platform.service'
+import { OPENAI_3_SMALL_MODEL_VERSION } from './embedder'
 import { isToolSearchEnabled } from './tool-search-flag'
 import { ReindexScope, toolSearchIndexCoverage, toolSearchReindexService, toolSearchTableExists } from './tool-search-reindex.service'
 
@@ -120,7 +121,7 @@ export const toolSearchReindexJob = (log: FastifyBaseLogger) => ({
             log.info('[toolSearchReindexJob#backfillIfNeeded] tool_search_index is absent (pgvector not installed) — skipping backfill; keyword floor serves.')
             return
         }
-        const coverage = await toolSearchIndexCoverage()
+        const coverage = await toolSearchIndexCoverage(OPENAI_3_SMALL_MODEL_VERSION)
         if (coverage.total > 0 && coverage.pending === 0) {
             log.info(coverage, '[toolSearchReindexJob#backfillIfNeeded] Tool-search index fully built — nothing to reconcile.')
             return

--- a/packages/server/api/src/app/tool-search/tool-search-reindex.service.ts
+++ b/packages/server/api/src/app/tool-search/tool-search-reindex.service.ts
@@ -35,14 +35,14 @@ export const toolSearchReindexService = (log: FastifyBaseLogger) => ({
             : await resolveEmbedder({ platformId: params.platformId, log }))
         if (isNil(embedder)) {
             log.info('[toolSearchReindexService#reindex] No embedder resolved — skipping reindex (keyword floor serves).')
-            return { status: 'no-embedder', objectsIndexed: 0, objectsEmbedded: 0, objectsDeleted: 0 }
+            return { status: 'no-embedder', objectsIndexed: 0, objectsEmbedded: 0, objectsDeleted: 0, objectsPending: 0 }
         }
         // The migration no-ops when pgvector is absent, so the table can be missing even with the flag
         // on. Degrade gracefully (keyword floor) instead of throwing "relation does not exist" on every
         // catalog-change reconcile.
         if (!await toolSearchTableExists()) {
             log.warn('[toolSearchReindexService#reindex] tool_search_index is absent (pgvector not installed) — skipping reindex; keyword floor serves.')
-            return { status: 'no-table', objectsIndexed: 0, objectsEmbedded: 0, objectsDeleted: 0 }
+            return { status: 'no-table', objectsIndexed: 0, objectsEmbedded: 0, objectsDeleted: 0, objectsPending: 0 }
         }
 
         const currentRelease = apVersionUtil.getCurrentRelease()
@@ -64,10 +64,17 @@ export const toolSearchReindexService = (log: FastifyBaseLogger) => ({
 
         // Embed only the rows still missing an embedding (the new + changed ones, plus any that failed
         // a previous run). Embedding is batched and never blocks the upsert diff above.
-        const objectsEmbedded = await embedPendingRows(embedder, scope, log)
+        const { embedded: objectsEmbedded, pending: objectsPending } = await embedPendingRows(embedder, scope, log)
 
-        log.info({ scope: scope.type, objectsIndexed: desired.length, objectsEmbedded, objectsDeleted }, '[toolSearchReindexService#reindex] Reindex complete.')
-        return { status: 'done', objectsIndexed: desired.length, objectsEmbedded, objectsDeleted }
+        // Rows left unembedded after a reconcile mean the embedder failed or was rate-limited on those
+        // batches: a NULL-embedding row is invisible to semantic ranking, so search silently under-serves
+        // until they are re-embedded. Surface it loudly — both the boot backfill and the sync hook retry.
+        if (objectsPending > 0) {
+            log.warn({ scope: scope.type, objectsIndexed: desired.length, objectsEmbedded, objectsPending, objectsDeleted }, '[toolSearchReindexService#reindex] Reindex left rows unembedded — embedding degraded; search partially served until the next boot or catalog sync retries.')
+        }
+
+        log.info({ scope: scope.type, objectsIndexed: desired.length, objectsEmbedded, objectsPending, objectsDeleted }, '[toolSearchReindexService#reindex] Reindex complete.')
+        return { status: 'done', objectsIndexed: desired.length, objectsEmbedded, objectsDeleted, objectsPending }
     },
 })
 
@@ -134,20 +141,36 @@ export async function toolSearchTableExists(): Promise<boolean> {
 }
 
 /**
+ * Coverage of `tool_search_index`: total rows vs. how many carry an embedding. The cold-start backfill
+ * reads this at boot to decide whether the index still needs work: an index with unembedded rows (a
+ * partial build a failed/rate-limited embed run left behind) is NOT "built" — search under-serves until
+ * those rows get vectors. Counts across all model versions so the check needs no resolved embedder.
+ */
+export async function toolSearchIndexCoverage(): Promise<ToolSearchIndexCoverage> {
+    const result = await databaseConnection().query(
+        'SELECT count(*)::int AS total, count("embedding")::int AS embedded FROM "tool_search_index"',
+    )
+    const total = Number(result?.[0]?.total ?? 0)
+    const embedded = Number(result?.[0]?.embedded ?? 0)
+    return { total, embedded, pending: total - embedded }
+}
+
+/**
  * Embed every row that still lacks an embedding at the current model_version (new rows, rows whose
  * text changed and were nulled by the upsert, and rows that failed a prior reindex). Batched; the
- * embedder owns retry/backoff. Returns the number of objects embedded.
+ * embedder owns retry/backoff. Returns the number of objects embedded this run plus the number still
+ * pending afterwards (rows whose batch failed) — a non-zero `pending` marks a degraded, partial index.
  */
-async function embedPendingRows(embedder: ToolSearchEmbedder, scope: ReindexScope, log: FastifyBaseLogger): Promise<number> {
+async function embedPendingRows(embedder: ToolSearchEmbedder, scope: ReindexScope, log: FastifyBaseLogger): Promise<EmbedResult> {
     const params: unknown[] = [embedder.modelVersion]
     const scopeClause = scope.type === 'platform' ? ` AND "platformId" = $${params.push(scope.platformId)}` : ''
-    const pending: PendingRow[] = await databaseConnection().query(
+    const pendingRows: PendingRow[] = await databaseConnection().query(
         `SELECT "id", "retrievalDoc" FROM "tool_search_index"
          WHERE "embedding" IS NULL AND "modelVersion" = $1${scopeClause}`,
         params,
     )
     let embedded = 0
-    for (const batch of chunk(pending, EMBED_BATCH_SIZE)) {
+    for (const batch of chunk(pendingRows, EMBED_BATCH_SIZE)) {
         // A batch that fails after the embedder's own retries leaves its rows NULL and is skipped, not
         // fatal — the next reindex re-selects them (still NULL) and retries. One bad batch never aborts
         // the whole reconcile or rolls back the rows that did embed.
@@ -173,7 +196,7 @@ async function embedPendingRows(embedder: ToolSearchEmbedder, scope: ReindexScop
         )
         embedded += batch.length
     }
-    return embedded
+    return { embedded, pending: pendingRows.length - embedded }
 }
 
 function explodePiece(piece: PieceMetadataSchema, modelVersion: string): DesiredRecord[] {
@@ -339,6 +362,19 @@ type ReindexResult = {
     objectsEmbedded: number
     /** rows removed because their key is no longer in the desired catalog. */
     objectsDeleted: number
+    /** rows still lacking an embedding after this run — non-zero means embedding is degraded. */
+    objectsPending: number
+}
+
+type EmbedResult = {
+    embedded: number
+    pending: number
+}
+
+type ToolSearchIndexCoverage = {
+    total: number
+    embedded: number
+    pending: number
 }
 
 type PendingRow = {

--- a/packages/server/api/src/app/tool-search/tool-search-reindex.service.ts
+++ b/packages/server/api/src/app/tool-search/tool-search-reindex.service.ts
@@ -141,14 +141,17 @@ export async function toolSearchTableExists(): Promise<boolean> {
 }
 
 /**
- * Coverage of `tool_search_index`: total rows vs. how many carry an embedding. The cold-start backfill
- * reads this at boot to decide whether the index still needs work: an index with unembedded rows (a
- * partial build a failed/rate-limited embed run left behind) is NOT "built" — search under-serves until
- * those rows get vectors. Counts across all model versions so the check needs no resolved embedder.
+ * Coverage of `tool_search_index` at one model version: total rows vs. how many carry an embedding. The
+ * boot backfill reads this to decide whether the index still needs work — an index with unembedded rows (a
+ * partial build a failed/rate-limited embed run left behind) is NOT "built", and search under-serves until
+ * those rows get vectors. Scoped to `modelVersion` (the one the current embedder fills) so NULL rows left
+ * at an OLD version by a past model transition — which the current embedder never touches — do not count
+ * as a permanent phantom `pending` that would re-enqueue a reconcile on every boot.
  */
-export async function toolSearchIndexCoverage(): Promise<ToolSearchIndexCoverage> {
+export async function toolSearchIndexCoverage(modelVersion: string): Promise<ToolSearchIndexCoverage> {
     const result = await databaseConnection().query(
-        'SELECT count(*)::int AS total, count("embedding")::int AS embedded FROM "tool_search_index"',
+        'SELECT count(*)::int AS total, count("embedding")::int AS embedded FROM "tool_search_index" WHERE "modelVersion" = $1',
+        [modelVersion],
     )
     const total = Number(result?.[0]?.total ?? 0)
     const embedded = Number(result?.[0]?.embedded ?? 0)

--- a/packages/server/api/src/app/tool-search/tool-search-reindex.service.ts
+++ b/packages/server/api/src/app/tool-search/tool-search-reindex.service.ts
@@ -203,6 +203,11 @@ async function embedPendingRows(embedder: ToolSearchEmbedder, scope: ReindexScop
 }
 
 function explodePiece(piece: PieceMetadataSchema, modelVersion: string): DesiredRecord[] {
+    // `requireAuth` became a required boolean only recently (the framework defaults it `?? true` at
+    // construction); piece_metadata rows written by older versions omit the key, so it reads back as
+    // undefined. Coalesce to true — matching that framework default — so it never binds NULL into the
+    // NOT NULL requiresConnection column, which would otherwise abort the whole upsert and leave the
+    // index unbuilt (so embedPendingRows never runs and search silently serves nothing).
     const actionRecords = Object.entries(piece.actions).map(([objectName, action]) => buildRecord({
         piece,
         modelVersion,
@@ -211,7 +216,7 @@ function explodePiece(piece: PieceMetadataSchema, modelVersion: string): Desired
         displayName: action.displayName,
         description: action.description,
         aiDescription: action.aiMetadata?.description,
-        requiresConnection: action.requireAuth,
+        requiresConnection: action.requireAuth ?? true,
         audience: action.audience ?? null,
     }))
     const triggerRecords = Object.entries(piece.triggers).map(([objectName, trigger]) => buildRecord({
@@ -222,7 +227,7 @@ function explodePiece(piece: PieceMetadataSchema, modelVersion: string): Desired
         displayName: trigger.displayName,
         description: trigger.description,
         aiDescription: trigger.aiMetadata?.description,
-        requiresConnection: trigger.requireAuth,
+        requiresConnection: trigger.requireAuth ?? true,
         audience: null,
     }))
     return [...actionRecords, ...triggerRecords]

--- a/packages/server/api/test/integration/ce/tool-search/tool-search-backfill.test.ts
+++ b/packages/server/api/test/integration/ce/tool-search/tool-search-backfill.test.ts
@@ -2,6 +2,7 @@ import { apId } from '@activepieces/shared'
 import { FastifyInstance } from 'fastify'
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
 import { databaseConnection } from '../../../../src/app/database/database-connection'
+import { OPENAI_3_SMALL_MODEL_VERSION } from '../../../../src/app/tool-search/embedder'
 import { toolSearchReindexJob } from '../../../../src/app/tool-search/tool-search-reindex.job'
 import { setupTestEnvironment, teardownTestEnvironment } from '../../../helpers/test-setup'
 
@@ -19,7 +20,7 @@ async function seedRow({ embedding }: { embedding: string | null }): Promise<voi
             "id", "objectKind", "pieceName", "pieceVersion", "objectName", "displayName",
             "retrievalDoc", "requiresConnection", "modelVersion", "embeddingInputHash", "embedding"
         ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11::vector)`,
-        [apId(), 'action', 'seed-piece', '0.0.1', 'seed_action', 'Seed Action', 'seed doc', false, 'test-model', 'seed-hash', embedding],
+        [apId(), 'action', 'seed-piece', '0.0.1', 'seed_action', 'Seed Action', 'seed doc', false, OPENAI_3_SMALL_MODEL_VERSION, 'seed-hash', embedding],
     )
 }
 

--- a/packages/server/api/test/integration/ce/tool-search/tool-search-backfill.test.ts
+++ b/packages/server/api/test/integration/ce/tool-search/tool-search-backfill.test.ts
@@ -6,20 +6,20 @@ import { toolSearchReindexJob } from '../../../../src/app/tool-search/tool-searc
 import { setupTestEnvironment, teardownTestEnvironment } from '../../../helpers/test-setup'
 
 // Boots the FULL server (setupServer → setupApp) on real redis-memory-server, so BullMQ + the RedLock
-// distributed lock genuinely run — same harness as tool-search-reindex-job.test.ts. backfillIfEmpty is
-// the cold-start path: it reads the live AP_TOOL_SEARCH_ENABLED flag and the real tool_search_index
-// table, then decides whether to schedule one global reconcile. We spy on the job's own enqueue (which
-// backfillIfEmpty calls via `this`) to assert the decision deterministically — no worker race, and the
-// flag / empty-index reads are the real ones.
+// distributed lock genuinely run — same harness as tool-search-reindex-job.test.ts. backfillIfNeeded is
+// the boot path: it reads the live AP_TOOL_SEARCH_ENABLED flag and the real tool_search_index table, then
+// decides whether to schedule one global reconcile. We spy on the job's own enqueue (which backfillIfNeeded
+// calls via `this`) to assert the decision deterministically — no worker race, and the flag / coverage
+// reads are the real ones.
 let app: FastifyInstance
 
-async function seedIndexRow(): Promise<void> {
+async function seedRow({ embedding }: { embedding: string | null }): Promise<void> {
     await databaseConnection().query(
         `INSERT INTO "tool_search_index" (
             "id", "objectKind", "pieceName", "pieceVersion", "objectName", "displayName",
-            "retrievalDoc", "requiresConnection", "modelVersion", "embeddingInputHash"
-        ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)`,
-        [apId(), 'action', 'seed-piece', '0.0.1', 'seed_action', 'Seed Action', 'seed doc', false, 'test-model', 'seed-hash'],
+            "retrievalDoc", "requiresConnection", "modelVersion", "embeddingInputHash", "embedding"
+        ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11::vector)`,
+        [apId(), 'action', 'seed-piece', '0.0.1', 'seed_action', 'Seed Action', 'seed doc', false, 'test-model', 'seed-hash', embedding],
     )
 }
 
@@ -41,7 +41,7 @@ afterEach(async () => {
     vi.restoreAllMocks()
 })
 
-describe('Tool Search backfill (cold-start backfill-if-empty)', () => {
+describe('Tool Search backfill (boot reconcile-if-needed)', () => {
     it('does NOT enqueue when the flag is OFF, even with an empty index', async () => {
         delete process.env.AP_TOOL_SEARCH_ENABLED
         await clearIndex()
@@ -49,19 +49,19 @@ describe('Tool Search backfill (cold-start backfill-if-empty)', () => {
         const job = toolSearchReindexJob(app.log)
         const enqueueSpy = vi.spyOn(job, 'enqueue')
 
-        await job.backfillIfEmpty()
+        await job.backfillIfNeeded()
 
         expect(enqueueSpy).not.toHaveBeenCalled()
     })
 
-    it('does NOT enqueue when the flag is ON but the index already has rows (steady-state owns deltas)', async () => {
+    it('does NOT enqueue when the flag is ON and every row is already embedded (fully built)', async () => {
         process.env.AP_TOOL_SEARCH_ENABLED = 'true'
-        await seedIndexRow()
+        await seedRow({ embedding: '[0.1,0.2,0.3]' })
 
         const job = toolSearchReindexJob(app.log)
         const enqueueSpy = vi.spyOn(job, 'enqueue')
 
-        await job.backfillIfEmpty()
+        await job.backfillIfNeeded()
 
         expect(enqueueSpy).not.toHaveBeenCalled()
     })
@@ -73,7 +73,20 @@ describe('Tool Search backfill (cold-start backfill-if-empty)', () => {
         const job = toolSearchReindexJob(app.log)
         const enqueueSpy = vi.spyOn(job, 'enqueue')
 
-        await job.backfillIfEmpty()
+        await job.backfillIfNeeded()
+
+        expect(enqueueSpy).toHaveBeenCalledTimes(1)
+        expect(enqueueSpy).toHaveBeenCalledWith({ type: 'all' })
+    })
+
+    it('DOES enqueue when the flag is ON and the index is partially embedded (a prior build left rows NULL)', async () => {
+        process.env.AP_TOOL_SEARCH_ENABLED = 'true'
+        await seedRow({ embedding: null })
+
+        const job = toolSearchReindexJob(app.log)
+        const enqueueSpy = vi.spyOn(job, 'enqueue')
+
+        await job.backfillIfNeeded()
 
         expect(enqueueSpy).toHaveBeenCalledTimes(1)
         expect(enqueueSpy).toHaveBeenCalledWith({ type: 'all' })

--- a/packages/server/api/test/integration/ce/tool-search/tool-search.test.ts
+++ b/packages/server/api/test/integration/ce/tool-search/tool-search.test.ts
@@ -131,6 +131,32 @@ describe('Tool Search Engine (Phase 1)', () => {
         expect(await indexRowCount()).toBe(4)
     })
 
+    it('defaults requiresConnection to true when requireAuth is absent (legacy piece_metadata)', async () => {
+        // Simulates a piece_metadata row written before requireAuth became a required boolean: the stored
+        // JSON has no requireAuth key, so it reads back as undefined. Before the `?? true` coalesce this
+        // bound NULL into the NOT NULL requiresConnection column, aborting the whole upsert (index unbuilt).
+        const legacyAction = { name: 'legacy_action', displayName: 'Legacy Action', description: 'Send a message to a Slack channel', props: {} } as unknown as ActionBase
+        await db.save('piece_metadata', createMockPieceMetadata({
+            name: '@activepieces/piece-legacy',
+            displayName: 'Legacy',
+            version: '1.0.0',
+            pieceType: PieceType.OFFICIAL,
+            packageType: PackageType.REGISTRY,
+            actions: { legacy_action: legacyAction },
+            triggers: {},
+        }))
+
+        const result = await toolSearchReindexService(log).reindex({ embedder: fakeEmbedder })
+
+        expect(result.status).toBe('done')
+        expect(result.objectsIndexed).toBe(1)
+        const [row] = await databaseConnection().query(
+            'SELECT "requiresConnection" FROM "tool_search_index" WHERE "pieceName" = $1 AND "objectName" = $2',
+            ['@activepieces/piece-legacy', 'legacy_action'],
+        )
+        expect(row.requiresConnection).toBe(true)
+    })
+
     it('searchActions ranks the semantically closest action first and returns the tiered envelope', async () => {
         await seedCatalog()
         await toolSearchReindexService(log).reindex({ embedder: fakeEmbedder })


### PR DESCRIPTION
## Problem

Semantic tool-search (`ap_search_actions` / `ap_search_triggers`) silently served nothing on a populated catalog — every query returned `[]` with `mode:"semantic"` while the index held ~7,300 rows but only a handful were embedded. Three compounding issues:

1. **Crash before embedding (root cause).** `explodePiece` passed `action.requireAuth` / `trigger.requireAuth` straight through. `requireAuth` became a required boolean only recently, so `piece_metadata` rows written by older framework versions omit it → `undefined` → binds `NULL` into the NOT NULL `requiresConnection` column → the upsert throws in `upsertBatch`, aborting `reindex()` **before** `embedPendingRows` ever runs. `upsertDesired` has no wrapping transaction, so chunks before the poison row commit (the ~7k NULL-embedding rows) while embedding is never reached — hence rows present, zero OpenAI traffic.
2. **No self-heal.** The boot backfill only rebuilt an *empty* index, so once partial rows existed a restart no-op'd; recovery needed a manual `TRUNCATE`.
3. **No signal.** Failure/skip logs were `info` (dropped at `warn`+) and a partial index produced no warning, so the outage was invisible.

## Changes

- **Root-cause fix:** coalesce `requireAuth ?? true` for both actions and triggers in `explodePiece`, matching the framework's own construction default (`action.ts:81`, `trigger.ts`). No more NULL → the upsert completes and embedding runs.
- **Self-heal:** `backfillIfEmpty` → `backfillIfNeeded` — re-enqueue a global reconcile when the index is empty **or has unembedded rows** (scoped to the current model version so old-version NULLs can't cause a phantom `pending`).
- **Observability:** boot logs coverage `{total, embedded, pending}` (`warn` when partial); reindex `warn`s when it leaves rows unembedded (`objectsPending`); the cloud "no `AP_OPENAI_API_KEY`" skip is now `warn`.

## Tests

- Regression: a `piece_metadata` action with no `requireAuth` reindexes without crashing and defaults `requiresConnection` to `true`.
- Backfill: fixed the "already has rows" case to seed an *embedded* row; added a partial-index → self-heal test.

## Follow-up (not in this PR)

`upsertDesired` has no wrapping transaction — a future poison row would again leave partial state. Worth making the reconcile upsert atomic separately.

Root cause diagnosed by Chacker via ClickHouse `otel_logs`.
