### PR TITLE
fix(flows): keyboard shortcuts no longer skip or delete steps while typing in step settings

### DIFF
--- a/packages/web/src/app/builder/flow-canvas/widgets/above-trigger-button.tsx
+++ b/packages/web/src/app/builder/flow-canvas/widgets/above-trigger-button.tsx
@@ -7,7 +7,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from '@/components/ui/tooltip';
-import { isMac } from '@/lib/dom-utils';
+import { isEditableTarget, isMac } from '@/lib/dom-utils';
 import { cn } from '@/lib/utils';
 
 type AboveTriggerButtonProps = {
@@ -35,12 +35,13 @@ const AboveTriggerButton = ({
     const keydownHandler = (event: KeyboardEvent) => {
       const isEscapePressed = event.key === 'Escape' && shortCutIsEscape;
       const ctrlAndDPressed =
-        (isMacSystem &&
+        !isEditableTarget(event.target) &&
+        ((isMacSystem &&
           event.metaKey &&
           event.key.toLocaleLowerCase() === 'd') ||
-        (!isMacSystem &&
-          event.ctrlKey &&
-          event.key.toLocaleLowerCase() === 'd');
+          (!isMacSystem &&
+            event.ctrlKey &&
+            event.key.toLocaleLowerCase() === 'd'));
       if (isEscapePressed || ctrlAndDPressed) {
         event.preventDefault();
         event.stopPropagation();

--- a/packages/web/src/app/builder/flow-canvas/widgets/above-trigger-button.tsx
+++ b/packages/web/src/app/builder/flow-canvas/widgets/above-trigger-button.tsx
@@ -33,15 +33,17 @@ const AboveTriggerButton = ({
 
   useEffect(() => {
     const keydownHandler = (event: KeyboardEvent) => {
+      if (isEditableTarget(event.target)) {
+        return;
+      }
       const isEscapePressed = event.key === 'Escape' && shortCutIsEscape;
       const ctrlAndDPressed =
-        !isEditableTarget(event.target) &&
-        ((isMacSystem &&
+        (isMacSystem &&
           event.metaKey &&
           event.key.toLocaleLowerCase() === 'd') ||
-          (!isMacSystem &&
-            event.ctrlKey &&
-            event.key.toLocaleLowerCase() === 'd'));
+        (!isMacSystem &&
+          event.ctrlKey &&
+          event.key.toLocaleLowerCase() === 'd');
       if (isEscapePressed || ctrlAndDPressed) {
         event.preventDefault();
         event.stopPropagation();

--- a/packages/web/src/app/builder/shortcuts.ts
+++ b/packages/web/src/app/builder/shortcuts.ts
@@ -4,6 +4,8 @@ import {
 } from '@activepieces/shared';
 import { useCallback, useEffect } from 'react';
 
+import { isEditableTarget } from '@/lib/dom-utils';
+
 import { useBuilderStateContext } from './builder-hooks';
 import { CanvasShortcutsProps } from './flow-canvas/context-menu/canvas-context-menu';
 import { canvasBulkActions } from './flow-canvas/utils/bulk-actions';
@@ -36,6 +38,9 @@ export const useHandleKeyPressOnCanvas = () => {
 
   const handleKeyDown = useCallback(
     (e: KeyboardEvent) => {
+      if (isEditableTarget(e.target)) {
+        return;
+      }
       const insideSelectionRect =
         e.target instanceof HTMLElement &&
         e.target.classList.contains(

--- a/packages/web/src/lib/dom-utils.ts
+++ b/packages/web/src/lib/dom-utils.ts
@@ -82,6 +82,16 @@ export const isMac = () => {
   return /(Mac)/i.test(navigator.userAgent);
 };
 
+export const isEditableTarget = (target: EventTarget | null): boolean => {
+  return (
+    target instanceof HTMLElement &&
+    (target.isContentEditable ||
+      target.tagName === 'INPUT' ||
+      target.tagName === 'TEXTAREA' ||
+      target.tagName === 'SELECT')
+  );
+};
+
 function getBlobType(extension: 'json' | 'txt' | 'csv') {
   switch (extension) {
     case 'csv':

--- a/packages/web/test/app/builder/shortcuts.test.tsx
+++ b/packages/web/test/app/builder/shortcuts.test.tsx
@@ -1,0 +1,191 @@
+/**
+ * @vitest-environment jsdom
+ */
+/* eslint-disable testing-library/no-unnecessary-act */
+import {
+  FlowOperationStatus,
+  FlowOperationType,
+  FlowStatus,
+  FlowTriggerType,
+  FlowVersionState,
+  PopulatedFlow,
+} from '@activepieces/shared';
+import { QueryClient } from '@tanstack/react-query';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { io } from 'socket.io-client';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  BuilderStateContext,
+  BuilderStore,
+  createBuilderStore,
+} from '@/app/builder/builder-hooks';
+import { useHandleKeyPressOnCanvas } from '@/app/builder/shortcuts';
+
+declare global {
+  // eslint-disable-next-line no-var
+  var IS_REACT_ACT_ENVIRONMENT: boolean;
+}
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+function buildFlow(): PopulatedFlow {
+  const now = new Date().toISOString();
+  return {
+    id: 'flow-1',
+    created: now,
+    updated: now,
+    projectId: 'project-1',
+    externalId: 'flow-1',
+    ownerId: null,
+    folderId: null,
+    status: FlowStatus.DISABLED,
+    publishedVersionId: null,
+    metadata: null,
+    operationStatus: FlowOperationStatus.NONE,
+    timeSavedPerRun: null,
+    templateId: null,
+    createdBy: null,
+    version: {
+      id: 'version-1',
+      created: now,
+      updated: now,
+      flowId: 'flow-1',
+      displayName: 'Test flow',
+      updatedBy: null,
+      valid: true,
+      schemaVersion: null,
+      agentIds: [],
+      state: FlowVersionState.DRAFT,
+      connectionIds: [],
+      backupFiles: null,
+      notes: [],
+      trigger: {
+        name: 'trigger',
+        valid: true,
+        displayName: 'Trigger',
+        type: FlowTriggerType.EMPTY,
+        settings: {},
+        lastUpdatedDate: now,
+        nextAction: {
+          name: 'step_1',
+          valid: true,
+          displayName: 'Step 1',
+          type: 'CODE',
+          settings: {},
+          skip: false,
+        },
+      },
+    },
+  };
+}
+
+function createStore(): BuilderStore {
+  const flow = buildFlow();
+  return createBuilderStore({
+    flow,
+    flowVersion: flow.version,
+    readonly: false,
+    hideTestWidget: false,
+    run: null,
+    outputSampleData: {},
+    inputSampleData: {},
+    socket: io('http://localhost', { autoConnect: false }),
+    queryClient: new QueryClient(),
+  });
+}
+
+function Probe() {
+  useHandleKeyPressOnCanvas();
+  return null;
+}
+
+function dispatchKeyFrom(target: HTMLElement, init: KeyboardEventInit): void {
+  target.dispatchEvent(
+    new KeyboardEvent('keydown', { bubbles: true, ...init }),
+  );
+}
+
+let container: HTMLDivElement | null = null;
+let root: Root | null = null;
+
+async function setup() {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+  const store = createStore();
+  const applyOperation = vi.fn();
+  store.setState({ applyOperation });
+  store.getState().selectStepByName('step_1');
+  const mountedRoot = root;
+  await act(async () => {
+    mountedRoot.render(
+      <BuilderStateContext.Provider value={store}>
+        <Probe />
+      </BuilderStateContext.Provider>,
+    );
+  });
+  return { container, applyOperation };
+}
+
+describe('canvas shortcuts while editing step inputs (GIT-1445)', () => {
+  afterEach(async () => {
+    const mountedRoot = root;
+    if (mountedRoot) {
+      await act(async () => {
+        mountedRoot.unmount();
+      });
+    }
+    container?.remove();
+    root = null;
+    container = null;
+  });
+
+  it.each(['input', 'textarea', 'select'] as const)(
+    'ignores Ctrl+E when focus is in a %s',
+    async (tagName) => {
+      const { container, applyOperation } = await setup();
+      const field = document.createElement(tagName);
+      container.appendChild(field);
+      dispatchKeyFrom(field, { key: 'e', ctrlKey: true });
+      expect(applyOperation).not.toHaveBeenCalled();
+    },
+  );
+
+  it('ignores Ctrl+E when focus is in a contenteditable element', async () => {
+    const { container, applyOperation } = await setup();
+    const editor = document.createElement('div');
+    Object.defineProperty(editor, 'isContentEditable', { value: true });
+    container.appendChild(editor);
+    dispatchKeyFrom(editor, { key: 'e', ctrlKey: true });
+    expect(applyOperation).not.toHaveBeenCalled();
+  });
+
+  it('ignores Shift+Delete when focus is in an input', async () => {
+    const { container, applyOperation } = await setup();
+    const field = document.createElement('input');
+    container.appendChild(field);
+    dispatchKeyFrom(field, { key: 'Delete', shiftKey: true });
+    expect(applyOperation).not.toHaveBeenCalled();
+  });
+
+  it('still toggles skip with Ctrl+E when focus is on the canvas', async () => {
+    const { applyOperation } = await setup();
+    dispatchKeyFrom(document.body, { key: 'e', ctrlKey: true });
+    expect(applyOperation).toHaveBeenCalledTimes(1);
+    expect(applyOperation).toHaveBeenCalledWith({
+      type: FlowOperationType.SET_SKIP_ACTION,
+      request: { names: ['step_1'], skip: true },
+    });
+  });
+
+  it('still deletes the selected step with Shift+Delete on the canvas', async () => {
+    const { applyOperation } = await setup();
+    dispatchKeyFrom(document.body, { key: 'Delete', shiftKey: true });
+    expect(applyOperation).toHaveBeenCalledWith({
+      type: FlowOperationType.DELETE_ACTION,
+      request: { names: ['step_1'] },
+    });
+  });
+});

--- a/packages/web/test/lib/dom-utils.test.ts
+++ b/packages/web/test/lib/dom-utils.test.ts
@@ -3,7 +3,7 @@
 // suite needs a DOM.
 import { describe, expect, it } from 'vitest';
 
-import { isStepFileUrl } from '@/lib/dom-utils';
+import { isEditableTarget, isStepFileUrl } from '@/lib/dom-utils';
 
 describe('isStepFileUrl', () => {
   it('detects the unified /api/v1/files/ read URLs (GIT-1618 regression)', () => {
@@ -69,5 +69,27 @@ describe('isStepFileUrl', () => {
     expect(isStepFileUrl(undefined)).toBe(false);
     expect(isStepFileUrl(42)).toBe(false);
     expect(isStepFileUrl({ url: '/api/v1/files/abc' })).toBe(false);
+  });
+});
+
+describe('isEditableTarget', () => {
+  it.each(['input', 'textarea', 'select'] as const)(
+    'is true for a %s element',
+    (tagName) => {
+      expect(isEditableTarget(document.createElement(tagName))).toBe(true);
+    },
+  );
+
+  it('is true for a contenteditable element', () => {
+    const div = document.createElement('div');
+    Object.defineProperty(div, 'isContentEditable', { value: true });
+    expect(isEditableTarget(div)).toBe(true);
+  });
+
+  it('is false for non-editable elements and null', () => {
+    expect(isEditableTarget(document.createElement('div'))).toBe(false);
+    expect(isEditableTarget(document.createElement('button'))).toBe(false);
+    expect(isEditableTarget(document.body)).toBe(false);
+    expect(isEditableTarget(null)).toBe(false);
   });
 });


### PR DESCRIPTION
Fixes [GIT-1445](https://linear.app/activepieces/issue/GIT-1445)
Closes #12535

## Problem
1. Ctrl+E while typing in a step's settings inputs toggled skip on the step being edited (the edited step is always in `selectedNodes`).
2. Same handler class: Shift+Delete while editing deleted the step (Shift+Delete is "cut" in text fields on Windows/Linux), Ctrl+C hijacked the clipboard, Ctrl+M toggled the minimap.
3. Sibling bug: Ctrl+D typed in any builder input ran the flow (`above-trigger-button.tsx` window listener, capture phase, no target check).

## Fix
- `lib/dom-utils.ts` — new `isEditableTarget()` (INPUT/TEXTAREA/SELECT/contenteditable).
- `builder/shortcuts.ts` — early-return in `handleKeyDown` for editable targets; `Paste` keeps its own stricter guard, `Escape`/ExitDrag guarded by the same early-return.
- `flow-canvas/widgets/above-trigger-button.tsx` — same early-return guard for the whole handler (Ctrl+D and Escape).

## Verification
- Regression tests (jsdom, real hook + real builder store): red-first proven — 4 editable-target cases fail on pre-fix code, all 7 pass with the fix; canvas-targeted Ctrl+E / Shift+Delete still fire.
- `isEditableTarget` unit tests incl. contenteditable branch.
- Real app (dev stack, Postgres): Ctrl+E targeted at the code editor and at inputs left `skip` unchanged (verified via API); body-targeted Ctrl+E toggled skip both ways; Shift+Delete at an input left the step intact.
- `npm run lint-dev` clean; full web suite 396/396.
- Visual: step settings + code editor Ctrl+E (step not skipped), canvas Ctrl+E (Skipped badge). Pre-fix in-app "before" screenshot not captured (requires re-standing the dev stack on the base commit); the red-first test run documents pre-fix behavior.

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)
