### PR TITLE
fix(ghostcms): Member Edited trigger no longer fires when a new member signs up

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -3554,7 +3554,7 @@
     },
     "packages/pieces/community/ghostcms": {
       "name": "@activepieces/piece-ghostcms",
-      "version": "0.1.6",
+      "version": "0.1.7",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -3565,6 +3565,7 @@
       "devDependencies": {
         "@types/jsonwebtoken": "9.0.10",
         "tslib": "2.6.2",
+        "vitest": "3.2.6",
       },
     },
     "packages/pieces/community/giftbit": {

--- a/packages/pieces/community/ghostcms/package.json
+++ b/packages/pieces/community/ghostcms/package.json
@@ -1,12 +1,13 @@
 {
   "name": "@activepieces/piece-ghostcms",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",
     "bundle": "node ../../../../dist/packages/cli/src/index.js pieces bundle",
-    "lint": "eslint 'src/**/*.ts'"
+    "lint": "eslint 'src/**/*.ts'",
+    "test": "vitest run"
   },
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
@@ -17,6 +18,7 @@
   },
   "devDependencies": {
     "@types/jsonwebtoken": "9.0.10",
-    "tslib": "2.6.2"
+    "tslib": "2.6.2",
+    "vitest": "3.2.6"
   }
 }

--- a/packages/pieces/community/ghostcms/src/lib/triggers/member-edited-utils.ts
+++ b/packages/pieces/community/ghostcms/src/lib/triggers/member-edited-utils.ts
@@ -1,0 +1,20 @@
+const ACTIVITY_STAMP_FIELDS = ['updated_at', 'last_seen_at', 'geolocation'];
+
+function hasMemberFieldChanges(body: unknown): boolean {
+  if (typeof body !== 'object' || body === null || !('member' in body)) {
+    return true;
+  }
+  const member = body.member;
+  if (typeof member !== 'object' || member === null || !('previous' in member)) {
+    return true;
+  }
+  const previous = member.previous;
+  if (typeof previous !== 'object' || previous === null) {
+    return true;
+  }
+  return Object.keys(previous).some(
+    (field) => !ACTIVITY_STAMP_FIELDS.includes(field)
+  );
+}
+
+export const memberEditedUtils = { hasMemberFieldChanges };

--- a/packages/pieces/community/ghostcms/src/lib/triggers/member-edited.ts
+++ b/packages/pieces/community/ghostcms/src/lib/triggers/member-edited.ts
@@ -2,6 +2,7 @@ import { TriggerStrategy, createTrigger } from '@activepieces/pieces-framework';
 
 import { ghostAuth } from '../..';
 import { common } from '../common';
+import { memberEditedUtils } from './member-edited-utils';
 
 export const memberEdited = createTrigger({
   auth: ghostAuth,
@@ -34,6 +35,9 @@ export const memberEdited = createTrigger({
     }
   },
   async run(context) {
+    if (!memberEditedUtils.hasMemberFieldChanges(context.payload.body)) {
+      return [];
+    }
     return [context.payload.body];
   },
 

--- a/packages/pieces/community/ghostcms/test/member-edited.test.ts
+++ b/packages/pieces/community/ghostcms/test/member-edited.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest';
+import { memberEditedUtils } from '../src/lib/triggers/member-edited-utils';
+
+function payloadWithPrevious(previous: Record<string, unknown>): unknown {
+  return {
+    member: {
+      current: {
+        id: '6a5e3d4116d89900011f4601',
+        email: 'portal1@example.com',
+        name: 'Portal One',
+        created_at: '2026-07-20T15:22:54.000Z',
+        updated_at: '2026-07-20T15:22:55.000Z',
+      },
+      previous,
+    },
+  };
+}
+
+describe('memberEditedUtils.hasMemberFieldChanges', () => {
+  it.each([
+    [
+      'filters the signup-driven last_seen_at stamp',
+      { last_seen_at: null, updated_at: '2026-07-20T15:22:54.000Z' },
+      false,
+    ],
+    [
+      'filters the async geolocation update',
+      { geolocation: null, updated_at: '2026-07-20T15:22:54.000Z' },
+      false,
+    ],
+    ['filters an empty previous object', {}, false],
+    [
+      'keeps a genuine name edit',
+      { name: null, updated_at: '2026-07-20T15:22:55.000Z' },
+      true,
+    ],
+    [
+      'keeps a genuine email edit',
+      { email: 'old@example.com', updated_at: '2026-07-20T15:22:55.000Z' },
+      true,
+    ],
+    [
+      'keeps an edit to any other member field',
+      { status: 'free', updated_at: '2026-07-20T15:22:55.000Z' },
+      true,
+    ],
+    [
+      'keeps an edit that also carries activity stamps',
+      {
+        name: null,
+        last_seen_at: null,
+        updated_at: '2026-07-20T15:22:55.000Z',
+      },
+      true,
+    ],
+  ])('%s', (_name, previous, expected) => {
+    expect(
+      memberEditedUtils.hasMemberFieldChanges(payloadWithPrevious(previous))
+    ).toBe(expected);
+  });
+
+  it('keeps payloads without a previous object', () => {
+    expect(
+      memberEditedUtils.hasMemberFieldChanges({ member: { current: {} } })
+    ).toBe(true);
+  });
+
+  it('keeps payloads without a member object', () => {
+    expect(memberEditedUtils.hasMemberFieldChanges({ other: true })).toBe(true);
+  });
+
+  it('keeps non-object payloads', () => {
+    expect(memberEditedUtils.hasMemberFieldChanges('raw')).toBe(true);
+    expect(memberEditedUtils.hasMemberFieldChanges(null)).toBe(true);
+  });
+});

--- a/packages/pieces/community/ghostcms/vitest.config.ts
+++ b/packages/pieces/community/ghostcms/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+  },
+})


### PR DESCRIPTION
Fixes [GIT-441](https://linear.app/activepieces/issue/GIT-441)
Closes #7074

## Description

1. Ghost emits `member.edited` for internal activity stamps: portal signup stamps `last_seen_at` ~500ms after `member.added`, and `geolocation` is set asynchronously from the signup IP. The GhostCMS "Member Edited" trigger forwarded every event, so flows ran on each new member signup and login, not only on real edits. Reproduced live on Ghost 5.130.6: spurious events carry `previous = {last_seen_at, updated_at}`; genuine edits carry the changed field, e.g. `previous = {name, updated_at}`.

## Fix

- `member-edited-utils.ts` (new): `hasMemberFieldChanges()` drops payloads whose `previous` diff contains only `updated_at` / `last_seen_at` / `geolocation`; unknown payload shapes pass through (fail open). Lives in a dependency-free file because the piece's index/triggers/common import cycle crashes vitest when the trigger module is imported directly.
- `member-edited.ts`: `run()` returns `[]` for stamp-only events.
- Piece version 0.1.6 to 0.1.7; vitest wiring mirrors the xquik piece.

## How was this tested?

- Red-first regression proof through the built trigger artifact on payloads recorded from a live Ghost 5.130.6 instance (portal magic-link signup + admin rename): pre-fix code emitted the signup event (RED), post-fix code filters it and keeps the genuine edit (GREEN).
- 10/10 vitest tests in `packages/pieces/community/ghostcms`.
- `npm run lint-dev` clean (30/30 packages).
- Editions: community piece, same code path on CE / EE / Cloud.
- Visual: none - webhook filtering logic only, no props/UI/strings changed.

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)
