### PR TITLE
fix(cli): verify a piece bundle installs and loads in isolation before publish

### DIFF
--- a/packages/cli/src/lib/utils/verify-piece-bundle.test.ts
+++ b/packages/cli/src/lib/utils/verify-piece-bundle.test.ts
@@ -1,0 +1,37 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import { verifyPieceBundleUtils } from './verify-piece-bundle'
+
+describe('verifyPieceBundleLoads', () => {
+    let root: string | undefined
+
+    afterEach(() => {
+        if (root) {
+            rmSync(root, { recursive: true, force: true })
+            root = undefined
+        }
+    })
+
+    it('passes for a bundle that installs and requires cleanly', async () => {
+        root = mkdtempSync(join(tmpdir(), 'ap-verify-piece-'))
+        writeFileSync(join(root, 'package.json'), JSON.stringify({ name: 'piece-ok', version: '0.0.1', main: 'index.js', files: ['index.js', 'package.json'] }))
+        writeFileSync(join(root, 'index.js'), 'module.exports = { ok: true }\n')
+
+        await expect(verifyPieceBundleUtils.verifyPieceBundleLoads({ distPath: root })).resolves.toBeUndefined()
+    })
+
+    it('fails for a bundle whose code references an asset that was never packed — the tiktoken-wasm class of bug', async () => {
+        root = mkdtempSync(join(tmpdir(), 'ap-verify-piece-'))
+        writeFileSync(join(root, 'package.json'), JSON.stringify({ name: 'piece-missing-asset', version: '0.0.1', main: 'index.js', files: ['index.js', 'package.json'] }))
+        mkdirSync(join(root, 'assets'), { recursive: true })
+        writeFileSync(join(root, 'assets', 'native.bin'), 'not-actually-packed')
+        writeFileSync(
+            join(root, 'index.js'),
+            'require(\'fs\').readFileSync(require(\'path\').join(__dirname, \'assets\', \'native.bin\'))\nmodule.exports = {}\n',
+        )
+
+        await expect(verifyPieceBundleUtils.verifyPieceBundleLoads({ distPath: root })).rejects.toThrow('failed to install and load')
+    })
+})

--- a/packages/cli/src/lib/utils/verify-piece-bundle.ts
+++ b/packages/cli/src/lib/utils/verify-piece-bundle.ts
@@ -1,0 +1,36 @@
+import { execFileSync } from 'node:child_process'
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+// Packs the already-prepared dist/ (exactly what `npm publish` would upload), installs that
+// tarball into a throwaway directory with NO ambient node_modules, and requires the package by
+// name. This is what a real installer (self-hosted or otherwise) actually does — unlike
+// requiring dist/ in-place inside the monorepo checkout, where hoisted workspace node_modules can
+// mask a dependency the published manifest never declared (e.g. an inlined-but-not-copied wasm
+// asset, or an externalized dep dropped from `dependencies`).
+async function verifyPieceBundleLoads({ distPath }: VerifyPieceBundleParams): Promise<void> {
+    const { name } = JSON.parse(readFileSync(join(distPath, 'package.json'), 'utf-8'))
+    const verifyDir = mkdtempSync(join(tmpdir(), 'ap-verify-piece-'))
+    try {
+        writeFileSync(join(verifyDir, 'package.json'), JSON.stringify({ name: 'ap-piece-verify', version: '0.0.0', private: true }))
+        const [{ filename }] = JSON.parse(
+            execFileSync('npm', ['pack', '--json', '--pack-destination', verifyDir], { cwd: distPath }).toString(),
+        )
+        execFileSync('npm', ['install', '--no-save', '--no-audit', '--no-fund', join(verifyDir, filename)], { cwd: verifyDir, stdio: 'pipe' })
+        execFileSync('node', ['-e', `require(${JSON.stringify(name)})`], { cwd: verifyDir, stdio: 'pipe' })
+    }
+    catch (error) {
+        const detail = error instanceof Error ? error.message : String(error)
+        throw new Error(`[verifyPieceBundle] ${name} failed to install and load from a clean, isolated install:\n${detail}`)
+    }
+    finally {
+        rmSync(verifyDir, { recursive: true, force: true })
+    }
+}
+
+export const verifyPieceBundleUtils = { verifyPieceBundleLoads }
+
+export type VerifyPieceBundleParams = {
+    distPath: string
+}

--- a/tools/scripts/utils/publish-npm-package.ts
+++ b/tools/scripts/utils/publish-npm-package.ts
@@ -6,6 +6,7 @@ import { readPackageJson } from './files'
 import { packagePrePublishChecks } from './package-pre-publish-checks'
 import { preparePieceDistForPublish } from '../../../packages/cli/src/lib/utils/prepare-piece-utils'
 import { isExactVersion } from '../../../packages/cli/src/lib/utils/workspace-utils'
+import { verifyPieceBundleUtils } from '../../../packages/cli/src/lib/utils/verify-piece-bundle'
 
 function assertNoSemverRanges(packageJsonPath: string): void {
   const json = JSON.parse(readFileSync(packageJsonPath).toString())
@@ -91,6 +92,10 @@ export const publishNpmPackage = async (path: string): Promise<void> => {
 
   assertNoUnpublishableDeps(`${outputPath}/package.json`)
   assertNoSemverRanges(`${outputPath}/package.json`)
+
+  // Gate before publish, not after: a bundle that can't install-and-load in isolation must never
+  // reach npm.
+  await verifyPieceBundleUtils.verifyPieceBundleLoads({ distPath: outputPath })
 
   execSync(`npm publish --access public --tag latest`, { cwd: outputPath, stdio: 'inherit' })
 


### PR DESCRIPTION
## Description

`piece-openai@0.10.0` published broken (#14369): tiktoken's inlined JS shipped without its wasm asset, and the manifest declared no dependency to fetch it, so `require()` threw before any action ran — connections, model dropdowns, and action execution were all broken.

Nothing in the release pipeline ever installed the *published* package in isolation before shipping it. The only post-build `require()` check (`update-pieces-metadata.ts`) runs inside the monorepo checkout, where hoisted workspace `node_modules` can mask a dependency the published manifest never declared — and it runs *after* `publish-pieces-to-npm.ts` has already pushed to npm, so even a caught failure wouldn't have blocked the publish.

Fix: `verifyPieceBundleLoads` (`packages/cli/src/lib/utils/verify-piece-bundle.ts`) packs the already-prepared `dist/` into the real tarball, installs it into a throwaway directory with zero ambient `node_modules`, and `require()`s it by name — reproducing exactly what a real installer does. Wired into `publishNpmPackage` (`tools/scripts/utils/publish-npm-package.ts`), right before the `npm publish` call, so a broken bundle blocks the publish for every call site (the bulk release pipeline and the single-piece CLI publish path both route through this one function).

## How was this tested?

- New test (`verify-piece-bundle.test.ts`): a passing bundle, and a failing one that reproduces the exact incident shape — code references an asset outside the manifest's `files` allow-list, so it's referenced but never packed.
- Ran against the real `piece-openai` bundle locally: packed, installed `tiktoken` (wasm included) from the registry into an isolated dir, required cleanly.
- Full `@activepieces/cli` suite: 24/24 passing.
- `npm run lint-dev` clean (pre-existing unrelated warnings only).

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact