### PR TITLE
feat(server): transparent canary frontend routing on the primary origin

### DIFF
--- a/.agents/features/canary.md
+++ b/.agents/features/canary.md
@@ -1,0 +1,41 @@
+# Canary Routing
+
+## Summary
+Canary is a **worker group that also has its own app tier** (`CANARY_APP_URL`, `IS_CANARY_APP`). A platform whose `platform_plan.workerGroupId === 'canary'` (`workerGroupService.isCanaryPlatform`) has its flow jobs routed to a dedicated queue **and** its HTTP/websocket traffic served by a separate canary deployment of the app — so a subset of real platforms exercises a new release before it is promoted to production. The prod app is the ingress and reverse-proxies canary platforms to the canary app; canary and prod **share the same Postgres and Redis**.
+
+This module makes the canary experience **transparent on the primary origin** (`cloud.activepieces.com`): a canary platform gets the new frontend + backend + websockets on the normal URL, so all auth/OAuth/SSO keep working (redirecting to a `canary.*` origin would break them — the session token is origin-scoped `localStorage`, and OAuth `redirect_uri`s are registered for the primary origin only).
+
+## How routing works
+All routing keys off one cookie, `ap_canary`, minted by the backend once an authenticated `/api` request confirms a canary platform.
+
+1. **`/api` (principal-based)** — `canary-routing.middleware.ts` (preHandler in the `/api` scope): resolves the platform from the principal (or the flow cache for webhooks), and if canary, reverse-proxies to `CANARY_APP_URL` **and** sets the `ap_canary` cookie. On the authoritative non-canary path it clears a stale cookie.
+2. **Static / SPA (cookie-based)** — `canary-static-routing.middleware.ts` (root `onRequest`): for the frontend surface (everything except `/api`, `/mcp`, `/ingest`, `/.well-known`, and ws upgrades), if the signed cookie validates, reverse-proxies to canary so the **canary bundle is served on the primary origin**.
+3. **Websocket (cookie-based)** — `canary-ws-routing.ts`: wraps the HTTP server `upgrade` event; a valid-cookie `/api/socket.io` upgrade is piped to canary (transparent passthrough via Node `http`/`https` — no frame parsing, so no `ws` dependency), everything else is delegated to socket.io's own captured upgrade listeners. This makes a canary user's socket terminate on **canary** code, so inbound handlers (locks, presence) run on the new version too — not just server→client broadcasts.
+4. **Bundle swap** — `main.tsx`: once the cookie is present, the frontend reloads **once** (guarded by `reloadOnceForStaleChunk`) so the reload request carries the cookie and the canary bundle is served in place of the prod one. The canary bundle also sees the cookie but skips on the session guard, so there is no loop.
+
+`reply.from` (`@fastify/reply-from`) is registered **once at the root** (`server.ts`) and shared by both the `/api` and static middlewares — it is `fastify-plugin`-wrapped, so registering it in both root and the `/api` scope would collide.
+
+## Security model
+- The `ap_canary` cookie is **HMAC-signed** with the JWT secret (via `@fastify/cookie`, registered at the root) so a client cannot forge one the server accepts.
+- It is **deliberately not HttpOnly** — the frontend reads its presence to trigger the one-time bundle swap. This is safe: the cookie carries **no privilege** (auth stays the token; the cookie only selects which code version serves), and signing prevents forgery. XSS reading a routing flag is harmless; XSS setting one fails signature verification.
+- `Secure`, `SameSite=Lax`, host-only, 1-day max-age.
+- **CDN contamination guard**: `index.html` is served `Cache-Control: no-store` + `Vary: Cookie` (a shared/CDN cache must never serve a canary `index.html` to a prod user, since it is an un-hashed shared URL). Hashed `/assets/*` stay `immutable` — unique filenames per build, safe to cache.
+- **No SSRF**: the proxy upstream is always the fixed `CANARY_APP_URL` (admin config), never user input.
+- All new paths are **no-ops when `CANARY_APP_URL` is unset** (self-hosted / CE default).
+
+## Key files
+| Concern | File |
+| --- | --- |
+| Cookie mint/clear/verify (delegates to `@fastify/cookie`) | `core/canary/canary-cookie.ts` |
+| `/api` principal-based proxy + cookie set/clear | `core/canary/canary-routing.middleware.ts` |
+| Static/SPA cookie-based proxy | `core/canary/canary-static-routing.middleware.ts` |
+| Websocket upgrade cookie-based proxy | `core/canary/canary-ws-routing.ts` |
+| Root wiring (cookie plugin, reply-from, hooks) | `app/server.ts` |
+| Canary worker group / `isCanaryPlatform` | `ee/platform/platform-plan/worker-group.service.ts` |
+| Frontend one-time bundle swap | `packages/web/src/main.tsx` |
+
+## Ops prerequisites
+- **Cloudflare**: bypass cache when the `ap_canary` cookie is present (belt-and-suspenders with the `no-store` header on `index.html`).
+- The **canary app must NOT set `CANARY_APP_URL`** (otherwise it proxies to itself — loop).
+- Keep the canary hostname/service pinned to the canary deployment.
+- Transparent primary-origin routing only takes effect **once this ships to prod** — the reload logic must live in the bundle users first load. Until then, canary is reached directly via `canary.activepieces.com`.

--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "activepieces",
@@ -97,7 +96,7 @@
     },
     "packages/core/execution": {
       "name": "@activepieces/core-execution",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -142,7 +141,7 @@
     },
     "packages/core/shared": {
       "name": "@activepieces/shared",
-      "version": "0.119.0",
+      "version": "0.120.0",
       "dependencies": {
         "@activepieces/core-execution": "workspace:*",
         "@activepieces/core-formula": "workspace:*",
@@ -875,7 +874,7 @@
     },
     "packages/pieces/community/aws-bedrock": {
       "name": "@activepieces/piece-aws-bedrock",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -5822,7 +5821,7 @@
     },
     "packages/pieces/community/microsoft-teams": {
       "name": "@activepieces/piece-microsoft-teams",
-      "version": "0.5.5",
+      "version": "0.6.0",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -10576,6 +10575,7 @@
         "@bull-board/fastify": "6.10.1",
         "@electric-sql/pglite": "0.3.14",
         "@fastify/basic-auth": "6.2.0",
+        "@fastify/cookie": "11.1.2",
         "@fastify/cors": "11.0.1",
         "@fastify/formbody": "8.0.2",
         "@fastify/http-proxy": "11.4.4",
@@ -13045,6 +13045,8 @@
 
     "@fastify/busboy": ["@fastify/busboy@3.2.0", "", {}, "sha512-m9FVDXU3GT2ITSe0UaMA5rU3QkfC/UXtCU8y0gSN/GugTqtVldOBWIB5V6V3sbmenVZUIpU6f+mPEO2+m5iTaA=="],
 
+    "@fastify/cookie": ["@fastify/cookie@11.1.2", "", { "dependencies": { "cookie": "^2.0.0", "fastify-plugin": "^6.0.0" } }, "sha512-Dtrpk/YOGUsbRMvP/8ZqPpwnMRv0qSqodFdoQ2B589Obc7jw4s4Qla+cV72Bsm7WsZJnqlYFX/i7uSBq0xzg6g=="],
+
     "@fastify/cors": ["@fastify/cors@11.0.1", "", { "dependencies": { "fastify-plugin": "^5.0.0", "toad-cache": "^3.7.0" } }, "sha512-dmZaE7M1f4SM8ZZuk5RhSsDJ+ezTgI7v3HHRj8Ow9CneczsPLZV6+2j2uwdaSLn8zhTv6QV0F4ZRcqdalGx1pQ=="],
 
     "@fastify/deepmerge": ["@fastify/deepmerge@2.0.2", "", {}, "sha512-3wuLdX5iiiYeZWP6bQrjqhrcvBIf0NHbQH1Ur1WbHvoiuTYUEItgygea3zs8aHpiitn0lOB8gX20u1qO+FDm7Q=="],
@@ -14897,7 +14899,7 @@
 
     "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
 
-    "cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
+    "cookie": ["cookie@2.0.1", "", {}, "sha512-yuToqVvRrj6pfDXREyQAAv8SkAEk/8GS3jQRTiUMm66TVtBYmqQeoEjL2Lmq8Rpo6271vH76InTChTitEAm65w=="],
 
     "cookie-signature": ["cookie-signature@1.2.2", "", {}, "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg=="],
 
@@ -18907,6 +18909,8 @@
 
     "@ethersproject/transactions/@ethersproject/signing-key": ["@ethersproject/signing-key@5.8.0", "", { "dependencies": { "@ethersproject/bytes": "^5.8.0", "@ethersproject/logger": "^5.8.0", "@ethersproject/properties": "^5.8.0", "bn.js": "^5.2.1", "elliptic": "6.6.1", "hash.js": "1.1.7" } }, "sha512-LrPW2ZxoigFi6U6aVkFN/fa9Yx/+4AtIUe4/HACTvKJdhm0eeb107EVCIQcrLZkxaSIgc/eCrX8Q1GtbH+9n3w=="],
 
+    "@fastify/cookie/fastify-plugin": ["fastify-plugin@6.0.0", "", {}, "sha512-fZOty7z3O7vOliF6d8bHE3wiEh1KcNnKEQensSgTk9C1DvN6nRLS++XVd86v33Hw/8u9Un8A1zDrQ8ujcQDHEg=="],
+
     "@fastify/http-proxy/fastify-plugin": ["fastify-plugin@5.1.0", "", {}, "sha512-FAIDA8eovSt5qcDgcBvDuX/v0Cjz0ohGhENZ/wpc3y+oZCY2afZ9Baqql3g/lC+OHRnciQol4ww7tuthOb9idw=="],
 
     "@fastify/reply-from/undici": ["undici@7.24.6", "", {}, "sha512-Xi4agocCbRzt0yYMZGMA6ApD7gvtUFaxm4ZmeacWI4cZxaF6C+8I8QfofC20NAePiB/IcvZmzkJ7XPa471AEtA=="],
@@ -19636,6 +19640,8 @@
     "express/body-parser": ["body-parser@2.2.2", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^1.0.5", "debug": "^4.4.3", "http-errors": "^2.0.0", "iconv-lite": "^0.7.0", "on-finished": "^2.4.1", "qs": "^6.14.1", "raw-body": "^3.0.1", "type-is": "^2.0.1" } }, "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA=="],
 
     "express/content-disposition": ["content-disposition@1.1.0", "", {}, "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g=="],
+
+    "express/cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
 
     "express/mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
 
@@ -21275,6 +21281,8 @@
 
     "supergateway/@modelcontextprotocol/sdk/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
+    "supergateway/express/cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
+
     "supergateway/express/cookie-signature": ["cookie-signature@1.0.7", "", {}, "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA=="],
 
     "supergateway/express/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
@@ -21667,6 +21675,8 @@
 
     "ai-gateway-provider/@ai-sdk/google-vertex/google-auth-library/jws": ["jws@4.0.1", "", { "dependencies": { "jwa": "^2.0.1", "safe-buffer": "^5.0.1" } }, "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA=="],
 
+    "api/socket.io/engine.io/cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
+
     "api/socket.io/engine.io/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
     "api/socket.io/engine.io/ws": ["ws@8.18.3", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg=="],
@@ -21842,6 +21852,8 @@
     "supergateway/@modelcontextprotocol/sdk/express/body-parser": ["body-parser@2.2.2", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^1.0.5", "debug": "^4.4.3", "http-errors": "^2.0.0", "iconv-lite": "^0.7.0", "on-finished": "^2.4.1", "qs": "^6.14.1", "raw-body": "^3.0.1", "type-is": "^2.0.1" } }, "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA=="],
 
     "supergateway/@modelcontextprotocol/sdk/express/content-disposition": ["content-disposition@1.1.0", "", {}, "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g=="],
+
+    "supergateway/@modelcontextprotocol/sdk/express/cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
 
     "supergateway/@modelcontextprotocol/sdk/express/mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
 

--- a/packages/server/api/package.json
+++ b/packages/server/api/package.json
@@ -30,6 +30,7 @@
     "@bull-board/fastify": "6.10.1",
     "@electric-sql/pglite": "0.3.14",
     "@fastify/basic-auth": "6.2.0",
+    "@fastify/cookie": "11.1.2",
     "@fastify/cors": "11.0.1",
     "@fastify/formbody": "8.0.2",
     "@fastify/http-proxy": "11.4.4",

--- a/packages/server/api/src/app/app.ts
+++ b/packages/server/api/src/app/app.ts
@@ -2,7 +2,6 @@ import { isNil, spreadIfDefined } from '@activepieces/core-utils'
 import { PieceMetadata } from '@activepieces/pieces-framework'
 import { apVersionUtil, onCallService, UNKNOWN_VERSION, wideEvent } from '@activepieces/server-utils'
 import { AddAllowedEmbedOriginsRequestBody, ApEdition, ApEnvironment, AppConnectionWithoutSensitiveData, ApplicationEventName, ConnectionDeletedEvent, ConnectionUpsertedEvent, Flow, FlowActivatedEvent, FlowCreatedEvent, FlowDeactivatedEvent, FlowDeletedEvent, FlowPublishedEvent, FlowRun, FlowRunFinishedEvent, FlowRunRetriedEvent, FlowRunStartedEvent, FlowUpdatedEvent, Folder, FolderCreatedEvent, FolderDeletedEvent, FolderUpdatedEvent, GitRepoWithoutSensitiveData, ProjectMember, ProjectRelease, ProjectReleaseEvent, ProjectRoleEvent, ProjectWithLimits, SigningKeyEvent, SignUpEvent, Template, UserEmailVerifiedEvent, UserInvitation, UserPasswordResetEvent, UserSignedInEvent, UserWithMetaInformation } from '@activepieces/shared'
-import replyFrom from '@fastify/reply-from'
 import swagger from '@fastify/swagger'
 import { createAdapter } from '@socket.io/redis-adapter'
 import { FastifyBaseLogger, FastifyInstance, FastifyRequest, HTTPMethods } from 'fastify'
@@ -205,9 +204,9 @@ export const setupApp = async (app: FastifyInstance): Promise<FastifyInstance> =
     app.addHook('preHandler', authorizationMiddleware)
     app.addHook('preHandler', rbacMiddleware)
 
+    // reply-from is registered once at the root (server.ts); this scope just adds the preHandler.
     const canaryAppUrl = system.get(AppSystemProp.CANARY_APP_URL)
     if (!isNil(canaryAppUrl)) {
-        await app.register(replyFrom, { base: canaryAppUrl })
         app.addHook('preHandler', canaryRoutingMiddleware)
     }
 

--- a/packages/server/api/src/app/core/canary/canary-cookie.ts
+++ b/packages/server/api/src/app/core/canary/canary-cookie.ts
@@ -1,0 +1,38 @@
+import { isNil } from '@activepieces/core-utils'
+import { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify'
+
+// Signing/parsing/verification are delegated to @fastify/cookie (see .agents/features/canary.md).
+export const canaryCookie = {
+    // Header form (not reply.setCookie): the canary response is streamed by @fastify/reply-from.
+    buildSetHeader(app: FastifyInstance): string {
+        return app.serializeCookie(CANARY_COOKIE_NAME, app.signCookie(CANARY_COOKIE_VALUE), CANARY_COOKIE_OPTIONS)
+    },
+    clear(reply: FastifyReply): void {
+        void reply.clearCookie(CANARY_COOKIE_NAME, { path: '/' })
+    },
+    isPresent(request: FastifyRequest): boolean {
+        return !isNil(request.cookies[CANARY_COOKIE_NAME])
+    },
+    isValidHeader(app: FastifyInstance, cookieHeader: string | undefined): boolean {
+        if (isNil(cookieHeader)) {
+            return false
+        }
+        const raw = app.parseCookie(cookieHeader)[CANARY_COOKIE_NAME]
+        if (isNil(raw)) {
+            return false
+        }
+        const { valid, value } = app.unsignCookie(raw)
+        return valid && value === CANARY_COOKIE_VALUE
+    },
+}
+
+export const CANARY_COOKIE_NAME = 'ap_canary'
+const CANARY_COOKIE_VALUE = '1'
+// Deliberately NOT HttpOnly — the frontend reads its presence to swap bundles. Safe: signed +
+// no privilege. See .agents/features/canary.md § Security model before changing these options.
+const CANARY_COOKIE_OPTIONS = {
+    path: '/',
+    maxAge: 60 * 60 * 24,
+    secure: true,
+    sameSite: 'lax',
+} as const

--- a/packages/server/api/src/app/core/canary/canary-routing.middleware.ts
+++ b/packages/server/api/src/app/core/canary/canary-routing.middleware.ts
@@ -6,6 +6,7 @@ import { workerGroupService } from '../../ee/platform/platform-plan/worker-group
 import { flowExecutionCache } from '../../flows/flow/flow-execution-cache'
 import { system } from '../../helper/system/system'
 import { AppSystemProp } from '../../helper/system/system-props'
+import { canaryCookie } from './canary-cookie'
 
 export const canaryRoutingMiddleware = async (request: FastifyRequest, reply: FastifyReply): Promise<void> => {
     if (request.headers.upgrade === 'websocket') return
@@ -23,23 +24,43 @@ export const canaryRoutingMiddleware = async (request: FastifyRequest, reply: Fa
         request.log.error({ error: canaryLookupError }, '[canaryRoutingMiddleware] failed to fetch canary platform IDs, falling through')
         return
     }
-    if (!shouldForward) return
+    if (!shouldForward) {
+        // Authoritative non-canary: drop a stale cookie (only if present, to stay off the hot path).
+        if (canaryCookie.isPresent(request)) {
+            canaryCookie.clear(reply)
+        }
+        return
+    }
 
     request.log.info({ platform: { id: platformId } }, '[canaryRoutingMiddleware] proxying to canary')
 
-    await awaitProxy(request, reply)
+    // Cookie steers the pre-principal surfaces (static bundle, ws upgrade) to canary too.
+    const setCookie = canaryCookie.buildSetHeader(request.server)
+    await awaitProxy(request, reply, setCookie)
 }
 
-async function awaitProxy(request: FastifyRequest, reply: FastifyReply): Promise<void> {
+async function awaitProxy(request: FastifyRequest, reply: FastifyReply, setCookie: string): Promise<void> {
     return new Promise<void>((resolve) => {
         reply.raw.once('finish', resolve)
         void reply.from(request.url, {
+            rewriteHeaders: (headers) => ({
+                ...headers,
+                'set-cookie': mergeSetCookie(headers['set-cookie'], setCookie),
+            }),
             onError: (reply, { error: proxyError }) => {
                 request.log.error({ error: proxyError }, '[canaryRoutingMiddleware] proxy failed')
                 void reply.send(proxyError)
             },
         })
     })
+}
+
+function mergeSetCookie(upstream: string | string[] | undefined, canary: string): string[] {
+    if (isNil(upstream)) {
+        return [canary]
+    }
+    const existing = Array.isArray(upstream) ? upstream : [upstream]
+    return [...existing, canary]
 }
 
 async function resolvePlatformId(request: FastifyRequest, log: FastifyBaseLogger): Promise<string | null> {

--- a/packages/server/api/src/app/core/canary/canary-static-routing.middleware.ts
+++ b/packages/server/api/src/app/core/canary/canary-static-routing.middleware.ts
@@ -1,0 +1,38 @@
+import '@fastify/reply-from'
+import { isNil } from '@activepieces/core-utils'
+import { FastifyReply, FastifyRequest } from 'fastify'
+import { system } from '../../helper/system/system'
+import { AppSystemProp } from '../../helper/system/system-props'
+import { canaryCookie } from './canary-cookie'
+
+// Backend surfaces route themselves (/api is principal-based, the rest are backend/discovery);
+// everything else is the frontend surface. See .agents/features/canary.md.
+const BACKEND_PREFIXES = ['/api', '/mcp', '/ingest', '/.well-known']
+
+export const canaryStaticRoutingMiddleware = async (request: FastifyRequest, reply: FastifyReply): Promise<void> => {
+    // ws upgrades go through the dedicated upgrade proxy, not here.
+    if (request.headers.upgrade === 'websocket') return
+
+    const pathOnly = request.url.split('?')[0]
+    if (BACKEND_PREFIXES.some((prefix) => pathOnly === prefix || pathOnly.startsWith(`${prefix}/`))) return
+
+    const canaryAppUrl = system.get(AppSystemProp.CANARY_APP_URL)
+    if (isNil(canaryAppUrl)) return
+
+    if (!canaryCookie.isValidHeader(request.server, request.headers.cookie)) return
+
+    request.log.info({ url: request.url }, '[canaryStaticRoutingMiddleware] proxying frontend to canary')
+    await awaitProxy(request, reply)
+}
+
+async function awaitProxy(request: FastifyRequest, reply: FastifyReply): Promise<void> {
+    return new Promise<void>((resolve) => {
+        reply.raw.once('finish', resolve)
+        void reply.from(request.url, {
+            onError: (reply, { error: proxyError }) => {
+                request.log.error({ error: proxyError }, '[canaryStaticRoutingMiddleware] proxy failed')
+                void reply.send(proxyError)
+            },
+        })
+    })
+}

--- a/packages/server/api/src/app/core/canary/canary-ws-routing.ts
+++ b/packages/server/api/src/app/core/canary/canary-ws-routing.ts
@@ -79,7 +79,11 @@ function proxyUpgrade({ canaryAppUrl, request, clientSocket, head, app }: ProxyU
         upstreamSocket.pipe(clientSocket)
         clientSocket.pipe(upstreamSocket)
     })
-    proxyReq.on('timeout', () => destroyBoth(new Error('canary ws upstream timeout')))
+    proxyReq.on('timeout', () => {
+        // A 'timeout' does not close the request — destroy it so the upstream socket isn't leaked.
+        proxyReq.destroy()
+        destroyBoth(new Error('canary ws upstream timeout'))
+    })
     proxyReq.on('error', (error) => destroyBoth(error))
     proxyReq.end()
 }

--- a/packages/server/api/src/app/core/canary/canary-ws-routing.ts
+++ b/packages/server/api/src/app/core/canary/canary-ws-routing.ts
@@ -1,0 +1,99 @@
+import http, { IncomingMessage } from 'node:http'
+import https from 'node:https'
+import { Duplex } from 'node:stream'
+import { isNil } from '@activepieces/core-utils'
+import { FastifyInstance } from 'fastify'
+import { system } from '../../helper/system/system'
+import { AppSystemProp } from '../../helper/system/system-props'
+import { canaryCookie } from './canary-cookie'
+
+const SOCKET_IO_PATH = '/api/socket.io'
+const UPSTREAM_TIMEOUT_MS = 10_000
+
+// Transparent ws passthrough to the fixed CANARY_APP_URL (no frame parsing → no `ws` dep, no SSRF).
+// See .agents/features/canary.md.
+export const canaryWsRouting = {
+    // Captures socket.io's own 'upgrade' listeners, then routes: canary-cookied /api/socket.io → canary,
+    // everything else → the captured listeners.
+    install(app: FastifyInstance): void {
+        const canaryAppUrl = system.get(AppSystemProp.CANARY_APP_URL)
+        if (isNil(canaryAppUrl)) {
+            return
+        }
+        const server = app.server
+        const socketIoListeners = server.listeners('upgrade')
+        server.removeAllListeners('upgrade')
+        server.on('upgrade', (request: IncomingMessage, socket: Duplex, head: Buffer) => {
+            if (canaryWsRouting.shouldProxy({ app, url: request.url, cookieHeader: request.headers.cookie })) {
+                proxyUpgrade({ canaryAppUrl, request, clientSocket: socket, head, app })
+                return
+            }
+            for (const listener of socketIoListeners) {
+                listener.call(server, request, socket, head)
+            }
+        })
+    },
+    shouldProxy({ app, url, cookieHeader }: ShouldProxyParams): boolean {
+        if (isNil(url) || !url.startsWith(SOCKET_IO_PATH)) {
+            return false
+        }
+        return canaryCookie.isValidHeader(app, cookieHeader)
+    },
+}
+
+function proxyUpgrade({ canaryAppUrl, request, clientSocket, head, app }: ProxyUpgradeParams): void {
+    const target = new URL(canaryAppUrl)
+    const client = target.protocol === 'https:' ? https : http
+    const destroyBoth = (error: Error, upstreamSocket?: Duplex): void => {
+        app.log.error({ error, url: request.url }, '[canaryWsRouting] ws proxy failed')
+        upstreamSocket?.destroy()
+        clientSocket.destroy()
+    }
+
+    const proxyReq = client.request({
+        protocol: target.protocol,
+        hostname: target.hostname,
+        port: target.port === '' ? undefined : target.port,
+        method: request.method,
+        path: request.url,
+        headers: request.headers,
+        timeout: UPSTREAM_TIMEOUT_MS,
+    })
+
+    proxyReq.on('upgrade', (proxyRes, upstreamSocket, upstreamHead) => {
+        const statusLine = `HTTP/1.1 ${proxyRes.statusCode} ${proxyRes.statusMessage}`
+        const headerLines = Object.entries(proxyRes.headers).flatMap(([key, value]) =>
+            (Array.isArray(value) ? value : [value]).filter((v): v is string => !isNil(v)).map((v) => `${key}: ${v}`),
+        )
+        clientSocket.write([statusLine, ...headerLines, '\r\n'].join('\r\n'))
+
+        if (upstreamHead.length > 0) {
+            clientSocket.write(upstreamHead)
+        }
+        if (head.length > 0) {
+            upstreamSocket.write(head)
+        }
+
+        upstreamSocket.on('error', (error) => destroyBoth(error, upstreamSocket))
+        clientSocket.on('error', (error) => destroyBoth(error, upstreamSocket))
+        upstreamSocket.pipe(clientSocket)
+        clientSocket.pipe(upstreamSocket)
+    })
+    proxyReq.on('timeout', () => destroyBoth(new Error('canary ws upstream timeout')))
+    proxyReq.on('error', (error) => destroyBoth(error))
+    proxyReq.end()
+}
+
+type ShouldProxyParams = {
+    app: FastifyInstance
+    url: string | undefined
+    cookieHeader: string | undefined
+}
+
+type ProxyUpgradeParams = {
+    canaryAppUrl: string
+    request: IncomingMessage
+    clientSocket: Duplex
+    head: Buffer
+    app: FastifyInstance
+}

--- a/packages/server/api/src/app/server.ts
+++ b/packages/server/api/src/app/server.ts
@@ -39,13 +39,12 @@ export let app: FastifyInstance | undefined = undefined
 export const setupServer = async (): Promise<FastifyInstance> => {
     app = await setupBaseApp()
 
-    // Signed-cookie support for canary routing, at the root so /api, static, and ws all see it.
-    await app.register(fastifyCookie, { secret: await jwtUtils.getJwtSecret() })
-
-    // Canary routing (see .agents/features/canary.md). reply-from is registered ONCE at the root and
-    // shared with the /api middleware — it is fastify-plugin wrapped, so a second registration collides.
+    // Canary routing (see .agents/features/canary.md). Cookie + reply-from are registered ONCE at the
+    // root here (only when canary is configured — no cost on workers / non-canary), before the /api
+    // scope so it inherits them. reply-from is fastify-plugin wrapped, so a second registration collides.
     const canaryAppUrl = system.get(AppSystemProp.CANARY_APP_URL)
     if (system.isApp() && !isNil(canaryAppUrl)) {
+        await app.register(fastifyCookie, { secret: await jwtUtils.getJwtSecret() })
         await app.register(replyFrom, { base: canaryAppUrl })
         app.addHook('onRequest', canaryStaticRoutingMiddleware)
         // onReady so socket.io's 'upgrade' listener is already attached to be captured.

--- a/packages/server/api/src/app/server.ts
+++ b/packages/server/api/src/app/server.ts
@@ -1,11 +1,13 @@
 import path from 'path'
-import { apId, spreadIfDefined } from '@activepieces/core-utils'
+import { apId, isNil, spreadIfDefined } from '@activepieces/core-utils'
 import { apLogger, wideEvent } from '@activepieces/server-utils'
 import { ApEnvironment, maxSocketHttpBufferSizeBytes } from '@activepieces/shared'
+import fastifyCookie from '@fastify/cookie'
 import cors from '@fastify/cors'
 import formBody from '@fastify/formbody'
 import fastifyHttpProxy from '@fastify/http-proxy'
 import fastifyMultipart from '@fastify/multipart'
+import replyFrom from '@fastify/reply-from'
 import fastifyStatic from '@fastify/static'
 import { evlog as evlogFastify, useLogger as useWideEventLogger } from 'evlog/fastify'
 import fastify, { FastifyInstance } from 'fastify'
@@ -15,12 +17,15 @@ import { validatorCompiler } from 'fastify-type-provider-zod'
 import qs from 'qs'
 import { Socket } from 'socket.io'
 import { getAdapter, setupApp } from './app'
+import { canaryStaticRoutingMiddleware } from './core/canary/canary-static-routing.middleware'
+import { canaryWsRouting } from './core/canary/canary-ws-routing'
 import { oidcDiscoveryController } from './core/security/oidc/oidc-discovery.controller'
 import { websocketService } from './core/websockets.service'
 import { healthModule } from './health/health.module'
 import { embedSecurity } from './helper/embed-security'
 import { enrichWideEventWithError, errorHandler } from './helper/error-handler'
 import { exceptionHandler } from './helper/exception-handler'
+import { jwtUtils } from './helper/jwt-utils'
 import { networkUtils } from './helper/network-utils'
 import { rejectedPromiseHandler } from './helper/promise-handler'
 import { system } from './helper/system/system'
@@ -33,6 +38,21 @@ export let app: FastifyInstance | undefined = undefined
 
 export const setupServer = async (): Promise<FastifyInstance> => {
     app = await setupBaseApp()
+
+    // Signed-cookie support for canary routing, at the root so /api, static, and ws all see it.
+    await app.register(fastifyCookie, { secret: await jwtUtils.getJwtSecret() })
+
+    // Canary routing (see .agents/features/canary.md). reply-from is registered ONCE at the root and
+    // shared with the /api middleware — it is fastify-plugin wrapped, so a second registration collides.
+    const canaryAppUrl = system.get(AppSystemProp.CANARY_APP_URL)
+    if (system.isApp() && !isNil(canaryAppUrl)) {
+        await app.register(replyFrom, { base: canaryAppUrl })
+        app.addHook('onRequest', canaryStaticRoutingMiddleware)
+        // onReady so socket.io's 'upgrade' listener is already attached to be captured.
+        app.addHook('onReady', async () => {
+            canaryWsRouting.install(app!)
+        })
+    }
 
     // MCP OAuth endpoints at domain root (required by MCP spec)
     // OIDC discovery endpoints at domain root (required by OIDC spec)
@@ -108,7 +128,10 @@ export const setupServer = async (): Promise<FastifyInstance> => {
             setHeaders: (res, filepath) => {
                 const normalized = filepath.replace(/\\/g, '/')
                 if (normalized.endsWith('.html')) {
-                    void res.setHeader('Cache-Control', 'no-cache')
+                    // Shared un-hashed URL that canary may swap per ap_canary cookie — never let a
+                    // shared/CDN cache reuse it across the boundary. See .agents/features/canary.md.
+                    void res.setHeader('Cache-Control', 'no-store, must-revalidate')
+                    void res.setHeader('Vary', 'Cookie')
                 }
                 else if (normalized.includes('/assets/')) {
                     void res.setHeader('Cache-Control', 'public, max-age=31536000, immutable')

--- a/packages/server/api/test/unit/app/core/canary/canary-cookie.test.ts
+++ b/packages/server/api/test/unit/app/core/canary/canary-cookie.test.ts
@@ -1,0 +1,62 @@
+import fastifyCookie from '@fastify/cookie'
+import Fastify, { FastifyInstance } from 'fastify'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { canaryCookie, CANARY_COOKIE_NAME } from '../../../../../src/app/core/canary/canary-cookie'
+
+const buildApp = async (secret: string): Promise<FastifyInstance> => {
+    const app = Fastify()
+    await app.register(fastifyCookie, { secret })
+    await app.ready()
+    return app
+}
+
+const cookiePair = (setCookieHeader: string): string => setCookieHeader.split(';')[0]
+
+describe('canaryCookie', () => {
+    let app: FastifyInstance
+
+    beforeEach(async () => {
+        app = await buildApp('test-secret')
+    })
+
+    afterEach(async () => {
+        await app.close()
+    })
+
+    it('builds a hardened Set-Cookie header', () => {
+        const header = canaryCookie.buildSetHeader(app)
+        expect(header).toContain(`${CANARY_COOKIE_NAME}=`)
+        expect(header).toMatch(/Secure/i)
+        expect(header).toMatch(/SameSite=Lax/i)
+        expect(header).toContain('Path=/')
+        // Intentionally readable by JS (not HttpOnly) so the frontend can trigger the canary swap.
+        expect(header).not.toMatch(/HttpOnly/i)
+    })
+
+    it('round-trips: a freshly built cookie validates', () => {
+        const header = cookiePair(canaryCookie.buildSetHeader(app))
+        expect(canaryCookie.isValidHeader(app, header)).toBe(true)
+    })
+
+    it('rejects a tampered signature', () => {
+        const header = cookiePair(canaryCookie.buildSetHeader(app))
+        expect(canaryCookie.isValidHeader(app, header.slice(0, -3) + 'xyz')).toBe(false)
+    })
+
+    it('rejects an unsigned / forged value', () => {
+        expect(canaryCookie.isValidHeader(app, `${CANARY_COOKIE_NAME}=1`)).toBe(false)
+    })
+
+    it('rejects a cookie signed with a different secret', async () => {
+        const header = cookiePair(canaryCookie.buildSetHeader(app))
+        const other = await buildApp('rotated-secret')
+        expect(canaryCookie.isValidHeader(other, header)).toBe(false)
+        await other.close()
+    })
+
+    it('treats absent / unrelated cookies as invalid', () => {
+        expect(canaryCookie.isValidHeader(app, undefined)).toBe(false)
+        expect(canaryCookie.isValidHeader(app, 'other=1; foo=bar')).toBe(false)
+    })
+})

--- a/packages/server/api/test/unit/app/core/canary/canary-proxy.integration.test.ts
+++ b/packages/server/api/test/unit/app/core/canary/canary-proxy.integration.test.ts
@@ -16,6 +16,7 @@
  */
 
 import { PrincipalType } from '@activepieces/shared'
+import fastifyCookie from '@fastify/cookie'
 import replyFrom from '@fastify/reply-from'
 import fastify, { FastifyInstance, FastifyRequest } from 'fastify'
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -96,6 +97,9 @@ let primaryApp: FastifyInstance
 async function buildPrimaryApp(platformId = 'canary-platform'): Promise<FastifyInstance> {
     const app = fastify()
 
+    // Mirror the real server: @fastify/cookie is registered at the root so the middleware can mint
+    // the signed canary routing cookie (canaryCookie.buildSetHeader uses app.signCookie/serializeCookie).
+    await app.register(fastifyCookie, { secret: 'integration-test-secret' })
     await app.register(replyFrom, { base: canaryUrl })
 
     app.addHook('onRequest', async (request: FastifyRequest) => {

--- a/packages/server/api/test/unit/app/core/canary/canary-routing.middleware.test.ts
+++ b/packages/server/api/test/unit/app/core/canary/canary-routing.middleware.test.ts
@@ -5,9 +5,21 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 // --- mocks (must be before the import under test) ---
 
-const { mockSystemGet, mockIsCanaryPlatform } = vi.hoisted(() => ({
+const { mockSystemGet, mockIsCanaryPlatform, mockBuildSetHeader, mockClear, mockIsPresent } = vi.hoisted(() => ({
     mockSystemGet: vi.fn(),
     mockIsCanaryPlatform: vi.fn(),
+    mockBuildSetHeader: vi.fn(),
+    mockClear: vi.fn(),
+    mockIsPresent: vi.fn(),
+}))
+
+vi.mock('../../../../../src/app/core/canary/canary-cookie', () => ({
+    canaryCookie: {
+        buildSetHeader: (...args: unknown[]) => mockBuildSetHeader(...args),
+        clear: (...args: unknown[]) => mockClear(...args),
+        isPresent: (...args: unknown[]) => mockIsPresent(...args),
+    },
+    CANARY_COOKIE_NAME: 'ap_canary',
 }))
 
 vi.mock('../../../../../src/app/helper/system/system', () => ({
@@ -78,6 +90,7 @@ function makeReply(opts: { sent?: boolean, proxyError?: Error } = {}): FastifyRe
         raw: rawEmitter,
         status: vi.fn().mockReturnThis(),
         headers: vi.fn().mockReturnThis(),
+        header: vi.fn().mockReturnThis(),
         send: vi.fn().mockReturnValue(undefined),
     }
 
@@ -105,6 +118,8 @@ describe('canaryRoutingMiddleware', () => {
     beforeEach(() => {
         vi.clearAllMocks()
         mockIsCanaryPlatform.mockResolvedValue(false)
+        mockBuildSetHeader.mockReturnValue('ap_canary=signed; Path=/; HttpOnly; Secure; SameSite=Lax')
+        mockIsPresent.mockReturnValue(false)
     })
 
     it('does nothing when CANARY_APP_URL is not set', async () => {
@@ -149,6 +164,23 @@ describe('canaryRoutingMiddleware', () => {
         await canaryRoutingMiddleware(request, reply)
 
         expect(reply.from).not.toHaveBeenCalled()
+        expect(mockClear).not.toHaveBeenCalled()
+    })
+
+    it('clears a stale canary cookie for a non-canary platform that still carries one', async () => {
+        mockSystemGet.mockReturnValue('http://canary:3000')
+        mockIsCanaryPlatform.mockResolvedValue(false)
+        mockIsPresent.mockReturnValue(true)
+        const request = makeRequest({
+            headers: { cookie: 'ap_canary=signed' },
+            principal: { type: PrincipalType.USER, platform: { id: 'platform-abc' } } as never,
+        })
+        const reply = makeReply()
+
+        await canaryRoutingMiddleware(request, reply)
+
+        expect(reply.from).not.toHaveBeenCalled()
+        expect(mockClear).toHaveBeenCalledWith(reply)
     })
 
     it('proxies request for a canary platform resolved from principal', async () => {
@@ -168,8 +200,9 @@ describe('canaryRoutingMiddleware', () => {
 
         expect(reply.from).toHaveBeenCalledWith(
             '/v1/flows',
-            expect.objectContaining({ onError: expect.any(Function) }),
+            expect.objectContaining({ onError: expect.any(Function), rewriteHeaders: expect.any(Function) }),
         )
+        expect(mockBuildSetHeader).toHaveBeenCalled()
     })
 
     it('proxies request for a canary platform resolved from flowId cache', async () => {

--- a/packages/server/api/test/unit/app/core/canary/canary-static-routing.middleware.test.ts
+++ b/packages/server/api/test/unit/app/core/canary/canary-static-routing.middleware.test.ts
@@ -1,0 +1,98 @@
+import { EventEmitter } from 'node:events'
+import { FastifyBaseLogger, FastifyReply, FastifyRequest } from 'fastify'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { mockSystemGet, mockIsValidHeader } = vi.hoisted(() => ({
+    mockSystemGet: vi.fn(),
+    mockIsValidHeader: vi.fn(),
+}))
+
+vi.mock('../../../../../src/app/helper/system/system', () => ({
+    system: {
+        get: (...args: unknown[]) => mockSystemGet(...args),
+    },
+}))
+
+vi.mock('../../../../../src/app/core/canary/canary-cookie', () => ({
+    canaryCookie: {
+        isValidHeader: (...args: unknown[]) => mockIsValidHeader(...args),
+    },
+    CANARY_COOKIE_NAME: 'ap_canary',
+}))
+
+import { canaryStaticRoutingMiddleware } from '../../../../../src/app/core/canary/canary-static-routing.middleware'
+import { AppSystemProp } from '../../../../../src/app/helper/system/system-props'
+
+const mockLog: FastifyBaseLogger = {
+    debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn(),
+    fatal: vi.fn(), trace: vi.fn(), child: vi.fn(),
+} as unknown as FastifyBaseLogger
+
+function makeRequest(overrides: Partial<FastifyRequest> = {}): FastifyRequest {
+    return {
+        method: 'GET',
+        url: '/',
+        headers: {},
+        log: mockLog,
+        server: {},
+        ...overrides,
+    } as unknown as FastifyRequest
+}
+
+function makeReply(): FastifyReply {
+    const rawEmitter = new EventEmitter()
+    const reply: Record<string, unknown> = { raw: rawEmitter, send: vi.fn() }
+    reply.from = vi.fn().mockImplementation(() => {
+        Promise.resolve().then(() => rawEmitter.emit('finish'))
+        return reply
+    })
+    return reply as unknown as FastifyReply
+}
+
+describe('canaryStaticRoutingMiddleware', () => {
+    beforeEach(() => {
+        vi.clearAllMocks()
+        mockSystemGet.mockImplementation((prop: AppSystemProp) =>
+            prop === AppSystemProp.CANARY_APP_URL ? 'http://canary:3000' : undefined,
+        )
+        mockIsValidHeader.mockReturnValue(true)
+    })
+
+    it.each(['/', '/index.html', '/assets/index-abc.js', '/flows', '/projects/p1'])(
+        'proxies frontend path %s when the canary cookie is valid',
+        async (url) => {
+            const reply = makeReply()
+            await canaryStaticRoutingMiddleware(makeRequest({ url }), reply)
+            expect(reply.from).toHaveBeenCalledWith(url, expect.objectContaining({ onError: expect.any(Function) }))
+        },
+    )
+
+    it.each(['/api/v1/flows', '/mcp/x', '/ingest/e', '/.well-known/openid-configuration'])(
+        'does not proxy backend path %s',
+        async (url) => {
+            const reply = makeReply()
+            await canaryStaticRoutingMiddleware(makeRequest({ url }), reply)
+            expect(reply.from).not.toHaveBeenCalled()
+        },
+    )
+
+    it('does not proxy websocket upgrades', async () => {
+        const reply = makeReply()
+        await canaryStaticRoutingMiddleware(makeRequest({ headers: { upgrade: 'websocket' } }), reply)
+        expect(reply.from).not.toHaveBeenCalled()
+    })
+
+    it('does not proxy when the canary cookie is missing or invalid', async () => {
+        mockIsValidHeader.mockReturnValue(false)
+        const reply = makeReply()
+        await canaryStaticRoutingMiddleware(makeRequest({ url: '/flows' }), reply)
+        expect(reply.from).not.toHaveBeenCalled()
+    })
+
+    it('does not proxy when CANARY_APP_URL is not configured', async () => {
+        mockSystemGet.mockReturnValue(undefined)
+        const reply = makeReply()
+        await canaryStaticRoutingMiddleware(makeRequest({ url: '/flows' }), reply)
+        expect(reply.from).not.toHaveBeenCalled()
+    })
+})

--- a/packages/server/api/test/unit/app/core/canary/canary-ws-routing.test.ts
+++ b/packages/server/api/test/unit/app/core/canary/canary-ws-routing.test.ts
@@ -1,0 +1,105 @@
+import { EventEmitter } from 'node:events'
+import { FastifyInstance } from 'fastify'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { mockSystemGet, mockIsValidHeader, mockHttpRequest, mockHttpsRequest } = vi.hoisted(() => ({
+    mockSystemGet: vi.fn(),
+    mockIsValidHeader: vi.fn(),
+    mockHttpRequest: vi.fn(),
+    mockHttpsRequest: vi.fn(),
+}))
+
+vi.mock('../../../../../src/app/helper/system/system', () => ({
+    system: { get: (...args: unknown[]) => mockSystemGet(...args) },
+}))
+
+vi.mock('../../../../../src/app/core/canary/canary-cookie', () => ({
+    canaryCookie: { isValidHeader: (...args: unknown[]) => mockIsValidHeader(...args) },
+    CANARY_COOKIE_NAME: 'ap_canary',
+}))
+
+vi.mock('node:http', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('node:http')>()
+    return { ...actual, default: { ...actual.default, request: mockHttpRequest } }
+})
+vi.mock('node:https', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('node:https')>()
+    return { ...actual, default: { ...actual.default, request: mockHttpsRequest } }
+})
+
+import { canaryWsRouting } from '../../../../../src/app/core/canary/canary-ws-routing'
+import { AppSystemProp } from '../../../../../src/app/helper/system/system-props'
+
+const fakeApp = { log: { error: vi.fn() } } as unknown as FastifyInstance
+
+describe('canaryWsRouting.shouldProxy', () => {
+    beforeEach(() => {
+        vi.clearAllMocks()
+        mockIsValidHeader.mockReturnValue(true)
+    })
+
+    it('proxies a valid-cookie /api/socket.io upgrade', () => {
+        expect(canaryWsRouting.shouldProxy({ app: fakeApp, url: '/api/socket.io/?EIO=4', cookieHeader: 'ap_canary=x' })).toBe(true)
+    })
+
+    it('does not proxy a non-socket.io url', () => {
+        expect(canaryWsRouting.shouldProxy({ app: fakeApp, url: '/api/v1/flows', cookieHeader: 'ap_canary=x' })).toBe(false)
+    })
+
+    it('does not proxy an undefined url', () => {
+        expect(canaryWsRouting.shouldProxy({ app: fakeApp, url: undefined, cookieHeader: 'ap_canary=x' })).toBe(false)
+    })
+
+    it('does not proxy when the cookie is invalid', () => {
+        mockIsValidHeader.mockReturnValue(false)
+        expect(canaryWsRouting.shouldProxy({ app: fakeApp, url: '/api/socket.io/', cookieHeader: 'ap_canary=bad' })).toBe(false)
+    })
+})
+
+describe('canaryWsRouting.install', () => {
+    let server: EventEmitter & { listeners: typeof EventEmitter.prototype.listeners }
+    let socketIoListener: ReturnType<typeof vi.fn>
+    let app: FastifyInstance
+
+    beforeEach(() => {
+        vi.clearAllMocks()
+        mockSystemGet.mockImplementation((prop: AppSystemProp) =>
+            prop === AppSystemProp.CANARY_APP_URL ? 'http://canary:3000' : undefined,
+        )
+        mockHttpRequest.mockReturnValue(Object.assign(new EventEmitter(), { end: vi.fn(), write: vi.fn() }))
+        server = new EventEmitter() as never
+        socketIoListener = vi.fn()
+        server.on('upgrade', socketIoListener)
+        app = { server, log: { error: vi.fn(), info: vi.fn() } } as unknown as FastifyInstance
+    })
+
+    it('is a no-op when CANARY_APP_URL is unset', () => {
+        mockSystemGet.mockReturnValue(undefined)
+        canaryWsRouting.install(app)
+        server.emit('upgrade', { url: '/api/socket.io/', headers: {} }, mockSocket(), Buffer.alloc(0))
+        expect(socketIoListener).toHaveBeenCalledTimes(1)
+    })
+
+    it('delegates non-canary upgrades to the captured socket.io listener', () => {
+        mockIsValidHeader.mockReturnValue(false)
+        canaryWsRouting.install(app)
+        const req = { url: '/api/socket.io/', headers: {} }
+        const socket = mockSocket()
+        const head = Buffer.alloc(0)
+        server.emit('upgrade', req, socket, head)
+        expect(socketIoListener).toHaveBeenCalledWith(req, socket, head)
+        expect(mockHttpRequest).not.toHaveBeenCalled()
+    })
+
+    it('proxies canary upgrades to the canary app and does not delegate to socket.io', () => {
+        mockIsValidHeader.mockReturnValue(true)
+        canaryWsRouting.install(app)
+        server.emit('upgrade', { url: '/api/socket.io/?EIO=4', method: 'GET', headers: { cookie: 'ap_canary=x' } }, mockSocket(), Buffer.alloc(0))
+        expect(socketIoListener).not.toHaveBeenCalled()
+        expect(mockHttpRequest).toHaveBeenCalledWith(expect.objectContaining({ hostname: 'canary', path: '/api/socket.io/?EIO=4' }))
+    })
+})
+
+function mockSocket(): EventEmitter & { write: () => void, destroy: () => void, pipe: () => void } {
+    return Object.assign(new EventEmitter(), { write: vi.fn(), destroy: vi.fn(), pipe: vi.fn() }) as never
+}

--- a/packages/server/api/test/unit/app/core/canary/canary-ws-routing.test.ts
+++ b/packages/server/api/test/unit/app/core/canary/canary-ws-routing.test.ts
@@ -98,6 +98,18 @@ describe('canaryWsRouting.install', () => {
         expect(socketIoListener).not.toHaveBeenCalled()
         expect(mockHttpRequest).toHaveBeenCalledWith(expect.objectContaining({ hostname: 'canary', path: '/api/socket.io/?EIO=4' }))
     })
+
+    it('destroys the upstream request (not just the client) on upstream timeout', () => {
+        mockIsValidHeader.mockReturnValue(true)
+        const proxyReq = Object.assign(new EventEmitter(), { end: vi.fn(), write: vi.fn(), destroy: vi.fn() })
+        mockHttpRequest.mockReturnValue(proxyReq)
+        canaryWsRouting.install(app)
+        const clientSocket = mockSocket()
+        server.emit('upgrade', { url: '/api/socket.io/', method: 'GET', headers: { cookie: 'ap_canary=x' } }, clientSocket, Buffer.alloc(0))
+        proxyReq.emit('timeout')
+        expect(proxyReq.destroy).toHaveBeenCalled()
+        expect(clientSocket.destroy).toHaveBeenCalled()
+    })
 })
 
 function mockSocket(): EventEmitter & { write: () => void, destroy: () => void, pipe: () => void } {

--- a/packages/web/src/main.tsx
+++ b/packages/web/src/main.tsx
@@ -34,11 +34,19 @@ window.addEventListener('unhandledrejection', (event) => {
   errorReporting.report({ error: event.reason, source: 'unhandled-rejection' });
 });
 
-const root = ReactDOM.createRoot(
-  document.getElementById('root') as HTMLElement,
-);
-root.render(
-  <StrictMode>
-    <App />
-  </StrictMode>,
-);
+// Canary transparent frontend: once the ap_canary cookie is set, reload once into the canary bundle.
+// Guarded to one reload/session so the canary bundle doesn't loop. See .agents/features/canary.md.
+const hasCanaryCookie = document.cookie
+  .split('; ')
+  .some((entry) => entry.startsWith('ap_canary='));
+
+if (!hasCanaryCookie || !reloadOnceForStaleChunk('canary-bundle-swap')) {
+  const root = ReactDOM.createRoot(
+    document.getElementById('root') as HTMLElement,
+  );
+  root.render(
+    <StrictMode>
+      <App />
+    </StrictMode>,
+  );
+}


### PR DESCRIPTION
## What does this PR do?

Lets a canary platform (worker group `canary`) get the **new frontend, backend, and websockets** transparently on `cloud.activepieces.com` — same URL, so all auth/OAuth/SSO keep working — instead of only the backend via the existing `/api` proxy. (Redirecting to a `canary.*` origin would break auth: the session token is origin-scoped `localStorage`, and OAuth/SSO `redirect_uri`s are registered for the primary origin only.)

Routing is driven by one signed `ap_canary` cookie the app sets once `/api` confirms a canary platform:
- **Static/SPA** requests with a valid cookie are reverse-proxied to the canary app (the canary bundle is served on the primary origin).
- **`/api/socket.io` upgrades** with a valid cookie are piped to the canary app; everything else is delegated to the local socket.io — so a canary user's realtime (incl. inbound lock/presence handlers) runs entirely on canary code, closing the new-frontend↔old-ws version seam.
- The frontend reloads **once** into the canary bundle when the cookie appears (guarded to one reload/session, so no loop).

Design + rationale live in `.agents/features/canary.md`.

### Security
- Cookie is **HMAC-signed** with the JWT secret (via `@fastify/cookie`), so it can't be forged. It grants **no privilege** (auth stays the token) — it only selects which code version serves; that's why it's deliberately readable (not HttpOnly) for the bundle-swap hint.
- `index.html` is `no-store` + `Vary: Cookie` so a shared/CDN cache can't serve a canary bundle to a prod user; hashed `/assets/*` stay `immutable` (unique per build).
- Proxy upstream is always the fixed `CANARY_APP_URL` (no SSRF). All new paths are **no-ops when `CANARY_APP_URL` is unset** (self-hosted / CE default → zero behavior change).

### Tests
40 unit/integration tests across the canary module: cookie sign/verify/tamper/rotated-secret, `/api` proxy (incl. real-TCP integration), static routing (path exclusions + cookie gating), ws routing (gate + capture/delegate/proxy). `api` + `web` lint clean.

## Ops prerequisites (before enabling)
1. **Cloudflare**: bypass cache when the `ap_canary` cookie is present (belt-and-suspenders with the `no-store` header).
2. The **canary app must NOT set `CANARY_APP_URL`** (else it proxies to itself — loop).
3. Keep the canary hostname/service pinned to the canary deployment.

> Note: transparent primary-origin routing only takes effect once this ships to **prod** (the reload logic must live in the bundle users first load). Until then, canary is reached directly via `canary.activepieces.com`.

## Breaking change?

- [ ] Yes
- [x] No

New code is gated on `CANARY_APP_URL`; no new required env vars, no schema changes, no API changes. Self-hosters/CE are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)