### PR TITLE
feat(mcp): AI clients can read a step's full settings when updating flows

### DIFF
--- a/.agents/features/mcp.md
+++ b/.agents/features/mcp.md
@@ -55,6 +55,7 @@ Exposes an Activepieces project as a Model Context Protocol (MCP) server so that
 - `ap_list_flows` — list all flows in project
 - `ap_flow_structure` — get flow definition and structure
 - `ap_read_step_code` — read full source code of a CODE step
+- `ap_read_step_settings` — read the full untruncated settings of any step (trigger included): piece input, code source, loop items, router branches, error handling options
 - `ap_validate_flow`, `ap_validate_step_config` — validation helpers
 - `ap_research_pieces` — piece discovery with intent-based recommended-action ranking
 - `ap_get_piece_props` — action/trigger input schema with required-input summaries and example input, action cardinality, curated expert notes (via `piece-expertise.ts`), AI description + idempotency hint, and output field paths (from a declared output schema, or derived from a trigger's sample data)

--- a/packages/server/api/src/app/mcp/tools/ap-read-step-code.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-read-step-code.ts
@@ -14,7 +14,7 @@ export const apReadStepCodeTool = (mcp: ProjectScopedMcpServer, log: FastifyBase
     return {
         title: 'ap_read_step_code',
         permission: Permission.READ_FLOW,
-        description: 'Read the full source code, package.json, and input of a CODE step. Returns untruncated content (unlike ap_flow_structure which truncates).',
+        description: 'Read the full source code, package.json, and input of a CODE step. Returns untruncated content (unlike ap_flow_structure which truncates). ap_read_step_settings reads full settings for any step type.',
         inputSchema: {
             flowId: z.string().describe('The id of the flow'),
             stepName: z.string().describe('The name of the CODE step (e.g. "step_1"). Use ap_flow_structure to get valid values.'),

--- a/packages/server/api/src/app/mcp/tools/ap-read-step-settings.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-read-step-settings.ts
@@ -1,0 +1,57 @@
+import { isNil, Permission } from '@activepieces/core-utils'
+import { flowStructureUtil, FlowTriggerType, McpToolDefinition, ProjectScopedMcpServer } from '@activepieces/shared'
+import { FastifyBaseLogger } from 'fastify'
+import { z } from 'zod'
+import { flowService } from '../../flows/flow/flow.service'
+import { mcpUtils } from './mcp-utils'
+
+const readStepSettingsInput = z.object({
+    flowId: z.string().describe('The id of the flow'),
+    stepName: z.string().describe('The name of the step (e.g. "trigger", "step_1"). Use ap_flow_structure to get valid values.'),
+})
+
+export const apReadStepSettingsTool = (mcp: ProjectScopedMcpServer, log: FastifyBaseLogger): McpToolDefinition => {
+    return {
+        title: 'ap_read_step_settings',
+        permission: Permission.READ_FLOW,
+        description: 'Read the full untruncated settings of any step, including the trigger: piece input, action/trigger name, loop items, router branches, and error handling options. Use this to see a step\'s current configuration before updating it (ap_flow_structure truncates piece input). For reviewing a CODE step\'s source, prefer ap_read_step_code.',
+        inputSchema: readStepSettingsInput.shape,
+        annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false },
+        execute: async (args) => {
+            try {
+                const { flowId, stepName } = readStepSettingsInput.parse(args)
+
+                const flow = await flowService(log).getOnePopulated({ id: flowId, projectId: mcp.projectId })
+                if (isNil(flow)) {
+                    return { content: [{ type: 'text', text: '❌ Flow not found' }] }
+                }
+
+                const step = flowStructureUtil.getStep(stepName, flow.version.trigger)
+                if (isNil(step)) {
+                    const allSteps = flowStructureUtil.getAllSteps(flow.version.trigger).map(s => s.name).join(', ')
+                    return { content: [{ type: 'text', text: `❌ Step "${stepName}" not found. Available steps: ${allSteps}` }] }
+                }
+
+                const emptyTriggerHint = step.type === FlowTriggerType.EMPTY
+                    ? '\n\nNo trigger selected yet. Use ap_update_trigger to configure one.'
+                    : ''
+                return {
+                    content: [{
+                        type: 'text',
+                        text: `Settings for step "${step.name}" (type: ${step.type}, displayName: "${step.displayName}"):\n\n${JSON.stringify(step.settings, null, 2)}${emptyTriggerHint}`,
+                    }],
+                    structuredContent: {
+                        stepName: step.name,
+                        type: step.type,
+                        displayName: step.displayName,
+                        valid: step.valid,
+                        settings: step.settings,
+                    },
+                }
+            }
+            catch (err) {
+                return mcpUtils.mcpToolError('Failed to read step settings', err)
+            }
+        },
+    }
+}

--- a/packages/server/api/src/app/mcp/tools/index.ts
+++ b/packages/server/api/src/app/mcp/tools/index.ts
@@ -27,6 +27,7 @@ import { apLockAndPublishTool } from './ap-lock-and-publish'
 import { apManageFieldsTool } from './ap-manage-fields'
 import { apManageNotesTool } from './ap-manage-notes'
 import { apReadStepCodeTool } from './ap-read-step-code'
+import { apReadStepSettingsTool } from './ap-read-step-settings'
 import { apRenameFlowTool } from './ap-rename-flow'
 import { apResearchPiecesTool } from './ap-research-pieces'
 import { apResolvePropertyChainTool } from './ap-resolve-property-chain'
@@ -55,6 +56,7 @@ export const LOCKED_TOOL_NAMES: string[] = [
     'ap_list_flows',
     'ap_flow_structure',
     'ap_read_step_code',
+    'ap_read_step_settings',
     'ap_validate_flow',
     'ap_research_pieces',
     'ap_get_piece_props',
@@ -117,6 +119,7 @@ export const activepiecesTools = (mcp: ProjectScopedMcpServer, userId: string | 
     apListFlowsTool(mcp, log),
     apFlowStructureTool(mcp, log),
     apReadStepCodeTool(mcp, log),
+    apReadStepSettingsTool(mcp, log),
     apValidateFlowTool(mcp, log),
     apResearchPiecesTool(mcp, log),
     // Tool-search engine — gated behind the AP_TOOL_SEARCH_ENABLED rollout flag (default off).

--- a/packages/server/api/test/integration/ce/mcp/mcp-tools.test.ts
+++ b/packages/server/api/test/integration/ce/mcp/mcp-tools.test.ts
@@ -26,6 +26,7 @@ import { apUpdateBranchTool } from '../../../../src/app/mcp/tools/ap-update-bran
 import { apListRunsTool } from '../../../../src/app/mcp/tools/ap-list-runs'
 import { apGetRunTool } from '../../../../src/app/mcp/tools/ap-get-run'
 import { apListFlowsTool } from '../../../../src/app/mcp/tools/ap-list-flows'
+import { apReadStepSettingsTool } from '../../../../src/app/mcp/tools/ap-read-step-settings'
 import { apRunActionTool } from '../../../../src/app/mcp/tools/ap-run-action'
 import { mcpUtils } from '../../../../src/app/mcp/tools/mcp-utils'
 import { db } from '../../../helpers/db'
@@ -2552,5 +2553,87 @@ describe('MCP Tools integration', () => {
         expect(response.statusCode).toBe(StatusCodes.CREATED)
         const flow = await flowService(mockLog).getOnePopulatedOrThrow({ id: response.json().id, projectId: ctx.project.id })
         expect(flow.createdBy ?? null).toBeNull()
+    })
+
+    it('ap_read_step_settings — returns full untruncated input for a PIECE step', async () => {
+        const ctx = await createTestContext(app)
+        const mcp = makeMcp(ctx.project.id)
+        const flowId = await createFlowAndGetId(mcp, 'Read Settings Flow')
+
+        const longValue = 'recipient-'.repeat(80)
+        await apAddStepTool(mcp, mockLog).execute({
+            flowId,
+            parentStepName: 'trigger',
+            stepLocationRelativeToParent: StepLocationRelativeToParent.AFTER,
+            stepType: FlowActionType.PIECE,
+            displayName: 'Send Email',
+            pieceName: '@activepieces/piece-test-email',
+            actionName: 'send_email',
+            input: { to: longValue, subject: 'Hello' },
+        })
+
+        const structure = await apFlowStructureTool(mcp, mockLog).execute({ flowId })
+        expect(text(structure)).toContain('(truncated)')
+        expect(text(structure)).not.toContain(longValue)
+
+        const result = await apReadStepSettingsTool(mcp, mockLog).execute({ flowId, stepName: 'step_1' })
+        expect(text(result)).not.toContain('❌')
+        expect(text(result)).toContain(longValue)
+        expect(text(result)).toContain('send_email')
+    })
+
+    it('ap_read_step_settings — returns sourceCode and packageJson for a CODE step', async () => {
+        const ctx = await createTestContext(app)
+        const mcp = makeMcp(ctx.project.id)
+        const flowId = await createFlowAndGetId(mcp, 'Read Code Settings Flow')
+
+        const sourceCode = 'export const code = async (inputs) => { return inputs.value * 2 }'
+        await apAddStepTool(mcp, mockLog).execute({
+            flowId,
+            parentStepName: 'trigger',
+            stepLocationRelativeToParent: StepLocationRelativeToParent.AFTER,
+            stepType: FlowActionType.CODE,
+            displayName: 'Double It',
+            sourceCode,
+            input: { value: '{{trigger}}' },
+        })
+
+        const result = await apReadStepSettingsTool(mcp, mockLog).execute({ flowId, stepName: 'step_1' })
+        expect(text(result)).not.toContain('❌')
+        expect(text(result)).toContain('inputs.value * 2')
+        expect(text(result)).toContain('packageJson')
+    })
+
+    it('ap_read_step_settings — reads the trigger step', async () => {
+        const ctx = await createTestContext(app)
+        const mcp = makeMcp(ctx.project.id)
+        const flowId = await createFlowAndGetId(mcp, 'Read Trigger Settings Flow')
+
+        const result = await apReadStepSettingsTool(mcp, mockLog).execute({ flowId, stepName: 'trigger' })
+        expect(text(result)).not.toContain('❌')
+        expect(text(result)).toContain('EMPTY')
+        expect(text(result)).toContain('ap_update_trigger')
+    })
+
+    it('ap_read_step_settings — unknown step returns available step names', async () => {
+        const ctx = await createTestContext(app)
+        const mcp = makeMcp(ctx.project.id)
+        const flowId = await createFlowAndGetId(mcp, 'Read Missing Step Flow')
+
+        const result = await apReadStepSettingsTool(mcp, mockLog).execute({ flowId, stepName: 'step_99' })
+        expect(text(result)).toContain('❌')
+        expect(text(result)).toContain('Available steps')
+        expect(text(result)).toContain('trigger')
+    })
+
+    it('ap_read_step_settings — cannot read a flow from another project', async () => {
+        const ctx1 = await createTestContext(app)
+        const ctx2 = await createTestContext(app)
+        const mcp2 = makeMcp(ctx2.project.id)
+        const flowId = await createFlowAndGetId(mcp2, 'Other Project Flow')
+
+        const mcp1 = makeMcp(ctx1.project.id)
+        const result = await apReadStepSettingsTool(mcp1, mockLog).execute({ flowId, stepName: 'trigger' })
+        expect(text(result)).toContain('❌ Flow not found')
     })
 })

--- a/packages/web/src/app/components/project-settings/mcp-server/utils/mcp-tools-metadata.ts
+++ b/packages/web/src/app/components/project-settings/mcp-server/utils/mcp-tools-metadata.ts
@@ -28,6 +28,11 @@ export const TOOL_CATEGORIES: ToolCategory[] = [
           'Read full source code, package.json, and input of a CODE step',
       },
       {
+        name: 'ap_read_step_settings',
+        description:
+          'Read the full untruncated settings of any step, including piece input, code source, loop items, and router branches',
+      },
+      {
         name: 'ap_validate_flow',
         description:
           'Validate a flow for structural issues without publishing — checks step validity, template references, and empty branches',

--- a/packages/web/src/features/chat/lib/tool-icons.ts
+++ b/packages/web/src/features/chat/lib/tool-icons.ts
@@ -72,6 +72,7 @@ const TOOL_ICONS: Record<string, LucideIcon> = {
   ap_delete_flow: Trash2,
   ap_flow_structure: Network,
   ap_read_step_code: Code,
+  ap_read_step_settings: SlidersHorizontal,
 
   ap_validate_flow: ShieldCheck,
   ap_validate_step_config: ShieldCheck,


### PR DESCRIPTION
Fixes [GIT-1640](https://linear.app/activepieces/issue/GIT-1640)
Closes #14285

## Problem
1. MCP clients editing an existing flow cannot read a step's current config: `ap_read_step_code` rejects non-CODE steps, and `ap_flow_structure` truncates piece input to 500 chars.

## Fix
- `packages/server/api/src/app/mcp/tools/ap-read-step-settings.ts`: new locked read-only tool returning full untruncated `settings` for any step type (trigger included), with an EMPTY-trigger hint steering to `ap_update_trigger`
- `tools/index.ts`: registered in `LOCKED_TOOL_NAMES` + `activepiecesTools`
- `ap-read-step-code.ts`: description cross-pointer
- web `mcp-tools-metadata.ts` + `tool-icons.ts`: settings-panel row and chat icon (sync mandated by list comments)
- `.agents/features/mcp.md`: registry updated

## Verification
- 5 new integration tests, MCP suite 100 passed; the piece-step test pins the gap (`ap_flow_structure` output truncated, new tool returns the 800-char value in full)
- Live MCP protocol e2e against the running dev stack: tools/list exposes the tool, full input returned, cross-project read returns Flow not found
- `npm run lint-dev` clean (0 errors)
- Security: `READ_FLOW` permission gate and `projectId` scoping verified; REST `GET /v1/flows/:id` already exposes identical data at the same permission
- Visual: project settings, MCP Server, Tools tab, Discovery category shows the new row (screenshot in comment); chat tool icon state not driven (registry map entry, fallback unchanged)

## Breaking change?
- [x] no
- [ ] yes-technical
- [ ] yes-functional

## Security impact?
- [x] no
- [ ] yes-security-sensitive
