### PR TITLE
fix(pieces): reject custom piece install when name collides with an o…

### DIFF
--- a/packages/server/api/src/app/pieces/metadata/piece-metadata-service.ts
+++ b/packages/server/api/src/app/pieces/metadata/piece-metadata-service.ts
@@ -157,6 +157,15 @@ export const pieceMetadataService = (log: FastifyBaseLogger) => {
             return savedPiece
         },
 
+        async officialPieceExists({ name }: { name: string }): Promise<boolean> {
+            const existing = await pieceRepos().findOneBy({
+                name,
+                platformId: IsNull(),
+                pieceType: PieceType.OFFICIAL,
+            })
+            return !isNil(existing)
+        },
+
         async bulkDelete(pieces: { name: string, version: string }[]): Promise<void> {
             const results = await Promise.all(pieces.map((piece) =>
                 pieceRepos().delete({ name: piece.name, version: piece.version }),

--- a/packages/server/api/src/app/pieces/piece-install-service.ts
+++ b/packages/server/api/src/app/pieces/piece-install-service.ts
@@ -20,6 +20,15 @@ export const pieceInstallService = (log: FastifyBaseLogger) => ({
                 ...piecePackage,
                 platformId,
             }, log)
+            const conflictsWithOfficial = await pieceMetadataService(log).officialPieceExists({ name: pieceInformation.name })
+            if (conflictsWithOfficial) {
+                throw new ActivepiecesError({
+                    code: ErrorCode.VALIDATION,
+                    params: {
+                        message: `piece_name_conflicts_with_official name=${pieceInformation.name}`,
+                    },
+                })
+            }
             const archiveId = piecePackage.packageType === PackageType.ARCHIVE ? piecePackage.archiveId : undefined
             const savedPiece = await pieceMetadataService(log).create({
                 pieceMetadata: {

--- a/packages/server/api/test/integration/ee/pieces/piece-install.test.ts
+++ b/packages/server/api/test/integration/ee/pieces/piece-install.test.ts
@@ -12,6 +12,8 @@ import { MockInstance } from 'vitest'
 import { databaseConnection } from '../../../../src/app/database/database-connection'
 import { pieceMetadataService } from '../../../../src/app/pieces/metadata/piece-metadata-service'
 import { userInteractionWatcher } from '../../../../src/app/workers/user-interaction-watcher'
+import { db } from '../../../helpers/db'
+import { createMockPieceMetadata } from '../../../helpers/mocks'
 import { createTestContext } from '../../../helpers/test-context'
 import { setupTestEnvironment, teardownTestEnvironment } from '../../../helpers/test-setup'
 
@@ -99,5 +101,42 @@ describe('POST /v1/pieces — private piece installation (EE)', () => {
         expect(saved.pieceType).toBe(PieceType.CUSTOM)
         expect(saved.packageType).toBe(PackageType.ARCHIVE)
         expect(saved.archiveId).toBeDefined()
+    })
+
+    it('rejects a custom piece whose name matches an official piece with 409 and persists nothing', async () => {
+        const ctx = await createTestContext(app!)
+
+        await db.save('piece_metadata', createMockPieceMetadata({
+            name: PIECE_NAME,
+            version: PIECE_VERSION,
+            packageType: PackageType.REGISTRY,
+            pieceType: PieceType.OFFICIAL,
+            platformId: undefined,
+        }))
+
+        const formData = new FormData()
+        formData.append(
+            'pieceArchive',
+            new Blob([tgzBuffer], { type: 'application/gzip' }),
+            'private-piece-test.tgz',
+        )
+        formData.append('pieceName', PIECE_NAME)
+        formData.append('pieceVersion', PIECE_VERSION)
+        formData.append('packageType', PackageType.ARCHIVE)
+        formData.append('scope', PieceScope.PLATFORM)
+
+        const response = await ctx.inject({
+            method: 'POST',
+            url: '/api/v1/pieces',
+            body: formData,
+        })
+
+        expect(response.statusCode).toBe(StatusCodes.CONFLICT)
+
+        const customPieces = await databaseConnection().getRepository('piece_metadata').findBy({
+            name: PIECE_NAME,
+            pieceType: PieceType.CUSTOM,
+        })
+        expect(customPieces).toHaveLength(0)
     })
 })


### PR DESCRIPTION
…fficial piece

## Description

Reject installing a **custom piece whose name matches an official piece**, instead of silently accepting it into an unusable state.

### The bug

Uploading a custom piece (archive or registry) with the same name as a shipped official piece returned **HTTP 201 (success)**, but the piece then **never appeared** in the Pieces list and could resolve non-deterministically at runtime. Reported via Pylon 4188.

Reproduced end-to-end: built a custom archive of the JSON piece with the **same name and version** as the official one (`@activepieces/piece-json@0.1.9`) and installed it on an EE platform. Install succeeded, the piece was invisible in the UI, and the DB held two rows:

| version | platformId | pieceType | packageType |
|---|---|---|---|
| 0.1.9 | *(null)* | OFFICIAL | REGISTRY |
| 0.1.9 | `<platform>` | CUSTOM | ARCHIVE |

### Root cause

Custom and official pieces coexist because the unique key is `(name, version, platformId)` and official pieces have `platformId = NULL`. But:

- The list builder `lastVersionOfEachPiece` (`piece-cache-utils.ts`) dedups by **name only**, keeping an entry only if the next is a *strictly newer* version — so a same-name piece is silently dropped.
- The reads backing this (`fetchRegistryFromDB`, `find({ where: { id: In(...) } })`) have **no `ORDER BY`**, so *which* of the two wins is non-deterministic.

The collision is driven by piece **name**, not name+version — so it can't be avoided with a version convention, and it applies to customer-uploaded custom pieces on their own platform.

### The fix

Guard the install path (`piece-install-service.ts`): if an official piece already exists with the same name, reject with **409** (`piece_name_conflicts_with_official`) and persist nothing — instead of a misleading 201 + invisible, orphaned row.

- Added `pieceMetadataService.officialPieceExists({ name })`.
- The check is **name-based (any version)** by design: a same-name custom piece either hides behind the official one (lower version) or *silently overrides* its code (higher version) — neither is a resolvable state, so all are rejected. Intentional override of an official piece is a separate, deliberate feature and out of scope here.

**Behaviour note:** the same request that previously returned a (non-functional) 201 now returns 409. No working capability is lost — the old path produced an invisible, unusable piece.

## How was this tested?

- **Manual, EE self-hosted:** reproduced the original bug (201 + invisible piece, two DB rows), applied the fix, re-uploaded → **409**, nothing persisted. Verified in the UI.
- **Automated:** added an EE integration test in `piece-install.test.ts` — seeds an official piece, attempts a same-name custom install, asserts **409** and **zero** custom rows persisted. Existing install test still passes.
- The guard lives in the shared install service, so CE / EE / Cloud all take the same path.

Fixes: Pylon 4188 · Linear git-1644
fixes: #14319
### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

<!-- The 201→409 change only affects a path that never produced a usable piece; no self-hoster or API consumer had working behaviour to lose. -->

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)

<!-- Hardening-positive: prevents a platform-admin-uploaded custom piece from silently shadowing/overriding official piece code. No new risk introduced; endpoint remains platform-admin-only. -->
