### PR TITLE
fix(platform): search piece sets by package name, not just display name

### DIFF
--- a/packages/web/src/app/routes/platform/setup/pieces/piece-sets/piece-set-pieces-tab.tsx
+++ b/packages/web/src/app/routes/platform/setup/pieces/piece-sets/piece-set-pieces-tab.tsx
@@ -19,6 +19,7 @@ import {
   SlidersHorizontal,
 } from 'lucide-react';
 import { useCallback, useMemo, useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
 
 import { DataTable, RowDataWithActions } from '@/components/custom/data-table';
 import { DataTableColumnHeader } from '@/components/custom/data-table/data-table-column-header';
@@ -152,7 +153,14 @@ const BulkPieceSetActions = ({
 };
 
 export const PieceSetPiecesTab = ({ pieceSet }: PieceSetPiecesTabProps) => {
+  const [searchParams] = useSearchParams();
+  // Search server-side like the main Pieces tab does, so a query matches the
+  // package name as well as the display name. Filtering client-side on
+  // `displayName` alone meant `@activepieces/piece-forms` found nothing,
+  // because that piece displays as "Human Input".
+  const searchQuery = searchParams.get('name') ?? '';
   const { pieces, isLoading } = piecesHooks.usePieces({
+    searchQuery,
     includeHidden: true,
     isTableQuery: true,
     skipProjectFilter: true,
@@ -350,7 +358,7 @@ export const PieceSetPiecesTab = ({ pieceSet }: PieceSetPiecesTabProps) => {
           {
             type: 'input',
             title: t('Piece Name'),
-            accessorKey: 'displayName',
+            accessorKey: 'name',
             icon: CheckIcon,
           },
         ]}


### PR DESCRIPTION
Closes #14392

### The bug

On **Platform Setup → Pieces → a piece set → Configure**, typing a package name such as `@activepieces/piece-forms` into the search box returns nothing, even though the piece is right there in the list. The same query on the main **Pieces** tab finds it.

### Why

The two tabs search differently.

The main Pieces tab passes the query to the server, and the server's matcher builds its haystack from **both** fields:

```ts
// packages/server/api/src/app/pieces/piece-searching.ts
const searchableText = `${piece.displayName} ${piece.name}`.toLowerCase()
```

The piece-set Configure tab instead fetched every piece and filtered in the browser on `displayName` alone. `@activepieces/piece-forms` displays as **"Human Input"**, so the package name never appears in the string being matched and the row is filtered out.

### The fix

Route the query through the same server search the main tab already uses.

```diff
+  const [searchParams] = useSearchParams();
+  const searchQuery = searchParams.get('name') ?? '';
   const { pieces, isLoading } = piecesHooks.usePieces({
+    searchQuery,
     includeHidden: true,
```

The filter's `accessorKey` doubles as the URL parameter name —

```ts
// packages/web/src/components/custom/data-table/data-table-filter.tsx
const paramKey = accessorKey ?? column?.id;
```

— so it moves from `displayName` to `name` to match the key the hook reads. One file, +9/-1.

### After

`@activepieces/piece-forms`, `piece-forms` and `Human Input` all return the Human Input row on the Configure tab, matching the behaviour of the main Pieces tab.
