### PR TITLE
feat(pieces-framework): opt-in streaming file inputs (ApStreamingFile)

### DIFF
--- a/.agents/contexts/data-storage/CONTEXT.md
+++ b/.agents/contexts/data-storage/CONTEXT.md
@@ -27,6 +27,10 @@ _Avoid_: table trigger
 A stored blob (S3 or DB) with type classification, optional compression, and expiry.
 _Avoid_: attachment, blob
 
+**ApStreamingFile**:
+The resolved value of a `Property.File({ streaming: true })` input — `{ filename, extension?, size?, body: Readable }`. A one-shot lazy file the engine exposes without buffering, so a piece can upload a large file to an external service. Contrast **ApFile**, the buffered (`Buffer` + `base64`) value of a plain `Property.File()`.
+_Avoid_: file stream, streamed file
+
 **Store Entry**:
 A key-value pair scoped to a project, used by pieces to persist state across flow runs.
 _Avoid_: kv store, project store

--- a/.agents/features/file-storage.md
+++ b/.agents/features/file-storage.md
@@ -122,8 +122,16 @@ Scheduled every hour (`30 */1 * * *`) via `SystemJobName.FILE_CLEANUP_TRIGGER`. 
 - **New dependency:** `@aws-sdk/lib-storage`.
 
 ### Deferred (not built)
-- **Property.file streaming (read side)** — a piece supplies its own `Readable`; a dedicated streaming file-input mode was judged YAGNI.
 - **Presigned multipart** (bytes off the app on `S3_USE_SIGNED_URLS`) — rejected as over-engineering; see ADR-0007.
+
+## Streaming — input path (implemented)
+
+`Property.File({ streaming: true })` resolves to `ApStreamingFile` instead of `ApFile`, so a piece can upload a large file to an external service without the engine buffering it in the sandbox first. See [ADR-0009](../../docs/adr/0009-streaming-file-inputs-resolve-to-a-lazy-apstreamingfile.md).
+
+- **Piece API:** `Property.File({ streaming: true })` → `ApStreamingFile = { filename, extension?, size?, body: Readable }` (`@activepieces/pieces-framework` ≥ 0.35.0). Plain `Property.File()` is unchanged (`ApFile`, buffered). Reuses `PropertyType.FILE` → **zero frontend change**.
+- **Resolution:** the engine's `fileProcessor` (`packages/server/engine/src/lib/variables/processors/file.ts`) branches on the `streaming` flag — a URL `fetch` exposes the undrained body as a `Readable` (`Readable.fromWeb`) with `size` from `Content-Length`; a base64 data URL decodes to a one-shot `Readable`. This replaces the unbounded `arrayBuffer()` buffer on the URL path. The `catch → null` contract is kept (a fetch failure fails required-prop validation as before).
+- **Consumers:** the Amazon S3 **Upload File** action — `putObject({ Body: file.body, ContentLength: file.size })` for a known size (single streamed PUT, no `@aws-sdk/lib-storage`), buffering only when `size` is absent (== pre-streaming behaviour). This is the reference pattern for Dropbox / Google Drive / any large-file upload piece.
+- **One-shot body:** no whole-stream retry; `size` is best-effort.
 
 ### Webhook streaming ingestion (implemented)
 Reuses `s3Helper.uploadStream` + `fileService.save({ data: Readable })` to stream inbound webhook files (multipart + raw-binary) to S3 without buffering. `@fastify/multipart`'s global `attachFieldsToBody` is gone, so every multipart consumer opts in explicitly — the webhook streams via `request.parts()`, `users` buffers via `request.file()`, and the routes whose schemas expect `ApMultipartFile` (piece install CE + EE, platform logos, knowledge-base upload) attach the per-route `attachMultipartFieldsToBody` hook. `rawBody` capture moved into a scoped `preParsing` hook (streamed types forgo `rawBody`). See the Webhooks feature doc for the full decision list and [ADR-0008](../../docs/adr/0008-webhook-files-stream-via-explicit-multipart-consumption.md).

--- a/docs/adr/0009-streaming-file-inputs-resolve-to-a-lazy-apstreamingfile.md
+++ b/docs/adr/0009-streaming-file-inputs-resolve-to-a-lazy-apstreamingfile.md
@@ -1,0 +1,24 @@
+---
+status: accepted
+---
+
+# Streaming file inputs resolve to a lazy ApStreamingFile
+
+A piece that uploads a large file to an external service (Amazon S3, Dropbox, Google Drive, …) declared its input as `Property.File()` and received an `ApFile` — which the engine's `fileProcessor` produced by buffering the **entire** file into a `Buffer` (via `arrayBuffer()` for URL inputs, unbounded) before `run()` was even called. The upload then streamed from that in-memory buffer, so the peak-RAM win of streaming was already lost upstream.
+
+**Decision.** Add an opt-in streaming file **input**: `Property.File({ streaming: true })` resolves to `ApStreamingFile = { filename, extension?, size?, body: Readable }` instead of `ApFile`. The engine's `fileProcessor` branches on the property's `streaming` flag: for a URL it `fetch`es and exposes the **undrained** response body as a Node `Readable` (`Readable.fromWeb`), deriving `size` from the `Content-Length` header; for a base64 data URL it decodes to a one-shot `Readable` with an exact `size`. It reuses the same `PropertyType.FILE`, so the frontend file picker is unchanged. This resolves the "Property.file streaming (read side)" item that [ADR-0007](0007-streaming-files-use-presigned-multipart-not-app-relay.md) deferred as YAGNI, now that concrete large-file upload pieces need it.
+
+## Considered options
+
+- **`ApStreamingFile` as a plain type, not a class (chosen).** Unlike `ApFile` (which carries a `base64` getter over its `Buffer`), a streaming file is a one-shot data carrier — the `body` can be read exactly once and has no replayable representation, so there is nothing for methods to wrap.
+- **`putObject({ Body, ContentLength })`, not `@aws-sdk/lib-storage` (chosen for the S3 consumer).** The write-side (ADR-0007) needed `lib-storage` because `ctx.files.write` streams *unknown*-length bodies. The upload-*to-external* side is the opposite: the source (URL `Content-Length` / base64 length) almost always reports a size, so a single streamed PUT works with **no new dependency** and byte-identical IAM (`s3:PutObject`) and ETag semantics. Sources with no size fall back to buffering — exactly the pre-streaming behaviour — so no upload that worked before breaks.
+- **A streaming flag on `Property.File` vs. a separate `Property.StreamingFile` builder.** Chose the flag: the wire contract (`PropertyType.FILE`) and the frontend renderer are identical either way, and the flag keeps the two file shapes discoverable under one name. Typed via overloads with the house `R extends true ? …` conditional-return pattern so `required` still narrows through `createAction`.
+
+## Consequences
+
+- The unconditional win is deleting the **unbounded** `arrayBuffer()` buffer on the URL input path. The additional peak-RAM win over the buffered path is marginal at the `AP_MAX_FILE_SIZE_MB` default (25 MB) and only material once that cap is raised or the source is an uncapped external URL.
+- `size` is best-effort: absent/invalid `Content-Length` → `undefined` → the consumer buffers (backward-compatible fallback). It is **also** dropped to `undefined` when the response carries a `Content-Encoding` (gzip/br/deflate): undici transparently decompresses the body but leaves the *compressed* `Content-Length` in place, so trusting it would understate the streamed byte count and silently truncate the destination object.
+- There is **no `AP_MAX_FILE_SIZE_MB` ceiling** on the streamed URL input. This is intentional — the feature exists to move large files, and the prior buffered path (`arrayBuffer()`) was likewise unbounded. Enforcing a cap is deferred (YAGNI); it would require a counting pass-through stream that aborts past the limit.
+- The `body` is **one-shot** — no whole-stream retry. Because it is a non-replayable `Readable`, the AWS SDK cannot replay it, so **any** failure once the PUT has started is non-retryable — not only mid-stream failures but also normally-retryable early ones (connection reset, throttling, HTTP 500). Whole-stream retry would require buffering the body, which defeats streaming.
+- The URL `fetch` opens the source connection at **input-resolution time** (before `run()`), like the buffered path.
+- SSRF posture is unchanged from the existing buffered `handleUrlFile`: the same raw `fetch` that also legitimately retrieves AP's own http internal `readUrl`s, so the https-only + `redirect:'error'` guard used by external-only piece code (e.g. SimplyPrint) is deliberately **not** applied here.

--- a/packages/pieces/community/amazon-s3/package.json
+++ b/packages/pieces/community/amazon-s3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-amazon-s3",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "dependencies": {

--- a/packages/pieces/community/amazon-s3/src/lib/actions/upload-file.ts
+++ b/packages/pieces/community/amazon-s3/src/lib/actions/upload-file.ts
@@ -1,3 +1,4 @@
+import { buffer as readableToBuffer } from 'node:stream/consumers';
 import { Property, createAction } from '@activepieces/pieces-framework';
 import { amazonS3CombinedAuth, S3AuthProps } from '../auth';
 import { resolveS3Client } from '../common';
@@ -19,6 +20,7 @@ export const amazons3UploadFile = createAction({
       displayName: 'File',
       description: 'The file to upload to S3.',
       required: true,
+      streaming: true,
     }),
     fileName: Property.ShortText({
       displayName: 'File Name (Optional)',
@@ -96,12 +98,19 @@ export const amazons3UploadFile = createAction({
 
     const finalFileName = fileName ? (fileName.endsWith(extension) ? fileName : fileName + extension) : generatedName;
 
+    // A known size lets putObject stream the body straight through (single PUT,
+    // UNSIGNED-PAYLOAD) without buffering it in the sandbox. Sources that don't
+    // report a size fall back to buffering — same behaviour as before streaming.
+    const body = file.size != null
+      ? { Body: file.body, ContentLength: file.size }
+      : { Body: await readableToBuffer(file.body) };
+
     const uploadResponse = await s3.putObject({
       Bucket: bucket,
       Key: finalFileName,
       ACL: acl as ObjectCannedACL | undefined,
       ContentType: contentType,
-      Body: file.data,
+      ...body,
     });
 
     return {

--- a/packages/pieces/framework/package.json
+++ b/packages/pieces/framework/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/pieces-framework",
-  "version": "0.34.0",
+  "version": "0.35.0",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/packages/pieces/framework/src/lib/property/index.ts
+++ b/packages/pieces/framework/src/lib/property/index.ts
@@ -6,6 +6,7 @@ import { DropdownState } from './input/dropdown/common';
 
 // EXPORTED
 export { ApFile } from './input/file-property';
+export type { ApStreamingFile } from './input/file-property';
 export { DropdownProperty, MultiSelectDropdownProperty } from './input/dropdown/dropdown-prop';
 export { DynamicProperties, DynamicProp } from './input/dynamic-prop';
 export { PropertyType } from './input/property-type';

--- a/packages/pieces/framework/src/lib/property/input/file-property.ts
+++ b/packages/pieces/framework/src/lib/property/input/file-property.ts
@@ -1,3 +1,4 @@
+import type { Readable } from "node:stream";
 import * as z from "zod/mini";
 import { BasePropertySchema, TPropertyValue } from "./common";
 import { PropertyType } from "./property-type";
@@ -16,8 +17,17 @@ export class ApFile {
 
 export const FileProperty = z.object({
     ...BasePropertySchema.shape,
+    streaming: z.optional(z.boolean()),
     ...TPropertyValue(z.unknown(), PropertyType.FILE).shape,
 })
 
-export type FileProperty<R extends boolean> = BasePropertySchema &
-    TPropertyValue<ApFile, PropertyType.FILE, R>;
+export type ApStreamingFile = {
+    filename: string;
+    extension?: string;
+    size?: number;
+    body: Readable;
+};
+
+export type FileProperty<R extends boolean, S extends boolean = false> = BasePropertySchema & {
+    streaming?: S;
+} & TPropertyValue<S extends true ? ApStreamingFile : ApFile, PropertyType.FILE, R>;

--- a/packages/pieces/framework/src/lib/property/input/index.ts
+++ b/packages/pieces/framework/src/lib/property/input/index.ts
@@ -58,7 +58,7 @@ export type InputProperty =
   | StaticMultiSelectDropdownProperty<any, boolean>
   | DynamicProperties<boolean, PieceAuthProperty | PieceAuthProperty[] | undefined>
   | DateTimeProperty<boolean>
-  | FileProperty<boolean>
+  | FileProperty<boolean, boolean>
   | CustomProperty<boolean>
   | ColorProperty<boolean>;
 
@@ -228,14 +228,14 @@ export const Property = {
       ? DateTimeProperty<true>
       : DateTimeProperty<false>;
   },
-  File<R extends boolean>(
-    request: Properties<FileProperty<R>>
-  ): R extends true ? FileProperty<true> : FileProperty<false> {
+  File<R extends boolean, S extends boolean = false>(
+    request: Properties<FileProperty<R, S>>
+  ): FileProperty<R extends true ? true : false, S extends true ? true : false> {
     return {
       ...request,
       valueSchema: undefined,
       type: PropertyType.FILE,
-    } as unknown as R extends true ? FileProperty<true> : FileProperty<false>;
+    } as unknown as FileProperty<R extends true ? true : false, S extends true ? true : false>;
   },
   Custom<R extends boolean>(
     request: Omit<Properties<CustomProperty<R>>, 'code'> & {

--- a/packages/server/engine/src/lib/variables/processors/file.ts
+++ b/packages/server/engine/src/lib/variables/processors/file.ts
@@ -76,6 +76,7 @@ async function handleStreamingFile(propertyValue: string): Promise<ApStreamingFi
 
     const fileResponse = await fetch(propertyValue)
     if (!fileResponse.ok || isNil(fileResponse.body)) {
+        await fileResponse.body?.cancel()
         return null
     }
     const filename = getFileName(propertyValue, fileResponse.headers.get('content-disposition'), fileResponse.headers.get('content-type') ?? undefined) ?? 'unknown'

--- a/packages/server/engine/src/lib/variables/processors/file.ts
+++ b/packages/server/engine/src/lib/variables/processors/file.ts
@@ -1,12 +1,17 @@
+import { Readable } from 'node:stream'
 import { isBase64, isNil, isString } from '@activepieces/core-utils'
-import { ApFile } from '@activepieces/pieces-framework'
+import { ApFile, ApStreamingFile, PropertyType } from '@activepieces/pieces-framework'
 import { ProcessorFn } from './types'
 
-export const fileProcessor: ProcessorFn = async (_property, urlOrBase64) => {
+export const fileProcessor: ProcessorFn = async (property, urlOrBase64) => {
     if (isNil(urlOrBase64) || !isString(urlOrBase64)) {
         return null
     }
+    const streaming = property.type === PropertyType.FILE && property.streaming === true
     try {
+        if (streaming) {
+            return await handleStreamingFile(urlOrBase64)
+        }
         const file = handleBase64File(urlOrBase64)
         if (!isNil(file)) {
             return file
@@ -19,7 +24,7 @@ export const fileProcessor: ProcessorFn = async (_property, urlOrBase64) => {
     }
 }
 
-function handleBase64File(propertyValue: string): ApFile | null {
+function parseBase64File(propertyValue: string): { extension: string, buffer: Buffer } | null {
     if (!isBase64(propertyValue, { allowMime: true })) {
         return null
     }
@@ -27,12 +32,21 @@ function handleBase64File(propertyValue: string): ApFile | null {
     if (!matches || matches?.length !== 3) {
         return null
     }
-    const base64 = matches[2]
-    const extension = mimeExtension(matches[1]) || 'bin'
+    return {
+        extension: mimeExtension(matches[1]) || 'bin',
+        buffer: Buffer.from(matches[2], 'base64'),
+    }
+}
+
+function handleBase64File(propertyValue: string): ApFile | null {
+    const parsed = parseBase64File(propertyValue)
+    if (isNil(parsed)) {
+        return null
+    }
     return new ApFile(
-        `unknown.${extension}`,
-        Buffer.from(base64, 'base64'),
-        extension,
+        `unknown.${parsed.extension}`,
+        parsed.buffer,
+        parsed.extension,
     )
 }
 
@@ -40,7 +54,7 @@ async function handleUrlFile(path: string): Promise<ApFile | null> {
     const fileResponse = await fetch(path)
 
     const filename = getFileName(path, fileResponse.headers.get('content-disposition'), fileResponse.headers.get('content-type') ?? undefined) ?? 'unknown'
-    const extension = filename.split('.').length > 1 ? filename.split('.').pop() : undefined
+    const extension = extensionFromFilename(filename)
 
     return new ApFile(
         filename,
@@ -49,6 +63,46 @@ async function handleUrlFile(path: string): Promise<ApFile | null> {
     )
 }
 
+async function handleStreamingFile(propertyValue: string): Promise<ApStreamingFile | null> {
+    const parsed = parseBase64File(propertyValue)
+    if (!isNil(parsed)) {
+        return {
+            filename: `unknown.${parsed.extension}`,
+            extension: parsed.extension,
+            size: parsed.buffer.length,
+            body: Readable.from(parsed.buffer),
+        }
+    }
+
+    const fileResponse = await fetch(propertyValue)
+    if (!fileResponse.ok || isNil(fileResponse.body)) {
+        return null
+    }
+    const filename = getFileName(propertyValue, fileResponse.headers.get('content-disposition'), fileResponse.headers.get('content-type') ?? undefined) ?? 'unknown'
+    const extension = extensionFromFilename(filename)
+    const contentEncoding = fileResponse.headers.get('content-encoding')
+    const contentLength = Number(fileResponse.headers.get('content-length'))
+    // undici transparently decompresses gzip/br/deflate but leaves the compressed
+    // Content-Length in place, so it would understate the streamed byte count and
+    // truncate the destination. Only trust the size when the body is not encoded.
+    const sizeIsTrustworthy = (isNil(contentEncoding) || contentEncoding.toLowerCase() === 'identity')
+        && Number.isInteger(contentLength) && contentLength > 0
+
+    return {
+        filename,
+        extension,
+        size: sizeIsTrustworthy ? contentLength : undefined,
+        // @ts-expect-error -- undici streams a Node web ReadableStream body; the DOM fetch types omit the fromWeb overload
+        body: Readable.fromWeb(fileResponse.body),
+    }
+}
+
+
+function extensionFromFilename(filename: string): string | undefined {
+    const parts = filename.split('.')
+    const last = parts.length > 1 ? parts.pop() : undefined
+    return last ? last : undefined
+}
 
 function getFileName(path: string, disposition: string | null, mimeType: string | undefined): string | null {
     const url = new URL(path)

--- a/packages/server/engine/src/lib/variables/props-processor.ts
+++ b/packages/server/engine/src/lib/variables/props-processor.ts
@@ -1,3 +1,4 @@
+import { Readable } from 'node:stream'
 import { isNil, isObject } from '@activepieces/core-utils'
 import { getAuthPropertyForValue, InputPropertyMap, PieceAuthProperty, PieceProperty, PiecePropertyMap, PropertyType, StaticPropsValue } from '@activepieces/pieces-framework'
 import { AppConnectionValue, AUTHENTICATION_PROPERTY_NAME, PropertySettings } from '@activepieces/shared'
@@ -108,8 +109,28 @@ export const propsProcessor = {
             }
         }
 
+        // Streaming file inputs open a live connection when resolved. If any property
+        // fails validation the action never runs, so drain those bodies here to avoid
+        // leaking connections until GC.
+        if (Object.keys(errors).length > 0) {
+            destroyOpenStreams(processedInput)
+        }
+
         return { processedInput, errors }
     },
+}
+
+function destroyOpenStreams(value: unknown): void {
+    if (isNil(value) || typeof value !== 'object' || Buffer.isBuffer(value)) {
+        return
+    }
+    if (value instanceof Readable) {
+        value.destroy()
+        return
+    }
+    for (const child of Object.values(value)) {
+        destroyOpenStreams(child)
+    }
 }
 
 const validateProperty = (property: PieceProperty, value: unknown, originalValue: unknown): string[] => {

--- a/packages/server/engine/test/variables/file-processor.test.ts
+++ b/packages/server/engine/test/variables/file-processor.test.ts
@@ -1,0 +1,111 @@
+import { buffer as readableToBuffer } from 'node:stream/consumers'
+import { ApFile, ApStreamingFile, PieceAuth, Property } from '@activepieces/pieces-framework'
+import { propsProcessor } from '../../src/lib/variables/props-processor'
+
+const HELLO_TXT_DATA_URL = 'data:text/plain;base64,aGVsbG8='
+const FILE_URL = 'https://example.com/report.csv'
+
+async function resolveStreamingFile(input: unknown, required = true): Promise<{ processedInput: Record<string, unknown>, errors: Record<string, unknown> }> {
+    const props = {
+        file: Property.File({ displayName: 'File', required, streaming: true }),
+    }
+    return propsProcessor.applyProcessorsAndValidators(
+        { file: input },
+        props,
+        PieceAuth.None(),
+        false,
+        {},
+    )
+}
+
+describe('File Processor', () => {
+    afterEach(() => {
+        vi.unstubAllGlobals()
+    })
+
+    it('resolves a streaming URL input to a lazy body, deriving size and name from headers', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('hello world', {
+            headers: { 'content-type': 'text/csv', 'content-length': '11' },
+        })))
+
+        const { processedInput, errors } = await resolveStreamingFile(FILE_URL)
+
+        expect(errors).toEqual({})
+        const file: ApStreamingFile = processedInput.file
+        expect(file.filename).toBe('report.csv')
+        expect(file.extension).toBe('csv')
+        expect(file.size).toBe(11)
+        expect((await readableToBuffer(file.body)).toString()).toBe('hello world')
+    })
+
+    it('drops the size when the body is compressed so the consumer falls back to buffering', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('hello', {
+            headers: { 'content-type': 'text/csv', 'content-length': '5', 'content-encoding': 'gzip' },
+        })))
+
+        const { processedInput } = await resolveStreamingFile(FILE_URL)
+
+        const file: ApStreamingFile = processedInput.file
+        expect(file.size).toBeUndefined()
+    })
+
+    it('resolves a trailing-dot filename to an undefined extension', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('data', {
+            headers: { 'content-disposition': 'attachment; filename="archive."', 'content-length': '4' },
+        })))
+
+        const { processedInput } = await resolveStreamingFile(FILE_URL)
+
+        const file: ApStreamingFile = processedInput.file
+        expect(file.filename).toBe('archive.')
+        expect(file.extension).toBeUndefined()
+    })
+
+    it('resolves to null when the URL responds with a non-ok status', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(null, { status: 404 })))
+
+        const { processedInput } = await resolveStreamingFile(FILE_URL, false)
+
+        expect(processedInput.file).toBeNull()
+    })
+
+    it('resolves a streaming file property to a lazy body without buffering', async () => {
+        const props = {
+            file: Property.File({ displayName: 'File', required: true, streaming: true }),
+        }
+
+        const { processedInput, errors } = await propsProcessor.applyProcessorsAndValidators(
+            { file: HELLO_TXT_DATA_URL },
+            props,
+            PieceAuth.None(),
+            false,
+            {},
+        )
+
+        expect(errors).toEqual({})
+        const file: ApStreamingFile = processedInput.file
+        expect(file.filename).toBe('unknown.txt')
+        expect(file.extension).toBe('txt')
+        expect(file.size).toBe(5)
+        expect((await readableToBuffer(file.body)).toString()).toBe('hello')
+    })
+
+    it('still resolves a plain file property to a buffered ApFile', async () => {
+        const props = {
+            file: Property.File({ displayName: 'File', required: true }),
+        }
+
+        const { processedInput, errors } = await propsProcessor.applyProcessorsAndValidators(
+            { file: HELLO_TXT_DATA_URL },
+            props,
+            PieceAuth.None(),
+            false,
+            {},
+        )
+
+        expect(errors).toEqual({})
+        const file: ApFile = processedInput.file
+        expect(file).toBeInstanceOf(ApFile)
+        expect(file.data.toString()).toBe('hello')
+    })
+})

--- a/packages/server/engine/test/variables/file-processor.test.ts
+++ b/packages/server/engine/test/variables/file-processor.test.ts
@@ -69,6 +69,40 @@ describe('File Processor', () => {
         expect(processedInput.file).toBeNull()
     })
 
+    it('cancels the response body when the URL responds with a non-ok status', async () => {
+        const response = new Response('error page', { status: 404 })
+        const cancelSpy = vi.spyOn(response.body!, 'cancel')
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(response))
+
+        const { processedInput } = await resolveStreamingFile(FILE_URL, false)
+
+        expect(processedInput.file).toBeNull()
+        expect(cancelSpy).toHaveBeenCalled()
+    })
+
+    it('destroys an opened streaming body when a sibling property fails validation', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('hello world', {
+            headers: { 'content-type': 'text/csv', 'content-length': '11' },
+        })))
+
+        const props = {
+            file: Property.File({ displayName: 'File', required: true, streaming: true }),
+            count: Property.Number({ displayName: 'Count', required: true }),
+        }
+
+        const { processedInput, errors } = await propsProcessor.applyProcessorsAndValidators(
+            { file: FILE_URL, count: 'not-a-number' },
+            props,
+            PieceAuth.None(),
+            false,
+            {},
+        )
+
+        expect(Object.keys(errors)).toContain('count')
+        const file: ApStreamingFile = processedInput.file
+        expect(file.body.destroyed).toBe(true)
+    })
+
     it('resolves a streaming file property to a lazy body without buffering', async () => {
         const props = {
             file: Property.File({ displayName: 'File', required: true, streaming: true }),


### PR DESCRIPTION
## Description

Adds an **opt-in streaming file input** so pieces that upload large files to external services can stream them instead of buffering the whole file into memory in the sandbox.

- `Property.File({ streaming: true })` resolves to a lazy `ApStreamingFile = { filename, extension?, size?, body: Readable }` instead of `ApFile`. Same `PropertyType.FILE` on the wire, so the frontend file picker is unchanged. Typed via the house `R extends true ? …` conditional-return pattern (`S extends boolean = false`), so existing `Property.File()` callers keep getting `ApFile` untouched.
- The engine's `fileProcessor` branches on the flag:
  - **URL input** → `fetch` and expose the undrained response body as a Node `Readable` (`Readable.fromWeb`); `size` from `Content-Length`, **dropped to `undefined` when a `Content-Encoding` is present** (undici transparently decompresses but leaves the compressed length, which would truncate the destination).
  - **base64 data URL** → decode to a one-shot `Readable` with an exact `size`.
- **amazon-s3 `upload-file`** is the first consumer: `putObject({ Body, ContentLength })` streams straight through when the source reports a size (single PUT, no new dependency, byte-identical IAM/ETag), and falls back to buffering — the exact pre-streaming behaviour — when it doesn't.

This resolves the "Property.file streaming (read side)" item deferred as YAGNI in ADR-0007. Full rationale, trade-offs, and consequences in [`docs/adr/0009`](docs/adr/0009-streaming-file-inputs-resolve-to-a-lazy-apstreamingfile.md).

Version bumps: `@activepieces/pieces-framework` 0.34.0 → 0.35.0 (new export), `@activepieces/piece-amazon-s3` 0.6.3 → 0.6.4.

## How was this tested?

- New unit test: `packages/server/engine/test/variables/file-processor.test.ts` covering the base64 and URL streaming paths and the `Content-Encoding` size-drop behaviour.
- `npm run test-unit`, `npm run lint-dev`.

Fixes # (issue)

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

The framework type signature gains a second, defaulted type param (`FileProperty<R, S = false>`); existing `Property.File()` callers are unaffected and continue to receive `ApFile`. Streaming is strictly opt-in.

### Security impact?  (required — CI fails if this is left unedited)

- [ ] no — reviewed, no security impact
- [x] yes — security-sensitive (call out the risk and mitigation in the description above)

Touches file handling and outbound HTTP. **SSRF posture is unchanged** from the existing buffered `handleUrlFile`: the streaming URL path uses the same raw `fetch` (which also legitimately retrieves AP's own internal `readUrl`s), so no new SSRF surface is introduced. Note also that the streamed body is one-shot and non-replayable, so a PUT that fails after starting is not retryable — documented in ADR-0009.

🤖 Generated with [Claude Code](https://claude.com/claude-code)