### PR TITLE
fix(tool-search): keep ai-audience actions visible to the search engine

### DIFF
--- a/packages/server/api/src/app/mcp/tools/ap-research-pieces.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-research-pieces.ts
@@ -1,5 +1,5 @@
 import { isNil, LocalesEnum } from '@activepieces/core-utils'
-import { McpToolDefinition, PieceCategory, ProjectScopedMcpServer, SuggestionType } from '@activepieces/shared'
+import { McpToolDefinition, PieceAudienceFilter, PieceCategory, ProjectScopedMcpServer, SuggestionType } from '@activepieces/shared'
 import { FastifyBaseLogger } from 'fastify'
 import { z } from 'zod'
 import { pieceMetadataService } from '../../pieces/metadata/piece-metadata-service'
@@ -143,6 +143,7 @@ async function searchPieces({ params, projectId, platformId, log }: {
         searchQuery: params.searchQuery,
         suggestionType: params.suggestionType as SuggestionType | undefined,
         locale: params.locale as LocalesEnum | undefined,
+        audience: PieceAudienceFilter.ALL,
     })
 
     if (pieces.length === 0) {

--- a/packages/server/api/src/app/tool-search/tool-search.service.ts
+++ b/packages/server/api/src/app/tool-search/tool-search.service.ts
@@ -1,4 +1,4 @@
-import { AppConnectionStatus, isNil, SuggestionType, tryCatch } from '@activepieces/shared'
+import { AppConnectionStatus, isNil, PieceAudienceFilter, SuggestionType, tryCatch } from '@activepieces/shared'
 import { FastifyBaseLogger } from 'fastify'
 import { appConnectionService } from '../app-connection/app-connection-service/app-connection-service'
 import { databaseConnection } from '../database/database-connection'
@@ -155,6 +155,7 @@ async function keywordSearch({ objectKind, query, opts, log, degradeReason }: Ke
         includeHidden: false,
         searchQuery: query,
         suggestionType: objectKind === 'action' ? SuggestionType.ACTION : SuggestionType.TRIGGER,
+        audience: PieceAudienceFilter.ALL,
     })
 
     // Honor the caller's pieceName scope in the keyword floor too. `pieceMetadataService.list`
@@ -194,6 +195,7 @@ async function resolveEnabledPieceNames(opts: ToolSearchParams, log: FastifyBase
         platformId,
         projectId,
         includeHidden: false,
+        audience: PieceAudienceFilter.ALL,
     }))
     if (isNil(pieces)) {
         log.warn({ error, platformId }, '[toolSearchService] Enabled-piece resolution failed — serving without the enabled filter.')

--- a/packages/server/api/test/integration/ce/tool-search/tool-search.test.ts
+++ b/packages/server/api/test/integration/ce/tool-search/tool-search.test.ts
@@ -734,6 +734,23 @@ describe('Tool Search Engine (Phase 5 — keyword floor / degradation)', () => {
         expect(results.length).toBeGreaterThan(0)
         expect(results.every((r) => r.pieceName === '@activepieces/piece-slack')).toBe(true)
     })
+
+    it('returns audience:"ai" actions in the keyword floor — the search engine sees the full audience, not the human view', async () => {
+        await db.save('piece_metadata', createMockPieceMetadata({
+            name: '@activepieces/piece-agent-tools',
+            displayName: 'Agent Tools',
+            version: '1.0.0',
+            pieceType: PieceType.OFFICIAL,
+            packageType: PackageType.REGISTRY,
+            actions: { send_ai_message: action({ name: 'send_ai_message', displayName: 'Send AI Message', description: 'Send a message to a channel', audience: 'ai' }) },
+            triggers: {},
+        }))
+
+        const { results, mode } = await toolSearchService(log).searchActions('send message', { limit: 5 })
+
+        expect(mode).toBe('keyword')
+        expect(results.some((r) => r.actionName === 'send_ai_message')).toBe(true)
+    })
 })
 
 // Two pieces each carrying both an action and a trigger, so the trigger-side query path can be


### PR DESCRIPTION
## Description

PR #13960 (canvas audience filter) made `pieceMetadataService.list()` default a missing `audience` param to `PieceAudienceFilter.HUMAN`, which filters out actions tagged `audience: 'ai'`. That default is correct for the human-facing pieces HTTP boundary (the flow-builder picker), but it silently changed the contract for **internal, agent-facing** callers that were reviewed against "see the whole catalog".

This restores the pre-#13960 behavior by passing `audience: PieceAudienceFilter.ALL` explicitly at the three internal `list()` call sites:

- **`tool-search` `keywordSearch()`** — the lexical fallback of `ap_search_actions` / `ap_search_triggers` when the semantic path is unavailable. Without this, once agent atomics land in the catalog, `audience:'ai'` actions become undiscoverable whenever search degrades to keyword mode (a silent, degraded-path-only failure).
- **`tool-search` `resolveEnabledPieceNames()`** — unaffected today (it only reads `piece.name`; audience filtering removes actions *within* pieces, never whole pieces), made explicit to protect against future filter changes.
- **`ap_research_pieces` `searchPieces()`** — the MCP piece-discovery tool, an agent-facing surface that should likewise see `audience:'ai'` actions.

`ALL` (not `AI`) is the conservative choice: it restores the old contract without newly hiding human-only actions from these callers. The bug is currently latent — no `audience:'ai'` actions exist in the catalog yet — so this lands ahead of the first agent-atomics PR.

## How was this tested?

- Added a keyword-floor regression test (CE integration suite) that seeds a piece with an `audience:'ai'` action, forces the degraded keyword path, and asserts the ai-tagged action is returned. Verified it fails without the fix and passes with it.
- `npx vitest run test/integration/ce/tool-search --no-file-parallelism` → 42/42 passing (PGLite).
- `npx turbo run build --filter=api` green; eslint clean on the changed files.

Fixes # (issue)

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)