### PR TITLE
fix(pieces): restore OpenAI piece connections, models, and actions in 0.10.1

### DIFF
--- a/packages/cli/src/lib/utils/bundle-piece-utils.test.ts
+++ b/packages/cli/src/lib/utils/bundle-piece-utils.test.ts
@@ -36,6 +36,31 @@ describe('bundlePiece — external dependency capture', () => {
         expect(result.external).not.toContain('fake-sdk')
     })
 
+    it('keeps wasm/native asset packages (tiktoken, sharp) external so their runtime-loaded assets resolve', async () => {
+        root = mkdtempSync(join(tmpdir(), 'ap-bundle-'))
+
+        for (const [name, version] of [['tiktoken', '1.0.11'], ['sharp', '0.35.2']]) {
+            const depDir = join(root, 'node_modules', name)
+            mkdirSync(depDir, { recursive: true })
+            writeFileSync(join(depDir, 'package.json'), JSON.stringify({ name, version, main: 'index.js' }))
+            writeFileSync(join(depDir, 'index.js'), 'module.exports = {};\n')
+        }
+
+        const piecePath = join(root, 'piece')
+        mkdirSync(join(piecePath, 'src'), { recursive: true })
+        writeFileSync(join(piecePath, 'package.json'), JSON.stringify({ name: 'piece-z', version: '0.0.1', dependencies: { tiktoken: '1.0.11', sharp: '0.35.2' } }))
+        writeFileSync(join(piecePath, 'src', 'index.ts'), 'import * as tiktoken from \'tiktoken\'\nimport * as sharp from \'sharp\'\nexport const piece = { tiktoken, sharp }\n')
+        const distPath = join(piecePath, 'dist')
+        mkdirSync(distPath, { recursive: true })
+
+        const result = await bundlePieceUtils.bundlePiece({ piecePath, distPath, repoRoot: root })
+
+        expect(result.external).toContain('tiktoken')
+        expect(result.external).toContain('sharp')
+        expect(result.inlined).not.toContain('tiktoken')
+        expect(result.inlined).not.toContain('sharp')
+    })
+
     it('externalizes an inlined package that relies on import.meta', async () => {
         root = mkdtempSync(join(tmpdir(), 'ap-bundle-'))
 

--- a/packages/cli/src/lib/utils/bundle-piece-utils.ts
+++ b/packages/cli/src/lib/utils/bundle-piece-utils.ts
@@ -311,6 +311,8 @@ const NATIVE_EXTERNALS = new Set<string>([
     'pg-native', 'mongodb-client-encryption', 'kerberos',
     'snappy', 'aws4', 'bson-ext', '@mongodb-js/zstd',
     'playwright', 'playwright-core', 'puppeteer', 'puppeteer-core',
+    'sharp',
+    'tiktoken',
     // native-backed SDK (pulls better-sqlite3), and packages that load sibling files at runtime:
     // pg-format → require(__dirname + '/reserved.js'); clarifai-nodejs-grpc → loadSync('*.proto').
     '@actual-app/api', 'pg-format', 'clarifai-nodejs-grpc',

--- a/packages/pieces/community/openai/package.json
+++ b/packages/pieces/community/openai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-openai",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "dependencies": {


### PR DESCRIPTION
## Description

`@activepieces/piece-openai@0.10.0` (first OpenAI release through the self-contained bundle pipeline) failed to load: esbuild inlined tiktoken's JS but not its `tiktoken_bg.wasm` asset, and the bundled manifest declared no dependencies, so `require` threw `Missing tiktoken_bg.wasm` before any action ran. Connections, model dropdowns, and action execution were all broken — and connection creation resolves the latest piece version, so users pinned to 0.9.2 could not create connections either.

Fix:

- `packages/cli/src/lib/utils/bundle-piece-utils.ts` — add `tiktoken` and `sharp` to `NATIVE_EXTERNALS`. Both load binary assets (`.wasm` / `.node`) at runtime and must stay external, kept as declared dependencies in the published manifest so the runtime installer fetches them. `sharp` externalization was lost in the bundler rewrite (#13822); adding it back protects `image-helper`'s next publish.
- `packages/pieces/community/openai/package.json` — `0.10.0 → 0.10.1` to republish through the fixed bundler.

Not bumped: `azure-openai` (tiktoken) and `image-helper` (sharp). Their published versions predate the bundler and work today; their next publish inherits the fix.

## How was this tested?

- Regression test, proven red-first: with `tiktoken` removed from `NATIVE_EXTERNALS` the new test fails (`expected [] to include 'tiktoken'`); passes with the fix. `packages/cli` suite 7/7.
- E2E: ran the publish prepare on the real openai piece — bundler emits `external=[tiktoken]`, the published manifest keeps `"tiktoken": "1.0.11"`, and the produced bundle `require()`s cleanly with deps installed. The published 0.10.0 artifact reproduces `Missing tiktoken_bg.wasm`.
- `npm run lint-dev` clean (30/30 tasks).
- Pre-existing, unrelated: `@activepieces/cli` tsc build fails on `benchmark.ts:683` (`ProjectLimits.reason`) on upstream/main — untouched by this diff.
- Visual: none - build tooling only, no user-visible surface.

Fixes [GIT-1651](https://linear.app/activepieces/issue/GIT-1651)
Closes #14366

Ref: Pylon 5433

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)
