### PR TITLE
feat(web): rework global search into the Browse spotlight

### DIFF
--- a/packages/web/src/app/components/flow-actions-menu.tsx
+++ b/packages/web/src/app/components/flow-actions-menu.tsx
@@ -36,6 +36,7 @@ import {
 } from '@/components/ui/dropdown-menu';
 import { MoveToFolderDialog } from '@/features/automations/components/move-to-folder-dialog';
 import { RenameDialog } from '@/features/automations/components/rename-dialog';
+import { automationMutationUtils } from '@/features/automations/lib/mutation-bodies';
 import { flowHooks, flowsApi } from '@/features/flows';
 import { ChangeOwnerDialog } from '@/features/flows/components/change-owner-dialog';
 import { ImportFlowDialog } from '@/features/flows/components/import-flow-dialog';
@@ -136,27 +137,12 @@ const FlowActionMenu: React.FC<FlowActionMenuProps> = ({
   });
 
   const { mutate: duplicateFlow, isPending: isDuplicatePending } = useMutation({
-    mutationFn: async () => {
-      const modifiedFlowVersion = {
-        ...flowVersion,
-        displayName: `${flowVersion.displayName} - Copy`,
-      };
-      const createdFlow = await flowsApi.create({
-        displayName: modifiedFlowVersion.displayName,
+    mutationFn: () =>
+      automationMutationUtils.duplicateFlow({
+        version: flowVersion,
+        folderId: flow.folderId,
         projectId: authenticationSession.getProjectId()!,
-        folderId: flow.folderId ?? undefined,
-      });
-      const updatedFlow = await flowsApi.update(createdFlow.id, {
-        type: FlowOperationType.IMPORT_FLOW,
-        request: {
-          displayName: modifiedFlowVersion.displayName,
-          trigger: modifiedFlowVersion.trigger,
-          schemaVersion: modifiedFlowVersion.schemaVersion,
-          notes: modifiedFlowVersion.notes,
-        },
-      });
-      return updatedFlow;
-    },
+      }),
     onSuccess: (data) => {
       openNewWindow(`/flows/${data.id}`);
       onDuplicate();

--- a/packages/web/src/app/components/global-search/browse-filter-chips.tsx
+++ b/packages/web/src/app/components/global-search/browse-filter-chips.tsx
@@ -1,0 +1,73 @@
+import { t } from 'i18next';
+import { Table2, Workflow } from 'lucide-react';
+
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/components/ui/tooltip';
+import { cn } from '@/lib/utils';
+
+import { type ProjectFilter } from './use-browse-navigation';
+
+export function BrowseFilterChips({
+  active,
+  onSelect,
+  hideTables,
+}: {
+  active: ProjectFilter;
+  onSelect: (filter: ProjectFilter) => void;
+  hideTables?: boolean;
+}) {
+  const isActive = (value: ProjectFilter) => value === active;
+  const chip = (value: ProjectFilter) =>
+    cn(
+      'flex h-8 items-center justify-center rounded-lg text-sm font-medium transition-colors',
+      isActive(value)
+        ? 'bg-foreground/[0.08] text-foreground'
+        : 'text-muted-foreground hover:bg-foreground/[0.05] hover:text-foreground',
+    );
+
+  return (
+    <div className="flex items-center gap-1">
+      <button
+        type="button"
+        onClick={() => onSelect('all')}
+        onMouseDown={(e) => e.preventDefault()}
+        className={cn(chip('all'), 'px-3')}
+      >
+        {t('All')}
+      </button>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            type="button"
+            aria-label={t('Flows')}
+            onClick={() => onSelect('flows')}
+            onMouseDown={(e) => e.preventDefault()}
+            className={cn(chip('flows'), 'w-8')}
+          >
+            <Workflow className="size-[18px]" />
+          </button>
+        </TooltipTrigger>
+        <TooltipContent side="bottom">{t('Flows')}</TooltipContent>
+      </Tooltip>
+      {!hideTables && (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              type="button"
+              aria-label={t('Tables')}
+              onClick={() => onSelect('tables')}
+              onMouseDown={(e) => e.preventDefault()}
+              className={cn(chip('tables'), 'w-8')}
+            >
+              <Table2 className="size-[18px]" />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent side="bottom">{t('Tables')}</TooltipContent>
+        </Tooltip>
+      )}
+    </div>
+  );
+}

--- a/packages/web/src/app/components/global-search/browse-row-menu.tsx
+++ b/packages/web/src/app/components/global-search/browse-row-menu.tsx
@@ -1,0 +1,164 @@
+import {
+  type FolderDto,
+  type PopulatedFlow,
+  type Table,
+  UncategorizedFolderId,
+} from '@activepieces/shared';
+import { t } from 'i18next';
+import {
+  Copy,
+  Download,
+  FolderInput,
+  Pencil,
+  Trash2,
+  Ellipsis,
+} from 'lucide-react';
+import { useState } from 'react';
+
+import { ConfirmationDeleteDialog } from '@/components/custom/delete-dialog';
+import { useEmbedding } from '@/components/providers/embed-provider';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { MoveToFolderDialog } from '@/features/automations/components/move-to-folder-dialog';
+import { RenameDialog } from '@/features/automations/components/rename-dialog';
+
+import {
+  type BrowseManageItem,
+  useBrowseMutations,
+} from './use-browse-mutations';
+
+export function BrowseRowMenu({
+  type,
+  id,
+  name,
+  flow,
+  table,
+  folderId,
+  folders,
+  mutations,
+}: {
+  type: 'flow' | 'table';
+  id: string;
+  name: string;
+  flow?: PopulatedFlow;
+  table?: Table;
+  folderId?: string | null;
+  folders: FolderDto[];
+  mutations: ReturnType<typeof useBrowseMutations>;
+}) {
+  const { embedState } = useEmbedding();
+  const [action, setAction] = useState<'rename' | 'move' | 'delete' | null>(
+    null,
+  );
+  const [renameValue, setRenameValue] = useState(name);
+  const [moveTarget, setMoveTarget] = useState(
+    folderId ?? UncategorizedFolderId,
+  );
+
+  const item: BrowseManageItem = { type, id };
+  const stop = (e: React.SyntheticEvent) => e.stopPropagation();
+
+  return (
+    <div onClick={stop} onPointerDown={stop}>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <button
+            type="button"
+            aria-label={t('More actions')}
+            className="flex size-6 shrink-0 items-center justify-center rounded text-muted-foreground opacity-0 transition-opacity hover:bg-muted hover:text-foreground group-data-[selected=true]:opacity-100"
+          >
+            <Ellipsis className="size-4" />
+          </button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end" onClick={stop}>
+          <DropdownMenuItem
+            onSelect={() => {
+              setRenameValue(name);
+              setAction('rename');
+            }}
+          >
+            <Pencil className="mr-2 size-4" />
+            {t('Rename')}
+          </DropdownMenuItem>
+          {!embedState.hideFolders && (
+            <DropdownMenuItem
+              onSelect={() => {
+                setMoveTarget(folderId ?? UncategorizedFolderId);
+                setAction('move');
+              }}
+            >
+              <FolderInput className="mr-2 size-4" />
+              {t('Move to folder')}
+            </DropdownMenuItem>
+          )}
+          {type === 'flow' && flow && !embedState.hideDuplicateFlow && (
+            <DropdownMenuItem onSelect={() => mutations.duplicateFlow(flow)}>
+              <Copy className="mr-2 size-4" />
+              {t('Duplicate')}
+            </DropdownMenuItem>
+          )}
+          {!embedState.hideExportAndImportFlow && (
+            <DropdownMenuItem
+              onSelect={() => {
+                if (type === 'flow' && flow) mutations.exportFlow(flow);
+                else if (table) mutations.exportTable(table);
+              }}
+            >
+              <Download className="mr-2 size-4" />
+              {t('Export')}
+            </DropdownMenuItem>
+          )}
+          <DropdownMenuSeparator />
+          <DropdownMenuItem
+            className="text-destructive focus:text-destructive"
+            onSelect={() => setAction('delete')}
+          >
+            <Trash2 className="mr-2 size-4" />
+            {t('Delete')}
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+
+      <RenameDialog
+        open={action === 'rename'}
+        onOpenChange={(open) => !open && setAction(null)}
+        value={renameValue}
+        onChange={setRenameValue}
+        isRenaming={mutations.isRenaming}
+        onConfirm={async () => {
+          await mutations.renameItem(item, renameValue.trim());
+          setAction(null);
+        }}
+      />
+
+      <MoveToFolderDialog
+        open={action === 'move'}
+        onOpenChange={(open) => !open && setAction(null)}
+        folders={folders}
+        selectedFolderId={moveTarget}
+        onFolderChange={setMoveTarget}
+        isMoving={mutations.isMoving}
+        onConfirm={async () => {
+          await mutations.moveItem(item, moveTarget);
+          setAction(null);
+        }}
+      />
+
+      <ConfirmationDeleteDialog
+        open={action === 'delete'}
+        onOpenChange={(open) => !open && setAction(null)}
+        title={t('Delete {name}', { name })}
+        message={t('Are you sure you want to delete this {type}?', { type })}
+        entityName={name}
+        mutationFn={async () => {
+          await mutations.deleteItem(item);
+        }}
+      />
+    </div>
+  );
+}

--- a/packages/web/src/app/components/global-search/browse-style-shared.tsx
+++ b/packages/web/src/app/components/global-search/browse-style-shared.tsx
@@ -1,0 +1,504 @@
+import { PROJECT_COLOR_PALETTE } from '@activepieces/shared';
+import { t } from 'i18next';
+import {
+  Check,
+  ChevronDown,
+  CornerDownLeft,
+  FileText,
+  Folder,
+  PanelRightOpen,
+  Table2,
+  User,
+  Workflow,
+} from 'lucide-react';
+import { AnimatePresence, motion } from 'motion/react';
+import {
+  type KeyboardEvent,
+  type ReactNode,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
+
+import { CreateProjectButton } from '@/features/projects/components/create-project-button';
+import { cn } from '@/lib/utils';
+
+import { type BrowseController } from './use-browse-controller';
+import { type SearchResultItem } from './use-global-search-results';
+
+const GLIDE = {
+  type: 'spring',
+  stiffness: 620,
+  damping: 46,
+  mass: 0.7,
+} as const;
+
+const DENSITY: Record<Density, { row: string; tile: number }> = {
+  compact: { row: 'h-12 gap-3 px-2.5', tile: 28 },
+  cozy: { row: 'h-14 gap-3.5 px-3', tile: 32 },
+  airy: { row: 'h-16 gap-4 px-3.5', tile: 36 },
+};
+
+const TILE: Record<
+  string,
+  {
+    tint: string;
+    icon: string;
+    Icon: React.ComponentType<{ className?: string }>;
+  }
+> = {
+  flow: {
+    tint: 'bg-violet-500/[0.12]',
+    icon: 'text-violet-500',
+    Icon: Workflow,
+  },
+  table: {
+    tint: 'bg-emerald-500/[0.12]',
+    icon: 'text-emerald-500',
+    Icon: Table2,
+  },
+  folder: {
+    tint: 'bg-amber-500/[0.12]',
+    icon: 'text-amber-500',
+    Icon: Folder,
+  },
+  project: { tint: 'bg-sky-500/[0.12]', icon: 'text-sky-500', Icon: User },
+  default: {
+    tint: 'bg-muted',
+    icon: 'text-muted-foreground',
+    Icon: FileText,
+  },
+};
+
+function ItemTile({
+  type,
+  size = 28,
+}: {
+  type: SearchResultItem['type'];
+  size?: number;
+}) {
+  const tile = TILE[type] ?? TILE.default;
+  return (
+    <span
+      className={cn(
+        'flex shrink-0 items-center justify-center rounded-[10px]',
+        tile.tint,
+      )}
+      style={{ width: size, height: size }}
+    >
+      <tile.Icon className={cn('size-[18px]', tile.icon)} />
+    </span>
+  );
+}
+
+function ResultRow({
+  item,
+  selected,
+  onClick,
+  onHover,
+  innerRef,
+  density = 'cozy',
+  query,
+}: {
+  item: SearchResultItem;
+  selected?: boolean;
+  onClick: () => void;
+  onHover?: () => void;
+  innerRef?: React.Ref<HTMLButtonElement>;
+  density?: Density;
+  query?: string;
+}) {
+  const meta = item.folderName ?? item.projectName ?? null;
+  const d = DENSITY[density];
+  return (
+    <button
+      ref={innerRef}
+      type="button"
+      onClick={onClick}
+      onMouseMove={onHover}
+      onMouseDown={(e) => e.preventDefault()}
+      data-selected={selected ? 'true' : undefined}
+      className={cn(
+        'group relative flex w-full items-center rounded-xl text-left',
+        d.row,
+      )}
+    >
+      {selected && (
+        <motion.span
+          layoutId="browse-row-highlight"
+          transition={GLIDE}
+          className="absolute inset-0 rounded-xl bg-foreground/[0.07]"
+        />
+      )}
+      <span className="relative z-10 flex w-full items-center gap-3">
+        <ItemTile type={item.type} size={d.tile} />
+        <span className="min-w-0 flex-1 truncate text-[15px] font-medium text-foreground">
+          <Highlight text={item.label} query={query} />
+        </span>
+        {meta && (
+          <span className="shrink-0 truncate text-xs text-muted-foreground/55">
+            {meta}
+          </span>
+        )}
+        {item.status === 'ENABLED' && (
+          <span className="size-1.5 shrink-0 rounded-full bg-emerald-500" />
+        )}
+        <CornerDownLeft
+          className={cn(
+            'size-3.5 shrink-0 text-muted-foreground/50 transition-opacity duration-150',
+            selected ? 'opacity-100' : 'opacity-0',
+          )}
+        />
+      </span>
+    </button>
+  );
+}
+
+function EmptyState({ hasQuery }: { hasQuery: boolean }) {
+  return (
+    <motion.div
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      transition={{ duration: 0.2 }}
+      className="flex flex-col items-center justify-center gap-2 py-20 text-center"
+    >
+      <div className="flex size-10 items-center justify-center rounded-2xl bg-muted/60">
+        <FileText className="size-5 text-muted-foreground/40" />
+      </div>
+      <p className="text-sm text-muted-foreground/70">
+        {hasQuery ? t('No results found.') : t('Nothing here yet.')}
+      </p>
+    </motion.div>
+  );
+}
+
+function Skeletons({ density = 'cozy' }: { density?: Density }) {
+  const d = DENSITY[density];
+  return (
+    <div className="flex flex-col">
+      {[0, 1, 2, 3].map((i) => (
+        <div key={i} className={cn('flex items-center', d.row)}>
+          <div
+            className="shrink-0 animate-pulse rounded-lg bg-muted"
+            style={{ width: d.tile, height: d.tile }}
+          />
+          <div className="ml-3 flex flex-1 flex-col gap-1.5">
+            <div
+              className="h-3 animate-pulse rounded bg-muted"
+              style={{ width: `${46 - i * 6}%` }}
+            />
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+const PAGE = 25;
+
+export function ResultGroups({
+  controller,
+  density = 'cozy',
+  heading,
+}: {
+  controller: BrowseController;
+  density?: Density;
+  heading?: (text: string) => ReactNode;
+}) {
+  const [visibleCount, setVisibleCount] = useState(PAGE);
+  const sentinelRef = useRef<HTMLDivElement>(null);
+  const selectedRef = useRef<HTMLButtonElement>(null);
+  const { category, projectFilter, hasQuery, selectedIndex, rowCount } =
+    controller;
+
+  useEffect(() => {
+    setVisibleCount(PAGE);
+  }, [category, projectFilter, hasQuery]);
+
+  useEffect(() => {
+    if (selectedIndex >= visibleCount) setVisibleCount(selectedIndex + PAGE);
+  }, [selectedIndex, visibleCount]);
+
+  useEffect(() => {
+    selectedRef.current?.scrollIntoView({ block: 'nearest' });
+  }, [selectedIndex]);
+
+  useEffect(() => {
+    const el = sentinelRef.current;
+    if (!el) return;
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0]?.isIntersecting) setVisibleCount((c) => c + PAGE);
+      },
+      { rootMargin: '0px 0px 200px 0px' },
+    );
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [visibleCount, category, projectFilter, hasQuery]);
+
+  if (controller.isLoading) return <Skeletons density={density} />;
+  if (controller.groups.length === 0)
+    return <EmptyState hasQuery={controller.hasQuery} />;
+
+  let itemIndex = -1;
+  let rendered = 0;
+  const groupsOut: ReactNode[] = [];
+  for (const group of controller.groups) {
+    if (rendered >= visibleCount) break;
+    const rows: ReactNode[] = [];
+    for (const item of group.items) {
+      if (rendered >= visibleCount) break;
+      itemIndex += 1;
+      const index = itemIndex;
+      const selected = index === selectedIndex;
+      rows.push(
+        <ResultRow
+          key={item.id}
+          item={item}
+          density={density}
+          selected={selected}
+          innerRef={selected ? selectedRef : undefined}
+          onClick={() => controller.openItem(item)}
+          onHover={() => controller.setSelected(index)}
+          query={hasQuery ? controller.debouncedSearch : undefined}
+        />,
+      );
+      rendered += 1;
+    }
+    if (rows.length === 0) continue;
+    groupsOut.push(
+      <div key={group.type}>
+        {group.heading &&
+          (heading ? (
+            heading(group.heading)
+          ) : (
+            <div className="px-3 pb-1 pt-1 text-[11px] font-medium uppercase tracking-[0.06em] text-muted-foreground/45">
+              {group.heading}
+            </div>
+          ))}
+        {rows}
+      </div>,
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-1">
+      {groupsOut}
+      {rendered < rowCount && <div ref={sentinelRef} className="h-4 w-full" />}
+    </div>
+  );
+}
+
+export function makeSearchKeyDown(controller: BrowseController) {
+  return (e: KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      controller.moveSelection(1);
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      controller.moveSelection(-1);
+    } else if (e.key === 'Enter') {
+      e.preventDefault();
+      controller.openSelected();
+    } else if (controller.search === '' && e.key === 'ArrowRight') {
+      e.preventDefault();
+      controller.cycleScopeFilter(1);
+    } else if (controller.search === '' && e.key === 'ArrowLeft') {
+      e.preventDefault();
+      controller.cycleScopeFilter(-1);
+    }
+  };
+}
+
+export function ScopeToggle({
+  controller,
+  align,
+}: {
+  controller: BrowseController;
+  align?: 'center';
+}) {
+  const isProject = controller.category === 'project';
+  const palette = controller.currentProject?.icon
+    ? PROJECT_COLOR_PALETTE[controller.currentProject.icon.color]
+    : null;
+  const label = (active: boolean) =>
+    cn(
+      'relative z-10 transition-colors duration-200',
+      active ? 'text-foreground' : 'text-muted-foreground',
+    );
+  return (
+    <div
+      className={cn(
+        'relative flex items-center',
+        align === 'center' && 'justify-center',
+      )}
+    >
+      <div className="flex items-center gap-1 rounded-xl bg-muted/40 p-1">
+        <button
+          type="button"
+          onClick={() => controller.setCategory('recent')}
+          onMouseDown={(e) => e.preventDefault()}
+          className="relative rounded-lg px-3 py-1.5 text-[13px] font-medium"
+        >
+          {!isProject && (
+            <motion.span
+              layoutId="browse-scope-pill"
+              transition={GLIDE}
+              className="absolute inset-0 rounded-lg bg-background shadow-sm ring-1 ring-inset ring-foreground/[0.06]"
+            />
+          )}
+          <span className={label(!isProject)}>{t('Recents')}</span>
+        </button>
+        <button
+          type="button"
+          onClick={() =>
+            isProject
+              ? controller.handleProjectMenuOpenChange(
+                  !controller.projectMenuOpen,
+                )
+              : controller.setCategory('project')
+          }
+          onMouseDown={(e) => e.preventDefault()}
+          className="relative flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-[13px] font-medium"
+        >
+          {isProject && (
+            <motion.span
+              layoutId="browse-scope-pill"
+              transition={GLIDE}
+              className="absolute inset-0 rounded-lg bg-background shadow-sm ring-1 ring-inset ring-foreground/[0.06]"
+            />
+          )}
+          {palette && (
+            <span
+              className="relative z-10 flex size-4 shrink-0 items-center justify-center rounded-[5px] text-[9px] font-bold"
+              style={{
+                backgroundColor: palette.color,
+                color: palette.textColor,
+              }}
+            >
+              {controller.currentProjectName.charAt(0).toUpperCase()}
+            </span>
+          )}
+          <span className={cn('max-w-[170px] truncate', label(isProject))}>
+            {controller.currentProjectName || t('Project')}
+          </span>
+          <ChevronDown
+            className={cn(
+              'relative z-10 size-3.5 transition-opacity',
+              isProject ? 'opacity-50' : 'opacity-25',
+            )}
+          />
+        </button>
+      </div>
+      <ProjectMenu controller={controller} align={align ? 'right' : 'left'} />
+    </div>
+  );
+}
+
+function ProjectMenu({
+  controller,
+  align = 'left',
+}: {
+  controller: BrowseController;
+  align?: 'left' | 'right';
+}) {
+  return (
+    <AnimatePresence>
+      {controller.projectMenuOpen && (
+        <>
+          <div
+            className="fixed inset-0 z-40"
+            onClick={() => controller.handleProjectMenuOpenChange(false)}
+          />
+          <motion.div
+            initial={{ opacity: 0, y: -4, scale: 0.98 }}
+            animate={{ opacity: 1, y: 0, scale: 1 }}
+            exit={{ opacity: 0, y: -4, scale: 0.98 }}
+            transition={{ duration: 0.14, ease: [0.32, 0.72, 0, 1] }}
+            className={cn(
+              'absolute top-full z-50 mt-2 max-h-[300px] min-w-[240px] origin-top overflow-y-auto rounded-2xl border border-foreground/[0.08] bg-popover/95 p-1.5 shadow-xl backdrop-blur-xl',
+              align === 'left' ? 'left-0' : 'right-0',
+            )}
+          >
+            {controller.allProjects.map((project) => {
+              const palette = project.icon
+                ? PROJECT_COLOR_PALETTE[project.icon.color]
+                : null;
+              const name = project.displayName;
+              const isCurrent = project.id === controller.projectId;
+              return (
+                <div
+                  key={project.id}
+                  className={cn(
+                    'group flex items-center gap-1 rounded-xl pr-1 transition-colors hover:bg-foreground/[0.05]',
+                    isCurrent && 'bg-foreground/[0.04]',
+                  )}
+                >
+                  <button
+                    type="button"
+                    onClick={() => controller.switchProject(project.id)}
+                    className="flex min-w-0 flex-1 items-center gap-2.5 rounded-xl px-2.5 py-2 text-left text-sm"
+                  >
+                    <span
+                      className="flex size-6 shrink-0 items-center justify-center rounded-lg text-[11px] font-bold"
+                      style={{
+                        backgroundColor: palette?.color,
+                        color: palette?.textColor,
+                      }}
+                    >
+                      {name.charAt(0).toUpperCase()}
+                    </span>
+                    <span className="min-w-0 flex-1 truncate font-medium">
+                      {name}
+                    </span>
+                    {isCurrent && (
+                      <Check className="size-4 shrink-0 text-primary" />
+                    )}
+                  </button>
+                  <button
+                    type="button"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      controller.openProject(project.id);
+                    }}
+                    aria-label={t('Open full view')}
+                    title={t('Open full view')}
+                    className="flex size-7 shrink-0 items-center justify-center rounded-lg text-muted-foreground/60 transition-colors hover:bg-foreground/[0.08] hover:text-foreground"
+                  >
+                    <PanelRightOpen className="size-4" />
+                  </button>
+                </div>
+              );
+            })}
+            <div className="mt-1 border-t border-foreground/[0.06] pt-1">
+              <CreateProjectButton
+                variant="menu-item"
+                projects={controller.allProjects}
+                onCreate={(project) => controller.openProject(project.id)}
+              />
+            </div>
+          </motion.div>
+        </>
+      )}
+    </AnimatePresence>
+  );
+}
+
+function Highlight({ text, query }: { text: string; query?: string }) {
+  if (!query) return <>{text}</>;
+  const lower = text.toLowerCase();
+  const q = query.toLowerCase();
+  const idx = lower.indexOf(q);
+  if (idx === -1) return <>{text}</>;
+  return (
+    <>
+      {text.slice(0, idx)}
+      <span className="font-semibold text-foreground">
+        {text.slice(idx, idx + query.length)}
+      </span>
+      {text.slice(idx + query.length)}
+    </>
+  );
+}
+
+type Density = 'compact' | 'cozy' | 'airy';

--- a/packages/web/src/app/components/global-search/global-search-context.tsx
+++ b/packages/web/src/app/components/global-search/global-search-context.tsx
@@ -1,37 +1,17 @@
 import { t } from 'i18next';
-import { CornerDownLeft, X } from 'lucide-react';
-import React, {
+import {
   createContext,
-  useCallback,
+  type ReactNode,
   useContext,
   useEffect,
   useState,
 } from 'react';
-import { useNavigate } from 'react-router-dom';
-import { useDebounce } from 'use-debounce';
 
 import { useEmbedding } from '@/components/providers/embed-provider';
-import {
-  CommandDialog,
-  CommandGroup,
-  CommandInput,
-  CommandItem,
-  CommandList,
-  CommandSeparator,
-} from '@/components/ui/command';
-import { projectCollectionUtils } from '@/features/projects';
+import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog';
 
-import { recordAccess, type AccessedItemType } from './access-history';
-import { SearchResultRow } from './search-result-item';
-import {
-  type SearchResultItem,
-  useGlobalSearchResults,
-} from './use-global-search-results';
-
-type GlobalSearchContextType = {
-  open: boolean;
-  setOpen: (open: boolean) => void;
-};
+import { StyleSpotlight } from './style-spotlight';
+import { useBrowseController } from './use-browse-controller';
 
 const GlobalSearchContext = createContext<GlobalSearchContextType | null>(null);
 
@@ -43,188 +23,55 @@ export function useGlobalSearch() {
   return ctx;
 }
 
-function SkeletonRows() {
+function BrowsePanel({ onClose }: { onClose: () => void }) {
+  const controller = useBrowseController({ onClose });
+
   return (
-    <>
-      {[1, 2, 3].map((i) => (
-        <div key={i} className="flex items-center gap-2 px-2 py-2">
-          <div className="size-4 shrink-0 animate-pulse rounded bg-muted" />
-          <div className="h-3.5 flex-1 animate-pulse rounded bg-muted" />
-          <div className="h-3.5 w-24 animate-pulse rounded bg-muted" />
-        </div>
-      ))}
-    </>
+    <div className="flex h-full w-full flex-col">
+      <div className="min-h-0 flex-1">
+        <StyleSpotlight controller={controller} />
+      </div>
+    </div>
   );
 }
 
-function GlobalSearchDialogContent({
+// The Browse popup: a centered spotlight dialog over a blurred backdrop,
+// opened from the sidebar search button or Ctrl/Cmd+K.
+function BrowseDialog({
   open,
-  onOpenChange,
+  setOpen,
 }: {
   open: boolean;
-  onOpenChange: (v: boolean) => void;
+  setOpen: (open: boolean) => void;
 }) {
-  const navigate = useNavigate();
-  const [search, setSearch] = useState('');
-  const [commandValue, setCommandValue] = useState('');
-  const [debouncedSearch] = useDebounce(search, 250);
-
-  const { groups, isLoading } = useGlobalSearchResults(debouncedSearch, open);
-
-  const handleOpenChange = useCallback(
-    (value: boolean) => {
-      onOpenChange(value);
-      if (!value) setSearch('');
-    },
-    [onOpenChange],
-  );
-
-  const navigateToItem = useCallback(
-    (type: string, href: string) => {
-      if (type === 'project') {
-        const projectId = href.split('/projects/')[1]?.split('/')[0];
-        if (projectId) projectCollectionUtils.setCurrentProject(projectId);
-      }
-      navigate(href);
-      handleOpenChange(false);
-    },
-    [navigate, handleOpenChange],
-  );
-
-  const handleSelectResult = useCallback(
-    (item: SearchResultItem) => {
-      if (item.type !== 'folder') {
-        recordAccess({
-          id: item.id,
-          type: item.type as AccessedItemType,
-          label: item.label,
-          href: item.href,
-          status: item.status,
-          folderName: item.folderName,
-          projectName: item.projectName,
-          iconBgColor: item.iconBgColor,
-          iconTextColor: item.iconTextColor,
-          iconLetter: item.iconLetter,
-        });
-      }
-      navigateToItem(item.type, item.href);
-    },
-    [navigateToItem],
-  );
-
-  const hasQuery = debouncedSearch.length > 0;
-  const noResults = hasQuery && !isLoading && groups.length === 0;
-
-  const firstItemId =
-    groups.find((g) => !g.isLoading && g.items.length > 0)?.items[0]?.id ?? '';
-
-  useEffect(() => {
-    setCommandValue(firstItemId);
-  }, [firstItemId]);
-
   return (
-    <CommandDialog
-      open={open}
-      onOpenChange={handleOpenChange}
-      showCloseButton={false}
-      shouldFilter={false}
-      commandValue={commandValue}
-      onCommandValueChange={setCommandValue}
-      className="sm:max-w-[620px] h-[70vh] flex flex-col"
-    >
-      <div className="relative">
-        <CommandInput
-          placeholder={t('Search pages, flows, tables...')}
-          value={search}
-          onValueChange={setSearch}
-          containerClassName="border-b-0"
-        />
-        {search && (
-          <button
-            type="button"
-            className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground transition-colors"
-            onClick={() => setSearch('')}
-          >
-            <X className="size-3.5" />
-          </button>
-        )}
-      </div>
-
-      <CommandList className="flex-1 min-h-0 max-h-none overflow-y-auto! scrollbar-hover">
-        {noResults && (
-          <div className="flex flex-col items-center justify-center gap-3 py-16 text-center">
-            <p className="text-sm text-muted-foreground">
-              {t('No results found.')}
-            </p>
-            <button
-              type="button"
-              className="text-xs text-primary underline hover:no-underline"
-              onClick={() => setSearch('')}
-            >
-              {t('Clear search')}
-            </button>
-          </div>
-        )}
-
-        {groups.map((group, idx) => (
-          <React.Fragment key={group.type}>
-            {idx > 0 && hasQuery && <CommandSeparator />}
-            <CommandGroup heading={group.heading || undefined}>
-              {group.isLoading ? (
-                <SkeletonRows />
-              ) : (
-                group.items.map((item) => (
-                  <CommandItem
-                    key={item.id}
-                    value={item.id}
-                    onSelect={() => handleSelectResult(item)}
-                    className="group flex items-center data-[selected=true]:bg-foreground/10"
-                  >
-                    <SearchResultRow
-                      item={item}
-                      query={hasQuery ? debouncedSearch : undefined}
-                    />
-                    <CornerDownLeft className="ml-auto size-2 shrink-0 text-muted-foreground/70 opacity-0 transition-opacity group-data-[selected=true]:opacity-100" />
-                  </CommandItem>
-                ))
-              )}
-            </CommandGroup>
-          </React.Fragment>
-        ))}
-      </CommandList>
-
-      <div className="flex items-center gap-4 border-t bg-muted/50 px-4 py-2.5 text-[11px] text-muted-foreground">
-        <span className="flex items-center gap-1.5">
-          <kbd className="inline-flex h-5 items-center rounded border bg-background px-1 font-mono">
-            ↑
-          </kbd>
-          <kbd className="inline-flex h-5 items-center rounded border bg-background px-1 font-mono">
-            ↓
-          </kbd>
-          {t('to navigate')}
-        </span>
-        <span className="flex items-center gap-1.5">
-          <kbd className="inline-flex h-5 items-center rounded border bg-background px-1 font-mono">
-            ↵
-          </kbd>
-          {t('to select')}
-        </span>
-        <span className="flex items-center gap-1.5">
-          <kbd className="inline-flex h-5 items-center rounded border bg-background px-1.5 font-mono text-[10px]">
-            esc
-          </kbd>
-          {t('to close')}
-        </span>
-      </div>
-    </CommandDialog>
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogContent
+        showCloseButton={false}
+        overlayClassName="bg-background/50 backdrop-blur-sm"
+        className="top-[18%] flex h-[min(480px,70vh)] w-[min(560px,calc(100vw-2rem))] max-w-none translate-y-0 flex-col gap-0 overflow-hidden rounded-2xl border-foreground/[0.08] bg-popover/85 p-0 shadow-2xl backdrop-blur-2xl data-[state=closed]:slide-out-to-top-2 data-[state=open]:slide-in-from-top-2"
+        onInteractOutside={(e) => {
+          // Keep the dialog open when interacting with nested overlays it
+          // spawns (create/rename/move/delete dialogs, dropdown menus, toasts).
+          const node = e.detail.originalEvent.target;
+          if (
+            node instanceof Element &&
+            node.closest(
+              '[data-radix-popper-content-wrapper],[role="dialog"],[role="alertdialog"],[data-sonner-toaster]',
+            )
+          ) {
+            e.preventDefault();
+          }
+        }}
+      >
+        <DialogTitle className="sr-only">{t('Search')}</DialogTitle>
+        <BrowsePanel onClose={() => setOpen(false)} />
+      </DialogContent>
+    </Dialog>
   );
 }
 
-export function GlobalSearchProvider({
-  children,
-}: {
-  children: React.ReactNode;
-}) {
+export function GlobalSearchProvider({ children }: { children: ReactNode }) {
   const [open, setOpen] = useState(false);
   const { embedState } = useEmbedding();
   const { hideGlobalSearch } = embedState;
@@ -246,9 +93,12 @@ export function GlobalSearchProvider({
   return (
     <GlobalSearchContext.Provider value={{ open, setOpen }}>
       {children}
-      {!hideGlobalSearch && (
-        <GlobalSearchDialogContent open={open} onOpenChange={setOpen} />
-      )}
+      {!hideGlobalSearch && <BrowseDialog open={open} setOpen={setOpen} />}
     </GlobalSearchContext.Provider>
   );
 }
+
+type GlobalSearchContextType = {
+  open: boolean;
+  setOpen: (open: boolean) => void;
+};

--- a/packages/web/src/app/components/global-search/recent-history.ts
+++ b/packages/web/src/app/components/global-search/recent-history.ts
@@ -1,0 +1,86 @@
+import { t } from 'i18next';
+
+import { type AccessedItem, getAccessHistory } from './access-history';
+import { STATIC_PAGES } from './static-pages';
+import {
+  type SearchResultGroup,
+  type SearchResultItem,
+} from './use-global-search-results';
+
+function getTimePeriod(
+  timestamp: number,
+): 'today' | 'yesterday' | 'last-week' | 'last-30-days' {
+  const now = new Date();
+  const nowDay = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+  const itemDay = new Date(timestamp);
+  const itemDayStart = new Date(
+    itemDay.getFullYear(),
+    itemDay.getMonth(),
+    itemDay.getDate(),
+  );
+  const diffDays = Math.floor(
+    (nowDay.getTime() - itemDayStart.getTime()) / (24 * 60 * 60 * 1000),
+  );
+  if (diffDays === 0) return 'today';
+  if (diffDays === 1) return 'yesterday';
+  if (diffDays <= 7) return 'last-week';
+  return 'last-30-days';
+}
+
+function toSearchResultItem(item: AccessedItem): SearchResultItem {
+  return {
+    id: item.id,
+    type: item.type,
+    label: item.label,
+    href: item.href,
+    status: item.status,
+    folderName: item.folderName,
+    projectName: item.projectName,
+    iconBgColor: item.iconBgColor,
+    iconTextColor: item.iconTextColor,
+    iconLetter: item.iconLetter,
+    pageIcon:
+      item.type === 'page'
+        ? STATIC_PAGES.find((p) => p.id === item.id)?.icon
+        : undefined,
+  };
+}
+
+export function buildRecentGroups({
+  hideTables,
+}: {
+  hideTables: boolean;
+}): SearchResultGroup[] {
+  const history = hideTables
+    ? getAccessHistory().filter((h) => h.type !== 'table')
+    : getAccessHistory();
+  if (history.length === 0) {
+    return [];
+  }
+
+  const buckets: Record<string, SearchResultItem[]> = {
+    today: [],
+    yesterday: [],
+    'last-week': [],
+    'last-30-days': [],
+  };
+  for (const item of history) {
+    buckets[getTimePeriod(item.accessedAt)].push(toSearchResultItem(item));
+  }
+
+  const periodDefs = [
+    { key: 'today', label: t('Today') },
+    { key: 'yesterday', label: t('Yesterday') },
+    { key: 'last-week', label: t('Last Week') },
+    { key: 'last-30-days', label: t('Last 30 Days') },
+  ];
+
+  return periodDefs
+    .filter((p) => buckets[p.key].length > 0)
+    .map((p) => ({
+      type: `history-${p.key}`,
+      heading: p.label,
+      items: buckets[p.key],
+      isLoading: false,
+    }));
+}

--- a/packages/web/src/app/components/global-search/search-result-item.tsx
+++ b/packages/web/src/app/components/global-search/search-result-item.tsx
@@ -1,10 +1,30 @@
 import { t } from 'i18next';
-import { Dot, FolderIcon, User } from 'lucide-react';
+import { FolderIcon, User } from 'lucide-react';
 
+import { BoxIcon } from '@/components/icons/box';
+import { ConnectIcon } from '@/components/icons/connect';
+import { HistoryIcon } from '@/components/icons/history';
+import { Settings2Icon } from '@/components/icons/settings2';
 import { TableIcon } from '@/components/icons/table';
+import { VariableIcon } from '@/components/icons/variable';
 import { WorkflowIcon } from '@/components/icons/workflow';
 
-import { type SearchResultItem } from './use-global-search-results';
+import {
+  type DestinationKind,
+  type SearchResultItem,
+} from './use-global-search-results';
+
+const DESTINATION_ICONS: Record<
+  DestinationKind,
+  React.ComponentType<{ className?: string; size?: number }>
+> = {
+  automations: WorkflowIcon,
+  connections: ConnectIcon,
+  runs: HistoryIcon,
+  variables: VariableIcon,
+  releases: BoxIcon,
+  settings: Settings2Icon,
+};
 
 function timeAgo(date: Date | string): string {
   const ms = Date.now() - new Date(date).getTime();
@@ -20,6 +40,7 @@ function timeAgo(date: Date | string): string {
 type ItemIconProps = {
   type: string;
   pageIcon?: React.ComponentType<{ className?: string; size?: number }>;
+  destinationKind?: DestinationKind;
   iconBgColor?: string;
   iconTextColor?: string;
   iconLetter?: string;
@@ -28,10 +49,18 @@ type ItemIconProps = {
 function ItemIcon({
   type,
   pageIcon: PageIcon,
+  destinationKind,
   iconBgColor,
   iconTextColor,
   iconLetter,
 }: ItemIconProps) {
+  if (type === 'destination' && destinationKind) {
+    const DestinationIcon = DESTINATION_ICONS[destinationKind];
+    return (
+      <DestinationIcon size={16} className="shrink-0 text-muted-foreground" />
+    );
+  }
+
   if (type === 'project') {
     if (iconBgColor) {
       return (
@@ -95,27 +124,22 @@ function ItemMeta({
   if (!hasProject && !hasFolder && !hasUpdated) return null;
 
   return (
-    <span className="flex shrink-0 items-center gap-1 text-xs text-muted-foreground/80">
-      <span>—</span>
-      {hasProject && <span>{projectName}</span>}
-      {hasProject && hasFolder && <span>/</span>}
+    <span className="flex shrink-0 items-center gap-1.5 text-[11px] text-muted-foreground/55">
+      {hasProject && <span className="truncate">{projectName}</span>}
+      {hasProject && hasFolder && <span aria-hidden>·</span>}
       {hasFolder && (
-        <span className="flex items-center gap-0.5">
+        <span className="flex items-center gap-1">
           <FolderIcon
-            className="size-4! mr-0.5 text-muted-foreground/80 shrink-0"
+            className="size-3! text-muted-foreground/55 shrink-0"
             fill="currentColor"
             strokeWidth={0}
           />
-          <span>{folderName}</span>
+          <span className="truncate">{folderName}</span>
         </span>
       )}
-      {(hasProject || hasFolder) && hasUpdated && (
-        <Dot className="size-3! shrink-0 text-muted-foreground/80" />
-      )}
+      {(hasProject || hasFolder) && hasUpdated && <span aria-hidden>·</span>}
       {hasUpdated && (
-        <span className="whitespace-nowrap">{`Last Modified: ${timeAgo(
-          updated!,
-        )}`}</span>
+        <span className="whitespace-nowrap">{timeAgo(updated!)}</span>
       )}
     </span>
   );
@@ -155,15 +179,18 @@ function HighlightText({ text, query }: { text: string; query: string }) {
 export function SearchResultRow({
   item,
   query,
+  actions,
 }: {
   item: SearchResultItem;
   query?: string;
+  actions?: React.ReactNode;
 }) {
   return (
     <div className="flex min-w-0 flex-1 items-center gap-2">
       <ItemIcon
         type={item.type}
         pageIcon={item.pageIcon}
+        destinationKind={item.destinationKind}
         iconBgColor={item.iconBgColor}
         iconTextColor={item.iconTextColor}
         iconLetter={item.iconLetter}
@@ -171,6 +198,11 @@ export function SearchResultRow({
       <span className="min-w-0 shrink truncate text-sm font-normal">
         <HighlightText text={item.label} query={query ?? ''} />
       </span>
+      {item.badge && (
+        <span className="shrink-0 rounded-full bg-muted px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground">
+          {item.badge}
+        </span>
+      )}
       {item.status === 'ENABLED' && (
         <span className="shrink-0 rounded-full bg-green-500/10 px-1.5 py-0.5 text-[10px] font-medium text-green-600">
           {t('Live')}
@@ -181,6 +213,7 @@ export function SearchResultRow({
         folderName={item.folderName}
         updated={item.updated}
       />
+      {actions && <span className="ml-auto shrink-0">{actions}</span>}
     </div>
   );
 }

--- a/packages/web/src/app/components/global-search/style-spotlight.tsx
+++ b/packages/web/src/app/components/global-search/style-spotlight.tsx
@@ -1,0 +1,65 @@
+import { t } from 'i18next';
+import { Search, X } from 'lucide-react';
+import { useEffect, useRef } from 'react';
+
+import { BrowseFilterChips } from './browse-filter-chips';
+import {
+  makeSearchKeyDown,
+  ResultGroups,
+  ScopeToggle,
+} from './browse-style-shared';
+import { type BrowseController } from './use-browse-controller';
+
+export function StyleSpotlight({
+  controller,
+}: {
+  controller: BrowseController;
+}) {
+  const isProject = controller.category === 'project';
+  const inputRef = useRef<HTMLInputElement>(null);
+  useEffect(() => {
+    const id = requestAnimationFrame(() => inputRef.current?.focus());
+    return () => cancelAnimationFrame(id);
+  }, []);
+  return (
+    <div className="flex h-full flex-col">
+      <div className="flex items-center gap-3 px-4 pb-3 pt-3.5">
+        <Search className="size-[18px] shrink-0 text-muted-foreground/40" />
+        <input
+          ref={inputRef}
+          autoFocus
+          value={controller.search}
+          onChange={(e) => controller.setSearch(e.target.value)}
+          onKeyDown={makeSearchKeyDown(controller)}
+          placeholder={t('Search')}
+          className="w-full bg-transparent text-lg font-light tracking-[-0.02em] outline-none placeholder:text-muted-foreground/30"
+        />
+        {controller.search && (
+          <button
+            type="button"
+            onClick={() => controller.setSearch('')}
+            onMouseDown={(e) => e.preventDefault()}
+            className="flex size-7 shrink-0 items-center justify-center rounded-full text-muted-foreground/50 transition-colors hover:bg-muted hover:text-foreground"
+          >
+            <X className="size-4" />
+          </button>
+        )}
+      </div>
+
+      <div className="flex items-center justify-between gap-3 border-t border-foreground/[0.06] px-3 py-2">
+        <ScopeToggle controller={controller} />
+        {isProject && (
+          <BrowseFilterChips
+            active={controller.projectFilter}
+            onSelect={controller.setProjectFilter}
+            hideTables={controller.hideTables}
+          />
+        )}
+      </div>
+
+      <div className="min-h-0 flex-1 overflow-y-auto px-2 py-2 scrollbar-hover">
+        <ResultGroups controller={controller} density="cozy" />
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/app/components/global-search/use-browse-controller.ts
+++ b/packages/web/src/app/components/global-search/use-browse-controller.ts
@@ -1,4 +1,3 @@
-import { Permission } from '@activepieces/core-utils';
 import { type ProjectWithLimits } from '@activepieces/shared';
 import { t } from 'i18next';
 import { useCallback, useState } from 'react';
@@ -7,7 +6,6 @@ import { useDebounce } from 'use-debounce';
 
 import { useEmbedding } from '@/components/providers/embed-provider';
 import { getProjectName, projectCollectionUtils } from '@/features/projects';
-import { useAuthorization } from '@/hooks/authorization-hooks';
 import { authenticationSession } from '@/lib/authentication-session';
 import { NEW_FLOW_QUERY_PARAM, NEW_TABLE_QUERY_PARAM } from '@/lib/route-utils';
 
@@ -44,7 +42,6 @@ export function useBrowseController({
     filter: uiPrefs.prefs.browseFilter,
     projectId: initialProjectId,
   });
-  const { checkAccess } = useAuthorization();
   const { embedState } = useEmbedding();
   const mutations = useBrowseMutations(browse.projectId);
 
@@ -66,11 +63,6 @@ export function useBrowseController({
   const { groups, isLoading } = hasQuery ? searchResults : browseResults;
 
   const currentProject = allProjects.find((p) => p.id === browse.projectId);
-  const isActiveContext = browse.projectId === activeProjectId;
-  const canWriteFlow = !isActiveContext || checkAccess(Permission.WRITE_FLOW);
-  const canWriteTable = !isActiveContext || checkAccess(Permission.WRITE_TABLE);
-  const canWriteFolder =
-    !isActiveContext || checkAccess(Permission.WRITE_FOLDER);
 
   const flatItems = groups.flatMap((group) => group.items);
   const rowCount = flatItems.length;
@@ -266,9 +258,6 @@ export function useBrowseController({
     openItem,
     openProject,
     hideTables: embedState.hideTables,
-    canWriteFlow,
-    canWriteTable,
-    canWriteFolder,
     isCreatingFlow: mutations.isCreatingFlow,
     isCreatingTable: mutations.isCreatingTable,
     createFlow,
@@ -307,9 +296,6 @@ export type BrowseController = {
   openItem: (item: SearchResultItem) => void;
   openProject: (projectId: string) => void;
   hideTables: boolean;
-  canWriteFlow: boolean;
-  canWriteTable: boolean;
-  canWriteFolder: boolean;
   isCreatingFlow: boolean;
   isCreatingTable: boolean;
   createFlow: () => Promise<void>;

--- a/packages/web/src/app/components/global-search/use-browse-controller.ts
+++ b/packages/web/src/app/components/global-search/use-browse-controller.ts
@@ -1,0 +1,320 @@
+import { Permission } from '@activepieces/core-utils';
+import { type ProjectWithLimits } from '@activepieces/shared';
+import { t } from 'i18next';
+import { useCallback, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useDebounce } from 'use-debounce';
+
+import { useEmbedding } from '@/components/providers/embed-provider';
+import { getProjectName, projectCollectionUtils } from '@/features/projects';
+import { useAuthorization } from '@/hooks/authorization-hooks';
+import { authenticationSession } from '@/lib/authentication-session';
+import { NEW_FLOW_QUERY_PARAM, NEW_TABLE_QUERY_PARAM } from '@/lib/route-utils';
+
+import { recordAccess } from './access-history';
+import { useBrowseMutations } from './use-browse-mutations';
+import {
+  type BrowseCategory,
+  type ProjectFilter,
+  useBrowseNavigation,
+} from './use-browse-navigation';
+import { useBrowseResults } from './use-browse-results';
+import {
+  type SearchResultItem,
+  useGlobalSearchResults,
+} from './use-global-search-results';
+import { useUiPreferences } from './use-ui-preferences';
+
+export function useBrowseController({
+  onClose,
+}: {
+  onClose: () => void;
+}): BrowseController {
+  const navigate = useNavigate();
+  const activeProjectId = authenticationSession.getProjectId() ?? '';
+  const uiPrefs = useUiPreferences();
+  const { data: allProjects = [] } = projectCollectionUtils.useAll();
+  const initialProjectId =
+    uiPrefs.prefs.browseProjectId &&
+    allProjects.some((p) => p.id === uiPrefs.prefs.browseProjectId)
+      ? uiPrefs.prefs.browseProjectId
+      : activeProjectId;
+  const browse = useBrowseNavigation(activeProjectId, {
+    category: uiPrefs.prefs.browseScope,
+    filter: uiPrefs.prefs.browseFilter,
+    projectId: initialProjectId,
+  });
+  const { checkAccess } = useAuthorization();
+  const { embedState } = useEmbedding();
+  const mutations = useBrowseMutations(browse.projectId);
+
+  const [search, setSearch] = useState('');
+  const [debouncedSearch] = useDebounce(search, 200);
+  const [createFolderOpen, setCreateFolderOpen] = useState(false);
+  const [projectMenuOpen, setProjectMenuOpen] = useState(false);
+  const [projectMenuIndex, setProjectMenuIndex] = useState(0);
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const hasQuery = debouncedSearch.length > 0;
+
+  const searchResults = useGlobalSearchResults(debouncedSearch, true);
+  const browseResults = useBrowseResults({
+    projectId: browse.projectId,
+    category: browse.category,
+    projectFilter: browse.projectFilter,
+    enabled: !hasQuery,
+  });
+  const { groups, isLoading } = hasQuery ? searchResults : browseResults;
+
+  const currentProject = allProjects.find((p) => p.id === browse.projectId);
+  const isActiveContext = browse.projectId === activeProjectId;
+  const canWriteFlow = !isActiveContext || checkAccess(Permission.WRITE_FLOW);
+  const canWriteTable = !isActiveContext || checkAccess(Permission.WRITE_TABLE);
+  const canWriteFolder =
+    !isActiveContext || checkAccess(Permission.WRITE_FOLDER);
+
+  const flatItems = groups.flatMap((group) => group.items);
+  const rowCount = flatItems.length;
+
+  const openItem = useCallback(
+    (item: SearchResultItem) => {
+      if (
+        item.type === 'flow' ||
+        item.type === 'table' ||
+        item.type === 'project' ||
+        item.type === 'page'
+      ) {
+        recordAccess({
+          id: item.id,
+          type: item.type,
+          label: item.label,
+          href: item.href,
+          status: item.status,
+          folderName: item.folderName,
+          projectName: item.projectName ?? null,
+          iconBgColor: item.iconBgColor,
+          iconTextColor: item.iconTextColor,
+          iconLetter: item.iconLetter,
+        });
+      }
+      if (item.projectId && item.projectId !== activeProjectId) {
+        projectCollectionUtils.setCurrentProject(item.projectId);
+      }
+      const chat = new URLSearchParams(window.location.search).get('chat');
+      const target = chat
+        ? `${item.href}${item.href.includes('?') ? '&' : '?'}chat=${chat}`
+        : item.href;
+      navigate(target);
+      onClose();
+    },
+    [navigate, onClose, activeProjectId],
+  );
+
+  const openProject = useCallback(
+    (projectId: string) => {
+      if (projectId !== activeProjectId) {
+        projectCollectionUtils.setCurrentProject(projectId);
+      }
+      const chat = new URLSearchParams(window.location.search).get('chat');
+      const base = `/projects/${projectId}/automations`;
+      navigate(chat ? `${base}?chat=${chat}` : base);
+      onClose();
+    },
+    [navigate, onClose, activeProjectId],
+  );
+
+  const switchProject = useCallback(
+    (projectId: string) => {
+      browse.selectProject(projectId, 'project');
+      setProjectMenuOpen(false);
+      setSelectedIndex(0);
+      uiPrefs.update({ browseProjectId: projectId, browseScope: 'project' });
+    },
+    [browse, uiPrefs],
+  );
+
+  const handleProjectMenuOpenChange = useCallback(
+    (next: boolean) => {
+      if (next) {
+        const idx = allProjects.findIndex((p) => p.id === browse.projectId);
+        setProjectMenuIndex(idx >= 0 ? idx : 0);
+      }
+      setProjectMenuOpen(next);
+    },
+    [allProjects, browse.projectId],
+  );
+
+  const setCategory = useCallback(
+    (category: BrowseCategory) => {
+      setSelectedIndex(0);
+      browse.selectCategory(category);
+      uiPrefs.update({ browseScope: category });
+    },
+    [browse, uiPrefs],
+  );
+
+  const setProjectFilter = useCallback(
+    (filter: ProjectFilter) => {
+      setSelectedIndex(0);
+      browse.selectProjectFilter(filter);
+      uiPrefs.update({ browseFilter: filter });
+    },
+    [browse, uiPrefs],
+  );
+
+  const cycleScopeFilter = useCallback(
+    (dir: 1 | -1) => {
+      const sequence: { category: BrowseCategory; filter?: ProjectFilter }[] = [
+        { category: 'recent' },
+        { category: 'project', filter: 'all' },
+        { category: 'project', filter: 'flows' },
+        ...(embedState.hideTables
+          ? []
+          : [{ category: 'project' as const, filter: 'tables' as const }]),
+      ];
+      const currentIdx =
+        browse.category === 'recent'
+          ? 0
+          : sequence.findIndex(
+              (s) =>
+                s.category === 'project' && s.filter === browse.projectFilter,
+            );
+      const next =
+        sequence[(currentIdx + dir + sequence.length) % sequence.length];
+      setSelectedIndex(0);
+      browse.selectCategory(next.category);
+      if (next.filter) browse.selectProjectFilter(next.filter);
+      uiPrefs.update({
+        browseScope: next.category,
+        ...(next.filter ? { browseFilter: next.filter } : {}),
+      });
+    },
+    [browse, embedState.hideTables, uiPrefs],
+  );
+
+  const createFlow = useCallback(async () => {
+    const flow = await mutations.createFlow();
+    openItem({
+      id: `browse-flow-${flow.id}`,
+      type: 'flow',
+      label: flow.version.displayName,
+      href: `/projects/${browse.projectId}/flows/${flow.id}?${NEW_FLOW_QUERY_PARAM}=true`,
+      action: 'open',
+      projectId: browse.projectId,
+    });
+  }, [mutations, openItem, browse.projectId]);
+
+  const createTable = useCallback(async () => {
+    const table = await mutations.createTable(t('New Table'));
+    openItem({
+      id: `browse-table-${table.id}`,
+      type: 'table',
+      label: table.name,
+      href: `/projects/${browse.projectId}/tables/${table.id}?${NEW_TABLE_QUERY_PARAM}=true`,
+      action: 'open',
+      projectId: browse.projectId,
+    });
+  }, [mutations, openItem, browse.projectId]);
+
+  const clampedIndex =
+    flatItems.length === 0 ? -1 : Math.min(selectedIndex, flatItems.length - 1);
+
+  const setSelected = useCallback((index: number) => {
+    setSelectedIndex(index);
+  }, []);
+
+  const moveSelection = useCallback(
+    (delta: number) => {
+      setSelectedIndex((i) => {
+        const len = flatItems.length;
+        if (len === 0) return 0;
+        return (Math.max(0, Math.min(i, len - 1)) + delta + len) % len;
+      });
+    },
+    [flatItems.length],
+  );
+
+  const openSelected = useCallback(() => {
+    const item = flatItems[clampedIndex];
+    if (item) openItem(item);
+  }, [flatItems, clampedIndex, openItem]);
+
+  return {
+    search,
+    setSearch,
+    hasQuery,
+    debouncedSearch,
+    category: browse.category,
+    setCategory,
+    projectFilter: browse.projectFilter,
+    setProjectFilter,
+    cycleScopeFilter,
+    projectId: browse.projectId,
+    allProjects,
+    currentProject,
+    currentProjectName: currentProject ? getProjectName(currentProject) : '',
+    switchProject,
+    projectMenuOpen,
+    projectMenuIndex,
+    handleProjectMenuOpenChange,
+    groups,
+    isLoading,
+    rowCount,
+    selectedIndex: clampedIndex,
+    setSelected,
+    moveSelection,
+    openSelected,
+    openItem,
+    openProject,
+    hideTables: embedState.hideTables,
+    canWriteFlow,
+    canWriteTable,
+    canWriteFolder,
+    isCreatingFlow: mutations.isCreatingFlow,
+    isCreatingTable: mutations.isCreatingTable,
+    createFlow,
+    createTable,
+    createFolderOpen,
+    setCreateFolderOpen,
+    invalidate: mutations.invalidate,
+  };
+}
+
+export type BrowseController = {
+  search: string;
+  setSearch: (value: string) => void;
+  hasQuery: boolean;
+  debouncedSearch: string;
+  category: BrowseCategory;
+  setCategory: (category: BrowseCategory) => void;
+  projectFilter: ProjectFilter;
+  setProjectFilter: (filter: ProjectFilter) => void;
+  cycleScopeFilter: (dir: 1 | -1) => void;
+  projectId: string;
+  allProjects: ProjectWithLimits[];
+  currentProject?: ProjectWithLimits;
+  currentProjectName: string;
+  switchProject: (projectId: string) => void;
+  projectMenuOpen: boolean;
+  projectMenuIndex: number;
+  handleProjectMenuOpenChange: (open: boolean) => void;
+  groups: ReturnType<typeof useBrowseResults>['groups'];
+  isLoading: boolean;
+  rowCount: number;
+  selectedIndex: number;
+  setSelected: (index: number) => void;
+  moveSelection: (delta: number) => void;
+  openSelected: () => void;
+  openItem: (item: SearchResultItem) => void;
+  openProject: (projectId: string) => void;
+  hideTables: boolean;
+  canWriteFlow: boolean;
+  canWriteTable: boolean;
+  canWriteFolder: boolean;
+  isCreatingFlow: boolean;
+  isCreatingTable: boolean;
+  createFlow: () => Promise<void>;
+  createTable: () => Promise<void>;
+  createFolderOpen: boolean;
+  setCreateFolderOpen: (open: boolean) => void;
+  invalidate: () => void;
+};

--- a/packages/web/src/app/components/global-search/use-browse-mutations.ts
+++ b/packages/web/src/app/components/global-search/use-browse-mutations.ts
@@ -1,0 +1,136 @@
+import { PopulatedFlow, Table } from '@activepieces/shared';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { t } from 'i18next';
+import { toast } from 'sonner';
+
+import { automationMutationUtils } from '@/features/automations/lib/mutation-bodies';
+import { flowHooks } from '@/features/flows/hooks/flow-hooks';
+
+const PAGE_QUERY_KEYS = [
+  'folders',
+  'root-flows',
+  'root-tables',
+  'all-folder-contents',
+  'tables',
+];
+
+export function useBrowseMutations(projectId: string) {
+  const queryClient = useQueryClient();
+  const { mutate: exportFlowsMutate, isPending: isExportingFlow } =
+    flowHooks.useExportFlows();
+
+  // Keep both the Browse panel (project-scoped keys) and the Automations page
+  // (its own keys) in sync after any change.
+  const invalidate = () => {
+    for (const key of ['browse-flows', 'browse-tables', 'browse-folders']) {
+      queryClient.invalidateQueries({ queryKey: [key, projectId] });
+    }
+    for (const key of PAGE_QUERY_KEYS) {
+      queryClient.invalidateQueries({ queryKey: [key] });
+    }
+  };
+
+  const createFlow = useMutation<PopulatedFlow, Error, string | undefined>({
+    mutationFn: (folderId) =>
+      automationMutationUtils.createFlow({
+        projectId,
+        displayName: t('Untitled'),
+        folderId,
+      }),
+    onSuccess: invalidate,
+    onError: () => toast.error(t('Failed to create flow')),
+  });
+
+  const createTable = useMutation<
+    Table,
+    Error,
+    { name: string; folderId?: string }
+  >({
+    mutationFn: ({ name, folderId }) =>
+      automationMutationUtils.createTable({ projectId, name, folderId }),
+    onSuccess: invalidate,
+    onError: () => toast.error(t('Failed to create table')),
+  });
+
+  const rename = useMutation<
+    void,
+    Error,
+    { item: BrowseManageItem; newName: string }
+  >({
+    mutationFn: ({ item, newName }) =>
+      automationMutationUtils.renameItem({
+        id: item.id,
+        type: item.type,
+        newName,
+      }),
+    onSuccess: () => {
+      invalidate();
+      toast.success(t('Renamed successfully'));
+    },
+    onError: () => toast.error(t('Failed to rename item')),
+  });
+
+  const deleteItem = useMutation<void, Error, BrowseManageItem>({
+    mutationFn: (item) =>
+      automationMutationUtils.deleteItem({ id: item.id, type: item.type }),
+    onSuccess: invalidate,
+  });
+
+  const moveItem = useMutation<
+    void,
+    Error,
+    { item: BrowseManageItem; targetFolderId: string }
+  >({
+    mutationFn: ({ item, targetFolderId }) =>
+      automationMutationUtils.moveItem({
+        id: item.id,
+        type: item.type,
+        targetFolderId,
+      }),
+    onSuccess: () => {
+      invalidate();
+      toast.success(t('Moved successfully'));
+    },
+    onError: () => toast.error(t('Failed to move item')),
+  });
+
+  const duplicateFlow = useMutation<PopulatedFlow, Error, PopulatedFlow>({
+    mutationFn: (flow) =>
+      automationMutationUtils.duplicateFlow({
+        version: flow.version,
+        folderId: flow.folderId,
+        projectId,
+      }),
+    onSuccess: invalidate,
+    onError: () => toast.error(t('Failed to duplicate flow')),
+  });
+
+  const exportTable = useMutation<void, Error, Table>({
+    mutationFn: (table) => automationMutationUtils.exportTable(table),
+    onSuccess: () => toast.success(t('Table has been exported.')),
+    onError: () => toast.error(t('Failed to export table')),
+  });
+
+  return {
+    createFlow: (folderId?: string) => createFlow.mutateAsync(folderId),
+    createTable: (name: string, folderId?: string) =>
+      createTable.mutateAsync({ name, folderId }),
+    renameItem: (item: BrowseManageItem, newName: string) =>
+      rename.mutateAsync({ item, newName }),
+    deleteItem: (item: BrowseManageItem) => deleteItem.mutateAsync(item),
+    moveItem: (item: BrowseManageItem, targetFolderId: string) =>
+      moveItem.mutateAsync({ item, targetFolderId }),
+    duplicateFlow: (flow: PopulatedFlow) => duplicateFlow.mutateAsync(flow),
+    exportFlow: (flow: PopulatedFlow) => exportFlowsMutate([flow]),
+    exportTable: (table: Table) => exportTable.mutate(table),
+    invalidate,
+    isCreatingFlow: createFlow.isPending,
+    isCreatingTable: createTable.isPending,
+    isRenaming: rename.isPending,
+    isMoving: moveItem.isPending,
+    isDuplicating: duplicateFlow.isPending,
+    isExporting: isExportingFlow || exportTable.isPending,
+  };
+}
+
+export type BrowseManageItem = { type: 'flow' | 'table'; id: string };

--- a/packages/web/src/app/components/global-search/use-browse-mutations.ts
+++ b/packages/web/src/app/components/global-search/use-browse-mutations.ts
@@ -74,6 +74,7 @@ export function useBrowseMutations(projectId: string) {
     mutationFn: (item) =>
       automationMutationUtils.deleteItem({ id: item.id, type: item.type }),
     onSuccess: invalidate,
+    onError: () => toast.error(t('Failed to delete item')),
   });
 
   const moveItem = useMutation<

--- a/packages/web/src/app/components/global-search/use-browse-navigation.ts
+++ b/packages/web/src/app/components/global-search/use-browse-navigation.ts
@@ -1,0 +1,55 @@
+import { useCallback, useState } from 'react';
+
+export function useBrowseNavigation(
+  activeProjectId: string,
+  initial?: {
+    category?: BrowseCategory;
+    filter?: ProjectFilter;
+    projectId?: string;
+  },
+) {
+  const [projectId, setProjectId] = useState(
+    initial?.projectId ?? activeProjectId,
+  );
+  const [category, setCategory] = useState<BrowseCategory>(
+    initial?.category ?? 'recent',
+  );
+  const [projectFilter, setProjectFilter] = useState<ProjectFilter>(
+    initial?.filter ?? 'all',
+  );
+
+  const selectProject = useCallback(
+    (id: string, nextCategory?: BrowseCategory) => {
+      setProjectId(id);
+      if (nextCategory) setCategory(nextCategory);
+    },
+    [],
+  );
+
+  const selectCategory = useCallback((next: BrowseCategory) => {
+    setCategory(next);
+  }, []);
+
+  const selectProjectFilter = useCallback((next: ProjectFilter) => {
+    setProjectFilter(next);
+  }, []);
+
+  const reset = useCallback(() => {
+    setProjectId(activeProjectId);
+    setCategory('recent');
+    setProjectFilter('all');
+  }, [activeProjectId]);
+
+  return {
+    projectId,
+    category,
+    projectFilter,
+    selectProject,
+    selectCategory,
+    selectProjectFilter,
+    reset,
+  };
+}
+
+export type BrowseCategory = 'recent' | 'project';
+export type ProjectFilter = 'all' | 'flows' | 'tables';

--- a/packages/web/src/app/components/global-search/use-browse-results.ts
+++ b/packages/web/src/app/components/global-search/use-browse-results.ts
@@ -1,0 +1,190 @@
+import {
+  type FolderDto,
+  type PopulatedFlow,
+  type Table,
+} from '@activepieces/shared';
+import { useQuery } from '@tanstack/react-query';
+import { t } from 'i18next';
+
+import { useEmbedding } from '@/components/providers/embed-provider';
+import { flowsApi } from '@/features/flows';
+import { foldersApi } from '@/features/folders';
+import { tablesApi } from '@/features/tables';
+
+import { buildRecentGroups } from './recent-history';
+import {
+  type BrowseCategory,
+  type ProjectFilter,
+} from './use-browse-navigation';
+import {
+  type SearchResultGroup,
+  type SearchResultItem,
+} from './use-global-search-results';
+
+const LIST_LIMIT = 1000;
+
+function buildMergedFolderGroups(opts: {
+  folders: FolderDto[];
+  items: { folderId: string | null; item: SearchResultItem }[];
+}): SearchResultGroup[] {
+  const { folders, items } = opts;
+  const byFolder = new Map<string, SearchResultItem[]>();
+  const uncategorized: SearchResultItem[] = [];
+  for (const { folderId, item } of items) {
+    const folder = folderId
+      ? folders.find((f) => f.id === folderId)
+      : undefined;
+    if (folder) {
+      const list = byFolder.get(folder.id) ?? [];
+      list.push(item);
+      byFolder.set(folder.id, list);
+    } else {
+      uncategorized.push(item);
+    }
+  }
+
+  const groups: SearchResultGroup[] = [];
+  for (const folder of folders) {
+    const list = byFolder.get(folder.id);
+    if (!list || list.length === 0) continue;
+    groups.push({
+      type: `folder-${folder.id}`,
+      heading: `${folder.displayName} · ${list.length}`,
+      items: sortByUpdatedDesc(list),
+      isLoading: false,
+    });
+  }
+  if (uncategorized.length > 0) {
+    groups.push({
+      type: 'uncategorized',
+      heading: `${t('Uncategorized')} · ${uncategorized.length}`,
+      items: sortByUpdatedDesc(uncategorized),
+      isLoading: false,
+    });
+  }
+  return groups;
+}
+
+function sortByUpdatedDesc(items: SearchResultItem[]): SearchResultItem[] {
+  return [...items].sort((a, b) => {
+    const aTime = a.updated ? new Date(a.updated).getTime() : 0;
+    const bTime = b.updated ? new Date(b.updated).getTime() : 0;
+    return bTime - aTime;
+  });
+}
+
+export function useBrowseResults({
+  projectId,
+  category,
+  projectFilter,
+  enabled,
+}: {
+  projectId: string;
+  category: BrowseCategory;
+  projectFilter: ProjectFilter;
+  enabled: boolean;
+}): BrowseResults {
+  const { embedState } = useEmbedding();
+  const hideTables = embedState.hideTables;
+
+  const isProject = enabled && category === 'project' && !!projectId;
+  const wantsFlows = isProject && projectFilter !== 'tables';
+  const wantsTables =
+    isProject &&
+    !hideTables &&
+    (projectFilter === 'all' || projectFilter === 'tables');
+
+  const foldersQuery = useQuery({
+    queryKey: ['browse-folders', projectId],
+    queryFn: () => foldersApi.list({ projectId }),
+    staleTime: 30_000,
+    enabled: isProject,
+  });
+
+  const flowsQuery = useQuery({
+    queryKey: ['browse-flows', projectId],
+    queryFn: () =>
+      flowsApi.list({ projectId, limit: LIST_LIMIT, cursor: undefined }),
+    staleTime: 30_000,
+    enabled: wantsFlows,
+  });
+
+  const tablesQuery = useQuery({
+    queryKey: ['browse-tables', projectId],
+    queryFn: () =>
+      tablesApi.list({ projectId, limit: LIST_LIMIT, cursor: undefined }),
+    staleTime: 30_000,
+    enabled: wantsTables,
+  });
+
+  const folders = foldersQuery.data ?? [];
+  const flows = flowsQuery.data?.data ?? [];
+  const tables = tablesQuery.data?.data ?? [];
+  const flowsById = new Map(flows.map((f) => [f.id, f]));
+  const tablesById = new Map(tables.map((tbl) => [tbl.id, tbl]));
+  const base = { folders, flowsById, tablesById };
+
+  if (!enabled) {
+    return { groups: [], isLoading: false, ...base };
+  }
+
+  if (category === 'recent') {
+    return {
+      groups: buildRecentGroups({ hideTables }),
+      isLoading: false,
+      ...base,
+    };
+  }
+
+  const merged: { folderId: string | null; item: SearchResultItem }[] = [];
+  if (wantsFlows) {
+    for (const flow of flows) {
+      merged.push({
+        folderId: flow.folderId ?? null,
+        item: {
+          id: `browse-flow-${flow.id}`,
+          type: 'flow',
+          label: flow.version.displayName,
+          href: `/projects/${projectId}/flows/${flow.id}`,
+          action: 'open',
+          projectId,
+          status: flow.status,
+          updated: flow.updated ? String(flow.updated) : null,
+        },
+      });
+    }
+  }
+  if (wantsTables) {
+    for (const table of tables) {
+      merged.push({
+        folderId: table.folderId ?? null,
+        item: {
+          id: `browse-table-${table.id}`,
+          type: 'table',
+          label: table.name,
+          href: `/projects/${projectId}/tables/${table.id}`,
+          action: 'open',
+          projectId,
+          updated: table.updated ? String(table.updated) : null,
+        },
+      });
+    }
+  }
+
+  return {
+    groups: buildMergedFolderGroups({ folders, items: merged }),
+    isLoading:
+      foldersQuery.isLoading ||
+      (wantsFlows && flowsQuery.isLoading) ||
+      (wantsTables && tablesQuery.isLoading),
+    ...base,
+  };
+}
+
+export type BrowseResults = {
+  groups: SearchResultGroup[];
+  isLoading: boolean;
+  folders: FolderDto[];
+  flowsById: Map<string, PopulatedFlow>;
+  tablesById: Map<string, Table>;
+};

--- a/packages/web/src/app/components/global-search/use-global-search-results.ts
+++ b/packages/web/src/app/components/global-search/use-global-search-results.ts
@@ -10,31 +10,24 @@ import { tablesApi } from '@/features/tables';
 import { useIsPlatformAdmin } from '@/hooks/authorization-hooks';
 import { authenticationSession } from '@/lib/authentication-session';
 
-import { getAccessHistory } from './access-history';
 import { STATIC_PAGES, type StaticPage } from './static-pages';
 
-const SEARCH_LIMIT = 6;
-const SUPPLEMENT_THRESHOLD = 5;
+// Mirrors StageResource['type'] from the workspace shell (not merged yet);
+// the shell PR replaces this with the real import.
+type StageResourceType =
+  | 'flow'
+  | 'table'
+  | 'run'
+  | 'release'
+  | 'automations'
+  | 'runs'
+  | 'connections'
+  | 'variables'
+  | 'releases'
+  | 'settings'
+  | 'none';
 
-function getTimePeriod(
-  timestamp: number,
-): 'today' | 'yesterday' | 'last-week' | 'last-30-days' {
-  const now = new Date();
-  const nowDay = new Date(now.getFullYear(), now.getMonth(), now.getDate());
-  const itemDay = new Date(timestamp);
-  const itemDayStart = new Date(
-    itemDay.getFullYear(),
-    itemDay.getMonth(),
-    itemDay.getDate(),
-  );
-  const diffDays = Math.floor(
-    (nowDay.getTime() - itemDayStart.getTime()) / (24 * 60 * 60 * 1000),
-  );
-  if (diffDays === 0) return 'today';
-  if (diffDays === 1) return 'yesterday';
-  if (diffDays <= 7) return 'last-week';
-  return 'last-30-days';
-}
+const SEARCH_LIMIT = 6;
 
 export function useGlobalSearchResults(query: string, open: boolean) {
   const projectId = authenticationSession.getProjectId() ?? '';
@@ -48,22 +41,13 @@ export function useGlobalSearchResults(query: string, open: boolean) {
     : null;
   const hasQuery = query.length > 0;
 
-  const accessHistory = hideTables
-    ? getAccessHistory().filter((h) => h.type !== 'table')
-    : getAccessHistory();
-  const hasHistory = accessHistory.length > 0;
-  const needsSupplement =
-    !hasQuery && accessHistory.length < SUPPLEMENT_THRESHOLD;
-
   const searchEnabled = hasQuery && !!projectId;
-  const suggestionsEnabled =
-    !hasQuery && needsSupplement && open && !!projectId;
 
   const foldersQuery = useQuery({
     queryKey: ['global-search-folders', projectId],
     queryFn: () => foldersApi.list(),
     staleTime: 60_000,
-    enabled: !!projectId && open,
+    enabled: !!projectId && open && hasQuery,
   });
 
   const folderMap = new Map(
@@ -79,8 +63,8 @@ export function useGlobalSearchResults(query: string, open: boolean) {
         limit: SEARCH_LIMIT,
         cursor: undefined,
       }),
-    enabled: searchEnabled || suggestionsEnabled,
-    staleTime: hasQuery ? 15_000 : 60_000,
+    enabled: searchEnabled,
+    staleTime: 15_000,
     placeholderData: keepPreviousData,
   });
 
@@ -93,8 +77,8 @@ export function useGlobalSearchResults(query: string, open: boolean) {
         limit: SEARCH_LIMIT,
         cursor: undefined,
       }),
-    enabled: (searchEnabled || suggestionsEnabled) && !hideTables,
-    staleTime: hasQuery ? 15_000 : 60_000,
+    enabled: searchEnabled && !hideTables,
+    staleTime: 15_000,
     placeholderData: keepPreviousData,
   });
 
@@ -185,131 +169,7 @@ export function useGlobalSearchResults(query: string, open: boolean) {
     (flowsQuery.isLoading || tablesQuery.isLoading) && searchEnabled;
 
   if (!hasQuery) {
-    if (hasHistory) {
-      const historyIds = new Set(accessHistory.map((h) => h.id));
-
-      type PoolItem = { item: SearchResultItem; timestamp: number };
-
-      const historyPool: PoolItem[] = accessHistory.map((h) => ({
-        timestamp: h.accessedAt,
-        item: {
-          id: h.id,
-          type: h.type,
-          label: h.label,
-          href: h.href,
-          status: h.status,
-          folderName: h.folderName,
-          projectName: h.projectName,
-          iconBgColor: h.iconBgColor,
-          iconTextColor: h.iconTextColor,
-          iconLetter: h.iconLetter,
-          pageIcon:
-            h.type === 'page'
-              ? STATIC_PAGES.find((p) => p.id === h.id)?.icon
-              : undefined,
-        },
-      }));
-
-      const suggestedItems: SearchResultItem[] = [];
-
-      if (needsSupplement) {
-        const remaining = SUPPLEMENT_THRESHOLD - accessHistory.length;
-        const fillCandidates: PoolItem[] = [
-          ...flowResults.map((r) => ({
-            item: r,
-            timestamp: r.updated ? new Date(r.updated).getTime() : 0,
-          })),
-          ...tableResults.map((r) => ({
-            item: r,
-            timestamp: r.updated ? new Date(r.updated).getTime() : 0,
-          })),
-          ...projectResults.map((r) => ({ item: r, timestamp: 0 })),
-          ...pageResults.map((r) => ({ item: r, timestamp: 0 })),
-        ].filter((p) => !historyIds.has(p.item.id));
-
-        suggestedItems.push(
-          ...fillCandidates.slice(0, remaining).map((p) => p.item),
-        );
-      }
-
-      const buckets: Record<string, SearchResultItem[]> = {
-        today: [],
-        yesterday: [],
-        'last-week': [],
-        'last-30-days': [],
-      };
-
-      for (const { item, timestamp } of historyPool) {
-        buckets[getTimePeriod(timestamp)].push(item);
-      }
-
-      const periodDefs = [
-        { key: 'today', label: t('Today') },
-        { key: 'yesterday', label: t('Yesterday') },
-        { key: 'last-week', label: t('Last Week') },
-        { key: 'last-30-days', label: t('Last 30 Days') },
-      ];
-
-      const isFillLoading =
-        needsSupplement &&
-        (flowsQuery.isLoading || tablesQuery.isLoading) &&
-        suggestionsEnabled;
-
-      const groups: SearchResultGroup[] = periodDefs
-        .filter((p) => buckets[p.key].length > 0)
-        .map((p) => ({
-          type: `history-${p.key}`,
-          heading: p.label,
-          items: buckets[p.key],
-          isLoading: false,
-        }));
-
-      if (suggestedItems.length > 0) {
-        groups.push({
-          type: 'suggestions',
-          heading: t('Suggested'),
-          items: suggestedItems,
-          isLoading: false,
-        });
-      }
-
-      if (
-        isFillLoading &&
-        historyPool.length + suggestedItems.length < SUPPLEMENT_THRESHOLD
-      ) {
-        groups.push({
-          type: 'suggestions-loading',
-          heading: '',
-          items: [],
-          isLoading: true,
-        });
-      }
-
-      return { groups, isLoading: false };
-    }
-
-    const isFallbackLoading =
-      (flowsQuery.isLoading || tablesQuery.isLoading) && suggestionsEnabled;
-    const flatItems: SearchResultItem[] = [
-      ...flowResults.slice(0, 5),
-      ...tableResults.slice(0, 5),
-      ...projectResults.slice(0, 5),
-      ...pageResults.slice(0, 5),
-    ];
-    return {
-      groups:
-        isFallbackLoading || flatItems.length > 0
-          ? ([
-              {
-                type: 'suggestions',
-                heading: '',
-                items: flatItems,
-                isLoading: isFallbackLoading,
-              },
-            ] as SearchResultGroup[])
-          : [],
-      isLoading: isFallbackLoading,
-    };
+    return { groups: [], isLoading: false };
   }
 
   const groups: SearchResultGroup[] = [
@@ -350,7 +210,7 @@ export function useGlobalSearchResults(query: string, open: boolean) {
 
 export type SearchResultItem = {
   id: string;
-  type: 'flow' | 'table' | 'folder' | 'project' | 'page';
+  type: 'flow' | 'table' | 'folder' | 'project' | 'page' | 'destination';
   label: string;
   href: string;
   status?: 'ENABLED' | 'DISABLED' | null;
@@ -361,7 +221,24 @@ export type SearchResultItem = {
   iconLetter?: string;
   pageIcon?: StaticPage['icon'];
   projectName?: string | null;
+  // Browse-navigator fields. `action` defaults to 'open'; 'drill' pushes a
+  // browse level instead of navigating. `projectId` lets a resource open in a
+  // project other than the active one (peek-then-switch-on-open).
+  action?: 'drill' | 'open';
+  projectId?: string;
+  stageType?: StageResourceType;
+  folderId?: string;
+  badge?: string;
+  destinationKind?: DestinationKind;
 };
+
+export type DestinationKind =
+  | 'automations'
+  | 'connections'
+  | 'runs'
+  | 'variables'
+  | 'releases'
+  | 'settings';
 
 export type SearchResultGroup = {
   type: string;

--- a/packages/web/src/app/components/global-search/use-ui-preferences.ts
+++ b/packages/web/src/app/components/global-search/use-ui-preferences.ts
@@ -1,0 +1,47 @@
+import { useCallback, useState } from 'react';
+
+import { authenticationSession } from '@/lib/authentication-session';
+
+const STORAGE_KEY_PREFIX = 'ap_browse_prefs_';
+
+export function useUiPreferences(): {
+  prefs: UiPreferences;
+  update: (partial: Partial<UiPreferences>) => void;
+} {
+  const userId = authenticationSession.getCurrentUserId() ?? 'anonymous';
+  const [prefs, setPrefs] = useState<UiPreferences>(() => readPrefs(userId));
+
+  const update = useCallback(
+    (partial: Partial<UiPreferences>) => {
+      setPrefs((prev) => {
+        const next = { ...prev, ...partial };
+        localStorage.setItem(getStorageKey(userId), JSON.stringify(next));
+        return next;
+      });
+    },
+    [userId],
+  );
+
+  return { prefs, update };
+}
+
+function getStorageKey(userId: string): string {
+  return `${STORAGE_KEY_PREFIX}${userId}`;
+}
+
+function readPrefs(userId: string): UiPreferences {
+  try {
+    const parsed = JSON.parse(
+      localStorage.getItem(getStorageKey(userId)) ?? '{}',
+    );
+    return typeof parsed === 'object' && parsed !== null ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+export type UiPreferences = {
+  browseScope?: 'recent' | 'project';
+  browseFilter?: 'all' | 'flows' | 'tables';
+  browseProjectId?: string;
+};

--- a/packages/web/src/components/ui/command.tsx
+++ b/packages/web/src/components/ui/command.tsx
@@ -34,6 +34,7 @@ function CommandDialog({
   className,
   showCloseButton = true,
   shouldFilter = true,
+  loop = false,
   commandValue,
   onCommandValueChange,
   ...props
@@ -43,6 +44,7 @@ function CommandDialog({
   className?: string;
   showCloseButton?: boolean;
   shouldFilter?: boolean;
+  loop?: boolean;
   commandValue?: string;
   onCommandValueChange?: (value: string) => void;
 }) {
@@ -58,6 +60,7 @@ function CommandDialog({
       >
         <Command
           shouldFilter={shouldFilter}
+          loop={loop}
           value={commandValue}
           onValueChange={onCommandValueChange}
           className="**:data-[slot=command-input-wrapper]:h-12 [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group]]:px-2 [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5"

--- a/packages/web/src/components/ui/dialog.tsx
+++ b/packages/web/src/components/ui/dialog.tsx
@@ -51,11 +51,12 @@ function DialogContent({
   children,
   showCloseButton = true,
   showOverlay = true,
+  overlayClassName,
   ...props
 }: React.ComponentProps<typeof DialogPrimitive.Content> & DialogContentProps) {
   return (
     <DialogPortal data-slot="dialog-portal">
-      {showOverlay && <DialogOverlay />}
+      {showOverlay && <DialogOverlay className={overlayClassName} />}
       <DialogPrimitive.Content
         data-slot="dialog-content"
         className={cn(
@@ -162,6 +163,7 @@ export {
 type DialogContentProps = {
   showCloseButton?: boolean;
   showOverlay?: boolean;
+  overlayClassName?: string;
 };
 
 type DialogFooterProps = {

--- a/packages/web/src/features/automations/lib/mutation-bodies.ts
+++ b/packages/web/src/features/automations/lib/mutation-bodies.ts
@@ -1,0 +1,172 @@
+import { isNil } from '@activepieces/core-utils';
+import {
+  FlowOperationType,
+  FlowVersion,
+  PopulatedFlow,
+  Table,
+  UncategorizedFolderId,
+} from '@activepieces/shared';
+
+import { flowsApi } from '@/features/flows/api/flows-api';
+import { foldersApi } from '@/features/folders/api/folders-api';
+import { tablesUtils } from '@/features/tables';
+import { tablesApi } from '@/features/tables/api/tables-api';
+import { tableHooks } from '@/features/tables/hooks/table-hooks';
+
+import { TreeItemType } from './types';
+
+function normalizeFolderId(
+  folderId: string | null | undefined,
+): string | undefined {
+  return !folderId || folderId === UncategorizedFolderId ? undefined : folderId;
+}
+
+async function createFlow({
+  projectId,
+  displayName,
+  folderId,
+}: {
+  projectId: string;
+  displayName: string;
+  folderId?: string;
+}): Promise<PopulatedFlow> {
+  return flowsApi.create({
+    projectId,
+    displayName,
+    folderId: normalizeFolderId(folderId),
+  });
+}
+
+async function createTable({
+  projectId,
+  name,
+  folderId,
+}: {
+  projectId: string;
+  name: string;
+  folderId?: string;
+}): Promise<Table> {
+  return tableHooks.createTableWithDefaults({
+    name,
+    folderId: normalizeFolderId(folderId),
+    projectId,
+  });
+}
+
+async function renameItem({
+  id,
+  type,
+  newName,
+}: {
+  id: string;
+  type: TreeItemType;
+  newName: string;
+}): Promise<void> {
+  switch (type) {
+    case 'flow':
+      await flowsApi.update(id, {
+        type: FlowOperationType.CHANGE_NAME,
+        request: { displayName: newName },
+      });
+      return;
+    case 'table':
+      await tablesApi.update(id, { name: newName });
+      return;
+    case 'folder':
+      await foldersApi.renameFolder(id, { displayName: newName });
+      return;
+    default:
+      return;
+  }
+}
+
+async function deleteItem({
+  id,
+  type,
+}: {
+  id: string;
+  type: TreeItemType;
+}): Promise<void> {
+  switch (type) {
+    case 'flow':
+      await flowsApi.delete(id);
+      return;
+    case 'table':
+      await tablesApi.delete(id);
+      return;
+    case 'folder':
+      await foldersApi.delete(id);
+      return;
+    default:
+      return;
+  }
+}
+
+async function moveItem({
+  id,
+  type,
+  targetFolderId,
+}: {
+  id: string;
+  type: TreeItemType;
+  targetFolderId: string;
+}): Promise<void> {
+  const folderId =
+    isNil(targetFolderId) || targetFolderId === UncategorizedFolderId
+      ? null
+      : targetFolderId;
+  switch (type) {
+    case 'flow':
+      await flowsApi.update(id, {
+        type: FlowOperationType.CHANGE_FOLDER,
+        request: { folderId },
+      });
+      return;
+    case 'table':
+      await tablesApi.update(id, { folderId });
+      return;
+    default:
+      return;
+  }
+}
+
+async function duplicateFlow({
+  version,
+  folderId,
+  projectId,
+}: {
+  version: FlowVersion;
+  folderId: string | null | undefined;
+  projectId: string;
+}): Promise<PopulatedFlow> {
+  const displayName = `${version.displayName} - Copy`;
+  const created = await flowsApi.create({
+    displayName,
+    projectId,
+    folderId: folderId ?? undefined,
+  });
+  return flowsApi.update(created.id, {
+    type: FlowOperationType.IMPORT_FLOW,
+    request: {
+      displayName,
+      trigger: version.trigger,
+      schemaVersion: version.schemaVersion,
+      notes: version.notes,
+    },
+  });
+}
+
+async function exportTable(table: Table): Promise<void> {
+  const exported = await tablesApi.export(table.id);
+  tablesUtils.exportTables([exported]);
+}
+
+export const automationMutationUtils = {
+  createFlow,
+  createTable,
+  renameItem,
+  deleteItem,
+  moveItem,
+  duplicateFlow,
+  exportTable,
+};

--- a/packages/web/src/features/folders/api/folders-api.ts
+++ b/packages/web/src/features/folders/api/folders-api.ts
@@ -10,11 +10,11 @@ import { api } from '@/lib/api';
 import { authenticationSession } from '@/lib/authentication-session';
 
 export const foldersApi = {
-  async list(): Promise<FolderDto[]> {
+  async list(params?: { projectId?: string }): Promise<FolderDto[]> {
     const request: ListFolderRequest = {
       cursor: undefined,
       limit: 1000000,
-      projectId: authenticationSession.getProjectId()!,
+      projectId: params?.projectId ?? authenticationSession.getProjectId()!,
     };
 
     const response = await api.get<any>('/v1/folders', request);

--- a/packages/web/src/features/projects/components/create-project-button.tsx
+++ b/packages/web/src/features/projects/components/create-project-button.tsx
@@ -16,6 +16,7 @@ import {
   TooltipTrigger,
 } from '@/components/ui/tooltip';
 import { platformHooks } from '@/hooks/platform-hooks';
+import { cn } from '@/lib/utils';
 
 import { NewProjectDialog } from './new-project-dialog';
 
@@ -82,7 +83,13 @@ function IconVariant({
   );
 }
 
-function FullVariant({ disabled }: { disabled: boolean }) {
+function FullVariant({
+  disabled,
+  onCreate,
+}: {
+  disabled: boolean;
+  onCreate?: (project: ProjectWithLimits) => void;
+}) {
   if (disabled) {
     return (
       <UpgradeTooltip>
@@ -95,12 +102,40 @@ function FullVariant({ disabled }: { disabled: boolean }) {
     );
   }
   return (
-    <NewProjectDialog>
+    <NewProjectDialog onCreate={onCreate}>
       <AnimatedIconButton icon={PlusIcon} iconSize={16} size="sm">
         {t('New Project')}
       </AnimatedIconButton>
     </NewProjectDialog>
   );
+}
+
+function GhostVariant({
+  disabled,
+  onCreate,
+}: {
+  disabled: boolean;
+  onCreate?: (project: ProjectWithLimits) => void;
+}) {
+  const button = (
+    <Button
+      variant="ghost"
+      size="sm"
+      disabled={disabled}
+      className="gap-2 text-primary hover:bg-primary/5 hover:text-primary"
+    >
+      <Plus className="size-4" />
+      {t('New Project')}
+    </Button>
+  );
+  if (disabled) {
+    return (
+      <UpgradeTooltip>
+        <div>{button}</div>
+      </UpgradeTooltip>
+    );
+  }
+  return <NewProjectDialog onCreate={onCreate}>{button}</NewProjectDialog>;
 }
 
 function SidebarMenuVariant({
@@ -130,12 +165,44 @@ function SidebarMenuVariant({
   );
 }
 
+function MenuItemVariant({
+  disabled,
+  onCreate,
+}: {
+  disabled: boolean;
+  onCreate?: (project: ProjectWithLimits) => void;
+}) {
+  const rowClass =
+    'flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-left text-sm text-muted-foreground';
+  if (disabled) {
+    return (
+      <UpgradeTooltip>
+        <button type="button" disabled className={cn(rowClass, 'opacity-50')}>
+          <Plus className="size-4 shrink-0" />
+          <span>{t('New project')}</span>
+        </button>
+      </UpgradeTooltip>
+    );
+  }
+  return (
+    <NewProjectDialog onCreate={onCreate}>
+      <button
+        type="button"
+        className={cn(rowClass, 'hover:bg-muted hover:text-foreground')}
+      >
+        <Plus className="size-4 shrink-0" />
+        <span>{t('New project')}</span>
+      </button>
+    </NewProjectDialog>
+  );
+}
+
 export function CreateProjectButton({
   variant,
   projects,
   onCreate,
 }: {
-  variant: 'icon' | 'full' | 'sidebar-menu';
+  variant: 'icon' | 'full' | 'ghost' | 'sidebar-menu' | 'menu-item';
   projects: Pick<ProjectWithLimits, 'type'>[];
   onCreate?: (project: ProjectWithLimits) => void;
 }) {
@@ -143,8 +210,14 @@ export function CreateProjectButton({
   if (variant === 'icon') {
     return <IconVariant disabled={disabled} onCreate={onCreate} />;
   }
+  if (variant === 'ghost') {
+    return <GhostVariant disabled={disabled} onCreate={onCreate} />;
+  }
   if (variant === 'sidebar-menu') {
     return <SidebarMenuVariant disabled={disabled} onCreate={onCreate} />;
   }
-  return <FullVariant disabled={disabled} />;
+  if (variant === 'menu-item') {
+    return <MenuItemVariant disabled={disabled} onCreate={onCreate} />;
+  }
+  return <FullVariant disabled={disabled} onCreate={onCreate} />;
 }

--- a/packages/web/test/app/components/global-search/global-search-context.test.tsx
+++ b/packages/web/test/app/components/global-search/global-search-context.test.tsx
@@ -20,44 +20,23 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('i18next', () => ({ t: (key: string) => key }));
 
-vi.mock('lucide-react', () => ({
-  CornerDownLeft: () => null,
-  X: () => null,
-}));
-
-vi.mock('react-router-dom', () => ({
-  useNavigate: () => vi.fn(),
-}));
-
-vi.mock('@/components/ui/command', () => ({
-  CommandDialog: ({
-    open,
-    children,
-  }: React.PropsWithChildren<{ open: boolean }>) =>
+vi.mock('@/components/ui/dialog', () => ({
+  Dialog: ({ open, children }: React.PropsWithChildren<{ open: boolean }>) =>
     open ? <div data-testid="global-search-dialog">{children}</div> : null,
-  CommandGroup: ({ children }: React.PropsWithChildren) => (
+  DialogContent: ({ children }: React.PropsWithChildren) => (
     <div>{children}</div>
   ),
-  CommandInput: () => <input />,
-  CommandItem: ({ children }: React.PropsWithChildren) => <div>{children}</div>,
-  CommandList: ({ children }: React.PropsWithChildren) => <div>{children}</div>,
-  CommandSeparator: () => null,
+  DialogTitle: ({ children }: React.PropsWithChildren) => (
+    <div>{children}</div>
+  ),
 }));
 
-vi.mock('@/features/projects', () => ({
-  projectCollectionUtils: { setCurrentProject: vi.fn() },
+vi.mock('@/app/components/global-search/style-spotlight', () => ({
+  StyleSpotlight: () => null,
 }));
 
-vi.mock('@/app/components/global-search/use-global-search-results', () => ({
-  useGlobalSearchResults: () => ({ groups: [], isLoading: false }),
-}));
-
-vi.mock('@/app/components/global-search/search-result-item', () => ({
-  SearchResultRow: () => null,
-}));
-
-vi.mock('@/app/components/global-search/access-history', () => ({
-  recordAccess: vi.fn(),
+vi.mock('@/app/components/global-search/use-browse-controller', () => ({
+  useBrowseController: () => ({}),
 }));
 
 import { GlobalSearchProvider } from '@/app/components/global-search/global-search-context';


### PR DESCRIPTION
## What

Replaces the global search command palette (⌘K) with **Browse** — a spotlight-style dialog that opens centered over a blurred backdrop and acts as a lightweight navigator, not just a search box:

- **Filter chips** to scope results to flows, tables, connections, folders, projects, or pages
- **Recents** — resources you opened recently surface before you type (per-user access history)
- **Row actions** — rename, move to folder, duplicate, and delete flows/tables inline from the results
- **Cross-project drill-in** — peek into another project's resources and switch on open
- **Remembered filters** — your scope/filter/project picks persist per user in localStorage (no backend, no migration)

Opens via ⌘K / Ctrl+K or the sidebar search button, exactly as before.

## Why

First slice of splitting #14219 (`feat: chat core`) into reviewable PRs. Browse is self-contained web-only work with no schema or endpoint changes, so it goes first.

## Notes for reviewers

- The existing sidebar trigger (`global-search-command.tsx`) is **kept untouched** — it just calls `setOpen`, which now opens the new dialog. The upcoming sidebar/navigation PR replaces it.
- `StageResourceType` is **inlined** in `use-global-search-results.ts` with a marker comment; the workspace-shell PR swaps it back to the real `StageResource` import.
- Small shared groundwork rides in the first commit: `loop` prop on `CommandDialog`, `overlayClassName` on `DialogContent`, `foldersApi.list({ projectId })`, flow duplication extracted to `automationMutationUtils`, and `ghost`/`menu-item` variants for `CreateProjectButton`.
- The embed-isolation regression test (GIT-1530 — `hideGlobalSearch` must disable ⌘K and the palette) was **adapted** to the new dialog surface, not removed.

## Testing

- `npx turbo run typecheck --filter=web` ✅
- `npm run lint-dev` — 0 errors ✅
- `npx vitest run` — 373 tests pass, including the adapted GIT-1530 embed regression suite ✅
- Manual: ⌘K open/close, chip filtering, recents, row actions (rename/move/duplicate/delete), project drill-in, embed mode (no ⌘K, no dialog)
