### PR TITLE
revert: "refactor: queue dispatcher (#13998)" — restore single-dequeue…

### DIFF
--- a/packages/server/api/src/app/workers/job-queue/job-broker.ts
+++ b/packages/server/api/src/app/workers/job-queue/job-broker.ts
@@ -73,6 +73,7 @@ function ensureDispatcher(queueName: string, worker: BullMQWorker, log: FastifyB
         queueName,
         worker,
         dequeue: tryDequeue,
+        onOrphanedJob: returnJobToQueue,
         log,
     })
     dispatchers.set(queueName, dispatcher)

--- a/packages/server/api/src/app/workers/job-queue/queue-dispatcher.ts
+++ b/packages/server/api/src/app/workers/job-queue/queue-dispatcher.ts
@@ -3,54 +3,84 @@ import { ConsumeJobRequest } from '@activepieces/shared'
 import { Worker as BullMQWorker } from 'bullmq'
 import { FastifyBaseLogger } from 'fastify'
 
-
-// worker's RPC timeout is 60s, and drainDelay is 15s, so we can safely set WAITER_TIMEOUT_MS to 40s. 
-const WAITER_TIMEOUT_MS = 40_000
+const WAITER_TIMEOUT_MS = 50_000
 const ERROR_RETRY_DELAY_MS = 5_000
 
 function createQueueDispatcher(params: {
     queueName: string
     worker: BullMQWorker
     dequeue: (worker: BullMQWorker, queueName: string, log: FastifyBaseLogger) => Promise<ConsumeJobRequest | null>
+    onOrphanedJob: (jobId: string, token: string, queueName: string, log: FastifyBaseLogger) => Promise<void>
     log: FastifyBaseLogger
 }): QueueDispatcher {
-    const { queueName, worker, dequeue, log } = params
-    let activePolls = 0
-    let closed = false
-
+    const { queueName, worker, dequeue, onOrphanedJob, log } = params
+    const waiters: Waiter[] = []
+    let loopRunning = false
 
     async function poll(): Promise<ConsumeJobRequest | null> {
-        activePolls++
-        log.info({ queueName, activePolls }, '[QueueDispatcher] poll started')
-        try {
-            const deadline = Date.now() + WAITER_TIMEOUT_MS
-            while (!closed && Date.now() < deadline) {
-                const { error, data: job } = await tryCatch(() => dequeue(worker, queueName, log))
-                if (error) {
-                    if (closed) return null
-                    log.error({ queueName, error: String(error) }, '[QueueDispatcher] dequeue error, retrying')
-                    await sleep(ERROR_RETRY_DELAY_MS)
-                    continue
+        return new Promise<ConsumeJobRequest | null>((resolve) => {
+            const timer = setTimeout(() => {
+                const idx = waiters.findIndex(w => w.resolve === resolve)
+                if (idx !== -1) {
+                    waiters.splice(idx, 1)
                 }
-                if (!isNil(job)) {
-                    log.info({ queueName, job: { id: job.jobId, type: job.jobData.jobType } }, '[QueueDispatcher] dequeued job')
-                    return job
-                }
+                resolve(null)
+            }, WAITER_TIMEOUT_MS)
+
+            waiters.push({ resolve, timer })
+            startLoop()
+        })
+    }
+
+    function startLoop(): void {
+        if (loopRunning) return
+        loopRunning = true
+        void runLoop()
+    }
+
+    async function runLoop(): Promise<void> {
+        while (waiters.length > 0) {
+            const { error, data: job } = await tryCatch(() => dequeue(worker, queueName, log))
+
+            if (error) {
+                log.error({ queueName, error: String(error) }, '[QueueDispatcher] dequeue error, retrying')
+                await sleep(ERROR_RETRY_DELAY_MS)
+                continue
             }
-            log.info({ queueName, closed }, '[QueueDispatcher] poll returned no job (timed out or closed)')
-            return null
+
+            if (isNil(job)) {
+                if (waiters.length === 0) break
+                continue
+            }
+
+            const waiter = waiters.shift()
+            if (isNil(waiter)) {
+                log.warn({ queueName, job: { id: job.jobId } }, '[QueueDispatcher] job dequeued but no waiter available, returning to queue')
+                const { error: orphanError } = await tryCatch(() => onOrphanedJob(job.jobId, job.token, job.queueName, log))
+                if (orphanError) {
+                    log.error({ queueName, job: { id: job.jobId }, error: String(orphanError) }, '[QueueDispatcher] failed to return orphaned job to queue')
+                }
+                continue
+            }
+
+            clearTimeout(waiter.timer)
+            waiter.resolve(job)
         }
-        finally {
-            activePolls--
-        }
+        loopRunning = false
     }
 
     function close(): void {
-        closed = true
+        for (const waiter of waiters) {
+            clearTimeout(waiter.timer)
+            waiter.resolve(null)
+        }
+        waiters.length = 0
+        // Do not reset loopRunning here — the in-flight runLoop will exit
+        // naturally when it sees waiters.length === 0 after dequeue returns.
     }
 
     function waiterCount(): number {
-        return activePolls
+        return waiters.length
     }
 
     return { poll, close, waiterCount }
@@ -58,6 +88,11 @@ function createQueueDispatcher(params: {
 
 function sleep(ms: number): Promise<void> {
     return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+type Waiter = {
+    resolve: (value: ConsumeJobRequest | null) => void
+    timer: ReturnType<typeof setTimeout>
 }
 
 export type QueueDispatcher = {

--- a/packages/server/api/test/unit/app/workers/job-queue/queue-dispatcher.test.ts
+++ b/packages/server/api/test/unit/app/workers/job-queue/queue-dispatcher.test.ts
@@ -32,6 +32,7 @@ function createFakeJob(id: string): ConsumeJobRequest {
 describe('QueueDispatcher', () => {
     let dispatcher: QueueDispatcher
     let dequeueMock: ReturnType<typeof vi.fn>
+    let onOrphanedJobMock: ReturnType<typeof vi.fn>
     let dequeueCallCount: number
     let pendingDequeues: Array<{
         resolve: (value: ConsumeJobRequest | null) => void
@@ -50,10 +51,13 @@ describe('QueueDispatcher', () => {
             })
         })
 
+        onOrphanedJobMock = vi.fn().mockResolvedValue(undefined)
+
         dispatcher = createQueueDispatcher({
             queueName: 'test-queue',
             worker: mockWorker,
             dequeue: dequeueMock,
+            onOrphanedJob: onOrphanedJobMock,
             log: mockLog,
         })
     })
@@ -63,99 +67,223 @@ describe('QueueDispatcher', () => {
         vi.useRealTimers()
     })
 
-    it('should resolve a poll with the job it dequeues', async () => {
+    it('should dispatch a job to the first waiter (FIFO)', async () => {
+        const poll1 = dispatcher.poll()
+        const poll2 = dispatcher.poll()
+
+        // Allow microtasks so the loop starts and calls dequeue
+        await vi.advanceTimersByTimeAsync(0)
+
+        expect(pendingDequeues).toHaveLength(1)
+
+        const job1 = createFakeJob('job-1')
+        pendingDequeues[0].resolve(job1)
+
+        // Allow microtasks for dispatch + next dequeue call
+        await vi.advanceTimersByTimeAsync(0)
+
+        const result1 = await poll1
+        expect(result1).toEqual(job1)
+
+        // Second dequeue should now be pending for the second waiter
+        expect(pendingDequeues).toHaveLength(2)
+
+        const job2 = createFakeJob('job-2')
+        pendingDequeues[1].resolve(job2)
+        await vi.advanceTimersByTimeAsync(0)
+
+        const result2 = await poll2
+        expect(result2).toEqual(job2)
+    })
+
+    it('should only have one active getNextJob call at a time', async () => {
+        dispatcher.poll()
+        dispatcher.poll()
+        dispatcher.poll()
+
+        await vi.advanceTimersByTimeAsync(0)
+
+        // Only one dequeue call should be active despite 3 waiters
+        expect(dequeueCallCount).toBe(1)
+        expect(pendingDequeues).toHaveLength(1)
+    })
+
+    it('should return null when waiter times out', async () => {
+        const pollPromise = dispatcher.poll()
+
+        await vi.advanceTimersByTimeAsync(0)
+
+        // Dequeue is pending but no job arrives
+        // Advance past the waiter timeout
+        await vi.advanceTimersByTimeAsync(WAITER_TIMEOUT_MS + 100)
+
+        const result = await pollPromise
+        expect(result).toBeNull()
+    })
+
+    it('should retry on dequeue error after delay', async () => {
+        const pollPromise = dispatcher.poll()
+
+        await vi.advanceTimersByTimeAsync(0)
+
+        // First dequeue fails
+        pendingDequeues[0].reject(new Error('Redis connection lost'))
+        await vi.advanceTimersByTimeAsync(0)
+
+        // Should not have retried yet (waiting for ERROR_RETRY_DELAY_MS)
+        expect(dequeueCallCount).toBe(1)
+
+        // Advance past the retry delay
+        await vi.advanceTimersByTimeAsync(ERROR_RETRY_DELAY_MS)
+
+        // Now it should have retried
+        expect(dequeueCallCount).toBe(2)
+
+        // Resolve the retry with a job
+        const job = createFakeJob('job-after-error')
+        pendingDequeues[1].resolve(job)
+        await vi.advanceTimersByTimeAsync(0)
+
+        const result = await pollPromise
+        expect(result).toEqual(job)
+    })
+
+    it('should loop back and retry when dequeue returns null (empty queue after drainDelay)', async () => {
+        const pollPromise = dispatcher.poll()
+
+        await vi.advanceTimersByTimeAsync(0)
+
+        // First dequeue returns null (queue empty, drainDelay expired)
+        pendingDequeues[0].resolve(null)
+        await vi.advanceTimersByTimeAsync(0)
+
+        // Should have called dequeue again
+        expect(dequeueCallCount).toBe(2)
+
+        // Second dequeue returns a job
+        const job = createFakeJob('job-retry')
+        pendingDequeues[1].resolve(job)
+        await vi.advanceTimersByTimeAsync(0)
+
+        const result = await pollPromise
+        expect(result).toEqual(job)
+    })
+
+    it('should stop the loop when no waiters remain', async () => {
+        const pollPromise = dispatcher.poll()
+
+        await vi.advanceTimersByTimeAsync(0)
+        expect(dequeueCallCount).toBe(1)
+
+        // Resolve with a job — this satisfies the only waiter
+        const job = createFakeJob('job-1')
+        pendingDequeues[0].resolve(job)
+        await vi.advanceTimersByTimeAsync(0)
+
+        await pollPromise
+
+        // No more waiters, so no further dequeue calls
+        // Wait a bit to confirm
+        await vi.advanceTimersByTimeAsync(1000)
+        expect(dequeueCallCount).toBe(1)
+    })
+
+    it('should restart the loop when a new poll arrives after loop stopped', async () => {
+        // First poll
+        const poll1 = dispatcher.poll()
+        await vi.advanceTimersByTimeAsync(0)
+
+        const job1 = createFakeJob('job-1')
+        pendingDequeues[0].resolve(job1)
+        await vi.advanceTimersByTimeAsync(0)
+        await poll1
+
+        // Loop has stopped. Start a new poll.
+        const poll2 = dispatcher.poll()
+        await vi.advanceTimersByTimeAsync(0)
+
+        expect(dequeueCallCount).toBe(2)
+
+        const job2 = createFakeJob('job-2')
+        pendingDequeues[1].resolve(job2)
+        await vi.advanceTimersByTimeAsync(0)
+
+        const result = await poll2
+        expect(result).toEqual(job2)
+    })
+
+    it('should close all pending waiters with null', async () => {
+        const poll1 = dispatcher.poll()
+        const poll2 = dispatcher.poll()
+
+        await vi.advanceTimersByTimeAsync(0)
+
+        dispatcher.close()
+
+        const [result1, result2] = await Promise.all([poll1, poll2])
+        expect(result1).toBeNull()
+        expect(result2).toBeNull()
+    })
+
+    it('should report waiter count', async () => {
+        expect(dispatcher.waiterCount()).toBe(0)
+
+        dispatcher.poll()
+        dispatcher.poll()
+
+        expect(dispatcher.waiterCount()).toBe(2)
+    })
+
+    it('should call onOrphanedJob when job is dequeued but all waiters timed out', async () => {
         const pollPromise = dispatcher.poll()
 
         await vi.advanceTimersByTimeAsync(0)
         expect(pendingDequeues).toHaveLength(1)
 
-        const job = createFakeJob('job-1')
-        pendingDequeues[0].resolve(job)
+        // Waiter times out before dequeue returns
+        await vi.advanceTimersByTimeAsync(WAITER_TIMEOUT_MS + 100)
+        const result = await pollPromise
+        expect(result).toBeNull()
 
-        expect(await pollPromise).toEqual(job)
-    })
-
-    it('should fetch one job per waiting worker, concurrently', async () => {
-        void dispatcher.poll()
-        void dispatcher.poll()
-        void dispatcher.poll()
-
+        // Now dequeue returns a job — but no waiter is left
+        const orphanedJob = createFakeJob('orphaned-job')
+        pendingDequeues[0].resolve(orphanedJob)
         await vi.advanceTimersByTimeAsync(0)
 
-        // Each poll fetches its own job — three concurrent getNextJob calls
-        expect(dequeueCallCount).toBe(3)
-        expect(pendingDequeues).toHaveLength(3)
+        expect(onOrphanedJobMock).toHaveBeenCalledWith('orphaned-job', 'job-token', 'test-queue', mockLog)
     })
 
-    it('should run a getNextJob for every one of 500 waiting workers (full-saturation)', async () => {
-        for (let i = 0; i < 500; i++) {
-            void dispatcher.poll()
-        }
-
+    it('should not spawn a second concurrent loop after close() while dequeue is in-flight', async () => {
+        const poll1 = dispatcher.poll()
         await vi.advanceTimersByTimeAsync(0)
 
-        expect(dequeueCallCount).toBe(500)
-        expect(pendingDequeues).toHaveLength(500)
-    })
-
-    it('should return null when the poll deadline passes with an empty queue', async () => {
-        // Empty queue: getNextJob blocks (drainDelay) then returns null, repeatedly.
-        dequeueMock.mockImplementation(() => {
-            dequeueCallCount++
-            return new Promise<ConsumeJobRequest | null>((resolve) => {
-                setTimeout(() => resolve(null), 15_000)
-            })
-        })
-
-        const pollPromise = dispatcher.poll()
-
-        await vi.advanceTimersByTimeAsync(WAITER_TIMEOUT_MS + 15_000)
-
-        expect(await pollPromise).toBeNull()
-        expect(dequeueCallCount).toBeGreaterThan(1)
-    })
-
-    it('should retry after a delay when dequeue errors, then return the job', async () => {
-        let call = 0
-        const job = createFakeJob('job-after-error')
-        dequeueMock.mockImplementation(() => {
-            call++
-            dequeueCallCount++
-            return call === 1
-                ? Promise.reject(new Error('Redis connection lost'))
-                : Promise.resolve(job)
-        })
-
-        const pollPromise = dispatcher.poll()
-
-        await vi.advanceTimersByTimeAsync(0)
-        // First call failed; waiting out the retry delay, no retry yet
-        expect(dequeueCallCount).toBe(1)
-
-        await vi.advanceTimersByTimeAsync(ERROR_RETRY_DELAY_MS)
-
-        expect(await pollPromise).toEqual(job)
-        expect(dequeueCallCount).toBe(2)
-    })
-
-    it('should report the number of in-flight polls as the waiter count', async () => {
-        expect(dispatcher.waiterCount()).toBe(0)
-
-        void dispatcher.poll()
-        void dispatcher.poll()
-
-        await vi.advanceTimersByTimeAsync(0)
-        expect(dispatcher.waiterCount()).toBe(2)
-    })
-
-    it('should stop polling and return null after close()', async () => {
-        const pollPromise = dispatcher.poll()
-        await vi.advanceTimersByTimeAsync(0)
-
+        // Dequeue #1 is in-flight. Close the dispatcher.
         dispatcher.close()
-        // The in-flight dequeue settles (empty); the loop then sees closed and exits.
-        pendingDequeues[0].resolve(null)
+        const result1 = await poll1
+        expect(result1).toBeNull()
 
-        expect(await pollPromise).toBeNull()
+        // A new poll arrives while the in-flight dequeue hasn't resolved yet.
+        // startLoop() sees loopRunning=true and does NOT spawn a second loop.
+        const poll2 = dispatcher.poll()
+        await vi.advanceTimersByTimeAsync(0)
+
+        // Still only 1 dequeue call — no second concurrent call was made
+        expect(dequeueCallCount).toBe(1)
+        expect(pendingDequeues).toHaveLength(1)
+
+        // The in-flight dequeue resolves — the existing loop finds the new waiter
+        // and continues (single loop, no concurrency). It makes dequeue call #2.
+        pendingDequeues[0].resolve(null)
+        await vi.advanceTimersByTimeAsync(0)
+
+        expect(dequeueCallCount).toBe(2)
+
+        // Resolve dequeue #2 with a job for the second waiter
+        const job = createFakeJob('job-after-close')
+        pendingDequeues[1].resolve(job)
+        await vi.advanceTimersByTimeAsync(0)
+
+        const result2 = await poll2
+        expect(result2).toEqual(job)
     })
 })


### PR DESCRIPTION
… loop

The per-poll dequeue design hot-spins: BullMQ allows one blocking bzpopmin waiter per Worker, so every other concurrent getNextJob falls back to a non-blocking moveToActive that returns null instantly on an empty queue. With 10 connected workers this burns ~0.6 CPU per app and >50k Redis ops/s at complete idle, and inflates every latency measured through the app. Restores the pre-13998 single fetch loop (one parked waiter, FIFO handoff, orphan requeue). CD workflow changes from the PR are kept.


### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)
