### PR TITLE
feat(jira-cloud): add three new triggers for system-wide entities

### DIFF
--- a/packages/pieces/community/jira-cloud/package.json
+++ b/packages/pieces/community/jira-cloud/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-jira-cloud",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "dependencies": {

--- a/packages/pieces/community/jira-cloud/src/index.ts
+++ b/packages/pieces/community/jira-cloud/src/index.ts
@@ -25,6 +25,9 @@ import { transitionIssueAction } from './lib/actions/transition-issue';
 import { newComment } from './lib/triggers/new-comment';
 import { issueAssigned } from './lib/triggers/issue-assigned';
 import { newAttachment } from './lib/triggers/new-attachment';
+import { newIssueType } from './lib/triggers/new-issue-type';
+import { newProject } from './lib/triggers/new-project';
+import { newPriority } from './lib/triggers/new-priority';
 
 export const jiraCloud = createPiece({
 	displayName: 'Jira Cloud',
@@ -67,5 +70,5 @@ export const jiraCloud = createPiece({
 			},
 		}),
 	],
-	triggers: [newIssue, updatedIssue, updatedIssueStatus, newComment, issueAssigned, newAttachment],
+	triggers: [newIssue, updatedIssue, updatedIssueStatus, newComment, issueAssigned, newAttachment, newIssueType, newProject, newPriority],
 });

--- a/packages/pieces/community/jira-cloud/src/lib/actions/link-issues.ts
+++ b/packages/pieces/community/jira-cloud/src/lib/actions/link-issues.ts
@@ -2,7 +2,7 @@ import { createAction } from '@activepieces/pieces-framework';
 import { jiraCloudAuth } from '../../auth';
 import { issueIdOrKeyProp, issueLinkTypeIdProp } from '../common/props';
 import { isNil } from '@activepieces/pieces-framework';
-import { HttpError, HttpMethod } from '@activepieces/pieces-common';
+import { HttpMethod } from '@activepieces/pieces-common';
 import { jiraApiCall } from '../common';
 
 export const linkIssuesAction = createAction({

--- a/packages/pieces/community/jira-cloud/src/lib/actions/transition-issue.ts
+++ b/packages/pieces/community/jira-cloud/src/lib/actions/transition-issue.ts
@@ -1,4 +1,4 @@
-import { createAction, Property } from '@activepieces/pieces-framework';
+import { createAction } from '@activepieces/pieces-framework';
 import { HttpMethod } from '@activepieces/pieces-common';
 import { isNil } from '@activepieces/pieces-framework';
 import { jiraCloudAuth } from '../../auth';

--- a/packages/pieces/community/jira-cloud/src/lib/triggers/new-issue-type.ts
+++ b/packages/pieces/community/jira-cloud/src/lib/triggers/new-issue-type.ts
@@ -1,0 +1,90 @@
+import { TriggerStrategy, createTrigger, isNil } from '@activepieces/pieces-framework';
+import { jiraCloudAuth } from '../../auth';
+import { getIssueTypes } from '../common';
+import { getProjectIdDropdown } from '../common/props';
+
+export const newIssueType = createTrigger({
+  name: 'new_issue_type',
+  displayName: 'New Issue Type',
+  description: 'Triggers when a new issue type is created in a project',
+  aiMetadata: {
+    description:
+      'Fires when a new issue type is added to a Jira project. Each event represents one newly created issue type with its full metadata (name, description, avatar, hierarchy level). Polling-based.',
+  },
+  auth: jiraCloudAuth,
+  type: TriggerStrategy.POLLING,
+  props: {
+    projectId: getProjectIdDropdown({
+      displayName: 'Project',
+      description: 'Select the project to watch for new issue types',
+      required: true,
+    }),
+  },
+  sampleData: {
+    id: '10000',
+    name: 'Story',
+    description: 'A user story or feature request',
+    isDefault: false,
+    avatarId: 10500,
+    hierarchyLevel: 0,
+  },
+  async onEnable(context) {
+    const { projectId } = context.propsValue;
+
+    const issueTypes = await getIssueTypes({
+      auth: context.auth,
+      projectId: projectId as string,
+    });
+
+    const ids = issueTypes.map((it) => it.id);
+    await context.store.put('issueTypeIds', JSON.stringify(ids));
+  },
+  async onDisable(context) {
+    await context.store.delete('issueTypeIds');
+  },
+  async run(context) {
+    const { projectId } = context.propsValue;
+
+    const issueTypes = await getIssueTypes({
+      auth: context.auth,
+      projectId: projectId as string,
+    });
+
+    if (isNil(issueTypes) || issueTypes.length === 0) {
+      return [];
+    }
+
+    const existingIds = (await context.store.get<string>('issueTypeIds')) ?? '[]';
+    const parsedExistingIds = JSON.parse(existingIds) as string[];
+
+    const newIssueTypes = issueTypes.filter(
+      (it) => !parsedExistingIds.includes(it.id)
+    );
+
+    if (newIssueTypes.length === 0) {
+      return [];
+    }
+
+    const newIds = newIssueTypes.map((it) => it.id);
+    await context.store.put(
+      'issueTypeIds',
+      JSON.stringify([...newIds, ...parsedExistingIds])
+    );
+
+    return newIssueTypes;
+  },
+  async test(context) {
+    const { projectId } = context.propsValue;
+
+    const issueTypes = await getIssueTypes({
+      auth: context.auth,
+      projectId: projectId as string,
+    });
+
+    if (isNil(issueTypes)) {
+      return [];
+    }
+
+    return issueTypes;
+  },
+});

--- a/packages/pieces/community/jira-cloud/src/lib/triggers/new-priority.ts
+++ b/packages/pieces/community/jira-cloud/src/lib/triggers/new-priority.ts
@@ -1,0 +1,68 @@
+import { TriggerStrategy, createTrigger, isNil } from '@activepieces/pieces-framework';
+import { jiraCloudAuth } from '../../auth';
+import { getPriorities } from '../common';
+
+export const newPriority = createTrigger({
+  name: 'new_priority',
+  displayName: 'New Priority',
+  description: 'Triggers when a new priority is created',
+  aiMetadata: {
+    description:
+      'Fires when a new priority level is added to Jira. Each event represents one newly created priority with its metadata (name, description, color, icon). Polling-based; events arrive on the next poll, not instantly.',
+  },
+  auth: jiraCloudAuth,
+  type: TriggerStrategy.POLLING,
+  props: {},
+  sampleData: {
+    self: 'https://instance.atlassian.net/rest/api/3/priority/1',
+    statusColor: '#e7243d',
+    description: 'The highest priority',
+    iconUrl:
+      'https://instance.atlassian.net/images/icons/priorities/highest.svg',
+    name: 'Highest',
+    id: '1',
+  },
+  async onEnable(context) {
+    const priorities = await getPriorities({ auth: context.auth });
+    const ids = priorities.map((p) => p.id).filter(Boolean);
+    await context.store.put('priorityIds', JSON.stringify(ids));
+  },
+  async onDisable(context) {
+    await context.store.delete('priorityIds');
+  },
+  async run(context) {
+    const priorities = await getPriorities({ auth: context.auth });
+
+    if (isNil(priorities) || priorities.length === 0) {
+      return [];
+    }
+
+    const existingIds = (await context.store.get<string>('priorityIds')) ?? '[]';
+    const parsedExistingIds = JSON.parse(existingIds) as string[];
+
+    const newPriorities = priorities.filter(
+      (p) => p.id && !parsedExistingIds.includes(p.id)
+    );
+
+    if (newPriorities.length === 0) {
+      return [];
+    }
+
+    const newIds = newPriorities.map((p) => p.id).filter(Boolean);
+    await context.store.put(
+      'priorityIds',
+      JSON.stringify([...newIds, ...parsedExistingIds])
+    );
+
+    return newPriorities;
+  },
+  async test(context) {
+    const priorities = await getPriorities({ auth: context.auth });
+
+    if (isNil(priorities)) {
+      return [];
+    }
+
+    return priorities;
+  },
+});

--- a/packages/pieces/community/jira-cloud/src/lib/triggers/new-project.ts
+++ b/packages/pieces/community/jira-cloud/src/lib/triggers/new-project.ts
@@ -1,0 +1,69 @@
+import { TriggerStrategy, createTrigger, isNil } from '@activepieces/pieces-framework';
+import { jiraCloudAuth } from '../../auth';
+import { getProjects } from '../common';
+
+export const newProject = createTrigger({
+  name: 'new_project',
+  displayName: 'New Project',
+  description: 'Triggers when a new project is created',
+  aiMetadata: {
+    description:
+      'Fires when a new Jira project is created. Each event represents one newly created project with its full metadata (name, key, type, privacy setting, style). Polling-based; events arrive on the next poll, not instantly.',
+  },
+  auth: jiraCloudAuth,
+  type: TriggerStrategy.POLLING,
+  props: {},
+  sampleData: {
+    id: '10000',
+    key: 'PROJ',
+    name: 'My Project',
+    projectTypeKey: 'software',
+    simplified: false,
+    style: 'classic',
+    isPrivate: false,
+    self: 'https://instance.atlassian.net/rest/api/3/project/10000',
+  },
+  async onEnable(context) {
+    const projects = await getProjects(context.auth);
+    const ids = projects.map((p) => p.id);
+    await context.store.put('projectIds', JSON.stringify(ids));
+  },
+  async onDisable(context) {
+    await context.store.delete('projectIds');
+  },
+  async run(context) {
+    const projects = await getProjects(context.auth);
+
+    if (isNil(projects) || projects.length === 0) {
+      return [];
+    }
+
+    const existingIds = (await context.store.get<string>('projectIds')) ?? '[]';
+    const parsedExistingIds = JSON.parse(existingIds) as string[];
+
+    const newProjects = projects.filter(
+      (p) => !parsedExistingIds.includes(p.id)
+    );
+
+    if (newProjects.length === 0) {
+      return [];
+    }
+
+    const newIds = newProjects.map((p) => p.id);
+    await context.store.put(
+      'projectIds',
+      JSON.stringify([...newIds, ...parsedExistingIds])
+    );
+
+    return newProjects;
+  },
+  async test(context) {
+    const projects = await getProjects(context.auth);
+
+    if (isNil(projects)) {
+      return [];
+    }
+
+    return projects;
+  },
+});


### PR DESCRIPTION
## Description

Adds three new triggers to the Jira Cloud piece to detect when new system-wide entities are created:

- **New Issue Type**: Fires when a new issue type is created in a selected project (required project dropdown)
- **New Project**: Fires when a new project is created in Jira
- **New Priority**: Fires when a new priority is created in Jira

All triggers use polling with store-based deduplication to track previously seen entities and only fire for new ones.

Fixes #7234

## How was this tested?

- Built and tested locally: `npm run build`
- Linted: no eslint errors on new code
- TypeScript compilation: successful
- All three triggers compile and export correctly

Tested on CE edition path.

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)