### PR TITLE
feat(intercom): add company/data-event actions and  ticket/unsubscrip…

### DIFF
--- a/packages/pieces/community/intercom/package.json
+++ b/packages/pieces/community/intercom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-intercom",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "dependencies": {

--- a/packages/pieces/community/intercom/src/index.ts
+++ b/packages/pieces/community/intercom/src/index.ts
@@ -1,13 +1,5 @@
-import {
-	AuthenticationType,
-	createCustomApiCallAction,
-	httpClient,
-	HttpMethod,
-} from '@activepieces/pieces-common';
-import {
-	PieceAuth,
-	createPiece,
-} from '@activepieces/pieces-framework';
+import { createCustomApiCallAction } from '@activepieces/pieces-common';
+import { createPiece } from '@activepieces/pieces-framework';
 import { PieceCategory } from '@activepieces/pieces-framework';
 import { getIntercomRegion, getIntercomToken, IntercomAuthValue } from './lib/common';
 import { sendMessageAction } from './lib/actions/send-message.action';
@@ -53,6 +45,12 @@ import { tagAddedToUserTrigger } from './lib/triggers/tag-added-to-user';
 import { contactUpdatedTrigger } from './lib/triggers/contact-updated';
 import { intercomAuth } from './lib/auth';
 import { assignConversationAction } from './lib/actions/assign-conversation-to-admin';
+import { createOrUpdateCompanyAction } from './lib/actions/create-update-company';
+import { createDataEventAction } from './lib/actions/create-data-event';
+import { findOrCreateCompanyAction } from './lib/actions/find-or-create-company';
+import { findOrCreateLeadAction } from './lib/actions/find-or-create-lead';
+import { updatedTicketTrigger } from './lib/triggers/updated-ticket';
+import { newUnsubscriptionTrigger } from './lib/triggers/new-unsubscription';
 
 export const intercom = createPiece({
 	displayName: 'Intercom',
@@ -79,8 +77,10 @@ export const intercom = createPiece({
 		assignConversationAction,
 		createArticleAction,
 		createConversationAction,
+		createDataEventAction,
 		createTicketAction,
 		createUserAction,
+		createOrUpdateCompanyAction,
 		createOrUpdateLeadAction,
 		createOrUpdateUserAction,
 		replyToConversation,
@@ -89,6 +89,8 @@ export const intercom = createPiece({
 		findCompanyAction,
 		findConversationAction,
 		findLeadAction,
+		findOrCreateCompanyAction,
+		findOrCreateLeadAction,
 		findUserAction,
 		listAllTagsAction,
 		getConversationAction,
@@ -114,7 +116,9 @@ export const intercom = createPiece({
 		conversationRated,
 		newLeadTrigger,
 		newTicketTrigger,
+		newUnsubscriptionTrigger,
 		newUserTrigger,
+		updatedTicketTrigger,
 		conversationPartTagged,
 		tagAddedToLeadTrigger,
 		tagAddedToUserTrigger,

--- a/packages/pieces/community/intercom/src/lib/actions/create-data-event.ts
+++ b/packages/pieces/community/intercom/src/lib/actions/create-data-event.ts
@@ -1,0 +1,74 @@
+import { intercomAuth } from '../auth';
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { intercomClient } from '../common';
+import dayjs from 'dayjs';
+
+export const createDataEventAction = createAction({
+	auth: intercomAuth,
+	name: 'create-data-event',
+	displayName: 'Create Data Event',
+	description: 'Submits a data event for a contact.',
+	audience: 'both',
+	aiMetadata: {
+		description:
+			'Submit a data (tracking) event against a contact, identified by their Intercom ID, external User ID, or email. Records something the contact did (an event name) with an optional metadata payload of string values. Each call logs a new event, so it is not idempotent.',
+		idempotent: false,
+	},
+	props: {
+		identifierType: Property.StaticDropdown({
+			displayName: 'Identify Contact By',
+			required: true,
+			defaultValue: 'email',
+			options: {
+				disabled: false,
+				options: [
+					{ label: 'Email', value: 'email' },
+					{ label: 'Intercom Contact ID', value: 'id' },
+					{ label: 'User ID', value: 'user_id' },
+				],
+			},
+		}),
+		identifierValue: Property.ShortText({
+			displayName: 'Identifier Value',
+			required: true,
+		}),
+		eventName: Property.ShortText({
+			displayName: 'Event Name',
+			description: 'The name of the event that occurred.',
+			required: true,
+		}),
+		createdAt: Property.DateTime({
+			displayName: 'Created At',
+			description: 'When the event happened. Defaults to now if left empty.',
+			required: false,
+		}),
+		metadata: Property.Object({
+			displayName: 'Metadata',
+			description: 'Optional key/value pairs describing the event.',
+			required: false,
+		}),
+	},
+	async run(context) {
+		const { identifierType, identifierValue, eventName, createdAt, metadata } =
+			context.propsValue;
+
+		const client = intercomClient(context.auth);
+
+		const createdAtUnix = createdAt ? dayjs(createdAt).unix() : dayjs().unix();
+		const stringMetadata = metadata
+			? Object.fromEntries(
+					Object.entries(metadata).map(([key, value]) => [key, String(value)]),
+			  )
+			: undefined;
+
+		await client.events.create(
+			identifierType === 'id'
+				? { id: identifierValue, event_name: eventName, created_at: createdAtUnix, metadata: stringMetadata }
+				: identifierType === 'user_id'
+				? { user_id: identifierValue, event_name: eventName, created_at: createdAtUnix, metadata: stringMetadata }
+				: { email: identifierValue, event_name: eventName, created_at: createdAtUnix, metadata: stringMetadata },
+		);
+
+		return { success: true };
+	},
+});

--- a/packages/pieces/community/intercom/src/lib/actions/create-update-company.ts
+++ b/packages/pieces/community/intercom/src/lib/actions/create-update-company.ts
@@ -1,0 +1,88 @@
+import { intercomAuth } from '../auth';
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { intercomClient } from '../common';
+import dayjs from 'dayjs';
+
+export const createOrUpdateCompanyAction = createAction({
+	auth: intercomAuth,
+	name: 'create-or-update-company',
+	displayName: 'Create or Update Company',
+	description: 'Creates a new company or updates an existing one (matched by Company ID).',
+	audience: 'both',
+	aiMetadata: {
+		description:
+			'Upsert a company: Intercom matches on the Company ID you provide and updates that company if it exists, otherwise creates a new one. Company ID cannot be changed after creation. Repeating with the same Company ID and fields converges on the same record, so it is effectively idempotent.',
+		idempotent: true,
+	},
+	props: {
+		companyId: Property.ShortText({
+			displayName: 'Company ID',
+			description: 'The company ID you have defined for the company. Cannot be updated later.',
+			required: false,
+		}),
+		name: Property.ShortText({
+			displayName: 'Name',
+			required: false,
+		}),
+		plan: Property.ShortText({
+			displayName: 'Plan',
+			required: false,
+		}),
+		size: Property.Number({
+			displayName: 'Size',
+			description: 'The number of employees in this company.',
+			required: false,
+		}),
+		website: Property.ShortText({
+			displayName: 'Website',
+			required: false,
+		}),
+		industry: Property.ShortText({
+			displayName: 'Industry',
+			required: false,
+		}),
+		monthlySpend: Property.Number({
+			displayName: 'Monthly Spend',
+			description: 'How much revenue the company generates for your business (whole integers only).',
+			required: false,
+		}),
+		remoteCreatedAt: Property.DateTime({
+			displayName: 'Created At',
+			description: 'The time the company was created by you.',
+			required: false,
+		}),
+		customAttributes: Property.Object({
+			displayName: 'Custom Attributes',
+			required: false,
+		}),
+	},
+	async run(context) {
+		const {
+			companyId,
+			name,
+			plan,
+			size,
+			website,
+			industry,
+			monthlySpend,
+			remoteCreatedAt,
+			customAttributes,
+		} = context.propsValue;
+
+		const client = intercomClient(context.auth);
+
+		const response = await client.companies.createOrUpdate({
+			company_id: companyId,
+			name,
+			plan,
+			size,
+			website,
+			industry,
+			monthly_spend: monthlySpend,
+			remote_created_at: remoteCreatedAt ? dayjs(remoteCreatedAt).unix() : undefined,
+			custom_attributes: customAttributes,
+		});
+
+		return response;
+	},
+});

--- a/packages/pieces/community/intercom/src/lib/actions/create-update-company.ts
+++ b/packages/pieces/community/intercom/src/lib/actions/create-update-company.ts
@@ -69,6 +69,10 @@ export const createOrUpdateCompanyAction = createAction({
 			customAttributes,
 		} = context.propsValue;
 
+		if (!companyId && !name) {
+			throw new Error('Provide a Company ID or a Name to create or update a company.');
+		}
+
 		const client = intercomClient(context.auth);
 
 		const response = await client.companies.createOrUpdate({

--- a/packages/pieces/community/intercom/src/lib/actions/find-or-create-company.ts
+++ b/packages/pieces/community/intercom/src/lib/actions/find-or-create-company.ts
@@ -1,0 +1,80 @@
+import { intercomAuth } from '../auth';
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { intercomClient } from '../common';
+
+export const findOrCreateCompanyAction = createAction({
+	auth: intercomAuth,
+	name: 'find-or-create-company',
+	displayName: 'Find or Create Company',
+	description: 'Finds a company by Company ID or name, creating it if none is found.',
+	audience: 'both',
+	aiMetadata: {
+		description:
+			'Resolve a company to a single record: looks it up by Company ID (preferred) or name and returns the match, or creates a new company when none exists. Returns the company plus a "created" flag. Effectively idempotent when a Company ID is supplied.',
+		idempotent: true,
+	},
+	props: {
+		companyId: Property.ShortText({
+			displayName: 'Company ID',
+			description: 'The company ID you have defined for the company. Used to look up and create.',
+			required: false,
+		}),
+		name: Property.ShortText({
+			displayName: 'Name',
+			description: 'Used to look up by name when no Company ID is given, and when creating.',
+			required: false,
+		}),
+		plan: Property.ShortText({
+			displayName: 'Plan',
+			required: false,
+		}),
+		size: Property.Number({
+			displayName: 'Size',
+			required: false,
+		}),
+		website: Property.ShortText({
+			displayName: 'Website',
+			required: false,
+		}),
+		industry: Property.ShortText({
+			displayName: 'Industry',
+			required: false,
+		}),
+		customAttributes: Property.Object({
+			displayName: 'Custom Attributes',
+			required: false,
+		}),
+	},
+	async run(context) {
+		const { companyId, name, plan, size, website, industry, customAttributes } =
+			context.propsValue;
+
+		if (!companyId && !name) {
+			throw new Error('Provide a Company ID or a Name to find or create a company.');
+		}
+
+		const client = intercomClient(context.auth);
+
+		const existing = await client.companies.retrieve({
+			company_id: companyId || undefined,
+			name: companyId ? undefined : name || undefined,
+			per_page: 1,
+		});
+
+		if (existing.data.length > 0) {
+			return { created: false, company: existing.data[0] };
+		}
+
+		const company = await client.companies.createOrUpdate({
+			company_id: companyId,
+			name,
+			plan,
+			size,
+			website,
+			industry,
+			custom_attributes: customAttributes,
+		});
+
+		return { created: true, company };
+	},
+});

--- a/packages/pieces/community/intercom/src/lib/actions/find-or-create-lead.ts
+++ b/packages/pieces/community/intercom/src/lib/actions/find-or-create-lead.ts
@@ -64,6 +64,12 @@ export const findOrCreateLeadAction = createAction({
 			return { created: false, lead: existing.data[0] };
 		}
 
+		if (searchField === 'id') {
+			throw new Error(
+				'No lead found with that Intercom ID. Intercom assigns IDs itself, so a lead can only be created when searching by Email or User ID.',
+			);
+		}
+
 		const lead = await client.contacts.create({
 			role: 'lead',
 			email: searchField === 'email' ? searchValue : undefined,

--- a/packages/pieces/community/intercom/src/lib/actions/find-or-create-lead.ts
+++ b/packages/pieces/community/intercom/src/lib/actions/find-or-create-lead.ts
@@ -1,0 +1,78 @@
+import { intercomAuth } from '../auth';
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { intercomClient } from '../common';
+
+export const findOrCreateLeadAction = createAction({
+	auth: intercomAuth,
+	name: 'find-or-create-lead',
+	displayName: 'Find or Create Lead',
+	description: 'Finds a lead by email, ID, or User ID, creating it if none is found.',
+	audience: 'both',
+	aiMetadata: {
+		description:
+			'Resolve a lead (role=lead prospect) to a single record: searches by email, Intercom ID, or external User ID and returns the match, or creates a new lead when none exists. Returns the lead plus a "created" flag. For signed-up users use Find User / Create User instead.',
+		idempotent: true,
+	},
+	props: {
+		searchField: Property.StaticDropdown({
+			displayName: 'Search Field',
+			required: true,
+			defaultValue: 'email',
+			options: {
+				disabled: false,
+				options: [
+					{ label: 'Email', value: 'email' },
+					{ label: 'ID', value: 'id' },
+					{ label: 'User ID', value: 'external_id' },
+				],
+			},
+		}),
+		searchValue: Property.ShortText({
+			displayName: 'Search Value',
+			required: true,
+		}),
+		name: Property.ShortText({
+			displayName: 'Full Name',
+			required: false,
+		}),
+		phone: Property.ShortText({
+			displayName: 'Phone',
+			required: false,
+		}),
+		customAttributes: Property.Object({
+			displayName: 'Custom Attributes',
+			required: false,
+		}),
+	},
+	async run(context) {
+		const { searchField, searchValue, name, phone, customAttributes } = context.propsValue;
+
+		const client = intercomClient(context.auth);
+
+		const existing = await client.contacts.search({
+			query: {
+				operator: 'AND',
+				value: [
+					{ field: searchField, operator: '=', value: searchValue },
+					{ field: 'role', operator: '=', value: 'lead' },
+				],
+			},
+			pagination: { per_page: 1 },
+		});
+
+		if (existing.data.length > 0) {
+			return { created: false, lead: existing.data[0] };
+		}
+
+		const lead = await client.contacts.create({
+			role: 'lead',
+			email: searchField === 'email' ? searchValue : undefined,
+			external_id: searchField === 'external_id' ? searchValue : undefined,
+			name,
+			phone,
+			custom_attributes: customAttributes,
+		});
+
+		return { created: true, lead };
+	},
+});

--- a/packages/pieces/community/intercom/src/lib/triggers/new-unsubscription.ts
+++ b/packages/pieces/community/intercom/src/lib/triggers/new-unsubscription.ts
@@ -1,0 +1,62 @@
+import { intercomAuth } from '../auth';
+import { createTrigger, TriggerStrategy } from '@activepieces/pieces-framework';
+import { intercomClient, TriggerPayload } from '../common';
+
+export const newUnsubscriptionTrigger = createTrigger({
+	auth: intercomAuth,
+	name: 'new-unsubscription',
+	displayName: 'New Unsubscription',
+	description: 'Triggers when a contact unsubscribes from your emails.',
+	aiMetadata: {
+		description:
+			'Fires when a contact unsubscribes from email in  Intercom. Outputs the contact that unsubscribed.',
+	},
+	props: {},
+	type: TriggerStrategy.APP_WEBHOOK,
+	async onEnable(context) {
+		const client = intercomClient(context.auth);
+		const response = await client.admins.identify(); 
+
+		if (!response.app?.id_code) {
+			throw new Error('Could not find admin id code');
+		}
+
+		context.app.createListeners({
+			events: ['contact.unsubscribed'],
+			identifierValue: response['app']['id_code'],
+		});
+	},
+	async onDisable(context) {
+		// implement webhook deletion logic
+	},
+	async test(context) {
+		const client = intercomClient(context.auth);
+
+		const response = await client.contacts.search({
+			query: {
+				field: 'unsubscribed_from_emails',
+				operator: '=',
+				value: 'true',
+			},
+			pagination: { per_page: 5 },
+		});
+
+		return response.data;
+	},
+	async run(context) {
+		const payload = context.payload.body as TriggerPayload;
+		return [payload.data.item];
+	},
+	sampleData: {
+		type: 'contact',
+		id: '67a9b9dfcc14109e073fbe19',
+		workspace_id: 'nzekhfwb',
+		external_id: '5b803f65-bcec-4198-b4f4-a0588454b537',
+		role: 'user',
+		email: 'john.doe@example.com',
+		name: 'John Doe',
+		unsubscribed_from_emails: true,
+		created_at: '2025-02-10T08:33:35.910+00:00',
+		updated_at: '2025-02-10T08:33:35.907+00:00',
+	},
+});

--- a/packages/pieces/community/intercom/src/lib/triggers/updated-ticket.ts
+++ b/packages/pieces/community/intercom/src/lib/triggers/updated-ticket.ts
@@ -1,0 +1,66 @@
+import { intercomAuth } from '../auth';
+import { createTrigger, TriggerStrategy } from '@activepieces/pieces-framework';
+import { intercomClient, TriggerPayload } from '../common';
+
+export const updatedTicketTrigger = createTrigger({
+	auth: intercomAuth,
+	name: 'updated-ticket',
+	displayName: 'Updated Ticket',
+	description: 'Triggers when a ticket is updated (state or attributes change).',
+	aiMetadata: {
+		description:
+			'Fires when an existing Intercom ticket changes, covering both ticket state transitions and ticket attribute updates. Outputs the updated ticket object.',
+	},
+	props: {},
+	type: TriggerStrategy.APP_WEBHOOK,
+	async onEnable(context) {
+		const client = intercomClient(context.auth);
+		const response = await client.admins.identify();
+
+		if (!response.app?.id_code) {
+			throw new Error('Could not find admin id code');
+		}
+
+		context.app.createListeners({
+			events: ['ticket.state.updated', 'ticket.attribute.updated'],
+			identifierValue: response['app']['id_code'],
+		});
+	},
+	async onDisable(context) {
+		// implement webhook deletion logic
+	},
+	async test(context) {
+		const client = intercomClient(context.auth);
+
+		const response = await client.tickets.search({
+			query: {
+				field: 'open',
+				operator: '=',
+				value: 'true',
+			},
+			pagination: { per_page: 5 },
+		});
+
+		return response.data;
+	},
+	async run(context) {
+		const payload = context.payload.body as TriggerPayload;
+		return [payload.data.item];
+	},
+	sampleData: {
+		type: 'ticket',
+		id: '2',
+		ticket_id: '1',
+		ticket_attributes: {
+			_default_title_: 'Cannot log in',
+			_default_description_: 'Customer is unable to log in to the dashboard.',
+		},
+		ticket_state: 'in_progress',
+		ticket_state_internal_label: 'In progress',
+		ticket_state_external_label: 'In progress',
+		open: true,
+		category: 'Customer',
+		created_at: 1739105560,
+		updated_at: 1739524230,
+	},
+});


### PR DESCRIPTION
…tion triggers

# Intercom Piece Enhancement

Adds the actions and triggers that were missing from the Intercom piece. Everything already covered by an existing step is skipped.

## New Actions

| Action | Intercom endpoint | Reference |
|--------|-------------------|-----------|
| Create or Update Company | `POST /companies` | [Create or Update a company](https://developers.intercom.com/docs/references/rest-api/api.intercom.io/companies/createorupdatecompany) |
| Create Data Event | `POST /events` | [Submit a data event](https://developers.intercom.com/docs/references/rest-api/api.intercom.io/data-events/createdataevent) |
| Find or Create Company | `GET /companies` (lookup) + `POST /companies` (create) | [Retrieve companies](https://developers.intercom.com/docs/references/rest-api/api.intercom.io/companies/retrievecompany) · [Create or Update a company](https://developers.intercom.com/docs/references/rest-api/api.intercom.io/companies/createorupdatecompany) |
| Find or Create Lead | `POST /contacts/search` (lookup) + `POST /contacts` (create) | [Search contacts](https://developers.intercom.com/docs/references/rest-api/api.intercom.io/contacts/searchcontacts) · [Create contact](https://developers.intercom.com/docs/references/rest-api/api.intercom.io/contacts/createcontact) |

## New Triggers (APP_WEBHOOK)

| Trigger | Webhook topic(s) | Reference |
|---------|------------------|-----------|
| Updated Ticket | `ticket.state.updated`, `ticket.attribute.updated` | [Webhook models](https://developers.intercom.com/docs/references/webhooks/webhook-models) |
| New Unsubscription | `contact.unsubscribed` | [Webhook models](https://developers.intercom.com/docs/references/webhooks/webhook-models) |

Both triggers use `GET /me` (`client.admins.identify`) on enable to resolve the workspace `app_id`, and `POST /tickets/search` / `POST /contacts/search` respectively for the sample/test data.

## Validation / Edge Cases

- **Find or Create Lead** refuses to create when the lookup field is Intercom `ID` — IDs are server-assigned, so a create can't reproduce the searched ID. Create is only valid for **Email** / **User ID** lookups.
- **Create or Update Company** and **Find or Create Company** require at least a **Company ID** or **Name** before calling the upsert, avoiding an opaque Intercom `400` on an empty body. (`name`-only creates are supported by Intercom and remain allowed.)

## Skipped — Already in the Piece

- **Send Incoming Message** → existing **Create Conversation** (`POST /conversations` from a contact).
- **Add Tag to Contact** / **Remove Tag from Contact** → existing combined **Add/Remove Tag on Contact**.
- **Tag Added to Conversation** → existing **Tag added to a conversation part** (`conversation_part.tag.created`, Intercom's only tag-on-conversation topic).
- Also present: Add/Remove Tag on Company & Conversation, Create/Update User, Create Article, Add Note, Create Ticket, Update Ticket, Create/Update Lead, Create User, Find Lead, Find Company, Find User, List All Tags, Retrieve Conversation.
- Triggers present: Lead Added Email, New Lead, Tag Added to Lead, New Company, New Ticket, Lead Converted to User, Contact Replied, New User, Updated Contact.

## Verification

- `npx turbo run lint --filter=@activepieces/piece-intercom` → 0 errors.
- `npx turbo run build --filter=@activepieces/piece-intercom` → passes (typechecks all `intercom-client` request shapes).

