### PR TITLE
fix(flows): code steps no longer crash runs with "o.send is not a function" under worker load

### DIFF
--- a/packages/server/engine/src/lib/core/code/no-op-code-sandbox.ts
+++ b/packages/server/engine/src/lib/core/code/no-op-code-sandbox.ts
@@ -83,7 +83,7 @@ async function runInChildProcess({ codeFilePath, inputs }: { codeFilePath: strin
             reject(buildError({ message: error.message, stdout: capturedStdout, stderr: capturedStderr }))
         })
 
-        child.send({ codeFilePath, inputs })
+        child.send?.({ codeFilePath, inputs })
     })
 }
 

--- a/packages/server/engine/test/core/code/no-op-code-sandbox.test.ts
+++ b/packages/server/engine/test/core/code/no-op-code-sandbox.test.ts
@@ -1,0 +1,59 @@
+import { ChildProcess } from 'node:child_process'
+import { EventEmitter } from 'node:events'
+import { unlink, writeFile } from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import { noOpCodeSandbox } from '../../../src/lib/core/code/no-op-code-sandbox'
+
+const spawnState = vi.hoisted(() => ({ failNextSpawnWith: null as string | null }))
+
+vi.mock('node:child_process', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('node:child_process')>()
+    return {
+        ...actual,
+        spawn: (...args: Parameters<typeof actual.spawn>): ChildProcess => {
+            if (spawnState.failNextSpawnWith === null) {
+                return actual.spawn(...args)
+            }
+            const errorCode = spawnState.failNextSpawnWith
+            spawnState.failNextSpawnWith = null
+            const child = new EventEmitter() as ChildProcess
+            setImmediate(() => child.emit('error', Object.assign(new Error(`spawn ${errorCode}`), { code: errorCode })))
+            return child
+        },
+    }
+})
+
+describe('noOpCodeSandbox', () => {
+    describe('runCodeModule', () => {
+        let tmpFile: string
+
+        beforeEach(() => {
+            spawnState.failNextSpawnWith = null
+            tmpFile = path.join(os.tmpdir(), `no-op-sandbox-test-${Date.now()}.js`)
+        })
+
+        afterEach(async () => {
+            await unlink(tmpFile).catch(() => undefined)
+        })
+
+        async function runWithSource(source: string, inputs: Record<string, unknown> = {}): Promise<unknown> {
+            await writeFile(tmpFile, source, 'utf8')
+            return noOpCodeSandbox.runCodeModule({ codeFilePath: tmpFile, inputs })
+        }
+
+        it('executes exports.code and returns the result', async () => {
+            const result = await runWithSource('exports.code = async (inputs) => ({ doubled: inputs.n * 2 })', { n: 3 })
+            expect(result).toEqual({ doubled: 6 })
+        })
+
+        it('propagates user errors thrown inside code', async () => {
+            await expect(runWithSource('exports.code = async () => { throw new Error(\'user error\') }')).rejects.toThrow('user error')
+        })
+
+        it('rejects with the spawn error instead of a send TypeError when the child has no IPC channel (GIT-1650)', async () => {
+            spawnState.failNextSpawnWith = 'EMFILE'
+            await expect(runWithSource('exports.code = async () => 1')).rejects.toThrow('spawn EMFILE')
+        })
+    })
+})


### PR DESCRIPTION
Fixes activepieces/activepieces#14361<br>Closes activepieces/activepieces#14361

## Problem

1. Flow runs with CODE steps intermittently fail with `TypeError: o.send is not a function` from the engine's `runCodeModule` — bursty, data-independent, retry usually succeeds, probability scales with code-step invocations per run.
2. Root cause: when `spawn()` fails with EMFILE/ENFILE (worker fd exhaustion), Node returns before attaching `ChildProcess.send`; the unguarded synchronous `child.send(...)` throws inside the Promise executor, masking the real spawn error carried by the async `error` event one tick later. Only EMFILE/ENFILE produce this signature.

## Fix

* `packages/server/engine/src/lib/core/code/no-op-code-sandbox.ts`: `child.send({...})` → `child.send?.({...})` — with no IPC channel attached, the existing `error` handler now rejects with the real spawn error (e.g. `spawn EMFILE`).

## Verification

* Regression test `no-op-code-sandbox.test.ts`, proven red-first: pre-fix run rejects with `child.send is not a function`; post-fix asserts `spawn EMFILE`.
* Real-EMFILE runtime repro (fd exhaustion under `ulimit -n 512`) against actual `runCodeModule`: pre-fix reproduces the reported TypeError; post-fix rejects with `spawn EMFILE`. Healthy path unchanged.
* Engine suite 359/359; `npm run lint-dev` clean (0 errors).
* fd-leak check: 50 sequential invocations, fd delta 0 — the exhaustion source is external to this code path; infra follow-up tracked in activepieces/activepieces#14361.
* Visual: none - engine-only; only changes a failed step's internal error text under OS fd exhaustion.

## Breaking change?

- [ ] Yes
- [X] No

## Security impact?

- [ ] Yes
- [X] No