### PR TITLE
fix(tool-search): derive requiresConnection from the piece's auth

### DIFF
--- a/packages/server/api/src/app/tool-search/tool-search-reindex.service.ts
+++ b/packages/server/api/src/app/tool-search/tool-search-reindex.service.ts
@@ -208,6 +208,7 @@ function explodePiece(piece: PieceMetadataSchema, modelVersion: string): Desired
     // undefined. Coalesce to true — matching that framework default — so it never binds NULL into the
     // NOT NULL requiresConnection column, which would otherwise abort the whole upsert and leave the
     // index unbuilt (so embedPendingRows never runs and search silently serves nothing).
+    const pieceHasAuth = !isNil(piece.auth)
     const actionRecords = Object.entries(piece.actions).map(([objectName, action]) => buildRecord({
         piece,
         modelVersion,
@@ -216,7 +217,7 @@ function explodePiece(piece: PieceMetadataSchema, modelVersion: string): Desired
         displayName: action.displayName,
         description: action.description,
         aiDescription: action.aiMetadata?.description,
-        requiresConnection: action.requireAuth ?? true,
+        requiresConnection: pieceHasAuth && (action.requireAuth ?? true),
         audience: action.audience ?? null,
     }))
     const triggerRecords = Object.entries(piece.triggers).map(([objectName, trigger]) => buildRecord({
@@ -227,7 +228,7 @@ function explodePiece(piece: PieceMetadataSchema, modelVersion: string): Desired
         displayName: trigger.displayName,
         description: trigger.description,
         aiDescription: trigger.aiMetadata?.description,
-        requiresConnection: trigger.requireAuth ?? true,
+        requiresConnection: pieceHasAuth && (trigger.requireAuth ?? true),
         audience: null,
     }))
     return [...actionRecords, ...triggerRecords]

--- a/packages/server/api/src/app/tool-search/tool-search.service.ts
+++ b/packages/server/api/src/app/tool-search/tool-search.service.ts
@@ -167,12 +167,13 @@ async function keywordSearch({ objectKind, query, opts, log, degradeReason }: Ke
 
     const results = scopedPieces.flatMap((piece) => {
         const suggestions = objectKind === 'action' ? (piece.suggestedActions ?? []) : (piece.suggestedTriggers ?? [])
+        const pieceHasAuth = !isNil(piece.auth)
         return suggestions.map((object): ToolSearchObjectResult => ({
             pieceName: piece.name,
             objectName: object.name,
             displayName: object.displayName,
             oneLineDescription: object.description,
-            requiresConnection: object.requireAuth,
+            requiresConnection: pieceHasAuth && (object.requireAuth ?? true),
         }))
     }).slice(0, limit)
     return { results, mode: 'keyword', degradeReason }

--- a/packages/server/api/test/integration/ce/tool-search/tool-search.test.ts
+++ b/packages/server/api/test/integration/ce/tool-search/tool-search.test.ts
@@ -1,4 +1,4 @@
-import { ActionBase, TriggerBase } from '@activepieces/pieces-framework'
+import { ActionBase, PieceAuth, TriggerBase } from '@activepieces/pieces-framework'
 import { apId, PackageType, PieceCategory, PieceType, TriggerStrategy, TriggerTestStrategy } from '@activepieces/shared'
 import { FastifyBaseLogger } from 'fastify'
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest'
@@ -34,6 +34,8 @@ const fakeEmbedder: ToolSearchEmbedder = {
     embed: (texts) => Promise.resolve(texts.map(bagOfWords)),
 }
 
+const pieceAuth = PieceAuth.SecretText({ displayName: 'API Key', required: true })
+
 function action(over: Pick<ActionBase, 'name' | 'displayName' | 'description'> & { requireAuth?: boolean, audience?: ActionBase['audience'] }): ActionBase {
     return { name: over.name, displayName: over.displayName, description: over.description, props: {}, requireAuth: over.requireAuth ?? true, audience: over.audience }
 }
@@ -56,6 +58,7 @@ async function seedCatalog(): Promise<void> {
         name: '@activepieces/piece-slack',
         displayName: 'Slack',
         version: '1.0.0',
+        auth: pieceAuth,
         pieceType: PieceType.OFFICIAL,
         packageType: PackageType.REGISTRY,
         actions: { send_channel_message: action({ name: 'send_channel_message', displayName: 'Send Channel Message', description: 'Send a message to a Slack channel' }) },
@@ -65,6 +68,7 @@ async function seedCatalog(): Promise<void> {
         name: '@activepieces/piece-google-calendar',
         displayName: 'Google Calendar',
         version: '1.0.0',
+        auth: pieceAuth,
         pieceType: PieceType.OFFICIAL,
         packageType: PackageType.REGISTRY,
         actions: { create_event: action({ name: 'create_event', displayName: 'Create Event', description: 'Create a new event in a Google Calendar' }) },
@@ -74,6 +78,7 @@ async function seedCatalog(): Promise<void> {
         name: '@activepieces/piece-gmail',
         displayName: 'Gmail',
         version: '1.0.0',
+        auth: pieceAuth,
         pieceType: PieceType.OFFICIAL,
         packageType: PackageType.REGISTRY,
         actions: { send_email: action({ name: 'send_email', displayName: 'Send Email', description: 'Send an email via Gmail' }) },
@@ -140,6 +145,7 @@ describe('Tool Search Engine (Phase 1)', () => {
             name: '@activepieces/piece-legacy',
             displayName: 'Legacy',
             version: '1.0.0',
+            auth: pieceAuth,
             pieceType: PieceType.OFFICIAL,
             packageType: PackageType.REGISTRY,
             actions: { legacy_action: legacyAction },
@@ -155,6 +161,29 @@ describe('Tool Search Engine (Phase 1)', () => {
             ['@activepieces/piece-legacy', 'legacy_action'],
         )
         expect(row.requiresConnection).toBe(true)
+    })
+
+    it('indexes an auth-less piece as requiresConnection false even though requireAuth is true', async () => {
+        await db.save('piece_metadata', createMockPieceMetadata({
+            name: '@activepieces/piece-math-helper',
+            displayName: 'Math Helper',
+            version: '1.0.0',
+            pieceType: PieceType.OFFICIAL,
+            packageType: PackageType.REGISTRY,
+            actions: { addition: action({ name: 'addition', displayName: 'Addition', description: 'Add two numbers together', requireAuth: true }) },
+            triggers: { new_number: trigger({ name: 'new_number', displayName: 'New Number', description: 'Triggers when a new number is produced' }) },
+        }))
+
+        await toolSearchReindexService(log).reindex({ embedder: fakeEmbedder })
+
+        const rows = await databaseConnection().query(
+            'SELECT "objectName", "requiresConnection" FROM "tool_search_index" WHERE "pieceName" = $1 ORDER BY "objectName"',
+            ['@activepieces/piece-math-helper'],
+        )
+        expect(rows).toEqual([
+            { objectName: 'addition', requiresConnection: false },
+            { objectName: 'new_number', requiresConnection: false },
+        ])
     })
 
     it('searchActions ranks the semantically closest action first and returns the tiered envelope', async () => {
@@ -760,6 +789,7 @@ async function seedTriggerCatalog(): Promise<void> {
         name: '@activepieces/piece-slack',
         displayName: 'Slack',
         version: '1.0.0',
+        auth: pieceAuth,
         pieceType: PieceType.OFFICIAL,
         packageType: PackageType.REGISTRY,
         actions: { send_channel_message: action({ name: 'send_channel_message', displayName: 'Send Channel Message', description: 'Send a message to a Slack channel' }) },
@@ -769,6 +799,7 @@ async function seedTriggerCatalog(): Promise<void> {
         name: '@activepieces/piece-google-calendar',
         displayName: 'Google Calendar',
         version: '1.0.0',
+        auth: pieceAuth,
         pieceType: PieceType.OFFICIAL,
         packageType: PackageType.REGISTRY,
         actions: { create_event: action({ name: 'create_event', displayName: 'Create Event', description: 'Create a new event in a Google Calendar' }) },


### PR DESCRIPTION
## Description

`requiresConnection` in the tool-search index was copied straight from `action.requireAuth ?? true`. The framework defaults `requireAuth` to `true` at construction regardless of whether the piece declares auth, so **every auth-less piece indexes as `requiresConnection: true`** — the flag effectively means "this action exists", not "a connection is needed".

The user-visible effect: an agent that searches for math-helper's `addition` is told it needs a connection to add two numbers, and there is no connection to make, because the piece's auth is `PieceAuth.None()`.

Verified against the live catalog — every one of these serves `auth: null` while reporting `requireAuth: true` on every action:

| Piece | `auth` | actions reporting `requireAuth: true` |
|---|---|---|
| `math-helper` | none | 6 / 6 |
| `text-helper` | none | 12 / 12 |
| `http` | none | 2 / 2 |

The fix gates the flag on the piece actually having auth: `pieceHasAuth && (requireAuth ?? true)`. The `?? true` coalesce is kept — it is what stops a legacy `piece_metadata` row (written before `requireAuth` became a required boolean) from binding NULL into the NOT NULL column.

Applied to **both** derivations, which had drifted apart:

- the reindex indexer, for actions **and** triggers (triggers on auth-less pieces such as `webhook` carried the same wrong value)
- the keyword-degrade floor in `tool-search.service`, which additionally read `object.requireAuth` with **no `?? true` fallback** and so could emit `undefined` in keyword mode

Server-side only. The flag is display-only (no query filters on it) and is not part of `retrievalDoc`/`embeddingInputHash`, so corrected values propagate on the next reconcile with **no re-embed** and no migration.

## How was this tested?

Ran the tool-search suites against a real PostgreSQL 16 + pgvector, matching the `tool-search (postgres)` CI job:

- `vitest run test/integration/ce/tool-search --no-file-parallelism` — **43 passed**
- `vitest run test/unit/app/tool-search test/unit/app/mcp/ap-search-tools.test.ts` — **50 passed**
- `tsc --noEmit -p packages/server/api/tsconfig.app.json` — clean
- `eslint` on the changed files — 0 errors

Added a regression test covering an auth-less piece whose action sets `requireAuth: true`; it asserts `requiresConnection: false` for both the action and the trigger. Confirmed it **fails on the unfixed code** (`true` instead of `false`) and passes with the fix.

The integration fixtures modelled Slack / Gmail / Google Calendar without auth while asserting `requiresConnection: true`, so they now declare auth like the real pieces they stand in for. Those assertions hold under both the old and new derivation, so that fixture change is behaviour-neutral.

Edition paths: CE integration suite; the change is edition-agnostic (no EE/Cloud-specific code touched).

Fixes # (issue)

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)