### PR TITLE
fix(ci): strip URL scheme from ZAP report for code scanning upload

### DIFF
--- a/.github/workflows/dast.yml
+++ b/.github/workflows/dast.yml
@@ -140,6 +140,11 @@ jobs:
           done
           if [ -n "$found" ]; then
             cp "$found" "${GITHUB_WORKSPACE}/.zap/reports/zap-dast.sarif"
+            # Code scanning rejects https URIs (expects repo-relative paths). Strip the scheme
+            # from finding/artifact LOCATIONS only — leave tool/rule metadata URIs (helpUri,
+            # informationUri) intact so Security-tab rule-help links stay clickable.
+            SARIF="${GITHUB_WORKSPACE}/.zap/reports/zap-dast.sarif"
+            jq '(.runs[]?.results[]?.locations[]?.physicalLocation.artifactLocation.uri?) |= sub("^https?://"; "") | (.runs[]?.results[]?.relatedLocations[]?.physicalLocation.artifactLocation.uri?) |= sub("^https?://"; "") | (.runs[]?.artifacts[]?.location.uri?) |= sub("^https?://"; "")' "$SARIF" > "$SARIF.tmp" && mv "$SARIF.tmp" "$SARIF"
             echo "found=true" >> "$GITHUB_OUTPUT"
           else
             echo "found=false" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Problem

The DAST workflow failed uploading results:
`SARIF URI scheme "https" did not match the checkout URI scheme "file"`.

Code scanning expects repo-relative file paths, but ZAP anchors findings to live URLs.

## Fix

Strip the `https://` scheme from URIs in the SARIF before upload, so they read as relative paths that code scanning accepts. Alerts now show as e.g. `stg.activepieces.com/api/v1/templates`.
