### PR TITLE
fix(subflows): stop Call Flow dropdown resetting when subflow sample data changes

### DIFF
--- a/packages/pieces/core/subflows/package.json
+++ b/packages/pieces/core/subflows/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-subflows",
-  "version": "0.4.15",
+  "version": "0.5.0",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {

--- a/packages/pieces/core/subflows/src/lib/actions/call-flow.ts
+++ b/packages/pieces/core/subflows/src/lib/actions/call-flow.ts
@@ -8,18 +8,13 @@ import { httpClient, HttpMethod } from '@activepieces/pieces-common';
 import { ExecutionType, FAIL_PARENT_ON_FAILURE_HEADER, FlowStatus, isNil, PARENT_RUN_ID_HEADER } from '@activepieces/pieces-framework';
 import { CallableFlowRequest, CallableFlowResponse, findFlowByExternalIdOrThrow, listFlowsWithSubflowTrigger } from '../common';
 
-type FlowValue = {
-  externalId: string;
-  exampleData: unknown;
-};
-
 export const callFlow = createAction({
   audience: 'human',
   name: 'callFlow',
   displayName: 'Call Flow',
   description: 'Call a flow that has "Callable Flow" trigger',
   props: {
-    flow: Property.Dropdown<FlowValue>({
+    flowId: Property.Dropdown<string>({
       auth: PieceAuth.None(),
       displayName: 'Flow',
       description: 'The flow to execute. Published flows with a "Callable Flow" trigger appear here; disabled flows are marked "(inactive)" and cannot be executed until they are enabled.',
@@ -30,10 +25,7 @@ export const callFlow = createAction({
         });
         return {
           options: flows.map((flow) => ({
-            value: {
-              externalId: flow.externalId ?? flow.id,
-              exampleData: flow.version.trigger.settings.input.exampleData,
-            },
+            value: flow.externalId ?? flow.id,
             label:
               flow.status === FlowStatus.ENABLED
                 ? flow.version.displayName
@@ -67,19 +59,24 @@ export const callFlow = createAction({
       description: '',
       displayName: '',
       required: true,
-      refreshers: ['flow', 'mode'],
-      props: async (propsValue) => {
-        const castedFlowValue = propsValue['flow'] as unknown as FlowValue;
+      refreshers: ['flowId', 'mode'],
+      props: async (propsValue, context) => {
+        const externalId = propsValue['flowId'] as unknown as string;
         const mode = propsValue['mode'] as unknown as string;
         const fields: DynamicPropsValue = {};
 
+        if (!isNil(externalId)) {
+          const flow = await findFlowByExternalIdOrThrow({
+            flowsContext: context.flows,
+            externalId,
+          });
+          const exampleData = flow.version.trigger.settings.input.exampleData as unknown as { sampleData: object };
 
-        if (!isNil(castedFlowValue)) {
           if (mode === 'simple') {
             fields['payload'] = Property.Object({
               displayName: 'Payload',
               required: true,
-              defaultValue: (castedFlowValue.exampleData as unknown as { sampleData: object }).sampleData,
+              defaultValue: exampleData.sampleData,
             });
           }
           else{
@@ -88,7 +85,7 @@ export const callFlow = createAction({
               description:
                 'Provide the data to be passed to the flow',
               required: true,
-              defaultValue: (castedFlowValue.exampleData as unknown as { sampleData: object }).sampleData,
+              defaultValue: exampleData.sampleData,
             });
           }
         }
@@ -116,13 +113,13 @@ export const callFlow = createAction({
     const payload = context.propsValue.flowProps['payload'];
     const flow = await findFlowByExternalIdOrThrow({
       flowsContext: context.flows,
-      externalId: context.propsValue.flow?.externalId,
+      externalId: context.propsValue.flowId,
     });
 
     if (flow.status !== FlowStatus.ENABLED) {
       throw new Error(JSON.stringify({
         message: 'The selected subflow is disabled. Enable it before calling it from a parent flow.',
-        externalId: context.propsValue.flow?.externalId,
+        externalId: context.propsValue.flowId,
         flowName: flow.version.displayName,
       }));
     }


### PR DESCRIPTION
## Description

The Call Flow action's Flow dropdown fell back to "Select an option" any time the target subflow's Callable Flow trigger sample data was edited and republished, even though the flow still executed correctly.

Root cause: the dropdown's stored value bundled `exampleData` alongside `externalId`. `exampleData` changes whenever the subflow's Sample Data field is edited, while `externalId` stays the same. `searchable-select.tsx` matches the saved value against fresh options via a full `deepEqual(option.value, value)`, so the mismatch dropped the match and the UI fell back to the placeholder.

Fix: the dropdown value is now just the flow's `externalId` (prop renamed `flow` → `flowId`). `flowProps` resolves `exampleData` separately via the existing `findFlowByExternalIdOrThrow` helper instead of carrying it in the dropdown's identity value.

`@activepieces/piece-subflows` bumped `0.4.15` → `0.5.0` for the prop shape/name change (piece-level, not a platform/API breaking change).

## How was this tested?

Traced the fix against the reported repro (change subflow sample data → reselect not required, dropdown stays matched) and verified `run()` still only reads `externalId`, so already-configured steps keep executing without needing manual re-selection.

Fixes #14348

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact