### PR TITLE
fix(ci): repair invalid close-external-prs workflow

### DIFF
--- a/.github/workflows/close-external-prs.yml
+++ b/.github/workflows/close-external-prs.yml
@@ -42,9 +42,9 @@ jobs:
         run: |
           gh pr comment "$PR" --body "Hey — thanks so much for taking the time to open this! 🙏
 
-We've **temporarily paused unsolicited pull requests** from outside the core team. This isn't about you or the quality of your change — an open PR is a promise from us to review it carefully, and right now the volume (a lot of it AI-generated) means we can't keep that promise for every PR without it becoming unfair to contributors who wait weeks for a reply. So instead of leaving PRs hanging, we close them and point you to a faster path.
+          We've **temporarily paused unsolicited pull requests** from outside the core team. This isn't about you or the quality of your change — an open PR is a promise from us to review it carefully, and right now the volume (a lot of it AI-generated) means we can't keep that promise for every PR without it becoming unfair to contributors who wait weeks for a reply. So instead of leaving PRs hanging, we close them and point you to a faster path.
 
-**Already working with us?** If you're an existing customer and we've already discussed this change over Slack, ping us there and we'll add the \`keep-open\` label and reopen this PR for review.
+          **Already working with us?** If you're an existing customer and we've already discussed this change over Slack, ping us there and we'll add the \`keep-open\` label and reopen this PR for review.
 
-You can still build and publish your own [piece](https://www.activepieces.com/docs/build-pieces/building-pieces/start-building) — just outside this repo, as your own package rather than a PR here. See [CONTRIBUTING.md](https://github.com/activepieces/activepieces/blob/main/CONTRIBUTING.md#pull-requests) for the full policy. Thanks again for caring about the project. 💜"
+          You can still build and publish your own [piece](https://www.activepieces.com/docs/build-pieces/building-pieces/start-building) — just outside this repo, as your own package rather than a PR here. See [CONTRIBUTING.md](https://github.com/activepieces/activepieces/blob/main/CONTRIBUTING.md#pull-requests) for the full policy. Thanks again for caring about the project. 💜"
           gh pr close "$PR"


### PR DESCRIPTION
The `close-external-prs.yml` workflow was a startup failure — the `run:` block's message body wrapped onto column-0 lines, which ends a YAML literal block scalar and makes the whole file unparseable. GitHub logged a failed run on every push (main included); the workflow never actually ran.

Fix: indent the continuation lines into the block. Validated with a real YAML parse — triggers intact, comment text renders clean.

This got separated from #14275, which squash-merged before this fix landed.