### PR TITLE
fix(secret-managers): verify TLS certificates for CyberArk Conjur connections

### DIFF
--- a/packages/core/shared/src/lib/ee/secret-managers/dto.ts
+++ b/packages/core/shared/src/lib/ee/secret-managers/dto.ts
@@ -40,6 +40,14 @@ export const CyberarkConjurProviderConfigSchema = z.object({
     loginId: z.string().min(1, formErrors.required),
     url: z.string().min(1, formErrors.required),
     apiKey: z.string().min(1, formErrors.required),
+    // TLS certificate verification for the Conjur connection. Both fields are
+    // optional and secure-by-default (verification ON when omitted). For an
+    // internal / self-signed Conjur host, pin its CA via `caCert` (preferred —
+    // keeps verification ON). `allowUnauthorizedCertificates` is an explicit,
+    // last-resort opt-out that disables verification, mirroring the
+    // allow_unauthorized_certificates option the SFTP/IMAP/Postgres pieces expose.
+    caCert: z.string().optional(),
+    allowUnauthorizedCertificates: z.boolean().optional(),
 })
 export type CyberarkConjurProviderConfig = z.infer<typeof CyberarkConjurProviderConfigSchema>
 

--- a/packages/server/api/src/app/ee/secret-managers/secret-manager-providers/cyberark-conjur-provider.ts
+++ b/packages/server/api/src/app/ee/secret-managers/secret-manager-providers/cyberark-conjur-provider.ts
@@ -1,16 +1,29 @@
 import { safeHttp } from '@activepieces/server-utils'
-import { SecretManagerProviderId } from '@activepieces/shared'
+import { CyberarkConjurProviderConfig, SecretManagerProviderId } from '@activepieces/shared'
 import { FastifyBaseLogger } from 'fastify'
 import { SecretManagerProvider, throwConnectionError, throwGetSecretError } from './secret-manager-providers'
 
-const conjurAxios = safeHttp.createRetryingAxios(undefined, {
-    httpsAgentOptions: { rejectUnauthorized: false },
-})
+// Build the Conjur HTTP client per connection so TLS certificate verification
+// honours that connection's config. Verification is now ON by default; it was
+// previously hardcoded OFF (`rejectUnauthorized: false`), so the certificate was
+// never validated on either the authentication call (which carries the Conjur
+// API key) or secret retrieval. Internal / self-signed deployments should pin
+// their CA via `caCert` (keeps verification ON); `allowUnauthorizedCertificates`
+// is an explicit, last-resort opt-out.
+const createConjurAxios = (config: CyberarkConjurProviderConfig) =>
+    safeHttp.createRetryingAxios(undefined, {
+        httpsAgentOptions: {
+            rejectUnauthorized: !(config.allowUnauthorizedCertificates ?? false),
+            ...(config.caCert ? { ca: config.caCert } : {}),
+        },
+    })
 
 export const cyberarkConjurProvider = (log: FastifyBaseLogger): SecretManagerProvider<SecretManagerProviderId.CYBERARK> => ({
     checkConnection: async (config) => {
+        const conjurAxios = createConjurAxios(config)
         const url = removeEndingSlash(config.url)
         const response = await conjurApi({
+            conjurAxios,
             url: `${url}/authn/${config.organizationAccountName}/${encodeURIComponent(config.loginId)}/authenticate`,
             method: 'POST',
             body: config.apiKey,
@@ -32,8 +45,10 @@ export const cyberarkConjurProvider = (log: FastifyBaseLogger): SecretManagerPro
     getSecret: async (request, config) => {
 
         const token = await cyberarkConjurProvider(log).checkConnection(config) as string
+        const conjurAxios = createConjurAxios(config)
         const url = removeEndingSlash(config.url)
         const response = await conjurApi({
+            conjurAxios,
             url: `${url}/secrets/${config.organizationAccountName}/variable/${encodeURIComponent(request.path)}`,
             token,
             method: 'GET',
@@ -54,11 +69,13 @@ const removeEndingSlash = (path: string) => {
 }
 
 const conjurApi = async ({
+    conjurAxios,
     url,
     token,
     method,
     body,
 }: {
+    conjurAxios: ReturnType<typeof safeHttp.createRetryingAxios>
     url: string
     token?: string
     namespace?: string


### PR DESCRIPTION
## What does this PR do?

Hardens the **CyberArk Conjur** secret-manager provider so its HTTPS calls **verify the server's TLS certificate**. Today the provider disables verification unconditionally:

`packages/server/api/src/app/ee/secret-managers/secret-manager-providers/cyberark-conjur-provider.ts`

```ts
const conjurAxios = safeHttp.createRetryingAxios(undefined, {
    httpsAgentOptions: { rejectUnauthorized: false },   // hardcoded, no opt-out
})
```

That `rejectUnauthorized: false` applies to **both** the authentication call (`POST /authn/.../authenticate`, whose body is the Conjur **API key**) and every secret read (`GET /secrets/...`), so the certificate is never validated on the connection to the secrets vault.

### Why this is a PR and not (just) an advisory

I reported this privately through a GitHub Security Advisory — **GHSA-j7fx-x94j-p75p** (CWE-295, Improper Certificate Validation). It was **closed as out-of-scope for scoring**, because exploiting it needs a man-in-the-middle position on the Activepieces ↔ Conjur link, which `SECURITY.md` lists as out of scope — that's a fair call, and I'd flagged the same caveat in the report. The maintainer (@KhaledR57) then followed up:

> Since it touches the secrets vault, we'd still love to harden it. If you are up for it, we'd be happy for you to open a PR.

So this PR is that hardening, opened at the maintainer's invitation. Framing it as a consistency/hardening improvement, not a scored vulnerability.

### The change (backend only)

- **Secure by default.** The Conjur HTTP client is now built **per connection** and verifies the certificate (`rejectUnauthorized: true`) unless the connection is explicitly configured otherwise.
- **Two new optional fields** on `CyberarkConjurProviderConfigSchema` (both optional → **non-breaking** to the schema/API):
  - `caCert` — a PEM CA bundle to trust for internal / self-signed Conjur hosts **while keeping verification on** (the preferred path).
  - `allowUnauthorizedCertificates` — an explicit, last-resort opt-out that disables verification. This mirrors the `allow_unauthorized_certificates` option the **SFTP / IMAP / Postgres** pieces already expose (default secure) — the convention this provider was inconsistent with.

`safeHttp`'s `httpsAgentOptions` is typed as Node's `https.AgentOptions`, so `rejectUnauthorized` and `ca` flow straight through the existing SSRF-filtering agent — no other behavior changes.

**Files touched**
- `packages/core/shared/src/lib/ee/secret-managers/dto.ts` — the two optional config fields.
- `packages/server/api/.../cyberark-conjur-provider.ts` — per-config client honoring them.

### Behavior change / migration

This flips the default from *no verification* to *verification on*. Connections to a Conjur host with a **publicly-trusted** certificate are unaffected. A connection to an **internal / self-signed** host that previously worked only because verification was off should either:
- set `caCert` to the trusted CA (or the self-signed cert itself) — recommended, stays secure; or
- set `allowUnauthorizedCertificates: true` to keep the previous behavior.

### Relevant User Scenarios

- A platform admin connecting Activepieces to a CyberArk Conjur vault over an internal network now has the secrets-vault traffic authenticated against the server certificate, removing an on-path capture/tamper vector on the Conjur API key and the retrieved secrets — while still supporting internal PKI via `caCert`.

### Notes for reviewers

- Kept intentionally **backend-only and minimal**. The two fields are optional, and the connect-secret-manager UI form is metadata-driven over `text`/`password` field types, so it compiles and behaves unchanged — new connections simply default to secure. If you'd like the fields surfaced in the UI (a checkbox for `allowUnauthorizedCertificates` + a CA-cert field), I'm glad to follow up; that needs a small `checkbox` type added to `SecretManagerFieldSchema` and the render loop, which felt out of scope for a focused security fix.
- I couldn't run the full Nx build locally, so I'm leaning on CI here. Happy to adjust to match any lint/style preferences.

Ref: GHSA-j7fx-x94j-p75p · CWE-295 (Improper Certificate Validation)

Fixes # (n/a — reported privately via GHSA-j7fx-x94j-p75p)
