### PR TITLE
feat(pieces): add aiMetadata to 155 actions and triggers across 32 pieces

### DIFF
--- a/packages/pieces/community/amazon-bedrock/package.json
+++ b/packages/pieces/community/amazon-bedrock/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-amazon-bedrock",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/packages/pieces/community/amazon-bedrock/src/lib/actions/custom-api-call.ts
+++ b/packages/pieces/community/amazon-bedrock/src/lib/actions/custom-api-call.ts
@@ -73,6 +73,7 @@ export const customApiCall = createAction({
   displayName: 'Custom API Call',
   description:
     'Make a custom API call to any AWS Bedrock endpoint. Requests are automatically signed with AWS Signature V4.',
+  aiMetadata: { description: 'Makes an arbitrary AWS SigV4-signed HTTP request to a chosen Bedrock endpoint - the Bedrock control plane, Bedrock Runtime, Bedrock Agent control plane, or Bedrock Agent Runtime - with your own method, path, query parameters, headers, and JSON body, optionally returning errors as output instead of failing the step. Use as an escape hatch for Bedrock operations this piece does not wrap, such as knowledge bases, guardrails, or agent invocation. Requires the service and path to match the AWS Bedrock API reference for the connected region. Idempotency depends on the call made: GET reads are safe to repeat, while model invocations and mutating writes are not.', idempotent: false },
   auth: awsBedrockCombinedAuth,
   requireAuth: true,
   props: {

--- a/packages/pieces/community/amazon-bedrock/src/lib/actions/generate-content-from-image.ts
+++ b/packages/pieces/community/amazon-bedrock/src/lib/actions/generate-content-from-image.ts
@@ -15,11 +15,12 @@ import {
 } from '../common';
 
 export const generateContentFromImage = createAction({
-  audience: 'human',
+  audience: 'both',
   auth: awsBedrockCombinedAuth,
   name: 'generate_content_from_image',
   displayName: 'Generate Content from Image',
   description: 'Ask a Bedrock model a question about an image.',
+  aiMetadata: { description: 'Asks a vision-capable Bedrock foundation model a question about one image and returns the answer as text; the image is supplied either as an uploaded file or by S3 bucket and key, and the model list is filtered to models that accept image input. Pick this for one-off image understanding such as OCR, description, classification, or extraction, and use Ask Bedrock instead when the prompt is text-only, needs conversation memory, or carries a document, video, or audio attachment; use Generate Image to create a picture rather than read one. Not idempotent: each call bills a fresh non-deterministic completion.', idempotent: false },
   props: {
     model: Property.Dropdown({
       displayName: 'Model',

--- a/packages/pieces/community/amazon-bedrock/src/lib/actions/generate-embeddings.ts
+++ b/packages/pieces/community/amazon-bedrock/src/lib/actions/generate-embeddings.ts
@@ -9,12 +9,13 @@ import {
 } from '../common';
 
 export const generateEmbeddings = createAction({
-  audience: 'human',
+  audience: 'both',
   auth: awsBedrockCombinedAuth,
   name: 'generate_embeddings',
   displayName: 'Generate Embeddings',
   description:
     'Generate vector embeddings from text using Amazon Titan Embed, Cohere Embed, or Amazon Nova Multimodal Embeddings models.',
+  aiMetadata: { description: 'Converts one text string into a numeric embedding vector using a Bedrock embedding model (Amazon Titan Embed, Cohere Embed, Nova Multimodal, or TwelveLabs), returning the vector and its dimension count; the request shape is adapted per model family, so Vector Dimensions, Normalize, and Embedding Purpose only take effect on the families that support them. Pick this for semantic search, similarity, or clustering pipelines rather than Ask Bedrock, which returns prose. Handles a single text per call - loop for batches - and requires an embedding-capable model enabled in the connected AWS region. Deterministic stateless inference, so repeat calls with the same input are idempotent.', idempotent: true },
   props: {
     model: Property.Dropdown({
       displayName: 'Model',

--- a/packages/pieces/community/amazon-bedrock/src/lib/actions/generate-image.ts
+++ b/packages/pieces/community/amazon-bedrock/src/lib/actions/generate-image.ts
@@ -9,12 +9,13 @@ import {
 } from '../common';
 
 export const generateImage = createAction({
-  audience: 'human',
+  audience: 'both',
   auth: awsBedrockCombinedAuth,
   name: 'generate_image',
   displayName: 'Generate Image',
   description:
     'Generate an image from a text prompt using Amazon Titan Image Generator or Stability AI models.',
+  aiMetadata: { description: 'Generates one image from a text prompt using a Bedrock image model (Amazon Titan Image Generator, Nova Canvas, or Stability AI) and stores it as a file reference; supports a negative prompt, width and height, and a seed for reproducible output. Pick this to create new imagery from a description - use Generate Content from Image to interpret an existing image, and Ask Bedrock for text output. Requires an image-output model enabled in the connected AWS region, at a resolution that model supports. Not idempotent: each call invokes the model and writes a new file, though a fixed seed with the same prompt reproduces the same picture.', idempotent: false },
   props: {
     model: Property.Dropdown({
       displayName: 'Model',

--- a/packages/pieces/community/amazon-bedrock/src/lib/actions/send-prompt.ts
+++ b/packages/pieces/community/amazon-bedrock/src/lib/actions/send-prompt.ts
@@ -21,11 +21,12 @@ import {
 } from '../common';
 
 export const sendPrompt = createAction({
-  audience: 'human',
+  audience: 'both',
   auth: awsBedrockCombinedAuth,
   name: 'send_prompt',
   displayName: 'Ask Bedrock',
   description: 'Send a text prompt to an Amazon Bedrock model.',
+  aiMetadata: { description: 'Sends a text prompt to a foundation model on Amazon Bedrock via the Converse API and returns the generated text, with optional system prompt, temperature, top-p, max-tokens, and stop sequences; leave Conversation Memory ID empty for a stateless one-off question or set one to persist message history across runs, and optionally attach a single file either uploaded directly or referenced by S3 bucket and key. This is the general-purpose text entry point for Bedrock - prefer Generate Content from Image for a one-off vision question, Generate Image to produce a picture, or Generate Embeddings for vectors. Requires a model id enabled in the connected AWS region. Not idempotent: each call bills a fresh non-deterministic completion and appends to the stored history whenever a memory key is set.', idempotent: false },
   props: {
     model: Property.Dropdown({
       displayName: 'Model',

--- a/packages/pieces/community/azure-openai/package.json
+++ b/packages/pieces/community/azure-openai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-azure-openai",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "dependencies": {

--- a/packages/pieces/community/azure-openai/src/lib/actions/ask-gpt.ts
+++ b/packages/pieces/community/azure-openai/src/lib/actions/ask-gpt.ts
@@ -10,11 +10,12 @@ import * as z from 'zod/mini'
 import { propsValidation } from '@activepieces/pieces-common';
 
 export const askGpt = createAction({
-  audience: 'human',
+  audience: 'both',
     auth: azureOpenaiAuth,
     name: 'ask_gpt',
     displayName: 'Ask GPT',
     description: 'Ask ChatGPT anything you want!',
+    aiMetadata: { description: 'Sends a prompt to a chat model deployed on your own Azure OpenAI resource and returns the generated answer text; leave the memory key empty for a stateless one-off question, or set one to share a conversation history across runs and flows so follow-up turns keep context. Requires the Azure deployment name (your own deployment, not a public model id) and a max-tokens value, so pick this only when the workflow must run through Azure OpenAI rather than the vendor-hosted OpenAI, Anthropic, or Google Gemini pieces. Not idempotent: every call is a fresh non-deterministic billed completion, and it appends to the stored history whenever a memory key is set.', idempotent: false },
     props: {
         deploymentId: Property.ShortText({
             displayName: 'Deployment Name',

--- a/packages/pieces/community/claude/package.json
+++ b/packages/pieces/community/claude/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-claude",
-  "version": "0.4.9",
+  "version": "0.4.10",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "dependencies": {

--- a/packages/pieces/community/claude/src/lib/actions/extract-structured-data.ts
+++ b/packages/pieces/community/claude/src/lib/actions/extract-structured-data.ts
@@ -9,11 +9,12 @@ import { modelDropdown } from '../common/common';
 import { extractStructuredDataActionOutputSchema } from '../output-schemas';
 
 export const extractStructuredDataAction = createAction({
-  audience: 'human',
+  audience: 'both',
   auth: claudeAuth,
   name: 'extract-structured-data',
   displayName: 'Extract Structured Data',
   description: 'Extract structured data from provided text,image or PDF.',
+  aiMetadata: { description: 'Runs a Claude model over supplied text, an image, or a PDF and returns only the fields you defined, using a forced tool call so the output matches your schema. The Data Schema Type prop switches between Simple mode (a list of named fields with types and required flags) and Advanced mode (a raw JSON Schema object); prefer the sibling Ask Claude action when you want free-form prose instead of typed fields. Requires a model, the field definitions, and at least one of Text or Image/PDF; not idempotent, since each call re-runs the model and extraction can vary.', idempotent: false },
   props: {
     model: modelDropdown,
     text: Property.LongText({

--- a/packages/pieces/community/claude/src/lib/actions/send-prompt.ts
+++ b/packages/pieces/community/claude/src/lib/actions/send-prompt.ts
@@ -15,11 +15,12 @@ import { billingIssueMessage, modelDropdown, unauthorizedMessage } from '../comm
 import { askClaudeActionOutputSchema } from '../output-schemas';
 const DEFAULT_TOKENS_FOR_THINKING_MODE = 1024;
 export const askClaude = createAction({
-  audience: 'human',
+  audience: 'both',
   auth: claudeAuth,
   name: 'ask_claude',
   displayName: 'Ask Claude',
   description: 'Ask Claude anything you want!',
+  aiMetadata: { description: 'Sends a free-form question or instruction to a chosen Anthropic Claude model and returns the reply as plain text, optionally with an image attached for vision and earlier user/assistant turns supplied as Roles for multi-turn context; enabling Extended Thinking Mode routes the call to Claude 3.7 Sonnet with a separate reasoning token budget. Prefer the sibling Extract Structured Data action when the answer must be constrained to defined fields rather than prose. Requires a model and a question, with temperature between 0 and 1; not idempotent, since each call is a fresh generation that can return different text.', idempotent: false },
   props: {
     model: modelDropdown,
     systemPrompt: Property.LongText({

--- a/packages/pieces/community/cohere/package.json
+++ b/packages/pieces/community/cohere/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-cohere",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {

--- a/packages/pieces/community/cohere/src/lib/actions/generate-text.ts
+++ b/packages/pieces/community/cohere/src/lib/actions/generate-text.ts
@@ -60,11 +60,12 @@ async function generateWithRetry(
 }
 
 export const generateText = createAction({
-  audience: 'human',
+  audience: 'both',
   auth: cohereAuth,
   name: 'generate_text',
   displayName: 'Generate Text',
   description: 'Generate a text response using Cohere AI Chat API',
+  aiMetadata: { description: 'Runs a single-turn completion against Cohere\'s v2 Chat API - one user prompt in, one generated message out - with optional model, temperature, and max-token controls. This is the only purpose-built action in the Cohere piece and covers only chat-style generation, not multi-turn conversation history, embeddings, rerank, or classify; use the piece\'s Custom API Call action to reach those Cohere endpoints. Requires a prompt and a chat-capable model name. Not idempotent: each call bills a fresh generation and the wording varies unless temperature is set to 0.', idempotent: false },
   props: {
     prompt: Property.LongText({
       displayName: 'Prompt',

--- a/packages/pieces/community/cometapi/package.json
+++ b/packages/pieces/community/cometapi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-cometapi",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/packages/pieces/community/cometapi/src/lib/actions/ask-cometapi.ts
+++ b/packages/pieces/community/cometapi/src/lib/actions/ask-cometapi.ts
@@ -36,10 +36,15 @@ interface ChatMessage {
 }
 
 export const askCometApiAction = createAction({
-  audience: 'human',
+  audience: 'both',
   name: 'ask-cometapi',
   displayName: 'Ask CometAPI',
   description: 'Sends a prompt to any AI model supported by CometAPI.',
+  aiMetadata: {
+    description:
+      'Sends a single-turn chat completion (one prompt plus an optional system message, with no multi-turn history) to any model in the CometAPI catalog, which fronts OpenAI, Anthropic, Gemini and other vendors behind one key. Requires a model id chosen from CometAPI\'s live model list, and accepts temperature, top_p and max tokens as optional sampling controls; pick it when the model should be selectable at runtime rather than fixed to a single vendor, and use this piece\'s Custom API Call for any other CometAPI endpoint such as image generation or embeddings. Not idempotent: each call runs a fresh generation and consumes tokens.',
+    idempotent: false,
+  },
   auth: cometApiAuth,
   props: {
     model: modelIdDropdown,

--- a/packages/pieces/community/dataforb2b/package.json
+++ b/packages/pieces/community/dataforb2b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-dataforb2b",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/packages/pieces/community/dataforb2b/src/lib/actions/enrich-company.ts
+++ b/packages/pieces/community/dataforb2b/src/lib/actions/enrich-company.ts
@@ -6,6 +6,11 @@ export const enrichCompany = createAction({
   name: 'enrich_company',
   displayName: 'Enrich Company',
   description: 'Retrieve comprehensive information about a company.',
+  audience: 'both',
+  aiMetadata: {
+    description: 'Look up one company in the DataForB2B database by slug, LinkedIn company URL, or encoded company ID, returning its full firmographic record. Use when you already hold a company identifier; use Search Companies to find companies by criteria, or Typeahead to resolve a company name to its stored identifier first. Read-only and idempotent.',
+    idempotent: true,
+  },
   props: {
     companyIdentifier: Property.ShortText({
       displayName: 'Company Identifier',

--- a/packages/pieces/community/dataforb2b/src/lib/actions/enrich-profile.ts
+++ b/packages/pieces/community/dataforb2b/src/lib/actions/enrich-profile.ts
@@ -6,6 +6,11 @@ export const enrichProfile = createAction({
   name: 'enrich_profile',
   displayName: 'Enrich Profile',
   description: 'Retrieve detailed professional data, work/personal email and phone for a person.',
+  audience: 'both',
+  aiMetadata: {
+    description: 'Look up one person in the DataForB2B database by LinkedIn URL, public ID, or encoded ID, with separate toggles selecting which enrichments run: full profile (the default when no toggle is set), work email, personal email, phone, and GitHub. Use when you already hold a person identifier and need their profile or contact details; use Search People instead to find people matching criteria. Read-only and idempotent.',
+    idempotent: true,
+  },
   props: {
     profileIdentifier: Property.ShortText({
       displayName: 'Profile Identifier',

--- a/packages/pieces/community/dataforb2b/src/lib/actions/reasoning-search.ts
+++ b/packages/pieces/community/dataforb2b/src/lib/actions/reasoning-search.ts
@@ -7,6 +7,11 @@ export const reasoningSearch = createAction({
   displayName: 'Reasoning Search',
   description:
     'Describe who you are looking for in plain language. An AI agent builds the best filters and runs the search. It may return status "needs_input" with questions — answer by calling again with the returned session_id and an answers object.',
+  audience: 'both',
+  aiMetadata: {
+    description: 'Run a plain-language people or company search in which a DataForB2B agent builds the filters, over two possible turns: a first call carrying the query, or a follow-up call carrying the session ID plus an answers object when a prior turn returned needs_input. Use when the criteria are fuzzy or unstructured; prefer Search People or Search Companies when the criteria map to explicit field filters. Requires either a query or a session ID with answers; read-only and idempotent.',
+    idempotent: true,
+  },
   props: {
     query: Property.LongText({
       displayName: 'Query',

--- a/packages/pieces/community/dataforb2b/src/lib/actions/search-companies.ts
+++ b/packages/pieces/community/dataforb2b/src/lib/actions/search-companies.ts
@@ -16,6 +16,11 @@ export const searchCompanies = createAction({
   name: 'search_companies',
   displayName: 'Search Companies',
   description: 'Find companies with advanced filters (industry, LinkedIn URL, size, location, growth, funding, investor...).',
+  audience: 'both',
+  aiMetadata: {
+    description: 'Search the DataForB2B company database with structured filter conditions over firmographic fields (name, domain, industry, employee count, location, growth, funding stage, investor), combined by AND or OR and optionally merged with a raw advanced-filter JSON group. Use to discover companies by criteria or to resolve a company to an identifier for Enrich Company; prefer Reasoning Search when the criteria are only expressible in plain language. Requires at least one filter or an advanced filter group; read-only and idempotent.',
+    idempotent: true,
+  },
   props: {
     match: filterLogicProp,
     filters: buildFiltersProp(companyFilterFields, 'name'),

--- a/packages/pieces/community/dataforb2b/src/lib/actions/search-people.ts
+++ b/packages/pieces/community/dataforb2b/src/lib/actions/search-people.ts
@@ -16,6 +16,11 @@ export const searchPeople = createAction({
   name: 'search_people',
   displayName: 'Search People',
   description: 'Find professionals using 50+ filters (title, company, LinkedIn URL, skills, location, education, funding...).',
+  audience: 'both',
+  aiMetadata: {
+    description: 'Search the DataForB2B people database with structured filter conditions across 50+ profile fields (current and past title, company, skills, location, education, languages, certifications, experience), combined by AND or OR and optionally merged with a raw advanced-filter JSON group. Use to build prospect or candidate lists by criteria, then pass a returned identifier to Enrich Profile for email and phone; prefer Reasoning Search when the criteria are only expressible in plain language. Requires at least one filter or an advanced filter group; read-only and idempotent.',
+    idempotent: true,
+  },
   props: {
     match: filterLogicProp,
     filters: buildFiltersProp(peopleFilterFields, 'current_title'),

--- a/packages/pieces/community/dataforb2b/src/lib/actions/typeahead.ts
+++ b/packages/pieces/community/dataforb2b/src/lib/actions/typeahead.ts
@@ -7,6 +7,11 @@ export const typeahead = createAction({
   displayName: 'Typeahead',
   description:
     'Resolve the exact stored value for a search filter (company, industry, category, location, school, title, skill, investor). Use it before filtering, or when a search returns few/no results.',
+  audience: 'both',
+  aiMetadata: {
+    description: 'Autocomplete a partial string against one DataForB2B reference vocabulary selected by the type prop: company (returns org_id), people industry, company industry, category, location, city, region, school, job title, skill, or investor. Use it before Search People or Search Companies to resolve a filter value to the exact stored spelling, or after a search returns few or no matches. Requires a type and a query of 1-100 characters; read-only and idempotent.',
+    idempotent: true,
+  },
   props: {
     type: Property.StaticDropdown({
       displayName: 'Type',

--- a/packages/pieces/community/deepseek/package.json
+++ b/packages/pieces/community/deepseek/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-deepseek",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "dependencies": {

--- a/packages/pieces/community/deepseek/src/lib/actions/ask-deepseek.ts
+++ b/packages/pieces/community/deepseek/src/lib/actions/ask-deepseek.ts
@@ -6,11 +6,12 @@ import * as z from 'zod/mini'
 import { propsValidation } from '@activepieces/pieces-common';
 
 export const askDeepseek = createAction({
-  audience: 'human',
+  audience: 'both',
   auth: deepseekAuth,
   name: 'ask_deepseek',
   displayName: 'Ask Deepseek',
   description: 'Ask Deepseek anything you want!',
+  aiMetadata: { description: 'Sends a question to a DeepSeek chat model and returns the generated text, with optional sampling controls and a text-or-JSON response format (JSON mode also requires instructing the model to emit JSON in the prompt); it runs stateless by default, or keeps conversation history across runs and flows when a memory key is set. It is the only action this piece exposes, so use it for any DeepSeek completion and pick a different vendor piece when the model must not be DeepSeek. Requires a model, a question, and a maximum token count; not idempotent: each call produces a fresh completion and, when a memory key is set, appends to the stored history.', idempotent: false },
   props: {
     model: Property.Dropdown({
       auth: deepseekAuth,

--- a/packages/pieces/community/flow-helper/package.json
+++ b/packages/pieces/community/flow-helper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-flow-helper",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {

--- a/packages/pieces/community/flow-helper/src/lib/actions/fail-flow.ts
+++ b/packages/pieces/community/flow-helper/src/lib/actions/fail-flow.ts
@@ -1,10 +1,11 @@
 import { createAction, Property } from '@activepieces/pieces-framework';
 
 export const failFlow = createAction({
-  audience: 'human',
+  audience: 'both',
   name: 'failFlow',
   displayName: 'Fail Flow',
   description: 'Fails the flow execution with a custom message.',
+  aiMetadata: { description: 'Aborts the current flow run by throwing the supplied message as an error, so the run is recorded as failed and no later steps execute. Use it to hard-fail on an unrecoverable condition; prefer Stop Flow when the early exit is a normal outcome that should still count as a success. Requires an error message, and the run continues past this step if continue-on-failure is enabled on it; idempotent, since it drives the run to the same failed end state and creates nothing.', idempotent: true },
   props: {
     message: Property.LongText({
       displayName: 'Error Message',

--- a/packages/pieces/community/flow-helper/src/lib/actions/get-run-id.ts
+++ b/packages/pieces/community/flow-helper/src/lib/actions/get-run-id.ts
@@ -1,11 +1,12 @@
 import { createAction } from '@activepieces/pieces-framework';
 
 export const getRunId = createAction({
-  audience: 'human',
+  audience: 'both',
   // auth: check https://www.activepieces.com/docs/developers/piece-reference/authentication,
   name: 'getRunId',
   displayName: 'Get Run Info',
   description: '',
+  aiMetadata: { description: 'Returns the identifier of the flow run that is currently executing, along with a direct link to that run in the Activepieces UI. Use it when a later step needs to reference or report the run itself (e.g. embedding a run link in a Slack alert or a support ticket); it only ever describes the in-progress run and cannot look up a different one. Takes no inputs; read-only and idempotent.', idempotent: true },
   props: {},
   async run(context) {
     const publicUrlWithoutApi = context.server.publicUrl.replace('/api', '');

--- a/packages/pieces/community/flow-helper/src/lib/actions/stop-flow.ts
+++ b/packages/pieces/community/flow-helper/src/lib/actions/stop-flow.ts
@@ -1,10 +1,11 @@
 import { createAction} from '@activepieces/pieces-framework';
 
 export const stopFlow = createAction({
-  audience: 'human',
+  audience: 'both',
   name: 'stopFlow',
   displayName: 'Stop Flow',
   description: 'Stops the flow immediately this step is reached.',
+  aiMetadata: { description: 'Ends the current flow run at this step and marks it as stopped rather than failed, so no later steps execute. Use it for an early exit when a condition means there is nothing left to do; prefer Fail Flow when the exit should be recorded as an error instead. Takes no inputs and stops the run without a custom webhook response; idempotent, since it drives the run to the same stopped end state and creates nothing.', idempotent: true },
   props: {},
   async run(context) {
     context.run.stop();

--- a/packages/pieces/community/google-gemini/package.json
+++ b/packages/pieces/community/google-gemini/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-google-gemini",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "dependencies": {

--- a/packages/pieces/community/google-gemini/src/lib/actions/chat-gemini.action.ts
+++ b/packages/pieces/community/google-gemini/src/lib/actions/chat-gemini.action.ts
@@ -12,11 +12,12 @@ import { propsValidation } from '@activepieces/pieces-common';
 import { chatGeminiActionOutputSchema } from '../output-schemas';
 
 export const chatGemini = createAction({
-  audience: 'human',
+  audience: 'both',
   auth: googleGeminiAuth,
   name: 'chat_gemini',
   displayName: 'Chat Gemini',
   description: 'Chat with Google Gemini',
+  aiMetadata: { description: 'Sends a prompt as one turn of a Gemini chat and returns the reply, with two modes: supply a memory key (max 128 characters) to load and persist the conversation history in project storage so later runs remember earlier turns, or leave it empty for a stateless single turn. Pick it over generate_content when the exchange spans multiple runs and must retain context; generate_content is the better choice for one-shot generation or when a built-in tool such as Google Search or File Search is needed. Not idempotent: each call produces a new reply and, when a memory key is set, rewrites the stored history.', idempotent: false },
   props: {
     model: Property.Dropdown({
       displayName: 'Model',

--- a/packages/pieces/community/google-gemini/src/lib/actions/create-video.action.ts
+++ b/packages/pieces/community/google-gemini/src/lib/actions/create-video.action.ts
@@ -6,11 +6,12 @@ import { GoogleGenAI } from '@google/genai';
 import mime from 'mime-types';
 
 export const createVideoAction = createAction({
-  audience: 'human',
+  audience: 'both',
   name: 'create_video',
   auth: googleGeminiAuth,
   displayName: 'Create Video',
   description: 'Generate a video from a text prompt using Google Veo models.',
+  aiMetadata: { description: 'Generates a short video with a Google Veo model from a text prompt, optionally seeded by a start image (image-to-video) or by both a start and end image (interpolation between those frames), polling the long-running generation job for up to 10 minutes before returning the finished MP4 as a file. Use it whenever the required output is video; text goes through generate_content and speech through text-to-speech. Note the model-dependent limits: 1080p needs Veo 3.0 or newer, 4K needs Veo 3.1, and both require an 8-second duration. Not idempotent: each call renders a new video.', idempotent: false },
   props: {
     model: Property.Dropdown({
       displayName: 'Model',

--- a/packages/pieces/community/google-gemini/src/lib/actions/generate-content-from-image.action.ts
+++ b/packages/pieces/community/google-gemini/src/lib/actions/generate-content-from-image.action.ts
@@ -9,9 +9,10 @@ import { defaultLLM, getGeminiModelOptions } from '../common/common';
 import { generateContentFromImageActionOutputSchema } from '../output-schemas';
 
 export const generateContentFromImageAction = createAction({
-  audience: 'human',
+  audience: 'both',
   description:
     'Generate content using Google Gemini using the "gemini-pro-vision" model',
+  aiMetadata: { description: 'Sends an image together with a prompt to a vision-capable Gemini model and returns the generated text describing or answering questions about that image, covering captioning, text extraction, and visual question answering. This is the only Gemini action here that accepts image input, so pick it over generate_content whenever a picture is part of the question; the image is required and is sent inline, so keep it small. Not idempotent: each call produces a fresh completion.', idempotent: false },
   displayName: 'Generate Content from Image',
   name: 'generate_content_from_image',
   auth: googleGeminiAuth,

--- a/packages/pieces/community/google-gemini/src/lib/actions/generate-content-with-file-search.ts
+++ b/packages/pieces/community/google-gemini/src/lib/actions/generate-content-with-file-search.ts
@@ -6,8 +6,9 @@ import mime from 'mime-types';
 import { generateContentWithFilesearchActionOutputSchema } from '../output-schemas';
 
 export const generateContentWithFileSearchAction = createAction({
-  audience: 'human',
+  audience: 'both',
   description: 'Generate content with file search functionality.',
+  aiMetadata: { description: 'Uploads one file to a newly created Gemini File Search store, waits for indexing to finish, then answers the prompt grounded on that document. Use it for one-shot question answering over a document supplied at run time; prefer generate_content when no file grounding is needed or when a different built-in tool such as Google Search or URL Context fits better. Both a file and a store display name are required. Not idempotent: every call creates another file search store and a fresh completion.', idempotent: false },
   displayName: 'Generate Content with File Search',
   name: 'generate_content_with_filesearch',
   auth: googleGeminiAuth,

--- a/packages/pieces/community/google-gemini/src/lib/actions/generate-content.action.ts
+++ b/packages/pieces/community/google-gemini/src/lib/actions/generate-content.action.ts
@@ -8,8 +8,9 @@ import mime from 'mime-types';
 import { generateContentActionOutputSchema } from '../output-schemas';
 
 export const generateContentAction = createAction({
-  audience: 'human',
+  audience: 'both',
 	description: 'Generate content using Google Gemini using the "gemini-pro" model',
+	aiMetadata: { description: 'Runs a single stateless prompt through a Gemini text model and returns the generated text, optionally grounded by one built-in tool: Google Search for live web results, URL Context to fetch pages named in the prompt, Google Maps scoped to a latitude/longitude, or File Search over an uploaded file. Use this as the default Gemini text-generation call; prefer chat_gemini when the exchange needs conversation memory, generate_content_from_image when the input includes an image, and create_video or text-to-speech for non-text output. Not idempotent: each call produces a fresh completion, and the File Search mode additionally creates a new file search store.', idempotent: false },
 	displayName: 'Generate Content',
 	name: 'generate_content',
 	auth: googleGeminiAuth,

--- a/packages/pieces/community/google-gemini/src/lib/actions/text-to-speech.action.ts
+++ b/packages/pieces/community/google-gemini/src/lib/actions/text-to-speech.action.ts
@@ -7,11 +7,12 @@ import { Writable } from 'stream';
 import { textToSpeechActionOutputSchema } from '../output-schemas';
 
 export const textToSpeechAction = createAction({
-  audience: 'human',
+  audience: 'both',
   name: 'text-to-speech',
   auth: googleGeminiAuth,
   displayName: 'Text to Speech',
   description: 'Converts text to audio file.',
+  aiMetadata: { description: 'Synthesizes spoken audio from input text using a Gemini TTS model and one of roughly thirty prebuilt named voices, returning a WAV file. This is the audio-output sibling of generate_content: use it when the flow needs speech instead of text, and create_video when it needs video. Requires a TTS-capable model, which the model dropdown restricts to. Not idempotent: each call renders a new audio file.', idempotent: false },
   props: {
     model: Property.Dropdown({
       displayName: 'Model',

--- a/packages/pieces/community/google-sheets/package.json
+++ b/packages/pieces/community/google-sheets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-google-sheets",
-  "version": "0.16.3",
+  "version": "0.16.4",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "dependencies": {

--- a/packages/pieces/community/google-sheets/src/lib/actions/clear-rows.ts
+++ b/packages/pieces/community/google-sheets/src/lib/actions/clear-rows.ts
@@ -11,6 +11,12 @@ export const clearRowsAction = createAction({
 	displayName: 'Clear Row(s)',
 	description:
 		'Clears the contents of one or more rows without removing the rows themselves. Useful when you want to keep formatting and references stable.',
+	audience: 'both',
+	aiMetadata: {
+		description:
+			'Blanks the cell contents of one row or a contiguous row range in a worksheet without removing the rows, so row numbers and downstream references stay stable — prefer Delete Row or Delete Multiple Rows when the rows themselves should disappear, and Clear Sheet when the whole sheet should be emptied. Requires a selected spreadsheet and worksheet plus a 1-based starting row; leaving the ending row empty clears only that single row. Idempotent — re-running over the same range leaves it equally empty, but the erased values cannot be recovered.',
+		idempotent: true,
+	},
 	props: {
 		...commonProps,
 		startingRow: Property.Number({

--- a/packages/pieces/community/google-sheets/src/lib/actions/delete-multiple-rows.ts
+++ b/packages/pieces/community/google-sheets/src/lib/actions/delete-multiple-rows.ts
@@ -10,6 +10,12 @@ export const deleteMultipleRowsAction = createAction({
 	displayName: 'Delete Multiple Rows',
 	description:
 		'Deletes a contiguous range of rows, or a list of specific row numbers. Row numbers are 1-based.',
+	audience: 'both',
+	aiMetadata: {
+		description:
+			'Permanently deletes rows from a worksheet in one batch, in either of two modes: a contiguous range given by starting and ending row, or a comma-separated list of specific 1-based row numbers. Use instead of Delete Row when several rows must go at once, and Clear Row(s) instead when the rows should stay in place with only their contents erased. Not idempotent — surviving rows renumber after each deletion, so repeating the same call removes different rows; re-resolve the targets before any retry.',
+		idempotent: false,
+	},
 	props: {
 		...commonProps,
 		mode: Property.StaticDropdown({

--- a/packages/pieces/community/google-sheets/src/lib/actions/find-or-create-row.ts
+++ b/packages/pieces/community/google-sheets/src/lib/actions/find-or-create-row.ts
@@ -22,6 +22,12 @@ export const findOrCreateRowAction = createAction({
 	name: 'find-or-create-row',
 	displayName: 'Find or Create Row',
 	description: 'Look up a row by column value; if no match is found, create a new row with the provided values.',
+	audience: 'both',
+	aiMetadata: {
+		description:
+			'Looks up the first row in a worksheet whose value in a chosen column matches a search value and returns it, or appends a new row from the supplied values when nothing matches, flagging which happened. Use instead of Add Row when the entry may already exist and duplicates must be avoided, and Find Rows when creation is not wanted. Matching is a case-insensitive substring test unless Exact Match is on; idempotent in practice — a second call finds the row the first one created, provided that row carries the search value in the searched column.',
+		idempotent: true,
+	},
 	props: {
 		...commonProps,
 		columnName: columnNameProp(),

--- a/packages/pieces/community/google-sheets/src/lib/actions/find-or-create-worksheet.ts
+++ b/packages/pieces/community/google-sheets/src/lib/actions/find-or-create-worksheet.ts
@@ -9,6 +9,12 @@ export const findOrCreateWorksheetAction = createAction({
 	name: 'find-or-create-worksheet',
 	displayName: 'Find or Create Worksheet',
 	description: 'Look up a worksheet by title in a spreadsheet; if not found, create it with optional headers.',
+	audience: 'both',
+	aiMetadata: {
+		description:
+			'Looks up a worksheet (tab) by exact, case-sensitive title inside a spreadsheet and returns it, or creates that tab — optionally seeding a header row — when no tab with the title exists, flagging which happened. Use instead of Create Worksheet when the tab may already exist, since Create Worksheet adds a duplicate tab regardless. Idempotent — a second call with the same title returns the existing tab rather than creating another, and the headers are written only on creation.',
+		idempotent: true,
+	},
 	props: {
 		includeTeamDrives: includeTeamDrivesProp(),
 		spreadsheetId: spreadsheetIdProp('Spreadsheet', 'The spreadsheet to look in.'),

--- a/packages/pieces/community/google-sheets/src/lib/actions/insert-row-at-top.ts
+++ b/packages/pieces/community/google-sheets/src/lib/actions/insert-row-at-top.ts
@@ -19,6 +19,12 @@ export const insertRowAtTopAction = createAction({
 	name: 'insert-row-at-top',
 	displayName: 'Add Row at Top',
 	description: 'Inserts a new row at the top of a worksheet, just below the header row.',
+	audience: 'both',
+	aiMetadata: {
+		description:
+			'Inserts a blank row near the top of a worksheet and writes the supplied values into it, shifting every existing row below it down by one; the insertion point defaults to just under row 1 but can be moved with Insert After Row. Use when newest-first ordering matters — prefer Add Row to append at the bottom, which is cheaper and does not renumber existing rows. Not idempotent: each call inserts another row and shifts the rest down again.',
+		idempotent: false,
+	},
 	props: {
 		...commonProps,
 		first_row_headers: isFirstRowHeaderProp(),

--- a/packages/pieces/community/google-sheets/src/lib/actions/read-data-range.ts
+++ b/packages/pieces/community/google-sheets/src/lib/actions/read-data-range.ts
@@ -16,6 +16,12 @@ export const readDataRangeAction = createAction({
 	displayName: 'Read Data Range',
 	description:
 		'Read cells from a range using A1 notation (e.g. A1:D10). Returns rows and the resolved range.',
+	audience: 'both',
+	aiMetadata: {
+		description:
+			'Reads raw cell values from a worksheet using an A1-notation range, where leaving the range empty reads the entire worksheet, with switchable orientation (one array per row or per column) and rendering (formatted text, unformatted values, or the underlying formulas). Use when an agent needs a specific block of cells or the formulas behind them; prefer Get All Rows or Find Rows when header-keyed row objects are wanted instead of positional arrays. Read-only and idempotent.',
+		idempotent: true,
+	},
 	props: {
 		...commonProps,
 		range: Property.ShortText({

--- a/packages/pieces/community/greenpt/package.json
+++ b/packages/pieces/community/greenpt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-greenpt",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/packages/pieces/community/greenpt/src/lib/actions/chat-completion.ts
+++ b/packages/pieces/community/greenpt/src/lib/actions/chat-completion.ts
@@ -4,11 +4,12 @@ import { makeRequest } from '../common/client';
 import { HttpMethod } from '@activepieces/pieces-common';
 
 export const chatCompletion = createAction({
-  audience: 'human',
+  audience: 'both',
   auth: greenptAuth,
   name: 'chatCompletion',
   displayName: 'Ask GreenPT',
   description: '',
+  aiMetadata: { description: 'Sends one user message to a GreenPT chat model (green-l, green-r, or their raw variants) and returns the generated reply as plain text, carrying a single user turn only with no system prompt or conversation history. Choose this for text generation or question answering on GreenPT; use Create Embeddings for vector output and Transcribe Audio for speech-to-text. Not idempotent: each call runs a fresh, non-deterministic completion.', idempotent: false },
   props: {
     model: Property.StaticDropdown({
       displayName: 'Model',

--- a/packages/pieces/community/greenpt/src/lib/actions/create-embeddings.ts
+++ b/packages/pieces/community/greenpt/src/lib/actions/create-embeddings.ts
@@ -4,12 +4,13 @@ import { makeRequest } from '../common/client';
 import { HttpMethod } from '@activepieces/pieces-common';
 
 export const createEmbeddings = createAction({
-  audience: 'human',
+  audience: 'both',
   auth: greenptAuth,
   name: 'createEmbeddings',
   displayName: 'Create Embeddings',
   description:
     'Generate embeddings for text input using GreenPT models for semantic search and similarity matching',
+  aiMetadata: { description: 'Converts text into embedding vectors with GreenPT\'s fixed green-embedding model, returned as floats or base64; newline-separated input is split so each non-empty line is embedded as its own vector, while single-line input embeds one string. Use for semantic search, clustering, or similarity scoring, rather than Ask GreenPT which returns generated text. Idempotent: no resource is created and the same text with the same encoding format yields the same vectors.', idempotent: true },
   props: {
     input: Property.LongText({
       displayName: 'Input Text',

--- a/packages/pieces/community/greenpt/src/lib/actions/transcribe-audio.ts
+++ b/packages/pieces/community/greenpt/src/lib/actions/transcribe-audio.ts
@@ -4,12 +4,13 @@ import { httpClient, HttpMethod } from '@activepieces/pieces-common';
 import { greenptAuth } from '../common/auth';
 
 export const transcribeAudio = createAction({
-  audience: 'human',
+  audience: 'both',
   auth: greenptAuth,
   name: 'transcribeAudio',
   displayName: 'Transcribe Audio',
   description:
     'Transcribe pre-recorded audio files with speaker diarization and advanced features',
+  aiMetadata: { description: 'Transcribes a pre-recorded audio file with a GreenPT speech-to-text model (green-s or green-s-pro), with optional speaker diarization, punctuation, smart formatting, filler words, numeral conversion, and sentiment, topic, or intent analysis. Requires the audio as a file input, supplied either as base64 data or as a URL the engine fetches, language is auto-detected unless a code is supplied, and only the plain transcript text is returned. Use this for speech input; use Ask GreenPT for text generation. Read-only inference and idempotent: nothing is created and the same file with the same options yields the same transcript.', idempotent: true },
   props: {
     audioUrl: Property.File({
       displayName: 'Audio File',

--- a/packages/pieces/community/grok-xai/package.json
+++ b/packages/pieces/community/grok-xai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-grok-xai",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/packages/pieces/community/grok-xai/src/lib/actions/ask-grok.ts
+++ b/packages/pieces/community/grok-xai/src/lib/actions/ask-grok.ts
@@ -19,11 +19,12 @@ import {
 import * as z from 'zod/mini'
 
 export const askGrok = createAction({
-  audience: 'human',
+  audience: 'both',
   auth: grokAuth,
   name: 'ask_grok',
   displayName: 'Ask Grok',
   description: 'Send prompts to Grok with real-time search, tools, and structured outputs.',
+  aiMetadata: { description: 'Sends a prompt to a Grok chat model and returns the completion, carrying the conversation as a required Messages array of role-and-content turns, which also covers a single-turn question as one user message and can pair it with an image URL for vision models. It is the general-purpose Grok call and the only one here that can turn on real-time web, news, and X search with citations, declare callable functions, or carry conversation history across runs via a memory key; prefer categorize_text to assign labels from a fixed set, extract_data_from_text to pull named fields out of prose, and generate_image for pictures. Messages must be supplied; the Quick Prompt field is a builder-side alternative that run() only reads when Messages is left empty. Not idempotent: each call produces a fresh completion and, when a memory key is set, appends to the stored history.', idempotent: false },
   props: {
     model: createModelProperty({
       displayName: 'Model',

--- a/packages/pieces/community/grok-xai/src/lib/actions/categorize-text.ts
+++ b/packages/pieces/community/grok-xai/src/lib/actions/categorize-text.ts
@@ -24,11 +24,12 @@ interface Category {
 }
 
 export const categorizeText = createAction({
-  audience: 'human',
+  audience: 'both',
   auth: grokAuth,
   name: 'categorize_text',
   displayName: 'Categorize Text',
   description: 'Assign categories to input text based on custom or predefined labels.',
+  aiMetadata: { description: 'Classifies one block of text against a caller-defined list of categories, each supplied as a name plus a description, returning the chosen labels with the model reasoning and optional per-category confidence scores; a flag switches it between single-label and multi-label assignment, and an optional context search lets the model consult the web before deciding. Pick it when the goal is sorting text into a known label set, rather than pulling values out of it (extract_data_from_text) or generating free-form output (ask_grok). Non-empty text and at least one category are required; not idempotent: each call is a fresh model completion and the assigned labels can vary between runs.', idempotent: false },
   props: {
     model: createModelProperty({
       displayName: 'Model',

--- a/packages/pieces/community/grok-xai/src/lib/actions/extract-data.ts
+++ b/packages/pieces/community/grok-xai/src/lib/actions/extract-data.ts
@@ -26,11 +26,12 @@ interface ExtractDataField {
 }
 
 export const extractDataFromText = createAction({
-  audience: 'human',
+  audience: 'both',
   auth: grokAuth,
   name: 'extract_data_from_text',
   displayName: 'Extract Data From Text',
   description: 'Extract structured data fields from unstructured text (e.g., names, addresses, dates).',
+  aiMetadata: { description: 'Pulls a caller-defined set of typed fields (string, number, boolean, array, or object, each named, described, and individually required or optional) out of one block of unstructured text and returns them as a structured object with extraction notes and optional per-field confidence scores; a strict mode restricts it to information explicitly present instead of allowing inference from context. Choose it to turn prose into known fields; prefer categorize_text when the goal is assigning a label from a fixed set, and ask_grok for open-ended generation or free-form structured output. Non-empty text and at least one field definition are required; not idempotent: each call is a fresh model completion and the extracted values can vary between runs.', idempotent: false },
   props: {
     model: createModelProperty({
       displayName: 'Model',

--- a/packages/pieces/community/grok-xai/src/lib/actions/generate-image.ts
+++ b/packages/pieces/community/grok-xai/src/lib/actions/generate-image.ts
@@ -16,11 +16,12 @@ import {
 import * as z from 'zod/mini'
 
 export const generateImage = createAction({
-  audience: 'human',
+  audience: 'both',
   auth: grokAuth,
   name: 'generate_image',
   displayName: 'Generate Image',
   description: 'Create images from text prompts using Grok\'s image generation.',
+  aiMetadata: { description: 'Generates one to ten images from a text prompt with a Grok image model, delivered either as hosted URLs or as base64 payloads depending on the chosen response format. This is the only action in the piece that produces images; ask_grok can accept an image URL as vision input but only ever returns text. Requires a non-empty prompt of at most 4000 characters, and the model must be an image model (the dropdown filters to those). Not idempotent: each call renders new images.', idempotent: false },
   props: {
     prompt: Property.LongText({
       displayName: 'Image Prompt',

--- a/packages/pieces/community/groq/package.json
+++ b/packages/pieces/community/groq/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-groq",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {

--- a/packages/pieces/community/groq/src/lib/actions/ask-groq.ts
+++ b/packages/pieces/community/groq/src/lib/actions/ask-groq.ts
@@ -4,11 +4,12 @@ import { httpClient, HttpMethod, AuthenticationType } from '@activepieces/pieces
 import { askAiActionOutputSchema } from '../output-schemas';
 
 export const askGroq = createAction({
-  audience: 'human',
+  audience: 'both',
 	auth: groqAuth,
 	name: 'ask-ai',
 	displayName: 'Ask AI',
 	description: 'Ask Groq anything using fast language models.',
+	aiMetadata: { description: 'Sends a prompt to a Groq-hosted chat model (Whisper speech models are excluded from the model list) and returns the generated text, with optional sampling controls and a roles array for system instructions. Runs stateless by default, or shares conversation history across runs and flows when a memory key is set. This is the only text-generation action in the piece - pick the sibling Transcribe Audio or Translate Audio actions when the input is a sound file rather than text. Requires a model, a question, and a maximum token count; not idempotent: each call produces a fresh completion and, when a memory key is set, appends to the stored project-scoped history.', idempotent: false },
 	props: {
 		model: Property.Dropdown({
 			auth: groqAuth,

--- a/packages/pieces/community/groq/src/lib/actions/transcribe-audio.ts
+++ b/packages/pieces/community/groq/src/lib/actions/transcribe-audio.ts
@@ -4,11 +4,12 @@ import { httpClient, HttpMethod, AuthenticationType } from '@activepieces/pieces
 import { transcribeAudioActionOutputSchema } from '../output-schemas';
 
 export const transcribeAudio = createAction({
-  audience: 'human',
+  audience: 'both',
 	auth: groqAuth,
 	name: 'transcribe-audio',
 	displayName: 'Transcribe Audio',
 	description: 'Transcribes audio into text in the input language.',
+	aiMetadata: { description: 'Runs Groq speech-to-text (Whisper) over an uploaded audio file and returns the spoken content transcribed in its original language; a response-format prop switches between plain text, JSON, and verbose JSON with segment timings. Choose this over the sibling Translate Audio action whenever the transcript must stay in the language that was spoken, since Translate Audio always renders English. Requires an audio file (flac, mp3, mp4, mpeg, mpga, m4a, ogg, wav, webm) and a Whisper model, with an optional ISO-639-1 language hint that improves accuracy; not idempotent: each call re-runs the model and may return slightly different text.', idempotent: false },
 	props: {
 		file: Property.File({
 			displayName: 'Audio File',

--- a/packages/pieces/community/groq/src/lib/actions/translate-audio.ts
+++ b/packages/pieces/community/groq/src/lib/actions/translate-audio.ts
@@ -4,11 +4,12 @@ import { httpClient, HttpMethod, AuthenticationType } from '@activepieces/pieces
 import { translateAudioActionOutputSchema } from '../output-schemas';
 
 export const translateAudio = createAction({
-  audience: 'human',
+  audience: 'both',
 	auth: groqAuth,
 	name: 'translate-audio',
 	displayName: 'Translate Audio',
 	description: 'Translates audio into English text.',
+	aiMetadata: { description: 'Runs Groq speech-to-text (Whisper) over an uploaded audio file and returns the spoken content as English text, translating from whatever language was spoken; a response-format prop switches between plain text, JSON, and verbose JSON with segment timings. Pick this only when English output is wanted - the target language cannot be changed, and the sibling Transcribe Audio action keeps the transcript in the original spoken language. Requires an audio file (flac, mp3, mp4, mpeg, mpga, m4a, ogg, wav, webm) and a Whisper model; not idempotent: each call re-runs the model and may return slightly different text.', idempotent: false },
 	props: {
 		file: Property.File({
 			displayName: 'Audio File',

--- a/packages/pieces/community/http-oauth2/package.json
+++ b/packages/pieces/community/http-oauth2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-http-oauth2",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "dependencies": {

--- a/packages/pieces/community/http-oauth2/src/lib/actions/send-oauth2-http-request.ts
+++ b/packages/pieces/community/http-oauth2/src/lib/actions/send-oauth2-http-request.ts
@@ -20,12 +20,13 @@ import FormData from 'form-data';
 import { ProxyAgent } from 'undici';
 
 export const httpOauth2RequestAction = createAction({
-  audience: 'human',
+  audience: 'both',
   auth: httpOauth2Auth,
   name: 'send-oauth2-request',
   displayName: 'Send an OAuth2 Request',
   description:
     'Sends HTTP request to a specified URL that requires OAuth 2.0 authorization and returns the response.',
+  aiMetadata: { description: 'Calls any HTTP endpoint with an OAuth 2.0 bearer token injected from the connection, choosing the method (GET/POST/PUT/PATCH/DELETE) and body mode (none, JSON, raw, or form-data), optionally routing through an HTTP proxy or returning the error text instead of throwing when the failsafe option is on. Prefer it over the core HTTP piece Send HTTP Request action only when the target API needs a managed OAuth2 token that Activepieces refreshes; it requires an OAuth2 connection set up with the authorize URL, token URL, and scopes, plus a full request URL. Not idempotent in general: the effect depends on the chosen method, and non-GET calls can create or change data on each call.', idempotent: false },
   props: {
     url: Property.ShortText({
       displayName: 'URL',

--- a/packages/pieces/community/hugging-face/package.json
+++ b/packages/pieces/community/hugging-face/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-hugging-face",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "dependencies": {

--- a/packages/pieces/community/hugging-face/src/lib/actions/chat-completion.ts
+++ b/packages/pieces/community/hugging-face/src/lib/actions/chat-completion.ts
@@ -5,12 +5,17 @@ import { httpClient, HttpMethod } from '@activepieces/pieces-common';
 import { huggingFaceAuth } from '../auth';
 
 export const chatCompletion = createAction({
-  audience: 'human',
+  audience: 'both',
   name: 'chat_completion',
   auth: huggingFaceAuth,
   displayName: 'Chat Completion',
   description:
     'Generate assistant replies using chat-style LLMs - perfect for FAQ bots, support agents, and content generation',
+  aiMetadata: {
+    description:
+      'Runs a free-form chat completion against a Hugging Face instruct model (Llama, Mistral, Qwen and similar) and returns the assistant reply, in one of three conversation modes: a single user message, a multi-turn exchange assembled from a conversation-history array, or a template mode that prepends a canned persona system prompt. This is the only open-ended text generator in this piece - prefer text_summarization to condense a document, language_translation to move text between languages, and text_classification to assign labels from a fixed set. A user message is required in single and template modes; not idempotent: each call is a fresh sampled completion and the wording varies between runs.',
+    idempotent: false,
+  },
   props: {
     useCase: Property.StaticDropdown({
       displayName: 'Use Case',

--- a/packages/pieces/community/hugging-face/src/lib/actions/create-image.ts
+++ b/packages/pieces/community/hugging-face/src/lib/actions/create-image.ts
@@ -5,12 +5,17 @@ import { httpClient, HttpMethod } from '@activepieces/pieces-common';
 import { huggingFaceAuth } from '../auth';
 
 export const createImage = createAction({
-  audience: 'human',
+  audience: 'both',
   name: 'create_image',
   auth: huggingFaceAuth,
   displayName: 'Create Image',
   description:
     'Generate stunning images from text prompts using state-of-the-art diffusion models - perfect for marketing, product design, and creative content',
+  aiMetadata: {
+    description:
+      'Generates an image from a text prompt with a Hugging Face text-to-image diffusion model (Stable Diffusion, FLUX and similar), sized by an aspect-ratio preset or custom width and height, and tuned by a quality preset that maps to a denoising-step count. This is the only action here that produces an image; the vision actions image_classification, object_detection, and document_question_answering consume one instead. A non-empty prompt is required; not idempotent: each call renders a new image, and unless an explicit seed is supplied the result differs every run.',
+    idempotent: false,
+  },
   props: {
     useCase: Property.StaticDropdown({
       displayName: 'Use Case',

--- a/packages/pieces/community/hugging-face/src/lib/actions/document-question-answering.ts
+++ b/packages/pieces/community/hugging-face/src/lib/actions/document-question-answering.ts
@@ -6,12 +6,17 @@ import {
 import { huggingFaceAuth } from '../auth';
 
 export const documentQuestionAnswering = createAction({
-  audience: 'human',
+  audience: 'both',
   name: 'document_question_answering',
   auth: huggingFaceAuth,
   displayName: 'Document Question Answering',
   description:
     'Answer questions from document images using Hugging Face models',
+  aiMetadata: {
+    description:
+      'Answers a natural-language question about an uploaded document image (invoice, contract, form) with a layout-aware extractive model such as LayoutLM, returning the matching text span and its confidence score. Choose it to pull one specific value out of a scanned document - use image_classification or object_detection for general-purpose vision, and chat_completion when the source text is already plain. Requires both a document image file and a question; read-only and idempotent, since it only analyses the supplied file.',
+    idempotent: true,
+  },
   props: {
     model: Property.StaticDropdown({
       displayName: 'Model',

--- a/packages/pieces/community/hugging-face/src/lib/actions/image-classification.ts
+++ b/packages/pieces/community/hugging-face/src/lib/actions/image-classification.ts
@@ -10,12 +10,17 @@ import { httpClient, HttpMethod } from '@activepieces/pieces-common';
 import { huggingFaceAuth } from '../auth';
 
 export const imageClassification = createAction({
-  audience: 'human',
+  audience: 'both',
   name: 'image_classification',
   auth: huggingFaceAuth,
   displayName: 'Image Classification',
   description:
     'Classify images with pre-trained models or custom categories - perfect for content moderation, automated tagging, and smart asset management',
+  aiMetadata: {
+    description:
+      'Assigns category labels to a whole image, supplied either as an uploaded file or as a URL the action fetches, in one of two modes: standard mode returns labels from the set the pre-trained model was trained on, while zero-shot mode scores the image against custom candidate categories you supply. Pick it for whole-image tagging or moderation; use object_detection when the positions or counts of individual objects matter, and document_question_answering to read a specific value out of a scanned document. Zero-shot mode requires a non-empty category list; read-only and idempotent, as it only analyses the image.',
+    idempotent: true,
+  },
   props: {
     classificationMode: Property.StaticDropdown({
       displayName: 'Classification Mode',

--- a/packages/pieces/community/hugging-face/src/lib/actions/language-translation.ts
+++ b/packages/pieces/community/hugging-face/src/lib/actions/language-translation.ts
@@ -4,12 +4,17 @@ import { httpClient, HttpMethod } from '@activepieces/pieces-common';
 import { huggingFaceAuth } from '../auth';
 
 export const languageTranslation = createAction({
-  audience: 'human',
+  audience: 'both',
   name: 'language_translation',
   auth: huggingFaceAuth,
   displayName: 'Language Translation',
   description:
     'Translate text between languages using specialized Hugging Face translation models',
+  aiMetadata: {
+    description:
+      'Translates a block of text with a dedicated Hugging Face machine-translation model, chosen either from the dropdown of Helsinki-NLP opus-mt language pairs or by passing any translation model ID in the custom-model field, which takes precedence over the dropdown. Use it instead of chat_completion whenever the task is purely translation, since these models are narrower and more consistent; the source and target language codes apply only to multilingual models, because a single-pair model already fixes the direction. Read-only and idempotent: it returns the translation and stores nothing.',
+    idempotent: true,
+  },
   props: {
     model: Property.Dropdown({
       auth: huggingFaceAuth,

--- a/packages/pieces/community/hugging-face/src/lib/actions/object-detection.ts
+++ b/packages/pieces/community/hugging-face/src/lib/actions/object-detection.ts
@@ -8,12 +8,17 @@ import { httpClient, HttpMethod } from '@activepieces/pieces-common';
 import { huggingFaceAuth } from '../auth';
 
 export const objectDetection = createAction({
-  audience: 'human',
+  audience: 'both',
   name: 'object_detection',
   auth: huggingFaceAuth,
   displayName: 'Object Detection',
   description:
     'Detect and locate objects in images with precise bounding boxes - perfect for inventory management, content moderation, and automated tagging',
+  aiMetadata: {
+    description:
+      'Locates the individual objects in an uploaded image with a DETR or YOLOS-style detection model, returning each one with a label, a confidence score, and bounding-box coordinates; a filter preset chooses the confidence cut-off (high, balanced, all, or a custom threshold) and a cap limits how many detections come back. Choose it when the positions or counts of objects matter - prefer image_classification for a single whole-image label, and document_question_answering to read a value out of a document scan. Requires an uploaded image file; read-only and idempotent, as it only analyses the image.',
+    idempotent: true,
+  },
   props: {
     useCase: Property.StaticDropdown({
       displayName: 'Use Case',

--- a/packages/pieces/community/hugging-face/src/lib/actions/text-classification.ts
+++ b/packages/pieces/community/hugging-face/src/lib/actions/text-classification.ts
@@ -8,12 +8,17 @@ import { httpClient, HttpMethod } from '@activepieces/pieces-common';
 import { huggingFaceAuth } from '../auth';
 
 export const textClassification = createAction({
-  audience: 'human',
+  audience: 'both',
   name: 'text_classification',
   auth: huggingFaceAuth,
   displayName: 'Text Classification',
   description:
     'Classify text into categories using Hugging Face models - includes zero-shot classification for custom categories',
+  aiMetadata: {
+    description:
+      'Scores a block of text against a set of labels and returns the ranked predictions, in one of three modes: zero-shot classifies into custom comma-separated categories you supply, pre-trained uses a curated sentiment, emotion, or topic model with its own fixed label set, and search runs any classification model looked up on the Hugging Face hub. Choose it to sort text into a known label set - use chat_completion for open-ended reasoning about the text, text_summarization to condense it, and image_classification when the input is an image rather than text. Zero-shot mode fails without at least one category; read-only and idempotent, as classifying stores nothing.',
+    idempotent: true,
+  },
   props: {
     classificationMode: Property.StaticDropdown({
       displayName: 'Classification Type',

--- a/packages/pieces/community/hugging-face/src/lib/actions/text-summarization.ts
+++ b/packages/pieces/community/hugging-face/src/lib/actions/text-summarization.ts
@@ -4,12 +4,17 @@ import { httpClient, HttpMethod } from '@activepieces/pieces-common';
 import { huggingFaceAuth } from '../auth';
 
 export const textSummarization = createAction({
-  audience: 'human',
+  audience: 'both',
   name: 'text_summarization',
   auth: huggingFaceAuth,
   displayName: 'Text Summarization',
   description:
     'Generate abstractive summaries of long text using Hugging Face models - optimized for business content',
+  aiMetadata: {
+    description:
+      'Condenses one long block of text into a shorter abstractive summary with a Hugging Face summarization model such as BART or Pegasus, targeting either a brief, medium, or detailed length preset or explicit min and max token counts. Choose it over chat_completion when the task is purely summarization, since it decodes greedily for stable output; use text_classification to label the text instead, or language_translation to change its language. Works best on inputs of roughly 512 to 1024 tokens and needs a truncation strategy for anything longer; read-only and idempotent, as it stores nothing.',
+    idempotent: true,
+  },
   props: {
     contentType: Property.StaticDropdown({
       displayName: 'Content Type',

--- a/packages/pieces/community/image-router/package.json
+++ b/packages/pieces/community/image-router/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-image-router",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/packages/pieces/community/image-router/src/lib/actions/create-image.ts
+++ b/packages/pieces/community/image-router/src/lib/actions/create-image.ts
@@ -7,11 +7,12 @@ import { randomBytes } from 'node:crypto';
 import { kebabCase } from '@activepieces/pieces-framework';
 
 export const createImage = createAction({
-  audience: 'human',
+  audience: 'both',
   auth: imageRouterAuth,
   name: 'createImage',
   displayName: 'Create Image',
   description: 'Generate an image from a text prompt using any available model',
+  aiMetadata: { description: 'Generates brand-new images from a text prompt alone, routing the request through ImageRouter to whichever hosted image model is named in the required Model input, then downloading each result and saving it as a flow file. Pick this when there is no source picture to work from; use Image to Image instead to edit, mask, or transform images you already have. Quality and size are advisory and are ignored by models that do not support them. Not idempotent: each call runs a fresh generation and returns different images.', idempotent: false },
   props: {
     prompt: Property.ShortText({
       displayName: 'Prompt',

--- a/packages/pieces/community/image-router/src/lib/actions/image-to-image.ts
+++ b/packages/pieces/community/image-router/src/lib/actions/image-to-image.ts
@@ -16,11 +16,12 @@ interface MaskItem {
 }
 
 export const imageToImage = createAction({
-  audience: 'human',
+  audience: 'both',
   auth: imageRouterAuth,
   name: 'imageToImage',
   displayName: 'Image to Image',
   description: 'Generate or edit images using input image(s) with optional mask',
+  aiMetadata: { description: 'Edits or transforms one to sixteen supplied image files against a text prompt via ImageRouter\'s image-edit endpoint, either rewriting the whole picture or, when mask files are attached, confining the changes to the masked areas (some models require a mask). Choose this whenever a source image must be sent - inpainting, style transfer, background swaps, multi-image composition; use Create Image when generating from a prompt with no input image. At least one image file is required and the selected model must support editing. Not idempotent: each call renders new output images.', idempotent: false },
   props: {
     prompt: Property.ShortText({
       displayName: 'Prompt',

--- a/packages/pieces/community/json/package.json
+++ b/packages/pieces/community/json/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-json",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {

--- a/packages/pieces/community/json/src/lib/actions/convert-json-to-text.ts
+++ b/packages/pieces/community/json/src/lib/actions/convert-json-to-text.ts
@@ -1,10 +1,11 @@
 import { createAction, Property } from '@activepieces/pieces-framework';
 
 export const convertJsonToText = createAction({
-  audience: 'human',
   name: 'convert_json_to_text',
   displayName: 'Convert Json to Text',
   description: 'Stringifies JSON.',
+  audience: 'both',
+  aiMetadata: { description: 'Serialize a JSON object or array into its string form, for downstream steps that need raw text rather than structured data — a request body, a file body, or a plain text field. Use convert_text_to_json for the reverse direction, run_jsonata_query when the data needs reshaping rather than stringifying, and merge_json to fold several objects into one first. Read-only and idempotent.', idempotent: true },
   props: {
     json: Property.Json({
       displayName: 'JSON',

--- a/packages/pieces/community/json/src/lib/actions/convert-text-to-json.ts
+++ b/packages/pieces/community/json/src/lib/actions/convert-text-to-json.ts
@@ -1,10 +1,11 @@
 import { createAction, Property } from '@activepieces/pieces-framework';
 
 export const convertTextToJson = createAction({
-  audience: 'human',
   name: 'convert_text_to_json',
   displayName: 'Convert Text to Json',
   description: 'Parses text into JSON.',
+  audience: 'both',
+  aiMetadata: { description: 'Parse a JSON-formatted string into a real object or array so later steps can reference its fields directly instead of handling raw text; the input must be strictly valid JSON, and malformed text throws rather than returning a partial result. Use convert_json_to_text for the reverse direction, or run_jsonata_query when the data is already structured and needs filtering or reshaping. Read-only and idempotent.', idempotent: true },
   props: {
     text: Property.LongText({
       displayName: 'Text',

--- a/packages/pieces/community/json/src/lib/actions/run-jsonata-query.ts
+++ b/packages/pieces/community/json/src/lib/actions/run-jsonata-query.ts
@@ -2,10 +2,11 @@ import { createAction, Property } from '@activepieces/pieces-framework';
 import jsonata from 'jsonata';
 
 export const runJsonataQuery = createAction({
-  audience: 'human',
   name: 'run_jsonata_query',
   displayName: 'Run JSONata Query',
   description: 'Use the JSONata language to filter, map, and transform complex JSON payloads natively in JavaScript.',
+  audience: 'both',
+  aiMetadata: { description: 'Evaluate a JSONata expression against a JSON object, array, or JSON string to filter, extract, group, or reshape it in a single step, covering transformations that would otherwise need custom code. Requires a syntactically valid JSONata expression — an invalid one fails the step, while a valid query that matches nothing returns null. Prefer merge_json to fold an array of objects into one, or convert_text_to_json / convert_json_to_text for plain parsing and stringifying. Read-only and idempotent.', idempotent: true },
   props: {
     json: Property.Json({
       displayName: 'JSON Data',

--- a/packages/pieces/community/linkupapi/package.json
+++ b/packages/pieces/community/linkupapi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-linkupapi",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/packages/pieces/community/linkupapi/src/lib/actions/check-invitation-status.ts
+++ b/packages/pieces/community/linkupapi/src/lib/actions/check-invitation-status.ts
@@ -6,6 +6,8 @@ export const checkInvitationStatus = createAction({
   name: 'check_invitation_status',
   displayName: 'Check Invitation Status',
   description: 'Check the status of a connection invitation sent to a profile.',
+  audience: 'both',
+  aiMetadata: { description: 'Checks the current state of a connection invitation sent from the connected account to a given profile URL. Use it to poll the outcome of Send Connection Request rather than re-sending; the Invitation Accepted trigger is the push alternative for flows that can wait. Requires the account ID and the target profile URL. Read-only and idempotent.', idempotent: true },
   props: {
     accountId: accountIdProp,
     profileUrl: Property.ShortText({

--- a/packages/pieces/community/linkupapi/src/lib/actions/get-account.ts
+++ b/packages/pieces/community/linkupapi/src/lib/actions/get-account.ts
@@ -6,6 +6,8 @@ export const getAccount = createAction({
   name: 'get_account',
   displayName: 'Get Account Details',
   description: 'Get detailed information and status for a specific connected account. Free (0 credits).',
+  audience: 'both',
+  aiMetadata: { description: 'Fetches the integration details and connection status of one connected LinkedIn account by its account ID. Use List Accounts instead when the ID is unknown, and Get My Profile when the LinkedIn profile behind the account is wanted rather than its connection state. Requires a valid account ID. Read-only and idempotent.', idempotent: true },
   props: {
     accountId: Property.ShortText({
       displayName: 'Account ID',

--- a/packages/pieces/community/linkupapi/src/lib/actions/get-company.ts
+++ b/packages/pieces/community/linkupapi/src/lib/actions/get-company.ts
@@ -6,6 +6,8 @@ export const getCompany = createAction({
   name: 'get_company',
   displayName: 'Get Company Info',
   description: 'Retrieve detailed information about a LinkedIn company page.',
+  audience: 'both',
+  aiMetadata: { description: 'Looks up one LinkedIn company page from its URL. Use Search Companies first when only a company name is known, and Get Profile Info for a person rather than an organisation. Requires both the account ID and an exact company page URL. Read-only and idempotent.', idempotent: true },
   props: {
     accountId: accountIdProp,
     companyUrl: Property.ShortText({

--- a/packages/pieces/community/linkupapi/src/lib/actions/get-conversation.ts
+++ b/packages/pieces/community/linkupapi/src/lib/actions/get-conversation.ts
@@ -6,6 +6,8 @@ export const getConversation = createAction({
   name: 'get_conversation',
   displayName: 'Get Conversation',
   description: 'Retrieve the message history of a LinkedIn conversation, by conversation ID or profile URL.',
+  audience: 'both',
+  aiMetadata: { description: 'Reads the message history of one LinkedIn thread, addressed either by conversation ID or by the other participant\'s profile URL, with count and cursor paging for longer threads. Use it to gather context before replying with Send Message. Requires the account ID plus one of the two addressing inputs. Read-only and idempotent.', idempotent: true },
   props: {
     accountId: accountIdProp,
     conversationId: Property.ShortText({

--- a/packages/pieces/community/linkupapi/src/lib/actions/get-my-profile.ts
+++ b/packages/pieces/community/linkupapi/src/lib/actions/get-my-profile.ts
@@ -6,6 +6,8 @@ export const getMyProfile = createAction({
   name: 'get_my_profile',
   displayName: 'Get My Profile',
   description: 'Retrieve the profile of the connected LinkedIn account.',
+  audience: 'both',
+  aiMetadata: { description: 'Retrieves the LinkedIn profile of the connected account itself, resolving who the automation is acting as. Use Get Profile Info for anyone else. Requires the account ID from List Accounts. Read-only and idempotent.', idempotent: true },
   props: {
     accountId: accountIdProp,
   },

--- a/packages/pieces/community/linkupapi/src/lib/actions/get-profile.ts
+++ b/packages/pieces/community/linkupapi/src/lib/actions/get-profile.ts
@@ -6,6 +6,8 @@ export const getProfile = createAction({
   name: 'get_profile',
   displayName: 'Get Profile Info',
   description: 'Retrieve detailed information about a LinkedIn profile by URL, public identifier, or URN.',
+  audience: 'both',
+  aiMetadata: { description: 'Looks up a LinkedIn person profile addressed in one of three interchangeable ways: full profile URL, public identifier, or profile URN. Use it when a specific person is already identified; use Search People to discover profiles from attributes, and Get My Profile for the connected account. Requires the account ID plus exactly one of the three address inputs. Read-only and idempotent.', idempotent: true },
   props: {
     accountId: accountIdProp,
     profileUrl: Property.ShortText({

--- a/packages/pieces/community/linkupapi/src/lib/actions/list-accounts.ts
+++ b/packages/pieces/community/linkupapi/src/lib/actions/list-accounts.ts
@@ -6,6 +6,8 @@ export const listAccounts = createAction({
   name: 'list_accounts',
   displayName: 'List Accounts',
   description: 'List all connected LinkedIn accounts linked to your API key. Free (0 credits). Use the returned account_id in other actions.',
+  audience: 'both',
+  aiMetadata: { description: 'Lists the LinkedIn accounts connected to this LinkupAPI key, paged by limit and offset. Call this first to obtain the account ID that every other LinkupAPI action and trigger requires; prefer Get Account Details when the ID is already known. Read-only and idempotent.', idempotent: true },
   props: {
     limit: Property.Number({
       displayName: 'Limit',

--- a/packages/pieces/community/linkupapi/src/lib/actions/search-companies.ts
+++ b/packages/pieces/community/linkupapi/src/lib/actions/search-companies.ts
@@ -6,6 +6,8 @@ export const searchCompanies = createAction({
   name: 'search_companies',
   displayName: 'Search Companies',
   description: 'Search LinkedIn companies by keyword, location, sector and company size.',
+  audience: 'both',
+  aiMetadata: { description: 'Searches LinkedIn company pages by keyword, location, sector, or company size, over a configurable page range. Use it to locate a company page when only a name or profile of the firm is known; call Get Company Info afterwards for the full record of a known company URL, and Search People to find individuals. Requires the account ID from List Accounts. Read-only and idempotent.', idempotent: true },
   props: {
     accountId: accountIdProp,
     keyword: Property.ShortText({ displayName: 'Keyword', required: false }),

--- a/packages/pieces/community/linkupapi/src/lib/actions/search-people.ts
+++ b/packages/pieces/community/linkupapi/src/lib/actions/search-people.ts
@@ -6,6 +6,8 @@ export const searchPeople = createAction({
   name: 'search_people',
   displayName: 'Search People',
   description: 'Search LinkedIn profiles by keyword, company, title, location, school, industry and more. Returns the LinkedIn URL of each match.',
+  audience: 'both',
+  aiMetadata: { description: 'Searches LinkedIn people by any combination of keyword, name, title, company, location, school, industry, or connection degree; alternatively it can enumerate the connections or followers of one given profile instead of running an attribute search. Use it to discover prospects when no profile URL is known, then switch to Get Profile Info once one is. Requires the account ID from List Accounts, and the result count is capped by Total Results. Read-only and idempotent.', idempotent: true },
   props: {
     accountId: accountIdProp,
     keyword: Property.ShortText({ displayName: 'Keyword', required: false }),

--- a/packages/pieces/community/linkupapi/src/lib/actions/send-connection-request.ts
+++ b/packages/pieces/community/linkupapi/src/lib/actions/send-connection-request.ts
@@ -6,6 +6,8 @@ export const sendConnectionRequest = createAction({
   name: 'send_connection_request',
   displayName: 'Send Connection Request',
   description: 'Send a LinkedIn connection invitation to a profile, with an optional note.',
+  audience: 'both',
+  aiMetadata: { description: 'Sends a LinkedIn connection invitation from the connected account to a person addressed by either profile URL or public identifier, with an optional note. Use it to open contact with someone outside the account network; Send Message is for people already reachable. Requires the account ID and one of the two address inputs. Not idempotent: each call issues a fresh invitation and consumes LinkedIn invite quota, so check Check Invitation Status before retrying.', idempotent: false },
   props: {
     accountId: accountIdProp,
     profileUrl: Property.ShortText({

--- a/packages/pieces/community/linkupapi/src/lib/actions/send-message.ts
+++ b/packages/pieces/community/linkupapi/src/lib/actions/send-message.ts
@@ -6,6 +6,8 @@ export const sendMessage = createAction({
   name: 'send_message',
   displayName: 'Send Message',
   description: 'Send a LinkedIn message to a profile, optionally with a media attachment.',
+  audience: 'both',
+  aiMetadata: { description: 'Sends a LinkedIn direct message from the connected account to a recipient profile URL, optionally attaching a media link. Use it for outreach or replies to an existing thread; Send Connection Request is the right action when the recipient cannot be messaged yet, and Get Conversation loads the thread context first. Requires the account ID, the recipient profile URL, and message text. Not idempotent: every call delivers another message, so retries duplicate it.', idempotent: false },
   props: {
     accountId: accountIdProp,
     profileUrl: Property.ShortText({

--- a/packages/pieces/community/linkupapi/src/lib/triggers/invitation-accepted.ts
+++ b/packages/pieces/community/linkupapi/src/lib/triggers/invitation-accepted.ts
@@ -12,6 +12,9 @@ export const invitationAccepted = createTrigger({
   displayName: 'Invitation Accepted',
   description:
     'Fires in real time when a connection request sent from the connected LinkedIn account is accepted. Registers a LinkupAPI webhook (≈10 credits/day per monitored account while active).',
+  aiMetadata: {
+    description: 'Fires once each time someone accepts a connection invitation previously sent from the connected LinkedIn account, in real time via a LinkupAPI webhook. Use it to continue outreach the moment a prospect connects instead of polling Check Invitation Status; it does not fire for invitations received by the account or for new messages (use New Message Received for those). Each enabled instance registers a webhook against a single account ID and bills credits daily while the flow stays on.',
+  },
   type: TriggerStrategy.WEBHOOK,
   props: {
     accountId: accountIdProp,

--- a/packages/pieces/community/linkupapi/src/lib/triggers/new-message-received.ts
+++ b/packages/pieces/community/linkupapi/src/lib/triggers/new-message-received.ts
@@ -12,6 +12,9 @@ export const newMessageReceived = createTrigger({
   displayName: 'New Message Received',
   description:
     'Fires in real time when the connected LinkedIn account receives a new message. Registers a LinkupAPI webhook (≈10 credits/day per monitored account while active).',
+  aiMetadata: {
+    description: 'Fires once for every inbound direct message received by one connected LinkedIn account, in real time via a LinkupAPI webhook. Use it to start reply, triage, or CRM-logging automations on incoming LinkedIn conversations; it covers only messages received, not messages the account sends, and not invitation activity (use Invitation Accepted for that). Each enabled instance registers a webhook against a single account ID and bills credits daily while the flow stays on.',
+  },
   type: TriggerStrategy.WEBHOOK,
   props: {
     accountId: accountIdProp,

--- a/packages/pieces/community/localai/package.json
+++ b/packages/pieces/community/localai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-localai",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "dependencies": {

--- a/packages/pieces/community/localai/src/lib/actions/send-prompt.ts
+++ b/packages/pieces/community/localai/src/lib/actions/send-prompt.ts
@@ -25,11 +25,12 @@ Ensure that your API key is valid. \n
 `;
 
 export const askLocalAI = createAction({
-  audience: 'human',
+  audience: 'both',
   auth: localaiAuth,
   name: 'ask_localai',
   displayName: 'Ask LocalAI',
   description: 'Ask LocalAI anything you want!',
+  aiMetadata: { description: 'Sends a prompt to a chat model running on your own self-hosted LocalAI server, through the OpenAI-compatible completions endpoint at the server URL stored on the connection, with optional sampling controls and a roles array for system or assistant priming; unlike the hosted-vendor pieces it keeps no conversation memory, so every call is stateless. Pick it only when inference must stay on your own LocalAI instance rather than a cloud provider such as OpenAI, Groq, or DeepSeek, and use the piece\'s Custom API Call action for LocalAI endpoints other than chat completions, such as embeddings, images, or audio. Requires a question and a model id that actually exists on that instance, since the dropdown lists only what the server reports and the default gpt-3.5-turbo may not be installed; not idempotent: each call produces a fresh completion.', idempotent: false },
   props: {
     model: Property.Dropdown({
       auth: localaiAuth,

--- a/packages/pieces/community/mcp-client/package.json
+++ b/packages/pieces/community/mcp-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-mcp-client",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/packages/pieces/community/mcp-client/src/lib/actions/call-tool.ts
+++ b/packages/pieces/community/mcp-client/src/lib/actions/call-tool.ts
@@ -12,6 +12,8 @@ export const callTool = createAction({
   name: 'call-tool',
   displayName: 'Call Tool',
   description: 'Invoke a specific tool on an external MCP server and return its result.',
+  audience: 'both',
+  aiMetadata: { description: 'Invokes one named tool on the connected external MCP server with arguments matching that tool\'s own input schema; the tool list and its input fields are discovered live from the server, so what is callable varies by which MCP server the connection points at. Use it to call a third-party MCP tool deterministically as a flow step instead of delegating the choice to an LLM. Requires the exact tool name the server exposes, and it fails when the server flags the result as an error. Not idempotent: the effect depends on the remote tool invoked, which may create or mutate data on every call.', idempotent: false },
   props: {
     tool: Property.Dropdown<string, true, typeof mcpClientAuth>({
       auth: mcpClientAuth,

--- a/packages/pieces/community/mcp/package.json
+++ b/packages/pieces/community/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-mcp",
-  "version": "0.0.18",
+  "version": "0.0.19",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {

--- a/packages/pieces/community/mcp/src/lib/actions/reply-to-mcp-client.ts
+++ b/packages/pieces/community/mcp/src/lib/actions/reply-to-mcp-client.ts
@@ -9,10 +9,11 @@ import { StatusCodes } from 'http-status-codes';
 
 
 export const replyToMcpClient = createAction({
-  audience: 'human',
+  audience: 'both',
   name: 'reply_to_mcp_client',
   displayName: 'Reply to MCP Client',
   description: 'Return a response to the MCP client that called the tool.',
+  aiMetadata: { description: 'Send a result payload back to the MCP client that invoked this flow through the MCP Tool trigger, supplied either as key-value pairs (Simple mode) or as raw JSON (Advanced mode), and either stop the run there or respond and let the remaining steps continue. Only meaningful in a flow started by the MCP Tool trigger with Wait for Response enabled; without that the client receives nothing. Not idempotent: each call emits a response to the waiting client and changes the run execution state.', idempotent: false },
   props: {
     note: Property.MarkDown({
       value: '**Important**: Make sure your MCP trigger has (Wait for Response) turned on.'

--- a/packages/pieces/community/mcp/src/lib/triggers/mcp-tool.ts
+++ b/packages/pieces/community/mcp/src/lib/triggers/mcp-tool.ts
@@ -11,6 +11,9 @@ export const mcpTool = createTrigger({
   name: 'mcp_tool',
   displayName: 'MCP Tool',
   description: 'Creates a tool that MCP clients can call to execute this flow',
+  aiMetadata: {
+    description: 'Fires when an MCP client such as Claude Desktop, Cursor, or Windsurf calls the tool that this flow publishes on the hosted MCP server, carrying the arguments the client supplied for the parameters declared on the trigger. The configured name and description are what the client sees when it picks the tool, any parameter marked required must be present or the call errors, and turning on Wait for Response holds the client until a Reply to MCP Client action returns a result.',
+  },
   props: {
     toolName: Property.ShortText({
       displayName: 'Name',

--- a/packages/pieces/community/microsoft-copilot/package.json
+++ b/packages/pieces/community/microsoft-copilot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-microsoft-copilot",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/packages/pieces/community/microsoft-copilot/src/lib/actions/chat-with-copilot.ts
+++ b/packages/pieces/community/microsoft-copilot/src/lib/actions/chat-with-copilot.ts
@@ -4,12 +4,16 @@ import { httpClient, HttpMethod } from '@activepieces/pieces-common';
 import { getGraphBaseUrl, getMicrosoftCloudFromAuth } from '../common/microsoft-cloud';
 
 export const chatWithCopilot = createAction({
-  audience: 'human',
+  audience: 'both',
   auth: microsoft365CopilotAuth,
   name: 'chatWithCopilot',
   displayName: 'Chat with Copilot',
   description:
     'Send a message to an existing Copilot conversation or creating a new one and get a response',
+  aiMetadata: {
+    description: 'Sends a prompt to Microsoft 365 Copilot and returns its reply, running in one of two modes: continuing an existing thread when a conversation ID is supplied, or silently creating a new conversation first when it is omitted. Use it when you want Copilot itself to reason over Microsoft 365 data and answer; prefer Search Copilot when you only need the matching OneDrive files back. Requires the message text and an IANA time zone, and can optionally ground the answer in web search. Not idempotent: each call posts a new message and, without a conversation ID, creates another conversation.',
+    idempotent: false,
+  },
   props: {
     conversationId: Property.ShortText({
       displayName: 'Conversation ID',

--- a/packages/pieces/community/microsoft-copilot/src/lib/actions/search-copilot.ts
+++ b/packages/pieces/community/microsoft-copilot/src/lib/actions/search-copilot.ts
@@ -4,12 +4,16 @@ import { httpClient, HttpMethod } from '@activepieces/pieces-common';
 import { getGraphBaseUrl, getMicrosoftCloudFromAuth } from '../common/microsoft-cloud';
 
 export const searchCopilot = createAction({
-  audience: 'human',
+  audience: 'both',
   auth: microsoft365CopilotAuth,
   name: 'searchCopilot',
   displayName: 'Search Copilot',
   description:
     'Perform hybrid (semantic and lexical) search across OneDrive for work or school content using natural language queries',
+  aiMetadata: {
+    description: 'Runs a hybrid semantic and lexical search over the connected user\'s OneDrive for work or school content from a natural-language query, optionally scoped by a KQL filter expression. Use it to find matching files in OneDrive; prefer Chat with Copilot when you want a synthesized answer rather than a list of results. Requires a query of at most 1,500 characters. Read-only and idempotent.',
+    idempotent: true,
+  },
   props: {
     query: Property.LongText({
       displayName: 'Search Query',

--- a/packages/pieces/community/mistral-ai/package.json
+++ b/packages/pieces/community/mistral-ai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-mistral-ai",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {

--- a/packages/pieces/community/mistral-ai/src/lib/actions/create-chat-completion.ts
+++ b/packages/pieces/community/mistral-ai/src/lib/actions/create-chat-completion.ts
@@ -5,11 +5,12 @@ import { modelDropdown, parseMistralError } from '../common/props';
 import { mistralRequest } from '../common/request';
 
 export const createChatCompletion = createAction({
-  audience: 'human',
+  audience: 'both',
 	auth: mistralAuth,
 	name: 'create_chat_completion',
 	displayName: 'Ask Mistral',
 	description: 'Ask Mistral anything you want!',
+	aiMetadata: { description: 'Sends one user prompt to a Mistral chat model through the chat-completions endpoint and returns only the assistant text of the first choice, with optional temperature, top-p, max-token and random-seed controls; it is stateless, with no conversation memory or system message. This is the piece\'s only text-generation action - prefer Create Embeddings when you need vectors rather than prose, and Run OCR when the text must be pulled out of a PDF or image instead of generated. Requires a model id from the account\'s live model list and a question; not idempotent: each call bills a fresh completion and the wording varies unless a random seed is pinned.', idempotent: false },
 	props: {
 		model: modelDropdown,
 		prompt: Property.LongText({

--- a/packages/pieces/community/mistral-ai/src/lib/actions/create-embeddings.ts
+++ b/packages/pieces/community/mistral-ai/src/lib/actions/create-embeddings.ts
@@ -5,11 +5,12 @@ import { parseMistralError } from '../common/props';
 import { mistralRequest } from '../common/request';
 
 export const createEmbeddings = createAction({
-  audience: 'human',
+  audience: 'both',
 	auth: mistralAuth,
 	name: 'create_embeddings',
 	displayName: 'Create Embeddings',
 	description: 'Creates new embedding in Mistral AI.',
+	aiMetadata: { description: 'Converts an array of text strings into numeric embedding vectors using Mistral\'s fixed mistral-embed model; the model is not selectable here, unlike the sibling Ask Mistral action, and a whole batch of strings is embedded in one call. Use it for semantic search, similarity, or clustering pipelines, and pick Ask Mistral when you need generated prose rather than numbers. Requires a non-empty array of input strings; idempotent: nothing is created server-side and the same input yields the same vectors.', idempotent: true },
 	props: {
 		input: Property.Array({
 			displayName: 'Input',

--- a/packages/pieces/community/mistral-ai/src/lib/actions/list-models.ts
+++ b/packages/pieces/community/mistral-ai/src/lib/actions/list-models.ts
@@ -5,11 +5,12 @@ import { parseMistralError } from '../common/props';
 import { mistralRequest } from '../common/request';
 
 export const listModels = createAction({
-  audience: 'human',
+  audience: 'both',
 	auth: mistralAuth,
 	name: 'list_models',
 	displayName: 'List Models',
 	description: 'Retrieves a list of available Mistral AI models.',
+	aiMetadata: { description: 'Returns every model the connected Mistral key can access, chat, embedding and OCR ids alike, exactly as the models endpoint reports them. Use it to discover a valid model id before calling Ask Mistral or Run OCR, both of which require one; it is the only discovery action here and takes no inputs, so it cannot filter or search. Read-only and idempotent.', idempotent: true },
 	props: {},
 	async run({ auth }) {
 		try {

--- a/packages/pieces/community/mistral-ai/src/lib/actions/run-ocr.ts
+++ b/packages/pieces/community/mistral-ai/src/lib/actions/run-ocr.ts
@@ -10,11 +10,12 @@ const OCR_MODEL_OPTIONS = [
 ];
 
 export const runOcr = createAction({
-  audience: 'human',
+  audience: 'both',
 	auth: mistralAuth,
 	name: 'run_ocr',
 	displayName: 'Run OCR',
 	description: 'Extract text from PDFs and images using mistral-ocr-latest. To OCR a file from a previous step, run Upload File first (with purpose=ocr) and pass the returned id here.',
+	aiMetadata: { description: 'Extracts the text of a PDF or image as Markdown with a Mistral OCR model, taking the document either from a public URL or from a Mistral file id (that mode first resolves a short-lived signed URL); optional zero-based page indices narrow the run and embedded images can come back as base64. Pick this to read text out of a document that already exists, and Ask Mistral when the answer has to be generated or reasoned about rather than transcribed. The file-id mode only works for a file that Upload File stored with purpose=ocr, and the document type must be set to PDF or image to match the source. Read-only extraction that stores nothing, so repeat calls are idempotent.', idempotent: true },
 	props: {
 		model: Property.StaticDropdown({
 			displayName: 'Model',

--- a/packages/pieces/community/mistral-ai/src/lib/actions/upload-file.ts
+++ b/packages/pieces/community/mistral-ai/src/lib/actions/upload-file.ts
@@ -26,11 +26,12 @@ function getFileExtension(filename: string): string {
 }
 
 export const uploadFile = createAction({
-  audience: 'human',
+  audience: 'both',
 	auth: mistralAuth,
 	name: 'upload_file',
 	displayName: 'Upload File',
 	description: 'Upload a file to Mistral AI (e.g., for fine-tuning or context storage).',
+	aiMetadata: { description: 'Stores a file in the connected Mistral account and returns its file id, tagged with a purpose of fine-tune, batch, or ocr that decides what the id may later be used for. Run it before Run OCR whenever the document is a step attachment rather than a public URL: upload with purpose=ocr and feed the returned id into that action. Rejects files above 512MB or with an extension outside jsonl, txt, csv, pdf, docx, png, jpg, jpeg, mp3, mp4; not idempotent: each call stores another copy and returns a new id.', idempotent: false },
 	props: {
 		file: Property.File({
 			displayName: 'File',

--- a/packages/pieces/community/muna-ai/package.json
+++ b/packages/pieces/community/muna-ai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-muna-ai",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/packages/pieces/community/muna-ai/src/lib/actions/create-prediction.ts
+++ b/packages/pieces/community/muna-ai/src/lib/actions/create-prediction.ts
@@ -3,10 +3,14 @@ import { httpClient, HttpMethod } from '@activepieces/pieces-common';
 import { munaAiAuth } from '../auth';
 
 export const createPrediction = createAction({
-  audience: 'human',
+  audience: 'both',
   name: 'create_prediction',
   displayName: 'Create Prediction',
   description: 'Run a predictor and get back prediction resources.',
+  aiMetadata: {
+    description: 'Creates a prediction against a named Muna predictor and returns the prediction record plus the resource URLs needed to run that predictor on-device; it provisions the run rather than returning model inference output, and it is the only purpose-built Muna action, so reach for the custom API call action for any other Muna endpoint. Requires the predictor tag (such as @org/my-model) and a client ID identifying the calling device or user; the optional configuration, device, and prior prediction IDs only steer which implementation Muna hands back. Not idempotent: each call creates a new prediction with a new ID.',
+    idempotent: false,
+  },
   auth: munaAiAuth,
   props: {
     tag: Property.ShortText({

--- a/packages/pieces/community/open-router/package.json
+++ b/packages/pieces/community/open-router/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-open-router",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {

--- a/packages/pieces/community/open-router/src/lib/actions/ask-open-router.ts
+++ b/packages/pieces/community/open-router/src/lib/actions/ask-open-router.ts
@@ -15,10 +15,11 @@ import { propsValidation } from '@activepieces/pieces-common';
 import { askLmmActionOutputSchema } from '../output-schemas';
 
 export const askOpenRouterAction = createAction({
-  audience: 'human',
+  audience: 'both',
   name: 'ask-lmm',
   displayName: 'Ask LLM',
   description: 'Ask any model supported by Open Router.',
+  aiMetadata: { description: 'Sends a single prompt to any model in the OpenRouter catalog through one unified completions endpoint and returns the generated text, with optional temperature, top-p, and max-token controls. It is the only first-class action in the piece and is single-turn - no conversation memory, no system-role array, and no image or audio input - so use the sibling Custom API Call for any other OpenRouter endpoint, and prefer a vendor-specific piece such as OpenAI, Anthropic, or Groq when the model must come from one provider. Requires a model id from the OpenRouter model list and a prompt; not idempotent: each call bills a fresh generation and may return different text for the same input.', idempotent: false },
   auth: openRouterAuth,
   props: {
     model: Property.Dropdown({

--- a/packages/pieces/community/openai/package.json
+++ b/packages/pieces/community/openai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-openai",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "dependencies": {

--- a/packages/pieces/community/openai/src/lib/actions/analyze-sentiment.ts
+++ b/packages/pieces/community/openai/src/lib/actions/analyze-sentiment.ts
@@ -5,12 +5,13 @@ import { openaiAuth } from '../auth';
 const sentiments = ['positive', 'negative', 'neutral'] as const;
 
 export const analyzeSentiment = createAction({
-  audience: 'human',
+  audience: 'both',
   auth: openaiAuth,
   name: 'analyze_sentiment',
   displayName: 'Analyze Text Sentiment',
   description:
     'Analyzes text for sentiment (positive, negative, or neutral).',
+  aiMetadata: { description: 'Judges the emotional tone of a block of text with a chat model at temperature 0, returning a positive, negative, or neutral label plus a confidence score and a short explanation. Pick it for tone or satisfaction scoring; classify_text is the one that checks text against OpenAI safety policies, and extract-structured-data is the one that pulls arbitrary named fields or custom labels out of prose. Requires the text and a chat model; not idempotent: each call is a fresh model completion and the label can shift between runs.', idempotent: false },
   props: {
     model: Property.StaticDropdown({
       displayName: 'Model',

--- a/packages/pieces/community/openai/src/lib/actions/ask-assistant.ts
+++ b/packages/pieces/community/openai/src/lib/actions/ask-assistant.ts
@@ -10,11 +10,12 @@ import * as z from 'zod/mini'
 import { propsValidation } from '@activepieces/pieces-common';
 
 export const askAssistant = createAction({
-  audience: 'human',
+  audience: 'both',
   auth: openaiAuth,
   name: 'ask_assistant',
   displayName: 'Ask Assistant',
   description: 'Ask a GPT assistant anything you want!',
+  aiMetadata: { description: 'Sends a question to a GPT Assistant that already exists in the connected OpenAI account, selected from the assistant dropdown, and waits for the Assistants run to finish before returning the assistant messages produced after that question. Two modes: with a memory key it reuses one stored thread across runs and flows so the assistant remembers earlier turns, without one it opens a throwaway thread each time. Prefer ask_chatgpt when there is no saved Assistant or when the model and sampling parameters must be chosen per call. Requires an assistant already configured on the OpenAI side; not idempotent: each call creates a thread message and a new run.', idempotent: false },
   props: {
     assistant: Property.Dropdown({
   auth: openaiAuth,

--- a/packages/pieces/community/openai/src/lib/actions/classify-text.ts
+++ b/packages/pieces/community/openai/src/lib/actions/classify-text.ts
@@ -3,12 +3,13 @@ import OpenAI from 'openai';
 import { openaiAuth } from '../auth';
 
 export const classifyText = createAction({
-  audience: 'human',
+  audience: 'both',
   auth: openaiAuth,
   name: 'classify_text',
   displayName: 'Classify Text (Moderation)',
   description:
     'Classify whether the supplied text violates OpenAI safety policies (harassment, hate, self-harm, sexual, violence, etc.).',
+  aiMetadata: { description: 'Runs the OpenAI moderation endpoint over a block of text and reports whether it breaches OpenAI safety policy, returning one flagged boolean plus per-category verdicts and scores for harassment, hate, self-harm, sexual, and violence. Use it to gate or filter user-generated content; it only scores that fixed safety taxonomy, so use analyze_sentiment for tone and extract-structured-data or ask_chatgpt to sort text into custom labels. Requires the input text and a moderation model. Read-only scoring call with no stored side effect, so repeating the same input is idempotent.', idempotent: true },
   props: {
     model: Property.StaticDropdown({
       displayName: 'Model',

--- a/packages/pieces/community/openai/src/lib/actions/create-embedding.ts
+++ b/packages/pieces/community/openai/src/lib/actions/create-embedding.ts
@@ -3,12 +3,13 @@ import OpenAI from 'openai';
 import { openaiAuth } from '../auth';
 
 export const createEmbedding = createAction({
-  audience: 'human',
+  audience: 'both',
   auth: openaiAuth,
   name: 'create_embedding',
   displayName: 'Create Embedding',
   description:
     'Generate a vector embedding for the supplied text. Useful for semantic search, clustering and RAG pipelines.',
+  aiMetadata: { description: 'Converts one block of text into a numeric embedding vector for storage in a vector database or for semantic search, clustering, and RAG pipelines. It handles a single input per call, so batch by looping or by using the custom API call action, and the dimensions option only takes effect on the text-embedding-3 models. Pick search_embeddings instead when the goal is simply ranking a list of candidate strings against a query in one step with no vector persisted. Deterministic stateless inference, so repeat calls with the same model and text return the same vector and are idempotent.', idempotent: true },
   props: {
     model: Property.StaticDropdown({
       displayName: 'Model',

--- a/packages/pieces/community/openai/src/lib/actions/delete-file.ts
+++ b/packages/pieces/community/openai/src/lib/actions/delete-file.ts
@@ -3,11 +3,12 @@ import OpenAI from 'openai';
 import { openaiAuth } from '../auth';
 
 export const deleteFile = createAction({
-  audience: 'human',
+  audience: 'both',
   auth: openaiAuth,
   name: 'delete_file',
   displayName: 'Delete File',
   description: 'Delete a file previously uploaded to the connected OpenAI account.',
+  aiMetadata: { description: 'Permanently removes one file from the connected OpenAI account, identified by the OpenAI file id returned by upload_file (it starts with file-). Use it to clean up assistant, vision, batch, or fine-tune uploads that are no longer needed; find_file resolves a filename to that id first. Deleting converges on the same end state so it counts as idempotent, but a repeat call for an id that is already gone fails with a not-found error.', idempotent: true },
   props: {
     fileId: Property.ShortText({
       displayName: 'File ID',

--- a/packages/pieces/community/openai/src/lib/actions/edit-image.ts
+++ b/packages/pieces/community/openai/src/lib/actions/edit-image.ts
@@ -6,11 +6,12 @@ import mime from 'mime-types';
 import { openaiAuth } from '../auth';
 
 export const editImage = createAction({
-  audience: 'human',
+  audience: 'both',
   auth: openaiAuth,
   name: 'edit_image',
   displayName: 'Edit Image',
   description: 'Edit an existing image using a text prompt with gpt-image-2',
+  aiMetadata: { description: 'Modifies an existing image supplied as a file, applying the changes described in a text prompt with the gpt-image-2 model, and writes the result out as a new PNG file. An optional mask image confines the edit to its transparent areas and must match the dimensions of the input image; size and quality can be left on auto. Pick generate_image instead when there is no source image to start from, and vision_prompt when the image only needs to be read rather than changed. Not idempotent: each call renders a fresh image.', idempotent: false },
   props: {
     image: Property.File({
       displayName: 'Image',

--- a/packages/pieces/community/openai/src/lib/actions/extract-structure-data.action.ts
+++ b/packages/pieces/community/openai/src/lib/actions/extract-structure-data.action.ts
@@ -4,11 +4,12 @@ import OpenAI from 'openai';
 import { isLLM } from '../common/common';
 
 export const extractStructuredDataAction = createAction({
-  audience: 'human',
+  audience: 'both',
 	auth: openaiAuth,
 	name: 'extract-structured-data',
 	displayName: 'Extract Structured Data from Text',
 	description: 'Returns structured data from provided unstructured text.',
+	aiMetadata: { description: 'Pulls a caller-defined set of named fields out of one block of unstructured text and returns them as a flat object, with each field declared as text, number, or boolean and optionally marked to fail the step when it is absent. Use it to turn prose, emails, or documents into machine-readable values; prefer analyze_sentiment or classify_text for a judgement about the text and ask_chatgpt for free-form output. Requires the text plus at least one field definition, and the step errors when the model returns no extraction at all. Not idempotent: each call is a fresh model completion and the extracted values can vary between runs.', idempotent: false },
 	props: {
 		model: Property.Dropdown({
   auth: openaiAuth,

--- a/packages/pieces/community/openai/src/lib/actions/find-file.ts
+++ b/packages/pieces/community/openai/src/lib/actions/find-file.ts
@@ -3,12 +3,13 @@ import OpenAI from 'openai';
 import { openaiAuth } from '../auth';
 
 export const findFile = createAction({
-  audience: 'human',
+  audience: 'both',
   auth: openaiAuth,
   name: 'find_file',
   displayName: 'Find File',
   description:
     'Check whether a file with the given name already exists in the connected OpenAI account.',
+  aiMetadata: { description: 'Checks whether a file with an exact filename, matched case-insensitively, already exists in the connected OpenAI account and returns a found flag, a match count, and the matching file records including their ids. Use it before upload_file to avoid duplicates, or to resolve a filename into the file id that delete_file needs; list_files is the one for browsing everything on the account. An optional purpose filter narrows the search to assistants, vision, batch, or fine-tune files. Read-only and idempotent.', idempotent: true },
   props: {
     fileName: Property.ShortText({
       displayName: 'File Name',

--- a/packages/pieces/community/openai/src/lib/actions/generate-image.ts
+++ b/packages/pieces/community/openai/src/lib/actions/generate-image.ts
@@ -6,11 +6,12 @@ import OpenAI from 'openai';
 import { openaiAuth } from '../auth';
 
 export const generateImage = createAction({
-  audience: 'human',
+  audience: 'both',
   auth: openaiAuth,
   name: 'generate_image',
   displayName: 'Generate Image',
   description: 'Generate an image using text-to-image models',
+  aiMetadata: { description: 'Creates a brand new image from a text prompt using an image model available to the account (gpt-image or dall-e), saving each returned image as a file and reporting its URL. Resolution and quality both default to auto. Pick edit_image instead when an existing image is the starting point, and vision_prompt when the task is reading an image rather than producing one. Requires the prompt and a model id; not idempotent: each call renders a fresh image.', idempotent: false },
   props: {
     model: Property.Dropdown({
       auth: openaiAuth,

--- a/packages/pieces/community/openai/src/lib/actions/list-files.ts
+++ b/packages/pieces/community/openai/src/lib/actions/list-files.ts
@@ -3,12 +3,13 @@ import OpenAI from 'openai';
 import { openaiAuth } from '../auth';
 
 export const listFiles = createAction({
-  audience: 'human',
+  audience: 'both',
   auth: openaiAuth,
   name: 'list_files',
   displayName: 'List Files',
   description:
     'Return the list of files uploaded to the connected OpenAI account, optionally filtered by purpose.',
+  aiMetadata: { description: 'Returns the files stored in the connected OpenAI account together with their ids, names, sizes, and purposes, either the whole account or, when a purpose filter is supplied, only assistants, vision, batch, or fine-tune files, capped by an optional limit. Use it to browse or audit what has been uploaded and to collect file ids; find_file is the better choice when checking for one exact filename. Read-only and idempotent.', idempotent: true },
   props: {
     purpose: Property.StaticDropdown({
       displayName: 'Purpose Filter',

--- a/packages/pieces/community/openai/src/lib/actions/list-models.ts
+++ b/packages/pieces/community/openai/src/lib/actions/list-models.ts
@@ -3,12 +3,13 @@ import OpenAI from 'openai';
 import { openaiAuth } from '../auth';
 
 export const listModels = createAction({
-  audience: 'human',
+  audience: 'both',
   auth: openaiAuth,
   name: 'list_models',
   displayName: 'List Models',
   description:
     'Return the list of models available to the connected OpenAI account, optionally filtered by an ID substring.',
+  aiMetadata: { description: 'Returns the model ids the connected API key can use, each with its creation timestamp and owner: the full catalog when no filter is given, or only the ids containing a case-insensitive substring such as gpt-4, embedding, or whisper when one is. Use it to confirm a model id exists on this account before passing it to ask_chatgpt, create_embedding, generate_image, or text_to_speech. Read-only and idempotent.', idempotent: true },
   props: {
     contains: Property.ShortText({
       displayName: 'Filter Substring',

--- a/packages/pieces/community/openai/src/lib/actions/search-embeddings.ts
+++ b/packages/pieces/community/openai/src/lib/actions/search-embeddings.ts
@@ -3,12 +3,13 @@ import OpenAI from 'openai';
 import { openaiAuth } from '../auth';
 
 export const searchEmbeddings = createAction({
-  audience: 'human',
+  audience: 'both',
   auth: openaiAuth,
   name: 'search_embeddings',
   displayName: 'Search Embeddings',
   description:
     'Matches a query string to a list of document strings for best results.',
+  aiMetadata: { description: 'Embeds a query and a list of document strings passed inline in the same call, then ranks those documents against the query by cosine similarity and returns the best match plus the scored ranking; setting Top K keeps only the leading matches, leaving it empty returns every document ranked. It is self-contained with no vector store, so the documents must be supplied on every run - use create_embedding with an external vector database when the corpus is large or must persist. Requires the query, the document list, and one embedding model used for both sides. Read-only and idempotent: the same inputs produce the same ranking.', idempotent: true },
   props: {
     model: Property.StaticDropdown({
       displayName: 'Model',

--- a/packages/pieces/community/openai/src/lib/actions/send-prompt.ts
+++ b/packages/pieces/community/openai/src/lib/actions/send-prompt.ts
@@ -15,11 +15,12 @@ import * as z from 'zod/mini'
 import { propsValidation } from '@activepieces/pieces-common';
 
 export const askOpenAI = createAction({
-  audience: 'human',
+  audience: 'both',
   auth: openaiAuth,
   name: 'ask_chatgpt',
   displayName: 'Ask ChatGPT',
   description: 'Ask ChatGPT anything you want!',
+  aiMetadata: { description: 'Sends a prompt to an OpenAI chat model and returns the reply text, with sampling controls (temperature, top P, frequency and presence penalties) and an optional roles array that supplies the system message. Two modes: stateless by default, or, when a memory key is set, loading and re-saving the conversation history in project storage so later runs continue the same thread, trimming it as it approaches the token limit. This is the general-purpose text call of this piece; prefer ask_assistant to route through a pre-built OpenAI Assistant, vision_prompt when an image is part of the question, and extract-structured-data when the answer must come back as named fields. A model, a question, and a maximum token count are required; not idempotent: each call produces a fresh completion and, with a memory key, rewrites the stored history.', idempotent: false },
   props: {
     model: Property.Dropdown({
   auth: openaiAuth,

--- a/packages/pieces/community/openai/src/lib/actions/text-to-speech.ts
+++ b/packages/pieces/community/openai/src/lib/actions/text-to-speech.ts
@@ -7,11 +7,12 @@ type Voice = 'alloy' | 'echo' | 'fable' | 'onyx' | 'nova' | 'shimmer';
 type ResponseFormat = 'mp3' | 'opus' | 'aac' | 'flac' | 'wav' | 'pcm';
 
 export const textToSpeech = createAction({
-  audience: 'human',
+  audience: 'both',
 	auth: openaiAuth,
 	name: 'text_to_speech',
 	displayName: 'Text-to-Speech',
 	description: 'Generate an audio recording from text',
+	aiMetadata: { description: 'Synthesizes spoken audio from text using an OpenAI TTS model and one of six prebuilt voices (alloy, echo, fable, onyx, nova, shimmer), writing the result as an mp3, opus, aac, or flac file at a playback speed between 0.25 and 4. This is the text-to-audio direction of this piece; transcribe and translate go the other way, turning audio into text. Requires the text, a TTS-capable model, a voice, and an output format. Not idempotent: each call renders a new audio file.', idempotent: false },
 	props: {
 		text: Property.LongText({
 			displayName: 'Text',

--- a/packages/pieces/community/openai/src/lib/actions/transcriptions.ts
+++ b/packages/pieces/community/openai/src/lib/actions/transcriptions.ts
@@ -10,10 +10,11 @@ import mime from 'mime-types';
 import { Languages, baseUrl } from '../common/common';
 
 export const transcribeAction = createAction({
-  audience: 'human',
+  audience: 'both',
   name: 'transcribe',
   displayName: 'Transcribe Audio',
   description: 'Transcribe audio to text using whisper-1 model',
+  aiMetadata: { description: 'Transcribes an uploaded audio file to text with the whisper-1 model, keeping the words in the language that was spoken, with an optional language hint (defaulting to English, and silently falling back to English when an unsupported code is given) that improves accuracy. Choose the sibling translate action instead whenever the output must be English no matter what language was spoken, and text_to_speech for the opposite direction. Requires an audio file; not idempotent: each call re-runs the model and the wording can vary slightly.', idempotent: false },
   auth: openaiAuth,
   props: {
     audio: Property.File({

--- a/packages/pieces/community/openai/src/lib/actions/translation.ts
+++ b/packages/pieces/community/openai/src/lib/actions/translation.ts
@@ -10,10 +10,11 @@ import mime from 'mime-types';
 import { baseUrl } from '../common/common';
 
 export const translateAction = createAction({
-  audience: 'human',
+  audience: 'both',
   name: 'translate',
   displayName: 'Translate Audio',
   description: 'Translate audio to text using whisper-1 model',
+  aiMetadata: { description: 'Turns an uploaded audio file into English text with the whisper-1 model, translating from whatever language was spoken; there is no target-language option, the output is always English. Pick the sibling transcribe action when the transcript must stay in the original language, and note this handles audio input only - it cannot translate a text string. Requires an audio file; not idempotent: each call re-runs the model and the wording can vary slightly.', idempotent: false },
   auth: openaiAuth,
   props: {
     audio: Property.File({

--- a/packages/pieces/community/openai/src/lib/actions/upload-file.ts
+++ b/packages/pieces/community/openai/src/lib/actions/upload-file.ts
@@ -15,12 +15,13 @@ const isFilePurpose = (value: string): value is FilePurpose =>
   allowedPurposes.some((p) => p === value);
 
 export const uploadFile = createAction({
-  audience: 'human',
+  audience: 'both',
   auth: openaiAuth,
   name: 'upload_file',
   displayName: 'Upload File',
   description:
     'Upload a file to OpenAI for use with Assistants, Vector Stores, Batch jobs, Fine-tuning, or Vision.',
+  aiMetadata: { description: 'Uploads a file to the connected OpenAI account and returns its file id for later use with Assistants, vector stores, batch jobs, fine-tuning, or vision. The purpose is required and decides which file types are accepted; the original filename is kept unless an override including the extension is supplied. Run find_file first to avoid duplicates, and delete_file to remove one afterwards. Not idempotent: every call stores another copy under a new file id, even for identical content.', idempotent: false },
   props: {
     file: Property.File({
       displayName: 'File',

--- a/packages/pieces/community/openai/src/lib/actions/vision-prompt.ts
+++ b/packages/pieces/community/openai/src/lib/actions/vision-prompt.ts
@@ -8,11 +8,12 @@ import * as z from 'zod/mini'
 import { propsValidation } from '@activepieces/pieces-common';
 
 export const visionPrompt = createAction({
-  audience: 'human',
+  audience: 'both',
   auth: openaiAuth,
   name: 'vision_prompt',
   displayName: 'Vision Prompt',
   description: 'Ask GPT a question about an image',
+  aiMetadata: { description: 'Answers a question about an image by sending the uploaded picture inline with the prompt to gpt-4o, covering captioning, reading text off an image, and visual question answering. It is the only action here that accepts image input, so pick it over ask_chatgpt whenever a picture is part of the question, and generate_image or edit_image when the goal is producing an image instead. The model is fixed at gpt-4o and the image is embedded as base64 in the request, so keep it small; a detail setting trades cost against fidelity. Not idempotent: each call produces a fresh completion.', idempotent: false },
   props: {
     image: Property.File({
       displayName: 'Image',

--- a/packages/pieces/community/perplexity-ai/package.json
+++ b/packages/pieces/community/perplexity-ai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-perplexity-ai",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {

--- a/packages/pieces/community/perplexity-ai/src/lib/actions/create-chat-completion.action.ts
+++ b/packages/pieces/community/perplexity-ai/src/lib/actions/create-chat-completion.action.ts
@@ -14,12 +14,13 @@ import * as z from 'zod/mini'
 import { propsValidation } from '@activepieces/pieces-common';
 
 export const createChatCompletionAction = createAction({
-  audience: 'human',
+  audience: 'both',
   auth: perplexityAiAuth,
   name: 'ask-ai',
   displayName: 'Ask AI',
   description:
     'Enables users to generate prompt completion based on a specified model.',
+  aiMetadata: { description: 'Sends a question to a Perplexity Sonar model, which answers from a live web search with source citations rather than model memory alone, choosing between the plain sonar models for fast grounded answers and the sonar-reasoning models for step-by-step reasoning. It is the only action in this piece; pick it when the reply must reflect current web content, and prefer a general LLM vendor piece such as OpenAI or Google Gemini when no web lookup is needed. Runs stateless - earlier turns must be supplied in the optional roles array, which alternates user and assistant after any system message; requires a model and a question, and is not idempotent: each call runs a new search and produces a fresh completion.', idempotent: false },
   props: {
     model: Property.StaticDropdown({
       displayName: 'Model',

--- a/packages/pieces/community/produktly/package.json
+++ b/packages/pieces/community/produktly/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-produktly",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "dependencies": {

--- a/packages/pieces/community/produktly/src/lib/actions/create-changelog-post.ts
+++ b/packages/pieces/community/produktly/src/lib/actions/create-changelog-post.ts
@@ -10,6 +10,8 @@ export const createChangelogPost = createAction({
   displayName: 'Create Changelog Post',
   description:
     'Publish a new post inside a changelog. Visible to your users once active.',
+  audience: 'both',
+  aiMetadata: { description: 'Create a post inside a specific Produktly changelog, with an optional body, release date, active/hidden state, and a list of tag names that must already exist (resolve them with List Tags). Pick this to announce a release to end users; use Update Changelog Post to revise an announcement that already exists. Requires a changelog ID and a title. Not idempotent: each call creates a new post, even with identical content.', idempotent: false },
   props: {
     changelog: produktlyProps.changelog,
     title: Property.ShortText({

--- a/packages/pieces/community/produktly/src/lib/actions/get-company-stats.ts
+++ b/packages/pieces/community/produktly/src/lib/actions/get-company-stats.ts
@@ -7,6 +7,8 @@ export const getCompanyStats = createAction({
   auth: produktlyAuth,
   name: 'get_company_stats',
   description: 'Get a company-wide statistics summary across all your Produktly features.',
+  audience: 'both',
+  aiMetadata: { description: 'Fetch one account-wide statistics summary covering every Produktly feature (tours, checklists, smart tips, announcements, changelogs, NPS widgets, roadmaps), for an optional start/end date window; omit both dates to use the API default period, which also reports the preceding comparison period. Pick this for a cross-feature rollup; use Get Widget Stats when you need per-entity event counts for a single feature type. Read-only and idempotent.', idempotent: true },
   displayName: 'Get Company Stats',
   props: {
     start_date: Property.ShortText({

--- a/packages/pieces/community/produktly/src/lib/actions/get-nps-score.ts
+++ b/packages/pieces/community/produktly/src/lib/actions/get-nps-score.ts
@@ -9,6 +9,8 @@ export const getNpsScore = createAction({
   name: 'get_nps_score',
   displayName: 'Get NPS Score',
   description: 'Get the current Net Promoter Score (NPS) for a widget, broken down into promoters, passives and detractors.',
+  audience: 'both',
+  aiMetadata: { description: 'Fetch the aggregated Net Promoter Score for one Produktly NPS widget, with promoter, passive, and detractor counts and percentages, optionally restricted to a start/end date window. Pick this when you want the computed score; use List NPS Responses when you need the individual ratings and free-text comments behind it. Requires an NPS widget ID (discover one with List NPS Widgets). Read-only and idempotent.', idempotent: true },
   props: {
     widget: produktlyProps.npsWidget,
     start_date: Property.ShortText({

--- a/packages/pieces/community/produktly/src/lib/actions/get-roadmap.ts
+++ b/packages/pieces/community/produktly/src/lib/actions/get-roadmap.ts
@@ -9,6 +9,8 @@ export const getRoadmap = createAction({
   name: 'get_roadmap',
   displayName: 'Get Roadmap',
   description: 'Get a single roadmap with its sections, items, tags and vote counts.',
+  audience: 'both',
+  aiMetadata: { description: 'Fetch one Produktly public roadmap by ID, expanded into its sections and their individual items with vote counts, tags, and last-updated timestamps. Pick this when you need the contents of a known roadmap; use List Roadmaps first to discover roadmap IDs or when section and item counts alone are enough. Requires a roadmap ID. Read-only and idempotent.', idempotent: true },
   props: {
     roadmap: produktlyProps.roadmap,
   },

--- a/packages/pieces/community/produktly/src/lib/actions/get-widget-stats.ts
+++ b/packages/pieces/community/produktly/src/lib/actions/get-widget-stats.ts
@@ -8,6 +8,8 @@ export const getWidgetStats = createAction({
   name: 'get_widget_stats',
   displayName: 'Get Widget Stats',
   description: 'Get event and unique-user statistics for a specific entity type (e.g. all changelogs, all NPS widgets).',
+  audience: 'both',
+  aiMetadata: { description: 'Fetch event and unique-user statistics for one Produktly feature type (product tour, checklist, smart tip, announcement, changelog, NPS widget, or roadmap), either across every entity of that type or narrowed to a single entity ID, over an optional start/end date window. Pick this for per-entity engagement numbers; use Get Company Stats for the account-wide rollup across all features. Requires an entity type. Read-only and idempotent.', idempotent: true },
   props: {
     entity_type: Property.StaticDropdown({
       displayName: 'Entity Type',

--- a/packages/pieces/community/produktly/src/lib/actions/list-changelog-posts.ts
+++ b/packages/pieces/community/produktly/src/lib/actions/list-changelog-posts.ts
@@ -9,6 +9,8 @@ export const listChangelogPosts = createAction({
   name: 'list_changelog_posts',
   displayName: 'List Changelog Posts',
   description: 'List all posts within a specific changelog.',
+  audience: 'both',
+  aiMetadata: { description: 'List the posts inside one Produktly changelog, paginated with limit and offset and optionally narrowed to a release-date range. Pick this to read announcements in a known changelog or to resolve a post ID for Update Changelog Post; use List Changelogs first to find the changelog itself. Requires a changelog ID. Read-only and idempotent.', idempotent: true },
   props: {
     changelog: produktlyProps.changelog,
     limit: Property.Number({

--- a/packages/pieces/community/produktly/src/lib/actions/list-changelogs.ts
+++ b/packages/pieces/community/produktly/src/lib/actions/list-changelogs.ts
@@ -8,6 +8,8 @@ export const listChangelogs = createAction({
   name: 'list_changelogs',
   displayName: 'List Changelogs',
   description: 'List all changelogs in your Produktly account.',
+  audience: 'both',
+  aiMetadata: { description: 'List every changelog in the Produktly account with its name, active state, and creation date, paginated with limit and offset. Pick this to discover changelog IDs before reading or writing posts; use List Changelog Posts for the announcements inside one changelog. Read-only and idempotent.', idempotent: true },
   props: {
     limit: Property.Number({
       displayName: 'Limit',

--- a/packages/pieces/community/produktly/src/lib/actions/list-feedback-responses.ts
+++ b/packages/pieces/community/produktly/src/lib/actions/list-feedback-responses.ts
@@ -9,6 +9,8 @@ export const listFeedbackResponses = createAction({
   name: 'list_feedback_responses',
   displayName: 'List Feedback Responses',
   description: 'List the user responses submitted through a feedback widget.',
+  audience: 'both',
+  aiMetadata: { description: 'List the responses submitted to one Produktly feedback widget, each with its reaction type, chosen option, free-text message, and submitter name, email, and originating page; paginated with limit and offset and optionally narrowed to a submission-date range. Pick this to pull collected feedback on demand; use the New Feedback Response trigger to act as submissions arrive. Requires a feedback widget ID (discover one with List Feedback Widgets). Read-only and idempotent.', idempotent: true },
   props: {
     widget: produktlyProps.feedbackWidget,
     limit: Property.Number({

--- a/packages/pieces/community/produktly/src/lib/actions/list-feedback-widgets.ts
+++ b/packages/pieces/community/produktly/src/lib/actions/list-feedback-widgets.ts
@@ -8,6 +8,8 @@ export const listFeedbackWidgets = createAction({
   name: 'list_feedback_widgets',
   displayName: 'List Feedback Widgets',
   description: 'List all feedback widgets configured in your Produktly account.',
+  audience: 'both',
+  aiMetadata: { description: 'List every feedback widget configured in the Produktly account with its name, active state, and creation date, paginated with limit and offset. Pick this to discover widget IDs before pulling submissions with List Feedback Responses; use List NPS Widgets for the rating-based NPS surveys instead. Read-only and idempotent.', idempotent: true },
   props: {
     limit: Property.Number({
       displayName: 'Limit',

--- a/packages/pieces/community/produktly/src/lib/actions/list-nps-responses.ts
+++ b/packages/pieces/community/produktly/src/lib/actions/list-nps-responses.ts
@@ -9,6 +9,8 @@ export const listNpsResponses = createAction({
   name: 'list_nps_responses',
   displayName: 'List NPS Responses',
   description: 'List individual NPS responses (rating + comment + user info) for a widget.',
+  audience: 'both',
+  aiMetadata: { description: 'List the individual NPS submissions for one Produktly NPS widget, each with its rating, free-text comment, and submitter name, email, user ID, and page URL; paginated with limit and offset and optionally narrowed to a submission-date range. Pick this when you need the raw responses; use Get NPS Score for the aggregated score and promoter/detractor breakdown. Requires an NPS widget ID. Read-only and idempotent.', idempotent: true },
   props: {
     widget: produktlyProps.npsWidget,
     limit: Property.Number({

--- a/packages/pieces/community/produktly/src/lib/actions/list-nps-widgets.ts
+++ b/packages/pieces/community/produktly/src/lib/actions/list-nps-widgets.ts
@@ -8,6 +8,8 @@ export const listNpsWidgets = createAction({
   name: 'list_nps_widgets',
   displayName: 'List NPS Widgets',
   description: 'List all NPS widgets configured in your Produktly account.',
+  audience: 'both',
+  aiMetadata: { description: 'List every NPS widget in the Produktly account with its name, active state, and creation date, paginated with limit and offset. Pick this to discover widget IDs before calling Get NPS Score or List NPS Responses; use List Feedback Widgets for the non-NPS feedback surveys instead. Read-only and idempotent.', idempotent: true },
   props: {
     limit: Property.Number({
       displayName: 'Limit',

--- a/packages/pieces/community/produktly/src/lib/actions/list-roadmaps.ts
+++ b/packages/pieces/community/produktly/src/lib/actions/list-roadmaps.ts
@@ -8,6 +8,8 @@ export const listRoadmaps = createAction({
   name: 'list_roadmaps',
   displayName: 'List Roadmaps',
   description: 'List all public roadmaps in your Produktly account.',
+  audience: 'both',
+  aiMetadata: { description: 'List every public roadmap in the Produktly account with its internal and public name, active state, custom domain, and section and item counts, paginated with limit and offset. Pick this to discover roadmap IDs or compare roadmaps at a glance; use Get Roadmap when you need the actual sections, items, tags, and vote counts. Read-only and idempotent.', idempotent: true },
   props: {
     limit: Property.Number({
       displayName: 'Limit',

--- a/packages/pieces/community/produktly/src/lib/actions/list-tags.ts
+++ b/packages/pieces/community/produktly/src/lib/actions/list-tags.ts
@@ -8,6 +8,8 @@ export const listTags = createAction({
   name: 'list_tags',
   displayName: 'List Tags',
   description: 'List all tags that can be attached to changelog posts.',
+  audience: 'both',
+  aiMetadata: { description: 'List the tags defined in the Produktly account that can label changelog posts, with their display colours, paginated with limit and offset. Pick this to resolve valid tag names before Create Changelog Post or Update Changelog Post, which only accept tags that already exist. Read-only and idempotent.', idempotent: true },
   props: {
     limit: Property.Number({
       displayName: 'Limit',

--- a/packages/pieces/community/produktly/src/lib/actions/update-changelog-post.ts
+++ b/packages/pieces/community/produktly/src/lib/actions/update-changelog-post.ts
@@ -10,6 +10,8 @@ export const updateChangelogPost = createAction({
   displayName: 'Update Changelog Post',
   description:
     'Edit an existing changelog post — change its title, body, tags or visibility.',
+  audience: 'both',
+  aiMetadata: { description: 'Partially update one existing post in a Produktly changelog: any of title, body, release date, active/hidden visibility, or the full tag list, leaving omitted fields untouched. Pick this to revise, publish, or unpublish an announcement that already exists; use Create Changelog Post for a new one. Requires both the changelog ID and the post ID (resolve it with List Changelog Posts), and any supplied tag names must already exist. Idempotent: repeating the same call converges on the same post state.', idempotent: true },
   props: {
     changelog: produktlyProps.changelog,
     post_id: Property.ShortText({

--- a/packages/pieces/community/produktly/src/lib/triggers/new-changelog-post.ts
+++ b/packages/pieces/community/produktly/src/lib/triggers/new-changelog-post.ts
@@ -59,6 +59,9 @@ export const newChangelogPost = createTrigger({
   name: 'new_changelog_post',
   displayName: 'New Changelog Post',
   description: 'Fires when a new post is published in the selected changelog.',
+  aiMetadata: {
+    description: 'Fires when a new post appears in one selected Produktly changelog, representing a product announcement or release note. Polls that changelog on a schedule and emits each post it has not seen before, including hidden (inactive) posts alongside published ones.',
+  },
   props: triggerProps,
   sampleData: {
     post_id: 123,

--- a/packages/pieces/community/produktly/src/lib/triggers/new-feedback-response.ts
+++ b/packages/pieces/community/produktly/src/lib/triggers/new-feedback-response.ts
@@ -65,6 +65,9 @@ export const newFeedbackResponse = createTrigger({
   name: 'new_feedback_response',
   displayName: 'New Feedback Response',
   description: 'Fires when a user submits a new response to the selected feedback widget.',
+  aiMetadata: {
+    description: 'Fires when an end user submits feedback through one selected Produktly feedback widget. Polls that widget on a schedule and emits each new submission, carrying the reaction type and option, any free-text message, the submitter name and email, and the page the feedback came from.',
+  },
   props: triggerProps,
   sampleData: {
     response_id: 456,

--- a/packages/pieces/community/produktly/src/lib/triggers/new-nps-response.ts
+++ b/packages/pieces/community/produktly/src/lib/triggers/new-nps-response.ts
@@ -65,6 +65,9 @@ export const newNpsResponse = createTrigger({
   name: 'new_nps_response',
   displayName: 'New NPS Response',
   description: 'Fires when a user submits a new NPS rating for the selected widget.',
+  aiMetadata: {
+    description: 'Fires when an end user submits an NPS rating through one selected Produktly NPS widget. Polls that widget on a schedule and emits each new response with its score, any free-text comment, and the submitter name, email, user ID, and page URL, so detractors can be routed for follow-up as they arrive.',
+  },
   props: triggerProps,
   sampleData: {
     response_id: 789,

--- a/packages/pieces/community/produktly/src/lib/triggers/new-tag.ts
+++ b/packages/pieces/community/produktly/src/lib/triggers/new-tag.ts
@@ -51,6 +51,9 @@ export const newTag = createTrigger({
   name: 'new_tag',
   displayName: 'New Tag',
   description: 'Fires when a new tag is created in your Produktly account.',
+  aiMetadata: {
+    description: 'Fires when a new tag is created anywhere in the Produktly account. Polls the account-wide tag list on a schedule and emits each tag it has not seen before, with its name and display colours; tags are the labels that changelog posts can be categorised with.',
+  },
   props: triggerProps,
   sampleData: {
     tag_id: 1,

--- a/packages/pieces/community/queue/package.json
+++ b/packages/pieces/community/queue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-queue",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {

--- a/packages/pieces/community/queue/src/lib/actions/clear-queue.ts
+++ b/packages/pieces/community/queue/src/lib/actions/clear-queue.ts
@@ -11,9 +11,10 @@ const notes = `**Note:**
 - The testing step work in isolation and doesn't affect the actual queue after publishing.
 `
 export const clearQueue = createAction({
-  audience: 'human',
+  audience: 'both',
     name: 'clear-queue',
     description: 'Clears all items inside a queue',
+    aiMetadata: { description: 'Permanently deletes a named project-scoped queue and every item stored in it, keyed by the exact queue name. Use it to reset a queue wholesale; prefer Pull items from queue when the buffered items still need to be read and processed. Idempotent: the queue ends up empty however many times it runs, and clearing an already-empty or never-created queue still succeeds.', idempotent: true },
     displayName: 'Clear queue',
     props: {
         info: Property.MarkDown({

--- a/packages/pieces/community/queue/src/lib/actions/pull-from-queue.ts
+++ b/packages/pieces/community/queue/src/lib/actions/pull-from-queue.ts
@@ -11,9 +11,10 @@ const notes = `**Note:**
 - The testing step work in isolation and doesn't affect the actual queue after publishing.
 `
 export const pullFromQueue = createAction({
-  audience: 'human',
+  audience: 'both',
     name: 'pull-from-queue',
     description: 'Pull items from queue',
+    aiMetadata: { description: 'Removes and returns the first N items of a named project-scoped FIFO queue and writes the remainder back, so it is a destructive consume rather than a peek - the returned items are gone from the queue, and fewer than requested come back when the queue holds less. Use it to drain work buffered by Push to Queue; prefer Clear queue when the aim is to empty the queue without reading the items. Not idempotent: every call consumes a further batch.', idempotent: false },
     displayName: 'Pull items from queue',
     props: {
         info: Property.MarkDown({

--- a/packages/pieces/community/queue/src/lib/actions/push-to-queue.ts
+++ b/packages/pieces/community/queue/src/lib/actions/push-to-queue.ts
@@ -11,9 +11,10 @@ const notes = `**Note:**
 - The testing step work in isolation and doesn't affect the actual queue after publishing.
 `
 export const pushToQueue = createAction({
-  audience: 'human',
+  audience: 'both',
   name: 'push-to-queue',
   description: 'Push item to queue',
+  aiMetadata: { description: 'Appends one or more items to the end of a named project-scoped FIFO queue, creating the queue on first use; the queue name is a plain string shared across the whole project, so any flow using the same name writes to the same queue. Use it to buffer or throttle work for later consumption, then read it back with Pull items from queue, or discard everything with Clear queue. Not idempotent: each call appends the items again, and the write fails once the accumulated queue exceeds the project store size limit.', idempotent: false },
   displayName: 'Push to Queue',
   props: {
     info: Property.MarkDown({

--- a/packages/pieces/community/straico/package.json
+++ b/packages/pieces/community/straico/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-straico",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {

--- a/packages/pieces/community/straico/src/lib/actions/agent-add-rag.ts
+++ b/packages/pieces/community/straico/src/lib/actions/agent-add-rag.ts
@@ -28,11 +28,12 @@ interface AgentAddRagResponse {
 }
 
 export const agentAddRag = createAction({
-  audience: 'human',
+  audience: 'both',
   auth: straicoAuth,
   name: 'agent-add-rag',
   displayName: 'Add RAG to Agent',
   description: 'Adds a new RAG to an agent in the database for the user.',
+  aiMetadata: { description: 'Associates an existing RAG knowledge base with an existing Straico agent so that later Agent Prompt Completion calls answer from that document set. Use it as the wiring step after Create Agent and Create RAG; it neither creates the agent nor ingests files, so use those actions first. Requires both an agent id and a RAG id that already exist in the account. Idempotent: attaching the same RAG again leaves the agent with the same association.', idempotent: true },
   props: {
     agent_id: agentIdDropdown('Agent','The agent to add the RAG to.'),
     rag_id: Property.Dropdown({

--- a/packages/pieces/community/straico/src/lib/actions/agent-create.ts
+++ b/packages/pieces/community/straico/src/lib/actions/agent-create.ts
@@ -36,11 +36,12 @@ interface AgentCreateResponse {
 }
 
 export const agentCreate = createAction({
-  audience: 'human',
+  audience: 'both',
   auth: straicoAuth,
   name: 'agent-create',
   displayName: 'Create Agent',
   description: 'Creates a new agent in the database for the user.',
+  aiMetadata: { description: 'Registers a new reusable Straico agent, a stored persona pairing a custom system prompt with a default chat LLM and optional tags, and returns its id for later prompting. Use it once when a persona should persist across runs; prefer Ask AI for a throwaway completion, Update Agent to change one that already exists, and Add RAG to Agent afterwards to ground it in documents. Requires a name, description, custom prompt and default LLM; it does not attach any knowledge base by itself. Not idempotent: each call creates another agent, duplicate names included.', idempotent: false },
   props: {
     name: Property.ShortText({
       displayName: 'Name',

--- a/packages/pieces/community/straico/src/lib/actions/agent-delete.ts
+++ b/packages/pieces/community/straico/src/lib/actions/agent-delete.ts
@@ -9,11 +9,12 @@ import { baseUrlv0 } from '../common/common';
 import { agentIdDropdown } from '../common/props';
 
 export const agentDelete = createAction({
-  audience: 'human',
+  audience: 'both',
   auth: straicoAuth,
   name: 'agent_delete',
   displayName: 'Delete Agent',
   description: 'Delete a specific agent by its ID',
+  aiMetadata: { description: 'Permanently removes a saved Straico agent (the stored persona made of a custom prompt, default LLM and any attached RAG base) from the account. Use only when the agent itself should stop existing; to pause it instead, prefer Update Agent with status set to inactive, and to detach knowledge without deleting, keep the agent and update it. Requires the agent id, which List Agents provides. Idempotent: the agent ends up gone no matter how many times it is called.', idempotent: true },
   props: {
     agentId: agentIdDropdown('Agent','Select the agent to delete')
   },

--- a/packages/pieces/community/straico/src/lib/actions/agent-get.ts
+++ b/packages/pieces/community/straico/src/lib/actions/agent-get.ts
@@ -25,11 +25,12 @@ interface AgentGetResponse {
 }
 
 export const agentGet = createAction({
-  audience: 'human',
+  audience: 'both',
   auth: straicoAuth,
   name: 'agent_get',
   displayName: 'Get Agent Details',
   description: 'Retrieve details of a specific agent',
+  aiMetadata: { description: 'Fetches the full configuration of one Straico agent by id, including its custom prompt, default LLM, status, visibility and any attached RAG base. Use it to inspect or verify a single agent before prompting or updating it; prefer List Agents when the id is not known yet or when several agents must be compared. Requires the agent id. Read-only and idempotent.', idempotent: true },
   props: {
     agentId:agentIdDropdown('Agent','Select the agent to get details for.')
   },

--- a/packages/pieces/community/straico/src/lib/actions/agent-list.ts
+++ b/packages/pieces/community/straico/src/lib/actions/agent-list.ts
@@ -27,11 +27,12 @@ interface AgentListResponse {
 }
 
 export const agentList = createAction({
-  audience: 'human',
+  audience: 'both',
   auth: straicoAuth,
   name: 'agent-list',
   displayName: 'List Agents',
   description: 'Retrieves the list of agents created by and available to the user.',
+  aiMetadata: { description: 'Returns every Straico agent available to the authenticated account with its id, name, default LLM, status, tags and RAG association. Use it as the id-discovery step before Get Agent Details, Update Agent, Delete Agent, Add RAG to Agent or Agent Prompt Completion; prefer Get Agent Details when the id is already known. Takes no inputs and cannot be filtered or searched server-side. Read-only and idempotent.', idempotent: true },
   props: {},
   async run({ auth }) {
     const response = await httpClient.sendRequest<AgentListResponse>({

--- a/packages/pieces/community/straico/src/lib/actions/agent-prompt-completion.ts
+++ b/packages/pieces/community/straico/src/lib/actions/agent-prompt-completion.ts
@@ -9,11 +9,12 @@ import { baseUrlv0 } from '../common/common';
 import { agentIdDropdown } from '../common/props';
 
 export const agentPromptCompletion = createAction({
-  audience: 'human',
+  audience: 'both',
   auth: straicoAuth,
   name: 'agent_prompt_completion',
   displayName: 'Agent Prompt Completion',
   description: 'Prompt an agent with a message and get a response',
+  aiMetadata: { description: 'Runs a prompt against a saved Straico agent, which supplies its own custom system prompt, default LLM and attached RAG base, so no model has to be chosen at call time. Pick this when the persona and knowledge are already configured server-side; prefer RAG Prompt Completion to query a knowledge base directly with an explicit model, or Ask AI for a plain one-off completion with no agent or retrieval. Requires the agent id and a prompt; the retrieval controls (search type similarity, mmr or similarity score threshold, plus k, fetch k, lambda mult and score threshold) only matter when the agent has a RAG attached. Not idempotent: each call spends credits and produces a fresh answer.', idempotent: false },
   props: {
     agentId: agentIdDropdown('Agent','Select the agent to prompt.'),
     prompt: Property.LongText({

--- a/packages/pieces/community/straico/src/lib/actions/agent-update.ts
+++ b/packages/pieces/community/straico/src/lib/actions/agent-update.ts
@@ -38,11 +38,12 @@ interface AgentUpdateResponse {
 }
 
 export const agentUpdate = createAction({
-  audience: 'human',
+  audience: 'both',
   auth: straicoAuth,
   name: 'agent_update',
   displayName: 'Update Agent',
   description: 'Update the details of a specific agent',
+  aiMetadata: { description: 'Edits an existing Straico agent in place, changing any subset of its name, description, custom prompt, default LLM, status (active or inactive) and visibility (private or public). Use it to retune or pause an agent instead of recreating it with Create Agent, and use Add RAG to Agent when the change is attaching a knowledge base rather than editing these fields. Requires the agent id plus at least one field to change, otherwise the call fails. Idempotent: sending the same values leaves the agent in the same state.', idempotent: true },
   props: {
     agentId: Property.Dropdown({
   auth: straicoAuth,

--- a/packages/pieces/community/straico/src/lib/actions/file-upload.ts
+++ b/packages/pieces/community/straico/src/lib/actions/file-upload.ts
@@ -15,11 +15,12 @@ const SUPPORTED_FILE_TYPES = [
 ];
 
 export const fileUpload = createAction({
-  audience: 'human',
+  audience: 'both',
   auth: straicoAuth,
   name: 'file_upload',
   displayName: 'Upload File',
   description: 'Upload a file to Straico API for processing.',
+  aiMetadata: { description: 'Uploads a document, image, audio or video file to Straico storage and returns a hosted URL. Use it as the preparation step whose URL is then passed into Ask AI as a file url or image url; prefer Create RAG when the file should instead be chunked and indexed for retrieval. The extension must be one of pdf, docx, pptx, txt, xlsx, mp3, mp4, html, csv, json, py, php, js, css, cs, swift, kt, xml, ts, png, jpg, jpeg, webp or gif, otherwise the call fails before any request is sent. Not idempotent: each call stores another copy at a new URL.', idempotent: false },
   props: {
     file: Property.File({
       displayName: 'File',

--- a/packages/pieces/community/straico/src/lib/actions/image-generation.ts
+++ b/packages/pieces/community/straico/src/lib/actions/image-generation.ts
@@ -9,11 +9,12 @@ import {
 import { baseUrlv0, baseUrlv1 } from '../common/common';
 
 export const imageGeneration = createAction({
-  audience: 'human',
+  audience: 'both',
   auth: straicoAuth,
   name: 'image_generation',
   displayName: 'Image Generation',
   description: 'Enables users to generate high-quality images based on textual descriptions.',
+  aiMetadata: { description: 'Generates one to four new images from a text description using a Straico image model such as DALL-E 3, in square, landscape or portrait shape, and returns their hosted URLs plus a zip. This is the only image-producing action in the piece; use Ask AI instead when the goal is text, including describing or reasoning about an image that has already been uploaded. Requires a model, a size, an image count and a detailed description; each generated image is billed separately. Not idempotent: every call renders fresh images even for an identical prompt.', idempotent: false },
   props: {
     variations: Property.StaticDropdown({
       displayName: 'Number of Images',

--- a/packages/pieces/community/straico/src/lib/actions/prompt-completion.ts
+++ b/packages/pieces/community/straico/src/lib/actions/prompt-completion.ts
@@ -11,12 +11,13 @@ import * as z from 'zod/mini'
 import { baseUrlv1 } from '../common/common';
 
 export const promptCompletion = createAction({
-  audience: 'human',
+  audience: 'both',
   auth: straicoAuth,
   name: 'prompt_completion',
   displayName: 'Ask AI',
   description:
     'Enables users to generate prompt completion based on a specified model.',
+  aiMetadata: { description: 'Sends a single prompt to any chat model in the Straico catalog and returns the completion text, optionally grounding it in attached context: up to four file URLs, up to four YouTube video URLs and image URLs, with transcripts returned when requested. This is the general-purpose text action; prefer RAG Prompt Completion to search an indexed knowledge base, Agent Prompt Completion to reuse a saved persona, and Image Generation for pictures. Requires a model and a prompt; attached files and images must first be hosted by Upload File, and enabling transcripts without a file or YouTube URL fails. Not idempotent: each call spends credits and returns a fresh completion.', idempotent: false },
   props: {
     model: Property.Dropdown({
   auth: straicoAuth,

--- a/packages/pieces/community/straico/src/lib/actions/rag-create.ts
+++ b/packages/pieces/community/straico/src/lib/actions/rag-create.ts
@@ -9,11 +9,12 @@ import { baseUrlv0 } from '../common/common';
 import FormData from 'form-data';
 
 export const createRag = createAction({
-  audience: 'human',
+  audience: 'both',
   auth: straicoAuth,
   name: 'create_rag',
   displayName: 'Create RAG',
   description: 'Create a new RAG (Retrieval-Augmented Generation) base in the database.',
+  aiMetadata: { description: 'Ingests one uploaded document into a brand new RAG knowledge base that can then be queried with RAG Prompt Completion or attached to an agent, chunking it by fixed size, recursive, markdown, python or semantic strategy. Use it to stand up a new searchable corpus; prefer Update RAG to add another file to a base that already exists, and Upload File when the document only needs a URL to pass into Ask AI rather than being indexed. Requires a name, a description and a file (pdf, docx, csv, txt, xlsx or py); the chunking options apply only to the matching method. Not idempotent: each call creates another RAG base and consumes credits for the ingest.', idempotent: false },
   props: {
     name: Property.ShortText({
       displayName: 'Name',

--- a/packages/pieces/community/straico/src/lib/actions/rag-delete.ts
+++ b/packages/pieces/community/straico/src/lib/actions/rag-delete.ts
@@ -8,11 +8,12 @@ import {
 import { baseUrlv0 } from '../common/common';
 
 export const deleteRag = createAction({
-  audience: 'human',
+  audience: 'both',
   auth: straicoAuth,
   name: 'delete_rag',
   displayName: 'Delete RAG',
   description: 'Delete a specific RAG (Retrieval-Augmented Generation) base by its ID.',
+  aiMetadata: { description: 'Permanently deletes a RAG knowledge base and its indexed documents from the account. Use it to retire a corpus entirely; there is no action to remove a single file from a base, so rebuilding a smaller base means Create RAG again. Requires a raw RAG id typed as text, obtainable from List RAGs, and any agent still pointing at that base will lose its grounding. Idempotent: the base ends up gone regardless of how many times it is called.', idempotent: true },
   props: {
     ragId: Property.ShortText({
       displayName: 'RAG ID',

--- a/packages/pieces/community/straico/src/lib/actions/rag-get-by-id.ts
+++ b/packages/pieces/community/straico/src/lib/actions/rag-get-by-id.ts
@@ -8,11 +8,12 @@ import {
 import { baseUrlv0 } from '../common/common';
 
 export const getRagById = createAction({
-  audience: 'human',
+  audience: 'both',
   auth: straicoAuth,
   name: 'get_rag_by_id',
   displayName: 'Get RAG by ID',
   description: 'Retrieve a specific RAG (Retrieval-Augmented Generation) base by its ID.',
+  aiMetadata: { description: 'Fetches the stored configuration of one RAG knowledge base, including its name, source filename and chunking settings. Use it to confirm a base exists or inspect how it was indexed before querying it; prefer List RAGs to discover ids or compare bases, and RAG Prompt Completion to actually search its contents, since this returns metadata only and no document text. Requires a raw RAG id typed as text. Read-only and idempotent.', idempotent: true },
   props: {
     ragId: Property.ShortText({
       displayName: 'RAG ID',

--- a/packages/pieces/community/straico/src/lib/actions/rag-list.ts
+++ b/packages/pieces/community/straico/src/lib/actions/rag-list.ts
@@ -8,11 +8,12 @@ import {
 import { baseUrlv0 } from '../common/common';
 
 export const listRags = createAction({
-  audience: 'human',
+  audience: 'both',
   auth: straicoAuth,
   name: 'list_rags',
   displayName: 'List RAGs',
   description: 'List all RAG (Retrieval-Augmented Generation) bases for a user.',
+  aiMetadata: { description: 'Returns every RAG knowledge base owned by the authenticated account with its id, name, source filename and chunking settings. Use it as the id-discovery step, since Get RAG by ID, Update RAG, Delete RAG and RAG Prompt Completion all take a raw id typed as text; prefer Get RAG by ID once that id is known. Takes no inputs and offers no server-side filtering or search. Read-only and idempotent.', idempotent: true },
   props: {},
   async run({ auth }) {
     const response = await httpClient.sendRequest<{

--- a/packages/pieces/community/straico/src/lib/actions/rag-prompt-completion.ts
+++ b/packages/pieces/community/straico/src/lib/actions/rag-prompt-completion.ts
@@ -8,11 +8,12 @@ import {
 import { baseUrlv0, baseUrlv1 } from '../common/common';
 
 export const ragPromptCompletion = createAction({
-  audience: 'human',
+  audience: 'both',
   auth: straicoAuth,
   name: 'rag_prompt_completion',
   displayName: 'RAG Prompt Completion',
   description: 'Send a prompt to a specific RAG (Retrieval-Augmented Generation) model.',
+  aiMetadata: { description: 'Answers a question from the documents indexed in one specific RAG knowledge base, returning the answer together with the source passages it was drawn from, and letting retrieval run as plain similarity, MMR for diversity or a similarity score threshold. Pick it when the reply must come from uploaded documents rather than model memory; prefer Ask AI when no document grounding is needed and Agent Prompt Completion when a saved agent already carries the model, persona and knowledge base. Requires a raw RAG id typed as text plus a prompt and an explicit chat model. Not idempotent: each call spends credits and returns a fresh answer.', idempotent: false },
   props: {
     ragId: Property.ShortText({
       displayName: 'RAG ID',

--- a/packages/pieces/community/straico/src/lib/actions/rag-update.ts
+++ b/packages/pieces/community/straico/src/lib/actions/rag-update.ts
@@ -9,11 +9,12 @@ import { baseUrlv0 } from '../common/common';
 import FormData from 'form-data';
 
 export const updateRag = createAction({
-  audience: 'human',
+  audience: 'both',
   auth: straicoAuth,
   name: 'update_rag',
   displayName: 'Update RAG',
   description: 'Update an existing RAG (Retrieval-Augmented Generation) base with additional files.',
+  aiMetadata: { description: 'Adds one more document to an existing RAG knowledge base, re-indexing it so later RAG Prompt Completion calls can draw on the new content. Despite the name it only appends a file and cannot rename a base or change its chunking settings, and it cannot remove content; use Create RAG to start a fresh base with different settings. Requires a raw RAG id typed as text and a file with a supported extension (pdf, docx, csv, txt, xlsx or py). Not idempotent: sending the same file twice ingests it again and spends credits each time.', idempotent: false },
   props: {
     ragId: Property.ShortText({
       displayName: 'RAG ID',

--- a/packages/pieces/community/workday/package.json
+++ b/packages/pieces/community/workday/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-workday",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/packages/pieces/community/workday/src/lib/action/call-operation.ts
+++ b/packages/pieces/community/workday/src/lib/action/call-operation.ts
@@ -12,6 +12,12 @@ export const callOperation = createAction({
 	displayName: 'Call Operation',
 	description:
 		'Calls a Workday REST sub-resource or SOAP operation (e.g. approve, close, submit).',
+	audience: 'both',
+	aiMetadata: {
+		description:
+			'Invokes a Workday operation that has no dedicated action, in one of two modes: a REST sub-resource call (POST, PUT, or PATCH against a business-object path such as /jobRequisitions/{id}/close) or a raw SOAP operation against a named web service such as Staffing. Use as the escape hatch for verbs like approve, close, or submit, and prefer the specific action (e.g. Approve Task, Update Business Object) whenever one exists. Requires the operation name, plus the SOAP service name when running in SOAP mode. Not idempotent: each call submits the operation as a fresh event.',
+		idempotent: false,
+	},
 	props: {
 		...sharedModuleProps,
 		operationType: Property.StaticDropdown({

--- a/packages/pieces/community/workday/src/lib/action/create-update-custom-object.ts
+++ b/packages/pieces/community/workday/src/lib/action/create-update-custom-object.ts
@@ -9,6 +9,12 @@ export const createUpdateCustomObject = createAction({
 	name: 'create_update_custom_object',
 	displayName: 'Create/Update Custom Object',
 	description: 'Creates or updates a Workday custom object instance (PUT upsert).',
+	audience: 'both',
+	aiMetadata: {
+		description:
+			'Writes an instance of a tenant-defined Workday custom object, chosen by its custom object definition ID, with the field values supplied as a JSON body. Leaving the Custom Object ID blank creates a new instance, while supplying an existing ID updates that instance in place. Call List Custom Object Definitions (Batch) first when the definition ID is unknown. Not idempotent: with no object ID every call creates another instance.',
+		idempotent: false,
+	},
 	props: {
 		definitionId: customObjectDefinitionProperty,
 		objectId: Property.ShortText({

--- a/packages/pieces/community/workday/src/lib/action/get-business-object-details-batch.ts
+++ b/packages/pieces/community/workday/src/lib/action/get-business-object-details-batch.ts
@@ -12,6 +12,12 @@ export const getBusinessObjectDetailsBatch = createAction({
 	displayName: 'Get Business Object Details (Batch)',
 	description:
 		'Retrieves details for one or more business objects by ID in a single step.',
+	audience: 'both',
+	aiMetadata: {
+		description:
+			'Fetches the full record for one or more Workday business objects by ID in a single step, after selecting the module (Recruiting, Onboarding, or HR Services & Time Tracking) and an object type such as Job Requisition, Candidate, or Worker, or supplying a custom REST path instead. Use when the record IDs are already known; use Search Business Object (Batch) to find records by criteria. Read-only and idempotent.',
+		idempotent: true,
+	},
 	props: {
 		...sharedModuleProps,
 		objectIds: objectIdsProperty,

--- a/packages/pieces/community/workday/src/lib/action/get-custom-objects.ts
+++ b/packages/pieces/community/workday/src/lib/action/get-custom-objects.ts
@@ -9,6 +9,12 @@ export const getCustomObjects = createAction({
 	name: 'get_custom_objects',
 	displayName: 'Get Custom Objects',
 	description: 'Retrieves a custom object instance by definition ID and object ID.',
+	audience: 'both',
+	aiMetadata: {
+		description:
+			'Retrieves a single instance of a tenant-defined Workday custom object, addressed by its custom object definition ID plus the instance ID. Use when both IDs are known; call List Custom Object Definitions (Batch) first to discover the definition ID, and use Get Business Object Details (Batch) for standard objects such as workers or job requisitions. Read-only and idempotent.',
+		idempotent: true,
+	},
 	props: {
 		definitionId: customObjectDefinitionProperty,
 		objectId: Property.ShortText({

--- a/packages/pieces/community/workday/src/lib/action/get-report-wql-batch.ts
+++ b/packages/pieces/community/workday/src/lib/action/get-report-wql-batch.ts
@@ -10,6 +10,12 @@ export const getReportWqlBatch = createAction({
 	displayName: 'Get Report using WQL (Batch)',
 	description:
 		'Executes a WQL query and returns all rows (use for report-style datasets).',
+	audience: 'both',
+	aiMetadata: {
+		description:
+			'Runs a Workday Query Language (WQL) query and pages through every result row, returning the complete set in one call. Use for report-style extracts where the whole dataset is needed rather than the single page Find Records (WQL) returns, and use Get Report when the data comes from a published report definition. Requires a valid WQL statement. Read-only and idempotent.',
+		idempotent: true,
+	},
 	props: {
 		query: wqlQueryProperty,
 	},

--- a/packages/pieces/community/workday/src/lib/action/get-report.ts
+++ b/packages/pieces/community/workday/src/lib/action/get-report.ts
@@ -10,6 +10,12 @@ export const getReport = createAction({
 	name: 'get_report',
 	displayName: 'Get Report',
 	description: 'Fetches a Workday report by ID or web service alias.',
+	audience: 'both',
+	aiMetadata: {
+		description:
+			'Runs a published Workday custom report, addressed by its report ID or web service alias, and returns its rows, optionally passing report prompt values as JSON. Use when the data is already shaped by a report definition in the tenant; prefer Find Records (WQL) or Get Report using WQL (Batch) when the query can be expressed in WQL instead. Read-only and idempotent.',
+		idempotent: true,
+	},
 	props: {
 		reportId: reportIdProperty,
 		reportParameters: Property.Json({

--- a/packages/pieces/community/workday/src/lib/action/list-custom-object-definitions-batch.ts
+++ b/packages/pieces/community/workday/src/lib/action/list-custom-object-definitions-batch.ts
@@ -9,6 +9,12 @@ export const listCustomObjectDefinitionsBatch = createAction({
 	displayName: 'List Custom Object Definitions (Batch)',
 	description:
 		'Lists all custom object definitions available in your Workday tenant.',
+	audience: 'both',
+	aiMetadata: {
+		description:
+			'Lists every custom object definition configured in the connected Workday tenant. Use as the discovery step before Get Custom Objects or Create/Update Custom Object, which both need a definition ID. Takes no inputs. Read-only and idempotent.',
+		idempotent: true,
+	},
 	props: {},
 	async run({ auth }) {
 		const definitions = await workdayListCustomObjectDefinitions(auth);

--- a/packages/pieces/community/workday/src/lib/action/search-business-object-batch.ts
+++ b/packages/pieces/community/workday/src/lib/action/search-business-object-batch.ts
@@ -12,6 +12,12 @@ export const searchBusinessObjectBatch = createAction({
 	displayName: 'Search Business Object (Batch)',
 	description:
 		'Searches business objects with pagination and returns all matching records.',
+	audience: 'both',
+	aiMetadata: {
+		description:
+			'Pages through a Workday business object collection and returns every matching record, after selecting the module (Recruiting, Onboarding, or HR Services & Time Tracking) and an object type such as Job Requisition, Candidate, or Worker, or supplying a custom REST path instead. Optional JSON query parameters narrow the results; omitting them returns all records of that type. Use to find records by criteria, and Get Business Object Details (Batch) when the IDs are already known. Read-only and idempotent.',
+		idempotent: true,
+	},
 	props: {
 		...sharedModuleProps,
 		queryParams: optionalQueryParamsProperty,

--- a/packages/pieces/community/workday/src/lib/action/update-business-object.ts
+++ b/packages/pieces/community/workday/src/lib/action/update-business-object.ts
@@ -11,6 +11,12 @@ export const updateBusinessObject = createAction({
 	name: 'update_business_object',
 	displayName: 'Update Business Object',
 	description: 'Updates an existing business object by ID using the REST API.',
+	audience: 'both',
+	aiMetadata: {
+		description:
+			'Updates one existing Workday business object by its ID, sending the new field values as a JSON body, after selecting the module (Recruiting, Onboarding, or HR Services & Time Tracking) and an object type such as Job Requisition, Candidate, or Worker, or supplying a custom REST path instead. Use for generic edits to recruiting, onboarding, or HR and time-tracking records, and prefer the dedicated action (e.g. Update Supplier, Change Job) when one exists. Requires the record ID and a JSON body. Idempotent: keyed on the object ID, so re-sending the same body converges to the same state.',
+		idempotent: true,
+	},
 	props: {
 		...sharedModuleProps,
 		objectId: Property.ShortText({

--- a/packages/pieces/community/workday/src/lib/trigger/new-or-updated-business-object-batch.ts
+++ b/packages/pieces/community/workday/src/lib/trigger/new-or-updated-business-object-batch.ts
@@ -104,6 +104,10 @@ export const newOrUpdatedBusinessObjectBatch = createTrigger({
 	displayName: 'New/Updated Business Object (Batch)',
 	description:
 		'Triggers with a batch of new or updated business objects in a single poll cycle.',
+	aiMetadata: {
+		description:
+			'Fires once per poll cycle carrying every Workday business object created or changed since the previous poll as a single batch, for the module (Recruiting, Onboarding, or HR Services & Time Tracking) and object type selected, or for a custom REST path. Recency is judged by a configurable date field, defaulting to lastFunctionallyUpdated. Use when the whole changed set should be processed at once instead of one flow run per record.',
+	},
 	props,
 	sampleData: {
 		total_count: 2,

--- a/packages/pieces/community/workday/src/lib/trigger/new-or-updated-business-object.ts
+++ b/packages/pieces/community/workday/src/lib/trigger/new-or-updated-business-object.ts
@@ -85,6 +85,10 @@ export const newOrUpdatedBusinessObject = createTrigger({
 	displayName: 'New/Updated Business Object',
 	description:
 		'Triggers when a business object is created or updated in Recruiting, Onboarding, or HR Services & Time Tracking.',
+	aiMetadata: {
+		description:
+			'Fires once per Workday business object created or changed since the last poll, for the module (Recruiting, Onboarding, or HR Services & Time Tracking) and object type selected, or for a custom REST path. Recency is judged by a configurable date field, defaulting to lastFunctionallyUpdated, and optional JSON filters narrow the polled set. Use when downstream work should run per record; use the batch variant to handle all changed records in one run.',
+	},
 	props,
 	sampleData: {
 		job_requisition_id: '3aa5550b7fe348b98d7b5741afc65534',

--- a/packages/pieces/community/workday/src/lib/trigger/scheduled-report-fetch-batch.ts
+++ b/packages/pieces/community/workday/src/lib/trigger/scheduled-report-fetch-batch.ts
@@ -70,6 +70,10 @@ export const scheduledReportFetchBatch = createTrigger({
 	displayName: 'Scheduled Report Fetch (Batch)',
 	description:
 		'Polls a Workday report on a schedule and returns all rows as a batch.',
+	aiMetadata: {
+		description:
+			'Fires on every poll with the full row set of a published Workday custom report, identified by report ID or web service alias and optionally given prompt values as JSON. The whole report is re-fetched each cycle rather than only changed rows, so treat it as a scheduled extract, not a change feed. Use Scheduled Report Fetch using WQL (Batch) instead when the data comes from a WQL query.',
+	},
 	props,
 	sampleData: {
 		total_count: 1,

--- a/packages/pieces/community/workday/src/lib/trigger/scheduled-report-fetch-wql-batch.ts
+++ b/packages/pieces/community/workday/src/lib/trigger/scheduled-report-fetch-wql-batch.ts
@@ -69,6 +69,10 @@ export const scheduledReportFetchWqlBatch = createTrigger({
 	displayName: 'Scheduled Report Fetch using WQL (Batch)',
 	description:
 		'Polls a WQL query on a schedule and returns matching rows as a batch.',
+	aiMetadata: {
+		description:
+			'Fires on every poll with the rows of a Workday Query Language (WQL) query that are newer than the previous run, delivered as one batch. Recency is judged by a configurable date field, defaulting to lastFunctionallyUpdated, so the query must select that column. Use for scheduled WQL extracts; use Scheduled Report Fetch (Batch) when the data comes from a published report definition instead.',
+	},
 	props,
 	sampleData: {
 		total_count: 1,

--- a/packages/pieces/community/youtube/package.json
+++ b/packages/pieces/community/youtube/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-youtube",
-  "version": "0.4.10",
+  "version": "0.4.11",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "dependencies": {

--- a/packages/pieces/community/youtube/src/lib/actions/download-caption.ts
+++ b/packages/pieces/community/youtube/src/lib/actions/download-caption.ts
@@ -11,6 +11,8 @@ export const youtubeDownloadCaptionAction = createAction({
   displayName: 'Download Caption',
   description:
     'Returns a caption track text by caption ID using the YouTube captions.download endpoint. Requires permission to edit the video, so it only works for captions on videos the authenticated user owns. Auto-generated (asr) caption tracks cannot be downloaded and will return a 403.',
+  audience: 'both',
+  aiMetadata: { description: 'Downloads the raw text of one YouTube caption track identified by its caption ID, optionally emitting it as SRT, VTT, SBV, SCC, or TTML and machine-translating it into a target language code. Use it after List Captions has supplied the caption ID; the endpoint only serves tracks on videos the authenticated account can edit, and auto-generated (asr) tracks are refused with a 403. Read-only and idempotent.', idempotent: true },
   props: {
     captionId: Property.ShortText({
       displayName: 'Caption ID',

--- a/packages/pieces/community/youtube/src/lib/actions/list-captions.ts
+++ b/packages/pieces/community/youtube/src/lib/actions/list-captions.ts
@@ -11,6 +11,8 @@ export const youtubeListCaptionsAction = createAction({
   displayName: 'List Captions',
   description:
     'Returns caption tracks for a specific YouTube video using the captions.list endpoint.',
+  audience: 'both',
+  aiMetadata: { description: 'Lists the caption tracks attached to a single YouTube video, covering every track on that video or only the ones named by a comma-separated list of caption IDs. Use it to discover which languages a video is captioned in and to obtain the caption ID that the Download Caption action requires. The video ID is mandatory. Read-only and idempotent.', idempotent: true },
   props: {
     videoId: Property.ShortText({
       displayName: 'Video ID',

--- a/packages/pieces/community/youtube/src/lib/actions/list-playlist-items.ts
+++ b/packages/pieces/community/youtube/src/lib/actions/list-playlist-items.ts
@@ -8,6 +8,8 @@ export const youtubeListPlaylistItemsAction = createAction({
   displayName: 'List Playlist Items',
   description:
     'Returns videos in a YouTube playlist. You can filter by playlist ID or by specific item IDs.',
+  audience: 'both',
+  aiMetadata: { description: 'Lists the entries of a YouTube playlist in one of two modes: pass a playlist ID to page through that whole playlist (optionally narrowed to entries containing one video ID), or pass a comma-separated list of playlist item IDs to fetch only those entries. Exactly one of the two is required, supplying both or filtering by video without a playlist ID fails validation, and Max Results is capped at 50 with further pages fetched via the page token. Run Search with type Playlist first when the playlist ID is unknown; read-only and idempotent.', idempotent: true },
   props: {
     playlistId: Property.ShortText({
       displayName: 'Playlist ID',

--- a/packages/pieces/community/youtube/src/lib/actions/search.ts
+++ b/packages/pieces/community/youtube/src/lib/actions/search.ts
@@ -8,6 +8,8 @@ export const youtubeSearchAction = createAction({
   displayName: 'Search',
   description:
     'Search YouTube videos, channels, and playlists using the YouTube Data API search.list endpoint.',
+  audience: 'both',
+  aiMetadata: { description: 'Runs a YouTube search.list query across videos, channels, and playlists at once or restricted to a single resource type, and can instead be scoped to uploads owned by the authenticated account (For Mine), a CMS content owner, or the developer project. Use it to turn a free-text query, channel, date range, region, or topic into video, channel, or playlist IDs for later steps; prefer List Playlist Items when the playlist ID is already known. Video-only filters such as duration, definition, caption, event type, and location require Type to be Video, and Location must be paired with Location Radius. Read-only and idempotent.', idempotent: true },
   props: {
     query: Property.ShortText({
       displayName: 'Query',


### PR DESCRIPTION
## Description

Fills the remaining `aiMetadata` gap in the community piece catalog: **155 actions and triggers across 32 pieces**, none of which previously carried any agent-facing metadata. An agent browsing the catalog saw only the builder-facing `description`.

Each action gains:
- `aiMetadata.description` — written for an agent choosing among hundreds of tools: what it does and on what object, when to pick it over a sibling action, the key constraint or required input, and idempotency stated in prose. Not a copy of the human description, and no output-shape modelling (that belongs to the output-schema stream).
- `aiMetadata.idempotent` — derived from the `run()` body (the HTTP method / operation), not from the action name. The batch lands at 78 `true` / 66 `false`.

Triggers gain `aiMetadata.description` only.

### Audience change

This also lifts `audience` from `'human'` to `'both'` on **92 actions** in vendor-LLM and utility pieces — openai (18), straico (16), hugging-face (8), google-gemini (6), mistral-ai (5), amazon-bedrock (4), grok-xai (4), groq (3), greenpt (3), json (3), queue (3), flow-helper (3), plus smaller ones. These are real integrations with distinct operations, and they were previously excluded from agent discovery.

Two deliberate exceptions stay untouched:
- the shared `createCustomApiCallAction(...)` entries, as before;
- `amazon-bedrock`'s hand-written `custom_api_call`, which keeps `audience: 'human'` because it is a blind SigV4-signed proxy over arbitrary Bedrock endpoints. It still gains `aiMetadata`.

### Scope

Additive only — no runtime behaviour, props, imports, or `src/index.ts` registration changed. The only deleted lines in the whole diff are the 92 `audience: 'human'` values being flipped and the 32 version lines. Each touched piece gets a patch bump.

Objects that exist as source files but are not registered in their piece's `index.ts` were deliberately left out, since curating them has no catalog effect. The same applies to the deprecated `aws-bedrock` piece, which the metadata service filters out of discovery.

## How was this tested?

Every action and trigger was curated and then independently re-verified by a second pass that re-derived `idempotent` from `run()`, checked each description against the house style, and confirmed the diff stayed additive. Three factual errors it surfaced were corrected: a greenpt transcription description that wrongly claimed a URL could not be used for a `Property.File` input (the engine's file processor falls back to `handleUrlFile`), a grok-xai description that framed a required structured-array prop as optional, and two microsoft-copilot descriptions steering agents to an action that is commented out of that piece's `index.ts`.

Gates run locally against `upstream/main`:
- `tsc` over all 32 touched pieces with root paths — 0 errors
- `eslint` over the 155 changed files — 0 errors (95 pre-existing warnings, all in untouched code)
- 32/32 `package.json` versions bumped by exactly one patch, no `aiReady` flag added
- field counts reconciled: 155 files ↔ 155 `aiMetadata`, 143 `audience: 'both'`, 0 `index.ts` touched

No edition-specific paths are involved; this is piece metadata only.


### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)
