### PR TITLE
feat(piece-deepseek): add deepseek-reasoner model support and resilient fallback options

### DIFF
--- a/packages/pieces/community/deepseek/src/lib/actions/ask-deepseek.ts
+++ b/packages/pieces/community/deepseek/src/lib/actions/ask-deepseek.ts
@@ -35,20 +35,31 @@ export const askDeepseek = createAction({
           const response = await openai.models.list();
           // We need to get only LLM models
           const models = response.data;
+          const options = models.map((model) => {
+            return {
+              label: model.id,
+              value: model.id,
+            };
+          });
+
+          if (!options.some((opt) => opt.value === 'deepseek-reasoner')) {
+            options.push({
+              label: 'deepseek-reasoner',
+              value: 'deepseek-reasoner',
+            });
+          }
+
           return {
             disabled: false,
-            options: models.map((model) => {
-              return {
-                label: model.id,
-                value: model.id,
-              };
-            }),
+            options,
           };
         } catch (error) {
           return {
-            disabled: true,
-            options: [],
-            placeholder: "Couldn't load models, API key is invalid",
+            disabled: false,
+            options: [
+              { label: 'deepseek-chat', value: 'deepseek-chat' },
+              { label: 'deepseek-reasoner', value: 'deepseek-reasoner' },
+            ],
           };
         }
       },


### PR DESCRIPTION
## Description
Adds explicit support for deepseek-reasoner (DeepSeek-R1) in the DeepSeek community piece model options and provides resilient fallback options (deepseek-chat, deepseek-reasoner) when model listing dynamic fetch is unavailable or fails.

## Changes
- Add deepseek-reasoner check to dynamic model options list in @activepieces/piece-deepseek.
- Ensure default options include both deepseek-chat and deepseek-reasoner on fallback error.