### PR TITLE
feat(sandbox): per-box netns egress isolation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,8 @@ ENV LANG=C.UTF-8 \
 
 # Install all system dependencies in a single layer with cache mounts.
 # libcap2 is isolate's runtime lib (the isolate binaries ship prebuilt in api assets).
+# iptables + iproute2 back the per-box egress network namespace (NAT + FORWARD firewall)
+# used when SANDBOX_PROCESS runs under AP_NETWORK_MODE=STRICT.
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt,sharing=locked \
     apt-get update && \
@@ -22,6 +24,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
         curl \
         ca-certificates \
         iptables \
+        iproute2 \
         libcap2
 
 # Download, extract, and clean up bun in a single layer so the zip never ships

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,12 @@ services:
     env_file: .env
     environment:
       - AP_CONTAINER_TYPE=WORKER
+    # Required only for AP_NETWORK_MODE=STRICT with AP_EXECUTION_MODE=SANDBOX_PROCESS or
+    # SANDBOX_CODE_AND_PROCESS, which also needs `privileged: true`. A container defaults
+    # ip_forward to 0 and the worker refuses to take jobs without it.
+    # See https://www.activepieces.com/docs/install/architecture/network-security
+    # sysctls:
+    #   - net.ipv4.ip_forward=1
     deploy:
       replicas: 5
     volumes:

--- a/docs/install/architecture/network-security.mdx
+++ b/docs/install/architecture/network-security.mdx
@@ -24,11 +24,12 @@ Every flow eventually runs **user-supplied code**: Code steps, piece actions, HT
 | Value | Effect |
 |---|---|
 | `UNRESTRICTED` | No outbound guard. User code can reach any host the worker can reach. |
-| `STRICT` | The engine SSRF guard is installed. Outbound connections to private, loopback, link-local, and cloud-metadata IPs are blocked from user code. |
+| `STRICT` | The engine SSRF guard is installed in every execution mode. Additionally, when `AP_EXECUTION_MODE` is `SANDBOX_PROCESS` or `SANDBOX_CODE_AND_PROCESS`, each sandbox box runs inside a locked-down Linux network namespace with iptables NAT/FORWARD rules (kernel boundary). |
 
-Related env var:
+Related env vars:
 
-- `AP_SSRF_ALLOW_LIST`: comma-separated IPs/CIDRs that bypass the block (for example an internal DB or sidecar). Shared with server-side egress.
+- `AP_SSRF_ALLOW_LIST`: comma-separated IPs/CIDRs that bypass the block (for example an internal DB or sidecar). Shared with server-side egress. Under isolate + STRICT, only IPv4 literals/CIDRs are enforced in the kernel (hostnames are ignored for iptables).
+- `AP_SANDBOX_EGRESS_SUBNET`: IPv4 `/16` used for per-box veth addresses (default `10.255.0.0/16`). Must not overlap addresses the host already uses inside that pool.
 
 ## How Isolation Works
 
@@ -39,13 +40,135 @@ In `STRICT` mode the engine installs an **in-process SSRF guard** before any use
 
 Together these cover `axios`, `fetch`, `undici`, and raw `http`/`net` in a single pass. A blocked target throws `SSRFBlockedError`. The blocklist is every non-`unicast` range (RFC1918, loopback, link-local, multicast, cloud metadata), minus anything in `AP_SSRF_ALLOW_LIST`.
 
-<Warning>
-The engine SSRF guard is **best-effort, in-process protection**. It reliably stops *accidental* SSRF, such as a flow or piece that naively follows a user-supplied URL to an internal host. It is **not** a hard boundary against deliberately malicious code: `worker_threads`, `child_process`, native addons, and `process.binding` can all sidestep the JavaScript-level monkey-patches.
+### Kernel egress (isolate + STRICT only)
 
-For multi-tenant deployments that run untrusted code, enforce the real egress boundary in **infrastructure**: a VPC firewall, network policy, or egress gateway that blocks the cloud-metadata IP (`169.254.169.254`) and your private ranges independently of the application. Treat `AP_NETWORK_MODE=STRICT` as defense-in-depth on top of that, not as a replacement for it.
+When execution mode is `SANDBOX_PROCESS` or `SANDBOX_CODE_AND_PROCESS` **and** `AP_NETWORK_MODE=STRICT`, the worker also provisions a per-box network namespace:
+
+- Public IPv4 egress is NAT'd; RFC1918, loopback, link-local, and cloud-metadata ranges are REJECTed in iptables (with `AP_SSRF_ALLOW_LIST` IPv4 entries accepted above those rejects).
+- The engine's app API URL is opened automatically and **port-scoped**:
+  - Loopback URLs (combined `WORKER_AND_APP`) are rewritten to the gateway veth IP; that TCP port is opened on host INPUT. A literal `127.0.0.1` cannot survive into the namespace, where loopback is the box's own empty interface, so this one URL genuinely has to change.
+  - Non-loopback URLs (standalone `WORKER`) keep their URL **exactly as configured**. Every resolved IPv4 address is accepted in the FORWARD chain for that TCP port only, never all ports on the API host, and the address list is handed to the engine as a DNS pin so it resolves the app hostname to precisely those addresses. The URL is never rewritten to an IP: that would drop the TLS SNI and send the wrong `Host` header, breaking any https app URL outright and misrouting an http one behind a vhost or ingress. The in-process SSRF guard gets a matching `AP_SANDBOX_API_ALLOW=ip:port` exemption for each address.
+- IPv6 out of the box netns is dropped (and veths use `addrgenmode none` so link-local is not auto-assigned).
+- Reply traffic to the box is admitted on connection state `ESTABLISHED`; `RELATED` is admitted for **ICMP only**, so path-MTU discovery and ICMP errors work while a conntrack helper cannot open an inbound port. The egress chain itself carries no state-based ACCEPT, because one would override the blocked-range rejects below it.
+- The box veth MTU is **lowered** to match the host uplink when the uplink is below 1500 (overlay CNI, VPN, and cloud networks commonly run 1400-1460). Without this the box emits oversized frames and large uploads blackhole even though handshakes succeed. The MTU is never raised above 1500.
+- Exactly **one** STRICT isolate worker may own a given host network namespace (enforced by a process lease). Run one worker process per container/pod netns; do not share `hostNetwork` across multiple STRICT workers on the same node. The worker logs a warning at startup if it can see node-level bridge interfaces, which usually means it is sharing the node's namespace and is therefore writing rules into the **node's** iptables tables.
+- The host must already have `net.ipv4.ip_forward=1`. The worker **verifies** this and fails readiness if it is off; it does not write the sysctl. See [Enabling `ip_forward`](#enabling-ip-forward) below.
+- An orphaned sandbox left in a box's namespace by a crashed worker is SIGKILLed so the namespace can be reused, but only after the process is re-confirmed to still belong to that namespace. This needs root (which STRICT isolate already requires); a non-root worker skips the kill and refuses to reuse the namespace instead.
+
+<Warning>
+Two limits worth knowing before you rely on this:
+
+- **The app API port is reachable from user code inside the box.** Opening it is what lets the engine fetch connections, files, and properties, but the in-process guard's exemption for it is process-wide rather than scoped to the engine's own HTTP client, so a Code step can reach the internal API too. Treat the internal API's own authentication as the control here, not network reachability.
+- **Only the app API URL is adapted for the namespace.** `AP_FRONTEND_URL` / `PUBLIC_URL` must be a genuinely reachable URL: a piece that fetches `server.publicUrl` will not reach a loopback value from inside the box, where loopback is the namespace's own empty interface.
 </Warning>
 
-The guard is independent of the sandbox execution mode. It is installed in every mode when `AP_NETWORK_MODE=STRICT`. See [Sandboxing](./sandboxing) for what each sandbox mode isolates at the process level. Network security is independent: it constrains what code is allowed to *reach*, regardless of *how* it runs.
+`SANDBOX_CODE_ONLY` / `UNSANDBOXED` under STRICT keep the in-process guard only (no netns).
+
+<Warning>
+The engine SSRF guard alone is **best-effort, in-process protection**. It reliably stops *accidental* SSRF, such as a flow or piece that naively follows a user-supplied URL to an internal host. It is **not** a hard boundary against deliberately malicious code: `worker_threads`, `child_process`, native addons, and `process.binding` can all sidestep the JavaScript-level monkey-patches.
+
+For isolate + STRICT, the netns/iptables layer is the hard boundary for that execution mode. For other modes, or as defense-in-depth on top of isolate, still enforce egress in **infrastructure**: a VPC firewall, network policy, or egress gateway that blocks the cloud-metadata IP (`169.254.169.254`) and your private ranges independently of the application.
+</Warning>
+
+The in-process guard is installed in every mode when `AP_NETWORK_MODE=STRICT`. See [Sandboxing](./sandboxing) for what each sandbox mode isolates at the process level.
+
+### Enabling ip_forward
+
+Whether you need to do anything here depends on the host. On a typical Docker host forwarding is already on
+(Docker enables it for bridge networking) and containers come up with `net.ipv4.ip_forward=1` inherited, so
+nothing is required. It is `0` where the host or node has forwarding disabled by policy, where `dockerd` runs
+with `--ip-forward=false`, on some Kubernetes nodes and CNIs, or where it is explicitly set off.
+
+Check before assuming, from inside the worker container:
+
+```bash
+cat /proc/sys/net/ipv4/ip_forward
+```
+
+The worker only reads this value, never writes it. If it is `0` the worker pauses polling and takes **no
+jobs**, logging an error every 60 seconds and reporting itself on `GET /v1/health/system`.
+
+Docker:
+
+```bash
+docker run --privileged --sysctl net.ipv4.ip_forward=1 ...
+```
+
+Docker Compose:
+
+```yaml
+services:
+  worker:
+    privileged: true
+    sysctls:
+      - net.ipv4.ip_forward=1
+```
+
+Kubernetes needs one extra step. `net.ipv4.ip_forward` is namespaced but is **not** on the kubelet's
+safe-sysctl list, so a pod that sets it is rejected until the node's kubelet allows it:
+
+```bash
+kubelet --allowed-unsafe-sysctls 'net.ipv4.ip_forward'
+```
+
+```yaml
+spec:
+  securityContext:
+    sysctls:
+      - name: net.ipv4.ip_forward
+        value: "1"
+```
+
+On a managed cluster where the kubelet flag is not yours to change, set it on the node instead, with a
+privileged init container or a DaemonSet running `sysctl -w net.ipv4.ip_forward=1`.
+
+### Verifying the kernel layer
+
+The unit suites assert the generated `ip` / `iptables` command strings against mocks, which cannot catch MTU
+or connection-state mistakes. A real-kernel suite covers those, and is opt-in because it needs root plus
+`CAP_NET_ADMIN`.
+
+Preferred: run it in a privileged container on the same base image the product ships, over a network whose
+MTU is deliberately below 1500 so the MTU-lowering path is actually exercised (a default bridge is 1500,
+which correctly skips it).
+
+```bash
+docker network create --opt com.docker.network.driver.mtu=1400 ap-mtu-test
+
+docker run --rm -it --privileged \
+  --network ap-mtu-test \
+  --sysctl net.ipv4.ip_forward=1 \
+  -v "$PWD":/repo -w /repo/packages/server/sandbox \
+  -e AP_SANDBOX_NETNS_E2E=1 \
+  node:24.14.0-bullseye-slim \
+  bash -c 'apt-get -qq update && apt-get -qq install -y iproute2 iptables procps >/dev/null \
+    && npx vitest run test/lib/sandbox/netns.e2e.test.ts'
+
+docker network rm ap-mtu-test
+```
+
+Two of those flags are load-bearing and one is insurance. `--privileged` for `CAP_NET_ADMIN` +
+`CAP_SYS_ADMIN`. `procps`, because `tree-kill` spawns `ps` to reap children: without it every command the
+suite runs hangs until the hook times out and the whole suite silently reports as **skipped** rather than
+failed, so always confirm the summary says 7 passed. The shipped images already install `procps`; the bare
+base image does not. `--sysctl net.ipv4.ip_forward=1` is insurance: containers usually inherit `1` from a
+Docker host that already forwards, but the suite fails closed wherever that is not true, so passing it makes
+the run reproducible on any host.
+
+Host-only alternative, no Docker. Uses a throwaway namespace so the host firewall is never touched, but its
+dummy uplink is MTU 1500, so the MTU case asserts the correct no-op rather than proving the lowering:
+
+```bash
+sudo unshare --net bash -c '
+  cd packages/server/sandbox
+  PATH="$(dirname "$(which node)")":$PATH AP_SANDBOX_NETNS_E2E=1 \
+    npx vitest run test/lib/sandbox/netns.e2e.test.ts
+'
+```
+
+`sudo` drops a version-manager `PATH`, hence the explicit re-injection. The suite provisions its own
+blackhole uplink when no default route exists, because the packet-counter assertions need a successful
+route lookup for the box's packet to reach the host FORWARD chain.
 
 ## Verifying Your Setup
 

--- a/docs/install/architecture/sandboxing.mdx
+++ b/docs/install/architecture/sandboxing.mdx
@@ -44,6 +44,12 @@ The engine runs as a plain `child_process.fork` with a memory cap. In `SANDBOX_C
 
 The engine runs inside [ioi/isolate](https://github.com/ioi/isolate), which creates fresh PID, mount, user, and UTS namespaces per run and mounts the engine and code artifacts read-only. Arbitrary `npm` packages are safe inside Code steps because filesystem and process state are scoped to the box. The cost: a cold boot per run (not reusable), and the worker container must hold `CAP_SYS_ADMIN` (`--privileged` in Docker, `securityContext.privileged: true` in Kubernetes).
 
+Pairing this mode with `AP_NETWORK_MODE=STRICT` adds a per-sandbox network namespace, which is the only
+configuration that gives you a real kernel egress boundary around user code. It needs one more piece of host
+setup: `net.ipv4.ip_forward=1` in the worker's network namespace. It is already on for most Docker hosts, but
+off on some nodes and CNIs, and the worker refuses to take any jobs while it is off. Check it and see
+[Enabling ip_forward](./network-security#enabling-ip-forward).
+
 ## Network Isolation
 
 Execution mode decides *how* user code runs; `AP_NETWORK_MODE` decides *what it can reach*. See [Network Security](./network-security) for the in-process SSRF guard that layers on top of every sandbox mode.

--- a/docs/install/reference/breaking-changes.mdx
+++ b/docs/install/reference/breaking-changes.mdx
@@ -5,6 +5,80 @@ icon: "hammer"
 ---
 
 
+## 0.87.0
+
+### What has changed?
+
+#### `STRICT` network mode with process sandboxing now needs host setup
+
+When `AP_NETWORK_MODE=STRICT` is combined with `AP_EXECUTION_MODE=SANDBOX_PROCESS` or
+`SANDBOX_CODE_AND_PROCESS`, each sandbox now runs inside its own Linux network namespace with iptables
+NAT and firewall rules, instead of sharing the worker's network. This is a real kernel boundary rather
+than the best-effort in-process guard, but it has prerequisites the previous release did not.
+
+The worker **verifies** them at startup and, if any is missing, pauses polling and takes **no jobs at
+all** rather than accepting work it would fail one request at a time. A worker in that state logs an
+error every 60 seconds and reports itself on `GET /v1/health/system`.
+
+What the worker now requires:
+
+- `net.ipv4.ip_forward=1` in the worker's network namespace. On a typical Docker host this is already the
+  case and no action is needed; it is off where the host or node disables forwarding, on some Kubernetes
+  nodes and CNIs, or with `dockerd --ip-forward=false`. Check with
+  `cat /proc/sys/net/ipv4/ip_forward` inside the worker container. The worker reads it, never writes it.
+- `iproute2`, `iptables` and `ip6tables` in the image. The official image ships all three.
+- `CAP_NET_ADMIN` and `CAP_SYS_ADMIN`, which `SANDBOX_PROCESS` already required via `privileged`.
+- An unused IPv4 `/16` for the per-sandbox addresses, `10.255.0.0/16` by default, overridable with
+  `AP_SANDBOX_EGRESS_SUBNET`.
+- One such worker per container or pod network namespace. Two workers sharing a namespace is rejected.
+
+Nothing changes for any other combination. `AP_NETWORK_MODE=UNRESTRICTED` (the default) and the
+`SANDBOX_CODE_ONLY` / `UNSANDBOXED` execution modes are unaffected.
+
+### Do you need to take action?
+
+- Only if you run `AP_NETWORK_MODE=STRICT` together with `SANDBOX_PROCESS` or
+  `SANDBOX_CODE_AND_PROCESS`, **and** `cat /proc/sys/net/ipv4/ip_forward` inside the worker container
+  prints `0`. Enable it **before** upgrading, or those workers will come back up and execute nothing.
+
+  Docker and Docker Compose:
+
+  ```bash
+  docker run --privileged --sysctl net.ipv4.ip_forward=1 ...
+  ```
+
+  ```yaml
+  services:
+    worker:
+      privileged: true
+      sysctls:
+        - net.ipv4.ip_forward=1
+  ```
+
+  Kubernetes: `net.ipv4.ip_forward` is namespaced but is **not** on the kubelet's safe-sysctl list, so
+  `securityContext.sysctls` alone is rejected. The node's kubelet must allow it first:
+
+  ```bash
+  kubelet --allowed-unsafe-sysctls 'net.ipv4.ip_forward'
+  ```
+
+  ```yaml
+  spec:
+    securityContext:
+      sysctls:
+        - name: net.ipv4.ip_forward
+          value: "1"
+  ```
+
+  If you cannot change the kubelet, set it on the node instead with a privileged init container or a
+  DaemonSet.
+
+- Only if `10.255.0.0/16` is already in use on your network. Point `AP_SANDBOX_EGRESS_SUBNET` at a free
+  `/16`. The worker refuses to start when the pool collides with an address the host already uses.
+
+- Only if you run more than one such worker process inside a single container or pod network namespace,
+  or with `hostNetwork`. Give each worker its own network namespace.
+
 ## 0.86.0
 
 ### What has changed?

--- a/docs/install/reference/environment-variables.mdx
+++ b/docs/install/reference/environment-variables.mdx
@@ -148,8 +148,9 @@ run timeouts, and the network egress posture for user code. Read
 | `AP_TRIGGER_TIMEOUT_SECONDS` | Maximum runtime for a trigger's polling, in seconds. | `60` |
 | `AP_DEFAULT_CONCURRENT_JOBS_LIMIT` | Default maximum concurrent runs per project. Can be overridden per project in settings. | `5` |
 | `AP_PROJECT_RATE_LIMITER_ENABLED` | Enforce per-project rate limits to prevent excessive usage. | `false` |
-| `AP_NETWORK_MODE` | Egress posture for user code. `STRICT` installs the engine's in-process SSRF guard, blocking outbound connections to private, loopback, link-local, and cloud-metadata IPs across every Node egress path (`axios`, `fetch`, `undici`, raw `http`/`net`). This is best-effort, in-process protection — enforce the real boundary in infrastructure (see [Network Security](/install/architecture/network-security)). `UNRESTRICTED` disables the guard. | `UNRESTRICTED` |
-| `AP_SSRF_ALLOW_LIST` | Comma-separated IPs or CIDR ranges that bypass `AP_NETWORK_MODE=STRICT`, e.g. `10.0.0.5,10.10.0.0/24`. Only applies when `AP_NETWORK_MODE=STRICT`. | `None` |
+| `AP_NETWORK_MODE` | Egress posture for user code. `STRICT` installs the engine's in-process SSRF guard. When execution mode is also `SANDBOX_PROCESS` or `SANDBOX_CODE_AND_PROCESS`, the worker adds per-box Linux network-namespace isolation (iptables NAT/FORWARD). Requires `net.ipv4.ip_forward=1` on the host (verified, not set by the worker) and one STRICT worker per container/pod network namespace. `UNRESTRICTED` disables the guards. See [Network Security](/install/architecture/network-security). | `UNRESTRICTED` |
+| `AP_SSRF_ALLOW_LIST` | Comma-separated IPs or CIDR ranges that bypass `AP_NETWORK_MODE=STRICT`, e.g. `10.0.0.5,10.10.0.0/24`. Only applies when `AP_NETWORK_MODE=STRICT`. Under isolate + STRICT, only IPv4 literals/CIDRs are applied in the kernel. | `None` |
+| `AP_SANDBOX_EGRESS_SUBNET` | IPv4 `/16` pool for per-box egress veth addresses when isolate + STRICT is active (e.g. `10.255.0.0/16`). Must not occupy addresses already used on the host inside that pool. | `10.255.0.0/16` |
 
 ---
 

--- a/packages/core/execution/src/lib/workers/index.ts
+++ b/packages/core/execution/src/lib/workers/index.ts
@@ -38,6 +38,8 @@ export const WorkerProps = z.object({
     SANDBOX_MEMORY_LIMIT: z.string().optional(),
     REUSE_SANDBOX: z.string().optional(),
     version: z.string().optional(),
+    // Absent until the capability probe has run, so the app learns a verdict from the next connect onward.
+    egressStatus: z.enum(['ok', 'unavailable']).optional(),
 })
 
 export type WorkerProps = z.infer<typeof WorkerProps>

--- a/packages/core/shared/package.json
+++ b/packages/core/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/shared",
-  "version": "0.123.0",
+  "version": "0.124.0",
   "type": "commonjs",
   "sideEffects": false,
   "main": "./dist/src/index.js",

--- a/packages/core/shared/src/lib/core/health/index.ts
+++ b/packages/core/shared/src/lib/core/health/index.ts
@@ -11,6 +11,12 @@ export const ReleaseHealth = z.object({
     }),
 })
 
+// The other "connected but idle" state, and in the combined container the only place it can surface.
+export const EgressHealth = z.object({
+    total: z.number(),
+    unavailable: z.number(),
+})
+
 export const GetSystemHealthChecksResponse = z.object({
     latestVersion: z.string(),
     appCpu: z.boolean(),
@@ -20,6 +26,7 @@ export const GetSystemHealthChecksResponse = z.object({
     workerRam: z.boolean().nullable(),
     database: z.boolean(),
     release: ReleaseHealth,
+    egress: EgressHealth,
 })
 
 // Server-measured infra round-trip, so a cross-region benchmark client gets the authoritative
@@ -83,6 +90,7 @@ export const GetDiagnosticsResponse = z.object({
 })
 
 export type ReleaseHealth = z.infer<typeof ReleaseHealth>
+export type EgressHealth = z.infer<typeof EgressHealth>
 export type GetSystemHealthChecksResponse = z.infer<typeof GetSystemHealthChecksResponse>
 export type InfraCheck = z.infer<typeof InfraCheck>
 export type DeploymentConfig = z.infer<typeof DeploymentConfig>

--- a/packages/server/api/src/app/health/health.service.ts
+++ b/packages/server/api/src/app/health/health.service.ts
@@ -1,5 +1,5 @@
 import { apVersionUtil, systemUsage, UNKNOWN_VERSION } from '@activepieces/server-utils'
-import { ActivepiecesError, ApEdition, apId, ErrorCode, FileLocation, GetDiagnosticsResponse, GetSystemHealthChecksResponse, InfraCheck, ReleaseHealth, tryCatch, unique } from '@activepieces/shared'
+import { ActivepiecesError, ApEdition, apId, EgressHealth, ErrorCode, FileLocation, GetDiagnosticsResponse, GetSystemHealthChecksResponse, InfraCheck, ReleaseHealth, tryCatch, unique } from '@activepieces/shared'
 import { FastifyBaseLogger } from 'fastify'
 import { databaseConnection } from '../database/database-connection'
 import { redisConnections } from '../database/redis-connections'
@@ -49,6 +49,7 @@ export const healthStatusService = (log: FastifyBaseLogger) => ({
         ])
         const hasWorkers = workers.length > 0
         const release = buildReleaseHealth(log, workers.map(worker => worker.information.workerProps.version))
+        const egress = buildEgressHealth(log, workers.map(worker => worker.information.workerProps.egressStatus))
 
         return {
             latestVersion,
@@ -59,6 +60,7 @@ export const healthStatusService = (log: FastifyBaseLogger) => ({
             workerRam: hasWorkers ? workers.every(worker => worker.information.totalAvailableRamInBytes >= gigaBytes(WORKER_MIN_RAM_GB)) : null,
             database: databaseHealthy,
             release,
+            egress,
         }
     },
     getDiagnostics: async (platformId: string): Promise<GetDiagnosticsResponse> => {
@@ -176,6 +178,18 @@ function buildReleaseHealth(log: FastifyBaseLogger, workerVersions: Array<string
             versionMismatched: mismatched.length,
             mismatchedVersions,
         },
+    }
+}
+
+// buildReleaseHealth's sibling: without it the combined container shows a healthy worker running nothing.
+function buildEgressHealth(log: FastifyBaseLogger, statuses: Array<string | undefined>): EgressHealth {
+    const unavailable = statuses.filter(status => status === 'unavailable').length
+    if (unavailable > 0) {
+        log.warn({ worker: { unavailable, total: statuses.length } }, '[health] Workers are connected but taking no jobs — STRICT sandbox egress could not be prepared')
+    }
+    return {
+        total: statuses.length,
+        unavailable,
     }
 }
 

--- a/packages/server/api/src/app/workers/rpc/worker-rpc-service.ts
+++ b/packages/server/api/src/app/workers/rpc/worker-rpc-service.ts
@@ -56,6 +56,12 @@ export function createHandlers(log: FastifyBaseLogger, assignment: WorkerGroupAs
         async poll(input) {
             log.info({ worker: { id: input.workerId }, workerGroup: assignment ?? undefined }, '[workerRpc#poll] Poll request received')
             await machineService(log).onConnection(input, assignment)
+            // onConnection above recorded the verdict for /v1/health/system; withhold the job so a
+            // worker whose STRICT egress prep failed idles instead of pulling a job onto broken egress.
+            if (input.workerProps.egressStatus === 'unavailable') {
+                log.warn({ worker: { id: input.workerId } }, '[workerRpc#poll] Withholding job — worker reports STRICT egress capabilities unavailable')
+                return null
+            }
             const workerVersion = input.workerProps.version
             const appVersion = apVersionUtil.getCurrentRelease()
             if (!apVersionUtil.versionsAreCompatible({ versionA: workerVersion, versionB: appVersion })) {

--- a/packages/server/api/test/integration/ce/workers/worker-poll-egress-gate.test.ts
+++ b/packages/server/api/test/integration/ce/workers/worker-poll-egress-gate.test.ts
@@ -1,0 +1,74 @@
+import { apId } from '@activepieces/core-utils'
+import { apVersionUtil } from '@activepieces/server-utils'
+import { LATEST_JOB_DATA_SCHEMA_VERSION, TriggerHookType, WorkerJobType, WorkerMachineHealthcheckRequest } from '@activepieces/shared'
+import { FastifyInstance } from 'fastify'
+import { engineResponseWatcher } from '../../../../src/app/workers/engine-response-watcher'
+import { jobBroker } from '../../../../src/app/workers/job-queue/job-broker'
+import { jobQueue, JobType } from '../../../../src/app/workers/job-queue/job-queue'
+import { workerMachineCache } from '../../../../src/app/workers/machine/machine-cache'
+import { createHandlers } from '../../../../src/app/workers/rpc/worker-rpc-service'
+import { mockAndSaveBasicSetup } from '../../../helpers/mocks'
+import { setupTestEnvironment, teardownTestEnvironment } from '../../../helpers/test-setup'
+
+let app: FastifyInstance
+
+beforeAll(async () => {
+    app = await setupTestEnvironment()
+    await jobBroker(app.log).init()
+})
+
+afterAll(async () => {
+    await jobBroker(app.log).close()
+    await teardownTestEnvironment()
+})
+
+function healthcheck(overrides: { workerId: string, egressStatus?: 'ok' | 'unavailable' }): WorkerMachineHealthcheckRequest {
+    return {
+        workerId: overrides.workerId,
+        cpuUsagePercentage: 0,
+        ramUsagePercentage: 0,
+        totalAvailableRamInBytes: 8 * 1024 * 1024 * 1024,
+        totalCpuCores: 4,
+        ip: '127.0.0.1',
+        diskInfo: { total: 100, free: 100, used: 0, percentage: 0 },
+        sandboxes: [],
+        workerProps: {
+            version: apVersionUtil.getCurrentRelease(),
+            ...(overrides.egressStatus ? { egressStatus: overrides.egressStatus } : {}),
+        },
+    }
+}
+
+describe('Worker poll egress gate', () => {
+    it('withholds a queued job from an egress-unavailable worker but records its verdict, then serves the job once egress is ok', async () => {
+        const { mockPlatform, mockProject } = await mockAndSaveBasicSetup()
+        const jobId = apId()
+        await jobQueue(app.log).add({
+            type: JobType.ONE_TIME,
+            id: jobId,
+            data: {
+                jobType: WorkerJobType.EXECUTE_TRIGGER_HOOK,
+                platformId: mockPlatform.id,
+                projectId: mockProject.id,
+                schemaVersion: LATEST_JOB_DATA_SCHEMA_VERSION,
+                flowId: apId(),
+                flowVersionId: apId(),
+                test: false,
+                hookType: TriggerHookType.ON_ENABLE,
+                requestId: apId(),
+                webserverId: engineResponseWatcher(app.log).getServerId(),
+            },
+        })
+
+        const handlers = createHandlers(app.log)
+        const unavailableWorkerId = apId()
+
+        const withheld = await handlers.poll(healthcheck({ workerId: unavailableWorkerId, egressStatus: 'unavailable' }))
+        expect(withheld).toBeNull()
+        const recorded = await workerMachineCache().findOne(unavailableWorkerId)
+        expect(recorded?.information.workerProps.egressStatus).toBe('unavailable')
+
+        const served = await handlers.poll(healthcheck({ workerId: apId(), egressStatus: 'ok' }))
+        expect(served?.jobId).toBe(jobId)
+    })
+})

--- a/packages/server/api/test/integration/cloud/health/system-health.test.ts
+++ b/packages/server/api/test/integration/cloud/health/system-health.test.ts
@@ -40,7 +40,23 @@ describe('System Health API', () => {
                         mismatchedVersions: expect.any(Array),
                     },
                 },
+                egress: {
+                    total: expect.any(Number),
+                    unavailable: expect.any(Number),
+                },
             })
+        })
+
+        // The combined container has no worker health server, so this block is the only place it shows up.
+        it('reports no egress-unavailable workers when none are connected', async () => {
+            const ctx = await createTestContext(app!)
+
+            const response = await ctx.get('/v1/health/system')
+
+            expect(response?.statusCode).toBe(StatusCodes.OK)
+            const { egress } = response?.json()
+            expect(egress.total).toBe(0)
+            expect(egress.unavailable).toBe(0)
         })
 
         it('reports no worker version skew when no workers are connected', async () => {

--- a/packages/server/engine/src/lib/network/dns-lookup-guard.ts
+++ b/packages/server/engine/src/lib/network/dns-lookup-guard.ts
@@ -36,6 +36,22 @@ function buildGuardedCallbackLookup({ policy, boundLookup }: BuildCallbackLookup
             ? optionsOrCallback
             : undefined
 
+        const pinned = resolvePinnedEntries({ policy, hostname, family: callerOptions?.family })
+        if (pinned) {
+            // dns.lookup always calls back asynchronously, even on an /etc/hosts hit; callers rely on it.
+            queueMicrotask(() => {
+                if (!callback) {
+                    return
+                }
+                if (callerOptions?.all) {
+                    callback(null, pinned)
+                    return
+                }
+                callback(null, pinned[0].address, pinned[0].family)
+            })
+            return
+        }
+
         const onResolved: DnsLookupCallback = (err, address, family) => {
             if (err || !callback) {
                 callback?.(err, address, family)
@@ -65,6 +81,10 @@ function buildGuardedCallbackLookup({ policy, boundLookup }: BuildCallbackLookup
 
 function buildGuardedPromiseLookup({ policy, boundPromisesLookup }: BuildPromiseLookupParams): GuardedPromiseLookup {
     return async function promiseLookup(hostname, options) {
+        const pinned = resolvePinnedEntries({ policy, hostname, family: options?.family })
+        if (pinned) {
+            return options?.all ? pinned : pinned[0]
+        }
         const allEntries = await boundPromisesLookup(hostname, { ...options, all: true })
         const blocked = findBlockedEntry({ entries: allEntries, allowList: policy.allowList })
         if (blocked) {
@@ -72,6 +92,18 @@ function buildGuardedPromiseLookup({ policy, boundPromisesLookup }: BuildPromise
         }
         return options?.all ? allEntries : allEntries[0]
     }
+}
+
+// Pinned answers skip findBlockedEntry by design; socket-connect-guard still gates the connect.
+function resolvePinnedEntries({ policy, hostname, family }: ResolvePinnedEntriesParams): dns.LookupAddress[] | null {
+    if (family === 6) {
+        return null
+    }
+    const pinned = policy.pinnedHosts.get(hostname.toLowerCase())
+    if (!pinned) {
+        return null
+    }
+    return pinned.map((address) => ({ address, family: 4 }))
 }
 
 function toAddressList({ address, family }: ToAddressListParams): dns.LookupAddress[] {
@@ -111,6 +143,12 @@ type BuildCallbackLookupParams = {
 type BuildPromiseLookupParams = {
     policy: GuardPolicy
     boundPromisesLookup: typeof dns.promises.lookup
+}
+
+type ResolvePinnedEntriesParams = {
+    policy: GuardPolicy
+    hostname: string
+    family?: number
 }
 
 type ToAddressListParams = {

--- a/packages/server/engine/src/lib/network/socket-connect-guard.ts
+++ b/packages/server/engine/src/lib/network/socket-connect-guard.ts
@@ -21,7 +21,8 @@ export function installSocketConnectGuard(policy: GuardPolicy): UninstallFn {
 }
 
 function readConnectTarget(args: unknown[]): ConnectTarget | undefined {
-    const first = args[0]
+    // normalizeArgs hands connect an [options, callback] ARRAY, so skipping arrays waved every fetch through.
+    const first = Array.isArray(args[0]) ? args[0][0] : args[0]
     if (typeof first === 'object' && first !== null && !Array.isArray(first)) {
         const opts = first as { host?: string, port?: number }
         return { host: opts.host, port: opts.port }
@@ -35,21 +36,25 @@ function readConnectTarget(args: unknown[]): ConnectTarget | undefined {
 
 function isBlockedRawIpTarget({ target, policy }: IsBlockedRawIpTargetParams): boolean {
     const host = target?.host
-    if (!host || isIP(host) === 0) return false
+    if (!host) return false
+    // A pinned hostname skips the dns blocked-IP check, so it must be scoped to the opened port here.
+    const pinned = policy.pinnedHosts.get(host.toLowerCase())
+    if (pinned) {
+        return !pinned.some((ip) => isExemptHostPort({ host: ip, port: target?.port, policy }))
+    }
+    if (isIP(host) === 0) return false
     if (!ssrfIpClassifier.isBlockedIp({ ip: host, allowList: policy.allowList })) return false
-    return !isExemptLoopbackPort({ host, port: target?.port, policy })
+    return !isExemptHostPort({ host, port: target?.port, policy })
 }
 
-function isExemptLoopbackPort({ host, port, policy }: IsExemptLoopbackPortParams): boolean {
-    if (!LOOPBACK_IPS.has(host) || port === undefined) return false
-    return policy.allowedLoopbackPorts.has(port)
+function isExemptHostPort({ host, port, policy }: IsExemptHostPortParams): boolean {
+    if (port === undefined) return false
+    return policy.allowedHostPorts.has(`${host}:${port}`)
 }
 
 function buildBlockedError({ host, ip }: BuildBlockedErrorParams): SSRFBlockedError {
     return new SSRFBlockedError({ host, ip })
 }
-
-const LOOPBACK_IPS = new Set(['127.0.0.1', '::1'])
 
 type ConnectTarget = {
     host?: string
@@ -61,7 +66,7 @@ type IsBlockedRawIpTargetParams = {
     policy: GuardPolicy
 }
 
-type IsExemptLoopbackPortParams = {
+type IsExemptHostPortParams = {
     host: string
     port: number | undefined
     policy: GuardPolicy

--- a/packages/server/engine/src/lib/network/ssrf-guard.ts
+++ b/packages/server/engine/src/lib/network/ssrf-guard.ts
@@ -48,10 +48,48 @@ function isGuardEnabled(options: InstallOptions): boolean {
 }
 
 function buildGuardPolicy(options: InstallOptions): GuardPolicy {
+    const allowedHostPorts = new Set<string>()
+    const loopbackPorts = options.allowedLoopbackPorts ?? readSandboxRpcPortFromEnv()
+    for (const port of loopbackPorts) {
+        allowedHostPorts.add(`127.0.0.1:${port}`)
+        allowedHostPorts.add(`::1:${port}`)
+    }
+    for (const endpoint of options.allowedHostPorts ?? []) {
+        allowedHostPorts.add(endpoint)
+    }
+    for (const endpoint of readSandboxHostPortsFromEnv()) {
+        allowedHostPorts.add(endpoint)
+    }
     return {
         allowList: options.allowList ?? splitCsv(process.env['AP_SSRF_ALLOW_LIST']),
-        allowedLoopbackPorts: new Set(options.allowedLoopbackPorts ?? readSandboxRpcPortFromEnv()),
+        allowedHostPorts,
+        pinnedHosts: buildPinnedHosts(options.pinnedHosts ?? process.env['AP_SANDBOX_API_HOST_PIN']),
     }
+}
+
+// An internal app hostname does not resolve inside the box, and rewriting the URL would drop SNI.
+function buildPinnedHosts(raw: string | Record<string, string[]> | undefined): Map<string, string[]> {
+    const pinned = new Map<string, string[]>()
+    if (!raw) {
+        return pinned
+    }
+    const entries = typeof raw === 'string' ? parsePinnedHostsSpec(raw) : Object.entries(raw)
+    for (const [hostname, ips] of entries) {
+        const usable = ips.map((ip) => ip.trim()).filter(isIpv4Literal)
+        if (hostname === '' || usable.length === 0) {
+            continue
+        }
+        pinned.set(hostname.toLowerCase(), usable)
+    }
+    return pinned
+}
+
+function parsePinnedHostsSpec(raw: string): Array<[string, string[]]> {
+    const separatorIndex = raw.indexOf('=')
+    if (separatorIndex <= 0) {
+        return []
+    }
+    return [[raw.slice(0, separatorIndex).trim(), raw.slice(separatorIndex + 1).split(',')]]
 }
 
 function readSandboxRpcPortFromEnv(): number[] {
@@ -59,16 +97,56 @@ function readSandboxRpcPortFromEnv(): number[] {
     return Number.isFinite(rpcPort) ? [rpcPort] : []
 }
 
+function readSandboxHostPortsFromEnv(): string[] {
+    const endpoints: string[] = []
+    const host = process.env['AP_SANDBOX_WS_HOST']?.trim()
+    if (host) {
+        const wsPort = parseInt(process.env['AP_SANDBOX_WS_PORT'] ?? '', 10)
+        if (Number.isFinite(wsPort)) {
+            endpoints.push(`${host}:${wsPort}`)
+        }
+        const callbackPort = parseInt(process.env['AP_SANDBOX_CALLBACK_PORT'] ?? '', 10)
+        if (Number.isFinite(callbackPort)) {
+            endpoints.push(`${host}:${callbackPort}`)
+        }
+    }
+    // One kernel ACCEPT per address, so the exemption must cover all of them; undici picks any.
+    for (const apiAllow of splitCsv(process.env['AP_SANDBOX_API_ALLOW'])) {
+        if (isHostPortEndpoint(apiAllow)) {
+            endpoints.push(apiAllow)
+        }
+    }
+    return endpoints
+}
+
+function isHostPortEndpoint(value: string): boolean {
+    const separatorIndex = value.lastIndexOf(':')
+    if (separatorIndex <= 0) {
+        return false
+    }
+    if (!isIpv4Literal(value.slice(0, separatorIndex))) {
+        return false
+    }
+    const port = Number(value.slice(separatorIndex + 1))
+    return Number.isInteger(port) && port > 0 && port <= 65535
+}
+
+function isIpv4Literal(value: string): boolean {
+    const octets = value.split('.')
+    return octets.length === 4 && octets.every((octet) => /^\d{1,3}$/.test(octet) && Number(octet) <= 255)
+}
+
 function splitCsv(raw: string | undefined): string[] {
     if (!raw) return []
     return raw.split(',').map((s) => s.trim()).filter(Boolean)
 }
 
-const DISABLED_POLICY: GuardPolicy = { allowList: [], allowedLoopbackPorts: new Set() }
+const DISABLED_POLICY: GuardPolicy = { allowList: [], allowedHostPorts: new Set(), pinnedHosts: new Map() }
 
 export type GuardPolicy = {
     allowList: string[]
-    allowedLoopbackPorts: Set<number>
+    allowedHostPorts: Set<string>
+    pinnedHosts: Map<string, string[]>
 }
 
 export type UninstallFn = () => void
@@ -77,6 +155,8 @@ type InstallOptions = {
     enabled?: boolean
     allowList?: string[]
     allowedLoopbackPorts?: number[]
+    allowedHostPorts?: string[]
+    pinnedHosts?: Record<string, string[]>
 }
 
 type ActiveGuard = {

--- a/packages/server/engine/src/lib/worker-socket.ts
+++ b/packages/server/engine/src/lib/worker-socket.ts
@@ -26,7 +26,8 @@ function clearInitialConnectWatchdog(): void {
 
 export const workerSocket = {
     init: (sandboxId: string): void => {
-        const wsUrl = `ws://127.0.0.1:${process.env.AP_SANDBOX_WS_PORT ?? '12345'}`
+        // In a netns 127.0.0.1 is the box's own loopback, so WS-RPC is only on the gateway veth IP.
+        const wsUrl = `ws://${process.env.AP_SANDBOX_WS_HOST ?? '127.0.0.1'}:${process.env.AP_SANDBOX_WS_PORT ?? '12345'}`
         socket = io(wsUrl, buildSocketOptions(sandboxId))
 
         // Without this watchdog, if the parent worker is SIGKILLed (OOM, crash) before

--- a/packages/server/engine/test/network/api-host-pin.test.ts
+++ b/packages/server/engine/test/network/api-host-pin.test.ts
@@ -1,0 +1,115 @@
+import { createServer as createHttpServer, Server as HttpServer } from 'node:http'
+import { createServer as createTcpServer, Server as TcpServer } from 'node:net'
+import { afterEach, describe, expect, it } from 'vitest'
+import { ssrfGuard } from '../../src/lib/network/ssrf-guard'
+
+// Asserts what the engine puts ON THE WIRE, because rewriting the URL silently dropped SNI and the Host.
+
+function readClientHelloSni(bytes: Buffer): string | null {
+    // TLS record header (5) + handshake header (4) + version (2) + random (32).
+    let offset = 5 + 4 + 2 + 32
+    if (bytes.length < offset + 1) {
+        return null
+    }
+    offset += 1 + bytes[offset]
+    if (bytes.length < offset + 2) {
+        return null
+    }
+    offset += 2 + bytes.readUInt16BE(offset)
+    if (bytes.length < offset + 1) {
+        return null
+    }
+    offset += 1 + bytes[offset]
+    if (bytes.length < offset + 2) {
+        return null
+    }
+    const extensionsEnd = offset + 2 + bytes.readUInt16BE(offset)
+    offset += 2
+    while (offset + 4 <= Math.min(extensionsEnd, bytes.length)) {
+        const type = bytes.readUInt16BE(offset)
+        const length = bytes.readUInt16BE(offset + 2)
+        if (type === 0) {
+            const nameLength = bytes.readUInt16BE(offset + 7)
+            return bytes.subarray(offset + 9, offset + 9 + nameLength).toString('utf8')
+        }
+        offset += 4 + length
+    }
+    return null
+}
+
+describe('app API host pin', () => {
+    let httpServer: HttpServer | null = null
+    let tcpServer: TcpServer | null = null
+
+    afterEach(async () => {
+        ssrfGuard.uninstall()
+        delete process.env['AP_SANDBOX_API_HOST_PIN']
+        delete process.env['AP_SANDBOX_API_ALLOW']
+        await new Promise<void>((resolve) => (httpServer ? httpServer.close(() => resolve()) : resolve()))
+        await new Promise<void>((resolve) => (tcpServer ? tcpServer.close(() => resolve()) : resolve()))
+        httpServer = null
+        tcpServer = null
+    })
+
+    it('sends the app hostname as TLS SNI while connecting to the pinned address', async () => {
+        const sni = await new Promise<string | null>((resolve, reject) => {
+            tcpServer = createTcpServer((socket) => {
+                socket.once('data', (chunk) => {
+                    resolve(readClientHelloSni(chunk))
+                    socket.destroy()
+                })
+            })
+            tcpServer.listen(0, '127.0.0.1', () => {
+                const port = (tcpServer!.address() as { port: number }).port
+                process.env['AP_SANDBOX_API_HOST_PIN'] = 'app.internal.test=127.0.0.1'
+                process.env['AP_SANDBOX_API_ALLOW'] = `127.0.0.1:${port}`
+                ssrfGuard.install({ enabled: true, allowList: [] })
+                // The URL keeps the hostname exactly as the operator configured it.
+                fetch(`https://app.internal.test:${port}/api/v1/engine/populated-flows`).catch(() => undefined)
+            })
+            tcpServer.once('error', reject)
+        })
+
+        expect(sni).toBe('app.internal.test')
+        expect(sni).not.toBe('127.0.0.1')
+    })
+
+    it('sends the app hostname as the Host header and keeps the path, over the pinned address', async () => {
+        const request = await new Promise<{ host: string | undefined, url: string | undefined }>((resolve, reject) => {
+            httpServer = createHttpServer((req, res) => {
+                res.writeHead(200)
+                res.end()
+                resolve({ host: req.headers.host, url: req.url })
+            })
+            httpServer.listen(0, '127.0.0.1', () => {
+                const port = (httpServer!.address() as { port: number }).port
+                process.env['AP_SANDBOX_API_HOST_PIN'] = 'app.internal.test=127.0.0.1'
+                process.env['AP_SANDBOX_API_ALLOW'] = `127.0.0.1:${port}`
+                ssrfGuard.install({ enabled: true, allowList: [] })
+                fetch(`http://app.internal.test:${port}/api/v1/engine/populated-flows`).catch(() => undefined)
+            })
+            httpServer.once('error', reject)
+        })
+
+        expect(request.host).toBe(`app.internal.test:${(httpServer!.address() as { port: number }).port}`)
+        expect(request.url).toBe('/api/v1/engine/populated-flows')
+    })
+
+    it('cannot reach a pinned address on a port the kernel did not open', async () => {
+        await new Promise<void>((resolve, reject) => {
+            httpServer = createHttpServer((_req, res) => {
+                res.writeHead(200)
+                res.end()
+            })
+            httpServer.listen(0, '127.0.0.1', () => resolve())
+            httpServer.once('error', reject)
+        })
+        const port = (httpServer!.address() as { port: number }).port
+        process.env['AP_SANDBOX_API_HOST_PIN'] = 'app.internal.test=127.0.0.1'
+        process.env['AP_SANDBOX_API_ALLOW'] = `127.0.0.1:${port + 1}`
+        ssrfGuard.install({ enabled: true, allowList: [] })
+
+        // The pin resolves the name but the socket guard still gates the connect: one endpoint, nothing more.
+        await expect(fetch(`http://app.internal.test:${port}/api/`)).rejects.toThrow()
+    })
+})

--- a/packages/server/engine/test/network/ssrf-guard.test.ts
+++ b/packages/server/engine/test/network/ssrf-guard.test.ts
@@ -1,17 +1,24 @@
 import dns from 'node:dns'
-import { createServer, Server, Socket } from 'node:net'
+import { connect as netConnect, createServer, Server, Socket } from 'node:net'
 import { SSRFBlockedError } from '@activepieces/shared'
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 import { ssrfGuard } from '../../src/lib/network/ssrf-guard'
 
-function connectOnce(options: { host: string, port: number }): Promise<{ connected: boolean, error?: Error }> {
+function connectOnce(options: { host: string, port: number }, timeoutMs = 2_000): Promise<{ connected: boolean, error?: Error }> {
     return new Promise((resolve) => {
         const socket = new Socket()
+        let settled = false
         const settle = (result: { connected: boolean, error?: Error }): void => {
+            if (settled) {
+                return
+            }
+            settled = true
+            clearTimeout(timer)
             socket.removeAllListeners()
             socket.destroy()
             resolve(result)
         }
+        const timer = setTimeout(() => settle({ connected: false, error: new Error('connect-timeout') }), timeoutMs)
         socket.once('connect', () => settle({ connected: true }))
         socket.once('error', (err) => settle({ connected: false, error: err }))
         socket.connect(options)
@@ -182,6 +189,61 @@ describe('ssrf-guard', () => {
         })
     })
 
+    // The pin has to win over the real resolver AND over the blocked-IP check.
+    describe('dns.lookup hook — pinned app API hostname', () => {
+        afterEach(() => {
+            vi.restoreAllMocks()
+            delete process.env['AP_SANDBOX_API_HOST_PIN']
+        })
+
+        it('promises api: returns the pinned private addresses without consulting the resolver', async () => {
+            const resolver = vi.spyOn(dns.promises, 'lookup')
+            ssrfGuard.install({ enabled: true, allowList: [], pinnedHosts: { 'api.internal': ['10.0.0.9', '10.0.0.10'] } })
+            const single = await dns.promises.lookup('api.internal')
+            expect(single).toEqual({ address: '10.0.0.9', family: 4 })
+            const all = await dns.promises.lookup('api.internal', { all: true })
+            expect(all).toEqual([{ address: '10.0.0.9', family: 4 }, { address: '10.0.0.10', family: 4 }])
+            expect(resolver).not.toHaveBeenCalled()
+        })
+
+        it('callback api: returns the pinned addresses, asynchronously, in both shapes', async () => {
+            const resolver = vi.spyOn(dns, 'lookup')
+            ssrfGuard.install({ enabled: true, allowList: [], pinnedHosts: { 'api.internal': ['10.0.0.9'] } })
+            let calledSynchronously = true
+            const single = await new Promise<{ err: unknown, address: unknown, family: unknown }>((resolve) => {
+                dns.lookup('api.internal', (err, address, family) => {
+                    expect(calledSynchronously).toBe(false)
+                    resolve({ err, address, family })
+                })
+                calledSynchronously = false
+            })
+            expect(single).toEqual({ err: null, address: '10.0.0.9', family: 4 })
+            const all = await new Promise<unknown>((resolve) => {
+                dns.lookup('api.internal', { all: true }, (_err, address) => resolve(address))
+            })
+            expect(all).toEqual([{ address: '10.0.0.9', family: 4 }])
+            expect(resolver).not.toHaveBeenCalled()
+        })
+
+        it('reads the pin from AP_SANDBOX_API_HOST_PIN and matches the hostname case-insensitively', async () => {
+            process.env['AP_SANDBOX_API_HOST_PIN'] = 'API.Internal=10.0.0.9'
+            ssrfGuard.install({ enabled: true, allowList: [] })
+            await expect(dns.promises.lookup('api.internal')).resolves.toEqual({ address: '10.0.0.9', family: 4 })
+        })
+
+        it('leaves every other hostname on the real resolver and still blocked', async () => {
+            vi.spyOn(dns.promises, 'lookup').mockResolvedValue([{ address: '10.0.0.1', family: 4 }] as unknown as dns.LookupAddress)
+            ssrfGuard.install({ enabled: true, allowList: [], pinnedHosts: { 'api.internal': ['10.0.0.9'] } })
+            await expect(dns.promises.lookup('other.internal')).rejects.toBeInstanceOf(SSRFBlockedError)
+        })
+
+        it('ignores a pin whose addresses are not IPv4 literals', async () => {
+            vi.spyOn(dns.promises, 'lookup').mockResolvedValue([{ address: '10.0.0.1', family: 4 }] as unknown as dns.LookupAddress)
+            ssrfGuard.install({ enabled: true, allowList: [], pinnedHosts: { 'api.internal': ['999.1.1.1', 'not-an-ip'] } })
+            await expect(dns.promises.lookup('api.internal')).rejects.toBeInstanceOf(SSRFBlockedError)
+        })
+    })
+
     describe('net.Socket.connect hook', () => {
         let publicServer: Server
         let publicPort: number
@@ -221,6 +283,87 @@ describe('ssrf-guard', () => {
             const result = await connectOnce({ host: '127.0.0.1', port: publicPort })
             expect(result.connected).toBe(false)
             expect(result.error).toBeInstanceOf(SSRFBlockedError)
+        })
+
+        it('allows a private gateway host:port pair without allowlisting the whole IP', async () => {
+            ssrfGuard.install({
+                enabled: true,
+                allowList: [],
+                allowedHostPorts: ['10.255.0.5:9'],
+            })
+            const allowed = await connectOnce({ host: '10.255.0.5', port: 9 }, 200)
+            expect(allowed.error).not.toBeInstanceOf(SSRFBlockedError)
+            const blocked = await connectOnce({ host: '10.255.0.5', port: 10 })
+            expect(blocked.connected).toBe(false)
+            expect(blocked.error).toBeInstanceOf(SSRFBlockedError)
+        })
+
+        it('allows AP_SANDBOX_API_ALLOW host:port from env without allowlisting the whole IP', async () => {
+            process.env['AP_SANDBOX_API_ALLOW'] = '10.0.0.9:3000'
+            try {
+                ssrfGuard.install({ enabled: true, allowList: [] })
+                const allowed = await connectOnce({ host: '10.0.0.9', port: 3000 }, 200)
+                expect(allowed.error).not.toBeInstanceOf(SSRFBlockedError)
+                const blocked = await connectOnce({ host: '10.0.0.9', port: 6379 })
+                expect(blocked.connected).toBe(false)
+                expect(blocked.error).toBeInstanceOf(SSRFBlockedError)
+            }
+            finally {
+                delete process.env['AP_SANDBOX_API_ALLOW']
+            }
+        })
+
+        // Exempting only the first address let undici's choice decide whether the job worked.
+        it('exempts EVERY endpoint in a comma-separated AP_SANDBOX_API_ALLOW, not just the first', async () => {
+            process.env['AP_SANDBOX_API_ALLOW'] = '10.0.0.9:3000,10.0.0.10:3000'
+            try {
+                ssrfGuard.install({ enabled: true, allowList: [] })
+                const first = await connectOnce({ host: '10.0.0.9', port: 3000 }, 200)
+                expect(first.error).not.toBeInstanceOf(SSRFBlockedError)
+                const second = await connectOnce({ host: '10.0.0.10', port: 3000 }, 200)
+                expect(second.error).not.toBeInstanceOf(SSRFBlockedError)
+                const blocked = await connectOnce({ host: '10.0.0.11', port: 3000 })
+                expect(blocked.connected).toBe(false)
+                expect(blocked.error).toBeInstanceOf(SSRFBlockedError)
+            }
+            finally {
+                delete process.env['AP_SANDBOX_API_ALLOW']
+            }
+        })
+
+        it('rejects a malformed AP_SANDBOX_API_ALLOW octet instead of exempting it', async () => {
+            process.env['AP_SANDBOX_API_ALLOW'] = '999.999.999.999:3000'
+            try {
+                ssrfGuard.install({ enabled: true, allowList: [] })
+                const blocked = await connectOnce({ host: '10.0.0.9', port: 3000 })
+                expect(blocked.error).toBeInstanceOf(SSRFBlockedError)
+            }
+            finally {
+                delete process.env['AP_SANDBOX_API_ALLOW']
+            }
+        })
+
+        // Asserting only that fetch rejects proves nothing, so the guard's own error has to be the cause.
+        it('blocks a raw private IP reached through fetch (the net.connect normalized-args path)', async () => {
+            ssrfGuard.install({ enabled: true, allowList: [] })
+            const cause = await fetch('http://10.0.0.5:443/').then(
+                () => null,
+                (error: { cause?: unknown }) => error.cause,
+            )
+            expect(cause).toBeInstanceOf(SSRFBlockedError)
+        })
+
+        it('blocks a raw private IP reached through net.connect(options)', async () => {
+            ssrfGuard.install({ enabled: true, allowList: [] })
+            const error = await new Promise<Error>((resolve) => {
+                const socket = netConnect({ host: '169.254.169.254', port: 80 })
+                socket.once('error', resolve)
+                socket.once('connect', () => {
+                    socket.destroy()
+                    resolve(new Error('connected'))
+                })
+            })
+            expect(error).toBeInstanceOf(SSRFBlockedError)
         })
 
         it('allowList overrides block for raw IP connect', async () => {

--- a/packages/server/sandbox/src/index.ts
+++ b/packages/server/sandbox/src/index.ts
@@ -1,5 +1,7 @@
 export { createSandboxRuntime } from './lib/sandbox'
 export { createResolver } from './lib/resolver'
+export { isIsolateMode } from './lib/create-sandbox-for-job'
+export { prepareEgressEnvironment } from './lib/sandbox/netns'
 
 export type {
     Runtime,
@@ -14,3 +16,5 @@ export type {
     SandboxDeps,
     CodeArtifact,
 } from './lib/types'
+
+export type { EgressNetworkLease } from './lib/sandbox/netns'

--- a/packages/server/sandbox/src/lib/create-sandbox-for-job.ts
+++ b/packages/server/sandbox/src/lib/create-sandbox-for-job.ts
@@ -6,7 +6,7 @@ import { sandboxCapacity } from './sandbox/capacity'
 import { simpleProcess } from './sandbox/fork'
 import { isolateProcess } from './sandbox/isolate'
 import { createSandbox } from './sandbox/sandbox'
-import { Sandbox, SandboxMount } from './sandbox/types'
+import { EgressInfo, Sandbox, SandboxLogger, SandboxMount } from './sandbox/types'
 import { SandboxSettings } from './types'
 
 export function createSandboxForJob(params: {
@@ -15,8 +15,10 @@ export function createSandboxForJob(params: {
     reusable: boolean
     basePath: string
     getSettings: () => SandboxSettings
+    getEgress?: (log: SandboxLogger) => Promise<EgressInfo | null>
+    egressNeedsRotation?: (log: SandboxLogger) => Promise<boolean>
 }): Sandbox {
-    const { log, boxId, reusable, basePath, getSettings } = params
+    const { log, boxId, reusable, basePath, getSettings, getEgress, egressNeedsRotation } = params
     const settings = getSettings()
     const sandboxId = nanoid()
     const paths = cacheUtils(basePath)
@@ -43,6 +45,8 @@ export function createSandboxForJob(params: {
             basePath,
             baseMounts,
             wsRpcPort: isIsolateMode(executionMode) ? sandboxCapacity.wsRpcPortForBox(boxId) : undefined,
+            getEgress: isIsolateMode(executionMode) ? getEgress : undefined,
+            egressNeedsRotation: isIsolateMode(executionMode) ? egressNeedsRotation : undefined,
         },
         processMaker,
     )
@@ -73,9 +77,6 @@ function parseMemoryLimit(memoryLimitKb: string): number {
 function buildSandboxEnv({ settings }: {
     settings: SandboxSettings
 }): Record<string, string> {
-    // STRICT enables the engine's in-process ssrfGuard (best-effort dns + socket
-    // guards only — there is no longer an egress proxy or kernel firewall). The hard
-    // egress boundary now lives in infrastructure (e.g. the Cloud VPC firewall).
     const networkMode = settings.NETWORK_MODE
     return {
         ...baseEnv({ settings, networkMode }),

--- a/packages/server/sandbox/src/lib/sandbox-manager.ts
+++ b/packages/server/sandbox/src/lib/sandbox-manager.ts
@@ -1,25 +1,165 @@
-import { isNil } from '@activepieces/core-utils'
+import { isNil, tryCatch } from '@activepieces/core-utils'
 import { type ApLogger } from '@activepieces/server-utils'
-import { ApEnvironment, ExecutionMode } from '@activepieces/shared'
-import { createSandboxForJob } from './create-sandbox-for-job'
-import { Sandbox } from './sandbox/types'
+import { ApEnvironment, ExecutionMode, NetworkMode } from '@activepieces/shared'
+import { createSandboxForJob, isIsolateMode } from './create-sandbox-for-job'
+import { type ApiEgressResolution, createEgressNetns, EgressNetns, resolveApiEgressCached } from './sandbox/netns'
+import { EgressInfo, Sandbox, SandboxLogger, SandboxStartOptions } from './sandbox/types'
 import { SandboxSettings } from './types'
 
-export function createSandboxManager({ boxId, basePath, getSettings }: { boxId: number, basePath: string, getSettings: () => SandboxSettings }): SandboxManager {
+export function createSandboxManager({ boxId, basePath, getSettings, internalApiUrl }: { boxId: number, basePath: string, getSettings: () => SandboxSettings, internalApiUrl?: string }): SandboxManager {
     let currentSandbox: Sandbox | null = null
+    let currentStart: Promise<void> | null = null
+    let egressPromise: Promise<EgressNetns> | null = null
+    let egressCacheKey: string | null = null
+    let lastEgressRotationAt = 0
+    let consecutiveEgressFailures = 0
+    let egressProbeAt = 0
+    let pendingEgressResolution: Promise<void> | null = null
+
+    // Resolves ONCE and keys off that same answer, so the key always describes the rules installed.
+    async function resolveEgressState(log: SandboxLogger): Promise<{ cacheKey: string, apiEgress: ApiEgressResolution }> {
+        const settings = getSettings()
+        const apiEgress = await resolveApiEgressCached({ internalApiUrl, log })
+        return {
+            cacheKey: `${normalizeAllowListKey(settings.SSRF_ALLOW_LIST)}|${apiEgress.fingerprint}`,
+            apiEgress,
+        }
+    }
+
+    async function egressNeedsRotation(log: SandboxLogger): Promise<boolean> {
+        const settings = getSettings()
+        const strictIsolate = isIsolateMode(settings.EXECUTION_MODE as ExecutionMode) && settings.NETWORK_MODE === NetworkMode.STRICT
+        if (!strictIsolate || isNil(egressCacheKey)) {
+            return false
+        }
+        // Each rotation tears down the netns and kills the child, so a flapping resolver is rate-limited.
+        if (Date.now() - lastEgressRotationAt < MIN_EGRESS_ROTATION_INTERVAL_MS) {
+            return false
+        }
+        const { cacheKey } = await resolveEgressState(log)
+        return egressCacheKey !== cacheKey
+    }
+
+    // The ONLY writer of the counter, and the gate returns before this, so the deadline alone unlatches it.
+    async function getEgress(log: SandboxLogger): Promise<EgressInfo | null> {
+        // Published for shutdown: egressPromise lands after the resolution, so a racing shutdown would leak it.
+        const pending = resolveBoxEgress(log)
+        pendingEgressResolution = pending.then(() => undefined, () => undefined)
+        const { data, error } = await tryCatch(() => pending)
+        if (error) {
+            consecutiveEgressFailures++
+            egressProbeAt = Date.now() + EGRESS_PROBE_INTERVAL_MS
+            log.error(
+                { boxId, consecutiveEgressFailures, error: String(error) },
+                'Egress setup failed for this box',
+            )
+            throw error
+        }
+        consecutiveEgressFailures = 0
+        egressProbeAt = 0
+        return data ?? null
+    }
+
+    async function resolveBoxEgress(log: SandboxLogger): Promise<EgressInfo | null> {
+        const settings = getSettings()
+        const strictIsolate = isIsolateMode(settings.EXECUTION_MODE as ExecutionMode) && settings.NETWORK_MODE === NetworkMode.STRICT
+        if (!strictIsolate) {
+            return null
+        }
+        // A failed resolution changes nothing, so the built namespace is still correct; a first boot has none.
+        const { data: state, error: resolveError } = await tryCatch(() => resolveEgressState(log))
+        if (isNil(state)) {
+            const cached = egressPromise
+            if (isNil(cached)) {
+                throw resolveError
+            }
+            const { data: handle } = await tryCatch(() => cached)
+            if (isNil(handle)) {
+                throw resolveError
+            }
+            log.warn(
+                { boxId, error: String(resolveError) },
+                'Could not re-resolve the app API address; reusing the existing egress namespace unchanged',
+            )
+            return toEgressInfo(handle)
+        }
+        const { cacheKey, apiEgress } = state
+        if (!isNil(egressPromise) && egressCacheKey !== cacheKey) {
+            const pending = egressPromise
+            egressPromise = null
+            egressCacheKey = null
+            lastEgressRotationAt = Date.now()
+            const { data: handle } = await tryCatch(() => pending)
+            if (!isNil(handle)) {
+                await handle.destroy()
+            }
+        }
+        if (isNil(egressPromise)) {
+            egressCacheKey = cacheKey
+            egressPromise = createEgressNetns({ log, boxId, internalApiUrl, allowList: settings.SSRF_ALLOW_LIST, apiEgress })
+                .catch((err) => {
+                    egressPromise = null
+                    egressCacheKey = null
+                    throw err
+                })
+        }
+        return toEgressInfo(await egressPromise)
+    }
+
+    async function teardownEgress(log: ApLogger): Promise<void> {
+        if (isNil(egressPromise)) {
+            return
+        }
+        const pending = egressPromise
+        egressPromise = null
+        egressCacheKey = null
+        const { data: handle, error } = await tryCatch(() => pending)
+        if (!isNil(error) || isNil(handle)) {
+            return
+        }
+        await handle.destroy()
+        log.info({ boxId }, 'Egress network namespace destroyed')
+    }
+
+    function trackStart(sandbox: Sandbox): Sandbox {
+        return {
+            ...sandbox,
+            start: (startOptions: SandboxStartOptions) => {
+                const pending = sandbox.start(startOptions)
+                currentStart = pending
+                void pending.catch(() => undefined).finally(() => {
+                    if (currentStart === pending) {
+                        currentStart = null
+                    }
+                })
+                return pending
+            },
+        }
+    }
 
     return {
-        acquire(params: { log: ApLogger }): Sandbox {
+        async acquire(params: { log: ApLogger }): Promise<Sandbox> {
             if (canReuseSandbox(getSettings) && currentSandbox && currentSandbox.isReady()) {
                 return currentSandbox
             }
             if (currentSandbox) {
                 params.log.info('Sandbox not ready or not reusable, creating fresh one')
-                currentSandbox.shutdown().catch((err) =>
-                    params.log.error({ error: err }, 'Error shutting down previous sandbox'),
-                )
+                const previous = currentSandbox
+                currentSandbox = null
+                const { error } = await tryCatch(() => previous.shutdown())
+                if (error) {
+                    params.log.error({ error }, 'Error shutting down previous sandbox')
+                }
             }
-            currentSandbox = createSandboxForJob({ ...params, boxId, reusable: canReuseSandbox(getSettings), basePath, getSettings })
+            currentSandbox = trackStart(createSandboxForJob({
+                ...params,
+                boxId,
+                reusable: canReuseSandbox(getSettings),
+                basePath,
+                getSettings,
+                getEgress,
+                egressNeedsRotation,
+            }))
             return currentSandbox
         },
         async invalidate(log: ApLogger): Promise<void> {
@@ -36,7 +176,22 @@ export function createSandboxManager({ boxId, basePath, getSettings }: { boxId: 
             }
         },
         async shutdown(log: ApLogger): Promise<void> {
+            const pendingStart = currentStart
+            if (!isNil(pendingStart)) {
+                await tryCatch(() => pendingStart)
+            }
+            const pendingEgress = pendingEgressResolution
+            if (!isNil(pendingEgress)) {
+                await pendingEgress
+            }
             await this.invalidate(log)
+            await teardownEgress(log)
+        },
+        isEgressUnhealthy(): boolean {
+            if (consecutiveEgressFailures < MAX_CONSECUTIVE_EGRESS_FAILURES) {
+                return false
+            }
+            return Date.now() < egressProbeAt
         },
         getActiveSandbox(): ActiveSandboxInfo | null {
             if (isNil(currentSandbox) || !currentSandbox.isReady()) {
@@ -54,6 +209,29 @@ export function createSandboxManager({ boxId, basePath, getSettings }: { boxId: 
             }
         },
     }
+}
+
+const MIN_EGRESS_ROTATION_INTERVAL_MS = 60_000
+
+const MAX_CONSECUTIVE_EGRESS_FAILURES = 3
+
+// Stamped at failure time, before the gate's first check, so this plus the gate's pause is one probe.
+const EGRESS_PROBE_INTERVAL_MS = 30_000
+
+function toEgressInfo(handle: EgressNetns): EgressInfo {
+    return {
+        netnsName: handle.netnsName,
+        gatewayHost: handle.gatewayHost,
+        callbackApiUrl: handle.callbackApiUrl,
+        callbackPort: handle.callbackPort,
+        apiAllow: handle.apiAllow,
+        apiHostPin: handle.apiHostPin,
+        fingerprint: handle.fingerprint,
+    }
+}
+
+function normalizeAllowListKey(allowList: string[]): string {
+    return [...allowList].map((entry) => entry.trim()).filter((entry) => entry !== '').sort().join(',')
 }
 
 function canReuseSandbox(getSettings: () => SandboxSettings): boolean {
@@ -79,9 +257,10 @@ export type ActiveSandboxInfo = {
 }
 
 export type SandboxManager = {
-    acquire(params: { log: ApLogger }): Sandbox
+    acquire(params: { log: ApLogger }): Promise<Sandbox>
     invalidate(log: ApLogger): Promise<void>
     release(log: ApLogger): Promise<void>
     shutdown(log: ApLogger): Promise<void>
+    isEgressUnhealthy(): boolean
     getActiveSandbox(): ActiveSandboxInfo | null
 }

--- a/packages/server/sandbox/src/lib/sandbox.ts
+++ b/packages/server/sandbox/src/lib/sandbox.ts
@@ -21,9 +21,9 @@ import {
 // (threadSafeMkdir / cache-state), so there is no per-key provision dedup here. execute owns the slot
 // lifecycle: acquire -> provision -> run -> release on success / invalidate on throw, re-raising the
 // sandbox ActivepiecesError codes (timeout / memory / log-size) that handlers already catch. See ADR 0004.
-export function createSandboxRuntime({ concurrency = 1, basePath, getSettings }: CreateSandboxRuntimeParams): Runtime {
+export function createSandboxRuntime({ concurrency = 1, basePath, getSettings, internalApiUrl }: CreateSandboxRuntimeParams): Runtime {
     const managers: SandboxManager[] = Array.from({ length: concurrency }, (_, index) =>
-        createSandboxManager({ boxId: index + 1, basePath, getSettings }),
+        createSandboxManager({ boxId: index + 1, basePath, getSettings, internalApiUrl }),
     )
 
     return {
@@ -35,7 +35,7 @@ export function createSandboxRuntime({ concurrency = 1, basePath, getSettings }:
                     params: { message: `No sandbox manager for worker index ${workerIndex} (concurrency=${concurrency})` },
                 })
             }
-            const sandbox = manager.acquire({ log })
+            const sandbox = await manager.acquire({ log })
 
             const provisionStartedAt = Date.now()
             const { error: provisionError } = await tryCatch(() => localExecutionCache(log, basePath, getSettings).provision({
@@ -87,6 +87,9 @@ export function createSandboxRuntime({ concurrency = 1, basePath, getSettings }:
                 await manager.invalidate(log)
                 throw error
             }
+        },
+        isExecutorPaused(workerIndex: number): boolean {
+            return managers[workerIndex]?.isEgressUnhealthy() ?? false
         },
         getActiveExecutors(): RuntimeExecutorInfo[] {
             return managers
@@ -141,5 +144,6 @@ type CreateSandboxRuntimeParams = {
     concurrency?: number
     basePath: string
     getSettings: () => SandboxSettings
-
+    // Forwarded to each box's egress setup so a loopback URL can be rewritten to the gateway veth IP.
+    internalApiUrl?: string
 }

--- a/packages/server/sandbox/src/lib/sandbox/isolate.ts
+++ b/packages/server/sandbox/src/lib/sandbox/isolate.ts
@@ -59,7 +59,7 @@ const etcDir = path.resolve(process.cwd(), 'packages/server/api/src/assets/etc')
 export function isolateProcess(log: SandboxLogger, enginePath: string, _codeDirectory: string, boxId: number): SandboxProcessMaker {
     return {
         create: async (params: CreateSandboxProcessParams) => {
-            const { sandboxId, mounts, env, resourceLimits } = params
+            const { sandboxId, mounts, env, resourceLimits, netnsName } = params
 
             for (const mount of mounts) {
                 assertMountInsideRoot(mount)
@@ -123,9 +123,13 @@ export function isolateProcess(log: SandboxLogger, enginePath: string, _codeDire
                 engineSandboxPath,
             ]
 
-            log.debug({ sandbox: { id: sandboxId }, command: `${isolateBinaryPath} ${args.join(' ')}` }, 'Spawning isolate process')
+            // --share-net makes isolate inherit the pre-provisioned netns rather than the host's.
+            const spawnCommand = netnsName ? 'ip' : isolateBinaryPath
+            const spawnArgs = netnsName ? ['netns', 'exec', netnsName, isolateBinaryPath, ...args] : args
 
-            const child = spawn(isolateBinaryPath, args, {
+            log.debug({ sandbox: { id: sandboxId }, netnsName: netnsName ?? 'host', command: `${spawnCommand} ${spawnArgs.join(' ')}` }, 'Spawning isolate process')
+
+            const child = spawn(spawnCommand, spawnArgs, {
                 shell: false,
             })
 

--- a/packages/server/sandbox/src/lib/sandbox/netns.ts
+++ b/packages/server/sandbox/src/lib/sandbox/netns.ts
@@ -1,0 +1,1248 @@
+import { randomBytes } from 'node:crypto'
+import dns from 'node:dns'
+import { readFile, stat } from 'node:fs/promises'
+import { createServer as createNetServer, Server as NetServer } from 'node:net'
+import { isNil, tryCatch, tryCatchSync } from '@activepieces/core-utils'
+import { spawnWithKill } from '../utils/exec'
+import { sandboxCapacity } from './capacity'
+import { SandboxLogger } from './types'
+
+export async function prepareEgressEnvironment({ log, allowList }: { log: SandboxLogger, allowList?: string[] }): Promise<EgressNetworkLease> {
+    const lease = await acquireEgressNetworkLease()
+    const { error } = await tryCatch(async () => {
+        await assertEgressCapabilities()
+        // At readiness, not per job, so a real collision pauses polling instead of failing jobs forever.
+        await assertNoSubnetOverlap({ log, base: resolveEgressBaseSubnet() })
+        // Logs only; toKernelAllowCidrs drops bad entries rather than throwing, and re-runs per box at create.
+        toKernelAllowCidrs({ allowList: allowList ?? [], log })
+        await warnOnSuspectedHostNetwork({ log })
+        await cleanupStaleEgress({ log })
+    })
+    if (error) {
+        const { error: releaseError } = await tryCatch(() => lease.release())
+        if (releaseError) {
+            log.error({ error: String(releaseError) }, 'Failed to release egress network ownership after preparation failure')
+        }
+        throw error
+    }
+    return lease
+}
+
+export async function acquireEgressNetworkLease(): Promise<EgressNetworkLease> {
+    const server = createNetServer((socket) => socket.destroy())
+    const { error } = await tryCatch(() => listenOnAbstractSocket({ server, socketName: EGRESS_LEASE_SOCKET }))
+    if (error) {
+        throw new EgressNetnsError(
+            'another STRICT sandbox worker already owns this network namespace. Run one worker per container/pod network namespace and disable host-network sharing.',
+        )
+    }
+    server.unref()
+    return {
+        release: () => closeNetServer(server),
+    }
+}
+
+export function createEgressNetns(params: CreateParams): Promise<EgressNetns> {
+    // Every resource name derives from boxId alone, so a teardown racing a create would delete the replacement.
+    return serializePerBox(params.boxId, () => createEgressNetnsInner(params))
+}
+
+async function createEgressNetnsInner({ log, boxId, internalApiUrl, allowList, apiEgress: providedApiEgress }: CreateParams): Promise<EgressNetns> {
+    // Tooling presence only; the CAP_NET_ADMIN probe runs once at readiness in assertEgressCapabilities.
+    await assertToolingAvailable()
+
+    const base = resolveEgressBaseSubnet()
+    const topology = buildTopology(boxId, base)
+
+    // A loopback app URL is the namespace's own empty loopback inside the netns, so it moves to the gateway.
+    const loopbackCallback = isNil(internalApiUrl) ? null : resolveCallbackRewrite({ internalApiUrl, gatewayHost: topology.gatewayHost })
+    const operatorAllowCidrs = toKernelAllowCidrs({ allowList: allowList ?? [], log })
+    // Reuse the caller's resolution: re-resolving could differ from the address set its cache key recorded.
+    const apiEgress = providedApiEgress ?? await resolveApiEgressCached({ internalApiUrl, log })
+    // apiEgress can be caller-injected, so this is the only place that still guarantees no forbidden ACCEPT.
+    const apiAllowEndpoints = apiEgress.endpoints.filter((endpoint) => !isForbiddenKernelAllowCidr(endpoint.cidr))
+    const callbackApiUrl = loopbackCallback?.url ?? null
+    const callbackPort = loopbackCallback?.port ?? null
+    const apiAllow = apiAllowEndpoints.length === 0
+        ? null
+        : apiAllowEndpoints.map((endpoint) => `${endpoint.ip}:${endpoint.port}`).join(',')
+    // Hand the engine the addresses; rewriting the URL to one would drop SNI and corrupt the Host header.
+    const apiHostPin = isNil(apiEgress.pinHostname) || apiAllowEndpoints.length === 0
+        ? null
+        : `${apiEgress.pinHostname}=${apiAllowEndpoints.map((endpoint) => endpoint.ip).join(',')}`
+
+    // A sub-1500 uplink would otherwise leave the box emitting oversized frames that partially blackhole.
+    const mtu = await resolveUplinkMtu({ log })
+
+    await assertNetnsNotInUse({ log, topology })
+    await preflightCleanup({ log, topology })
+
+    for (const command of buildCreateCommands(topology, {
+        callbackPort: loopbackCallback?.port,
+        allowCidrs: operatorAllowCidrs,
+        apiAllowEndpoints,
+        mtu,
+    })) {
+        const { error } = await tryCatch(() => runCommand(command))
+        if (error) {
+            log.error({ error: String(error), command: `${command.binary} ${command.args.join(' ')}` }, 'egress netns setup step failed; rolling back')
+            await guardedDestroy({ log, topology })
+            throw new EgressNetnsError(
+                `Egress netns setup failed at "${command.binary} ${command.args.join(' ')}". SANDBOX_PROCESS + STRICT needs CAP_NET_ADMIN, iproute2 and iptables in the worker image. ${error.message}`,
+            )
+        }
+    }
+
+    const owner = Symbol(`egress-box-${boxId}`)
+    boxOwners.set(boxId, owner)
+
+    log.info({ netnsName: topology.netnsName, gatewayHost: topology.gatewayHost, boxId, callbackApiUrl, apiAllow, apiHostPin }, 'Egress network namespace created')
+    return {
+        netnsName: topology.netnsName,
+        gatewayHost: topology.gatewayHost,
+        callbackApiUrl,
+        callbackPort,
+        apiAllow,
+        apiHostPin,
+        fingerprint: apiEgress.fingerprint,
+        destroy: () => serializePerBox(boxId, async () => {
+            if (boxOwners.get(boxId) !== owner) {
+                log.debug({ boxId, netnsName: topology.netnsName }, 'Skipping egress teardown — superseded by a newer namespace for this box')
+                return
+            }
+            const cleaned = await guardedDestroy({ log, topology })
+            if (cleaned) {
+                boxOwners.delete(boxId)
+            }
+        }),
+    }
+}
+
+function serializePerBox<T>(boxId: number, operation: () => Promise<T>): Promise<T> {
+    const previous = boxOperationLocks.get(boxId) ?? Promise.resolve()
+    const result = previous.then(operation, operation)
+    boxOperationLocks.set(boxId, result.then(() => undefined, () => undefined))
+    return result
+}
+
+async function guardedDestroy({ log, topology }: { log: SandboxLogger, topology: NetnsTopology }): Promise<boolean> {
+    let severed = false
+    for (const command of buildSeverCommands(topology)) {
+        const { error } = await tryCatch(() => runCommand(command))
+        if (isNil(error) && isVethSeverCommand({ command, vethHost: topology.vethHost })) {
+            severed = true
+        }
+        else if (!isNil(error)) {
+            log.warn({ error: String(error), command: `${command.binary} ${command.args.join(' ')}` }, 'egress sever step failed (best-effort)')
+        }
+    }
+    if (!severed && await isVethAbsent(topology.vethHost)) {
+        severed = true
+    }
+    if (!severed) {
+        log.error({ boxId: topology.boxId, netnsName: topology.netnsName }, 'Could not confirm the box veth is down/absent; LEAVING firewall rules armed (fail-closed) rather than exposing an unfiltered box')
+        return false
+    }
+    for (const command of buildFilterCleanupCommands(topology)) {
+        const { error } = await tryCatch(() => runCommand(command))
+        if (error) {
+            log.warn({ error: String(error), command: `${command.binary} ${command.args.join(' ')}` }, 'egress filter cleanup command failed (best-effort)')
+        }
+    }
+    return true
+}
+
+async function isVethAbsent(vethHost: string): Promise<boolean> {
+    const { error } = await tryCatch(() => spawnWithKill({ cmd: 'ip', args: ['link', 'show', vethHost], timeoutMs: COMMAND_TIMEOUT_MS }))
+    if (isNil(error)) {
+        return false
+    }
+    // Only iproute2's "device not found" proves absence; a timeout or spawn error reads as PRESENT, fail-closed.
+    return /does not exist|Cannot find device/i.test(error.message)
+}
+
+function isVethSeverCommand({ command, vethHost }: { command: NetnsCommand, vethHost: string }): boolean {
+    if (command.binary !== 'ip' || command.args[0] !== 'link') {
+        return false
+    }
+    const isDown = command.args[1] === 'set' && command.args[2] === vethHost && command.args.includes('down')
+    const isDelete = command.args[1] === 'del' && command.args[2] === vethHost
+    return isDown || isDelete
+}
+
+async function inspectNetns({ netnsName }: { netnsName: string }): Promise<NetnsInspection> {
+    // Errors propagate: a failed inspection must never read as "zero pids", which would destroy a live netns.
+    const listing = await listCommand({ cmd: 'ip', args: ['netns', 'list'] })
+    if (!listing.split('\n').some((line) => lineHasNetnsName({ line, netnsName }))) {
+        return { exists: false }
+    }
+    const result = await spawnWithKill({ cmd: 'ip', args: ['netns', 'pids', netnsName], timeoutMs: COMMAND_TIMEOUT_MS })
+    const pids = result.stdout.split('\n').map((line) => line.trim()).filter((line) => /^\d+$/.test(line))
+    return { exists: true, pids }
+}
+
+function lineHasNetnsName({ line, netnsName }: { line: string, netnsName: string }): boolean {
+    return line === netnsName || line.startsWith(`${netnsName} `)
+}
+
+async function assertNetnsNotInUse({ log, topology }: { log: SandboxLogger, topology: NetnsTopology }): Promise<void> {
+    let inspection = await inspectNetns({ netnsName: topology.netnsName })
+    for (let attempt = 0; attempt < NETNS_FREE_RETRIES && inspection.exists && inspection.pids.length > 0; attempt++) {
+        log.debug({ netnsName: topology.netnsName, pids: inspection.pids }, 'Egress namespace still has live pids; waiting for them to exit')
+        await delay(NETNS_FREE_RETRY_DELAY_MS)
+        inspection = await inspectNetns({ netnsName: topology.netnsName })
+    }
+    if (inspection.exists && inspection.pids.length > 0) {
+        log.warn({ netnsName: topology.netnsName, pids: inspection.pids }, 'Egress namespace still has live pids after wait; SIGKILL orphans then re-check')
+        await killOrphanPids({ netnsName: topology.netnsName, log })
+        for (let attempt = 0; attempt < ORPHAN_KILL_REAP_RETRIES; attempt++) {
+            await delay(NETNS_FREE_RETRY_DELAY_MS)
+            inspection = await inspectNetns({ netnsName: topology.netnsName })
+            if (!inspection.exists || inspection.pids.length === 0) {
+                return
+            }
+        }
+        log.error({ netnsName: topology.netnsName, pids: inspection.pids }, 'Egress namespace still has live processes after SIGKILL; refusing to reuse it')
+        throw new EgressNetnsError(
+            `network namespace ${topology.netnsName} is still in use by ${inspection.pids.length} live process(es) after SIGKILL. ` +
+            'Terminate the orphaned sandbox before restarting STRICT execution.',
+        )
+    }
+}
+
+// Runs as root, so re-confirm each pid still resolves to this namespace before signalling a recycled pid.
+async function killOrphanPids({ netnsName, log }: { netnsName: string, log: SandboxLogger }): Promise<void> {
+    const target = await statOrNull(`/run/netns/${netnsName}`)
+    if (isNil(target)) {
+        log.warn({ netnsName }, 'Cannot stat the egress namespace; skipping orphan SIGKILL rather than risk signalling an unrelated pid')
+        return
+    }
+    // Swallowed: a failed re-read must not fail readiness, and the caller's stale list is the risk being removed.
+    const { data: inspection } = await tryCatch(() => inspectNetns({ netnsName }))
+    if (isNil(inspection) || !inspection.exists) {
+        log.warn({ netnsName }, 'Could not re-read the egress namespace pid list; skipping orphan SIGKILL')
+        return
+    }
+    for (const pidText of inspection.pids) {
+        const pid = Number(pidText)
+        if (!Number.isInteger(pid) || pid <= 1 || pid === process.pid || pid === process.ppid) {
+            continue
+        }
+        const owner = await statOrNull(`/proc/${pid}/ns/net`)
+        // Inode numbers are unique only per superblock, so the device must match too.
+        if (isNil(owner) || owner.dev !== target.dev || owner.ino !== target.ino) {
+            log.warn({ pid: pidText, netnsName }, 'Skipping orphan SIGKILL — pid no longer resolves to this egress namespace (exited, recycled, or not readable)')
+            continue
+        }
+        const { error } = tryCatchSync(() => {
+            process.kill(pid, 'SIGKILL')
+        })
+        if (error) {
+            log.warn({ pid: pidText, error: String(error) }, 'Failed to SIGKILL orphan egress namespace pid')
+        }
+    }
+}
+
+async function statOrNull(path: string): Promise<{ dev: number, ino: number } | null> {
+    const { data } = await tryCatch(() => stat(path))
+    return isNil(data) ? null : { dev: data.dev, ino: data.ino }
+}
+
+function delay(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+async function preflightCleanup({ log, topology }: { log: SandboxLogger, topology: NetnsTopology }): Promise<void> {
+    const cleaned = await guardedDestroy({ log, topology })
+    if (!cleaned) {
+        log.debug({ netnsName: topology.netnsName }, 'egress netns preflight could not sever prior path; leaving filters armed')
+    }
+}
+
+async function assertIpForwardingEnabled(): Promise<void> {
+    const forwardPath = '/proc/sys/net/ipv4/ip_forward'
+    const { data: current, error } = await tryCatch(() => readFile(forwardPath, 'utf8'))
+    if (current?.trim() !== '1') {
+        throw new EgressNetnsError(
+            `net.ipv4.ip_forward is not 1, so the sandbox would have no egress. Enable it on the host or node before starting STRICT isolate workers; the worker never writes it. ${error?.message ?? ''}`,
+        )
+    }
+}
+
+export async function cleanupStaleEgress({ log }: { log: SandboxLogger }): Promise<void> {
+    if (staleSwept) {
+        return
+    }
+    const boxIds = await inventoryStaleBoxIds()
+    const base = resolveEgressBaseSubnet()
+    for (const boxId of boxIds) {
+        const topology = buildTopology(boxId, base)
+        await serializePerBox(boxId, async () => {
+            // Inside the lock, or it is a TOCTOU that sweeps a box whose create had not yet recorded ownership.
+            if (boxOwners.has(boxId)) {
+                return
+            }
+            const inspection = await inspectNetns({ netnsName: topology.netnsName })
+            if (inspection.exists && inspection.pids.length > 0) {
+                log.warn({ netnsName: topology.netnsName, pids: inspection.pids }, 'Stale egress namespace has live pids; SIGKILL orphans before cleanup')
+                await killOrphanPids({ netnsName: topology.netnsName, log })
+                for (let attempt = 0; attempt < ORPHAN_KILL_REAP_RETRIES; attempt++) {
+                    await delay(NETNS_FREE_RETRY_DELAY_MS)
+                    const again = await inspectNetns({ netnsName: topology.netnsName })
+                    if (!again.exists || again.pids.length === 0) {
+                        break
+                    }
+                    if (attempt === ORPHAN_KILL_REAP_RETRIES - 1) {
+                        throw new EgressNetnsError(
+                            `cannot clean stale namespace ${topology.netnsName} while ${again.pids.length} process(es) still use it after SIGKILL`,
+                        )
+                    }
+                }
+            }
+            await guardedDestroy({ log, topology })
+        })
+    }
+    staleSwept = true
+    if (boxIds.length > 0) {
+        log.info({ boxIds }, 'Swept stale egress resources left by a previous worker process')
+    }
+}
+
+async function inventoryStaleBoxIds(): Promise<number[]> {
+    // A crash leaks a netns, a veth or a chain independently, so all three listings have to be unioned.
+    const ids = new Set<number>()
+    const listings = await Promise.all([
+        listCommandBestEffort({ cmd: 'ip', args: ['netns', 'list'] }),
+        listCommandBestEffort({ cmd: 'ip', args: ['-o', 'link', 'show'] }),
+        listCommandBestEffort({ cmd: 'iptables', args: ['-S'] }),
+        listCommandBestEffort({ cmd: 'iptables', args: ['-t', 'nat', '-S'] }),
+    ])
+    for (const boxId of parseNetnsBoxIds(listings[0])) {
+        ids.add(boxId)
+    }
+    for (const boxId of parseResourceBoxIds(listings.slice(1).join('\n'))) {
+        ids.add(boxId)
+    }
+    return [...ids]
+}
+
+async function listCommandBestEffort(command: { cmd: string, args: string[] }): Promise<string> {
+    const { data, error } = await tryCatch(() => listCommand(command))
+    if (!isNil(error) || isNil(data)) {
+        return ''
+    }
+    return data
+}
+
+function parseNetnsBoxIds(listing: string): number[] {
+    const ids = new Set<number>()
+    for (const line of listing.split('\n')) {
+        const match = line.match(/^ap-egress-(\d+)\b/)
+        if (match) {
+            ids.add(Number(match[1]))
+        }
+    }
+    return [...ids]
+}
+
+function parseResourceBoxIds(listing: string): number[] {
+    // Matches our veth (`ap-veth-h<box>`) and iptables chains (`AP_EG_FWD_<box>` / `AP_EG_IN_<box>`).
+    const ids = new Set<number>()
+    for (const match of listing.matchAll(/(?:ap-veth-h|AP_EG_FWD_|AP_EG_IN_)(\d+)\b/g)) {
+        ids.add(Number(match[1]))
+    }
+    return [...ids]
+}
+
+async function listCommand(command: { cmd: string, args: string[] }): Promise<string> {
+    const result = await spawnWithKill({ cmd: command.cmd, args: command.args, timeoutMs: COMMAND_TIMEOUT_MS })
+    return result.stdout
+}
+
+async function runCommand(command: NetnsCommand): Promise<void> {
+    const { binary, args } = withXtablesWait(command)
+    await spawnWithKill({ cmd: binary, args, timeoutMs: COMMAND_TIMEOUT_MS })
+}
+
+function withXtablesWait({ binary, args }: NetnsCommand): NetnsCommand {
+    // ip netns exec does not unshare /run, so in-netns ip6tables contends on the same xtables.lock as the host's.
+    const tokens = [binary, ...args]
+    const xtablesIdx = tokens.findIndex((token) => token === 'iptables' || token === 'ip6tables')
+    if (xtablesIdx === -1) {
+        return { binary, args }
+    }
+    const withWait = [...tokens.slice(0, xtablesIdx + 1), '--wait', String(XTABLES_WAIT_SECONDS), ...tokens.slice(xtablesIdx + 1)]
+    return { binary: withWait[0], args: withWait.slice(1) }
+}
+
+function resolveCallbackRewrite({ internalApiUrl, gatewayHost }: { internalApiUrl: string, gatewayHost: string }): CallbackRewrite | null {
+    const { data: parsed } = tryCatchSync(() => new URL(internalApiUrl))
+    if (isNil(parsed) || !isLoopbackHostname(parsed.hostname)) {
+        return null
+    }
+    const port = parsed.port !== '' ? Number(parsed.port) : defaultPortForProtocol(parsed.protocol)
+    if (!Number.isInteger(port) || port <= 0 || port > 65535) {
+        return null
+    }
+    parsed.hostname = gatewayHost
+    return { port, url: parsed.toString() }
+}
+
+// A failed lookup rides the last known-good answer for a bounded window, then throws.
+export async function resolveApiEgressCached({ internalApiUrl, log }: { internalApiUrl: string | undefined, log: SandboxLogger }): Promise<ApiEgressResolution> {
+    const cacheKey = internalApiUrl?.trim() ?? ''
+    const now = Date.now()
+    const cached = apiEgressCache.get(cacheKey)
+    if (!isNil(cached) && now < cached.freshUntil) {
+        return cached.resolution
+    }
+    const { data, error } = await tryCatch(() => resolveApiEgress({ internalApiUrl, log }))
+    if (isNil(error) && !isNil(data)) {
+        apiEgressCache.set(cacheKey, {
+            resolution: data,
+            freshUntil: now + API_EGRESS_TTL_MS,
+            // Anchored to this SUCCESS, so repeated stale serves never extend the window.
+            staleUntil: now + API_EGRESS_STALE_LIMIT_MS,
+        })
+        return data
+    }
+    // Only a lookup failure is transient; a bad URL or an all-forbidden resolution must stay loud.
+    if (!(error instanceof ApiDnsLookupError)) {
+        throw error ?? new EgressNetnsError(`cannot resolve the app API address for "${internalApiUrl ?? ''}"`)
+    }
+    if (isNil(cached) || now >= cached.staleUntil) {
+        log.error(
+            { internalApiUrl, error: String(error) },
+            'App API address is unresolvable and there is no usable last known-good result left; failing STRICT egress setup',
+        )
+        throw error
+    }
+    log.warn(
+        { internalApiUrl, error: String(error), apiAllow: cached.resolution.fingerprint },
+        'Could not re-resolve the app API address; reusing the last known-good result. STRICT egress rules are unchanged',
+    )
+    return cached.resolution
+}
+
+async function resolveApiEgress({ internalApiUrl, log }: { internalApiUrl: string | undefined, log: SandboxLogger }): Promise<ApiEgressResolution> {
+    if (isNil(internalApiUrl) || internalApiUrl.trim() === '') {
+        return EMPTY_API_EGRESS
+    }
+    const { data: parsed } = tryCatchSync(() => new URL(internalApiUrl))
+    if (isNil(parsed)) {
+        throw new EgressNetnsError(
+            `internalApiUrl "${internalApiUrl}" is not a valid URL; cannot open STRICT egress to the app API. ` +
+            'Fix AP_FRONTEND_URL / the worker API URL.',
+        )
+    }
+    const hostname = parsed.hostname.replace(/^\[|\]$/g, '')
+    if (isLoopbackHostname(hostname)) {
+        return EMPTY_API_EGRESS
+    }
+    const port = parsed.port !== '' ? Number(parsed.port) : defaultPortForProtocol(parsed.protocol)
+    if (!Number.isInteger(port) || port <= 0 || port > 65535) {
+        throw new EgressNetnsError(
+            `internalApiUrl "${internalApiUrl}" has an invalid port; cannot open STRICT egress to the app API.`,
+        )
+    }
+    const ips = await resolveApiHostnameToIpv4({ hostname, internalApiUrl })
+    const endpoints: ApiAllowEndpoint[] = []
+    for (const ip of ips) {
+        const cidr = `${ip}/32`
+        if (isForbiddenKernelAllowCidr(cidr)) {
+            log.error(
+                { internalApiUrl, ip },
+                'Refusing kernel egress ACCEPT for app API address in metadata/link-local/CGNAT/this-host range',
+            )
+            continue
+        }
+        endpoints.push({ ip, port, cidr })
+    }
+    if (endpoints.length === 0) {
+        throw new EgressNetnsError(
+            `internalApiUrl "${internalApiUrl}" resolved to no usable IPv4 address for STRICT egress ` +
+            `(got: ${ips.join(', ') || 'none'}). Use a reachable IPv4 API URL / AP_FRONTEND_URL, or ensure DNS returns A records.`,
+        )
+    }
+    const fingerprint = [...new Set(endpoints.map((endpoint) => `${endpoint.ip}:${endpoint.port}`))].sort().join(',')
+    return {
+        endpoints,
+        // An address literal needs no pin — the box dials it directly and there is nothing to resolve.
+        pinHostname: isNil(parseIpv4Cidr(hostname)) ? hostname : null,
+        fingerprint,
+    }
+}
+
+async function resolveApiHostnameToIpv4({ hostname, internalApiUrl }: { hostname: string, internalApiUrl: string }): Promise<string[]> {
+    if (!isNil(parseIpv4Cidr(hostname))) {
+        return [hostname]
+    }
+    // Only v6 needs rejecting here: the URL host parser already rejects an out-of-range dotted quad.
+    if (hostname.includes(':')) {
+        throw new EgressNetnsError(
+            `internalApiUrl "${internalApiUrl}" host "${hostname}" is not a usable IPv4 address for STRICT egress.`,
+        )
+    }
+    const { data: entries, error } = await tryCatch(() => dns.promises.lookup(hostname, { all: true, family: 4 }))
+    if (error || isNil(entries) || entries.length === 0) {
+        throw new ApiDnsLookupError(
+            `cannot resolve internalApiUrl host "${hostname}" to IPv4 for STRICT egress. ` +
+            `Fix DNS or AP_FRONTEND_URL. ${error?.message ?? 'no A records'}`,
+        )
+    }
+    return [...new Set(entries.map((entry) => entry.address))]
+}
+
+function isLoopbackHostname(hostname: string): boolean {
+    const host = hostname.replace(/^\[|\]$/g, '')
+    return host === 'localhost' || host === '::1' || host.startsWith('127.')
+}
+
+function toKernelAllowCidrs({ allowList, log }: { allowList: string[], log: SandboxLogger }): string[] {
+    const cidrs: string[] = []
+    for (const raw of allowList) {
+        const entry = raw.trim()
+        if (entry === '') {
+            continue
+        }
+        if (isHostnameAllowEntry(entry)) {
+            // Drop, don't throw: a hostname has no static iptables -d rule, and throwing would idle the worker.
+            log.error(
+                { allowEntry: entry },
+                'Dropping AP_SSRF_ALLOW_LIST hostname from kernel egress rules — STRICT accepts only IPv4 literals/CIDRs; the box cannot reach this host by name under STRICT',
+            )
+            continue
+        }
+        const cidr = parseIpv4Cidr(entry)
+        if (isNil(cidr)) {
+            log.warn({ allowEntry: entry }, 'Dropping AP_SSRF_ALLOW_LIST entry from kernel egress rules (not a valid IPv4 literal/CIDR)')
+            continue
+        }
+        if (isForbiddenKernelAllowCidr(cidr)) {
+            log.error(
+                { allowEntry: entry, cidr },
+                'Refusing kernel egress ACCEPT for metadata/link-local/CGNAT/this-host range (overlaps 169.254.0.0/16, 100.64.0.0/10, or 0.0.0.0/8); dropping entry',
+            )
+            continue
+        }
+        cidrs.push(cidr)
+    }
+    return [...new Set(cidrs)]
+}
+
+function isHostnameAllowEntry(entry: string): boolean {
+    if (entry.includes(':')) {
+        return false
+    }
+    return /[a-zA-Z_]/.test(entry)
+}
+
+function isForbiddenKernelAllowCidr(cidr: string): boolean {
+    const range = cidrToRange(cidr)
+    if (isNil(range)) {
+        return true
+    }
+    return FORBIDDEN_KERNEL_ALLOW_CIDRS.some((denied) => {
+        const deniedRange = cidrToRange(denied)
+        return !isNil(deniedRange) && rangesOverlap(range, deniedRange)
+    })
+}
+
+function parseIpv4Cidr(entry: string): string | null {
+    const [ip, prefix, ...rest] = entry.trim().split('/')
+    if (rest.length > 0) {
+        return null
+    }
+    const octets = ip.split('.')
+    if (octets.length !== 4 || !octets.every(isByte)) {
+        return null
+    }
+    if (isNil(prefix)) {
+        return `${ip}/32`
+    }
+    const bits = Number(prefix)
+    if (!Number.isInteger(bits) || bits < 0 || bits > 32) {
+        return null
+    }
+    return `${ip}/${bits}`
+}
+
+function isByte(part: string): boolean {
+    if (!/^\d{1,3}$/.test(part)) {
+        return false
+    }
+    const value = Number(part)
+    return value >= 0 && value <= 255
+}
+
+function defaultPortForProtocol(protocol: string): number {
+    return protocol === 'https:' ? 443 : 80
+}
+
+function resolveEgressBaseSubnet(): EgressBaseSubnet {
+    const raw = process.env['AP_SANDBOX_EGRESS_SUBNET']?.trim()
+    if (isNil(raw) || raw === '') {
+        return DEFAULT_EGRESS_SUBNET
+    }
+    const parsed = parseSlash16(raw)
+    if (isNil(parsed)) {
+        throw new EgressNetnsError(`AP_SANDBOX_EGRESS_SUBNET must be an IPv4 /16 like "10.255.0.0/16", got "${raw}"`)
+    }
+    return parsed
+}
+
+function parseSlash16(raw: string): EgressBaseSubnet | null {
+    const [network, prefix] = raw.split('/')
+    if (prefix !== '16') {
+        return null
+    }
+    const octets = network.split('.')
+    if (octets.length !== 4 || !octets.every(isByte) || octets[2] !== '0' || octets[3] !== '0') {
+        return null
+    }
+    return { prefix: `${octets[0]}.${octets[1]}`, cidr: raw }
+}
+
+async function assertNoSubnetOverlap({ log, base }: { log: SandboxLogger, base: EgressBaseSubnet }): Promise<void> {
+    // Only a host network INSIDE the pool conflicts; a summary route containing it loses to our /30s.
+    if (overlapChecked) {
+        return
+    }
+    const { data: inventory, error } = await tryCatch(() => listHostInventory())
+    if (!isNil(error) || isNil(inventory)) {
+        throw new EgressNetnsError(
+            'cannot inventory host IPv4 addresses/routes to check egress subnet overlap; failing closed rather than risking a silent VPC collision. ' +
+            `${error?.message ?? 'ip addr/route returned no data'}`,
+        )
+    }
+    const ours = cidrToRange(base.cidr)
+    // Two ways in: a CIDR subset of the pool, or a bare address (next-hop, or a mask wider than /16).
+    const cidrClash = isNil(ours) ? undefined : inventory.cidrs.find((cidr) => {
+        const range = cidrToRange(cidr)
+        return !isNil(range) && isRangeWithin({ inner: range, outer: ours })
+    })
+    const addressClash = isNil(ours) ? undefined : inventory.addresses.find((ip) => {
+        const value = ipv4ToInt(ip)
+        return !isNil(value) && value >= ours[0] && value <= ours[1]
+    })
+    const clash = cidrClash ?? addressClash
+    if (!isNil(clash)) {
+        throw new EgressNetnsError(
+            `egress subnet ${base.cidr} overlaps an existing host network (${clash}) that occupies addresses inside the pool; ` +
+            'the box veth /30s would collide with real host routes. Set AP_SANDBOX_EGRESS_SUBNET to a free IPv4 /16.',
+        )
+    }
+    overlapChecked = true
+    log.debug({ egressSubnet: base.cidr }, 'Egress subnet does not overlap host networks')
+}
+
+function isRangeWithin({ inner, outer }: { inner: [number, number], outer: [number, number] }): boolean {
+    return inner[0] >= outer[0] && inner[1] <= outer[1]
+}
+
+// Warn only: node-level bridges suggest the rules land on the NODE's tables, but docker0 is legitimate.
+async function warnOnSuspectedHostNetwork({ log }: { log: SandboxLogger }): Promise<void> {
+    const linkOutput = await listCommandBestEffort({ cmd: 'ip', args: ['-o', 'link', 'show'] })
+    const names = parseLinkNames(linkOutput)
+    const nodeInterfaces = names.filter((name) => NODE_NETWORK_INTERFACE_PATTERNS.some((pattern) => pattern.test(name)))
+    if (nodeInterfaces.length === 0) {
+        return
+    }
+    log.warn(
+        { nodeInterfaces },
+        'Node-level network interfaces are visible from this worker, which suggests it shares the host/node network namespace. STRICT egress writes iptables FORWARD/INPUT/nat rules into the tables it can see, so these land on the NODE and an unclean shutdown leaves them behind. Run the worker in its own container/pod network namespace',
+    )
+}
+
+function parseLinkNames(linkOutput: string): string[] {
+    const names = new Set<string>()
+    for (const line of linkOutput.split('\n')) {
+        const match = line.match(/^\d+:\s*([^:@\s]+)/)
+        if (match) {
+            names.add(match[1])
+        }
+    }
+    return [...names]
+}
+
+// Memoizes the PROMISE, so N boxes starting at once do not each spawn the discovery commands.
+function resolveUplinkMtu({ log }: { log: SandboxLogger }): Promise<number | null> {
+    uplinkMtuPromise = uplinkMtuPromise ?? discoverUplinkMtu({ log })
+    return uplinkMtuPromise
+}
+
+async function discoverUplinkMtu({ log }: { log: SandboxLogger }): Promise<number | null> {
+    const routeOutput = await listCommandBestEffort({ cmd: 'ip', args: ['-o', '-4', 'route', 'show', 'default'] })
+    const devices = parseDefaultRouteDevices(routeOutput)
+    if (devices.length === 0) {
+        log.warn({}, 'No IPv4 default-route device found; leaving the box veth at the kernel default MTU. Large uploads from a sandbox may blackhole if the real uplink MTU is below 1500')
+        return null
+    }
+    const mtus: number[] = []
+    for (const device of devices) {
+        const linkOutput = await listCommandBestEffort({ cmd: 'ip', args: ['-o', 'link', 'show', 'dev', device] })
+        const mtu = parseLinkMtu(linkOutput)
+        if (!isNil(mtu)) {
+            mtus.push(mtu)
+        }
+    }
+    // Smallest wins across ECMP uplinks: too-small only costs throughput, too-large blackholes.
+    const smallest = mtus.length === 0 ? null : Math.min(...mtus)
+    if (isNil(smallest) || smallest < MIN_VETH_MTU) {
+        log.warn({ uplinkDevices: devices, discoveredMtu: smallest }, 'Could not read a usable uplink MTU; leaving the box veth at the kernel default MTU. Large uploads from a sandbox may blackhole if the real uplink MTU is below 1500')
+        return null
+    }
+    // Lower only: raising it above 1500 would make the box depend on PMTUD, which is the blackhole this removes.
+    const mtu = Math.min(smallest, DEFAULT_VETH_MTU)
+    if (mtu === DEFAULT_VETH_MTU) {
+        log.debug({ uplinkDevices: devices, discoveredMtu: smallest }, 'Uplink MTU is at or above the standard 1500; leaving the box veth at the default')
+        return null
+    }
+    log.info({ uplinkDevices: devices, mtu }, 'Lowering the box veth MTU to match the uplink')
+    return mtu
+}
+
+function parseDefaultRouteDevices(routeOutput: string): string[] {
+    const devices = new Set<string>()
+    for (const line of routeOutput.split('\n')) {
+        if (!/^default\b/.test(line.trim())) {
+            continue
+        }
+        // ECMP renders as one line whose devices live only in `nexthop ... dev X`, so collect every match.
+        for (const match of line.matchAll(/\bdev\s+(\S+)/g)) {
+            if (isValidInterfaceName(match[1]) && !match[1].startsWith('ap-veth-')) {
+                devices.add(match[1])
+            }
+        }
+    }
+    return [...devices]
+}
+
+// IFNAMSIZ-bounded, and it keeps a malformed route parse from handing `ip` a token that reads as an option.
+function isValidInterfaceName(name: string): boolean {
+    return /^[A-Za-z0-9_.:@-]{1,15}$/.test(name) && !name.startsWith('-')
+}
+
+function parseLinkMtu(linkOutput: string): number | null {
+    const match = linkOutput.match(/\bmtu\s+(\d+)\b/)
+    if (isNil(match)) {
+        return null
+    }
+    const mtu = Number(match[1])
+    return Number.isInteger(mtu) && mtu > 0 ? mtu : null
+}
+
+async function listHostInventory(): Promise<{ cidrs: string[], addresses: string[] }> {
+    const addr = await spawnWithKill({ cmd: 'ip', args: ['-o', '-4', 'addr', 'show'], timeoutMs: COMMAND_TIMEOUT_MS })
+    const route = await spawnWithKill({ cmd: 'ip', args: ['-o', '-4', 'route', 'show'], timeoutMs: COMMAND_TIMEOUT_MS })
+    return {
+        cidrs: parseHostCidrs({ addrOutput: addr.stdout, routeOutput: route.stdout }),
+        addresses: parseHostAddresses({ addrOutput: addr.stdout, routeOutput: route.stdout }),
+    }
+}
+
+function parseHostAddresses({ addrOutput, routeOutput }: { addrOutput: string, routeOutput: string }): string[] {
+    const addresses = new Set<string>()
+    for (const line of addrOutput.split('\n')) {
+        if (/\bap-veth-/.test(line)) {
+            continue
+        }
+        // The unmasked address: a wide mask hides it from the subset-CIDR test though it sits in the pool.
+        const match = line.match(/\binet\s+(\d+\.\d+\.\d+\.\d+)\/\d+/)
+        if (match) {
+            addresses.add(match[1])
+        }
+    }
+    for (const line of routeOutput.split('\n')) {
+        if (/\bdev\s+ap-veth-/.test(line)) {
+            continue
+        }
+        // Route next-hops: a gateway inside the pool that the leading-CIDR route parse never sees.
+        const match = line.match(/\bvia\s+(\d+\.\d+\.\d+\.\d+)/)
+        if (match) {
+            addresses.add(match[1])
+        }
+    }
+    return [...addresses]
+}
+
+function parseHostCidrs({ addrOutput, routeOutput }: { addrOutput: string, routeOutput: string }): string[] {
+    const cidrs = new Set<string>()
+    for (const line of addrOutput.split('\n')) {
+        // ap-veth-* are our own gateway addresses — exclude them so a stale veth never self-flags.
+        if (/\bap-veth-/.test(line)) {
+            continue
+        }
+        const match = line.match(/\binet\s+(\d+\.\d+\.\d+\.\d+\/\d+)/)
+        if (match) {
+            cidrs.add(match[1])
+        }
+    }
+    for (const line of routeOutput.split('\n')) {
+        if (/\bdev\s+ap-veth-/.test(line)) {
+            continue
+        }
+        const match = line.match(/^(\d+\.\d+\.\d+\.\d+\/\d+)\b/)
+        if (match) {
+            cidrs.add(match[1])
+        }
+    }
+    return [...cidrs]
+}
+
+function cidrToRange(cidr: string): [number, number] | null {
+    const [ip, prefix] = cidr.split('/')
+    const start = ipv4ToInt(ip)
+    const bits = Number(prefix)
+    if (isNil(start) || !Number.isInteger(bits) || bits < 0 || bits > 32) {
+        return null
+    }
+    const size = 2 ** (32 - bits)
+    const network = Math.floor(start / size) * size
+    return [network, network + size - 1]
+}
+
+function ipv4ToInt(ip: string): number | null {
+    const octets = ip.split('.')
+    if (octets.length !== 4 || !octets.every(isByte)) {
+        return null
+    }
+    return octets.reduce((acc, octet) => acc * 256 + Number(octet), 0)
+}
+
+function rangesOverlap(a: [number, number], b: [number, number]): boolean {
+    return a[0] <= b[1] && b[0] <= a[1]
+}
+
+export async function assertEgressCapabilities(): Promise<void> {
+    // EXERCISES the privileged ops: a binary-presence check passes without CAP_NET_ADMIN, then fails every job.
+    await assertToolingAvailable()
+    await assertCanCreateNamespace()
+    await assertCanEditIptables()
+}
+
+async function assertToolingAvailable(): Promise<void> {
+    await assertBinaryAvailable({ binary: 'ip' })
+    await assertBinaryAvailable({ binary: 'iptables' })
+    await assertBinaryAvailable({ binary: 'ip6tables' })
+    await assertIpForwardingEnabled()
+}
+
+async function assertCanCreateNamespace(): Promise<void> {
+    // Unique per probe, deleted only if we created it; exec is probed separately because it remounts sysfs.
+    const probeNetns = `ap-egress-probe-${createProbeSuffix()}`
+    const { error } = await tryCatch(() => runCommand({ binary: 'ip', args: ['netns', 'add', probeNetns] }))
+    if (error) {
+        throw new EgressNetnsError(
+            'cannot create a network namespace — STRICT egress needs CAP_NET_ADMIN + CAP_SYS_ADMIN ' +
+            `(the privileged sandbox container grants these). ${error.message}`,
+        )
+    }
+    const { error: execError } = await tryCatch(() => runCommand({ binary: 'ip', args: ['netns', 'exec', probeNetns, 'true'] }))
+    if (execError) {
+        await tryCatch(() => runCommand({ binary: 'ip', args: ['netns', 'del', probeNetns] }))
+        throw new EgressNetnsError(
+            `cannot exec into a network namespace (ip netns exec) — STRICT job spawn requires this. ${execError.message}`,
+        )
+    }
+    const { error: cleanupError } = await tryCatch(() => runCommand({ binary: 'ip', args: ['netns', 'del', probeNetns] }))
+    if (cleanupError) {
+        throw new EgressNetnsError(`cannot delete capability-probe namespace ${probeNetns}. ${cleanupError.message}`)
+    }
+}
+
+async function assertCanEditIptables(): Promise<void> {
+    // The real RULE SHAPES: a kernel missing xt_conntrack or ipt_REJECT passes a bare chain-create.
+    await probeChainShapes({
+        binary: 'iptables',
+        label: 'filter',
+        rules: [
+            ['-m', 'conntrack', '--ctstate', 'ESTABLISHED', '-j', 'ACCEPT'],
+            ['-p', 'icmp', '-m', 'conntrack', '--ctstate', 'RELATED', '-j', 'ACCEPT'],
+            ['-d', '192.0.2.1/32', '-j', 'REJECT', '--reject-with', 'icmp-host-prohibited'],
+            ['-d', '192.0.2.1/32', '-p', 'tcp', '--dport', '443', '-j', 'ACCEPT'],
+        ],
+    })
+    await assertCanMasquerade()
+    await probeChainShapes({
+        binary: 'ip6tables',
+        label: 'ip6 filter',
+        rules: [['-j', 'DROP']],
+    })
+}
+
+async function assertCanMasquerade(): Promise<void> {
+    // MASQUERADE is hook-bound under iptables-nft, so a user chain would false-fail on a healthy host.
+    const rule = ['-s', '192.0.2.0/30', '!', '-o', 'lo', '-j', 'MASQUERADE']
+    const { error } = await tryCatch(() => runCommand({ binary: 'iptables', args: ['-t', 'nat', '-I', 'POSTROUTING', '1', ...rule] }))
+    if (error) {
+        throw new EgressNetnsError(`cannot install a nat POSTROUTING MASQUERADE rule — STRICT egress needs CAP_NET_ADMIN and nf_nat/MASQUERADE loaded. ${error.message}`)
+    }
+    const { error: deleteError } = await tryCatch(() => runCommand({ binary: 'iptables', args: ['-t', 'nat', '-D', 'POSTROUTING', ...rule] }))
+    if (deleteError) {
+        throw new EgressNetnsError(`cannot remove the nat POSTROUTING MASQUERADE probe rule. ${deleteError.message}`)
+    }
+}
+
+async function probeChainShapes({ binary, label, rules }: { binary: 'iptables' | 'ip6tables', label: string, rules: string[][] }): Promise<void> {
+    const chain = `AP_EG_P_${createProbeSuffix()}`.slice(0, IPTABLES_CHAIN_NAME_MAX_LENGTH)
+    const { error: createError } = await tryCatch(() => runCommand({ binary, args: ['-N', chain] }))
+    if (createError) {
+        throw new EgressNetnsError(`cannot create an iptables ${label} chain — STRICT egress needs CAP_NET_ADMIN and a loaded ${label} backend. ${createError.message}`)
+    }
+    for (const rule of rules) {
+        const { error: appendError } = await tryCatch(() => runCommand({ binary, args: ['-A', chain, ...rule] }))
+        if (appendError) {
+            await tryCatch(() => runCommand({ binary, args: ['-F', chain] }))
+            await tryCatch(() => runCommand({ binary, args: ['-X', chain] }))
+            throw new EgressNetnsError(`cannot append the ${label} rule "${rule.join(' ')}" — a required kernel module (conntrack / REJECT / ip6tables) is missing. ${appendError.message}`)
+        }
+    }
+    const { error: flushError } = await tryCatch(() => runCommand({ binary, args: ['-F', chain] }))
+    const { error: deleteError } = await tryCatch(() => runCommand({ binary, args: ['-X', chain] }))
+    if (flushError || deleteError) {
+        throw new EgressNetnsError(`cannot clean up the ${label} probe chain ${chain}. ${(flushError ?? deleteError)?.message ?? ''}`)
+    }
+}
+
+function createProbeSuffix(): string {
+    return `${process.pid.toString(36)}-${randomBytes(4).toString('hex')}`
+}
+
+function listenOnAbstractSocket({ server, socketName }: { server: NetServer, socketName: string }): Promise<void> {
+    return new Promise((resolve, reject) => {
+        const onError = (error: Error): void => {
+            server.removeListener('listening', onListening)
+            reject(error)
+        }
+        const onListening = (): void => {
+            server.removeListener('error', onError)
+            resolve()
+        }
+        server.once('error', onError)
+        server.once('listening', onListening)
+        server.listen(socketName)
+    })
+}
+
+function closeNetServer(server: NetServer): Promise<void> {
+    if (!server.listening) {
+        return Promise.resolve()
+    }
+    return new Promise((resolve, reject) => {
+        server.close((error) => {
+            if (error) {
+                reject(error)
+                return
+            }
+            resolve()
+        })
+    })
+}
+
+async function assertBinaryAvailable({ binary }: { binary: string }): Promise<void> {
+    const versionFlag = binary === 'ip' ? '-V' : '--version'
+    const { error } = await tryCatch(() => spawnWithKill({ cmd: binary, args: [versionFlag], timeoutMs: COMMAND_TIMEOUT_MS }))
+    if (error) {
+        throw new EgressNetnsError(
+            `"${binary}" binary not available. Install ${binary === 'ip' ? 'iproute2' : binary} in the worker image ` +
+            `for network-namespace egress isolation in STRICT mode. ${error.message}`,
+        )
+    }
+}
+
+function buildTopology(boxId: number, base: EgressBaseSubnet = DEFAULT_EGRESS_SUBNET): NetnsTopology {
+    // Per-box /30 from base/16: network = boxId*4, gateway = +1 (host, WS-RPC), box = +2 (in the netns).
+    const offset = boxId * 4
+    if (offset + 3 > 0xffff) {
+        throw new EgressNetnsError(`boxId ${boxId} is too large for the ${base.cidr} egress pool`)
+    }
+    const octet = (value: number): string => `${base.prefix}.${Math.floor(value / 256)}.${value % 256}`
+    return {
+        boxId,
+        netnsName: `ap-egress-${boxId}`,
+        vethHost: `ap-veth-h${boxId}`,
+        vethBox: `ap-veth-b${boxId}`,
+        subnetCidr: `${octet(offset)}/30`,
+        poolCidr: base.cidr,
+        gatewayHost: octet(offset + 1),
+        boxHost: octet(offset + 2),
+        chain: `AP_EG_FWD_${boxId}`,
+        inChain: `AP_EG_IN_${boxId}`,
+        rpcPort: sandboxCapacity.wsRpcPortForBox(boxId),
+    }
+}
+
+function buildCreateCommands(t: NetnsTopology, options: BuildCreateOptions = {}): NetnsCommand[] {
+    const { callbackPort, allowCidrs = [], apiAllowEndpoints = [], mtu } = options
+    const ip = (...args: string[]): NetnsCommand => ({ binary: 'ip', args })
+    const iptables = (...args: string[]): NetnsCommand => ({ binary: 'iptables', args })
+    return [
+        ip('netns', 'add', t.netnsName),
+        ip('link', 'add', t.vethHost, 'type', 'veth', 'peer', 'name', t.vethBox),
+        ip('link', 'set', t.vethBox, 'netns', t.netnsName),
+        ip('addr', 'add', `${t.gatewayHost}/30`, 'dev', t.vethHost),
+        ip('netns', 'exec', t.netnsName, 'ip', 'addr', 'add', `${t.boxHost}/30`, 'dev', t.vethBox),
+        ip('link', 'set', t.vethHost, 'addrgenmode', 'none'),
+        ip('netns', 'exec', t.netnsName, 'ip', 'link', 'set', t.vethBox, 'addrgenmode', 'none'),
+        ...(isNil(mtu) ? [] : [
+            ip('link', 'set', t.vethHost, 'mtu', String(mtu)),
+            ip('netns', 'exec', t.netnsName, 'ip', 'link', 'set', t.vethBox, 'mtu', String(mtu)),
+        ]),
+        iptables('-t', 'nat', '-I', 'POSTROUTING', '1', '-s', t.subnetCidr, '!', '-o', t.vethHost, '-j', 'MASQUERADE'),
+        iptables('-N', t.chain),
+        iptables('-A', t.chain, '-d', t.poolCidr, '-j', 'REJECT', '--reject-with', 'icmp-host-prohibited'),
+        ...allowCidrs.map((cidr) => iptables('-A', t.chain, '-d', cidr, '-j', 'ACCEPT')),
+        ...apiAllowEndpoints.map((endpoint) => iptables(
+            '-A', t.chain, '-d', endpoint.cidr, '-p', 'tcp', '--dport', String(endpoint.port), '-j', 'ACCEPT',
+        )),
+        ...BLOCKED_CIDRS.map((cidr) => iptables('-A', t.chain, '-d', cidr, '-j', 'REJECT', '--reject-with', 'icmp-host-prohibited')),
+        iptables('-A', t.chain, '-j', 'ACCEPT'),
+        iptables('-I', 'FORWARD', '1', '-i', t.vethHost, '!', '-s', t.subnetCidr, '-j', 'DROP'),
+        iptables('-I', 'FORWARD', '1', '-o', t.vethHost, '-p', 'icmp', '-m', 'conntrack', '--ctstate', 'RELATED', '-j', 'ACCEPT'),
+        iptables('-I', 'FORWARD', '1', '-o', t.vethHost, '-m', 'conntrack', '--ctstate', 'ESTABLISHED', '-j', 'ACCEPT'),
+        iptables('-I', 'FORWARD', '1', '-i', t.vethHost, '-s', t.subnetCidr, '-j', t.chain),
+        iptables('-N', t.inChain),
+        iptables('-A', t.inChain, '-d', t.gatewayHost, '-p', 'tcp', '--dport', String(t.rpcPort), '-j', 'ACCEPT'),
+        ...(isNil(callbackPort) ? [] : [iptables('-A', t.inChain, '-d', t.gatewayHost, '-p', 'tcp', '--dport', String(callbackPort), '-j', 'ACCEPT')]),
+        iptables('-A', t.inChain, '-j', 'DROP'),
+        iptables('-I', 'INPUT', '1', '-i', t.vethHost, '-j', t.inChain),
+        iptables('-I', 'INPUT', '1', '!', '-i', t.vethHost, '-d', t.gatewayHost, '-j', 'DROP'),
+        ip('netns', 'exec', t.netnsName, 'ip6tables', '-A', 'OUTPUT', '-j', 'DROP'),
+        ip('link', 'set', t.vethHost, 'up'),
+        ip('netns', 'exec', t.netnsName, 'ip', 'link', 'set', t.vethBox, 'up'),
+        ip('netns', 'exec', t.netnsName, 'ip', 'link', 'set', 'lo', 'up'),
+        ip('netns', 'exec', t.netnsName, 'ip', 'route', 'add', 'default', 'via', t.gatewayHost),
+    ]
+}
+
+function buildSeverCommands(t: NetnsTopology): NetnsCommand[] {
+    const ip = (...args: string[]): NetnsCommand => ({ binary: 'ip', args })
+    // Any one of these succeeding means the box can no longer forward: no interface, or no namespace.
+    return [
+        ip('link', 'set', t.vethHost, 'down'),
+        ip('netns', 'del', t.netnsName),
+        ip('link', 'del', t.vethHost),
+    ]
+}
+
+function buildFilterCleanupCommands(t: NetnsTopology): NetnsCommand[] {
+    const iptables = (...args: string[]): NetnsCommand => ({ binary: 'iptables', args })
+    return [
+        iptables('-D', 'INPUT', '!', '-i', t.vethHost, '-d', t.gatewayHost, '-j', 'DROP'),
+        iptables('-D', 'INPUT', '-i', t.vethHost, '-j', t.inChain),
+        iptables('-F', t.inChain),
+        iptables('-X', t.inChain),
+        iptables('-D', 'FORWARD', '-i', t.vethHost, '-s', t.subnetCidr, '-j', t.chain),
+        iptables('-D', 'FORWARD', '-o', t.vethHost, '-m', 'conntrack', '--ctstate', 'ESTABLISHED', '-j', 'ACCEPT'),
+        iptables('-D', 'FORWARD', '-o', t.vethHost, '-p', 'icmp', '-m', 'conntrack', '--ctstate', 'RELATED', '-j', 'ACCEPT'),
+        iptables('-D', 'FORWARD', '-i', t.vethHost, '!', '-s', t.subnetCidr, '-j', 'DROP'),
+        iptables('-F', t.chain),
+        iptables('-X', t.chain),
+        iptables('-t', 'nat', '-D', 'POSTROUTING', '-s', t.subnetCidr, '!', '-o', t.vethHost, '-j', 'MASQUERADE'),
+    ]
+}
+
+function buildDestroyCommands(t: NetnsTopology): NetnsCommand[] {
+    return [...buildSeverCommands(t), ...buildFilterCleanupCommands(t)]
+}
+
+export class EgressNetnsError extends Error {
+    constructor(message: string) {
+        super(message)
+        this.name = 'EgressNetnsError'
+    }
+}
+
+// Distinct from its parent so the cached resolver can tell a transient lookup failure from a permanent one.
+export class ApiDnsLookupError extends EgressNetnsError {
+    constructor(message: string) {
+        super(message)
+        this.name = 'ApiDnsLookupError'
+    }
+}
+
+// Interfaces a container cannot normally see from its own netns, so they hint at a root netns.
+const NODE_NETWORK_INTERFACE_PATTERNS: readonly RegExp[] = [
+    /^docker0$/,
+    /^cni0$/,
+    /^flannel/,
+    /^kube-ipvs0$/,
+    /^cilium_host$/,
+    /^br-[0-9a-f]{12}$/,
+]
+
+// Allow-list ACCEPTs sit above BLOCKED_CIDRS, so these must never be punched through. RFC1918 still can be.
+const FORBIDDEN_KERNEL_ALLOW_CIDRS: readonly string[] = [
+    '169.254.0.0/16',
+    '100.64.0.0/10',
+    '0.0.0.0/8',
+]
+
+// Must agree with ssrfIpClassifier, which a parity test in netns.test.ts asserts; v6 is dropped wholesale.
+const BLOCKED_CIDRS: readonly string[] = [
+    '0.0.0.0/8',        // "this host" / current network — 0.0.0.0 can alias localhost on Linux
+    '10.0.0.0/8',       // RFC1918 private
+    '100.64.0.0/10',    // CGNAT (RFC6598), incl. Alibaba metadata 100.100.100.200
+    '127.0.0.0/8',      // IPv4 loopback
+    '169.254.0.0/16',   // link-local, incl. cloud metadata (169.254.169.254) and ECS creds (169.254.170.2)
+    '172.16.0.0/12',    // RFC1918 private
+    '192.0.0.0/24',     // IETF protocol assignments (RFC6890)
+    '192.0.2.0/24',     // TEST-NET-1 (documentation)
+    '192.88.99.0/24',   // 6to4 relay anycast (RFC3068)
+    '192.168.0.0/16',   // RFC1918 private
+    '198.18.0.0/15',    // benchmarking (RFC2544)
+    '198.51.100.0/24',  // TEST-NET-2 (documentation)
+    '203.0.113.0/24',   // TEST-NET-3 (documentation)
+    '224.0.0.0/4',      // multicast (class D)
+    '240.0.0.0/4',      // reserved / "future use", incl. 255.255.255.255 limited broadcast
+]
+
+export const egressNetnsInternals = {
+    buildTopology,
+    buildCreateCommands,
+    buildDestroyCommands,
+    serializePerBox,
+    parseNetnsBoxIds,
+    parseResourceBoxIds,
+    resolveCallbackRewrite,
+    resolveApiEgress,
+    toKernelAllowCidrs,
+    withXtablesWait,
+    parseSlash16,
+    parseHostCidrs,
+    parseHostAddresses,
+    parseDefaultRouteDevices,
+    parseLinkMtu,
+    cidrToRange,
+    rangesOverlap,
+    BLOCKED_CIDRS,
+    resetStateForTests: (): void => {
+        staleSwept = false
+        overlapChecked = false
+        uplinkMtuPromise = null
+        boxOwners.clear()
+        boxOperationLocks.clear()
+        apiEgressCache.clear()
+    },
+}
+
+const COMMAND_TIMEOUT_MS = 5_000
+
+const XTABLES_WAIT_SECONDS = 3
+
+const IPTABLES_CHAIN_NAME_MAX_LENGTH = 28
+
+const NETNS_FREE_RETRIES = 40
+const NETNS_FREE_RETRY_DELAY_MS = 300
+const ORPHAN_KILL_REAP_RETRIES = 3
+
+// Floor ignores a bogus reading that would break TLS-heavy pieces; ceiling is the veth's own default.
+const MIN_VETH_MTU = 1280
+const DEFAULT_VETH_MTU = 1500
+
+const API_EGRESS_TTL_MS = 30_000
+const API_EGRESS_STALE_LIMIT_MS = 600_000
+
+const EGRESS_LEASE_SOCKET = '\0activepieces-egress-owner'
+
+const EMPTY_API_EGRESS: ApiEgressResolution = {
+    endpoints: [],
+    pinHostname: null,
+    fingerprint: '',
+}
+
+const boxOperationLocks = new Map<number, Promise<unknown>>()
+
+const boxOwners = new Map<number, symbol>()
+
+const apiEgressCache = new Map<string, CachedApiEgress>()
+
+let staleSwept = false
+
+let overlapChecked = false
+
+let uplinkMtuPromise: Promise<number | null> | null = null
+
+const DEFAULT_EGRESS_SUBNET: EgressBaseSubnet = { prefix: '10.255', cidr: '10.255.0.0/16' }
+
+type EgressBaseSubnet = {
+    prefix: string
+    cidr: string
+}
+
+type NetnsCommand = {
+    binary: string
+    args: string[]
+}
+
+type NetnsTopology = {
+    boxId: number
+    netnsName: string
+    vethHost: string
+    vethBox: string
+    subnetCidr: string
+    poolCidr: string
+    gatewayHost: string
+    boxHost: string
+    chain: string
+    inChain: string
+    rpcPort: number
+}
+
+type CallbackRewrite = {
+    port: number
+    url: string
+}
+
+type ApiAllowEndpoint = {
+    ip: string
+    port: number
+    cidr: string
+}
+
+export type ApiEgressResolution = {
+    endpoints: ApiAllowEndpoint[]
+    pinHostname: string | null
+    fingerprint: string
+}
+
+type CachedApiEgress = {
+    resolution: ApiEgressResolution
+    freshUntil: number
+    staleUntil: number
+}
+
+type BuildCreateOptions = {
+    callbackPort?: number
+    allowCidrs?: string[]
+    apiAllowEndpoints?: ApiAllowEndpoint[]
+    mtu?: number | null
+}
+
+type CreateParams = {
+    log: SandboxLogger
+    boxId: number
+    internalApiUrl?: string
+    allowList?: string[]
+    apiEgress?: ApiEgressResolution
+}
+
+type NetnsInspection =
+    | { exists: false }
+    | { exists: true, pids: string[] }
+
+export type EgressNetworkLease = {
+    release: () => Promise<void>
+}
+
+export type EgressNetns = {
+    netnsName: string
+    gatewayHost: string
+    callbackApiUrl: string | null
+    callbackPort: number | null
+    apiAllow: string | null
+    apiHostPin: string | null
+    fingerprint: string
+    destroy: () => Promise<void>
+}

--- a/packages/server/sandbox/src/lib/sandbox/sandbox.ts
+++ b/packages/server/sandbox/src/lib/sandbox/sandbox.ts
@@ -8,7 +8,7 @@ import { Socket, Server as SocketIOServer } from 'socket.io'
 import treeKill from 'tree-kill'
 import { cacheUtils } from '../cache/cache-paths'
 import { assertSafePathSegment } from '../utils/path-safety'
-import { Sandbox, SandboxInitOptions, SandboxLogger, SandboxMount, SandboxOptions, SandboxProcessMaker, SandboxResult } from './types'
+import { EgressInfo, Sandbox, SandboxInitOptions, SandboxLogger, SandboxMount, SandboxOptions, SandboxProcessMaker, SandboxResult } from './types'
 
 function assertSandboxPathUnderRoot(mount: SandboxMount): void {
     const normalized = path.posix.normalize(mount.sandboxPath)
@@ -51,6 +51,7 @@ export function createSandbox(
     let connectedSocket: Socket | null = null
     let connectionResolve: (() => void) | null = null
     let wsRpcToken: string | null = null
+    let egressInfo: EgressInfo | null = null
     let busy = false
     let killedByShutdown = false
     let nativeStdOut = ''
@@ -88,7 +89,7 @@ export function createSandbox(
     // which is exactly what made busy workers crash-loop. Await the bind, and on a bind error retry a
     // few times (a concurrent close frees the port within a beat); if it never frees, fail just this
     // sandbox with a catchable error. A random port (listen(0)) can't collide, so it needs no retries.
-    async function createSocketServer(): Promise<number> {
+    async function createSocketServer(host: string): Promise<number> {
         const requestedPort = options.wsRpcPort ?? 0
         const maxAttempts = requestedPort === 0 ? 1 : 30
         for (let attempt = 1; attempt <= maxAttempts; attempt++) {
@@ -100,7 +101,7 @@ export function createSandbox(
             })
             wireConnectionHandler(ioServer)
 
-            const { error } = await tryCatch(() => listenOnce(server, requestedPort))
+            const { error } = await tryCatch(() => listenOnce(server, requestedPort, host))
             if (isNil(error)) {
                 io = ioServer
                 const address = server.address()
@@ -151,7 +152,28 @@ export function createSandbox(
         id: sandboxId,
         start: async ({ flowVersionId, platformId, mounts }) => {
             if (isReady()) {
-                return
+                const needsRotation = options.egressNeedsRotation
+                    ? await options.egressNeedsRotation(log)
+                    : false
+                if (!needsRotation) {
+                    return
+                }
+                log.info({ sandbox: { id: sandboxId } }, 'Egress allow-list or API endpoint changed; restarting sandbox')
+                killedByShutdown = true
+                if (!isNil(childProcess)) {
+                    await killProcess(childProcess, log)
+                    childProcess = null
+                }
+                connectedSocket?.disconnect()
+                connectedSocket = null
+                if (io) {
+                    // eslint-disable-next-line @typescript-eslint/await-thenable
+                    await io.close()
+                }
+                io = null
+                wsRpcToken = null
+                egressInfo = null
+                killedByShutdown = false
             }
             log.debug({
                 sandbox: { id: sandboxId },
@@ -160,7 +182,10 @@ export function createSandbox(
             }, 'Starting sandbox')
 
             wsRpcToken = randomBytes(32).toString('hex')
-            const port = await createSocketServer()
+            const egress = options.getEgress ? await options.getEgress(log) : null
+            egressInfo = egress
+            const wsRpcHost = egress?.gatewayHost ?? '127.0.0.1'
+            const port = await createSocketServer(wsRpcHost)
 
             const codeMount = buildCodeMount({ flowVersionId, reusable: options.reusable, basePath: options.basePath })
             const customPieceMounts: SandboxMount[] = []
@@ -188,10 +213,19 @@ export function createSandbox(
                 sandboxId,
                 command: options.command ?? [],
                 mounts: allMounts,
+                netnsName: egress?.netnsName,
                 env: {
                     ...options.env,
                     AP_SANDBOX_WS_PORT: String(port),
                     AP_SANDBOX_WS_TOKEN: wsRpcToken,
+                    ...(egress
+                        ? {
+                            AP_SANDBOX_WS_HOST: egress.gatewayHost,
+                            ...(isNil(egress.callbackPort) ? {} : { AP_SANDBOX_CALLBACK_PORT: String(egress.callbackPort) }),
+                            ...(isNil(egress.apiAllow) ? {} : { AP_SANDBOX_API_ALLOW: egress.apiAllow }),
+                            ...(isNil(egress.apiHostPin) ? {} : { AP_SANDBOX_API_HOST_PIN: egress.apiHostPin }),
+                        }
+                        : {}),
                     ...(customPieceMounts.length > 0
                         ? { AP_CUSTOM_PIECES_PATHS: '/root/custom_pieces' }
                         : {}),
@@ -215,8 +249,6 @@ export function createSandbox(
             })
 
             const exitPromise = new Promise<never>((_, reject) => {
-                // 'close' (not 'exit') so the child's stdout/stderr pipes are fully drained first —
-                // 'exit' can fire before the final 'data' chunk, leaving nativeStdError empty.
                 childProcess!.once('close', (code, signal) => {
                     reject(new Error(`Sandbox ${sandboxId} exited before connecting (code=${code}, signal=${signal}) standardError=${nativeStdError}`))
                 })
@@ -286,7 +318,9 @@ export function createSandbox(
                 log.debug({ sandbox: { id: sandboxId }, operationType }, '[Sandbox] Executing operation via RPC')
                 const operationTimeoutMs = (executeOptions.timeoutInSeconds + 5) * 1000
                 const client = createRpcClient<EngineContract>(executeSocket, operationTimeoutMs)
-                client.executeOperation({ operationType, operation }).then((engineResponse: EngineResponse<unknown>) => {
+                // In a netns the loopback app API is unreachable, so point it at the gateway callback URL.
+                const dispatchOperation = rewriteInternalApiUrl(operation, egressInfo?.callbackApiUrl ?? null)
+                client.executeOperation({ operationType, operation: dispatchOperation }).then((engineResponse: EngineResponse<unknown>) => {
                     resolve({ ...engineResponse, logs: buildLogs(stdOut, stdError) })
                 }).catch((error: unknown) => {
                     log.error({ sandbox: { id: sandboxId }, error: String(error) }, '[Sandbox] RPC call failed')
@@ -334,7 +368,7 @@ export function createSandbox(
     }
 }
 
-function listenOnce(server: HttpServer, port: number): Promise<void> {
+function listenOnce(server: HttpServer, port: number, host: string): Promise<void> {
     return new Promise<void>((resolve, reject) => {
         const onError = (err: Error): void => {
             server.removeListener('listening', onListening)
@@ -346,7 +380,7 @@ function listenOnce(server: HttpServer, port: number): Promise<void> {
         }
         server.once('error', onError)
         server.once('listening', onListening)
-        server.listen(port)
+        server.listen(port, host)
     })
 }
 
@@ -358,6 +392,13 @@ function closeServer(ioServer: SocketIOServer): Promise<void> {
 
 function delay(ms: number): Promise<void> {
     return new Promise<void>((resolve) => setTimeout(resolve, ms))
+}
+
+function rewriteInternalApiUrl(operation: EngineOperation, callbackApiUrl: string | null): EngineOperation {
+    if (isNil(callbackApiUrl) || !('internalApiUrl' in operation) || typeof operation.internalApiUrl !== 'string') {
+        return operation
+    }
+    return { ...operation, internalApiUrl: callbackApiUrl }
 }
 
 const MAX_NATIVE_OUTPUT_CHARS = 8192
@@ -469,6 +510,10 @@ function authenticateHandshake({ getExpectedToken, log, sandboxId }: {
         }
         next()
     }
+}
+
+export const sandboxRpcInternals = {
+    rewriteInternalApiUrl,
 }
 
 type ProcessExitParams = {

--- a/packages/server/sandbox/src/lib/sandbox/types.ts
+++ b/packages/server/sandbox/src/lib/sandbox/types.ts
@@ -19,6 +19,8 @@ export type CreateSandboxProcessParams = {
     mounts: SandboxMount[]
     env: Record<string, string>
     resourceLimits: SandboxResourceLimits
+    // When set, the box launches inside this pre-provisioned namespace instead of the host netns.
+    netnsName?: string
 }
 
 export type SandboxProcessMaker = {
@@ -56,6 +58,19 @@ export type SandboxInitOptions = {
     command?: string[]
     baseMounts?: SandboxMount[]
     wsRpcPort?: number
+    // Resolves the per-box egress namespace under isolate + STRICT; the WS-RPC server binds gatewayHost.
+    getEgress?: (log: SandboxLogger) => Promise<EgressInfo | null>
+    egressNeedsRotation?: (log: SandboxLogger) => Promise<boolean>
+}
+
+export type EgressInfo = {
+    netnsName: string
+    gatewayHost: string
+    callbackApiUrl: string | null
+    callbackPort: number | null
+    apiAllow: string | null
+    apiHostPin: string | null
+    fingerprint: string
 }
 
 export type SandboxOptions = {

--- a/packages/server/sandbox/src/lib/types.ts
+++ b/packages/server/sandbox/src/lib/types.ts
@@ -30,6 +30,8 @@ export type Runtime = {
     // internally: acquire -> run -> release on success / invalidate on throw. Re-raises the sandbox
     // ActivepiecesError codes (timeout / memory / log-size) that handlers already catch.
     execute(params: ExecuteParams): Promise<RuntimeExecutionResult>
+    // True once a box's egress setup has failed repeatedly, so the poll loop can back that box off.
+    isExecutorPaused(workerIndex: number): boolean
     getActiveExecutors(): RuntimeExecutorInfo[]
     prewarm(params: PreWarmSandboxParams): Promise<void>
     shutdown(log: ApLogger): Promise<void>

--- a/packages/server/sandbox/test/lib/sandbox-manager-egress.test.ts
+++ b/packages/server/sandbox/test/lib/sandbox-manager-egress.test.ts
@@ -1,0 +1,403 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { ApEnvironment, ExecutionMode, NetworkMode } from '@activepieces/shared'
+
+const { createEgressNetnsMock, destroyMock, resolveApiEgressCachedMock } = vi.hoisted(() => ({
+    createEgressNetnsMock: vi.fn(),
+    destroyMock: vi.fn(),
+    resolveApiEgressCachedMock: vi.fn(),
+}))
+
+vi.mock('../../src/lib/sandbox/netns', () => ({
+    createEgressNetns: createEgressNetnsMock,
+    resolveApiEgressCached: resolveApiEgressCachedMock,
+}))
+
+// Stands in for sandbox.start(), which runs AFTER the gate, so gate contracts use isEgressUnhealthy alone.
+let capturedGetEgress: ((log: unknown) => Promise<unknown>) | undefined
+
+vi.mock('../../src/lib/create-sandbox-for-job', () => ({
+    createSandboxForJob: vi.fn((params: { getEgress?: (log: unknown) => Promise<unknown> }) => {
+        capturedGetEgress = params.getEgress
+        return { isReady: () => true, start: vi.fn().mockResolvedValue(undefined), shutdown: vi.fn().mockResolvedValue(undefined) }
+    }),
+    isIsolateMode: (mode: string) => mode === ExecutionMode.SANDBOX_PROCESS || mode === ExecutionMode.SANDBOX_CODE_AND_PROCESS,
+}))
+
+import { createSandboxForJob } from '../../src/lib/create-sandbox-for-job'
+import { createSandboxManager } from '../../src/lib/sandbox-manager'
+
+const tick = (): Promise<void> => new Promise((resolve) => setTimeout(resolve, 0))
+
+// Resolved once per getEgress and threaded through, so the cache key and the installed rules agree.
+const apiEgress = (fingerprint: string) => ({ endpoints: [], pinHostname: null, fingerprint })
+
+const log = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() } as never
+
+function buildSettings({ executionMode, networkMode }: { executionMode: string, networkMode: NetworkMode }) {
+    return {
+        EXECUTION_MODE: executionMode,
+        NETWORK_MODE: networkMode,
+        ENVIRONMENT: ApEnvironment.PRODUCTION,
+        REUSE_SANDBOX: undefined as string | undefined,
+        FLOW_TIMEOUT_SECONDS: 600,
+        MAX_FLOW_RUN_LOG_SIZE_MB: 10,
+        MAX_FILE_SIZE_MB: 10,
+        SANDBOX_MEMORY_LIMIT: '1024',
+        SANDBOX_PROPAGATED_ENV_VARS: [] as string[],
+        DEV_PIECES: [] as string[],
+        SSRF_ALLOW_LIST: [] as string[],
+    } as never
+}
+
+const strictSettings = (over: { allowList?: string[] } = {}) => ({
+    ...buildSettings({ executionMode: ExecutionMode.SANDBOX_PROCESS, networkMode: NetworkMode.STRICT }),
+    ...(over.allowList ? { SSRF_ALLOW_LIST: over.allowList } : {}),
+} as never)
+
+const strictManager = (over: { internalApiUrl?: string, settings?: unknown } = {}) => createSandboxManager({
+    boxId: 1,
+    basePath: '/tmp',
+    getSettings: () => (over.settings ?? strictSettings()) as never,
+    internalApiUrl: over.internalApiUrl,
+})
+
+const handle = (over: Record<string, unknown> = {}) => ({
+    netnsName: 'ap-egress-1',
+    gatewayHost: '10.255.0.5',
+    callbackApiUrl: null,
+    callbackPort: null,
+    apiAllow: null,
+    apiHostPin: null,
+    fingerprint: '',
+    destroy: destroyMock,
+    ...over,
+})
+
+const info = (over: Record<string, unknown> = {}) => {
+    const { destroy, ...rest } = handle(over)
+    void destroy
+    return rest
+}
+
+describe('sandbox-manager egress lifecycle', () => {
+    beforeEach(() => {
+        // The probe-window cases fake the clock; restoring here stops a leak reaching later tests.
+        vi.useRealTimers()
+        createEgressNetnsMock.mockReset()
+        destroyMock.mockReset()
+        resolveApiEgressCachedMock.mockReset()
+        resolveApiEgressCachedMock.mockResolvedValue(apiEgress(''))
+        capturedGetEgress = undefined
+    })
+
+    it('creates the netns once (cached) under isolate + STRICT and destroys it on shutdown', async () => {
+        createEgressNetnsMock.mockResolvedValue(handle())
+        const manager = strictManager()
+
+        await manager.acquire({ log })
+        expect(capturedGetEgress).toBeDefined()
+
+        const first = await capturedGetEgress!(log)
+        const second = await capturedGetEgress!(log)
+
+        expect(first).toEqual(info())
+        expect(second).toEqual(info())
+        expect(createEgressNetnsMock).toHaveBeenCalledTimes(1)
+        expect(createEgressNetnsMock).toHaveBeenCalledWith({ log, boxId: 1, internalApiUrl: undefined, allowList: [], apiEgress: apiEgress('') })
+
+        await manager.shutdown(log)
+        expect(destroyMock).toHaveBeenCalledTimes(1)
+    })
+
+    it('forwards internalApiUrl to netns creation and surfaces the gateway callback URL + host pin', async () => {
+        createEgressNetnsMock.mockResolvedValue(handle({ callbackApiUrl: 'http://10.255.0.5:3000/api/', callbackPort: 3000 }))
+        const manager = strictManager({ internalApiUrl: 'http://127.0.0.1:3000/api/' })
+
+        await manager.acquire({ log })
+        const egress = await capturedGetEgress!(log)
+
+        expect(createEgressNetnsMock).toHaveBeenCalledWith({ log, boxId: 1, internalApiUrl: 'http://127.0.0.1:3000/api/', allowList: [], apiEgress: apiEgress('') })
+        expect(egress).toEqual(info({ callbackApiUrl: 'http://10.255.0.5:3000/api/', callbackPort: 3000 }))
+    })
+
+    it('awaits an in-flight create during shutdown and destroys it (no leak on the race)', async () => {
+        let resolveCreate: (() => void) | undefined
+        const created = { netnsName: 'ap-egress-1', gatewayHost: '10.255.0.5', destroy: destroyMock }
+        createEgressNetnsMock.mockReturnValue(new Promise((resolve) => { resolveCreate = () => resolve(created) }))
+        const manager = strictManager()
+
+        await manager.acquire({ log })
+        // Kick off creation but do NOT await it — simulates sandbox.start() still in flight...
+        const inflight = capturedGetEgress!(log)
+        // ...when shutdown races in. teardown must await the pending create, not skip it.
+        const shutdownP = manager.shutdown(log)
+        resolveCreate!()
+        await inflight.catch(() => undefined)
+        await shutdownP
+
+        expect(createEgressNetnsMock).toHaveBeenCalledTimes(1)
+        expect(destroyMock).toHaveBeenCalledTimes(1)
+    })
+
+    it('shutdown waits for an in-flight start() to settle before destroying the netns', async () => {
+        createEgressNetnsMock.mockResolvedValue({ netnsName: 'ap-egress-1', gatewayHost: '10.255.0.5', destroy: destroyMock })
+        let resolveStart: () => void = () => undefined
+        const startGate = new Promise<void>((resolve) => { resolveStart = resolve })
+        const shutdownSpy = vi.fn().mockResolvedValue(undefined)
+        vi.mocked(createSandboxForJob).mockImplementationOnce(((params: { getEgress?: (log: unknown) => Promise<unknown> }) => ({
+            isReady: () => false,
+            shutdown: shutdownSpy,
+            start: async () => { await params.getEgress!(log); await startGate }, // creates netns, then blocks
+        })) as never)
+        const manager = strictManager()
+
+        const sandbox = await manager.acquire({ log })
+        const startPromise = sandbox.start({ flowVersionId: undefined, platformId: 'p1', mounts: [] })
+        await tick() // let start() run getEgress (creates the netns) then block on the gate
+
+        let shutdownDone = false
+        const shutdownPromise = manager.shutdown(log).then(() => { shutdownDone = true })
+        await tick()
+        expect(shutdownDone).toBe(false)             // shutdown is blocked on the in-flight start
+        expect(destroyMock).not.toHaveBeenCalled()   // netns must NOT be torn down mid-startup
+
+        resolveStart()
+        await startPromise
+        await shutdownPromise
+        expect(shutdownSpy).toHaveBeenCalled()       // invalidate ran (would kill the child) first
+        expect(destroyMock).toHaveBeenCalledTimes(1) // netns destroyed only after start settled
+    })
+
+    it('does NOT create a netns when NETWORK_MODE is UNRESTRICTED (guards the settings-drift class)', async () => {
+        const manager = strictManager({ settings: buildSettings({ executionMode: ExecutionMode.SANDBOX_PROCESS, networkMode: NetworkMode.UNRESTRICTED }) })
+
+        await manager.acquire({ log })
+        const result = await capturedGetEgress!(log)
+
+        expect(result).toBeNull()
+        expect(createEgressNetnsMock).not.toHaveBeenCalled()
+        await manager.shutdown(log)
+        expect(destroyMock).not.toHaveBeenCalled()
+    })
+
+    it('does NOT create a netns for a non-isolate mode even under STRICT', async () => {
+        const manager = strictManager({ settings: buildSettings({ executionMode: ExecutionMode.SANDBOX_CODE_ONLY, networkMode: NetworkMode.STRICT }) })
+
+        await manager.acquire({ log })
+        const result = await capturedGetEgress!(log)
+
+        expect(result).toBeNull()
+        expect(createEgressNetnsMock).not.toHaveBeenCalled()
+    })
+
+    it('retries creation on a later start after a failure (does not cache the rejection)', async () => {
+        createEgressNetnsMock
+            .mockRejectedValueOnce(new Error('no NET_ADMIN'))
+            .mockResolvedValueOnce(handle())
+        const manager = strictManager()
+
+        await manager.acquire({ log })
+        await expect(capturedGetEgress!(log)).rejects.toThrow(/no NET_ADMIN/)
+        const retried = await capturedGetEgress!(log)
+
+        expect(retried).toEqual(info())
+        expect(createEgressNetnsMock).toHaveBeenCalledTimes(2)
+    })
+
+    // Without this the box fails every job routed to it while the worker still reports healthy.
+    it('reports the box unhealthy after repeated egress failures so the poll loop can back it off', async () => {
+        createEgressNetnsMock.mockRejectedValue(new Error('no NET_ADMIN'))
+        const manager = strictManager()
+
+        await manager.acquire({ log })
+        expect(manager.isEgressUnhealthy()).toBe(false)
+
+        await expect(capturedGetEgress!(log)).rejects.toThrow()
+        await expect(capturedGetEgress!(log)).rejects.toThrow()
+        expect(manager.isEgressUnhealthy()).toBe(false)
+
+        await expect(capturedGetEgress!(log)).rejects.toThrow()
+        expect(manager.isEgressUnhealthy()).toBe(true)
+    })
+
+    it('clears the unhealthy verdict when a create succeeds', async () => {
+        createEgressNetnsMock
+            .mockRejectedValueOnce(new Error('boom'))
+            .mockRejectedValueOnce(new Error('boom'))
+            .mockRejectedValueOnce(new Error('boom'))
+            .mockResolvedValueOnce(handle())
+        const manager = strictManager()
+
+        await manager.acquire({ log })
+        for (let attempt = 0; attempt < 3; attempt++) {
+            await expect(capturedGetEgress!(log)).rejects.toThrow()
+        }
+        expect(manager.isEgressUnhealthy()).toBe(true)
+
+        await capturedGetEgress!(log)
+        expect(manager.isEgressUnhealthy()).toBe(false)
+    })
+
+    // The verdict must clear WITHOUT calling getEgress, since the gate returns before the job that would.
+    it('re-arms after the probe window without any getEgress call', async () => {
+        createEgressNetnsMock.mockRejectedValue(new Error('no NET_ADMIN'))
+        const manager = strictManager()
+
+        await manager.acquire({ log })
+        for (let attempt = 0; attempt < 3; attempt++) {
+            await expect(capturedGetEgress!(log)).rejects.toThrow()
+        }
+        expect(manager.isEgressUnhealthy()).toBe(true)
+
+        vi.useFakeTimers({ shouldAdvanceTime: true })
+        vi.setSystemTime(Date.now() + 30_001)
+
+        expect(manager.isEgressUnhealthy()).toBe(false)
+    })
+
+    it('re-latches when the probe fails again (half-open, not permanently open)', async () => {
+        createEgressNetnsMock.mockRejectedValue(new Error('no NET_ADMIN'))
+        const manager = strictManager()
+
+        await manager.acquire({ log })
+        for (let attempt = 0; attempt < 3; attempt++) {
+            await expect(capturedGetEgress!(log)).rejects.toThrow()
+        }
+        vi.useFakeTimers({ shouldAdvanceTime: true })
+        vi.setSystemTime(Date.now() + 30_001)
+        expect(manager.isEgressUnhealthy()).toBe(false)
+
+        await expect(capturedGetEgress!(log)).rejects.toThrow()
+
+        expect(manager.isEgressUnhealthy()).toBe(true)
+    })
+
+    it('serves the existing namespace when the app API can no longer be resolved', async () => {
+        createEgressNetnsMock.mockResolvedValue(handle({ apiAllow: '10.0.0.9:443', apiHostPin: 'api.internal=10.0.0.9', fingerprint: 'fp-1' }))
+        const manager = strictManager()
+
+        await manager.acquire({ log })
+        const first = await capturedGetEgress!(log)
+        resolveApiEgressCachedMock.mockRejectedValue(new Error('cannot resolve internalApiUrl host'))
+
+        const second = await capturedGetEgress!(log)
+
+        expect(second).toEqual(first)
+        expect(createEgressNetnsMock).toHaveBeenCalledTimes(1)
+        expect(destroyMock).not.toHaveBeenCalled()
+        expect(manager.isEgressUnhealthy()).toBe(false)
+    })
+
+    it('still fails when the app API cannot be resolved and no namespace exists yet', async () => {
+        resolveApiEgressCachedMock.mockRejectedValue(new Error('cannot resolve internalApiUrl host'))
+        const manager = strictManager()
+
+        await manager.acquire({ log })
+
+        await expect(capturedGetEgress!(log)).rejects.toThrow(/cannot resolve internalApiUrl host/)
+        expect(createEgressNetnsMock).not.toHaveBeenCalled()
+    })
+
+    it('never reports a non-STRICT box unhealthy (getEgress is a no-op there)', async () => {
+        const manager = strictManager({ settings: buildSettings({ executionMode: ExecutionMode.SANDBOX_PROCESS, networkMode: NetworkMode.UNRESTRICTED }) })
+
+        await manager.acquire({ log })
+        for (let attempt = 0; attempt < 5; attempt++) {
+            expect(await capturedGetEgress!(log)).toBeNull()
+        }
+        expect(manager.isEgressUnhealthy()).toBe(false)
+    })
+
+    it('recreates the netns when SSRF_ALLOW_LIST changes between getEgress calls', async () => {
+        destroyMock.mockResolvedValue(undefined)
+        createEgressNetnsMock
+            .mockResolvedValueOnce(handle())
+            .mockResolvedValueOnce(handle())
+        let allowList: string[] = []
+        const base = buildSettings({ executionMode: ExecutionMode.SANDBOX_PROCESS, networkMode: NetworkMode.STRICT })
+        const manager = createSandboxManager({
+            boxId: 1,
+            basePath: '/tmp',
+            getSettings: () => ({ ...base, SSRF_ALLOW_LIST: allowList }),
+        })
+
+        await manager.acquire({ log })
+        await capturedGetEgress!(log)
+        expect(createEgressNetnsMock).toHaveBeenCalledTimes(1)
+        expect(createEgressNetnsMock).toHaveBeenLastCalledWith(expect.objectContaining({ allowList: [] }))
+
+        allowList = ['10.9.9.9/32']
+        await capturedGetEgress!(log)
+
+        expect(destroyMock).toHaveBeenCalledTimes(1)
+        expect(createEgressNetnsMock).toHaveBeenCalledTimes(2)
+        expect(createEgressNetnsMock).toHaveBeenLastCalledWith(expect.objectContaining({ allowList: ['10.9.9.9/32'] }))
+    })
+
+    it('recreates the netns when the API DNS fingerprint changes', async () => {
+        destroyMock.mockResolvedValue(undefined)
+        resolveApiEgressCachedMock
+            .mockResolvedValueOnce(apiEgress('10.0.0.9:3000'))
+            .mockResolvedValueOnce(apiEgress('10.0.0.10:3000'))
+        createEgressNetnsMock
+            .mockResolvedValueOnce(handle({ apiAllow: '10.0.0.9:3000', apiHostPin: 'api.internal=10.0.0.9', fingerprint: '10.0.0.9:3000' }))
+            .mockResolvedValueOnce(handle({ apiAllow: '10.0.0.10:3000', apiHostPin: 'api.internal=10.0.0.10', fingerprint: '10.0.0.10:3000' }))
+        const settings = buildSettings({ executionMode: ExecutionMode.SANDBOX_PROCESS, networkMode: NetworkMode.STRICT })
+        const manager = createSandboxManager({
+            boxId: 1,
+            basePath: '/tmp',
+            getSettings: () => settings,
+            internalApiUrl: 'http://api.internal/api/',
+        })
+
+        await manager.acquire({ log })
+        const first = await capturedGetEgress!(log)
+        expect(first).toMatchObject({ apiAllow: '10.0.0.9:3000', fingerprint: '10.0.0.9:3000' })
+        expect(createEgressNetnsMock).toHaveBeenCalledTimes(1)
+
+        const second = await capturedGetEgress!(log)
+        expect(destroyMock).toHaveBeenCalledTimes(1)
+        expect(createEgressNetnsMock).toHaveBeenCalledTimes(2)
+        expect(second).toMatchObject({ apiAllow: '10.0.0.10:3000', fingerprint: '10.0.0.10:3000' })
+    })
+
+    it('awaits the previous sandbox shutdown before creating a replacement', async () => {
+        let resolveShutdown: () => void = () => undefined
+        const shutdownGate = new Promise<void>((resolve) => { resolveShutdown = resolve })
+        const firstShutdown = vi.fn(() => shutdownGate)
+        const secondShutdown = vi.fn().mockResolvedValue(undefined)
+        vi.mocked(createSandboxForJob).mockReset()
+        vi.mocked(createSandboxForJob)
+            .mockImplementationOnce(((params: { getEgress?: (log: unknown) => Promise<unknown> }) => {
+                capturedGetEgress = params.getEgress
+                return {
+                    isReady: () => false,
+                    start: vi.fn().mockResolvedValue(undefined),
+                    shutdown: firstShutdown,
+                }
+            }) as never)
+            .mockImplementationOnce(((params: { getEgress?: (log: unknown) => Promise<unknown> }) => {
+                capturedGetEgress = params.getEgress
+                return {
+                    isReady: () => true,
+                    start: vi.fn().mockResolvedValue(undefined),
+                    shutdown: secondShutdown,
+                }
+            }) as never)
+        const manager = strictManager()
+
+        await manager.acquire({ log })
+        expect(createSandboxForJob).toHaveBeenCalledTimes(1)
+
+        let secondReady = false
+        const secondAcquire = manager.acquire({ log }).then(() => { secondReady = true })
+        await tick()
+        expect(firstShutdown).toHaveBeenCalled()
+        expect(secondReady).toBe(false)
+        expect(createSandboxForJob).toHaveBeenCalledTimes(1)
+
+        resolveShutdown()
+        await secondAcquire
+        expect(createSandboxForJob).toHaveBeenCalledTimes(2)
+    })
+})

--- a/packages/server/sandbox/test/lib/sandbox-manager.test.ts
+++ b/packages/server/sandbox/test/lib/sandbox-manager.test.ts
@@ -63,13 +63,13 @@ describe('sandbox-manager canReuseSandbox', () => {
         })
 
         const manager = createSandboxManager({ boxId: 1, basePath: '/tmp', getSettings: () => settings })
-        manager.acquire({ log })
+        await manager.acquire({ log })
         await manager.release(log)
 
         const { createSandboxForJob } = await import('../../src/lib/create-sandbox-for-job')
         expect(createSandboxForJob).toHaveBeenCalledTimes(1)
 
-        manager.acquire({ log })
+        await manager.acquire({ log })
         expect(createSandboxForJob).toHaveBeenCalledTimes(2)
     })
 
@@ -80,11 +80,11 @@ describe('sandbox-manager canReuseSandbox', () => {
         })
 
         const manager = createSandboxManager({ boxId: 1, basePath: '/tmp', getSettings: () => settings })
-        manager.acquire({ log })
+        await manager.acquire({ log })
         await manager.release(log)
 
         const { createSandboxForJob } = await import('../../src/lib/create-sandbox-for-job')
-        manager.acquire({ log })
+        await manager.acquire({ log })
         expect(createSandboxForJob).toHaveBeenCalledTimes(2)
     })
 
@@ -95,11 +95,11 @@ describe('sandbox-manager canReuseSandbox', () => {
         })
 
         const manager = createSandboxManager({ boxId: 1, basePath: '/tmp', getSettings: () => settings })
-        manager.acquire({ log })
+        await manager.acquire({ log })
         await manager.release(log)
 
         const { createSandboxForJob } = await import('../../src/lib/create-sandbox-for-job')
-        manager.acquire({ log })
+        await manager.acquire({ log })
         expect(createSandboxForJob).toHaveBeenCalledTimes(1)
     })
 
@@ -110,11 +110,11 @@ describe('sandbox-manager canReuseSandbox', () => {
         })
 
         const manager = createSandboxManager({ boxId: 1, basePath: '/tmp', getSettings: () => settings })
-        manager.acquire({ log })
+        await manager.acquire({ log })
         await manager.release(log)
 
         const { createSandboxForJob } = await import('../../src/lib/create-sandbox-for-job')
-        manager.acquire({ log })
+        await manager.acquire({ log })
         expect(createSandboxForJob).toHaveBeenCalledTimes(1)
     })
 
@@ -125,11 +125,11 @@ describe('sandbox-manager canReuseSandbox', () => {
         })
 
         const manager = createSandboxManager({ boxId: 1, basePath: '/tmp', getSettings: () => settings })
-        manager.acquire({ log })
+        await manager.acquire({ log })
         await manager.release(log)
 
         const { createSandboxForJob } = await import('../../src/lib/create-sandbox-for-job')
-        manager.acquire({ log })
+        await manager.acquire({ log })
         expect(createSandboxForJob).toHaveBeenCalledTimes(1)
     })
 })

--- a/packages/server/sandbox/test/lib/sandbox.test.ts
+++ b/packages/server/sandbox/test/lib/sandbox.test.ts
@@ -21,7 +21,7 @@ vi.mock('../../src/lib/cache/local-execution-cache', () => ({
 
 vi.mock('../../src/lib/sandbox-manager', () => ({
     createSandboxManager: vi.fn(({ boxId }: { boxId: number }) => ({
-        acquire: vi.fn(() => {
+        acquire: vi.fn(async () => {
             acquiredBoxIds.push(boxId)
             return {
                 start: vi.fn().mockResolvedValue(undefined),

--- a/packages/server/sandbox/test/lib/sandbox/dispatch-rewrite.test.ts
+++ b/packages/server/sandbox/test/lib/sandbox/dispatch-rewrite.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest'
+import { EngineOperation } from '@activepieces/shared'
+import { sandboxRpcInternals } from '../../../src/lib/sandbox/sandbox'
+
+const { rewriteInternalApiUrl } = sandboxRpcInternals
+
+function op(fields: Record<string, unknown>): EngineOperation {
+    return fields as unknown as EngineOperation
+}
+
+describe('rewriteInternalApiUrl (netns operation dispatch)', () => {
+    it('replaces internalApiUrl with the gateway callback URL when one is set', () => {
+        const rewritten = rewriteInternalApiUrl(op({ internalApiUrl: 'http://127.0.0.1:3000/api/', engineToken: 't' }), 'http://10.255.0.5:3000/api/')
+        expect(rewritten).toEqual({ internalApiUrl: 'http://10.255.0.5:3000/api/', engineToken: 't' })
+    })
+
+    it('returns the operation untouched when there is no callback URL (no netns)', () => {
+        const original = op({ internalApiUrl: 'http://127.0.0.1:3000/api/' })
+        expect(rewriteInternalApiUrl(original, null)).toBe(original)
+    })
+
+    it('returns the operation untouched when it carries no internalApiUrl field', () => {
+        const original = op({ engineToken: 't' })
+        expect(rewriteInternalApiUrl(original, 'http://10.255.0.5:3000/api/')).toBe(original)
+    })
+
+    it('does not mutate the caller operation', () => {
+        const original = op({ internalApiUrl: 'http://127.0.0.1:3000/api/' })
+        rewriteInternalApiUrl(original, 'http://10.255.0.5:3000/api/')
+        expect(original).toEqual({ internalApiUrl: 'http://127.0.0.1:3000/api/' })
+    })
+})

--- a/packages/server/sandbox/test/lib/sandbox/isolate.test.ts
+++ b/packages/server/sandbox/test/lib/sandbox/isolate.test.ts
@@ -55,12 +55,14 @@ async function callCreate({
     boxId = 7,
     enginePath = '/host/cache/common/main.js',
     sandboxId = 'sb-abc',
+    netnsName,
 }: {
     mounts?: SandboxMount[]
     env?: Record<string, string>
     boxId?: number
     enginePath?: string
     sandboxId?: string
+    netnsName?: string
 } = {}) {
     const maker = isolateProcess(createMockLogger(), enginePath, '/host/cache/codes', boxId)
     return maker.create({
@@ -68,9 +70,12 @@ async function callCreate({
         command: [],
         mounts,
         env,
+        netnsName,
         resourceLimits: { memoryLimitMb: 256, cpuMsPerSec: 1000, timeLimitSeconds: 60 },
     })
 }
+
+const isolateBinaryPath = path.resolve(process.cwd(), 'packages/server/api/src/assets', getIsolateExecutableName())
 
 describe('isolateProcess', () => {
     beforeEach(() => {
@@ -332,6 +337,32 @@ describe('isolateProcess', () => {
             await expect(callCreate({ env })).rejects.toThrow(/must not contain newlines or NUL bytes/)
             expect(execPromiseMock).not.toHaveBeenCalled()
             expect(spawnMock).not.toHaveBeenCalled()
+        })
+    })
+
+    describe('netns wrapping', () => {
+        it('spawns the isolate binary directly (host netns) when no netnsName is given', async () => {
+            await callCreate({ boxId: 7 })
+            expect(spawnMock.mock.calls[0][0]).toBe(isolateBinaryPath)
+            const args: string[] = spawnMock.mock.calls[0][1]
+            expect(args[0]).toBe('--no-default-dirs')
+            expect(args).toContain('--share-net')
+        })
+
+        it('wraps the spawn in `ip netns exec <netns>` when a netnsName is given', async () => {
+            await callCreate({ boxId: 7, netnsName: 'ap-egress-7' })
+            expect(spawnMock.mock.calls[0][0]).toBe('ip')
+            const args: string[] = spawnMock.mock.calls[0][1]
+            expect(args.slice(0, 4)).toEqual(['netns', 'exec', 'ap-egress-7', isolateBinaryPath])
+            // the isolate flags follow, unchanged, so --share-net now binds the restricted netns
+            expect(args[4]).toBe('--no-default-dirs')
+            expect(args).toContain('--share-net')
+            expect(args[args.length - 1]).toBe('/root/common/main.js')
+        })
+
+        it('keeps shell: false whether or not a netns is used', async () => {
+            await callCreate({ netnsName: 'ap-egress-7' })
+            expect(spawnMock.mock.calls[0][2]).toEqual({ shell: false })
         })
     })
 

--- a/packages/server/sandbox/test/lib/sandbox/netns-lifecycle.test.ts
+++ b/packages/server/sandbox/test/lib/sandbox/netns-lifecycle.test.ts
@@ -1,0 +1,499 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const { spawnWithKillMock, writeFileMock, readFileMock, statMock } = vi.hoisted(() => ({
+    spawnWithKillMock: vi.fn(),
+    writeFileMock: vi.fn(),
+    readFileMock: vi.fn(),
+    statMock: vi.fn(),
+}))
+
+vi.mock('../../../src/lib/utils/exec', () => ({
+    spawnWithKill: spawnWithKillMock,
+}))
+
+vi.mock('node:fs/promises', () => ({
+    writeFile: writeFileMock,
+    readFile: readFileMock,
+    stat: statMock,
+}))
+
+import { acquireEgressNetworkLease, createEgressNetns, cleanupStaleEgress, assertEgressCapabilities, prepareEgressEnvironment, egressNetnsInternals } from '../../../src/lib/sandbox/netns'
+import { SandboxLogger } from '../../../src/lib/sandbox/types'
+
+// Both stats default to the SAME (dev, ino) so the kill path runs; a test wanting a refusal overrides one.
+const SAME_NETNS = { dev: 4, ino: 4026532001 }
+
+function mkLog(): SandboxLogger {
+    return { info: vi.fn(), debug: vi.fn(), error: vi.fn(), warn: vi.fn() }
+}
+
+function ranCommands(): string[] {
+    return spawnWithKillMock.mock.calls.map(([o]) => `${o.cmd} ${o.args.join(' ')}`)
+}
+
+type Cmd = { cmd: string, args: string[] }
+
+// Reject only the commands a test is about; everything else succeeds so the path under test still runs.
+function denyCommand(matches: (c: Cmd) => boolean, message = 'Operation not permitted'): void {
+    spawnWithKillMock.mockImplementation((opts: Cmd) =>
+        matches(opts) ? Promise.reject(new Error(message)) : Promise.resolve({ stdout: '', stderr: '' }))
+}
+
+// Give one exact command a canned stdout (or a rejection); every other command succeeds empty.
+function stubCommand(command: string, result: string | Error): void {
+    spawnWithKillMock.mockImplementation((opts: Cmd) => {
+        if (`${opts.cmd} ${opts.args.join(' ')}` !== command) {
+            return Promise.resolve({ stdout: '', stderr: '' })
+        }
+        return result instanceof Error ? Promise.reject(result) : Promise.resolve({ stdout: result, stderr: '' })
+    })
+}
+
+describe('createEgressNetns lifecycle', () => {
+    beforeEach(() => {
+        spawnWithKillMock.mockReset()
+        writeFileMock.mockReset()
+        readFileMock.mockReset()
+        spawnWithKillMock.mockResolvedValue({ stdout: '', stderr: '' })
+        writeFileMock.mockResolvedValue(undefined)
+        readFileMock.mockResolvedValue('1') // ip_forward reads back as enabled
+        statMock.mockReset()
+        statMock.mockResolvedValue(SAME_NETNS)
+        egressNetnsInternals.resetStateForTests()
+        vi.spyOn(process, 'kill').mockImplementation(() => true)
+    })
+
+    it('a create that is superseded by a newer create makes the stale handle.destroy() a no-op', async () => {
+        const log = mkLog()
+        const stale = await createEgressNetns({ log, boxId: 1 })
+        const current = await createEgressNetns({ log, boxId: 1 }) // supersedes `stale`
+
+        spawnWithKillMock.mockClear()
+        await stale.destroy() // superseded owner → must NOT tear anything down
+        expect(ranCommands()).toEqual([])
+
+        await current.destroy() // current owner → tears the box down
+        expect(ranCommands()).toContain('ip netns del ap-egress-1')
+    })
+
+    it('fails closed when ip_forward is not already enabled (verify-only, never writes)', async () => {
+        readFileMock.mockResolvedValue('0')
+        await expect(createEgressNetns({ log: mkLog(), boxId: 8 })).rejects.toThrow(/net\.ipv4\.ip_forward/)
+        expect(writeFileMock).not.toHaveBeenCalled()
+    })
+
+    it('assertEgressCapabilities EXERCISES netns creation — throws when `ip netns add` is denied (not just binary presence)', async () => {
+        denyCommand((c) => c.cmd === 'ip' && c.args[0] === 'netns' && c.args[1] === 'add')
+        await expect(assertEgressCapabilities()).rejects.toThrow(/cannot create a network namespace/)
+        expect(ranCommands().some((command) => command.startsWith('ip netns del ap-egress-probe-'))).toBe(false)
+    })
+
+    it('assertEgressCapabilities EXERCISES iptables — throws when chain creation is denied (ip_forward already 1 is not enough)', async () => {
+        denyCommand((c) => c.cmd === 'iptables' && c.args.includes('-N'), 'Permission denied')
+        await expect(assertEgressCapabilities()).rejects.toThrow(/cannot create an iptables filter chain/)
+    })
+
+    it('assertEgressCapabilities cleans up its probe netns + filter/nat chains and exercises ip netns exec', async () => {
+        await assertEgressCapabilities()
+        const cmds = ranCommands()
+        const addNetns = cmds.find((command) => command.startsWith('ip netns add ap-egress-probe-'))
+        const execNetns = cmds.find((command) => /^ip netns exec ap-egress-probe-\S+ true$/.test(command))
+        const addFilterChain = cmds.find((command) => command.startsWith('iptables --wait 3 -N AP_EG_P_'))
+        expect(addNetns).toBeDefined()
+        expect(execNetns).toBeDefined()
+        expect(addFilterChain).toBeDefined()
+        if (!addNetns || !addFilterChain) {
+            throw new Error('Capability probes were not created')
+        }
+        expect(cmds).toContain(addNetns.replace(' add ', ' del '))
+        expect(cmds).toContain(addFilterChain.replace(' -N ', ' -X '))
+        // MASQUERADE is hook-bound, so it is probed on the REAL POSTROUTING hook, never a user chain.
+        expect(cmds).toContain('iptables --wait 3 -t nat -I POSTROUTING 1 -s 192.0.2.0/30 ! -o lo -j MASQUERADE')
+        expect(cmds).toContain('iptables --wait 3 -t nat -D POSTROUTING -s 192.0.2.0/30 ! -o lo -j MASQUERADE')
+        // ip6tables rule shape is exercised too
+        expect(cmds.some((c) => c.startsWith('ip6tables --wait 3 -N AP_EG_P_'))).toBe(true)
+        // A probe chain is NEVER created in the nat table; masquerade is hook-bound so it goes to POSTROUTING.
+        expect(cmds.some((c) => /-t nat .* -N AP_EG_P_/.test(c))).toBe(false)
+    })
+
+    it('assertEgressCapabilities fails closed when ip netns exec is denied', async () => {
+        denyCommand((c) => c.cmd === 'ip' && c.args[0] === 'netns' && c.args[1] === 'exec')
+        await expect(assertEgressCapabilities()).rejects.toThrow(/cannot exec into a network namespace/)
+    })
+
+    it('assertEgressCapabilities fails closed when nat MASQUERADE cannot be installed (probed on the REAL POSTROUTING hook, not a user chain)', async () => {
+        denyCommand((c) => c.cmd === 'iptables' && c.args.includes('nat') && c.args.includes('MASQUERADE'), 'No chain/target/match by that name')
+        await expect(assertEgressCapabilities()).rejects.toThrow(/nat POSTROUTING MASQUERADE/)
+    })
+
+    it('assertEgressCapabilities fails closed when a rule shape (conntrack/REJECT/MASQUERADE) is unsupported', async () => {
+        denyCommand((c) => c.cmd === 'iptables' && c.args.includes('conntrack'), 'Couldn\'t load match `conntrack')
+        await expect(assertEgressCapabilities()).rejects.toThrow(/kernel module .*conntrack/)
+    })
+
+    it('assertEgressCapabilities fails closed when ip6tables rules are unsupported', async () => {
+        denyCommand((c) => c.cmd === 'ip6tables' && c.args.includes('-N'), 'ip6tables: can\'t initialize')
+        await expect(assertEgressCapabilities()).rejects.toThrow(/ip6 filter chain/)
+    })
+
+    it('stale inventory tolerates nat listing failure (best-effort per source)', async () => {
+        denyCommand((c) => c.cmd === 'iptables' && c.args.includes('nat') && c.args.includes('-S'), 'iptable_nat not loaded')
+        const lease = await prepareEgressEnvironment({ log: mkLog(), allowList: [] })
+        await lease.release()
+    })
+
+    it('fails closed when a required binary is missing (probed before any resource is created)', async () => {
+        denyCommand((c) => c.cmd === 'ip6tables' && c.args.includes('--version'), 'not found')
+        await expect(createEgressNetns({ log: mkLog(), boxId: 9 })).rejects.toThrow(/ip6tables.*not available/)
+        expect(ranCommands()).not.toContain('ip netns add ap-egress-9')
+    })
+
+    it('prepareEgressEnvironment fails closed when a host network is INSIDE the egress /16', async () => {
+        stubCommand('ip -o -4 addr show', '2: eth0    inet 10.255.7.2/24 scope global eth0')
+        await expect(prepareEgressEnvironment({ log: mkLog() })).rejects.toThrow(/overlaps an existing host network/)
+    })
+
+    it('prepareEgressEnvironment does NOT trip on a SUMMARY route that merely contains the pool (10.0.0.0/8, GKE 10.128.0.0/9)', async () => {
+        stubCommand('ip -o -4 route show', '10.0.0.0/8 via 10.1.2.3 dev eth0\n10.128.0.0/9 dev eth0 proto kernel')
+        const lease = await prepareEgressEnvironment({ log: mkLog() })
+        await lease.release()
+    })
+
+    it('prepareEgressEnvironment fails closed on a route NEXT-HOP inside the pool (via 10.255.0.1)', async () => {
+        stubCommand('ip -o -4 route show', 'default via 10.255.0.1 dev eth0')
+        await expect(prepareEgressEnvironment({ log: mkLog() })).rejects.toThrow(/overlaps an existing host network/)
+    })
+
+    it('prepareEgressEnvironment fails closed on an interface address inside the pool with a mask WIDER than /16 (inet 10.255.0.7/8)', async () => {
+        stubCommand('ip -o -4 addr show', '2: eth0    inet 10.255.0.7/8 scope global eth0')
+        await expect(prepareEgressEnvironment({ log: mkLog() })).rejects.toThrow(/overlaps an existing host network/)
+    })
+
+    it('prepareEgressEnvironment fails closed when host network inventory (ip addr/route) cannot be read', async () => {
+        denyCommand((c) => c.cmd === 'ip' && c.args.join(' ') === '-o -4 addr show', 'Operation not permitted')
+        await expect(prepareEgressEnvironment({ log: mkLog() })).rejects.toThrow(/cannot inventory host IPv4/)
+    })
+
+    it('DROPS a hostname allow-list entry and still creates the netns (worker keeps running, not bricked)', async () => {
+        const log = mkLog()
+        await expect(createEgressNetns({ log, boxId: 4, allowList: ['db.internal', '10.9.9.9'] })).resolves.toMatchObject({ netnsName: 'ap-egress-4' })
+        expect(ranCommands()).toContain('ip netns add ap-egress-4') // created, not refused
+        expect(ranCommands().some((c) => c.includes('AP_EG_FWD_4') && c.includes('10.9.9.9/32') && c.includes('ACCEPT'))).toBe(true) // valid IP still allow-listed
+        expect(ranCommands().some((c) => c.includes('db.internal'))).toBe(false) // hostname never reaches the kernel
+        expect(log.error).toHaveBeenCalled() // loud
+    })
+
+    it('prepareEgressEnvironment does NOT brick on a hostname allow-list (drops it, keeps polling)', async () => {
+        const lease = await prepareEgressEnvironment({ log: mkLog(), allowList: ['db.internal'] })
+        expect(lease.release).toBeInstanceOf(Function)
+        await lease.release() // free the abstract-socket lease for other tests
+    })
+
+    it('does NOT install a kernel ACCEPT for metadata/CGNAT even when allow-listed', async () => {
+        const handle = await createEgressNetns({
+            log: mkLog(),
+            boxId: 3,
+            allowList: ['169.254.169.254', '100.100.100.200', '10.9.9.9'],
+        })
+        const cmds = ranCommands()
+        expect(cmds).toContain('iptables --wait 3 -A AP_EG_FWD_3 -d 10.9.9.9/32 -j ACCEPT')
+        expect(cmds.some((command) => command.includes('169.254') && command.includes('ACCEPT'))).toBe(false)
+        expect(cmds.some((command) => command.includes('100.100.100.200') && command.includes('ACCEPT'))).toBe(false)
+        await handle.destroy()
+    })
+
+    it('does NOT flag overlap against our own ap-veth addresses', async () => {
+        stubCommand('ip -o -4 addr show', '9: ap-veth-h1    inet 10.255.0.5/30 scope global ap-veth-h1')
+        await expect(createEgressNetns({ log: mkLog(), boxId: 1 })).resolves.toMatchObject({ netnsName: 'ap-egress-1' })
+    })
+
+    it('REFUSES to clobber a namespace that survives SIGKILL of orphan pids', async () => {
+        spawnWithKillMock.mockImplementation((opts: { cmd: string, args: string[] }) => {
+            const command = `${opts.cmd} ${opts.args.join(' ')}`
+            if (command === 'ip netns list') {
+                return Promise.resolve({ stdout: 'ap-egress-7 (id: 0)', stderr: '' })
+            }
+            if (command === 'ip netns pids ap-egress-7') {
+                return Promise.resolve({ stdout: '1234\n5678\n', stderr: '' })
+            }
+            return Promise.resolve({ stdout: '', stderr: '' })
+        })
+        await expect(createEgressNetns({ log: mkLog(), boxId: 7 })).rejects.toThrow(/still in use by 2 live process/)
+        expect(process.kill).toHaveBeenCalledWith(1234, 'SIGKILL')
+        expect(process.kill).toHaveBeenCalledWith(5678, 'SIGKILL')
+        expect(ranCommands()).not.toContain('ip netns del ap-egress-7')
+        expect(ranCommands()).not.toContain('ip netns add ap-egress-7')
+    }, 20_000)
+
+    it('SIGKILLs orphans that outlive the wait window, then creates once they exit', async () => {
+        // Keyed on the kill landing, not a call count, which would encode how many inspections happen.
+        let killed = false
+        vi.spyOn(process, 'kill').mockImplementation(() => {
+            killed = true
+            return true
+        })
+        spawnWithKillMock.mockImplementation((opts: { cmd: string, args: string[] }) => {
+            const command = `${opts.cmd} ${opts.args.join(' ')}`
+            if (command === 'ip netns list') {
+                return Promise.resolve({ stdout: 'ap-egress-7 (id: 0)', stderr: '' })
+            }
+            if (command === 'ip netns pids ap-egress-7') {
+                return Promise.resolve({ stdout: killed ? '' : '4321\n', stderr: '' })
+            }
+            return Promise.resolve({ stdout: '', stderr: '' })
+        })
+        await expect(createEgressNetns({ log: mkLog(), boxId: 7 })).resolves.toMatchObject({ netnsName: 'ap-egress-7' })
+        expect(process.kill).toHaveBeenCalledWith(4321, 'SIGKILL')
+        expect(ranCommands()).toContain('ip netns add ap-egress-7')
+    }, 20_000)
+
+    it('does NOT SIGKILL a pid that no longer resolves to this namespace (recycled pid guard)', async () => {
+        // The pid list can be seconds stale, so an identity mismatch must skip the signal, not guess.
+        statMock.mockImplementation((path: string) => Promise.resolve(
+            path.startsWith('/proc/') ? { dev: 4, ino: 999999 } : SAME_NETNS,
+        ))
+        spawnWithKillMock.mockImplementation((opts: { cmd: string, args: string[] }) => {
+            const command = `${opts.cmd} ${opts.args.join(' ')}`
+            if (command === 'ip netns list') {
+                return Promise.resolve({ stdout: 'ap-egress-7 (id: 0)', stderr: '' })
+            }
+            if (command === 'ip netns pids ap-egress-7') {
+                return Promise.resolve({ stdout: '4321\n', stderr: '' })
+            }
+            return Promise.resolve({ stdout: '', stderr: '' })
+        })
+        await expect(createEgressNetns({ log: mkLog(), boxId: 7 })).rejects.toThrow(/still in use by 1 live process/)
+        expect(process.kill).not.toHaveBeenCalled()
+        expect(ranCommands()).not.toContain('ip netns add ap-egress-7')
+    }, 20_000)
+
+    it('waits for a reconnect-orphaned child to exit within the bounded window, then creates', async () => {
+        let pidChecks = 0
+        spawnWithKillMock.mockImplementation((opts: { cmd: string, args: string[] }) => {
+            const command = `${opts.cmd} ${opts.args.join(' ')}`
+            if (command === 'ip netns list') {
+                return Promise.resolve({ stdout: 'ap-egress-7 (id: 0)', stderr: '' })
+            }
+            if (command === 'ip netns pids ap-egress-7') {
+                pidChecks++
+                return Promise.resolve({ stdout: pidChecks <= 2 ? '4321\n' : '', stderr: '' })
+            }
+            return Promise.resolve({ stdout: '', stderr: '' })
+        })
+        await expect(createEgressNetns({ log: mkLog(), boxId: 7 })).resolves.toMatchObject({ netnsName: 'ap-egress-7' })
+        expect(pidChecks).toBeGreaterThanOrEqual(3)
+        expect(process.kill).not.toHaveBeenCalled()
+        expect(ranCommands()).toContain('ip netns add ap-egress-7')
+    })
+
+    it('fails closed when an existing namespace cannot be inspected', async () => {
+        spawnWithKillMock.mockImplementation((opts: { cmd: string, args: string[] }) => {
+            const command = `${opts.cmd} ${opts.args.join(' ')}`
+            if (command === 'ip netns list') {
+                return Promise.resolve({ stdout: 'ap-egress-7 (id: 0)', stderr: '' })
+            }
+            if (command === 'ip netns pids ap-egress-7') {
+                return Promise.reject(new Error('permission denied'))
+            }
+            return Promise.resolve({ stdout: '', stderr: '' })
+        })
+        await expect(createEgressNetns({ log: mkLog(), boxId: 7 })).rejects.toThrow(/permission denied/)
+        expect(ranCommands()).not.toContain('ip netns del ap-egress-7')
+    })
+
+    it('LEAVES firewall rules armed when the box VETH cannot be brought down/away — even if `netns del` succeeds (fail-closed)', async () => {
+        const log = mkLog()
+        const handle = await createEgressNetns({ log, boxId: 4 })
+
+        // netns-del alone does not sever, since a live box keeps the namespace, so filters must stay armed.
+        spawnWithKillMock.mockImplementation((opts: { cmd: string, args: string[] }) => {
+            const cmd = `${opts.cmd} ${opts.args.join(' ')}`
+            if (cmd === 'ip link set ap-veth-h4 down' || cmd === 'ip link del ap-veth-h4') {
+                return Promise.reject(new Error('device busy'))
+            }
+            return Promise.resolve({ stdout: '', stderr: '' }) // netns del + everything else succeed
+        })
+        spawnWithKillMock.mockClear()
+
+        await handle.destroy()
+        const cmds = ranCommands()
+        expect(cmds).toContain('ip netns del ap-egress-4') // netns del was attempted and "succeeded"
+        expect(cmds.some((c) => c.includes('iptables') && (c.includes(' -D ') || c.includes(' -F ') || c.includes(' -X ')))).toBe(false)
+        expect(log.error).toHaveBeenCalled()
+    })
+
+    it('removes firewall rules once the box veth IS brought down (severed)', async () => {
+        const log = mkLog()
+        const handle = await createEgressNetns({ log, boxId: 4 })
+        spawnWithKillMock.mockClear() // all commands succeed (default mock)
+
+        await handle.destroy()
+        const cmds = ranCommands()
+        expect(cmds).toContain('ip link set ap-veth-h4 down')
+        expect(cmds.some((c) => c.includes('iptables') && c.includes(' -X '))).toBe(true) // filters removed
+    })
+
+    it('treats a CONFIRMED-absent veth as severed and removes the firewall rules (not a leak)', async () => {
+        const log = mkLog()
+        const handle = await createEgressNetns({ log, boxId: 4 })
+        spawnWithKillMock.mockImplementation((opts: { cmd: string, args: string[] }) => {
+            const cmd = `${opts.cmd} ${opts.args.join(' ')}`
+            if (cmd === 'ip link set ap-veth-h4 down' || cmd === 'ip link del ap-veth-h4') {
+                return Promise.reject(new Error('Cannot find device "ap-veth-h4"'))
+            }
+            if (cmd === 'ip link show ap-veth-h4') {
+                return Promise.reject(new Error('Device "ap-veth-h4" does not exist.'))
+            }
+            return Promise.resolve({ stdout: '', stderr: '' })
+        })
+        spawnWithKillMock.mockClear()
+
+        await handle.destroy()
+        expect(ranCommands().some((c) => c.includes('iptables') && c.includes(' -X '))).toBe(true) // absent veth ⇒ severed ⇒ filters removed
+    })
+
+    it('does NOT treat a veth-show TIMEOUT as absent — keeps firewall rules armed (fail-closed)', async () => {
+        const log = mkLog()
+        const handle = await createEgressNetns({ log, boxId: 4 })
+        spawnWithKillMock.mockImplementation((opts: { cmd: string, args: string[] }) => {
+            const cmd = `${opts.cmd} ${opts.args.join(' ')}`
+            if (cmd === 'ip link set ap-veth-h4 down' || cmd === 'ip link del ap-veth-h4') {
+                return Promise.reject(new Error('device busy'))
+            }
+            if (cmd === 'ip link show ap-veth-h4') {
+                return Promise.reject(new Error('Timeout after 5000ms\nstdout: \nstderr: ')) // NOT proof of absence
+            }
+            return Promise.resolve({ stdout: '', stderr: '' })
+        })
+        spawnWithKillMock.mockClear()
+
+        await handle.destroy()
+        expect(ranCommands().some((c) => c.includes('iptables') && (c.includes(' -D ') || c.includes(' -F ') || c.includes(' -X ')))).toBe(false)
+        expect(log.error).toHaveBeenCalled()
+    })
+})
+
+describe('cleanupStaleEgress', () => {
+    beforeEach(() => {
+        spawnWithKillMock.mockReset()
+        spawnWithKillMock.mockResolvedValue({ stdout: '', stderr: '' })
+        writeFileMock.mockResolvedValue(undefined)
+        readFileMock.mockResolvedValue('1')
+        statMock.mockReset()
+        statMock.mockResolvedValue(SAME_NETNS)
+        egressNetnsInternals.resetStateForTests()
+        vi.spyOn(process, 'kill').mockImplementation(() => true)
+    })
+
+    it('reaps unowned stale namespaces, SKIPS a box owned by a live create, and runs once', async () => {
+        const log = mkLog()
+        await createEgressNetns({ log, boxId: 3 }) // live box → ownership recorded
+
+        spawnWithKillMock.mockImplementation((opts: { cmd: string, args: string[] }) =>
+            (opts.cmd === 'ip' && opts.args.join(' ') === 'netns list')
+                ? Promise.resolve({ stdout: 'ap-egress-2 (id: 0)\nap-egress-3 (id: 1)\nother-ns', stderr: '' })
+                : Promise.resolve({ stdout: '', stderr: '' }))
+        spawnWithKillMock.mockClear()
+
+        await cleanupStaleEgress({ log })
+        const cmds = ranCommands()
+        expect(cmds).toContain('ip netns del ap-egress-2')     // unowned → swept
+        expect(cmds).not.toContain('ip netns del ap-egress-3') // live-owned → skipped (P1b TOCTOU fix)
+
+        spawnWithKillMock.mockClear()
+        await cleanupStaleEgress({ log }) // once-guard: subsequent calls do nothing
+        expect(spawnWithKillMock).not.toHaveBeenCalled()
+    })
+
+    it('reaps a veth/chain-only leak that has NO netns (inventory across all three listings)', async () => {
+        spawnWithKillMock.mockImplementation((opts: { cmd: string, args: string[] }) => {
+            const cmd = `${opts.cmd} ${opts.args.join(' ')}`
+            if (cmd === 'ip netns list') {
+                return Promise.resolve({ stdout: '', stderr: '' }) // no netns at all
+            }
+            if (cmd === 'ip -o link show') {
+                return Promise.resolve({ stdout: '9: ap-veth-h9@if8: <BROADCAST> mtu 1500', stderr: '' })
+            }
+            if (cmd === 'iptables -S') {
+                return Promise.resolve({ stdout: '-N AP_EG_FWD_9\n-A AP_EG_IN_9 -j DROP', stderr: '' })
+            }
+            return Promise.resolve({ stdout: '', stderr: '' })
+        })
+
+        await cleanupStaleEgress({ log: mkLog() })
+        const cmds = ranCommands()
+        expect(cmds).toContain('ip link del ap-veth-h9')            // veth-only leak swept
+        expect(cmds).toContain('iptables --wait 3 -X AP_EG_FWD_9')  // chain-only leak swept (--wait applied at run time)
+    })
+
+    it('SIGKILLs orphan pids then reaps the stale namespace', async () => {
+        let killed = false
+        vi.spyOn(process, 'kill').mockImplementation(() => {
+            killed = true
+            return true
+        })
+        spawnWithKillMock.mockImplementation((opts: { cmd: string, args: string[] }) => {
+            const cmd = `${opts.cmd} ${opts.args.join(' ')}`
+            if (cmd === 'ip netns list') {
+                return Promise.resolve({ stdout: 'ap-egress-2 (id: 0)\nap-egress-5 (id: 1)', stderr: '' })
+            }
+            if (cmd === 'ip netns pids ap-egress-5') {
+                return Promise.resolve({ stdout: killed ? '' : '4321\n', stderr: '' })
+            }
+            return Promise.resolve({ stdout: '', stderr: '' })
+        })
+
+        await cleanupStaleEgress({ log: mkLog() })
+        expect(process.kill).toHaveBeenCalledWith(4321, 'SIGKILL')
+        const cmds = ranCommands()
+        expect(cmds).toContain('ip netns del ap-egress-2')
+        expect(cmds).toContain('ip netns del ap-egress-5')
+    })
+
+    it('fails stale cleanup when orphans survive SIGKILL', async () => {
+        spawnWithKillMock.mockImplementation((opts: { cmd: string, args: string[] }) => {
+            const cmd = `${opts.cmd} ${opts.args.join(' ')}`
+            if (cmd === 'ip netns list') {
+                return Promise.resolve({ stdout: 'ap-egress-5 (id: 1)', stderr: '' })
+            }
+            if (cmd === 'ip netns pids ap-egress-5') {
+                return Promise.resolve({ stdout: '4321\n', stderr: '' })
+            }
+            return Promise.resolve({ stdout: '', stderr: '' })
+        })
+
+        await expect(cleanupStaleEgress({ log: mkLog() })).rejects.toThrow(/cannot clean stale namespace ap-egress-5/)
+        expect(process.kill).toHaveBeenCalledWith(4321, 'SIGKILL')
+        expect(ranCommands()).not.toContain('ip netns del ap-egress-5')
+    }, 10_000)
+
+    it('treats a failed inventory listing as empty (best-effort) rather than failing readiness', async () => {
+        denyCommand((c) => c.cmd === 'ip' && c.args.join(' ') === 'netns list', 'ip netns list failed')
+        await expect(cleanupStaleEgress({ log: mkLog() })).resolves.toBeUndefined()
+        expect(ranCommands()).not.toContain('ip netns del ap-egress-1')
+    })
+
+    it('reaps a NAT-only leak discovered from the nat table (nothing else left behind)', async () => {
+        spawnWithKillMock.mockImplementation((opts: { cmd: string, args: string[] }) => {
+            const cmd = `${opts.cmd} ${opts.args.join(' ')}`
+            if (cmd === 'iptables -t nat -S') {
+                return Promise.resolve({ stdout: '-A POSTROUTING -s 10.255.0.28/30 ! -o ap-veth-h7 -j MASQUERADE', stderr: '' })
+            }
+            return Promise.resolve({ stdout: '', stderr: '' }) // no netns, no veth, no filter chains
+        })
+
+        await cleanupStaleEgress({ log: mkLog() })
+        expect(ranCommands()).toContain('iptables --wait 3 -t nat -D POSTROUTING -s 10.255.0.28/30 ! -o ap-veth-h7 -j MASQUERADE')
+    })
+})
+
+describe('egress network ownership lease', () => {
+    it('allows only one STRICT worker in a network namespace and releases ownership', async () => {
+        const first = await acquireEgressNetworkLease()
+        await expect(acquireEgressNetworkLease()).rejects.toThrow(/already owns this network namespace/)
+        await first.release()
+
+        const replacement = await acquireEgressNetworkLease()
+        await replacement.release()
+    })
+})

--- a/packages/server/sandbox/test/lib/sandbox/netns.e2e.test.ts
+++ b/packages/server/sandbox/test/lib/sandbox/netns.e2e.test.ts
@@ -1,0 +1,179 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest'
+import { spawnWithKill } from '../../../src/lib/utils/exec'
+import { assertEgressCapabilities, createEgressNetns, egressNetnsInternals, EgressNetns } from '../../../src/lib/sandbox/netns'
+import { SandboxLogger } from '../../../src/lib/sandbox/types'
+
+// Real kernel, not mocked command strings: opt-in via AP_SANDBOX_NETNS_E2E=1 on a privileged runner.
+const E2E_ENABLED = process.env['AP_SANDBOX_NETNS_E2E'] === '1' && typeof process.getuid === 'function' && process.getuid() === 0
+
+const E2E_BOX_ID = 991
+
+function mkLog(): SandboxLogger {
+    return { info: () => undefined, debug: () => undefined, error: () => undefined, warn: () => undefined }
+}
+
+async function run(cmd: string, args: string[]): Promise<{ ok: boolean, stdout: string }> {
+    try {
+        const { stdout } = await spawnWithKill({ cmd, args, timeoutMs: 8000 })
+        return { ok: true, stdout }
+    }
+    catch {
+        return { ok: false, stdout: '' }
+    }
+}
+
+// A failed connect alone is a WEAK oracle, so pair it with the REJECT counter below.
+async function boxTryConnect({ netnsName, host, port }: { netnsName: string, host: string, port: number }): Promise<boolean> {
+    const { ok } = await run('ip', ['netns', 'exec', netnsName, 'timeout', '3', 'bash', '-c', `echo > /dev/tcp/${host}/${port}`])
+    return ok
+}
+
+// The strong oracle: it proves our rule fired, not merely that the host was unreachable.
+async function rejectPktCount({ boxId, cidr }: { boxId: number, cidr: string }): Promise<number> {
+    return chainRulePktCount({ boxId, cidr, verdict: 'REJECT' })
+}
+
+// The positive oracle: an allow-listed CIDR's ACCEPT rule counted the box's packet.
+async function acceptPktCount({ boxId, cidr }: { boxId: number, cidr: string }): Promise<number> {
+    return chainRulePktCount({ boxId, cidr, verdict: 'ACCEPT' })
+}
+
+async function chainRulePktCount({ boxId, cidr, verdict }: { boxId: number, cidr: string, verdict: string }): Promise<number> {
+    const { stdout } = await run('iptables', ['-L', `AP_EG_FWD_${boxId}`, '-v', '-n', '-x'])
+    const line = stdout.split('\n').find((l) => l.includes(cidr) && l.includes(verdict))
+    if (!line) {
+        return 0
+    }
+    const pkts = Number(line.trim().split(/\s+/)[0])
+    return Number.isFinite(pkts) ? pkts : 0
+}
+
+// Without a default route the packet dies at routing before our chain, so provision a throwaway uplink.
+const E2E_UPLINK_DEV = 'ap-e2e-up'
+
+async function hasDefaultRoute(): Promise<boolean> {
+    const { stdout } = await run('ip', ['route', 'show', 'default'])
+    return stdout.trim() !== ''
+}
+
+describe.skipIf(!E2E_ENABLED)('netns egress (real kernel, privileged)', () => {
+    let handle: EgressNetns | null = null
+    let createdUplink = false
+
+    beforeAll(async () => {
+        await run('ip', ['link', 'set', 'lo', 'up'])
+        if (await hasDefaultRoute()) {
+            return
+        }
+        await run('ip', ['link', 'add', E2E_UPLINK_DEV, 'type', 'dummy'])
+        await run('ip', ['addr', 'add', '203.0.113.1/24', 'dev', E2E_UPLINK_DEV])
+        await run('ip', ['link', 'set', E2E_UPLINK_DEV, 'up'])
+        await run('ip', ['route', 'add', 'default', 'via', '203.0.113.254', 'dev', E2E_UPLINK_DEV, 'onlink'])
+        createdUplink = true
+    })
+
+    afterAll(async () => {
+        if (createdUplink) {
+            await run('ip', ['link', 'del', E2E_UPLINK_DEV])
+        }
+    })
+
+    afterEach(async () => {
+        if (handle) {
+            await handle.destroy()
+            handle = null
+        }
+        for (const command of egressNetnsInternals.buildDestroyCommands(egressNetnsInternals.buildTopology(E2E_BOX_ID))) {
+            await run(command.binary, command.args)
+        }
+    })
+
+    it('assertEgressCapabilities passes on a real privileged kernel', async () => {
+        await expect(assertEgressCapabilities()).resolves.toBeUndefined()
+    })
+
+    it('creates a namespace + veth + chains that actually exist in the kernel (valid ip/iptables syntax)', async () => {
+        handle = await createEgressNetns({ log: mkLog(), boxId: E2E_BOX_ID })
+        expect((await run('ip', ['netns', 'list'])).stdout).toContain(`ap-egress-${E2E_BOX_ID}`)
+        const rules = (await run('iptables', ['-S'])).stdout
+        expect(rules).toContain(`AP_EG_FWD_${E2E_BOX_ID}`)
+        expect(rules).toContain(`AP_EG_IN_${E2E_BOX_ID}`)
+    })
+
+    it('REJECTs cloud metadata via the egress chain (packet counter proves OUR rule fired, not ambient unreachability)', async () => {
+        handle = await createEgressNetns({ log: mkLog(), boxId: E2E_BOX_ID })
+        const netnsName = `ap-egress-${E2E_BOX_ID}`
+
+        const before = await rejectPktCount({ boxId: E2E_BOX_ID, cidr: '169.254.0.0/16' })
+        const connected = await boxTryConnect({ netnsName, host: '169.254.169.254', port: 80 })
+        const after = await rejectPktCount({ boxId: E2E_BOX_ID, cidr: '169.254.0.0/16' })
+
+        expect(connected).toBe(false)     // weak corroboration
+        expect(after).toBeGreaterThan(before) // strong: our REJECT rule counted the box's packet(s)
+    }, 30_000)
+
+    it('REJECTs RFC1918 via the egress chain (counter oracle)', async () => {
+        handle = await createEgressNetns({ log: mkLog(), boxId: E2E_BOX_ID })
+        const netnsName = `ap-egress-${E2E_BOX_ID}`
+
+        const before = await rejectPktCount({ boxId: E2E_BOX_ID, cidr: '10.0.0.0/8' })
+        await boxTryConnect({ netnsName, host: '10.0.0.1', port: 80 })
+        const after = await rejectPktCount({ boxId: E2E_BOX_ID, cidr: '10.0.0.0/8' })
+
+        expect(after).toBeGreaterThan(before)
+    }, 30_000)
+
+    it('ACCEPTs an operator allow-listed target while a non-allow-listed sibling stays REJECTed (allow-list really punches through the RFC1918 block)', async () => {
+        handle = await createEgressNetns({ log: mkLog(), boxId: E2E_BOX_ID, allowList: ['10.9.9.0/24'] })
+        const netnsName = `ap-egress-${E2E_BOX_ID}`
+
+        const accBefore = await acceptPktCount({ boxId: E2E_BOX_ID, cidr: '10.9.9.0/24' })
+        const rejBefore = await rejectPktCount({ boxId: E2E_BOX_ID, cidr: '10.0.0.0/8' })
+        await boxTryConnect({ netnsName, host: '10.9.9.9', port: 80 })
+        // The allow-listed target hit OUR ACCEPT rule and never fell through to the RFC1918 REJECT.
+        expect(await acceptPktCount({ boxId: E2E_BOX_ID, cidr: '10.9.9.0/24' })).toBeGreaterThan(accBefore)
+        expect(await rejectPktCount({ boxId: E2E_BOX_ID, cidr: '10.0.0.0/8' })).toBe(rejBefore)
+
+        // A sibling one /24 over, not on the allow-list, is still blocked by the same RFC1918 REJECT.
+        const rejBeforeSibling = await rejectPktCount({ boxId: E2E_BOX_ID, cidr: '10.0.0.0/8' })
+        await boxTryConnect({ netnsName, host: '10.8.8.8', port: 80 })
+        expect(await rejectPktCount({ boxId: E2E_BOX_ID, cidr: '10.0.0.0/8' })).toBeGreaterThan(rejBeforeSibling)
+    }, 30_000)
+
+    it('leaves NO netns / veth / chain / nat behind after destroy', async () => {
+        handle = await createEgressNetns({ log: mkLog(), boxId: E2E_BOX_ID })
+        await handle.destroy()
+        handle = null
+        expect((await run('ip', ['netns', 'list'])).stdout).not.toContain(`ap-egress-${E2E_BOX_ID}`)
+        expect((await run('ip', ['-o', 'link', 'show'])).stdout).not.toContain(`ap-veth-h${E2E_BOX_ID}`)
+        expect((await run('iptables', ['-S'])).stdout).not.toContain(`AP_EG_FWD_${E2E_BOX_ID}`)
+        expect((await run('iptables', ['-t', 'nat', '-S'])).stdout).not.toContain(`ap-veth-h${E2E_BOX_ID}`)
+        // Rules in the SHARED chains only name the veth, and they outlive the box, so check for it nowhere.
+        expect((await run('iptables', ['-S'])).stdout).not.toContain(`ap-veth-h${E2E_BOX_ID}`)
+    })
+
+    it('lowers the box veth MTU to the uplink on both ends (no oversized frames from the box)', async () => {
+        const uplinkDev = (await run('ip', ['-o', '-4', 'route', 'show', 'default'])).stdout.match(/\bdev\s+(\S+)/)?.[1]
+        expect(uplinkDev).toBeDefined()
+        const uplinkMtu = Number((await run('ip', ['-o', 'link', 'show', 'dev', uplinkDev as string])).stdout.match(/\bmtu\s+(\d+)/)?.[1])
+        handle = await createEgressNetns({ log: mkLog(), boxId: E2E_BOX_ID })
+
+        const hostVeth = (await run('ip', ['-o', 'link', 'show', 'dev', `ap-veth-h${E2E_BOX_ID}`])).stdout
+        const boxVeth = (await run('ip', ['netns', 'exec', `ap-egress-${E2E_BOX_ID}`, 'ip', '-o', 'link', 'show', 'dev', `ap-veth-b${E2E_BOX_ID}`])).stdout
+        // Discovery only ever LOWERS: a >=1500 uplink leaves the kernel default in place, which is correct.
+        const expected = Math.min(uplinkMtu, 1500)
+        expect(Number(hostVeth.match(/\bmtu\s+(\d+)/)?.[1])).toBe(expected)
+        expect(Number(boxVeth.match(/\bmtu\s+(\d+)/)?.[1])).toBe(expected)
+    }, 30_000)
+
+    it('installs no conntrack-state ACCEPT in the egress chain (the RELATED metadata bypass)', async () => {
+        handle = await createEgressNetns({ log: mkLog(), boxId: E2E_BOX_ID })
+        const chain = (await run('iptables', ['-S', `AP_EG_FWD_${E2E_BOX_ID}`])).stdout
+        expect(chain).not.toContain('ctstate')
+        // The reply path keeps ESTABLISHED, and admits RELATED for ICMP only so PMTUD still works.
+        const forward = (await run('iptables', ['-S', 'FORWARD'])).stdout
+        expect(forward).toContain('--ctstate ESTABLISHED -j ACCEPT')
+        expect(forward).toContain('-p icmp -m conntrack --ctstate RELATED -j ACCEPT')
+        expect(forward).not.toContain('ESTABLISHED,RELATED')
+    }, 30_000)
+})

--- a/packages/server/sandbox/test/lib/sandbox/netns.test.ts
+++ b/packages/server/sandbox/test/lib/sandbox/netns.test.ts
@@ -1,0 +1,595 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import dns from 'node:dns'
+import { ssrfIpClassifier } from '@activepieces/core-utils'
+import { sandboxCapacity } from '../../../src/lib/sandbox/capacity'
+import { egressNetnsInternals } from '../../../src/lib/sandbox/netns'
+
+function flat(commands: { binary: string, args: string[] }[]): string[] {
+    return commands.map((c) => `${c.binary} ${c.args.join(' ')}`)
+}
+
+describe('egressNetnsInternals.buildTopology', () => {
+    it('carves a /30 per box from 10.255.0.0/16 (gateway = net+1, box = net+2)', () => {
+        const t = egressNetnsInternals.buildTopology(1)
+        expect(t).toMatchObject({
+            boxId: 1,
+            netnsName: 'ap-egress-1',
+            vethHost: 'ap-veth-h1',
+            vethBox: 'ap-veth-b1',
+            subnetCidr: '10.255.0.4/30',
+            gatewayHost: '10.255.0.5',
+            boxHost: '10.255.0.6',
+            chain: 'AP_EG_FWD_1',
+            rpcPort: sandboxCapacity.wsRpcPortForBox(1),
+        })
+    })
+
+    it('rolls into the next third octet past box 63 (offset 256)', () => {
+        const t = egressNetnsInternals.buildTopology(64)
+        expect(t.subnetCidr).toBe('10.255.1.0/30')
+        expect(t.gatewayHost).toBe('10.255.1.1')
+        expect(t.boxHost).toBe('10.255.1.2')
+    })
+
+    it('gives distinct, non-overlapping /30s to distinct boxes', () => {
+        const gateways = new Set<string>()
+        for (let boxId = 1; boxId <= 200; boxId++) {
+            gateways.add(egressNetnsInternals.buildTopology(boxId).gatewayHost)
+        }
+        expect(gateways.size).toBe(200)
+    })
+
+    it('throws when boxId exceeds the 10.255.0.0/16 pool', () => {
+        expect(() => egressNetnsInternals.buildTopology(20000)).toThrow(/too large/)
+    })
+})
+
+describe('egressNetnsInternals.buildCreateCommands', () => {
+    const t = egressNetnsInternals.buildTopology(1)
+    const commands = egressNetnsInternals.buildCreateCommands(t)
+    const lines = flat(commands)
+
+    it('creates the netns, veth pair, addressing and default route', () => {
+        expect(lines).toContain('ip netns add ap-egress-1')
+        expect(lines).toContain('ip link add ap-veth-h1 type veth peer name ap-veth-b1')
+        expect(lines).toContain('ip link set ap-veth-b1 netns ap-egress-1')
+        expect(lines).toContain('ip addr add 10.255.0.5/30 dev ap-veth-h1')
+        expect(lines).toContain('ip netns exec ap-egress-1 ip addr add 10.255.0.6/30 dev ap-veth-b1')
+        expect(lines).toContain('ip netns exec ap-egress-1 ip route add default via 10.255.0.5')
+    })
+
+    it('arms FORWARD/INPUT filters and ip6tables DROP before bringing links up', () => {
+        const firstUp = lines.findIndex((l) => l.includes('link set') && l.endsWith(' up'))
+        const forwardJump = lines.findIndex((l) => l.includes('-I FORWARD 1') && l.includes('AP_EG_FWD_1'))
+        const ip6Drop = lines.findIndex((l) => l.includes('ip6tables') && l.includes('OUTPUT') && l.includes('DROP'))
+        expect(firstUp).toBeGreaterThan(-1)
+        expect(forwardJump).toBeGreaterThan(-1)
+        expect(ip6Drop).toBeGreaterThan(-1)
+        expect(forwardJump).toBeLessThan(firstUp)
+        expect(ip6Drop).toBeLessThan(firstUp)
+    })
+
+    it('disables IPv6 addrgen on both veth ends before up', () => {
+        expect(lines).toContain('ip link set ap-veth-h1 addrgenmode none')
+        expect(lines).toContain('ip netns exec ap-egress-1 ip link set ap-veth-b1 addrgenmode none')
+    })
+
+    it('emits NO mtu commands when the uplink MTU could not be discovered (keeps the kernel default)', () => {
+        expect(lines.some((l) => l.includes(' mtu '))).toBe(false)
+    })
+
+    it('sets the discovered MTU on BOTH veth ends before bringing them up (each end is independent)', () => {
+        const withMtu = flat(egressNetnsInternals.buildCreateCommands(t, { mtu: 1450 }))
+        expect(withMtu).toContain('ip link set ap-veth-h1 mtu 1450')
+        expect(withMtu).toContain('ip netns exec ap-egress-1 ip link set ap-veth-b1 mtu 1450')
+        const lastMtu = withMtu.reduce((acc, l, i) => (l.includes(' mtu ') ? i : acc), -1)
+        const firstUp = withMtu.findIndex((l) => l.includes('link set') && l.endsWith(' up'))
+        expect(lastMtu).toBeLessThan(firstUp)
+    })
+
+    it('NATs the box /30 out the uplink (never back into its own veth), inserted at the top of nat', () => {
+        expect(lines).toContain('iptables -t nat -I POSTROUTING 1 -s 10.255.0.4/30 ! -o ap-veth-h1 -j MASQUERADE')
+    })
+
+    it('REJECTs 0.0.0.0/8, metadata, loopback and every RFC1918 range from the box', () => {
+        for (const cidr of ['0.0.0.0/8', '169.254.0.0/16', '127.0.0.0/8', '10.0.0.0/8', '172.16.0.0/12', '192.168.0.0/16', '100.64.0.0/10']) {
+            expect(lines).toContain(`iptables -A AP_EG_FWD_1 -d ${cidr} -j REJECT --reject-with icmp-host-prohibited`)
+        }
+    })
+
+    it('drops all IPv6 out of the box netns (belt-and-suspenders for v6 metadata like fd00:ec2::254)', () => {
+        expect(lines).toContain('ip netns exec ap-egress-1 ip6tables -A OUTPUT -j DROP')
+    })
+
+    it('rejects the pool first and puts public egress last (order matters)', () => {
+        const chainRules = lines.filter((l) => l.startsWith('iptables -A AP_EG_FWD_1'))
+        expect(chainRules[0]).toBe('iptables -A AP_EG_FWD_1 -d 10.255.0.0/16 -j REJECT --reject-with icmp-host-prohibited')
+        const lastAccept = 'iptables -A AP_EG_FWD_1 -j ACCEPT'
+        const rejectIdxs = chainRules.map((l, i) => (l.includes('REJECT') ? i : -1)).filter((i) => i >= 0)
+        // the catch-all ACCEPT must come AFTER every REJECT, otherwise internal ranges would leak
+        expect(chainRules.indexOf(lastAccept)).toBeGreaterThan(Math.max(...rejectIdxs))
+    })
+
+    it('carries NO conntrack state ACCEPT in the egress chain — it would override every REJECT below it', () => {
+        // A state-based ACCEPT here would sit above every REJECT and let a conntrack helper reach metadata.
+        const chainRules = lines.filter((l) => l.startsWith('iptables -A AP_EG_FWD_1'))
+        expect(chainRules.some((l) => l.includes('conntrack'))).toBe(false)
+    })
+
+    it('INSERTS the FORWARD jump at the top, pinned to the box interface + source, so a pre-existing ACCEPT cannot bypass the chain', () => {
+        expect(lines).toContain('iptables -I FORWARD 1 -i ap-veth-h1 -s 10.255.0.4/30 -j AP_EG_FWD_1')
+        // must not append — an appended jump runs after any earlier ACCEPT (Docker/CNI/ops)
+        expect(lines.some((l) => l.startsWith('iptables -A FORWARD '))).toBe(false)
+    })
+
+    it('DROPs spoofed source: any packet from the box interface whose source is not the box /30', () => {
+        expect(lines).toContain('iptables -I FORWARD 1 -i ap-veth-h1 ! -s 10.255.0.4/30 -j DROP')
+    })
+
+    it('admits established reply traffic on the box veth independent of the ambient FORWARD policy', () => {
+        // Replies are -d subnet and skip the egress jump, so without this they hang under FORWARD DROP.
+        expect(lines).toContain('iptables -I FORWARD 1 -o ap-veth-h1 -m conntrack --ctstate ESTABLISHED -j ACCEPT')
+    })
+
+    it('admits RELATED replies only for ICMP, so PMTUD survives but helper expectations cannot open a port', () => {
+        // RELATED is ICMP-only: widening it lets a conntrack helper open an inbound expectation.
+        expect(lines).toContain('iptables -I FORWARD 1 -o ap-veth-h1 -p icmp -m conntrack --ctstate RELATED -j ACCEPT')
+        expect(lines.some((l) => l.includes('--ctstate ESTABLISHED,RELATED'))).toBe(false)
+    })
+
+    it('lets the box reach ONLY its own gateway IP + WS-RPC port via a per-box INPUT chain, dropping other host services', () => {
+        const rpcPort = sandboxCapacity.wsRpcPortForBox(1)
+        // ACCEPT is pinned to the gateway IP (-d) and port, inside a per-box chain above the catch-all DROP
+        expect(lines).toContain(`iptables -A AP_EG_IN_1 -d 10.255.0.5 -p tcp --dport ${rpcPort} -j ACCEPT`)
+        expect(lines).toContain('iptables -A AP_EG_IN_1 -j DROP')
+        expect(lines).toContain('iptables -I INPUT 1 -i ap-veth-h1 -j AP_EG_IN_1')
+        // hostNetwork / shared-netns: drop anything to the gateway that did not arrive on the box veth
+        expect(lines).toContain('iptables -I INPUT 1 ! -i ap-veth-h1 -d 10.255.0.5 -j DROP')
+        // Both are top-inserted so they sit above any ambient ACCEPT; neither may be appended.
+        expect(lines.filter((l) => l.startsWith('iptables -I INPUT 1 ')).length).toBe(2)
+        // the jump goes through the chain — no ad-hoc rules appended straight to INPUT
+        expect(lines.some((l) => l.startsWith('iptables -A INPUT '))).toBe(false)
+    })
+
+    it('does NOT open an app callback port when none is given (no loopback rewrite)', () => {
+        expect(lines.some((l) => l.includes('AP_EG_IN_1') && l.includes('ACCEPT') && !l.includes(String(sandboxCapacity.wsRpcPortForBox(1))))).toBe(false)
+    })
+
+    it('opens the app callback port in the INPUT chain, above the DROP, when one is passed', () => {
+        const withCallback = flat(egressNetnsInternals.buildCreateCommands(t, { callbackPort: 3000 }))
+        const accept = 'iptables -A AP_EG_IN_1 -d 10.255.0.5 -p tcp --dport 3000 -j ACCEPT'
+        const drop = 'iptables -A AP_EG_IN_1 -j DROP'
+        expect(withCallback).toContain(accept)
+        expect(withCallback.indexOf(accept)).toBeLessThan(withCallback.indexOf(drop))
+    })
+
+    it('ACCEPTs operator allow-list CIDRs ABOVE the blocked-range REJECTs (so an allowed internal host is reachable)', () => {
+        const withAllow = flat(egressNetnsInternals.buildCreateCommands(t, { allowCidrs: ['10.9.9.9/32', '172.30.0.0/16'] }))
+        const allowRule = 'iptables -A AP_EG_FWD_1 -d 10.9.9.9/32 -j ACCEPT'
+        const firstBlockedReject = withAllow.findIndex((l) => l.startsWith('iptables -A AP_EG_FWD_1 -d 10.0.0.0/8 -j REJECT'))
+        expect(withAllow).toContain(allowRule)
+        expect(withAllow).toContain('iptables -A AP_EG_FWD_1 -d 172.30.0.0/16 -j ACCEPT')
+        expect(withAllow.indexOf(allowRule)).toBeLessThan(firstBlockedReject)
+    })
+
+    it('ACCEPTs auto API endpoints port-scoped (not all ports on the API host)', () => {
+        const withApi = flat(egressNetnsInternals.buildCreateCommands(t, {
+            apiAllowEndpoints: [{ ip: '10.96.0.10', port: 3000, cidr: '10.96.0.10/32' }],
+        }))
+        expect(withApi).toContain('iptables -A AP_EG_FWD_1 -d 10.96.0.10/32 -p tcp --dport 3000 -j ACCEPT')
+        expect(withApi).not.toContain('iptables -A AP_EG_FWD_1 -d 10.96.0.10/32 -j ACCEPT')
+    })
+
+    it('REJECTs the whole egress pool ABOVE the allow-list (cross-tenant box↔box isolation, even if allow-listed)', () => {
+        const withAllow = flat(egressNetnsInternals.buildCreateCommands(t, { allowCidrs: ['10.0.0.0/8'] }))
+        const poolReject = 'iptables -A AP_EG_FWD_1 -d 10.255.0.0/16 -j REJECT --reject-with icmp-host-prohibited'
+        const allow = 'iptables -A AP_EG_FWD_1 -d 10.0.0.0/8 -j ACCEPT'
+        expect(withAllow).toContain(poolReject)
+        expect(withAllow.indexOf(poolReject)).toBeLessThan(withAllow.indexOf(allow))
+    })
+})
+
+describe('egressNetnsInternals.resolveCallbackRewrite', () => {
+    it('rewrites a host-loopback internalApiUrl to the gateway IP, keeping port + path', () => {
+        expect(egressNetnsInternals.resolveCallbackRewrite({ internalApiUrl: 'http://127.0.0.1:3000/api/', gatewayHost: '10.255.0.5' }))
+            .toEqual({ port: 3000, url: 'http://10.255.0.5:3000/api/' })
+    })
+
+    it('treats localhost and ::1 as loopback', () => {
+        expect(egressNetnsInternals.resolveCallbackRewrite({ internalApiUrl: 'http://localhost:8080/api/', gatewayHost: '10.255.0.5' }))
+            .toEqual({ port: 8080, url: 'http://10.255.0.5:8080/api/' })
+        expect(egressNetnsInternals.resolveCallbackRewrite({ internalApiUrl: 'http://[::1]:8080/api/', gatewayHost: '10.255.0.5' })?.url)
+            .toBe('http://10.255.0.5:8080/api/')
+    })
+
+    it('defaults the port from the protocol when the URL omits it', () => {
+        expect(egressNetnsInternals.resolveCallbackRewrite({ internalApiUrl: 'http://127.0.0.1/api/', gatewayHost: '10.255.0.5' })?.port).toBe(80)
+        expect(egressNetnsInternals.resolveCallbackRewrite({ internalApiUrl: 'https://127.0.0.1/api/', gatewayHost: '10.255.0.5' })?.port).toBe(443)
+    })
+
+    it('returns null for a NON-loopback URL (remote rewrite is resolveApiEgress)', () => {
+        expect(egressNetnsInternals.resolveCallbackRewrite({ internalApiUrl: 'https://app.example.com/api/', gatewayHost: '10.255.0.5' })).toBeNull()
+        expect(egressNetnsInternals.resolveCallbackRewrite({ internalApiUrl: 'http://10.0.0.9:3000/api/', gatewayHost: '10.255.0.5' })).toBeNull()
+    })
+
+    it('returns null for an unparseable URL rather than throwing', () => {
+        expect(egressNetnsInternals.resolveCallbackRewrite({ internalApiUrl: 'not a url', gatewayHost: '10.255.0.5' })).toBeNull()
+    })
+})
+
+describe('egressNetnsInternals.resolveApiEgress', () => {
+    const log = {
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        debug: vi.fn(),
+    }
+
+    beforeEach(() => {
+        log.info.mockClear()
+        log.warn.mockClear()
+        log.error.mockClear()
+        log.debug.mockClear()
+        vi.restoreAllMocks()
+    })
+
+    it('returns empty for missing URL or loopback (INPUT punch / loopback rewrite path)', async () => {
+        expect(await egressNetnsInternals.resolveApiEgress({ internalApiUrl: undefined, log })).toEqual({
+            endpoints: [],
+            pinHostname: null,
+            fingerprint: '',
+        })
+        expect(await egressNetnsInternals.resolveApiEgress({ internalApiUrl: 'http://127.0.0.1:3000/api/', log })).toEqual({
+            endpoints: [],
+            pinHostname: null,
+            fingerprint: '',
+        })
+        expect(await egressNetnsInternals.resolveApiEgress({ internalApiUrl: 'http://localhost:3000/api/', log })).toEqual({
+            endpoints: [],
+            pinHostname: null,
+            fingerprint: '',
+        })
+    })
+
+    it('needs NO host pin for a private IPv4 literal API URL (nothing to resolve) but still port-scopes it', async () => {
+        expect(await egressNetnsInternals.resolveApiEgress({ internalApiUrl: 'http://10.0.0.9:3000/api/', log }))
+            .toEqual({
+                endpoints: [{ ip: '10.0.0.9', port: 3000, cidr: '10.0.0.9/32' }],
+                pinHostname: null,
+                fingerprint: '10.0.0.9:3000',
+            })
+    })
+
+    it('resolves a hostname to EVERY IPv4 endpoint and pins the NAME, never rewriting it to an address', async () => {
+        vi.spyOn(dns.promises, 'lookup').mockResolvedValue([
+            { address: '10.96.0.10', family: 4 },
+            { address: '10.96.0.11', family: 4 },
+        ] as never)
+        expect(await egressNetnsInternals.resolveApiEgress({ internalApiUrl: 'http://api.default.svc/api/', log }))
+            .toEqual({
+                endpoints: [
+                    { ip: '10.96.0.10', port: 80, cidr: '10.96.0.10/32' },
+                    { ip: '10.96.0.11', port: 80, cidr: '10.96.0.11/32' },
+                ],
+                pinHostname: 'api.default.svc',
+                fingerprint: '10.96.0.10:80,10.96.0.11:80',
+            })
+    })
+
+    // Rewriting the hostname to an address dropped SNI and failed the handshake on every https app URL.
+    it('leaves an https hostname URL completely untouched (no address ever replaces the name)', async () => {
+        vi.spyOn(dns.promises, 'lookup').mockResolvedValue([
+            { address: '104.21.83.205', family: 4 },
+            { address: '172.67.181.76', family: 4 },
+        ] as never)
+        const resolution = await egressNetnsInternals.resolveApiEgress({ internalApiUrl: 'https://app.example.com/api/', log })
+        expect(resolution.pinHostname).toBe('app.example.com')
+        expect(JSON.stringify(resolution)).not.toContain('https://104.21.83.205')
+        expect(resolution.endpoints.map((endpoint) => `${endpoint.ip}:${endpoint.port}`))
+            .toEqual(['104.21.83.205:443', '172.67.181.76:443'])
+    })
+
+    it('returns a port-scoped endpoint for a public IPv4 literal', async () => {
+        expect(await egressNetnsInternals.resolveApiEgress({ internalApiUrl: 'https://203.0.113.50/api/', log }))
+            .toEqual({
+                endpoints: [{ ip: '203.0.113.50', port: 443, cidr: '203.0.113.50/32' }],
+                pinHostname: null,
+                fingerprint: '203.0.113.50:443',
+            })
+    })
+
+    // Rejected by the WHATWG URL host parser, not the IPv4 guard, which is why that guard is IPv6-only.
+    it('rejects a dotted-quad host whose octets are out of range', async () => {
+        await expect(egressNetnsInternals.resolveApiEgress({ internalApiUrl: 'http://999.1.1.1:3000/api/', log }))
+            .rejects.toThrow(/is not a valid URL/)
+    })
+
+    it('rejects a non-loopback IPv6 host (no v6 egress exists inside the box)', async () => {
+        await expect(egressNetnsInternals.resolveApiEgress({ internalApiUrl: 'http://[2001:db8::1]:3000/api/', log }))
+            .rejects.toThrow(/not a usable IPv4 address/)
+    })
+
+    it.each(['http://2130706433:3000/api/', 'http://0x7f000001:3000/api/'])(
+        'treats a decimal/hex-encoded loopback host as loopback, not as an egress endpoint (%s)',
+        async (internalApiUrl) => {
+            expect(await egressNetnsInternals.resolveApiEgress({ internalApiUrl, log }))
+                .toEqual({ endpoints: [], pinHostname: null, fingerprint: '' })
+        },
+    )
+
+    it('fails closed when DNS yields no usable IPv4 (all forbidden or empty)', async () => {
+        vi.spyOn(dns.promises, 'lookup').mockResolvedValue([
+            { address: '169.254.169.254', family: 4 },
+        ] as never)
+        await expect(egressNetnsInternals.resolveApiEgress({ internalApiUrl: 'http://meta.internal/api/', log }))
+            .rejects.toThrow(/no usable IPv4/)
+    })
+
+    it('fails closed when DNS lookup fails', async () => {
+        vi.spyOn(dns.promises, 'lookup').mockRejectedValue(new Error('ENOTFOUND'))
+        await expect(egressNetnsInternals.resolveApiEgress({ internalApiUrl: 'http://missing.example/api/', log }))
+            .rejects.toThrow(/cannot resolve/)
+    })
+})
+
+describe('egressNetnsInternals.serializePerBox', () => {
+    const delayed = (order: string[], label: string, ms: number) => () =>
+        new Promise<void>((resolve) => setTimeout(() => { order.push(label); resolve() }, ms))
+
+    it('runs operations for the SAME box strictly in order, even when a later one is faster', async () => {
+        const order: string[] = []
+        await Promise.all([
+            egressNetnsInternals.serializePerBox(1, delayed(order, 'first', 20)),
+            egressNetnsInternals.serializePerBox(1, delayed(order, 'second', 1)),
+        ])
+        expect(order).toEqual(['first', 'second'])
+    })
+
+    it('does not block a rejected op from letting the next same-box op run (chain survives errors)', async () => {
+        const order: string[] = []
+        await egressNetnsInternals.serializePerBox(2, () => Promise.reject(new Error('boom'))).catch(() => undefined)
+        await egressNetnsInternals.serializePerBox(2, delayed(order, 'after-failure', 1))
+        expect(order).toEqual(['after-failure'])
+    })
+
+    it('lets different boxes run concurrently', async () => {
+        const order: string[] = []
+        await Promise.all([
+            egressNetnsInternals.serializePerBox(3, delayed(order, 'slow-box3', 20)),
+            egressNetnsInternals.serializePerBox(4, delayed(order, 'fast-box4', 1)),
+        ])
+        expect(order).toEqual(['fast-box4', 'slow-box3'])
+    })
+})
+
+describe('egressNetnsInternals.parseNetnsBoxIds', () => {
+    it('extracts boxIds from `ip netns list`, ignoring non-egress namespaces', () => {
+        const listing = ['ap-egress-1 (id: 0)', 'ap-egress-42', 'some-other-ns (id: 3)', 'ap-egress-7 (id: 1)', ''].join('\n')
+        expect(egressNetnsInternals.parseNetnsBoxIds(listing).sort((a, b) => a - b)).toEqual([1, 7, 42])
+    })
+
+    it('returns empty when there are no egress namespaces', () => {
+        expect(egressNetnsInternals.parseNetnsBoxIds('lo\ndefault (id: 0)')).toEqual([])
+    })
+
+    it('does not match lookalikes (ap-egress-foo, prefixed, or no id)', () => {
+        expect(egressNetnsInternals.parseNetnsBoxIds('ap-egress-foo\nxap-egress-1\nap-egress-')).toEqual([])
+    })
+})
+
+describe('egressNetnsInternals.buildDestroyCommands', () => {
+    const t = egressNetnsInternals.buildTopology(1)
+    const lines = flat(egressNetnsInternals.buildDestroyCommands(t))
+
+    it('removes every resource (veth, netns, chains, nat, jumps)', () => {
+        expect(lines).toContain('ip link set ap-veth-h1 down')
+        expect(lines).toContain('ip netns del ap-egress-1')
+        expect(lines).toContain('ip link del ap-veth-h1')
+        expect(lines).toContain('iptables -X AP_EG_FWD_1')
+        expect(lines).toContain('iptables -X AP_EG_IN_1')
+        expect(lines).toContain('iptables -D INPUT ! -i ap-veth-h1 -d 10.255.0.5 -j DROP')
+        expect(lines).toContain('iptables -D FORWARD -i ap-veth-h1 -s 10.255.0.4/30 -j AP_EG_FWD_1')
+        expect(lines).toContain('iptables -D FORWARD -o ap-veth-h1 -m conntrack --ctstate ESTABLISHED -j ACCEPT')
+        expect(lines).toContain('iptables -D FORWARD -o ap-veth-h1 -p icmp -m conntrack --ctstate RELATED -j ACCEPT')
+        expect(lines).toContain('iptables -D FORWARD -i ap-veth-h1 ! -s 10.255.0.4/30 -j DROP')
+        expect(lines).toContain('iptables -t nat -D POSTROUTING -s 10.255.0.4/30 ! -o ap-veth-h1 -j MASQUERADE')
+    })
+
+    // Rules in SHARED chains are removed by exact spec, so an unmirrored create leaves one armed forever.
+    it('is an exact inverse of buildCreateCommands for every shared-chain rule (-I must have a matching -D)', () => {
+        const spec = (line: string, flag: '-I' | '-D'): string | null => {
+            const match = line.match(new RegExp(`^iptables (-t \\w+ )?\\${flag} (FORWARD|INPUT|POSTROUTING) (?:1 )?(.+)$`))
+            return match ? `${match[1] ?? ''}${match[2]} ${match[3]}` : null
+        }
+        const created = flat(egressNetnsInternals.buildCreateCommands(t, {
+            callbackPort: 3000,
+            allowCidrs: ['10.9.0.0/24'],
+            apiAllowEndpoints: [{ ip: '10.8.0.1', port: 443, cidr: '10.8.0.1/32' }],
+            mtu: 1450,
+        })).map((l) => spec(l, '-I')).filter((s): s is string => s !== null)
+        const removed = flat(egressNetnsInternals.buildDestroyCommands(t)).map((l) => spec(l, '-D')).filter((s): s is string => s !== null)
+
+        expect(created.length).toBeGreaterThan(0)
+        expect([...created].sort()).toEqual([...removed].sort())
+    })
+
+    it('FAILS CLOSED: severs the egress path (veth down, netns/veth deleted) BEFORE removing host filter rules', () => {
+        const vethDown = lines.indexOf('ip link set ap-veth-h1 down')
+        const netnsDel = lines.indexOf('ip netns del ap-egress-1')
+        const vethDel = lines.indexOf('ip link del ap-veth-h1')
+        const firstHostRuleRemoval = lines.findIndex((l) => l.startsWith('iptables -D') || l.startsWith('iptables -F') || l.startsWith('iptables -X'))
+        expect(vethDown).toBeLessThan(netnsDel)
+        expect(vethDel).toBeLessThan(firstHostRuleRemoval)
+    })
+})
+
+describe('BLOCKED_CIDRS parity with ssrfIpClassifier (kernel list must not drift from the in-process guard)', () => {
+    const representativeIps: Record<string, string> = {
+        '0.0.0.0/8': '0.1.2.3',
+        '10.0.0.0/8': '10.1.2.3',
+        '100.64.0.0/10': '100.100.100.200',
+        '127.0.0.0/8': '127.0.0.1',
+        '169.254.0.0/16': '169.254.169.254',
+        '172.16.0.0/12': '172.16.5.5',
+        '192.0.0.0/24': '192.0.0.192',
+        '192.0.2.0/24': '192.0.2.5',
+        '192.88.99.0/24': '192.88.99.1',
+        '192.168.0.0/16': '192.168.1.1',
+        '198.18.0.0/15': '198.18.0.1',
+        '198.51.100.0/24': '198.51.100.5',
+        '203.0.113.0/24': '203.0.113.5',
+        '224.0.0.0/4': '239.1.2.3',
+        '240.0.0.0/4': '255.255.255.255',
+    }
+
+    it('covers exactly the ranges enumerated (kept in sync with the representative-IP map)', () => {
+        expect([...egressNetnsInternals.BLOCKED_CIDRS].sort()).toEqual(Object.keys(representativeIps).sort())
+    })
+
+    it('ssrfIpClassifier.isBlockedIp is true for a representative IP in every kernel-blocked CIDR', () => {
+        for (const [cidr, ip] of Object.entries(representativeIps)) {
+            expect(ssrfIpClassifier.isBlockedIp({ ip, allowList: [] }), `${ip} (${cidr})`).toBe(true)
+        }
+    })
+
+    it('a public unicast IP is NOT in any kernel-blocked CIDR (and the classifier agrees)', () => {
+        const publicIp = '93.184.216.34'
+        expect([...egressNetnsInternals.BLOCKED_CIDRS].some((cidr) => {
+            const range = egressNetnsInternals.cidrToRange(cidr)
+            const ipRange = egressNetnsInternals.cidrToRange(`${publicIp}/32`)
+            return range !== null && ipRange !== null && egressNetnsInternals.rangesOverlap(range, ipRange)
+        })).toBe(false)
+        expect(ssrfIpClassifier.isBlockedIp({ ip: publicIp, allowList: [] })).toBe(false)
+    })
+})
+
+describe('egressNetnsInternals.toKernelAllowCidrs', () => {
+    const log = {
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        debug: vi.fn(),
+    }
+
+    beforeEach(() => {
+        log.info.mockClear()
+        log.warn.mockClear()
+        log.error.mockClear()
+        log.debug.mockClear()
+    })
+
+    it('keeps IPv4 literals (as /32) and RFC1918 CIDRs; drops IPv6 with a warn', () => {
+        expect(egressNetnsInternals.toKernelAllowCidrs({
+            allowList: ['10.9.9.9', '172.30.0.0/16', 'fd00::1', '2001:db8::/32'],
+            log,
+        })).toEqual(['10.9.9.9/32', '172.30.0.0/16'])
+        expect(log.warn).toHaveBeenCalled()
+    })
+
+    it('DROPS hostnames with an error log (kernel cannot pin names) but keeps valid IPs — never throws', () => {
+        expect(egressNetnsInternals.toKernelAllowCidrs({
+            allowList: ['10.9.9.9', 'db.internal'],
+            log,
+        })).toEqual(['10.9.9.9/32'])
+        expect(log.error).toHaveBeenCalled()
+    })
+
+    it('drops metadata/link-local, CGNAT (Alibaba), and 0.0.0.0/8 (incl. 0.0.0.0/0) with an error log; keeps RFC1918', () => {
+        expect(egressNetnsInternals.toKernelAllowCidrs({
+            allowList: [
+                '169.254.169.254',
+                '169.254.0.0/16',
+                '100.100.100.200',
+                '100.64.0.0/10',
+                '0.0.0.0/0',
+                '0.0.0.0/8',
+                '0.1.2.3',
+                '10.9.9.9/32',
+                '192.168.1.0/24',
+            ],
+            log,
+        })).toEqual(['10.9.9.9/32', '192.168.1.0/24'])
+        expect(log.error).toHaveBeenCalled()
+        expect(log.error.mock.calls.some((call) => String(call[1]).includes('metadata/link-local/CGNAT'))).toBe(true)
+    })
+
+    it('rejects malformed IPs/prefixes and dedupes', () => {
+        expect(egressNetnsInternals.toKernelAllowCidrs({
+            allowList: ['999.1.1.1', '10.0.0.1/33', '10.0.0.1/8', '10.0.0.1/8'],
+            log,
+        })).toEqual(['10.0.0.1/8'])
+    })
+})
+
+describe('egressNetnsInternals.withXtablesWait', () => {
+    it('prepends a bounded --wait (below the process timeout) to host iptables commands only', () => {
+        expect(egressNetnsInternals.withXtablesWait({ binary: 'iptables', args: ['-N', 'AP_EG_FWD_1'] }))
+            .toEqual({ binary: 'iptables', args: ['--wait', '3', '-N', 'AP_EG_FWD_1'] })
+    })
+
+    it('leaves ip / in-netns commands untouched', () => {
+        expect(egressNetnsInternals.withXtablesWait({ binary: 'ip', args: ['netns', 'add', 'ap-egress-1'] }))
+            .toEqual({ binary: 'ip', args: ['netns', 'add', 'ap-egress-1'] })
+    })
+})
+
+describe('egressNetnsInternals subnet config + host-overlap', () => {
+    it('parses a valid /16 override and rejects non-/16 or non-zero-tail values', () => {
+        expect(egressNetnsInternals.parseSlash16('172.30.0.0/16')).toEqual({ prefix: '172.30', cidr: '172.30.0.0/16' })
+        expect(egressNetnsInternals.parseSlash16('10.255.0.0/24')).toBeNull()
+        expect(egressNetnsInternals.parseSlash16('10.255.1.0/16')).toBeNull()
+        expect(egressNetnsInternals.parseSlash16('999.0.0.0/16')).toBeNull()
+    })
+
+    it('carves the box /30 from a configured base prefix', () => {
+        const t = egressNetnsInternals.buildTopology(1, { prefix: '172.30', cidr: '172.30.0.0/16' })
+        expect(t.gatewayHost).toBe('172.30.0.5')
+        expect(t.boxHost).toBe('172.30.0.6')
+        expect(t.subnetCidr).toBe('172.30.0.4/30')
+    })
+
+    it('detects overlap between the egress /16 and host networks, excluding our own ap-veth addresses', () => {
+        const ours = egressNetnsInternals.cidrToRange('10.255.0.0/16')!
+        const hostCidrs = egressNetnsInternals.parseHostCidrs({
+            addrOutput: [
+                '2: eth0    inet 10.255.4.2/24 scope global eth0',       // a real host network inside our /16 → overlap
+                '9: ap-veth-h1    inet 10.255.0.5/30 scope global ap-veth-h1', // our own veth → excluded
+            ].join('\n'),
+            routeOutput: '10.0.0.0/24 dev eth0 proto kernel scope link',
+        })
+        expect(hostCidrs).toContain('10.255.4.2/24')
+        expect(hostCidrs).not.toContain('10.255.0.5/30')
+        expect(hostCidrs.some((c) => egressNetnsInternals.rangesOverlap(ours, egressNetnsInternals.cidrToRange(c)!))).toBe(true)
+    })
+
+    it('no overlap when host networks are disjoint from the egress /16', () => {
+        const ours = egressNetnsInternals.cidrToRange('10.255.0.0/16')!
+        const hostCidrs = egressNetnsInternals.parseHostCidrs({ addrOutput: '2: eth0 inet 192.168.1.10/24 scope global eth0', routeOutput: 'default via 192.168.1.1 dev eth0' })
+        expect(hostCidrs.some((c) => egressNetnsInternals.rangesOverlap(ours, egressNetnsInternals.cidrToRange(c)!))).toBe(false)
+    })
+
+    it('parseHostAddresses captures route next-hops and UNMASKED interface addresses (excluding our veth)', () => {
+        const addresses = egressNetnsInternals.parseHostAddresses({
+            addrOutput: [
+                '2: eth0    inet 10.255.0.7/8 scope global eth0',              // wide mask hides it from the subset CIDR test
+                '9: ap-veth-h1    inet 10.255.0.5/30 scope global ap-veth-h1', // ours → excluded
+            ].join('\n'),
+            routeOutput: 'default via 10.255.0.1 dev eth0',                    // next-hop inside the pool
+        })
+        expect(addresses).toContain('10.255.0.7') // unmasked address, not 10.0.0.0/8
+        expect(addresses).toContain('10.255.0.1') // next-hop
+        expect(addresses).not.toContain('10.255.0.5') // our own veth excluded
+    })
+})
+
+describe('egressNetnsInternals.parseResourceBoxIds', () => {
+    it('extracts boxIds from veth links and iptables chains (union with netns for the sweep)', () => {
+        const listing = [
+            '9: ap-veth-h2@if8: <BROADCAST> mtu 1500',
+            '-N AP_EG_FWD_5',
+            '-A AP_EG_IN_5 -j DROP',
+            'lo unrelated',
+        ].join('\n')
+        expect(egressNetnsInternals.parseResourceBoxIds(listing).sort((a, b) => a - b)).toEqual([2, 5])
+    })
+})

--- a/packages/server/sandbox/test/lib/sandbox/sandbox.test.ts
+++ b/packages/server/sandbox/test/lib/sandbox/sandbox.test.ts
@@ -127,6 +127,49 @@ describe('createSandbox', () => {
             )
         })
 
+        // These three env vars ARE the contract; rewriting the URL to an address dropped SNI and the Host.
+        it('hands the box the netns, the gateway WS host, and EVERY opened API endpoint plus the DNS pin', async () => {
+            const log = createMockLogger()
+            testPM = createTestProcessMaker()
+            const getEgress = vi.fn().mockResolvedValue({
+                netnsName: 'ap-egress-1',
+                gatewayHost: '127.0.0.1',
+                callbackApiUrl: null,
+                callbackPort: null,
+                apiAllow: '10.0.0.9:3000,10.0.0.10:3000',
+                apiHostPin: 'api.internal=10.0.0.9,10.0.0.10',
+                fingerprint: '10.0.0.9:3000,10.0.0.10:3000',
+            })
+            sandbox = createSandbox(log, 'sb-egress', { ...defaultOptions, getEgress }, testPM.maker)
+
+            await sandbox.start(startOptions)
+
+            expect(testPM.maker.create).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    netnsName: 'ap-egress-1',
+                    env: expect.objectContaining({
+                        AP_SANDBOX_WS_HOST: '127.0.0.1',
+                        AP_SANDBOX_API_ALLOW: '10.0.0.9:3000,10.0.0.10:3000',
+                        AP_SANDBOX_API_HOST_PIN: 'api.internal=10.0.0.9,10.0.0.10',
+                    }),
+                }),
+            )
+        })
+
+        it('omits the netns and egress env entirely when there is no egress (host netns modes)', async () => {
+            const log = createMockLogger()
+            testPM = createTestProcessMaker()
+            sandbox = createSandbox(log, 'sb-no-egress', defaultOptions, testPM.maker)
+
+            await sandbox.start(startOptions)
+
+            const params = testPM.maker.create.mock.calls[0][0]
+            expect(params.netnsName).toBeUndefined()
+            expect(params.env).not.toHaveProperty('AP_SANDBOX_WS_HOST')
+            expect(params.env).not.toHaveProperty('AP_SANDBOX_API_ALLOW')
+            expect(params.env).not.toHaveProperty('AP_SANDBOX_API_HOST_PIN')
+        })
+
         it('does not add custom piece mount when platformId is empty', async () => {
             const log = createMockLogger()
             testPM = createTestProcessMaker()

--- a/packages/server/worker/src/lib/worker.ts
+++ b/packages/server/worker/src/lib/worker.ts
@@ -1,9 +1,9 @@
 import { createServer } from 'http'
 import os from 'os'
 import { ActivepiecesError, isNil, spreadIfDefined, tryCatch } from '@activepieces/core-utils'
-import { createResolver, createSandboxRuntime, Runtime } from '@activepieces/sandbox'
+import { createResolver, createSandboxRuntime, type EgressNetworkLease, isIsolateMode, prepareEgressEnvironment, Runtime } from '@activepieces/sandbox'
 import { apVersionUtil, createLogger, onCallService, systemUsage, UNKNOWN_VERSION, wideEvent } from '@activepieces/server-utils'
-import { ApiToWorkerContract, ConsumeJobRequest, createNotifyServer, createRpcClient, EngineResponseStatus, ExecutionMode, JobData, SandboxInformation, WebsocketServerEvent, WorkerJobType, WorkerMachineHealthcheckRequest, WorkerProps, WorkerSettingsResponse, WorkerToApiContract } from '@activepieces/shared'
+import { ApiToWorkerContract, ConsumeJobRequest, createNotifyServer, createRpcClient, EngineResponseStatus, ExecutionMode, JobData, NetworkMode, SandboxInformation, WebsocketServerEvent, WorkerJobType, WorkerMachineHealthcheckRequest, WorkerProps, WorkerSettingsResponse, WorkerToApiContract } from '@activepieces/shared'
 import { nanoid } from 'nanoid'
 import { io, Socket } from 'socket.io-client'
 import { createApiToWorkerHandlers } from './api-notify-service'
@@ -19,7 +19,17 @@ const AP_VERSION = apVersionUtil.getCurrentRelease()
 
 const VERSION_MISMATCH_POLL_PAUSE_MS = 10_000
 
+const BOX_EGRESS_POLL_PAUSE_MS = 30_000
+
+const EGRESS_UNAVAILABLE_REMINDER_MS = 60_000
+
+// Must stay under the app's 60s offline-prune so a parked worker keeps reporting 'unavailable' instead of vanishing.
+const EGRESS_VERDICT_HEARTBEAT_MS = 30_000
+
+const EGRESS_UNAVAILABLE_MESSAGE = 'STRICT egress preparation failed — this worker is taking NO jobs instead of failing every one. Causes: missing privileges/tooling (CAP_NET_ADMIN, iproute2, iptables, ip6tables), net.ipv4.ip_forward not enabled on the host (the worker verifies but does not set it), the egress subnet overlapping a host network (set AP_SANDBOX_EGRESS_SUBNET to a free /16), or another worker already owning this network namespace. Fix and restart the worker'
+
 let pagedForUnreadableWorkerVersion = false
+let pagedForEgressUnavailable = false
 
 function pageOnceForUnreadableWorkerVersion(workerLog: typeof logger): void {
     if (pagedForUnreadableWorkerVersion) {
@@ -32,6 +42,20 @@ function pageOnceForUnreadableWorkerVersion(workerLog: typeof logger): void {
         params: { workerVersion: AP_VERSION },
     }).catch((pageError) => {
         workerLog.error({ pageError }, 'Failed to send on-call page for unreadable worker version')
+    })
+}
+
+function pageOnceForEgressUnavailable({ error }: { error: unknown }): void {
+    if (pagedForEgressUnavailable) {
+        return
+    }
+    pagedForEgressUnavailable = true
+    onCallService(logger, workerSettings.getSettings().PAGE_ONCALL_WEBHOOK).page({
+        code: 'WORKER_EGRESS_CAPABILITIES_UNAVAILABLE',
+        message: 'STRICT sandbox egress capabilities failed; polling is paused and will NOT self-heal on reconnect until privileges/tooling/allow-list are fixed and the worker is restarted',
+        params: { error: String(error) },
+    }).catch((pageError) => {
+        logger.error({ pageError }, 'Failed to send on-call page for unavailable STRICT egress capabilities')
     })
 }
 
@@ -60,6 +84,14 @@ const workerHostname = os.hostname()
 let healthServerInstance: ReturnType<typeof createServer> | null = null
 
 let runtime: Runtime | null = null
+let runtimeShutdownPromise: Promise<void> | null = null
+let reconnectShutdownTimeoutCount = 0
+let boxEgressPauseCount = 0
+let egressCapabilityState: 'unknown' | 'ok' | 'unavailable' = 'unknown'
+let egressUnavailableReminder: NodeJS.Timeout | null = null
+let egressReminderTick = 0
+let egressPreparationPromise: Promise<EgressNetworkLease> | null = null
+let egressNetworkLease: EgressNetworkLease | null = null
 
 // Jobs executing across all poll loops. stop() waits for these to finish + report before tearing
 // down, so a deploy doesn't orphan them in the app's BullMQ `active` list. Abrupt death (OOM/SIGKILL)
@@ -67,6 +99,9 @@ let runtime: Runtime | null = null
 let inFlightJobs = 0
 
 const DRAIN_TIMEOUT_MS = 25_000
+
+// Bounded so a wedged teardown cannot silently stall polling; createEgressNetns's pid-retry is the net.
+const RECONNECT_SHUTDOWN_TIMEOUT_MS = 10_000
 
 // Sandbox memory/state is UI-only telemetry (the workers page). Computing it needs a full
 // process-table scan (si.processes()), so it must NOT run on the poll hot path — sampling it on
@@ -115,7 +150,7 @@ export const worker = {
             // reclaims that job on disconnect, so kill the runtime now or the original keeps executing
             // to completion and double-runs the requeued copy. (The reconnect path recreates it.)
             if (reason !== 'io client disconnect') {
-                abortInFlightRuntime()
+                void abortInFlightRuntime()
             }
             // Socket.IO does NOT auto-reconnect when the server initiates the disconnect
             // (reason 'io server disconnect' — e.g. the API process restarts/hot-reloads).
@@ -151,10 +186,19 @@ export const worker = {
         stopPollWatchdog()
         stopSandboxInfoSampling()
         await drainInFlightJobs()
-        if (runtime) {
-            await runtime.shutdown(logger)
-            runtime = null
+        await abortInFlightRuntime()
+        if (egressNetworkLease) {
+            const lease = egressNetworkLease
+            egressNetworkLease = null
+            const { error } = await tryCatch(() => lease.release())
+            if (error) {
+                logger.error({ error }, 'Failed to release egress network ownership')
+            }
         }
+        egressPreparationPromise = null
+        egressCapabilityState = 'unknown'
+        stopEgressUnavailableReminder()
+        pagedForEgressUnavailable = false
         socket?.disconnect()
         socket = null
         healthServerInstance?.close()
@@ -185,20 +229,54 @@ async function startPollingWorkers(apiClient: WorkerToApiContract): Promise<void
     }
     // Bring up a fresh runtime on every (re)connect — a prior connection's in-flight job is killed
     // along with its box (usually already done by the disconnect handler), so it fails fast and is
-    // retried instead of lingering on a reused box. Reusing the box made the next generation's poll
-    // loop run a second operation on the same single-operation engine child (acquire() hands back a
-    // busy sandbox) and let the lingering job's lock lapse during the reconnect → BullMQ "stalled";
-    // a deploy disconnects every worker at once, so reuse turned that into mass stalls.
-    abortInFlightRuntime()
+    // retried. The old shutdown is awaited first: createEgressNetns fail-closes on a live isolate.
+    await boundedShutdownWait(abortInFlightRuntime())
 
-    runtime = createSandboxRuntime({
+    // A disconnect during that await bumps the generation, and without this bail the loser's box leaks.
+    if (connectionGeneration !== generation) {
+        return
+    }
+
+    const localRuntime = createSandboxRuntime({
         concurrency,
         basePath: sandboxConfig.getCacheBasePath(),
         getSettings: () => sandboxConfig.getSandboxSettings(),
+        internalApiUrl: getApiUrl(),
     })
+    runtime = localRuntime
+
+    // Missing capabilities pause polling so the worker idles loudly instead of failing jobs one by one.
+    if (!(await ensureEgressCapabilities(apiClient))) {
+        polling = false
+        // Deregister the loops, or the stall watchdog turns this deliberate pause into a restart loop.
+        resetPollLoopLiveness({ loopCount: 0 })
+        if (runtime === localRuntime) {
+            runtime = null
+            const { error } = await tryCatch(() => localRuntime.shutdown(logger))
+            if (error) {
+                logger.error({ error }, 'Failed to shut down runtime after STRICT egress capability failure')
+            }
+        }
+        return
+    }
+
+    // Same generation race as above, since ensureEgressCapabilities awaits: never touch a newer runtime.
+    if (connectionGeneration !== generation) {
+        if (runtime === localRuntime) {
+            runtime = null
+            const { error } = await tryCatch(() => localRuntime.shutdown(logger))
+            if (error) {
+                logger.error({ error }, 'Failed to shut down stale runtime after generation bump')
+            }
+        }
+        return
+    }
+    if (isNil(runtime) || runtime !== localRuntime) {
+        return
+    }
 
     // Fire-and-forget: warm the piece cache for this platform's flows without blocking the poll loop.
-    void runtime.prewarm({
+    void localRuntime.prewarm({
         log: logger, 
         apiClient,
         publicApiUrl: ensurePublicApiUrl(workerSettings.getSettings().PUBLIC_URL),
@@ -207,9 +285,8 @@ async function startPollingWorkers(apiClient: WorkerToApiContract): Promise<void
     logger.info({ concurrency }, 'Starting poll loops')
 
     resetPollLoopLiveness({ loopCount: concurrency })
-    const activeRuntime = runtime
     await Promise.all(Array.from({ length: concurrency }, (_, workerIndex) =>
-        pollAndExecute(apiClient, activeRuntime, workerIndex, generation),
+        pollAndExecute(apiClient, localRuntime, workerIndex, generation),
     ))
 }
 
@@ -232,6 +309,18 @@ async function pollAndExecute(apiClient: WorkerToApiContract, runtime: Runtime, 
                 pageOnceForUnreadableWorkerVersion(workerLog)
             }
             await sleep(VERSION_MISMATCH_POLL_PAUSE_MS)
+            continue
+        }
+
+        // The readiness gate covers only the process-wide class, so one bad box is backed off here instead.
+        if (runtime.isExecutorPaused(workerIndex)) {
+            boxEgressPauseCount++
+            workerLog.error({
+                code: 'WORKER_BOX_EGRESS_UNHEALTHY',
+                pauseMs: BOX_EGRESS_POLL_PAUSE_MS,
+                count: boxEgressPauseCount,
+            }, 'Pausing this box — its STRICT egress setup has failed repeatedly. Check the worker logs for the underlying egress error')
+            await sleep(BOX_EGRESS_POLL_PAUSE_MS)
             continue
         }
 
@@ -311,20 +400,113 @@ async function drainInFlightJobs(): Promise<void> {
     }
 }
 
-// Kill the current runtime (and the job running on it) without awaiting — awaiting the shutdown
-// while a job is in-flight deadlocks (the await never resolves, polling never restarts). Nulling
-// `runtime` lets the next (re)connect create a fresh box.
-function abortInFlightRuntime(): void {
-    if (isNil(runtime)) {
+// Cached: an 'unavailable' verdict does NOT self-heal on reconnect, matching the version-skew gate.
+async function ensureEgressCapabilities(apiClient: WorkerToApiContract): Promise<boolean> {
+    const settings = sandboxConfig.getSandboxSettings()
+    const strictIsolate = isIsolateMode(settings.EXECUTION_MODE as ExecutionMode) && settings.NETWORK_MODE === NetworkMode.STRICT
+    if (!strictIsolate) {
+        return true
+    }
+    if (egressCapabilityState === 'unavailable') {
+        return false
+    }
+    if (!isNil(egressNetworkLease)) {
+        return true
+    }
+    const pending = egressPreparationPromise ?? prepareEgressEnvironment({
+        log: logger,
+        allowList: settings.SSRF_ALLOW_LIST,
+    })
+    egressPreparationPromise = pending
+    const { data: lease, error } = await tryCatch(() => pending)
+    if (error || isNil(lease)) {
+        egressCapabilityState = 'unavailable'
+        egressPreparationPromise = null
+        logger.error({ error: String(error) }, EGRESS_UNAVAILABLE_MESSAGE)
+        startEgressUnavailableReminder(apiClient)
+        pageOnceForEgressUnavailable({ error })
+        return false
+    }
+    egressNetworkLease = lease
+    egressCapabilityState = 'ok'
+    stopEgressUnavailableReminder()
+    logger.info('STRICT egress capabilities and network-namespace ownership verified')
+    return true
+}
+
+// Heartbeat the 'unavailable' verdict (the connect-time send predated the probe and the paused poll loop
+// never re-sends) and log it (the combined container has no worker health server, so this is its only trace).
+function startEgressUnavailableReminder(apiClient: WorkerToApiContract): void {
+    if (!isNil(egressUnavailableReminder)) {
         return
+    }
+    egressReminderTick = 0
+    void pushEgressVerdict(apiClient)
+    egressUnavailableReminder = setInterval(() => {
+        void pushEgressVerdict(apiClient)
+        egressReminderTick++
+        if (egressReminderTick % (EGRESS_UNAVAILABLE_REMINDER_MS / EGRESS_VERDICT_HEARTBEAT_MS) === 0) {
+            logger.error({ code: 'WORKER_EGRESS_CAPABILITIES_UNAVAILABLE' }, EGRESS_UNAVAILABLE_MESSAGE)
+        }
+    }, EGRESS_VERDICT_HEARTBEAT_MS)
+    egressUnavailableReminder.unref()
+}
+
+// The app withholds jobs from a worker reporting egressStatus 'unavailable', so this only refreshes the
+// machine cache feeding /v1/health/system and keeps the worker from being pruned as offline — no job returns.
+async function pushEgressVerdict(apiClient: WorkerToApiContract): Promise<void> {
+    const { data: machineInfo, error } = await tryCatch(buildMachineInfo)
+    if (error) {
+        return
+    }
+    await tryCatch(() => apiClient.poll(machineInfo))
+}
+
+function stopEgressUnavailableReminder(): void {
+    if (isNil(egressUnavailableReminder)) {
+        return
+    }
+    clearInterval(egressUnavailableReminder)
+    egressUnavailableReminder = null
+}
+
+// Disconnect handlers fire-and-forget this to avoid deadlocking the socket loop; reconnect awaits it.
+function abortInFlightRuntime(): Promise<void> {
+    if (isNil(runtime)) {
+        return runtimeShutdownPromise ?? Promise.resolve()
     }
     const oldRuntime = runtime
     runtime = null
-    void tryCatch(() => oldRuntime.shutdown(logger)).then(({ error }) => {
+    const pending = (async () => {
+        const { error } = await tryCatch(() => oldRuntime.shutdown(logger))
         if (error) {
             logger.error({ error }, 'Failed to shut down runtime')
         }
+    })()
+    runtimeShutdownPromise = pending
+    void pending.finally(() => {
+        if (runtimeShutdownPromise === pending) {
+            runtimeShutdownPromise = null
+        }
     })
+    return pending
+}
+
+// A wedged teardown must not stall polling forever; on timeout createEgressNetns absorbs the dying child.
+async function boundedShutdownWait(shutdown: Promise<void>): Promise<void> {
+    let timer: NodeJS.Timeout | undefined
+    const timeout = new Promise<void>((resolve) => {
+        timer = setTimeout(() => {
+            // Countable rather than a page: jobs retry, so ops want a rate, not an incident.
+            reconnectShutdownTimeoutCount++
+            logger.warn({ code: 'WORKER_RECONNECT_SHUTDOWN_TIMEOUT', timeoutMs: RECONNECT_SHUTDOWN_TIMEOUT_MS, count: reconnectShutdownTimeoutCount }, 'Old runtime teardown exceeded the reconnect budget; proceeding (createEgressNetns will wait for the netns to free or fail just that job)')
+            resolve()
+        }, RECONNECT_SHUTDOWN_TIMEOUT_MS)
+    })
+    await Promise.race([shutdown, timeout])
+    if (timer) {
+        clearTimeout(timer)
+    }
 }
 
 async function executeJob(apiClient: WorkerToApiContract, job: ConsumeJobRequest, runtime: Runtime, workerIndex: number): Promise<JobResult> {
@@ -439,6 +621,7 @@ function getWorkerProps(): WorkerProps {
             SANDBOX_MEMORY_LIMIT: settings.SANDBOX_MEMORY_LIMIT,
             REUSE_SANDBOX: system.get(WorkerSystemProp.REUSE_SANDBOX) ?? 'false',
             version: AP_VERSION,
+            ...spreadIfDefined('egressStatus', egressCapabilityState === 'unknown' ? undefined : egressCapabilityState),
         }
     }
     catch {
@@ -614,6 +797,12 @@ function startHealthServer(): ReturnType<typeof createServer> {
     const healthPaths = new Set(['/worker/health', '/v1/health', '/api/v1/health'])
     const server = createServer((req, res) => {
         if (req.method === 'GET' && req.url && healthPaths.has(req.url)) {
+            // Egress-unavailable is a pause a restart will not clear, so report it before the stall wedge.
+            if (egressCapabilityState === 'unavailable') {
+                res.writeHead(503, { 'Content-Type': 'application/json' })
+                res.end(JSON.stringify({ status: 'unavailable', reason: 'egress_capabilities' }))
+                return
+            }
             const stalled = !isNil(findStalledPollLoop())
             res.writeHead(stalled ? 503 : 200, { 'Content-Type': 'application/json' })
             res.end(JSON.stringify({ status: stalled ? 'poll_loop_stalled' : 'ok' }))

--- a/packages/server/worker/test/lib/worker.test.ts
+++ b/packages/server/worker/test/lib/worker.test.ts
@@ -51,6 +51,7 @@ vi.mock('../../src/lib/config/logger', () => {
 
 type StubRuntime = {
     execute: ReturnType<typeof vi.fn>
+    isExecutorPaused: ReturnType<typeof vi.fn>
     getActiveExecutors: ReturnType<typeof vi.fn>
     prewarm: ReturnType<typeof vi.fn>
     shutdown: ReturnType<typeof vi.fn>
@@ -63,6 +64,7 @@ vi.mock('@activepieces/sandbox', () => ({
     createSandboxRuntime: vi.fn(() => {
         const rt: StubRuntime = {
             execute: vi.fn(),
+            isExecutorPaused: vi.fn(() => false),
             getActiveExecutors: vi.fn(() => []),
             prewarm: vi.fn().mockResolvedValue(undefined),
             shutdown: vi.fn().mockResolvedValue(undefined),


### PR DESCRIPTION
## Description

Improves how sandboxed code is run so it stays in a more isolated environment, rather than sharing the same surroundings as everything else.

Everything that worked before continues to work exactly the same way, and all existing integrations keep functioning normally. The isolation is set up automatically for each run and cleaned up afterwards, and if the environment isn't ready for it, it stops safely instead of running in a broken state.

This only applies to the stricter execution setup and makes no difference to standard configurations. It has been tested to confirm that normal usage and existing integrations are unaffected.