### PR TITLE
feat(mailchimp): add Create Tag, Send Campaign, and Create Custom Event actions

### DIFF
--- a/packages/pieces/community/mailchimp/package.json
+++ b/packages/pieces/community/mailchimp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-mailchimp",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "dependencies": {

--- a/packages/pieces/community/mailchimp/src/index.ts
+++ b/packages/pieces/community/mailchimp/src/index.ts
@@ -13,6 +13,9 @@ import { findCampaign } from './lib/actions/find-campaign';
 import { findCustomer } from './lib/actions/find-customer';
 import { findTag } from './lib/actions/find-tag';
 import { findSubscriber } from './lib/actions/find-subscriber';
+import { createTag } from './lib/actions/create-tag';
+import { sendCampaign } from './lib/actions/send-campaign';
+import { createCustomEvent } from './lib/actions/create-custom-event';
 
 import { PieceCategory } from '@activepieces/pieces-framework';
 import { mailChimpSubscribeTrigger } from './lib/triggers/subscribe-trigger';
@@ -56,6 +59,9 @@ export const mailchimp = createPiece({
     findCustomer,
     findTag,
     findSubscriber,
+    createTag,
+    sendCampaign,
+    createCustomEvent,
   ],
   triggers: [
     mailChimpSubscribeTrigger, 

--- a/packages/pieces/community/mailchimp/src/lib/actions/create-custom-event.ts
+++ b/packages/pieces/community/mailchimp/src/lib/actions/create-custom-event.ts
@@ -1,0 +1,63 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { getAccessTokenOrThrow } from '@activepieces/pieces-common';
+import { mailchimpCommon } from '../common';
+import { mailchimpAuth } from '../..';
+import mailchimp from '@mailchimp/mailchimp_marketing';
+import { MailchimpClient } from '../common/types';
+
+export const createCustomEvent = createAction({
+  auth: mailchimpAuth,
+  name: 'create_custom_event',
+  displayName: 'Create Custom Event',
+  description: 'Log a custom event for an existing subscriber, for use in automations and segmentation',
+  audience: 'both',
+  aiMetadata: { description: 'Records a named event (with optional properties) against an existing subscriber, identified by email, in an audience (list). Use to feed subscriber behavior into automations or segments. Not idempotent: each call logs a new, distinct event occurrence.', idempotent: false },
+  props: {
+    list_id: mailchimpCommon.mailChimpListIdDropdown,
+    email: Property.ShortText({
+      displayName: 'Email Address',
+      description: 'The email address of the subscriber to log the event for',
+      required: true,
+    }),
+    name: Property.ShortText({
+      displayName: 'Event Name',
+      description: 'The name of the event (lowercase letters, numbers, and underscores only, e.g. "purchased_item")',
+      required: true,
+    }),
+    properties: Property.Object({
+      displayName: 'Properties',
+      description: 'Optional key/value data to attach to the event',
+      required: false,
+    }),
+  },
+  async run(context) {
+    const { list_id, email, name, properties } = context.propsValue;
+    const accessToken = getAccessTokenOrThrow(context.auth);
+    const server = await mailchimpCommon.getMailChimpServerPrefix(accessToken);
+    const subscriberHash = mailchimpCommon.getMD5EmailHash(email);
+
+    const client = mailchimp as unknown as MailchimpClient;
+    client.setConfig({
+      accessToken: accessToken,
+      server: server,
+    });
+
+    try {
+      // Docs: https://mailchimp.com/developer/marketing/api/list-member-events/add-event/
+      await client.lists.createListMemberEvent(list_id as string, subscriberHash, {
+        name,
+        ...(properties ? { properties } : {}),
+      });
+
+      return {
+        success: true,
+        message: `Successfully created event "${name}" for ${email}`,
+        list_id,
+        email,
+        name,
+      };
+    } catch (error: any) {
+      throw new Error(`Failed to create custom event: ${error.message || JSON.stringify(error)}`);
+    }
+  },
+});

--- a/packages/pieces/community/mailchimp/src/lib/actions/create-tag.ts
+++ b/packages/pieces/community/mailchimp/src/lib/actions/create-tag.ts
@@ -1,0 +1,51 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { getAccessTokenOrThrow } from '@activepieces/pieces-common';
+import { mailchimpCommon } from '../common';
+import { mailchimpAuth } from '../..';
+import mailchimp from '@mailchimp/mailchimp_marketing';
+import { MailchimpClient } from '../common/types';
+
+export const createTag = createAction({
+  auth: mailchimpAuth,
+  name: 'create_tag',
+  displayName: 'Create Tag',
+  description: 'Create a new tag in a Mailchimp audience',
+  audience: 'both',
+  aiMetadata: { description: 'Creates a new tag on an audience (list) so it can later be applied to subscribers. Use to set up a tag ahead of tagging contacts. Not idempotent: calling again with the same name creates a duplicate tag.', idempotent: false },
+  props: {
+    list_id: mailchimpCommon.mailChimpListIdDropdown,
+    name: Property.ShortText({
+      displayName: 'Tag Name',
+      description: 'The name of the tag to create',
+      required: true,
+    }),
+  },
+  async run(context) {
+    const { list_id, name } = context.propsValue;
+    const accessToken = getAccessTokenOrThrow(context.auth);
+    const server = await mailchimpCommon.getMailChimpServerPrefix(accessToken);
+
+    const client = mailchimp as unknown as MailchimpClient;
+    client.setConfig({
+      accessToken: accessToken,
+      server: server,
+    });
+
+    try {
+      // Tags are static segments with no members yet.
+      // Docs: https://mailchimp.com/developer/marketing/api/list-segments/add-segment/
+      const segment = await client.lists.createSegment(list_id as string, {
+        name,
+        static_segment: [],
+      });
+
+      return {
+        success: true,
+        message: `Successfully created tag "${name}"`,
+        tag: segment,
+      };
+    } catch (error: any) {
+      throw new Error(`Failed to create tag: ${error.message || JSON.stringify(error)}`);
+    }
+  },
+});

--- a/packages/pieces/community/mailchimp/src/lib/actions/send-campaign.ts
+++ b/packages/pieces/community/mailchimp/src/lib/actions/send-campaign.ts
@@ -1,0 +1,42 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { getAccessTokenOrThrow } from '@activepieces/pieces-common';
+import { mailchimpCommon } from '../common';
+import { mailchimpAuth } from '../..';
+import mailchimp from '@mailchimp/mailchimp_marketing';
+import { MailchimpClient } from '../common/types';
+
+export const sendCampaign = createAction({
+  auth: mailchimpAuth,
+  name: 'send_campaign',
+  displayName: 'Send Campaign',
+  description: 'Send a draft campaign to the subscribers in its audience, segment, or tag',
+  audience: 'both',
+  aiMetadata: { description: 'Sends an existing draft campaign to its configured recipients immediately (RSS campaigns follow their schedule instead). Use once the campaign is fully set up; there is no undo, so confirm the campaign content and audience beforehand. Not idempotent: calling again on an already-sent campaign fails.', idempotent: false },
+  props: {
+    campaign_id: mailchimpCommon.mailChimpCampaignIdDropdown,
+  },
+  async run(context) {
+    const { campaign_id } = context.propsValue;
+    const accessToken = getAccessTokenOrThrow(context.auth);
+    const server = await mailchimpCommon.getMailChimpServerPrefix(accessToken);
+
+    const client = mailchimp as unknown as MailchimpClient;
+    client.setConfig({
+      accessToken: accessToken,
+      server: server,
+    });
+
+    try {
+      // Docs: https://mailchimp.com/developer/marketing/api/campaigns/send-campaign/
+      await client.campaigns.send(campaign_id as string);
+
+      return {
+        success: true,
+        message: 'Campaign sent successfully',
+        campaign_id,
+      };
+    } catch (error: any) {
+      throw new Error(`Failed to send campaign: ${error.message || JSON.stringify(error)}`);
+    }
+  },
+});

--- a/packages/pieces/community/mailchimp/src/lib/actions/send-campaign.ts
+++ b/packages/pieces/community/mailchimp/src/lib/actions/send-campaign.ts
@@ -13,7 +13,7 @@ export const sendCampaign = createAction({
   audience: 'both',
   aiMetadata: { description: 'Sends an existing draft campaign to its configured recipients immediately (RSS campaigns follow their schedule instead). Use once the campaign is fully set up; there is no undo, so confirm the campaign content and audience beforehand. Not idempotent: calling again on an already-sent campaign fails.', idempotent: false },
   props: {
-    campaign_id: mailchimpCommon.mailChimpCampaignIdDropdown,
+    campaign_id: mailchimpCommon.mailChimpDraftCampaignIdDropdown,
   },
   async run(context) {
     const { campaign_id } = context.propsValue;

--- a/packages/pieces/community/mailchimp/src/lib/common/index.ts
+++ b/packages/pieces/community/mailchimp/src/lib/common/index.ts
@@ -89,7 +89,7 @@ export const mailchimpCommon = {
     },
   }),
 
-  getUserCampaigns: async (authProp: OAuth2PropertyValue) => {
+  getUserCampaigns: async (authProp: OAuth2PropertyValue, options?: { status?: string }) => {
     const access_token = authProp.access_token;
     const mailChimpServerPrefix =
       await mailchimpCommon.getMailChimpServerPrefix(access_token!);
@@ -102,8 +102,43 @@ export const mailchimpCommon = {
     return await (mailchimp as any).campaigns.list({
       fields: ['campaigns.id', 'campaigns.settings.title', 'campaigns.status', 'total_items'],
       count: 1000,
+      ...(options?.status ? { status: options.status } : {}),
     });
   },
+
+  mailChimpDraftCampaignIdDropdown: Property.Dropdown<string,true,typeof mailchimpAuth >({
+    auth: mailchimpAuth,
+    displayName: 'Campaign',
+    refreshers: [],
+    description: 'Select the draft campaign to send',
+    required: true,
+    options: async ({ auth }) => {
+      if (!auth) {
+        return {
+          disabled: true,
+          options: [],
+          placeholder: 'Please select a connection',
+        };
+      }
+
+      const authProp = auth as OAuth2PropertyValue;
+      // Mailchimp only accepts the send action on campaigns in "save" (draft) status.
+      const campaignResponse = (await mailchimpCommon.getUserCampaigns(
+        authProp,
+        { status: 'save' }
+      )) as any;
+
+      const options = campaignResponse.campaigns.map((campaign: any) => ({
+        label: `${campaign.settings?.title || campaign.id}`,
+        value: campaign.id,
+      }));
+
+      return {
+        disabled: false,
+        options,
+      };
+    },
+  }),
 
   mailChimpStoreIdDropdown: Property.Dropdown<string,true,typeof mailchimpAuth >({
     auth: mailchimpAuth,

--- a/packages/pieces/community/mailchimp/src/lib/common/types.ts
+++ b/packages/pieces/community/mailchimp/src/lib/common/types.ts
@@ -170,6 +170,29 @@ export interface MailchimpListsApi {
   getAllLists(options?: any): Promise<any>;
   tagSearch(listId: string, opts?: any): Promise<any>;
   updateListMemberTags(listId: string, subscriberHash: string, data: any): Promise<any>;
+  createSegment(listId: string, data: CreateSegmentData): Promise<Segment>;
+  createListMemberEvent(listId: string, subscriberHash: string, data: CreateListMemberEventData): Promise<void>;
+}
+
+export interface CreateSegmentData {
+  name: string;
+  static_segment?: string[];
+}
+
+export interface Segment {
+  id: number;
+  name: string;
+  list_id: string;
+  type: string;
+  created_at: string;
+  updated_at: string;
+  member_count: number;
+}
+
+export interface CreateListMemberEventData {
+  name: string;
+  properties?: Record<string, unknown>;
+  occurred_at?: string;
 }
 
 export interface MailchimpReportsApi {


### PR DESCRIPTION
## Description

Adds three actions missing from the Mailchimp piece per #7236:

- **Create Tag** — creates a new tag (static segment) on an audience via `POST /lists/{list_id}/segments`.
- **Send Campaign** — sends an existing draft campaign via `POST /campaigns/{campaign_id}/actions/send`.
- **Create Custom Event** — logs a custom event against a subscriber for use in automations/segmentation via `POST /lists/{list_id}/members/{subscriber_hash}/events`.

Bumped `@activepieces/piece-mailchimp` to `0.5.6`.

## How was this tested?

- `npx turbo run lint --filter=@activepieces/piece-mailchimp` — 0 errors (pre-existing warnings only, unrelated to this change).
- Manual code review against the Mailchimp Marketing API docs and SDK for each endpoint/method used.

Fixes  #7236

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)
