### PR TITLE
chore: verify draft PR reviewer auto-assignment

### DIFF
--- a/DRAFT_PR_ASSIGN_TEST.md
+++ b/DRAFT_PR_ASSIGN_TEST.md
@@ -1,0 +1,6 @@
+# Draft PR assignment test
+
+Throwaway file to verify that opening a **draft** PR does not auto-assign a
+reviewer via CODEOWNERS round-robin until "Ready for review" is clicked.
+
+Safe to delete — close this PR and delete the branch after the check.


### PR DESCRIPTION
Throwaway draft PR to verify CODEOWNERS round-robin does NOT auto-assign a reviewer while the PR is a draft. Will close + delete branch after the check. [skip ci]