### PR TITLE
chore(release): v0.86.3

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   app:
-    image: ghcr.io/activepieces/activepieces:0.86.2
+    image: ghcr.io/activepieces/activepieces:0.86.3
     container_name: activepieces-app
     restart: unless-stopped
     ports:
@@ -16,7 +16,7 @@ services:
     networks:
       - activepieces
   worker:
-    image: ghcr.io/activepieces/activepieces:0.86.2
+    image: ghcr.io/activepieces/activepieces:0.86.3
     restart: unless-stopped
     depends_on:
       - app


### PR DESCRIPTION
Release v0.86.3.

- Bump `docker-compose.yml` image tags 0.86.2 → 0.86.3.
- `package.json` already at 0.86.3 on main (no bump needed).

Release self-hosted workflow dispatched for tag `0.86.3`.