### PR TITLE
chore(deps): consolidate axios 1.18.0 & exifreader 4.40.1 bumps

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -17,7 +17,7 @@
         "@typescript-eslint/parser": "7.18.0",
         "@typescript-eslint/utils": "7.18.0",
         "@vitejs/plugin-react": "4.7.0",
-        "axios": "1.16.0",
+        "axios": "1.18.0",
         "chalk": "4.1.2",
         "concurrently": "8.2.1",
         "dotenv": "17.2.3",
@@ -69,7 +69,7 @@
     },
     "packages/cli": {
       "name": "@activepieces/cli",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "bin": {
         "pieces-cli": "../../dist/packages/cli/src/index.js",
       },
@@ -97,7 +97,7 @@
     },
     "packages/core/execution": {
       "name": "@activepieces/core-execution",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -142,7 +142,7 @@
     },
     "packages/core/shared": {
       "name": "@activepieces/shared",
-      "version": "0.119.0",
+      "version": "0.120.1",
       "dependencies": {
         "@activepieces/core-execution": "workspace:*",
         "@activepieces/core-formula": "workspace:*",
@@ -875,7 +875,7 @@
     },
     "packages/pieces/community/aws-bedrock": {
       "name": "@activepieces/piece-aws-bedrock",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -4593,7 +4593,7 @@
     },
     "packages/pieces/community/jira-cloud": {
       "name": "@activepieces/piece-jira-cloud",
-      "version": "0.3.7",
+      "version": "0.3.8",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -5325,7 +5325,7 @@
     },
     "packages/pieces/community/mailchimp": {
       "name": "@activepieces/piece-mailchimp",
-      "version": "0.5.5",
+      "version": "0.5.6",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -5822,7 +5822,7 @@
     },
     "packages/pieces/community/microsoft-teams": {
       "name": "@activepieces/piece-microsoft-teams",
-      "version": "0.5.5",
+      "version": "0.6.0",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -6441,7 +6441,7 @@
     },
     "packages/pieces/community/openai": {
       "name": "@activepieces/piece-openai",
-      "version": "0.9.2",
+      "version": "0.10.0",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -7893,7 +7893,7 @@
     },
     "packages/pieces/community/sendgrid": {
       "name": "@activepieces/piece-sendgrid",
-      "version": "0.5.4",
+      "version": "0.5.5",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -9804,7 +9804,7 @@
     },
     "packages/pieces/community/xero": {
       "name": "@activepieces/piece-xero",
-      "version": "0.6.7",
+      "version": "0.6.8",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -9902,7 +9902,7 @@
     },
     "packages/pieces/community/zendesk": {
       "name": "@activepieces/piece-zendesk",
-      "version": "0.2.9",
+      "version": "0.2.10",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -10286,7 +10286,7 @@
         "@activepieces/core-utils": "workspace:*",
         "@activepieces/pieces-common": "workspace:*",
         "@activepieces/pieces-framework": "workspace:*",
-        "exifreader": "4.39.0",
+        "exifreader": "4.40.1",
         "heic-convert": "2.1.0",
         "jimp": "^0.22.12",
         "mime-types": "2.1.35",
@@ -10595,7 +10595,7 @@
         "ai": "^6.0.0",
         "ai-gateway-provider": "3.1.1",
         "async-mutex": "0.4.0",
-        "axios": "1.16.0",
+        "axios": "1.18.0",
         "bcrypt": "6.0.0",
         "bullmq": "5.61.0",
         "chokidar": "4.0.3",
@@ -10745,7 +10745,7 @@
         "@openrouter/ai-sdk-provider": "2.1.1",
         "ai": "^6.0.0",
         "async-mutex": "0.4.0",
-        "axios": "1.16.0",
+        "axios": "1.18.0",
         "axios-retry": "4.4.1",
         "check-disk-space": "3.4.0",
         "dayjs": "1.11.9",
@@ -10866,7 +10866,7 @@
         "@xyflow/react": "12.3.5",
         "ai": "^6.0.0",
         "async-mutex": "0.4.0",
-        "axios": "1.16.0",
+        "axios": "1.18.0",
         "boring-avatars": "1.11.2",
         "canvas-confetti": "^1.9.4",
         "class-variance-authority": "0.7.1",
@@ -10952,7 +10952,7 @@
     "isolated-vm",
   ],
   "overrides": {
-    "axios": "1.16.0",
+    "axios": "1.18.0",
     "rollup": "npm:@rollup/wasm-node",
   },
   "packages": {
@@ -14584,7 +14584,7 @@
 
     "axe-core": ["axe-core@4.11.4", "", {}, "sha512-KunSNx+TVpkAw/6ULfhnx+HWRecjqZGTOyquAoWHYLRSdK1tB5Ihce1ZW+UY3fj33bYAFWPu7W/GRSmmrCGuxA=="],
 
-    "axios": ["axios@1.16.0", "", { "dependencies": { "follow-redirects": "^1.16.0", "form-data": "^4.0.5", "proxy-from-env": "^2.1.0" } }, "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w=="],
+    "axios": ["axios@1.18.0", "", { "dependencies": { "follow-redirects": "^1.16.0", "form-data": "^4.0.5", "https-proxy-agent": "^5.0.1", "proxy-from-env": "^2.1.0" } }, "sha512-E32NzpYKp++W7XRe52rHiXV2ehxmh3wbdgO7MHeFM+vqxLBYHzt0ElkiImtOBxtOmyp0yoC8C6uESVV84Y2/hw=="],
 
     "axios-ntlm": ["axios-ntlm@1.4.6", "", { "dependencies": { "axios": "^1.12.2", "des.js": "^1.1.0", "dev-null": "^0.1.1", "js-md4": "^0.3.2" } }, "sha512-4nR5cbVEBfPMTFkd77FEDpDuaR205JKibmrkaQyNwGcCx0szWNpRZaL0jZyMx4+mVY2PXHjRHuJafv9Oipl0Kg=="],
 
@@ -15336,7 +15336,7 @@
 
     "exif-parser": ["exif-parser@0.1.12", "", {}, "sha512-c2bQfLNbMzLPmzQuOr8fy0csy84WmwnER81W88DzTp9CYNPJ6yzOj2EZAh9pywYpqHnshVLHQJ8WzldAyfY+Iw=="],
 
-    "exifreader": ["exifreader@4.39.0", "", { "optionalDependencies": { "@xmldom/xmldom": "^0.9.9" } }, "sha512-lP/BslNNbT3zZDtNyVli8XaPCxKE8f0OXb5hGhPVqaoIGCvOVanICwM3FXO45MkDjI3KHgFBk0KKVAw/W4xP2A=="],
+    "exifreader": ["exifreader@4.40.1", "", { "optionalDependencies": { "@xmldom/xmldom": "^0.9.9" } }, "sha512-Xavsts17ZYZoxUsUn+HCvGf8LB2ry7/pLSk2bYhXPGNLKciQDOxsY2EoytnKWfGmBRm4yvHVkw8RWsG5J8s3pA=="],
 
     "expand-template": ["expand-template@2.0.3", "", {}, "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg=="],
 
@@ -19408,6 +19408,8 @@
 
     "autocannon/semver": ["semver@7.8.5", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA=="],
 
+    "axios/https-proxy-agent": ["https-proxy-agent@5.0.1", "", { "dependencies": { "agent-base": "6", "debug": "4" } }, "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA=="],
+
     "babel-runtime/core-js": ["core-js@2.6.12", "", {}, "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ=="],
 
     "babel-runtime/regenerator-runtime": ["regenerator-runtime@0.11.1", "", {}, "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="],
@@ -20709,6 +20711,8 @@
     "archiver/readable-stream/string_decoder": ["string_decoder@1.3.0", "", { "dependencies": { "safe-buffer": "~5.2.0" } }, "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA=="],
 
     "are-we-there-yet/readable-stream/string_decoder": ["string_decoder@1.3.0", "", { "dependencies": { "safe-buffer": "~5.2.0" } }, "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA=="],
+
+    "axios/https-proxy-agent/agent-base": ["agent-base@6.0.2", "", { "dependencies": { "debug": "4" } }, "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ=="],
 
     "bl/readable-stream/string_decoder": ["string_decoder@1.3.0", "", { "dependencies": { "safe-buffer": "~5.2.0" } }, "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA=="],
 

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "@typescript-eslint/parser": "7.18.0",
     "@typescript-eslint/utils": "7.18.0",
     "@vitejs/plugin-react": "4.7.0",
-    "axios": "1.16.0",
+    "axios": "1.18.0",
     "chalk": "4.1.2",
     "concurrently": "8.2.1",
     "dotenv": "17.2.3",
@@ -133,6 +133,6 @@
   ],
   "resolutions": {
     "rollup": "npm:@rollup/wasm-node",
-    "axios": "1.16.0"
+    "axios": "1.18.0"
   }
 }

--- a/packages/pieces/core/image-helper/package.json
+++ b/packages/pieces/core/image-helper/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "exifreader": "4.39.0",
+    "exifreader": "4.40.1",
     "heic-convert": "2.1.0",
     "jimp": "^0.22.12",
     "sharp": "^0.35.2",

--- a/packages/server/api/package.json
+++ b/packages/server/api/package.json
@@ -50,7 +50,7 @@
     "ai": "^6.0.0",
     "ai-gateway-provider": "3.1.1",
     "async-mutex": "0.4.0",
-    "axios": "1.16.0",
+    "axios": "1.18.0",
     "bcrypt": "6.0.0",
     "bullmq": "5.61.0",
     "chokidar": "4.0.3",

--- a/packages/server/utils/package.json
+++ b/packages/server/utils/package.json
@@ -21,7 +21,7 @@
     "@openrouter/ai-sdk-provider": "2.1.1",
     "ai": "^6.0.0",
     "async-mutex": "0.4.0",
-    "axios": "1.16.0",
+    "axios": "1.18.0",
     "axios-retry": "4.4.1",
     "check-disk-space": "3.4.0",
     "dayjs": "1.11.9",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -49,7 +49,7 @@
     "@xyflow/react": "12.3.5",
     "ai": "^6.0.0",
     "async-mutex": "0.4.0",
-    "axios": "1.16.0",
+    "axios": "1.18.0",
     "boring-avatars": "1.11.2",
     "canvas-confetti": "^1.9.4",
     "class-variance-authority": "0.7.1",


### PR DESCRIPTION
Consolidates the open Dependabot dependency bumps into a single PR:

- **axios** `1.16.0` → `1.18.0` — root (deps + resolutions), `packages/server/api`, `packages/server/utils`, `packages/web` (closes #14335, #14332, #14337, #14338)
- **exifreader** `4.39.0` → `4.40.1` — `packages/pieces/core/image-helper` (closes #14296)

`bun.lock` regenerated via `bun install`.

## Breaking change?

- [ ] Yes
- [x] No

Version bumps only; no API, schema, env var, or behaviour changes.