### PR TITLE
Piece/publish gate

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -7181,6 +7181,16 @@
         "tslib": "2.6.2",
       },
     },
+    "packages/pieces/community/publish-gate": {
+      "name": "@activepieces/piece-publish-gate",
+      "version": "0.0.1",
+      "dependencies": {
+        "@activepieces/pieces-framework": "workspace:*",
+      },
+      "devDependencies": {
+        "tslib": "2.6.2",
+      },
+    },
     "packages/pieces/community/pubrio": {
       "name": "@activepieces/piece-pubrio",
       "version": "0.0.4",
@@ -12014,6 +12024,8 @@
     "@activepieces/piece-provenexpert": ["@activepieces/piece-provenexpert@workspace:packages/pieces/community/provenexpert"],
 
     "@activepieces/piece-proxycurl": ["@activepieces/piece-proxycurl@workspace:packages/pieces/community/proxycurl"],
+
+    "@activepieces/piece-publish-gate": ["@activepieces/piece-publish-gate@workspace:packages/pieces/community/publish-gate"],
 
     "@activepieces/piece-pubrio": ["@activepieces/piece-pubrio@workspace:packages/pieces/community/pubrio"],
 

--- a/packages/pieces/community/publish-gate/.eslintrc.json
+++ b/packages/pieces/community/publish-gate/.eslintrc.json
@@ -1,0 +1,47 @@
+{
+  "extends": [
+    "../../../../.eslintrc.json"
+  ],
+  "ignorePatterns": [
+    "!**/*"
+  ],
+  "overrides": [
+    {
+      "files": [
+        "*.ts",
+        "*.tsx",
+        "*.js",
+        "*.jsx"
+      ],
+      "rules": {}
+    },
+    {
+      "files": [
+        "*.ts",
+        "*.tsx"
+      ],
+      "rules": {
+        "no-restricted-imports": [
+          "error",
+          {
+            "patterns": [
+              "lodash",
+              "lodash/*",
+              "@activepieces/core-*",
+              "@activepieces/server*",
+              "@activepieces/engine",
+              "@activepieces/shared"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "files": [
+        "*.js",
+        "*.jsx"
+      ],
+      "rules": {}
+    }
+  ]
+}

--- a/packages/pieces/community/publish-gate/README.md
+++ b/packages/pieces/community/publish-gate/README.md
@@ -1,0 +1,8 @@
+# pieces-publish-gate
+
+Stops a flow before its next steps unless the flow has been published, so test
+and draft runs never trigger the real actions placed below the gate.
+
+## Building
+
+Run `turbo run build --filter=@activepieces/piece-publish-gate` to build the library.

--- a/packages/pieces/community/publish-gate/package.json
+++ b/packages/pieces/community/publish-gate/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@activepieces/piece-publish-gate",
+  "version": "0.0.1",
+  "main": "./dist/src/index.js",
+  "types": "./dist/src/index.d.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.lib.json && cp package.json dist/",
+    "bundle": "node ../../../../dist/packages/cli/src/index.js pieces bundle",
+    "lint": "eslint 'src/**/*.ts'"
+  },
+  "dependencies": {
+    "@activepieces/pieces-framework": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
+  }
+}

--- a/packages/pieces/community/publish-gate/src/i18n/translation.json
+++ b/packages/pieces/community/publish-gate/src/i18n/translation.json
@@ -1,0 +1,10 @@
+{
+  "Publish Gate": "Publish Gate",
+  "Stops an automation before its next steps unless it has been published, so test runs never trigger your real actions.": "Stops an automation before its next steps unless it has been published, so test runs never trigger your real actions.",
+  "Continue Only If Published": "Continue Only If Published",
+  "Only lets the steps below run when this automation is published. Otherwise it stops the run so nothing below executes.": "Only lets the steps below run when this automation is published. Otherwise it stops the run so nothing below executes.",
+  "Place every step you only want to run on the **published** automation **below** this one.\n\nWhile you are building or testing, those steps are skipped automatically.": "Place every step you only want to run on the **published** automation **below** this one.\n\nWhile you are building or testing, those steps are skipped automatically.",
+  "When should the steps below run?": "When should the steps below run?",
+  "Only when the published automation runs for real": "Only when the published automation runs for real",
+  "Whenever the automation has been published": "Whenever the automation has been published"
+}

--- a/packages/pieces/community/publish-gate/src/index.ts
+++ b/packages/pieces/community/publish-gate/src/index.ts
@@ -10,7 +10,8 @@ export const publishGate = createPiece({
   description:
     'Stops an automation before its next steps unless it has been published, so test runs never trigger your real actions.',
   minimumSupportedRelease: '0.86.0',
-  logoUrl: 'https://cdn.activepieces.com/pieces/publish-gate.png',
+  logoUrl:
+    'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCIgZmlsbD0ibm9uZSIgc3Ryb2tlPSIjNmIzZmEwIiBzdHJva2Utd2lkdGg9IjIiIHN0cm9rZS1saW5lY2FwPSJyb3VuZCIgc3Ryb2tlLWxpbmVqb2luPSJyb3VuZCI+PHBhdGggZD0iTTEyIDIyczgtNCA4LTEwVjVsLTgtMy04IDN2N2MwIDYgOCAxMCA4IDEweiIvPjxwYXRoIGQ9Im05IDEyIDIgMiA0LTQiLz48L3N2Zz4=',
   categories: [PieceCategory.CORE, PieceCategory.FLOW_CONTROL],
   authors: ['Devansh-hello'],
   auth: PieceAuth.None(),

--- a/packages/pieces/community/publish-gate/src/index.ts
+++ b/packages/pieces/community/publish-gate/src/index.ts
@@ -1,0 +1,19 @@
+import {
+  createPiece,
+  PieceAuth,
+  PieceCategory,
+} from '@activepieces/pieces-framework';
+import { continueIfPublished } from './lib/actions/continue-if-published';
+
+export const publishGate = createPiece({
+  displayName: 'Publish Gate',
+  description:
+    'Stops an automation before its next steps unless it has been published, so test runs never trigger your real actions.',
+  minimumSupportedRelease: '0.86.0',
+  logoUrl: 'https://cdn.activepieces.com/pieces/publish-gate.png',
+  categories: [PieceCategory.CORE, PieceCategory.FLOW_CONTROL],
+  authors: ['Devansh-hello'],
+  auth: PieceAuth.None(),
+  actions: [continueIfPublished],
+  triggers: [],
+});

--- a/packages/pieces/community/publish-gate/src/lib/actions/continue-if-published.ts
+++ b/packages/pieces/community/publish-gate/src/lib/actions/continue-if-published.ts
@@ -1,0 +1,81 @@
+import {
+  createAction,
+  MarkdownVariant,
+  Property,
+  StopResponse,
+} from '@activepieces/pieces-framework';
+import {
+  getCurrentFlowOrThrow,
+  isPublishedForMode,
+  PublishGateMode,
+} from '../common/flow-status';
+
+export const continueIfPublished = createAction({
+  name: 'continue_if_published',
+  displayName: 'Continue Only If Published',
+  description:
+    'Only lets the steps below run when this automation is published. Otherwise it stops the run so nothing below executes.',
+  errorHandlingOptions: {
+    // A gate must never be bypassable: "continue on failure" would let the
+    // steps below run even if the publish check itself failed.
+    continueOnFailure: {
+      hide: true,
+    },
+    retryOnFailure: {
+      hide: true,
+    },
+  },
+  props: {
+    info: Property.MarkDown({
+      variant: MarkdownVariant.INFO,
+      value:
+        'Place every step you only want to run on the **published** automation **below** this one.\n\nWhile you are building or testing, those steps are skipped automatically.',
+    }),
+    mode: Property.StaticDropdown<PublishGateMode>({
+      displayName: 'When should the steps below run?',
+      required: true,
+      defaultValue: 'live',
+      options: {
+        disabled: false,
+        options: [
+          {
+            label: 'Only when the published automation runs for real',
+            value: 'live',
+          },
+          {
+            label: 'Whenever the automation has been published',
+            value: 'published',
+          },
+        ],
+      },
+    }),
+  },
+  async run(context) {
+    const mode = context.propsValue.mode ?? 'live';
+    const currentFlow = await getCurrentFlowOrThrow({ flows: context.flows });
+    const allowedToContinue = isPublishedForMode({
+      flow: currentFlow,
+      runningVersionId: context.flows.current.version.id,
+      mode,
+    });
+
+    if (allowedToContinue) {
+      return {
+        continued: true,
+        reason: 'published',
+      };
+    }
+
+    const response: StopResponse = {
+      status: 200,
+      body: {
+        continued: false,
+        reason: 'not_published',
+        message:
+          'This automation is not published yet, so the steps after this point were skipped.',
+      },
+    };
+    context.run.stop({ response });
+    return response.body;
+  },
+});

--- a/packages/pieces/community/publish-gate/src/lib/common/flow-status.ts
+++ b/packages/pieces/community/publish-gate/src/lib/common/flow-status.ts
@@ -1,0 +1,82 @@
+import {
+  FlowsContext,
+  FlowStatus,
+  isNil,
+  PopulatedFlowSummary,
+} from '@activepieces/pieces-framework';
+
+// `flows.list()` is typed as `PopulatedFlowSummary` since AP 0.86, but the
+// engine endpoint behind it still serves full flow records, and the publish
+// state lives only in those extra fields. They are read off this widened type;
+// if the engine ever really strips them, every check below fails closed (the
+// gate blocks) instead of letting a test run reach the real actions.
+type GateFlow = PopulatedFlowSummary & {
+  status?: string;
+  publishedVersionId?: string | null;
+};
+
+/**
+ * Loads the flow that the current run belongs to, so its publish state can be
+ * inspected. The engine exposes the current flow id on `flows.current`, but not
+ * its publish status, so the full record is fetched through `flows.list()`.
+ */
+export async function getCurrentFlowOrThrow({
+  flows,
+}: {
+  flows: FlowsContext;
+}): Promise<GateFlow> {
+  const currentFlowId = flows.current.id;
+  const allFlows = await listFlowsOrThrow({ flows });
+  const currentFlow = allFlows.find((flow) => flow.id === currentFlowId);
+  if (isNil(currentFlow)) {
+    throw new Error(
+      'Publish Gate could not find the current automation while checking whether it is published.'
+    );
+  }
+  return currentFlow;
+}
+
+/**
+ * Decides whether the steps after the gate are allowed to run.
+ *
+ * - `live`: only a real run of the published, switched-on automation passes.
+ *   Test/draft runs are blocked even after the automation has been published,
+ *   because they execute a different (draft) version than the published one.
+ * - `published`: passes as long as the automation has a published version,
+ *   which also lets test runs through once it has been published at least once.
+ */
+export function isPublishedForMode({
+  flow,
+  runningVersionId,
+  mode,
+}: {
+  flow: GateFlow;
+  runningVersionId: string;
+  mode: PublishGateMode;
+}): boolean {
+  const hasPublishedVersion = !isNil(flow.publishedVersionId);
+  if (mode === 'published') {
+    return hasPublishedVersion;
+  }
+  const isSwitchedOn = flow.status === FlowStatus.ENABLED;
+  const isRunningPublishedVersion = flow.publishedVersionId === runningVersionId;
+  return hasPublishedVersion && isSwitchedOn && isRunningPublishedVersion;
+}
+
+async function listFlowsOrThrow({
+  flows,
+}: {
+  flows: FlowsContext;
+}): Promise<GateFlow[]> {
+  try {
+    const page = await flows.list();
+    return page.data as GateFlow[];
+  } catch {
+    throw new Error(
+      "Publish Gate could not check the automation's publish status. Please try running it again."
+    );
+  }
+}
+
+export const PUBLISH_GATE_MODES = ['live', 'published'] as const;
+export type PublishGateMode = (typeof PUBLISH_GATE_MODES)[number];

--- a/packages/pieces/community/publish-gate/tsconfig.json
+++ b/packages/pieces/community/publish-gate/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ],
+  "compilerOptions": {
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  }
+}

--- a/packages/pieces/community/publish-gate/tsconfig.lib.json
+++ b/packages/pieces/community/publish-gate/tsconfig.lib.json
@@ -1,0 +1,15 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "rootDir": ".",
+    "baseUrl": ".",
+    "paths": {},
+    "outDir": "./dist",
+    "declaration": true,
+    "declarationMap": true,
+    "types": ["node"]
+  },
+  "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"],
+  "include": ["src/**/*.ts"]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1040,6 +1040,9 @@
       "@activepieces/piece-provenexpert": [
         "packages/pieces/community/provenexpert/src/index.ts"
       ],
+      "@activepieces/piece-publish-gate": [
+        "packages/pieces/community/publish-gate/src/index.ts"
+      ],
       "@activepieces/piece-pubrio": [
         "packages/pieces/community/pubrio/src/index.ts"
       ],


### PR DESCRIPTION
# feat(pieces): add Publish Gate piece

## What does this PR do?

Adds a new community flow-control piece, **Publish Gate**, with one action: **Continue Only If Published**. Placed mid-flow, it stops the run before the steps below it unless the flow is published — so test and draft runs never fire the real actions (emails, posts, orders) placed after the gate.

### Explain How the Feature Works

- The action reads the current flow's publish state through `context.flows.list()` and compares the running version against the published one.
- Two modes (static dropdown, default `live`):
  - **Only when the published automation runs for real** — passes only when the flow is published, enabled, and executing its published version. Test/draft runs stop.
  - **Whenever the automation has been published** — passes as soon as any published version exists (lets test runs through after first publish).
- When blocked it calls `context.run.stop()` with a structured body (`continued: false, reason: 'not_published'`), so webhook callers get a clean 200 rather than an error.
- `continueOnFailure` / `retryOnFailure` are hidden so the gate can't be bypassed by error-handling settings.
- No auth (`PieceAuth.None()`), categories CORE + FLOW_CONTROL, i18n included, imports only from `@activepieces/pieces-framework` per the piece import boundary.

### Relevant User Scenarios

- Builders iterating on flows with real side effects (send email, post to Slack, create orders) who want Test Flow to be safe by default.
- Template/marketplace authors shipping flows to non-technical users, where a preview run must never hit live systems. We (Gravity) run this piece in production on our AP-based marketplace — every published agent carries it.
- Anyone reproducing the common "my test run sent a real message" complaint.

### Notes for reviewers

- Logo is a self-contained SVG data URI (shield + check) so the piece renders without a CDN asset; happy to supply a PNG for `cdn.activepieces.com` if you prefer the CDN convention.
- `flows.list()` is typed `PopulatedFlowSummary` since 0.86 but the engine endpoint serves full flow records; the piece reads `status` / `publishedVersionId` through a widened type and **fails closed** (blocks) if those fields are ever absent. Happy to switch to a first-class API if you'd rather expose publish state on the flows context directly.
- Built and linted green via `turbo run build lint --filter=@activepieces/piece-publish-gate`.

A version of this piece has been on public npm as `gravity-piece-publish-gate` since June 2026; this PR contributes the unbranded original so it's available in the standard catalog.
