### PR TITLE
feat(quickbooks): add Create Bill, Find Vendor, Record Payment, and A…

### DIFF
--- a/packages/pieces/community/quickbooks/package.json
+++ b/packages/pieces/community/quickbooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-quickbooks",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {

--- a/packages/pieces/community/quickbooks/src/actions/create-bill.ts
+++ b/packages/pieces/community/quickbooks/src/actions/create-bill.ts
@@ -85,7 +85,7 @@ export const createBillAction = createAction({
 				expenseAccountId: Property.ShortText({
 					displayName: 'Expense Category/Account ID',
 					description:
-						'Enter the ID of the Expense Account. Required for Account Based Expense Line Detail.',
+						'The Id of the expense account. Use the "Find Account" action (filter by type Expense) to look this up.',
 					required: true,
 				}),
 			},

--- a/packages/pieces/community/quickbooks/src/actions/create-bill.ts
+++ b/packages/pieces/community/quickbooks/src/actions/create-bill.ts
@@ -1,0 +1,174 @@
+import { Property, createAction, OAuth2PropertyValue } from '@activepieces/pieces-framework';
+import { HttpMethod, httpClient } from '@activepieces/pieces-common';
+import { quickbooksAuth } from '../lib/auth';
+import { quickbooksCommon, QuickbooksEntityResponse } from '../lib/common';
+import { QuickbooksBill, QuickbooksVendor, QuickbooksRef } from '../lib/types';
+
+export const createBillAction = createAction({
+	auth: quickbooksAuth,
+	name: 'create_bill',
+	displayName: 'Create Bill',
+	description: 'Creates a bill (accounts payable) in QuickBooks.',
+	audience: 'both',
+	aiMetadata: {
+		description: 'Record a new bill owed to a vendor, with one or more account-based line items (each needs an amount and an expense account Id). Optionally set the bill date, due date, bill number, and memo. Not idempotent: each call creates a new bill, so guard against duplicates.',
+		idempotent: false,
+	},
+	props: {
+		vendorRef: Property.Dropdown({
+			auth: quickbooksAuth,
+			displayName: 'Vendor',
+			required: true,
+			refreshers: [],
+			options: async ({ auth }) => {
+				if (!auth) {
+					return { disabled: true, placeholder: 'Connect your account first', options: [] };
+				}
+				const { access_token, props } = auth as OAuth2PropertyValue;
+				const companyId = props?.['companyId'];
+				const apiUrl = quickbooksCommon.getApiUrl(companyId);
+				const query = `SELECT Id, DisplayName FROM Vendor STARTPOSITION 1 MAXRESULTS 1000`;
+				const response = await httpClient.sendRequest<QuickbooksEntityResponse<QuickbooksVendor>>({
+					method: HttpMethod.GET,
+					url: `${apiUrl}/query`,
+					queryParams: { query: query, minorversion: '70' },
+					headers: {
+						Authorization: `Bearer ${access_token}`,
+						Accept: 'application/json',
+					},
+				});
+
+				if (response.body.Fault) {
+					throw new Error(
+						`QuickBooks API Error fetching vendors: ${response.body.Fault.Error.map(
+							(e: { Message: string }) => e.Message,
+						).join(', ')}`,
+					);
+				}
+
+				const vendors = response.body.QueryResponse?.['Vendor'] ?? [];
+				return {
+					disabled: false,
+					options: vendors.map((vendor) => ({
+						label: vendor.DisplayName,
+						value: vendor.Id,
+					})),
+				};
+			},
+		}),
+		lineItems: Property.Array({
+			displayName: 'Line Items',
+			description: 'Details of the bill (expense categories). At least one line is required.',
+			required: true,
+			properties: {
+				amount: Property.Number({
+					displayName: 'Amount',
+					required: true,
+				}),
+				description: Property.ShortText({
+					displayName: 'Description',
+					required: false,
+				}),
+				detailType: Property.StaticDropdown({
+					displayName: 'Detail Type',
+					required: true,
+					options: {
+						options: [
+							{
+								label: 'Account Based Expense Line Detail',
+								value: 'AccountBasedExpenseLineDetail',
+							},
+						],
+					},
+					defaultValue: 'AccountBasedExpenseLineDetail',
+				}),
+				expenseAccountId: Property.ShortText({
+					displayName: 'Expense Category/Account ID',
+					description:
+						'Enter the ID of the Expense Account. Required for Account Based Expense Line Detail.',
+					required: true,
+				}),
+			},
+		}),
+		txnDate: Property.DateTime({
+			displayName: 'Bill Date',
+			description: 'The date of the bill. Defaults to today if empty.',
+			required: false,
+		}),
+		dueDate: Property.DateTime({
+			displayName: 'Due Date',
+			description: 'The date the payment is due. If empty, the vendor/company term is used.',
+			required: false,
+		}),
+		docNumber: Property.ShortText({
+			displayName: 'Bill Number',
+			description: 'Reference number for the bill.',
+			required: false,
+		}),
+		privateNote: Property.LongText({
+			displayName: 'Memo (Private Note)',
+			description: 'Internal note about the bill.',
+			required: false,
+		}),
+	},
+	async run(context) {
+		const { access_token } = context.auth;
+		const companyId = context.auth.props?.['companyId'];
+
+		const apiUrl = quickbooksCommon.getApiUrl(companyId as string);
+		const props = context.propsValue;
+
+		const lines = (props['lineItems'] as any[]).map((line) => {
+			if (!line['expenseAccountId']) {
+				throw new Error('Expense Category/Account ID is required for each line.');
+			}
+			return {
+				Amount: line['amount'],
+				Description: line['description'],
+				DetailType: line['detailType'],
+				AccountBasedExpenseLineDetail: {
+					AccountRef: { value: line['expenseAccountId'] } as QuickbooksRef,
+				},
+			};
+		});
+
+		if (lines.length === 0) {
+			throw new Error('At least one line item is required.');
+		}
+
+		const billPayload: Partial<QuickbooksBill> = {
+			VendorRef: { value: props['vendorRef'] } as QuickbooksRef,
+			Line: lines,
+			...(props['txnDate'] && { TxnDate: props['txnDate'].split('T')[0] }),
+			...(props['dueDate'] && { DueDate: props['dueDate'].split('T')[0] }),
+			...(props['docNumber'] && { DocNumber: props['docNumber'] }),
+			...(props['privateNote'] && { PrivateNote: props['privateNote'] }),
+		};
+
+		const response = await httpClient.sendRequest<{
+			Bill: QuickbooksBill;
+			time: string;
+			Fault?: { Error: { Message: string; Detail?: string; code: string }[]; type: string };
+		}>({
+			method: HttpMethod.POST,
+			url: `${apiUrl}/bill`,
+			queryParams: { minorversion: '70' },
+			headers: {
+				Authorization: `Bearer ${access_token}`,
+				Accept: 'application/json',
+				'Content-Type': 'application/json',
+			},
+			body: billPayload,
+		});
+
+		if (response.body.Fault) {
+			throw new Error(
+				`QuickBooks API Error creating bill: ${response.body.Fault.Error.map(
+					(e: any) => e.Message,
+				).join(', ')} - Detail: ${response.body.Fault.Error.map((e: any) => e.Detail).join(', ')}`,
+			);
+		}
+
+		return response.body.Bill;
+	},
+});

--- a/packages/pieces/community/quickbooks/src/actions/create-expense.ts
+++ b/packages/pieces/community/quickbooks/src/actions/create-expense.ts
@@ -157,7 +157,7 @@ export const createExpenseAction = createAction({
 				expenseAccountId: Property.ShortText({
 					displayName: 'Expense Category/Account ID',
 					description:
-						'Enter the ID of the Expense Account. Required for AccountBasedExpenseLineDetail.',
+						'The Id of the expense account. Use the "Find Account" action (filter by type Expense) to look this up.',
 					required: true,
 				}),
 			},

--- a/packages/pieces/community/quickbooks/src/actions/find-account.ts
+++ b/packages/pieces/community/quickbooks/src/actions/find-account.ts
@@ -1,0 +1,89 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod, httpClient, AuthenticationType } from '@activepieces/pieces-common';
+import { quickbooksAuth } from '../lib/auth';
+import { quickbooksCommon, QuickbooksEntityResponse } from '../lib/common';
+import { QuickbooksAccount } from '../lib/types';
+
+export const findAccountAction = createAction({
+	auth: quickbooksAuth,
+	name: 'find_account',
+	displayName: 'Find Account',
+	description: 'List or search the chart of accounts to get an account Id (e.g. an expense account for a bill).',
+	audience: 'both',
+	aiMetadata: {
+		description: 'List QuickBooks chart-of-accounts entries to resolve an account name to its Id. Optionally filter by a name substring and/or account type (e.g. Expense, Bank, Accounts Payable). Use this to find the expense-account Id required by Create Bill / Create Expense line items. Read-only and idempotent.',
+		idempotent: true,
+	},
+	props: {
+		search_term: Property.ShortText({
+			displayName: 'Account Name Contains',
+			description: 'Optional. Filter accounts whose name contains this text.',
+			required: false,
+		}),
+		accountType: Property.StaticDropdown({
+			displayName: 'Account Type',
+			description: 'Optional. Filter by account type.',
+			required: false,
+			options: {
+				options: [
+					{ label: 'Bank', value: 'Bank' },
+					{ label: 'Accounts Receivable', value: 'Accounts Receivable' },
+					{ label: 'Other Current Asset', value: 'Other Current Asset' },
+					{ label: 'Fixed Asset', value: 'Fixed Asset' },
+					{ label: 'Other Asset', value: 'Other Asset' },
+					{ label: 'Accounts Payable', value: 'Accounts Payable' },
+					{ label: 'Credit Card', value: 'Credit Card' },
+					{ label: 'Other Current Liability', value: 'Other Current Liability' },
+					{ label: 'Long Term Liability', value: 'Long Term Liability' },
+					{ label: 'Equity', value: 'Equity' },
+					{ label: 'Income', value: 'Income' },
+					{ label: 'Cost of Goods Sold', value: 'Cost of Goods Sold' },
+					{ label: 'Expense', value: 'Expense' },
+					{ label: 'Other Income', value: 'Other Income' },
+					{ label: 'Other Expense', value: 'Other Expense' },
+				],
+			},
+		}),
+	},
+	async run(context) {
+		const { search_term, accountType } = context.propsValue;
+		const companyId = context.auth.props?.['companyId'];
+
+		if (!companyId) {
+			throw new Error('Realm ID not found in authentication data. Please reconnect your account.');
+		}
+
+		const apiUrl = quickbooksCommon.getApiUrl(companyId as string);
+
+		const conditions = ['Active = true'];
+		if (search_term) {
+			conditions.push(`Name LIKE '%${search_term.replace(/'/g, "\\'")}%'`);
+		}
+		if (accountType) {
+			conditions.push(`AccountType = '${accountType}'`);
+		}
+		const query = `SELECT * FROM Account WHERE ${conditions.join(' AND ')} MAXRESULTS 1000`;
+
+		const response = await httpClient.sendRequest<QuickbooksEntityResponse<QuickbooksAccount>>({
+			method: HttpMethod.GET,
+			url: `${apiUrl}/query`,
+			queryParams: {
+				query: query,
+				minorversion: '70',
+			},
+			authentication: {
+				type: AuthenticationType.BEARER_TOKEN,
+				token: context.auth.access_token,
+			},
+			headers: {
+				Accept: 'application/json',
+			},
+		});
+
+		const accounts = response.body?.QueryResponse?.['Account'] ?? [];
+		return {
+			found: accounts.length > 0,
+			result: accounts,
+		};
+	},
+});

--- a/packages/pieces/community/quickbooks/src/actions/find-vendor.ts
+++ b/packages/pieces/community/quickbooks/src/actions/find-vendor.ts
@@ -1,0 +1,69 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod, httpClient, AuthenticationType } from '@activepieces/pieces-common';
+import { quickbooksAuth } from '../lib/auth';
+import { quickbooksCommon, QuickbooksEntityResponse } from '../lib/common';
+import { QuickbooksVendor } from '../lib/types';
+
+export const findVendorAction = createAction({
+	auth: quickbooksAuth,
+	name: 'find_vendor',
+	displayName: 'Find Vendor',
+	description: 'Search for a vendor by display name in QuickBooks.',
+	audience: 'both',
+	aiMetadata: {
+		description: 'Look up a single QuickBooks vendor by exact display name, returning the first match. Use to resolve a vendor name to its full record (including its Id) before referencing it elsewhere; the match is exact, not fuzzy. Read-only and idempotent.',
+		idempotent: true,
+	},
+	props: {
+		search_term: Property.ShortText({
+			displayName: 'Vendor Name',
+			description: 'The display name of the vendor to search for.',
+			required: true,
+		}),
+	},
+	async run(context) {
+		const { search_term } = context.propsValue;
+		const companyId = context.auth.props?.['companyId'];
+
+		if (!companyId) {
+			throw new Error('Realm ID not found in authentication data. Please reconnect your account.');
+		}
+
+		const apiUrl = quickbooksCommon.getApiUrl(companyId as string);
+		const query = `SELECT * FROM Vendor WHERE DisplayName = '${search_term.replace(
+			/'/g,
+			"\\'",
+		)}' MAXRESULTS 1`;
+
+		const response = await httpClient.sendRequest<QuickbooksEntityResponse<QuickbooksVendor>>({
+			method: HttpMethod.GET,
+			url: `${apiUrl}/query`,
+			queryParams: {
+				query: query,
+				minorversion: '70',
+			},
+			authentication: {
+				type: AuthenticationType.BEARER_TOKEN,
+				token: context.auth.access_token,
+			},
+			headers: {
+				Accept: 'application/json',
+			},
+		});
+
+		if (
+			response.body?.QueryResponse?.['Vendor'] &&
+			response.body.QueryResponse['Vendor'].length > 0
+		) {
+			return {
+				found: true,
+				result: response.body.QueryResponse['Vendor'][0],
+			};
+		}
+
+		return {
+			found: false,
+			result: {},
+		};
+	},
+});

--- a/packages/pieces/community/quickbooks/src/actions/read-aging-report.ts
+++ b/packages/pieces/community/quickbooks/src/actions/read-aging-report.ts
@@ -1,0 +1,89 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod, httpClient, AuthenticationType } from '@activepieces/pieces-common';
+import { quickbooksAuth } from '../lib/auth';
+import { quickbooksCommon } from '../lib/common';
+import { QuickbooksReport } from '../lib/types';
+
+export const readAgingReportAction = createAction({
+	auth: quickbooksAuth,
+	name: 'read_aging_report',
+	displayName: 'Read AR/AP Aging',
+	description: 'Reads an accounts receivable or accounts payable aging report from QuickBooks.',
+	audience: 'both',
+	aiMetadata: {
+		description: 'Fetch an aging report showing outstanding receivables (money owed to the company) or payables (money the company owes), bucketed by how overdue they are. Choose the report type, optionally set the as-of date, the number of days per aging bucket, and the number of buckets. Read-only and idempotent.',
+		idempotent: true,
+	},
+	props: {
+		reportType: Property.StaticDropdown({
+			displayName: 'Report',
+			required: true,
+			options: {
+				options: [
+					{ label: 'A/R Aging Summary', value: 'AgedReceivables' },
+					{ label: 'A/R Aging Detail', value: 'AgedReceivableDetail' },
+					{ label: 'A/P Aging Summary', value: 'AgedPayables' },
+					{ label: 'A/P Aging Detail', value: 'AgedPayableDetail' },
+				],
+			},
+			defaultValue: 'AgedReceivables',
+		}),
+		reportDate: Property.DateTime({
+			displayName: 'As Of Date',
+			description: 'The date to age balances against. Defaults to today if empty.',
+			required: false,
+		}),
+		agingPeriod: Property.Number({
+			displayName: 'Days Per Period',
+			description: 'Number of days in each aging bucket (e.g. 30).',
+			required: false,
+		}),
+		numPeriods: Property.Number({
+			displayName: 'Number of Periods',
+			description: 'How many aging buckets to include.',
+			required: false,
+		}),
+	},
+	async run(context) {
+		const { reportType, reportDate, agingPeriod, numPeriods } = context.propsValue;
+		const companyId = context.auth.props?.['companyId'];
+
+		if (!companyId) {
+			throw new Error('Realm ID not found in authentication data. Please reconnect your account.');
+		}
+
+		const apiUrl = quickbooksCommon.getApiUrl(companyId as string);
+
+		const response = await httpClient.sendRequest<
+			QuickbooksReport & {
+				Fault?: { Error: { Message: string; Detail?: string; code: string }[]; type: string };
+			}
+		>({
+			method: HttpMethod.GET,
+			url: `${apiUrl}/reports/${reportType}`,
+			queryParams: {
+				minorversion: '70',
+				...(reportDate && { report_date: reportDate.split('T')[0] }),
+				...(agingPeriod != null && { aging_period: String(agingPeriod) }),
+				...(numPeriods != null && { num_periods: String(numPeriods) }),
+			},
+			authentication: {
+				type: AuthenticationType.BEARER_TOKEN,
+				token: context.auth.access_token,
+			},
+			headers: {
+				Accept: 'application/json',
+			},
+		});
+
+		if (response.body.Fault) {
+			throw new Error(
+				`QuickBooks API Error fetching report: ${response.body.Fault.Error.map(
+					(e: { Message: string }) => e.Message,
+				).join(', ')}`,
+			);
+		}
+
+		return response.body;
+	},
+});

--- a/packages/pieces/community/quickbooks/src/actions/record-payment.ts
+++ b/packages/pieces/community/quickbooks/src/actions/record-payment.ts
@@ -1,0 +1,158 @@
+import { createAction, Property, OAuth2PropertyValue } from '@activepieces/pieces-framework';
+import { HttpMethod, httpClient } from '@activepieces/pieces-common';
+import { quickbooksAuth } from '../lib/auth';
+import { quickbooksCommon, QuickbooksEntityResponse } from '../lib/common';
+import { QuickbooksCustomer, QuickbooksPayment, QuickbooksRef } from '../lib/types';
+
+export const recordPaymentAction = createAction({
+	auth: quickbooksAuth,
+	name: 'record_payment',
+	displayName: 'Record Payment',
+	description: 'Records a customer payment in QuickBooks, optionally applying it to invoices.',
+	audience: 'both',
+	aiMetadata: {
+		description: 'Record a payment received from a customer for a given total amount. Optionally apply the payment to one or more specific invoices by their transaction Id, set the deposit-to account, payment date, and reference number. If no invoices are specified, QuickBooks leaves the amount unapplied. Not idempotent: each call creates a new payment, so guard against duplicates.',
+		idempotent: false,
+	},
+	props: {
+		customerRef: Property.Dropdown({
+			auth: quickbooksAuth,
+			displayName: 'Customer',
+			required: true,
+			refreshers: [],
+			options: async ({ auth }) => {
+				if (!auth) {
+					return {
+						disabled: true,
+						placeholder: 'Connect your account first',
+						options: [],
+					};
+				}
+				const { access_token, props } = auth as OAuth2PropertyValue;
+				const companyId = props?.['companyId'];
+				const apiUrl = quickbooksCommon.getApiUrl(companyId);
+				const query = `SELECT Id, DisplayName FROM Customer STARTPOSITION 1 MAXRESULTS 1000`;
+				const response = await httpClient.sendRequest<QuickbooksEntityResponse<QuickbooksCustomer>>({
+					method: HttpMethod.GET,
+					url: `${apiUrl}/query`,
+					queryParams: { query: query, minorversion: '70' },
+					headers: {
+						Authorization: `Bearer ${access_token}`,
+						Accept: 'application/json',
+					},
+				});
+
+				if (response.body.Fault) {
+					throw new Error(
+						`QuickBooks API Error: ${response.body.Fault.Error.map(
+							(e: { Message: string }) => e.Message,
+						).join(', ')}`,
+					);
+				}
+
+				const customers = response.body.QueryResponse?.['Customer'] ?? [];
+				return {
+					disabled: false,
+					options: customers.map((customer) => ({
+						label: customer.DisplayName,
+						value: customer.Id,
+					})),
+				};
+			},
+		}),
+		totalAmount: Property.Number({
+			displayName: 'Total Amount',
+			description: 'The total amount of the payment received.',
+			required: true,
+		}),
+		lineItems: Property.Array({
+			displayName: 'Apply to Invoices',
+			description:
+				'Optional. Apply this payment to specific invoices. Leave empty to keep the amount unapplied.',
+			required: false,
+			properties: {
+				invoiceId: Property.ShortText({
+					displayName: 'Invoice ID',
+					description: 'The transaction Id of the invoice to apply the payment to.',
+					required: true,
+				}),
+				amount: Property.Number({
+					displayName: 'Amount Applied',
+					description: 'The amount of this payment to apply to the invoice.',
+					required: true,
+				}),
+			},
+		}),
+		depositToAccountId: Property.ShortText({
+			displayName: 'Deposit To Account ID',
+			description:
+				'Optional. The account to deposit the payment into. Defaults to Undeposited Funds if empty.',
+			required: false,
+		}),
+		txnDate: Property.DateTime({
+			displayName: 'Payment Date',
+			description: 'The date the payment was received. Defaults to today if empty.',
+			required: false,
+		}),
+		paymentRefNum: Property.ShortText({
+			displayName: 'Reference Number',
+			description: 'Optional reference number for the payment (e.g. check number).',
+			required: false,
+		}),
+		privateNote: Property.LongText({
+			displayName: 'Memo (Private Note)',
+			description: 'Internal note about the payment.',
+			required: false,
+		}),
+	},
+	async run(context) {
+		const { access_token } = context.auth;
+		const companyId = context.auth.props?.['companyId'];
+
+		const apiUrl = quickbooksCommon.getApiUrl(companyId as string);
+		const props = context.propsValue;
+
+		const lines = ((props['lineItems'] as any[]) ?? []).map((line) => ({
+			Amount: line['amount'],
+			LinkedTxn: [{ TxnId: line['invoiceId'], TxnType: 'Invoice' }],
+		}));
+
+		const paymentPayload: Partial<QuickbooksPayment> = {
+			CustomerRef: { value: props['customerRef'] } as QuickbooksRef,
+			TotalAmt: props['totalAmount'],
+			...(lines.length > 0 && { Line: lines }),
+			...(props['depositToAccountId'] && {
+				DepositToAccountRef: { value: props['depositToAccountId'] } as QuickbooksRef,
+			}),
+			...(props['txnDate'] && { TxnDate: props['txnDate'].split('T')[0] }),
+			...(props['paymentRefNum'] && { PaymentRefNum: props['paymentRefNum'] }),
+			...(props['privateNote'] && { PrivateNote: props['privateNote'] }),
+		};
+
+		const response = await httpClient.sendRequest<{
+			Payment: QuickbooksPayment;
+			time: string;
+			Fault?: { Error: { Message: string; Detail?: string; code: string }[]; type: string };
+		}>({
+			method: HttpMethod.POST,
+			url: `${apiUrl}/payment`,
+			queryParams: { minorversion: '70' },
+			headers: {
+				Authorization: `Bearer ${access_token}`,
+				Accept: 'application/json',
+				'Content-Type': 'application/json',
+			},
+			body: paymentPayload,
+		});
+
+		if (response.body.Fault) {
+			throw new Error(
+				`QuickBooks API Error recording payment: ${response.body.Fault.Error.map(
+					(e: any) => e.Message,
+				).join(', ')} - Detail: ${response.body.Fault.Error.map((e: any) => e.Detail).join(', ')}`,
+			);
+		}
+
+		return response.body.Payment;
+	},
+});

--- a/packages/pieces/community/quickbooks/src/index.ts
+++ b/packages/pieces/community/quickbooks/src/index.ts
@@ -6,6 +6,7 @@ import { createInvoiceAction } from "./actions/create-invoice";
 import { createExpenseAction } from "./actions/create-expense";
 import { createBillAction } from "./actions/create-bill";
 import { findVendorAction } from "./actions/find-vendor";
+import { findAccountAction } from "./actions/find-account";
 import { recordPaymentAction } from "./actions/record-payment";
 import { readAgingReportAction } from "./actions/read-aging-report";
 import { newInvoice } from "./triggers/new-invoice";
@@ -31,6 +32,7 @@ export const quickbooks = createPiece({
     createExpenseAction,
     createBillAction,
     findVendorAction,
+    findAccountAction,
     recordPaymentAction,
     readAgingReportAction,
     createCustomApiCallAction({

--- a/packages/pieces/community/quickbooks/src/index.ts
+++ b/packages/pieces/community/quickbooks/src/index.ts
@@ -4,6 +4,10 @@ import { findCustomerAction } from "./actions/find-customer";
 import { findPaymentAction } from "./actions/find-payment";
 import { createInvoiceAction } from "./actions/create-invoice";
 import { createExpenseAction } from "./actions/create-expense";
+import { createBillAction } from "./actions/create-bill";
+import { findVendorAction } from "./actions/find-vendor";
+import { recordPaymentAction } from "./actions/record-payment";
+import { readAgingReportAction } from "./actions/read-aging-report";
 import { newInvoice } from "./triggers/new-invoice";
 import { newExpense } from "./triggers/new-expense";
 import { newCustomer } from "./triggers/new-customer";
@@ -18,31 +22,33 @@ export const quickbooks = createPiece({
   auth: quickbooksAuth,
   minimumSupportedRelease: '0.36.1',
   logoUrl: "https://cdn.activepieces.com/pieces/quickbooks.png",
-  authors: [
-    'onyedikachi-david'
-  ],
+  authors: [ 'onyedikachi-david', 'sanket-a11y'],
   actions: [
     findInvoiceAction,
     findCustomerAction,
     findPaymentAction,
     createInvoiceAction,
     createExpenseAction,
-	createCustomApiCallAction({
-		auth:quickbooksAuth,
-		baseUrl:(auth)=>{
-			const authValue = auth as PiecePropValueSchema<typeof quickbooksAuth>;
-			 const companyId = authValue.props?.['companyId'];
-			
-				const apiUrl = quickbooksCommon.getApiUrl(companyId);
-				return apiUrl
+    createBillAction,
+    findVendorAction,
+    recordPaymentAction,
+    readAgingReportAction,
+    createCustomApiCallAction({
+      auth:quickbooksAuth,
+      baseUrl:(auth)=>{
+        const authValue = auth as PiecePropValueSchema<typeof quickbooksAuth>;
+        const companyId = authValue.props?.['companyId'];
+        
+          const apiUrl = quickbooksCommon.getApiUrl(companyId);
+          return apiUrl
 
-		},
-		authMapping:async (auth)=>{
-        return {
-          Authorization:`Bearer ${(auth as OAuth2PropertyValue).access_token}`
+      },
+      authMapping:async (auth)=>{
+          return {
+            Authorization:`Bearer ${(auth as OAuth2PropertyValue).access_token}`
+          }
         }
-      }
-	})
+    })
   ],
   triggers: [
     newInvoice,

--- a/packages/pieces/community/quickbooks/src/lib/common.ts
+++ b/packages/pieces/community/quickbooks/src/lib/common.ts
@@ -3,7 +3,7 @@ const QUICKBOOKS_API_URL_PRODUCTION = 'https://quickbooks.api.intuit.com/v3/comp
 
 export const quickbooksCommon = {
     getApiUrl: (realmId: string) => {
-        const baseUrl = QUICKBOOKS_API_URL_SANDBOX;
+        const baseUrl = QUICKBOOKS_API_URL_PRODUCTION;
         return `${baseUrl}/${realmId}`;
     },
 };

--- a/packages/pieces/community/quickbooks/src/lib/common.ts
+++ b/packages/pieces/community/quickbooks/src/lib/common.ts
@@ -3,7 +3,7 @@ const QUICKBOOKS_API_URL_PRODUCTION = 'https://quickbooks.api.intuit.com/v3/comp
 
 export const quickbooksCommon = {
     getApiUrl: (realmId: string) => {
-        const baseUrl = QUICKBOOKS_API_URL_PRODUCTION;
+        const baseUrl = QUICKBOOKS_API_URL_SANDBOX;
         return `${baseUrl}/${realmId}`;
     },
 };

--- a/packages/pieces/community/quickbooks/src/lib/types.ts
+++ b/packages/pieces/community/quickbooks/src/lib/types.ts
@@ -243,6 +243,54 @@ export interface QuickbooksPurchaseLine {
     // Add other detail types if needed
 }
 
+export interface QuickbooksBill {
+    Id?: string;
+    SyncToken?: string;
+    MetaData?: QuickbooksMetaData;
+    DocNumber?: string;
+    TxnDate?: string;
+    DueDate?: string;
+    CurrencyRef?: QuickbooksCurrencyRef;
+    PrivateNote?: string;
+    Line: QuickbooksPurchaseLine[];
+    VendorRef: QuickbooksRef;
+    APAccountRef?: QuickbooksRef;
+    SalesTermRef?: QuickbooksRef;
+    TotalAmt?: number;
+    Balance?: number;
+    domain?: string;
+    sparse?: boolean;
+}
+
+export interface QuickbooksPaymentLine {
+    Amount: number;
+    LinkedTxn?: { TxnId: string; TxnType: string }[];
+}
+
+export interface QuickbooksPayment {
+    Id?: string;
+    SyncToken?: string;
+    MetaData?: QuickbooksMetaData;
+    TxnDate?: string;
+    CurrencyRef?: QuickbooksCurrencyRef;
+    CustomerRef: QuickbooksRef;
+    DepositToAccountRef?: QuickbooksRef;
+    PaymentMethodRef?: QuickbooksRef;
+    PaymentRefNum?: string;
+    TotalAmt: number;
+    UnappliedAmt?: number;
+    PrivateNote?: string;
+    Line?: QuickbooksPaymentLine[];
+    domain?: string;
+    sparse?: boolean;
+}
+
+export interface QuickbooksReport {
+    Header?: Record<string, unknown>;
+    Columns?: Record<string, unknown>;
+    Rows?: Record<string, unknown>;
+}
+
 export interface QuickbooksEstimate {
     Id: string;
     SyncToken?: string;


### PR DESCRIPTION
…R/AP Aging actions

## Description

Adds four new actions to the **QuickBooks Online** piece, covering common accounts-payable and reporting workflows:

- **Create Bill** — record an accounts-payable bill against a vendor, with one or more account-based expense line items. Optional bill date, due date, bill number, and memo.
- **Find Vendor** — look up a vendor by exact display name and return its full record (including `Id`).
- **Record Payment** — record a customer payment for a given amount, optionally applying it to one or more specific invoices, with optional deposit-to account, payment date, and reference number.
- **Read AR/AP Aging** — fetch an Accounts Receivable or Accounts Payable aging report (summary or detail), with optional as-of date and aging-bucket controls.

New shared types (`QuickbooksBill`, `QuickbooksPayment`, `QuickbooksReport`) were added to `lib/types.ts`, and the piece version was bumped `0.1.6 → 0.1.7`.

## How was this tested?

- Piece builds (`tsc`) and lints with no errors.
- Each action was exercised manually against a QuickBooks **sandbox** company via the flow builder's *Test step*:
  - **Read AR/AP Aging** returns the report payload.
  - **Find Vendor** resolves a seed vendor to its record.
  - **Create Bill** creates a bill and returns the object with its `Id`/`Balance`.
  - **Record Payment** creates a payment and returns the object with its `Id`.

Edition paths: this is a community piece change and is edition-agnostic (CE / EE / Cloud all load pieces the same way).

Fixes PIE-367

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)
