### PR TITLE
fix(engine): fail cleanly on unserializable step data instead of INTERNAL_ERROR

### DIFF
--- a/brain/wiki/execution-runtime/gotcha-engine-callback-error-name-tells-you-where-it-died.md
+++ b/brain/wiki/execution-runtime/gotcha-engine-callback-error-name-tells-you-where-it-died.md
@@ -1,0 +1,47 @@
+---
+icon: 🔌
+---
+
+# Gotcha: the engine callback's error *name* tells you where it died
+
+When a run fails with `ProgressUpdateError` vs `EngineRunCallbackError`, the name is a precise diagnostic — don't read either as "the callback POST failed".
+
+`engineRunApi.post()` throws `EngineRunCallbackError` (an `EngineGenericError`, so type ENGINE) for a non-ok HTTP response. `utils.tryCatchAndThrowOnEngineError` rethrows ENGINE errors untouched. So:
+
+- **`EngineRunCallbackError`** → the app answered with an error status. Real HTTP failure.
+- **`ProgressUpdateError`** → the underlying error was *not* an `ExecutionError` at all. `tryCatchAndThrowOnEngineError` passed it through and `flow-run-progress-reporter` wrapped it. **This can never be an HTTP error status.**
+
+Second discriminator, **timing**: `PROGRESS_RETRY_CONFIG` is `retries: 3, retryDelay: 3000`, and `fetch-retry` *does* retry network-level rejections when `retryOn` is an array (only the `.catch` → `attempt < retries` branch; easy to misread as status-only). So any genuine network failure burns **≥9s** before surfacing. A `ProgressUpdateError` on a job that finished in 3s never touched the network.
+
+Together those pin the failure to a synchronous throw inside `post()` before any fetch — in practice `JSON.stringify(body)`, which is evaluated eagerly while building the fetch `init` and therefore sits *outside* the retry wrapper entirely.
+
+**Why this bit us (July 2026):** 19 failed jobs reading only `ProgressUpdateError: {"message": "Failed to send updateRunProgress"}`. All 19 — sampled across 3 flows, 2 projects, both TESTING and PRODUCTION — were the *same* cause: **`TypeError: Converting circular structure to JSON`**.
+
+**The cycle, which is an engine bug, not bad user data.** Referencing a loop step's output from a step *inside* that loop (`{{step_2['output']}}`) is legitimate — `LoopStepOutput.output` is `{ item, index, iterations }`, so `data.item…` works. But the engine aliases it live rather than snapshotting:
+
+- `executionJournal.upsertStep` walks to `loopOutput.output.iterations[i]` and does `target[stepName] = stepOutput` — **in-place mutation**, returning the same `steps` object.
+- `LoopStepOutput.setItemAndIndex` forwards **the same array** (`iterations: this.output?.iterations ?? []`).
+
+So the nested step's resolved `input` holds a live reference to the loop output, and the moment `upsertStep` records that step into `iterations[i]`, you get `step_3.input.data.iterations[0].step_3 === step_3`. It throws on the step's **RUNNING** update, before the step body executes.
+
+Note this is exactly the mutation-across-a-function-boundary that the root `CLAUDE.md` forbids. A true fix means making the journal immutable — but beware: `loop-executor.ts` *depends* on the in-place write. It keeps `stepOutput` as a local across iterations and `addIteration()` spreads `this.output.iterations`, which only holds nested results because they were mutated into the shared array. Go immutable without re-reading via `getLoopStepOutput()` each iteration and every nested step's output silently vanishes.
+
+Contained (not cured) by typing the serialization failure as a USER `CallbackSerializationError` so the run FAILS cleanly, plus guarding the trailing `sendUpdate`/`backup` in `flow.operation.ts`, which sat outside every `tryCatch`. Do **not** make progress updates best-effort instead: the same graph fails again at `backup()`, so you'd run every loop iteration's side effects (outbound HTTP, webhooks) and still fail — then repeat on each retry.
+
+**Where the real cause actually lives.** `formatMessage` serializes only `{ message }`, so the cause never reaches `failedReason`, and the engine's stderr goes into the BullMQ job rather than ClickHouse. But it is **not** lost: the run log's `internalError.raw` holds the full Node inspection *including* the `cause:` block with the original `TypeError` and its stack.
+
+To read it, fetch `files.logFile.s3Key` and decompress. `debug-failed-job.js` cannot — the DevOps box is on Node 20 and the log is ZSTD (needs ≥22.15), which is why the script reports `runLogs: null` with a note. Pull the bytes down and decompress on a modern Node instead:
+
+```bash
+# on the box: base64 the S3 object to stdout (reuses /root/queue's dotenv + aws-sdk)
+ssh <host> 'cd /root/queue && node -' < fetch.js "<s3Key>" > log.b64
+# locally, Node >= 22.15:
+node -e "const z=require('zlib'),f=require('fs');
+console.log(z.zstdDecompressSync(Buffer.from(f.readFileSync('log.b64','utf8'),'base64')).toString())"
+```
+
+**Do this first.** The two discriminators above narrow it, but the log gives you the exact error and stack in a couple of minutes.
+
+**`isTestFlow` does not mean "TESTING run".** The per-step gate is `if (!stepNameToUpdate || !engineConstants.isTestFlow) return`, and `isTestFlow` is defined as `streamStepProgress === StreamStepProgress.WEBSOCKET` — nothing to do with `RunEnvironment`. PRODUCTION runs stream too, so they take the same path. Don't conclude from an `updateRunProgress` failure that the run was a builder test; 6 of the 19 above were PRODUCTION.
+
+Also note `sendUpdateProgress` and `sendLogsUpdate` both throw under the name `ProgressUpdateError` — only the inner text (`Failed to send updateRunProgress` vs `uploadRunLog`) tells you which call site died.

--- a/brain/wiki/execution-runtime/gotcha-retrying-the-failed-job-backlog-resurrects-unfixable-zombies.md
+++ b/brain/wiki/execution-runtime/gotcha-retrying-the-failed-job-backlog-resurrects-unfixable-zombies.md
@@ -1,0 +1,17 @@
+---
+icon: 🧟
+---
+
+# Gotcha: retrying the failed-job backlog resurrects unfixable zombies
+
+Before you read anything into a "top failure reasons" tally of `workerJobs`, **check how old the underlying runs are**. A bulk retry of the failed set re-runs jobs whose payload / log files expired months ago. Those can never succeed, so they immediately re-fail, land back in the failed set, and dominate the categorizer's counts with a failure mode nobody can act on.
+
+The BullMQ job carries no useful timestamp for this — `processedOn` / `finishedOn` come back empty on these. Get the age from the Postgres `flow_run` row instead: `created` is the real run date, `updated` is when it was last retried. A cluster of wildly different `created` values sharing one near-identical `updated` timestamp *is* the bulk-retry signature.
+
+**Seen July 2026:** 59 failed jobs categorized as if they were current. 35 of them (59%) were zombies — `created` spanning 2025-10-28 to 2026-03-31, all `updated` within the same two minutes that morning. Every one was a RESUME whose payload/log file was long gone, i.e. the exact class already fixed by #14211 (404/410 → USER-typed `EngineFileNotFoundError` → clean FAILED run). Their stack traces still referenced `packages/shared/src/lib/core/common/try-catch.ts`, a path that no longer exists — a cheap tell that a job predates a refactor. Only ~23 jobs were genuinely live.
+
+**Practical rules**
+- Cross-check `created` before believing any category count; report live vs. stale separately.
+- **`attemptsMade > 2` proves a manual retry.** The queue's `defaultJobOptions` is `attempts: 2` (exponential backoff, 8 min) — see `job-queue.ts`. So auto-retry can never exceed 2, and the 9–12 counts on these were hand-retried. Corollary: a genuine one-off failure costs *one* wasted re-execution, not a retry storm — don't over-rate the severity of a single failed job.
+- A stack-trace path that doesn't exist in `main` dates the job better than anything in Redis.
+- Drain the stale ones rather than "fixing" them; the fix already shipped.

--- a/brain/wiki/execution-runtime/index.md
+++ b/brain/wiki/execution-runtime/index.md
@@ -50,3 +50,5 @@ The four calls a run emits to the app during execution: `updateRunProgress`, `up
 - **Benchmark CLI** — measuring throughput; queue-wait vs service-time
 - **Gotcha: engine vitest needs fresh core-execution dist** — why a stale dist fails the engine tests
 - **Gotcha: system-job "No handler" = worker running the wrong edition** — diagnosing edition skew
+- **Gotcha: the engine callback's error name tells you where it died** — `ProgressUpdateError` vs `EngineRunCallbackError`, and why the cause is missing
+- **Gotcha: retrying the failed-job backlog resurrects unfixable zombies** — why a "top failure reasons" count misleads

--- a/bun.lock
+++ b/bun.lock
@@ -97,7 +97,7 @@
     },
     "packages/core/execution": {
       "name": "@activepieces/core-execution",
-      "version": "0.9.2",
+      "version": "0.10.0",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -142,7 +142,7 @@
     },
     "packages/core/shared": {
       "name": "@activepieces/shared",
-      "version": "0.121.1",
+      "version": "0.122.0",
       "dependencies": {
         "@activepieces/core-execution": "workspace:*",
         "@activepieces/core-formula": "workspace:*",

--- a/packages/core/execution/package.json
+++ b/packages/core/execution/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/core-execution",
-  "version": "0.9.2",
+  "version": "0.10.0",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "scripts": {

--- a/packages/core/execution/src/lib/engine/execution-errors.ts
+++ b/packages/core/execution/src/lib/engine/execution-errors.ts
@@ -137,3 +137,16 @@ export class SSRFBlockedError extends ExecutionError {
         )
     }
 }
+
+export class CallbackSerializationError extends ExecutionError {
+    constructor({ path, cause }: { path: string, cause?: unknown }) {
+        super(
+            CALLBACK_SERIALIZATION_ERROR_NAME,
+            formatMessage(`Step data cannot be converted to JSON, so the ${path} callback could not be sent: ${cause instanceof Error ? cause.message : String(cause)}`),
+            ExecutionErrorType.USER,
+            cause,
+        )
+    }
+}
+
+export const CALLBACK_SERIALIZATION_ERROR_NAME = 'CallbackSerializationError'

--- a/packages/core/shared/package.json
+++ b/packages/core/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/shared",
-  "version": "0.121.1",
+  "version": "0.122.0",
   "type": "commonjs",
   "sideEffects": false,
   "main": "./dist/src/index.js",

--- a/packages/server/api/src/app/flows/flow-run/engine-run-callback-service.ts
+++ b/packages/server/api/src/app/flows/flow-run/engine-run-callback-service.ts
@@ -1,5 +1,5 @@
 import { isNil, tryCatch } from '@activepieces/core-utils'
-import { ApEdition, ExecutioOutputFile, FileCompression, FileType, isFlowRunStateTerminal, logSerializer, RunInternalError, RunInternalErrorSource, SendFlowResponseRequest, StreamStepProgress, truncateFailedStepMessage, UpdateStepProgressRequest, UploadRunLogsRequest, WebsocketClientEvent } from '@activepieces/shared'
+import { ApEdition, CALLBACK_SERIALIZATION_ERROR_NAME, ExecutioOutputFile, FileCompression, FileType, isFlowRunStateTerminal, logSerializer, RunInternalError, RunInternalErrorSource, SendFlowResponseRequest, StreamStepProgress, truncateFailedStepMessage, UpdateStepProgressRequest, UploadRunLogsRequest, WebsocketClientEvent } from '@activepieces/shared'
 import { FastifyBaseLogger } from 'fastify'
 import { websocketService } from '../../core/websockets.service'
 import { fileCompressor } from '../../file/file-compressor'
@@ -54,6 +54,14 @@ export const engineRunCallbackService = (log: FastifyBaseLogger) => ({
             runMs: request.runMs,
         }
         await runsMetadataQueue(log).add(logData)
+
+        if (request.failedStep?.message?.includes(CALLBACK_SERIALIZATION_ERROR_NAME)) {
+            log.error({
+                flowRun: { id: request.runId, status: request.status },
+                project: { id: projectId },
+                step: { name: request.failedStep.name },
+            }, '[uploadRunLog] Engine produced step data that cannot be serialized')
+        }
 
         if (request.stepResponse && request.streamStepProgress === StreamStepProgress.WEBSOCKET) {
             const stepData = { ...request.stepResponse, projectId }

--- a/packages/server/engine/src/lib/api/engine-run-api.ts
+++ b/packages/server/engine/src/lib/api/engine-run-api.ts
@@ -1,4 +1,5 @@
-import { EngineGenericError, SendFlowResponseRequest, UpdateRunProgressRequest, UpdateStepProgressRequest, UploadRunLogsRequest } from '@activepieces/shared'
+import { tryCatchSync } from '@activepieces/core-utils'
+import { CallbackSerializationError, EngineGenericError, SendFlowResponseRequest, UpdateRunProgressRequest, UpdateStepProgressRequest, UploadRunLogsRequest } from '@activepieces/shared'
 import fetchRetry from 'fetch-retry'
 
 const TERMINAL_RETRY_CONFIG = {
@@ -29,6 +30,10 @@ export const engineRunApi = {
 }
 
 async function post({ apiUrl, engineToken, path, body, retry }: PostParams): Promise<void> {
+    const { data: serializedBody, error: serializationError } = tryCatchSync(() => JSON.stringify(body))
+    if (serializationError) {
+        throw new CallbackSerializationError({ path, cause: serializationError })
+    }
     const fetchWithRetry = fetchRetry(global.fetch)
     const response = await fetchWithRetry(`${apiUrl}v1/engine/${path}`, {
         method: 'POST',
@@ -36,7 +41,7 @@ async function post({ apiUrl, engineToken, path, body, retry }: PostParams): Pro
             'Content-Type': 'application/json',
             Authorization: `Bearer ${engineToken}`,
         },
-        body: JSON.stringify(body),
+        body: serializedBody,
         ...retry,
     })
     if (!response.ok) {

--- a/packages/server/engine/src/lib/helper/flow-run-progress-reporter.ts
+++ b/packages/server/engine/src/lib/helper/flow-run-progress-reporter.ts
@@ -3,7 +3,7 @@ import { zstdCompress as zstdCompressCallback } from 'node:zlib'
 import { setTimeout } from 'timers/promises'
 import { isNil, tryCatch } from '@activepieces/core-utils'
 import { OutputContext } from '@activepieces/pieces-framework'
-import { DEFAULT_MCP_DATA, EngineGenericError, FileCompression, FileType, isFlowRunStateTerminal, logSerializer, RunEnvironment, StepOutputStatus, StepRunResponse, UpdateRunProgressRequest, UploadRunLogsRequest } from '@activepieces/shared'
+import { CallbackSerializationError, DEFAULT_MCP_DATA, EngineGenericError, ExecutionError, FileCompression, FileType, isFlowRunStateTerminal, logSerializer, RunEnvironment, StepOutputStatus, StepRunResponse, UpdateRunProgressRequest, UploadRunLogsRequest } from '@activepieces/shared'
 import { Mutex } from 'async-mutex'
 import dayjs from 'dayjs'
 import { engineFileApi } from '../api/engine-file-api'
@@ -103,12 +103,15 @@ export const flowRunProgressReporter = {
             const status = flowExecutorContext.verdict.status
             const isTerminal = isFlowRunStateTerminal({ status, ignoreInternalError: false })
 
-            const serialized = await logSerializer.serialize({
+            const { data: serialized, error: serializeError } = await tryCatch(() => logSerializer.serialize({
                 executionState: {
                     steps: flowExecutorContext.steps,
                     tags: Array.from(flowExecutorContext.tags),
                 },
-            })
+            }))
+            if (serializeError) {
+                throw new CallbackSerializationError({ path: 'run-logs', cause: serializeError })
+            }
             const executionState = await zstdCompress(serialized)
 
             const logsFileId = engineConstants.logsFileId
@@ -189,7 +192,9 @@ const sendUpdateProgress = async ({ engineConstants, request }: SendUpdateProgre
         }),
     )
     if (result.error) {
-        throw new EngineGenericError('ProgressUpdateError', 'Failed to send updateRunProgress', result.error)
+        throw result.error instanceof ExecutionError
+            ? result.error
+            : new EngineGenericError('ProgressUpdateError', 'Failed to send updateRunProgress', result.error)
     }
 }
 
@@ -202,7 +207,9 @@ const sendLogsUpdate = async ({ engineConstants, request }: SendLogsUpdateParams
         }),
     )
     if (result.error) {
-        throw new EngineGenericError('ProgressUpdateError', 'Failed to send uploadRunLog', result.error)
+        throw result.error instanceof ExecutionError
+            ? result.error
+            : new EngineGenericError('ProgressUpdateError', 'Failed to send uploadRunLog', result.error)
     }
 }
 

--- a/packages/server/engine/src/lib/operations/flow.operation.ts
+++ b/packages/server/engine/src/lib/operations/flow.operation.ts
@@ -38,11 +38,21 @@ export const flowOperation = {
             return reportFailedRun({ input, constants, error: executionError })
         }
         const finished = output.finishExecution()
-        await flowRunProgressReporter.sendUpdate({
-            engineConstants: constants,
-            flowExecutorContext: finished,
+        const { error: reportError } = await tryCatch(async () => {
+            await flowRunProgressReporter.sendUpdate({
+                engineConstants: constants,
+                flowExecutorContext: finished,
+            })
+            await flowRunProgressReporter.backup()
         })
-        await flowRunProgressReporter.backup()
+        if (reportError) {
+            // Polarity is inverted vs. the execution guards above: an unknown failure here is likelier
+            // transient infra (a raw fetch rejection from the log upload) than a user fault, so it still retries.
+            if (isUserExecutionError(reportError)) {
+                return reportFailedRun({ input, constants, error: reportError })
+            }
+            throw reportError
+        }
         const status = finished.verdict.status === FlowRunStatus.LOG_SIZE_EXCEEDED
             ? EngineResponseStatus.LOG_SIZE_EXCEEDED
             : EngineResponseStatus.OK
@@ -55,6 +65,10 @@ export const flowOperation = {
 
 function isEngineExecutionError(error: unknown): boolean {
     return error instanceof ExecutionError && error.type === ExecutionErrorType.ENGINE
+}
+
+function isUserExecutionError(error: unknown): boolean {
+    return error instanceof ExecutionError && error.type === ExecutionErrorType.USER
 }
 
 async function reportFailedTriggerRun({ operation, error }: ReportFailedTriggerRunParams): Promise<EngineResponse<undefined>> {

--- a/packages/server/engine/test/api/engine-run-api-serialization.test.ts
+++ b/packages/server/engine/test/api/engine-run-api-serialization.test.ts
@@ -1,0 +1,76 @@
+import { CallbackSerializationError, ExecutionError, ExecutionErrorType } from '@activepieces/shared'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { engineRunApi } from '../../src/lib/api/engine-run-api'
+
+const circularStep = (): Record<string, unknown> => {
+    const step: Record<string, unknown> = { name: 'step_3' }
+    step.self = step
+    return step
+}
+
+describe('engine run callbacks with a non-serializable body', () => {
+    beforeEach(() => {
+        vi.restoreAllMocks()
+    })
+
+    it('fails as a USER error naming the cause, without calling fetch or burning retries', async () => {
+        const fetchSpy = vi.spyOn(global, 'fetch')
+        const startedAt = Date.now()
+
+        const thrown = await engineRunApi.updateRunProgress({
+            apiUrl: 'http://127.0.0.1:1/',
+            engineToken: 'token',
+            request: { step: circularStep() } as never,
+        }).catch((error: unknown) => error)
+
+        expect(thrown).toBeInstanceOf(CallbackSerializationError)
+        expect((thrown as ExecutionError).type).toBe(ExecutionErrorType.USER)
+        expect((thrown as ExecutionError).message).toContain('run-progress')
+        expect((thrown as ExecutionError).message).toContain('circular')
+        expect(fetchSpy).not.toHaveBeenCalled()
+        expect(Date.now() - startedAt).toBeLessThan(1000)
+    })
+
+    it('classifies an unserializable run-log upload the same way', async () => {
+        const thrown = await engineRunApi.uploadRunLog({
+            apiUrl: 'http://127.0.0.1:1/',
+            engineToken: 'token',
+            request: { runId: 'run', output: { rows: 10n } } as never,
+        }).catch((error: unknown) => error)
+
+        expect(thrown).toBeInstanceOf(CallbackSerializationError)
+        expect((thrown as ExecutionError).type).toBe(ExecutionErrorType.USER)
+        expect((thrown as ExecutionError).message).toContain('BigInt')
+    })
+
+    it('keeps a raw network rejection unclassified so the trailing guard still retries it', async () => {
+        vi.spyOn(global, 'fetch').mockRejectedValue(new TypeError('fetch failed'))
+        vi.useFakeTimers()
+
+        const pending = engineRunApi.updateRunProgress({
+            apiUrl: 'http://127.0.0.1:1/',
+            engineToken: 'token',
+            request: { step: { name: 'step_3' } } as never,
+        }).catch((error: unknown) => error)
+        await vi.runAllTimersAsync()
+        const thrown = await pending
+        vi.useRealTimers()
+
+        expect(thrown).toBeInstanceOf(TypeError)
+        expect(thrown).not.toBeInstanceOf(CallbackSerializationError)
+    })
+
+    it('keeps a non-ok response an ENGINE error so genuine outages still retry', async () => {
+        vi.spyOn(global, 'fetch').mockResolvedValue(new Response('nope', { status: 400, statusText: 'Bad Request' }))
+
+        const thrown = await engineRunApi.updateRunProgress({
+            apiUrl: 'http://127.0.0.1:1/',
+            engineToken: 'token',
+            request: { step: { name: 'step_3' } } as never,
+        }).catch((error: unknown) => error)
+
+        expect(thrown).toBeInstanceOf(ExecutionError)
+        expect((thrown as ExecutionError).name).toBe('EngineRunCallbackError')
+        expect((thrown as ExecutionError).type).toBe(ExecutionErrorType.ENGINE)
+    })
+})


### PR DESCRIPTION
## Description

A flow run whose step data cannot be JSON-serialized ended as `INTERNAL_ERROR`, which fails the worker job and burns a pointless retry (`attempts: 2`) on a run that can never serialize — even though the flow itself had already executed successfully. Those runs accumulate in the failed queue and page oncall for something no retry can fix.

Such a failure is now reported as a clean `FAILED` run whose message names the underlying JSON error. Genuine outages are untouched: a non-ok HTTP response still yields `EngineRunCallbackError` (ENGINE), so it keeps retrying and paging.

### Why it went wrong

The error was misclassified at four consecutive gates, so fixing any one of them alone does nothing:

1. `engine-run-api.ts` — `JSON.stringify(body)` was evaluated eagerly while building the fetch `init`, so it threw a plain `TypeError` **outside** the retry wrapper (no HTTP, no retry).
2. `tryCatchAndThrowOnEngineError` only rethrows ENGINE `ExecutionError`s, so a plain `TypeError` fell through as a returned value.
3. `flow-run-progress-reporter.ts` blanket-wrapped it in `EngineGenericError`, which is hardcoded to ENGINE — relabelling a deterministic data problem as an engine bug.
4. `flow.operation.ts` — the trailing `sendUpdate`/`backup` sat outside every `tryCatch`, so it escaped `execute()` entirely. (The two sibling paths were already guarded; this one was missed.)

### Scope — this contains the symptom, it does not fix the root cause

The production trigger, confirmed by decompressing the run logs of 4 failed jobs spanning **3 flows / 2 projects / both TESTING and PRODUCTION** — all identical:

```
TypeError: Converting circular structure to JSON
    |  property 'input' -> 'data' -> ... -> index 0
    --- property 'step_3' closes the circle
```

Referencing a loop step's output from a step *inside* that loop (`{{step_2['output']}}`) is legitimate — `LoopStepOutput.output` is `{ item, index, iterations }`. But `executionJournal.upsertStep` mutates `iterations[i]` **in place** while the nested step's resolved input holds a live reference to it, so the graph becomes self-referential.

**That engine-side aliasing is not fixed here.** Affected flows still fail — cleanly, with a real message, instead of wedging the queue. The real fix is making the journal immutable, which is riskier than it looks: `loop-executor.ts` *depends* on the in-place write (it keeps `stepOutput` as a local across iterations and `addIteration()` spreads `this.output.iterations`), so going immutable without re-reading via `getLoopStepOutput()` each iteration would silently drop every nested step's output. Written up in `brain/wiki/execution-runtime/` rather than attempted here.

### Keeping the signal

Failing quietly means these stop appearing in the failed-job backlog — which is exactly how this bug was found. The API now logs the occurrence at `error` level so it stays alertable:

```sql
SELECT count() FROM default.otel_logs
WHERE Timestamp >= now() - INTERVAL 1 HOUR
  AND ServiceName = 'activepieces-api' AND SeverityText = 'error'
  AND position(Body, 'cannot be serialized') > 0
```

## How was this tested?

- New unit tests (`packages/server/engine/test/api/engine-run-api-serialization.test.ts`) against the real `engineRunApi`, covering circular refs, `BigInt`, and the preserved ENGINE path for non-ok responses. The load-bearing assertion is `expect(fetchSpy).not.toHaveBeenCalled()` — it pins the eager-stringify behaviour, so moving serialization back inside the retry wrapper fails the test.
- Full engine suite compared against a stashed clean tree: **identical** 10 failed files / 30 failed tests before and after (all pre-existing, caused by unbuilt dev pieces), +3 passing from this PR.
- `lint`: 0 errors across `engine`, `core-execution`, and `api`.
- Edition paths: engine/worker error classification only — no UI, no edition-gated behaviour, identical on CE / EE / Cloud.

Not verified end-to-end against a live loop flow; the root cause was confirmed from production run logs rather than reproduced locally.

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

A run that previously ended `INTERNAL_ERROR` in this specific case now ends `FAILED`, but no self-hoster or API consumer must take action, and the new `CALLBACK_SERIALIZATION_ERROR_NAME` export is additive. Same shape as #14211, which shipped as a plain bug fix.

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)

Touches the engine→app callback path but changes no URL construction, authentication, or request target — only whether the body is serialized before the request is built.
