### PR TITLE
feat(release): make RC GitHub Release opt-in (default off)

### DIFF
--- a/.github/workflows/release-self-hosted.yml
+++ b/.github/workflows/release-self-hosted.yml
@@ -88,6 +88,7 @@ jobs:
           git push origin ${{ inputs.tag }} --force
 
       - name: Create or update changelog via release-drafter
+        if: ${{ !contains(inputs.tag, '-rc') }}
         uses: release-drafter/release-drafter@v7
         with:
           commitish: ${{ github.ref_name }}
@@ -95,7 +96,7 @@ jobs:
           tag: ${{ inputs.tag }}
           name: ${{ inputs.tag }}
           version: ${{ inputs.tag }}
-          latest: ${{ !contains(inputs.tag, '-rc') }}
+          latest: true
           publish: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-self-hosted.yml
+++ b/.github/workflows/release-self-hosted.yml
@@ -12,6 +12,11 @@ on:
         required: false
         default: false
         type: boolean
+      publish_rc_release:
+        description: 'Publish a GitHub Release for RC tags too (ignored for final tags)'
+        required: false
+        default: false
+        type: boolean
 
 jobs:
   # Preflight: build the image and run functional smoke tests + the perf-regression
@@ -88,15 +93,15 @@ jobs:
           git push origin ${{ inputs.tag }} --force
 
       - name: Create or update changelog via release-drafter
-        if: ${{ !contains(inputs.tag, '-rc') }}
+        if: ${{ !contains(inputs.tag, '-rc') || inputs.publish_rc_release }}
         uses: release-drafter/release-drafter@v7
         with:
           commitish: ${{ github.ref_name }}
-          prerelease: false
+          prerelease: ${{ contains(inputs.tag, '-rc') }}
           tag: ${{ inputs.tag }}
           name: ${{ inputs.tag }}
           version: ${{ inputs.tag }}
-          latest: true
+          latest: ${{ !contains(inputs.tag, '-rc') }}
           publish: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Fixes activepieces/activepieces#14292
Closes activepieces/activepieces#14292

## Problem

1. Every manual RC dispatch of `release-self-hosted.yml` publishes a full GitHub Release with `prerelease: false` — nine+ `0.86.3-rc.*` entries currently sit on the releases page.
2. release-drafter then anchors "previous release" on the newest RC, so a cycle's PRs fragment across rc.1…rc.9 and the final release notes only cover PRs merged after the last RC.

## Fix

RC dispatches no longer publish a GitHub Release **by default** — they still produce the docker image and git tag. A new `publish_rc_release` workflow input opts in per dispatch when a release is actually wanted.

* **New input `publish_rc_release`** (boolean, default `false`): tick it at dispatch to publish a GitHub Release for an RC tag; ignored for final tags.
* **`if:`** on the release-drafter step → `!contains(tag, '-rc') || publish_rc_release`. Final/hotfix tags always publish; RC tags only when the box is ticked.
* **`prerelease:`** → `contains(tag, '-rc')`. An opted-in RC is published as a **pre-release**, so it is excluded from the "Latest" badge, the repo sidebar, and `GET /releases/latest`.
* **`latest:`** keeps the original `!contains(tag, '-rc')` guard.

Because prereleases are excluded from release-drafter's previous-release anchor (`include-pre-releases: false`, already in `.github/release-drafter.yml`), the next **final** release lists every PR since the last final — RC-described PRs included — fixing problem #2 regardless of whether an RC was published.

## Behavior

| Tag | `publish_rc_release` | GitHub Release |
|---|---|---|
| `0.86.3` (final/hotfix) | any | published, marked "Latest" |
| `0.86.3-rc.1` | `false` (default) | none — kept off the releases page |
| `0.86.3-rc.1` | `true` | published as **Pre-release** (not "Latest") |

## Verification

* Workflow YAML parse validated; `if`/`prerelease`/`latest` reuse the same `contains()` guard already proven on the original `latest:` input.
* lint/test gates: N/A — CI workflow YAML only, no runtime code. Verifiable on the next RC dispatch (expect: no new GitHub Release unless `publish_rc_release` is ticked).
* Visual: none — CI workflow change, no user-visible surface.

## Breaking change?
- [x] no
- [ ] yes-technical
- [ ] yes-functional

## Security impact?
- [x] no
- [ ] yes-security-sensitive
