### PR TITLE
fix(worker): stop a hung server-ping from silently wedging the poll loop

### DIFF
--- a/brain/wiki/execution-runtime/gotcha-polling-starves-first-when-the-fleet-loses-capacity.md
+++ b/brain/wiki/execution-runtime/gotcha-polling-starves-first-when-the-fleet-loses-capacity.md
@@ -1,0 +1,57 @@
+---
+icon: 🐌
+---
+
+# Gotcha: polling starves first when the fleet loses capacity
+
+`EXECUTE_POLLING` and `RENEW_WEBHOOK` are `veryLow` = **priority 5**
+(`packages/core/execution/src/lib/workers/job-data.ts:51`). Webhooks and async flows are 3, sync
+flows and chat agents 2, user-interaction jobs 1. BullMQ pops the lowest score first, so when worker
+capacity drops, **schedule/polling triggers are the first thing to go silent** — everything else still
+looks fine because it preempts them.
+
+That makes "my `*/1` schedule flow isn't triggering" the *earliest* symptom of a partial fleet wedge,
+long before anyone calls it an outage.
+
+**Seen 2026-07-27.** 484 worker containers up, `active:103` (healthy baseline ~408 — see
+[[gotcha-workers-wedge-silently-and-report-healthy]], still on `0.86.3`, fix not deployed). The
+priority-5 lane held **13,190** jobs; 5,318 of them 15–30 min overdue, 54 over an hour. A single
+customer flow's poll job moved rank 8803 → 7319 in 8 minutes: **~20–75 min per poll** on a
+one-minute cron. The surviving ~100 slots were ~95% `EXECUTE_WEBHOOK`.
+
+## Diagnosing it
+
+Bucket the prioritized zset by priority — BullMQ scores are `priority * 2^32 + counter`, so
+`ZCOUNT bull:workerJobs:prioritized <p>*2^32 <p+1>*2^32-1` gives the depth of each lane:
+
+```
+prio 3:      12      webhooks — consumed on arrival, never backs up
+prio 5:  13,092      EXECUTE_POLLING — the real lag
+prio 6: 115,902      rate-limited EXECUTE_FLOW — parked, not blocking
+```
+
+A huge `prioritized` total is **not** by itself the signal; check which lane. Then take a repeat
+job's rank twice a few minutes apart (`ZRANK`) — the drift rate is the lane's true drain rate, and it
+is far lower than the queue's overall completion rate because higher priorities keep cutting in.
+
+For a repeat job, lateness comes from the **scheduled millis in its id suffix**
+(`repeat:<flowVersionId>:<millis>`), not the `timestamp` hash field — `timestamp` is when the
+scheduler produced the job, which for a daily cron is 24h before it is due.
+
+## Two things that look like bugs and aren't
+
+- **Republishing does not help.** It correctly removes the old scheduler and arms a new one keyed by
+  the new `flowVersionId` (`job-queue.ts` `upsertJobScheduler(data.flowVersionId, …)`), but the new
+  job joins the back of the same starved lane.
+- **Removing a scheduler does not remove its already-enqueued job.** `removeJobScheduler` leaves the
+  outstanding `repeat:<oldVersionId>:<millis>` in `prioritized`, so it fires once against a
+  soft-deleted `trigger_source`.
+
+## The priority-6 sludge
+
+`RATE_LIMIT_PRIORITY` is `lowest` = 6. Rate-limited `EXECUTE_FLOW` jobs re-enter at that priority and
+sit **behind** the polling lane — so while polling is chronically backed up, they never drain. The
+2026-07-27 pile held jobs going back to **2026-07-08** (19 days), ~52% from one project. Anything
+demoted to priority 6 on a queue with a standing priority-5 backlog is effectively dropped, silently.
+
+Related: [[gotcha-workers-wedge-silently-and-report-healthy]] — the capacity loss that triggers this.

--- a/brain/wiki/execution-runtime/gotcha-workers-wedge-silently-and-report-healthy.md
+++ b/brain/wiki/execution-runtime/gotcha-workers-wedge-silently-and-report-healthy.md
@@ -9,6 +9,20 @@ containers were `Up 2 days (healthy)`. Fleet throughput hit zero around 20:00 UT
 container restored job execution within seconds; a rolling `docker restart` across all 25 hosts
 recovered the fleet (`active:408`, backlog draining ~5k/min).
 
+**Where it came from.** `probeServerPing` did not exist before **2026-07-21**; PR #14181
+("benchmark rate limiter info", `92b8115b21`) added it to `buildMachineInfo()` purely to populate a
+`serverPingMs` field on the workers page. `buildMachineInfo()` is awaited **inside the poll loop,
+once per iteration, before `apiClient.poll()`** — so a diagnostic call landed on the hot path. It
+first reached prod in image `0.86.3.9c53aeaf` (commit 2026-07-24 10:37, containers created
+10:46 UTC); the image it replaced, `0.86.3.01757ac6` (2026-07-20 18:34), does not contain it. Two
+days later the fleet started wedging. That is the regression window — if a worker "used to be fine",
+this is why.
+
+Recurrence is fast: after the 2026-07-26 21:31 recovery restart, **13 of 14 sampled containers on
+one host were wedged again by 07:30 the next morning** (~14h), fleet `active:103` against 484
+containers. See [[gotcha-polling-starves-first-when-the-fleet-loses-capacity]] for what a partial
+wedge looks like from the customer side.
+
 **The workers were not crashing and not disconnected.** The Socket.IO connection stayed live the
 whole time — the wedged containers kept receiving `Flow published, prewarming flow cache` pushes and
 kept emitting `system.snapshot` heartbeats. They simply stopped calling `poll`. App-side proof: only
@@ -53,19 +67,57 @@ The whole diagnosis is one ratio and one grep:
 
 ## Recovery
 
-`docker restart` the `activepieces-shared05_*` containers, staggered per host. A fresh process is the
-only thing that re-arms the loop; nothing self-heals. Keep 2–3 frozen containers unrestarted for
-forensics — they are the only evidence, and a fleet-wide restart destroys it.
+**On a build that predates the fix below** (anything up to and including `0.86.3.9c53aeaf`):
+`~/restart-workers.sh` on the DevOps box (`root@49.13.51.126`). It holds the 25-host list, forks one
+ssh per host, and inside each host restarts `activepieces-shared05_*` sequentially with
+`docker restart -t 30` and a 2s stagger — roughly **20 minutes fleet-wide** (28 containers × ~45s).
+A fresh process is the only thing that re-arms the loop; nothing self-heals.
 
-## Fixes worth landing
+Two signals to read while it rolls, both of which confirm the diagnosis rather than just the restart:
 
-- Wrap `buildMachineInfo()` in a timeout, and make `probeServerPing` consume or cancel its response
-  body. Smallest fix that prevents the wedge.
-- Make the health server assert `polling === true` **and** a recent successful poll, so the 848
-  invisible restarts and the wedge both become visible and self-healing.
-- Log at warn when a poll loop exits — today it terminates completely silently.
+- Every container burns the **full 30s SIGTERM timeout** before dying. A wedged node process does not
+  answer SIGTERM; if containers stop in 2–3s instead, they were idle, not wedged, and you are chasing
+  the wrong thing.
+- Restarted containers report `(healthy)` within **22 seconds**, before they have polled anything.
+  That is the lying health server — watch `workerJobs:active` climbing instead.
+
+Redis is DigitalOcean-managed and its cert does not verify from the DevOps box; the working invocation
+is `docker exec redis redis-cli --tls --insecure -h <AP_REDIS_HOST> -p 25061 --user default -a <pw>`,
+with creds read off any `activepieces-app_*` container's env. Workers carry no Redis env at all — they
+reach the queue only through the app over Socket.IO.
+
+Keep 2–3 frozen containers unrestarted for forensics — they are the only evidence, and a fleet-wide
+restart destroys it. `restart-workers.sh` already skips `shared05_1/_3/_7` on `188.245.191.196` and
+`shared05_2` on `91.98.16.70`; at ~0.8% of capacity that is cheap enough to leave in place every run.
+
+**A restart buys ~14 hours, not a fix.** After the 2026-07-26 21:31 recovery, 13 of 14 sampled
+containers were wedged again by 07:30 the next morning with the backlog at 128k. Until the
+`probeServerPing` fix ships, budget on re-running this daily.
+
+**On a build that carries the fix:** a wedged loop restarts itself. The watchdog exits the process
+after `POLL_LIVENESS_TIMEOUT_MS` (180s) of no iteration and pm2 brings it back, so the manual rolling
+restart is a fallback, not the routine. If you still find wedged containers, the watchdog itself is
+not firing — treat that as a new bug and preserve a container before restarting.
+
+## What the fix changed
+
+Landed in `fix(worker): stop a hung server-ping from silently wedging the poll loop`:
+
+- `probeServerPing` races its fetch against its own timeout and cancels the response body, so it
+  always resolves. Wrapping `buildMachineInfo()` in a timeout alone was not enough — a permanently
+  hung probe still starved the loop through its 20s error-retry path.
+- A poll watchdog exits the process when the socket is connected and a loop has not iterated for 180s;
+  the health endpoint returns **503** on the same condition instead of an unconditional 200. Liveness
+  is tracked **per poll loop**, so with `AP_WORKER_CONCURRENCY > 1` a healthy sibling cannot mask a
+  wedged loop; a loop executing a job is excluded rather than the whole worker.
+- The poll loop logs at warn when it exits, which it previously did in complete silence.
+
+## Still worth landing
+
 - Raise the `memory: 1g` limit for `AP_WORKER_CONCURRENCY: 1` shared workers, or lower
-  `--max-old-space-size=768`; the OOM loop is what supplies the wedge its 848 attempts.
+  `--max-old-space-size=768`; the OOM loop is what supplied the wedge its 848 attempts. This is a
+  `mrsk/prod/config/worker.yml` change, not a repo change.
+- Add `packages/server/worker` to CI's test filter — `worker.test.ts` does not run in CI today.
 
 Related: [[gotcha-kamal-app-exec-leaks-a-permanent-worker]] — the other way a worker container looks
 alive and healthy while consuming nothing.

--- a/brain/wiki/execution-runtime/gotcha-workers-wedge-silently-and-report-healthy.md
+++ b/brain/wiki/execution-runtime/gotcha-workers-wedge-silently-and-report-healthy.md
@@ -1,0 +1,71 @@
+---
+icon: 🧟
+---
+
+# Gotcha: a worker can wedge mid-poll-loop and still report healthy
+
+**Incident 2026-07-26.** `workerJobs` reached **229,682 prioritized / active:1** while all ~450 worker
+containers were `Up 2 days (healthy)`. Fleet throughput hit zero around 20:00 UTC. Restarting a
+container restored job execution within seconds; a rolling `docker restart` across all 25 hosts
+recovered the fleet (`active:408`, backlog draining ~5k/min).
+
+**The workers were not crashing and not disconnected.** The Socket.IO connection stayed live the
+whole time — the wedged containers kept receiving `Flow published, prewarming flow cache` pushes and
+kept emitting `system.snapshot` heartbeats. They simply stopped calling `poll`. App-side proof: only
+**4–5 distinct worker ids** appeared in `[workerRpc#poll] Poll request received` during the incident,
+out of ~450. The app withheld nothing — zero `[workerRpc#poll] Withholding job` lines, worker and app
+both on `0.86.3`, identical image digest.
+
+## The three things that stack up
+
+1. **PM2 restarts are invisible to Docker.** A wedged sample (`shared05_1`) had `oom_kill 847` in its
+   cgroup and PM2 `↺ 848`, against `RestartCount: 0` and health `healthy` for 38.7 hours. The 0.5cpu /
+   **1g** shared workers OOM-SIGKILL the node process roughly every 4 minutes; pm2-runtime replaces it
+   and Docker never sees a thing. Each restart is a fresh chance to wedge.
+2. **The poll loop can park before its first poll.** Log counts on the wedged sample were
+   `Connected to API server via Socket.IO` : `Starting poll loops` : `Polling worker started` = **44:44:44**
+   — the loop always started. But then: zero `job.execute`, zero `Poll failed`, zero
+   `Connected app version mismatch`, zero errors, for 38 hours. `process.getActiveResourcesInfo()` on
+   the live wedged process showed only 3 stdio pipes, the one websocket, the health server and 2
+   timers — **no HTTP client handle**. `buildMachineInfo()` (`worker.ts:227` → `probeServerPing`) never
+   returned, so `apiClient.poll()` was never reached. `probeServerPing` never consumes or cancels the
+   `fetch` response body, so its 5s `AbortController` does not reliably release a request queued
+   behind a busy undici client.
+3. **The health server lies.** It returns `200 {"status":"ok"}` unconditionally — it never checks
+   `polling` or last-successful-poll time. So Docker, Kamal and any uptime probe call a worker that has
+   consumed nothing in 38 hours "healthy."
+
+## How to tell this apart from the alternatives, fast
+
+The whole diagnosis is one ratio and one grep:
+
+- Worker logs: count `Connected to API server via Socket.IO` vs `Starting poll loops` vs
+  `Polling worker started`. **1:1:1 with no `job.execute` after** = wedged inside the loop (this bug).
+  Connect **without** a following `Starting poll loops` = the `if (polling) return` latch in
+  `startPollingWorkers` (`worker.ts:158`) or a hung `fetchAndStoreSettings`.
+- App logs: `grep '\[workerRpc#poll\] Withholding job'`. Any hits = version gate, not this. Also count
+  distinct `worker-*` ids polling and compare to fleet size — that single number separates
+  "workers stopped asking" from "app stopped answering".
+- Queue shape `prioritized` huge + `active` ≈ 1 is **not** an app-side dispatcher wedge. The dispatcher
+  is pull-only (`queue-dispatcher.ts:42` `while (waiters.length > 0)`), so zero pollers means zero
+  dequeues by design. Confirm before chasing `loopRunning`: when a poll does arrive, dequeue takes
+  ~22ms (`Poll request received` 21:14:19.585 → `Dequeued job` 21:14:19.607).
+
+## Recovery
+
+`docker restart` the `activepieces-shared05_*` containers, staggered per host. A fresh process is the
+only thing that re-arms the loop; nothing self-heals. Keep 2–3 frozen containers unrestarted for
+forensics — they are the only evidence, and a fleet-wide restart destroys it.
+
+## Fixes worth landing
+
+- Wrap `buildMachineInfo()` in a timeout, and make `probeServerPing` consume or cancel its response
+  body. Smallest fix that prevents the wedge.
+- Make the health server assert `polling === true` **and** a recent successful poll, so the 848
+  invisible restarts and the wedge both become visible and self-healing.
+- Log at warn when a poll loop exits — today it terminates completely silently.
+- Raise the `memory: 1g` limit for `AP_WORKER_CONCURRENCY: 1` shared workers, or lower
+  `--max-old-space-size=768`; the OOM loop is what supplies the wedge its 848 attempts.
+
+Related: [[gotcha-kamal-app-exec-leaks-a-permanent-worker]] — the other way a worker container looks
+alive and healthy while consuming nothing.

--- a/brain/wiki/execution-runtime/index.md
+++ b/brain/wiki/execution-runtime/index.md
@@ -50,3 +50,5 @@ The four calls a run emits to the app during execution: `updateRunProgress`, `up
 - **Benchmark CLI** — measuring throughput; queue-wait vs service-time
 - **Gotcha: engine vitest needs fresh core-execution dist** — why a stale dist fails the engine tests
 - **Gotcha: system-job "No handler" = worker running the wrong edition** — diagnosing edition skew
+- **Gotcha: `kamal app exec` on the worker image leaks a permanent worker** — the entrypoint ignores your command and boots a worker
+- **Gotcha: a worker can wedge mid-poll-loop and still report healthy** — live socket, green healthcheck, zero polls; how to tell it apart from the version gate and the app-side dispatcher

--- a/brain/wiki/execution-runtime/index.md
+++ b/brain/wiki/execution-runtime/index.md
@@ -52,3 +52,4 @@ The four calls a run emits to the app during execution: `updateRunProgress`, `up
 - **Gotcha: system-job "No handler" = worker running the wrong edition** — diagnosing edition skew
 - **Gotcha: `kamal app exec` on the worker image leaks a permanent worker** — the entrypoint ignores your command and boots a worker
 - **Gotcha: a worker can wedge mid-poll-loop and still report healthy** — live socket, green healthcheck, zero polls; how to tell it apart from the version gate and the app-side dispatcher
+- **Gotcha: polling starves first when the fleet loses capacity** — `EXECUTE_POLLING` is priority 5, so "my schedule flow isn't triggering" is the earliest symptom of a partial wedge; how to read the priority lanes

--- a/packages/server/worker/src/lib/worker.ts
+++ b/packages/server/worker/src/lib/worker.ts
@@ -81,7 +81,7 @@ const MACHINE_INFO_TIMEOUT_MS = 15_000
 const POLL_LIVENESS_TIMEOUT_MS = 180_000
 const POLL_WATCHDOG_INTERVAL_MS = 30_000
 
-let lastPollIterationAt: number | null = null
+let pollLoopLiveness: PollLoopLiveness[] = []
 let pollWatchdogInterval: NodeJS.Timeout | null = null
 
 export const worker = {
@@ -100,7 +100,7 @@ export const worker = {
 
         socket.on('connect', async () => {
             logger.info('Connected to API server via Socket.IO')
-            lastPollIterationAt = Date.now()
+            resetPollLoopLiveness({ loopCount: 1 })
             await fetchAndStoreSettings(socket!)
             void startPollingWorkers(apiClient).catch((err) => {
                 logger.error({ error: err }, 'Polling workers crashed unexpectedly')
@@ -148,7 +148,7 @@ export const worker = {
 
     async stop(): Promise<void> {
         polling = false
-        lastPollIterationAt = null
+        pollLoopLiveness = []
         stopPollWatchdog()
         stopSandboxInfoSampling()
         await drainInFlightJobs()
@@ -207,6 +207,7 @@ async function startPollingWorkers(apiClient: WorkerToApiContract): Promise<void
 
     logger.info({ concurrency }, 'Starting poll loops')
 
+    resetPollLoopLiveness({ loopCount: concurrency })
     const activeRuntime = runtime
     await Promise.all(Array.from({ length: concurrency }, (_, workerIndex) =>
         pollAndExecute(apiClient, activeRuntime, workerIndex, generation),
@@ -218,7 +219,7 @@ async function pollAndExecute(apiClient: WorkerToApiContract, runtime: Runtime, 
     workerLog.info('Polling worker started')
 
     while (polling && connectionGeneration === generation) {
-        lastPollIterationAt = Date.now()
+        markPollLoopIteration({ workerIndex, busy: false })
         const appVersion = workerSettings.getSettings().APP_VERSION
         if (!apVersionUtil.versionsAreCompatible({ versionA: appVersion, versionB: AP_VERSION })) {
             const versionUnreadable = appVersion === UNKNOWN_VERSION || AP_VERSION === UNKNOWN_VERSION
@@ -259,6 +260,7 @@ async function pollAndExecute(apiClient: WorkerToApiContract, runtime: Runtime, 
         // Counted for the duration of execute + completeJob so a graceful shutdown can wait for
         // the report to land before tearing down the socket (otherwise the job is orphaned in active).
         inFlightJobs++
+        markPollLoopIteration({ workerIndex, busy: true })
         try {
             const lockExtensionInterval = setInterval(() => {
                 void tryCatch(() => apiClient.extendLock({ jobId: job.jobId, token: job.token, queueName: job.queueName })).then(({ error }) => {
@@ -294,6 +296,7 @@ async function pollAndExecute(apiClient: WorkerToApiContract, runtime: Runtime, 
         }
         finally {
             inFlightJobs--
+            markPollLoopIteration({ workerIndex, busy: false })
         }
     }
     workerLog.warn({ polling, generation, connectionGeneration }, 'Poll loop exited — this worker consumes no jobs until it starts again')
@@ -557,12 +560,31 @@ function sleep(ms: number): Promise<void> {
     return new Promise((resolve) => setTimeout(resolve, ms))
 }
 
-function pollLoopStalled(): boolean {
-    const connected = socket?.connected ?? false
-    if (!connected || isNil(lastPollIterationAt) || inFlightJobs > 0) {
-        return false
+function resetPollLoopLiveness({ loopCount }: { loopCount: number }): void {
+    const startedAt = Date.now()
+    pollLoopLiveness = Array.from({ length: loopCount }, () => ({ iteratedAt: startedAt, busy: false }))
+}
+
+function markPollLoopIteration({ workerIndex, busy }: { workerIndex: number, busy: boolean }): void {
+    const liveness = pollLoopLiveness[workerIndex]
+    if (isNil(liveness)) {
+        return
     }
-    return Date.now() - lastPollIterationAt > POLL_LIVENESS_TIMEOUT_MS
+    liveness.iteratedAt = Date.now()
+    liveness.busy = busy
+}
+
+function findStalledPollLoop(): StalledPollLoop | undefined {
+    const connected = socket?.connected ?? false
+    if (!connected) {
+        return undefined
+    }
+    const now = Date.now()
+    const workerIndex = findStalledLoopIndex({ loops: pollLoopLiveness, now, timeoutMs: POLL_LIVENESS_TIMEOUT_MS })
+    if (workerIndex === -1) {
+        return undefined
+    }
+    return { workerIndex, stalledForMs: now - pollLoopLiveness[workerIndex].iteratedAt }
 }
 
 function startPollWatchdog(): void {
@@ -570,10 +592,11 @@ function startPollWatchdog(): void {
         return
     }
     pollWatchdogInterval = setInterval(() => {
-        if (!pollLoopStalled()) {
+        const stalled = findStalledPollLoop()
+        if (isNil(stalled)) {
             return
         }
-        logger.error({ lastPollIterationAt, stalledForMs: Date.now() - (lastPollIterationAt ?? 0) }, 'Poll loop stalled — exiting so the process manager restarts a worker that can consume jobs')
+        logger.error({ ...stalled, loopCount: pollLoopLiveness.length }, 'Poll loop stalled — exiting so the process manager restarts a worker that can consume jobs')
         process.exit(1)
     }, POLL_WATCHDOG_INTERVAL_MS)
     pollWatchdogInterval.unref()
@@ -592,7 +615,7 @@ function startHealthServer(): ReturnType<typeof createServer> {
     const healthPaths = new Set(['/worker/health', '/v1/health', '/api/v1/health'])
     const server = createServer((req, res) => {
         if (req.method === 'GET' && req.url && healthPaths.has(req.url)) {
-            const stalled = pollLoopStalled()
+            const stalled = !isNil(findStalledPollLoop())
             res.writeHead(stalled ? 503 : 200, { 'Content-Type': 'application/json' })
             res.end(JSON.stringify({ status: stalled ? 'poll_loop_stalled' : 'ok' }))
         }
@@ -612,4 +635,18 @@ type WorkerStartParams = {
     socketUrl: { url: string, path: string }
     workerToken: string
     withHealthServer?: boolean
+}
+
+export function findStalledLoopIndex({ loops, now, timeoutMs }: { loops: PollLoopLiveness[], now: number, timeoutMs: number }): number {
+    return loops.findIndex((loop) => !loop.busy && now - loop.iteratedAt > timeoutMs)
+}
+
+export type PollLoopLiveness = {
+    iteratedAt: number
+    busy: boolean
+}
+
+type StalledPollLoop = {
+    workerIndex: number
+    stalledForMs: number
 }

--- a/packages/server/worker/src/lib/worker.ts
+++ b/packages/server/worker/src/lib/worker.ts
@@ -77,6 +77,12 @@ let cachedSandboxInfo: SandboxInformation[] = []
 let sandboxInfoInterval: NodeJS.Timeout | null = null
 const SANDBOX_INFO_REFRESH_MS = 15_000
 const SERVER_PING_TIMEOUT_MS = 5_000
+const MACHINE_INFO_TIMEOUT_MS = 15_000
+const POLL_LIVENESS_TIMEOUT_MS = 180_000
+const POLL_WATCHDOG_INTERVAL_MS = 30_000
+
+let lastPollIterationAt: number | null = null
+let pollWatchdogInterval: NodeJS.Timeout | null = null
 
 export const worker = {
     async start({ apiUrl, socketUrl, workerToken, withHealthServer = false }: WorkerStartParams): Promise<void> {
@@ -94,6 +100,7 @@ export const worker = {
 
         socket.on('connect', async () => {
             logger.info('Connected to API server via Socket.IO')
+            lastPollIterationAt = Date.now()
             await fetchAndStoreSettings(socket!)
             void startPollingWorkers(apiClient).catch((err) => {
                 logger.error({ error: err }, 'Polling workers crashed unexpectedly')
@@ -135,11 +142,14 @@ export const worker = {
             healthServerInstance = startHealthServer()
         }
         startSandboxInfoSampling()
+        startPollWatchdog()
         logger.info({ apiUrl, socketUrl }, 'Worker started, polling for jobs...')
     },
 
     async stop(): Promise<void> {
         polling = false
+        lastPollIterationAt = null
+        stopPollWatchdog()
         stopSandboxInfoSampling()
         await drainInFlightJobs()
         if (runtime) {
@@ -208,6 +218,7 @@ async function pollAndExecute(apiClient: WorkerToApiContract, runtime: Runtime, 
     workerLog.info('Polling worker started')
 
     while (polling && connectionGeneration === generation) {
+        lastPollIterationAt = Date.now()
         const appVersion = workerSettings.getSettings().APP_VERSION
         if (!apVersionUtil.versionsAreCompatible({ versionA: appVersion, versionB: AP_VERSION })) {
             const versionUnreadable = appVersion === UNKNOWN_VERSION || AP_VERSION === UNKNOWN_VERSION
@@ -285,6 +296,7 @@ async function pollAndExecute(apiClient: WorkerToApiContract, runtime: Runtime, 
             inFlightJobs--
         }
     }
+    workerLog.warn({ polling, generation, connectionGeneration }, 'Poll loop exited — this worker consumes no jobs until it starts again')
 }
 
 async function drainInFlightJobs(): Promise<void> {
@@ -433,6 +445,14 @@ function getWorkerProps(): WorkerProps {
 }
 
 async function buildMachineInfo(): Promise<WorkerMachineHealthcheckRequest> {
+    return withTimeout({
+        promise: collectMachineInfo(),
+        timeoutMs: MACHINE_INFO_TIMEOUT_MS,
+        message: 'Timed out collecting machine info',
+    })
+}
+
+async function collectMachineInfo(): Promise<WorkerMachineHealthcheckRequest> {
     const memInfo = await systemUsage.getContainerMemoryUsage()
     const diskInfo = await systemUsage.getDiskInfo()
     const cpuCores = await systemUsage.getCpuCores()
@@ -452,12 +472,20 @@ async function buildMachineInfo(): Promise<WorkerMachineHealthcheckRequest> {
 }
 
 async function probeServerPing(): Promise<number | undefined> {
-    const controller = new AbortController()
-    const timeout = setTimeout(() => controller.abort(), SERVER_PING_TIMEOUT_MS)
     const startedAt = Date.now()
-    const { error } = await tryCatch(() => fetch(`${getApiUrl()}v1/health`, { signal: controller.signal }))
-    clearTimeout(timeout)
-    return error ? undefined : Date.now() - startedAt
+    const probe = tryCatch(() => fetch(`${getApiUrl()}v1/health`, { signal: AbortSignal.timeout(SERVER_PING_TIMEOUT_MS) }))
+        .then(({ data: response, error }) => {
+            void response?.body?.cancel()
+            return error ? undefined : Date.now() - startedAt
+        })
+    return Promise.race([probe, sleep(SERVER_PING_TIMEOUT_MS).then(() => undefined)])
+}
+
+function withTimeout<T>({ promise, timeoutMs, message }: { promise: Promise<T>, timeoutMs: number, message: string }): Promise<T> {
+    return new Promise<T>((resolve, reject) => {
+        const timer = setTimeout(() => reject(new Error(message)), timeoutMs)
+        promise.then(resolve, reject).finally(() => clearTimeout(timer))
+    })
 }
 
 function startSandboxInfoSampling(): void {
@@ -529,14 +557,44 @@ function sleep(ms: number): Promise<void> {
     return new Promise((resolve) => setTimeout(resolve, ms))
 }
 
+function pollLoopStalled(): boolean {
+    const connected = socket?.connected ?? false
+    if (!connected || isNil(lastPollIterationAt) || inFlightJobs > 0) {
+        return false
+    }
+    return Date.now() - lastPollIterationAt > POLL_LIVENESS_TIMEOUT_MS
+}
+
+function startPollWatchdog(): void {
+    if (!isNil(pollWatchdogInterval)) {
+        return
+    }
+    pollWatchdogInterval = setInterval(() => {
+        if (!pollLoopStalled()) {
+            return
+        }
+        logger.error({ lastPollIterationAt, stalledForMs: Date.now() - (lastPollIterationAt ?? 0) }, 'Poll loop stalled — exiting so the process manager restarts a worker that can consume jobs')
+        process.exit(1)
+    }, POLL_WATCHDOG_INTERVAL_MS)
+    pollWatchdogInterval.unref()
+}
+
+function stopPollWatchdog(): void {
+    if (!isNil(pollWatchdogInterval)) {
+        clearInterval(pollWatchdogInterval)
+        pollWatchdogInterval = null
+    }
+}
+
 
 function startHealthServer(): ReturnType<typeof createServer> {
     const port = Number(process.env[WorkerSystemProp.PORT] ?? system.get(WorkerSystemProp.PORT))
     const healthPaths = new Set(['/worker/health', '/v1/health', '/api/v1/health'])
     const server = createServer((req, res) => {
         if (req.method === 'GET' && req.url && healthPaths.has(req.url)) {
-            res.writeHead(200, { 'Content-Type': 'application/json' })
-            res.end(JSON.stringify({ status: 'ok' }))
+            const stalled = pollLoopStalled()
+            res.writeHead(stalled ? 503 : 200, { 'Content-Type': 'application/json' })
+            res.end(JSON.stringify({ status: stalled ? 'poll_loop_stalled' : 'ok' }))
         }
         else {
             res.writeHead(404)

--- a/packages/server/worker/test/lib/worker.test.ts
+++ b/packages/server/worker/test/lib/worker.test.ts
@@ -132,6 +132,7 @@ describe('worker integration', () => {
     afterEach(async () => {
         await worker.stop()
         mockGetHandler.mockReset()
+        vi.restoreAllMocks()
         delete process.env.AP_WORKER_CONCURRENCY
         await new Promise<void>((resolve) => {
             ioServer.close(() => resolve())
@@ -227,6 +228,33 @@ describe('worker integration', () => {
         expect(completeJobCalls[0].status).toBe(EngineResponseStatus.OK)
         expect(mockGetHandler).toHaveBeenCalledWith(WorkerJobType.EXECUTE_EXTRACT_PIECE_INFORMATION)
     }, 15_000)
+
+    it('keeps polling when the server-ping probe never settles', async () => {
+        const realFetch = globalThis.fetch
+        let healthProbes = 0
+        vi.spyOn(globalThis, 'fetch').mockImplementation((input, init) => {
+            const url = typeof input === 'string' ? input : input.toString()
+            if (!url.endsWith('/v1/health')) {
+                return realFetch(input, init)
+            }
+            healthProbes++
+            return healthProbes <= 2
+                ? Promise.resolve(new Response('{}', { status: 200 }))
+                : new Promise(() => {})
+        })
+
+        mockGetHandler.mockReturnValue({
+            jobType: WorkerJobType.EXECUTE_EXTRACT_PIECE_INFORMATION,
+            execute: vi.fn().mockResolvedValue({ kind: JobResultKind.FIRE_AND_FORGET, status: EngineResponseStatus.OK }),
+        })
+
+        const job = buildConsumeJobRequest({ jobId: 'job-hung-ping' })
+        const { completeJobCalls } = await connectWorkerWithPoll([job, null])
+
+        expect(completeJobCalls.length).toBe(1)
+        expect(completeJobCalls[0].jobId).toBe('job-hung-ping')
+        expect(healthProbes).toBeGreaterThan(2)
+    }, 45_000)
 
     it('reports error when job execution fails', async () => {
         mockGetHandler.mockReturnValue({

--- a/packages/server/worker/test/lib/worker.test.ts
+++ b/packages/server/worker/test/lib/worker.test.ts
@@ -24,32 +24,30 @@ vi.mock('../../src/lib/execute/job-registry', () => ({
 
 // APP_VERSION must match the worker's own AP_VERSION (apVersionUtil.getCurrentRelease, read from the
 // same cwd package.json) or the worker↔app version gate fail-closes and pauses polling forever.
+// These are plain functions, not vi.fn().mockReturnValue(...) — afterEach calls vi.restoreAllMocks(),
+// which strips a mock's return value and would make getSettings() return undefined from the second
+// test onward, crashing every poll loop before it reaches poll().
 vi.mock('../../src/lib/config/worker-settings', async () => {
     const { apVersionUtil } = await vi.importActual<typeof import('@activepieces/server-utils')>('@activepieces/server-utils')
-    const appVersion = apVersionUtil.getCurrentRelease()
+    const settings = { PUBLIC_URL: 'http://localhost:3000', APP_VERSION: apVersionUtil.getCurrentRelease() }
     return {
         workerSettings: {
-            set: vi.fn(),
-            waitForSettings: vi.fn().mockResolvedValue({ PUBLIC_URL: 'http://localhost:3000', APP_VERSION: appVersion }),
-            getSettings: vi.fn().mockReturnValue({ PUBLIC_URL: 'http://localhost:3000', APP_VERSION: appVersion }),
+            set: () => undefined,
+            waitForSettings: () => Promise.resolve(settings),
+            getSettings: () => settings,
         },
     }
 })
 
-vi.mock('../../src/lib/config/logger', () => ({
-    logger: {
-        info: vi.fn(),
-        warn: vi.fn(),
-        error: vi.fn(),
-        debug: vi.fn(),
-        child: vi.fn().mockReturnValue({
-            info: vi.fn(),
-            warn: vi.fn(),
-            error: vi.fn(),
-            debug: vi.fn(),
-        }),
-    },
-}))
+vi.mock('../../src/lib/config/logger', () => {
+    const noopLogger = {
+        info: () => undefined,
+        warn: () => undefined,
+        error: () => undefined,
+        debug: () => undefined,
+    }
+    return { logger: { ...noopLogger, child: () => noopLogger } }
+})
 
 type StubRuntime = {
     execute: ReturnType<typeof vi.fn>
@@ -74,7 +72,7 @@ vi.mock('@activepieces/sandbox', () => ({
     }),
 }))
 
-import { worker } from '../../src/lib/worker'
+import { findStalledLoopIndex, worker } from '../../src/lib/worker'
 
 function buildExtractPieceJob(): ExecuteExtractPieceMetadataJobData {
     return {
@@ -112,7 +110,10 @@ describe('worker integration', () => {
     let port: number
 
     beforeEach(async () => {
-        httpServer = createServer()
+        httpServer = createServer((_req, res) => {
+            res.writeHead(200, { 'Content-Type': 'application/json' })
+            res.end('{}')
+        })
         ioServer = new IOServer(httpServer, { transports: ['websocket'], path: '/api/socket.io' })
         await new Promise<void>((resolve) => {
             httpServer.listen(0, () => {
@@ -146,67 +147,51 @@ describe('worker integration', () => {
         let pollIndex = 0
 
         return new Promise((resolve) => {
-            ioServer.on('connection', (serverSocket) => {
-                // Handle the FETCH_WORKER_SETTINGS event that the worker emits on connect
-                serverSocket.on(WebsocketServerEvent.FETCH_WORKER_SETTINGS, (...args: unknown[]) => {
-                    const callback = args[args.length - 1]
-                    if (typeof callback === 'function') {
-                        callback({
-                            PUBLIC_URL: 'http://localhost:3000',
-                            ENVIRONMENT: 'test',
-                            EXECUTION_MODE: 'SANDBOX_CODE_AND_PROCESS',
-                            TRIGGER_TIMEOUT_SECONDS: 60,
-                            TRIGGER_HOOKS_TIMEOUT_SECONDS: 60,
-                            PAUSED_FLOW_TIMEOUT_DAYS: 30,
-                            FLOW_TIMEOUT_SECONDS: 600,
-                            LOG_LEVEL: 'info',
-                            LOG_PRETTY: 'false',
-                            APP_WEBHOOK_SECRETS: '{}',
-                            MAX_FLOW_RUN_LOG_SIZE_MB: 10,
-                            MAX_FILE_SIZE_MB: 10,
-                            SANDBOX_MEMORY_LIMIT: '1024',
-                            SANDBOX_PROPAGATED_ENV_VARS: [],
-                            DEV_PIECES: [],
-                            OTEL_ENABLED: false,
-                            FILE_STORAGE_LOCATION: '/tmp',
-                            S3_USE_SIGNED_URLS: 'false',
-                            EVENT_DESTINATION_TIMEOUT_SECONDS: 30,
-                            EDITION: 'community',
-                        })
+            registerRpcServer({
+                poll: vi.fn(async () => {
+                    const response = pollIndex < pollResponses.length ? pollResponses[pollIndex] : null
+                    pollIndex++
+                    if (pollIndex >= pollResponses.length) {
+                        setTimeout(() => resolve({ completeJobCalls }), 200)
                     }
-                })
-
-                const handlers: WorkerToApiContract = {
-                    poll: vi.fn(async () => {
-                        const response = pollIndex < pollResponses.length ? pollResponses[pollIndex] : null
-                        pollIndex++
-                        if (pollIndex >= pollResponses.length) {
-                            setTimeout(() => resolve({ completeJobCalls }), 200)
-                        }
-                        return response
-                    }),
-                    completeJob: vi.fn(async (input) => {
-                        completeJobCalls.push(input)
-                    }),
-                    updateRunProgress: vi.fn(),
-                    uploadRunLog: vi.fn(),
-                    sendFlowResponse: vi.fn(),
-                    updateStepProgress: vi.fn(),
-                    submitPayloads: vi.fn(),
-                    savePayloads: vi.fn(),
-                    getFlowVersion: vi.fn(),
-                    getPiece: vi.fn(),
-                    getPieceArchive: vi.fn(),
-                    extendLock: vi.fn(),
-                    recordTriggerRun: vi.fn(),
-                    disableFlow: vi.fn(),
-                }
-                createRpcServer<WorkerToApiContract>(serverSocket, handlers)
+                    return response
+                }),
+                completeJob: vi.fn(async (input) => {
+                    completeJobCalls.push(input)
+                }),
             })
             worker.start({
                 apiUrl: `http://127.0.0.1:${port}/api/`,
                 socketUrl: { url: `http://127.0.0.1:${port}`, path: '/api/socket.io' },
                 workerToken: 'test-token',
+            })
+        })
+    }
+
+    function registerRpcServer(overrides: Partial<WorkerToApiContract>): void {
+        ioServer.on('connection', (serverSocket) => {
+            serverSocket.on(WebsocketServerEvent.FETCH_WORKER_SETTINGS, (...args: unknown[]) => {
+                const callback = args[args.length - 1]
+                if (typeof callback === 'function') {
+                    callback(WORKER_SETTINGS)
+                }
+            })
+            createRpcServer<WorkerToApiContract>(serverSocket, {
+                poll: vi.fn(async () => null),
+                completeJob: vi.fn(),
+                updateRunProgress: vi.fn(),
+                uploadRunLog: vi.fn(),
+                sendFlowResponse: vi.fn(),
+                updateStepProgress: vi.fn(),
+                submitPayloads: vi.fn(),
+                savePayloads: vi.fn(),
+                getFlowVersion: vi.fn(),
+                getPiece: vi.fn(),
+                getPieceArchive: vi.fn(),
+                extendLock: vi.fn(),
+                recordTriggerRun: vi.fn(),
+                disableFlow: vi.fn(),
+                ...overrides,
             })
         })
     }
@@ -533,43 +518,12 @@ describe('worker integration', () => {
     })
 
     describe('runtime lifecycle on reconnect', () => {
-        async function waitFor(predicate: () => boolean, timeoutMs = 5_000): Promise<void> {
-            const start = Date.now()
-            while (!predicate()) {
-                if (Date.now() - start > timeoutMs) {
-                    throw new Error('waitFor timed out')
-                }
-                await new Promise<void>((resolve) => setTimeout(resolve, 20))
-            }
-        }
-
         function acceptConnections(serverSockets: Socket[]): void {
             ioServer.on('connection', (serverSocket) => {
                 serverSocket.on(WebsocketServerEvent.FETCH_WORKER_SETTINGS, (...args: unknown[]) => {
                     const callback = args[args.length - 1]
                     if (typeof callback === 'function') {
-                        callback({
-                            PUBLIC_URL: 'http://localhost:3000',
-                            ENVIRONMENT: 'test',
-                            EXECUTION_MODE: 'SANDBOX_CODE_AND_PROCESS',
-                            TRIGGER_TIMEOUT_SECONDS: 60,
-                            TRIGGER_HOOKS_TIMEOUT_SECONDS: 60,
-                            PAUSED_FLOW_TIMEOUT_DAYS: 30,
-                            FLOW_TIMEOUT_SECONDS: 600,
-                            LOG_LEVEL: 'info',
-                            LOG_PRETTY: 'false',
-                            APP_WEBHOOK_SECRETS: '{}',
-                            MAX_FLOW_RUN_LOG_SIZE_MB: 10,
-                            MAX_FILE_SIZE_MB: 10,
-                            SANDBOX_MEMORY_LIMIT: '1024',
-                            SANDBOX_PROPAGATED_ENV_VARS: [],
-                            DEV_PIECES: [],
-                            OTEL_ENABLED: false,
-                            FILE_STORAGE_LOCATION: '/tmp',
-                            S3_USE_SIGNED_URLS: 'false',
-                            EVENT_DESTINATION_TIMEOUT_SECONDS: 30,
-                            EDITION: 'community',
-                        })
+                        callback(WORKER_SETTINGS)
                     }
                 })
                 // Park the worker idle: never ack poll so it neither hot-loops nor consumes jobs.
@@ -675,6 +629,77 @@ describe('worker integration', () => {
     })
 })
 
+describe('findStalledLoopIndex', () => {
+    const NOW = 1_000_000
+    const TIMEOUT_MS = 180_000
+
+    it('flags a wedged loop even while a sibling keeps iterating', () => {
+        const index = findStalledLoopIndex({
+            loops: [
+                { iteratedAt: NOW, busy: false },
+                { iteratedAt: NOW - TIMEOUT_MS - 1, busy: false },
+            ],
+            now: NOW,
+            timeoutMs: TIMEOUT_MS,
+        })
+
+        expect(index).toBe(1)
+    })
+
+    it('flags a wedged loop even while a sibling is executing a job', () => {
+        const index = findStalledLoopIndex({
+            loops: [
+                { iteratedAt: NOW - TIMEOUT_MS - 1, busy: true },
+                { iteratedAt: NOW - TIMEOUT_MS - 1, busy: false },
+            ],
+            now: NOW,
+            timeoutMs: TIMEOUT_MS,
+        })
+
+        expect(index).toBe(1)
+    })
+
+    it('reports nothing while every loop is executing a job', () => {
+        const index = findStalledLoopIndex({
+            loops: [
+                { iteratedAt: NOW - TIMEOUT_MS - 1, busy: true },
+                { iteratedAt: NOW - TIMEOUT_MS - 1, busy: true },
+            ],
+            now: NOW,
+            timeoutMs: TIMEOUT_MS,
+        })
+
+        expect(index).toBe(-1)
+    })
+
+    it('reports nothing while every loop is iterating', () => {
+        const index = findStalledLoopIndex({
+            loops: [
+                { iteratedAt: NOW, busy: false },
+                { iteratedAt: NOW - TIMEOUT_MS, busy: false },
+            ],
+            now: NOW,
+            timeoutMs: TIMEOUT_MS,
+        })
+
+        expect(index).toBe(-1)
+    })
+
+    it('reports nothing before any loop has registered', () => {
+        expect(findStalledLoopIndex({ loops: [], now: NOW, timeoutMs: TIMEOUT_MS })).toBe(-1)
+    })
+})
+
+async function waitFor(predicate: () => boolean): Promise<void> {
+    for (let i = 0; i < WAIT_ATTEMPTS; i++) {
+        if (predicate()) {
+            return
+        }
+        await new Promise<void>((resolve) => setTimeout(resolve, POLL_INTERVAL_MS))
+    }
+    throw new Error('waitFor timed out')
+}
+
 function getFreePort(): Promise<number> {
     return new Promise((resolve) => {
         const srv = createServer()
@@ -683,6 +708,33 @@ function getFreePort(): Promise<number> {
             srv.close(() => resolve(port))
         })
     })
+}
+
+const POLL_INTERVAL_MS = 20
+
+const WAIT_ATTEMPTS = 250
+
+const WORKER_SETTINGS = {
+    PUBLIC_URL: 'http://localhost:3000',
+    ENVIRONMENT: 'test',
+    EXECUTION_MODE: 'SANDBOX_CODE_AND_PROCESS',
+    TRIGGER_TIMEOUT_SECONDS: 60,
+    TRIGGER_HOOKS_TIMEOUT_SECONDS: 60,
+    PAUSED_FLOW_TIMEOUT_DAYS: 30,
+    FLOW_TIMEOUT_SECONDS: 600,
+    LOG_LEVEL: 'info',
+    LOG_PRETTY: 'false',
+    APP_WEBHOOK_SECRETS: '{}',
+    MAX_FLOW_RUN_LOG_SIZE_MB: 10,
+    MAX_FILE_SIZE_MB: 10,
+    SANDBOX_MEMORY_LIMIT: '1024',
+    SANDBOX_PROPAGATED_ENV_VARS: [],
+    DEV_PIECES: [],
+    OTEL_ENABLED: false,
+    FILE_STORAGE_LOCATION: '/tmp',
+    S3_USE_SIGNED_URLS: 'false',
+    EVENT_DESTINATION_TIMEOUT_SECONDS: 30,
+    EDITION: 'community',
 }
 
 type CompleteJobCall = {


### PR DESCRIPTION
## Description

Prod incident 2026-07-26: the whole worker fleet (~450 containers) stopped consuming jobs while every container reported `Up (healthy)`. `workerJobs` piled to **229,682 prioritized / active:1**. Restarting a container restored execution within seconds; a rolling restart across all 25 hosts recovered the fleet.

**The workers were not crashing and not disconnected.** Socket.IO stayed live the whole time — wedged containers kept receiving `Flow published` pushes and emitting `system.snapshot` heartbeats. They simply stopped calling `poll`. App-side proof: only **4–5 distinct worker ids** appeared in `[workerRpc#poll] Poll request received` out of ~450. The app withheld nothing — zero `Withholding job` lines, worker and app both on `0.86.3` with an identical image digest, and when a poll did arrive it was served in ~22ms.

### Root cause

`serverPingMs` is telemetry for the workers page, but `probeServerPing()` sat on the poll hot path with nothing that reliably bounded it. Its `fetch` never consumed or cancelled the response body, so the `AbortController` did not release a request queued behind a busy undici client. When that happened, `buildMachineInfo()` never returned and the loop parked **before** `apiClient.poll()` was ever reached.

Evidence from a preserved wedged container (`shared05_1`, 38.7h wedged):

- Log counts `Connected to API server via Socket.IO` : `Starting poll loops` : `Polling worker started` = **44 : 44 : 44** — the loop always started.
- After the last restart: zero `job.execute`, zero `Poll failed`, zero `Connected app version mismatch`, zero errors of any kind.
- `process.getActiveResourcesInfo()` on the live process: 3 stdio pipes, one TCP socket (the websocket), the health server, 2 timers. **No HTTP client handle** — the loop was blocked on a promise with no backing libuv handle.
- `/proc/net/tcp`: exactly one ESTABLISHED connection, sampled for 60s, no new outbound connection ever appeared.

Two things made it invisible and permanent. The 1g cgroup OOM-SIGKILLs the node process roughly every 4 minutes and pm2 restarts it — the sample showed cgroup `oom_kill 847` / pm2 `↺ 848` against Docker `RestartCount: 0` — so each restart was another chance to hit the wedge, unseen. And the health server returned `200 {"status":"ok"}` unconditionally, so Docker, Kamal and every uptime probe called a worker healthy that had consumed nothing in 38 hours.

### The fix

- **`probeServerPing` can no longer block a poll.** It races its fetch against its own timeout and cancels the response body, so it always resolves within `SERVER_PING_TIMEOUT_MS`. Wrapping `buildMachineInfo` alone was *not* sufficient — a permanently hung probe still starved the worker through the loop's 20s error-retry path, which is why the regression test still failed until this landed.
- **`buildMachineInfo` is wrapped in a timeout** as a backstop for the remaining system-usage reads.
- **A poll watchdog exits the process** when the socket is connected, no job is in flight, and the loop has not iterated for `POLL_LIVENESS_TIMEOUT_MS` (180s). The health endpoint returns 503 on the same condition. Docker does not act on health status, so the watchdog is what actually makes this self-heal under pm2. It also covers the *other* silent-death shape — `polling === true` with zero loops running — because `lastPollIterationAt` is stamped on connect and only refreshed by a live loop iteration.
- **The poll loop logs at warn when it exits.** It previously terminated in complete silence, which is why ~450 workers went quiet invisibly.

The watchdog cannot fire spuriously: the version-mismatch pause, the machine-info failure path and the poll-failure path all sit *after* the `lastPollIterationAt` stamp inside the loop, so a worker that is merely idle or waiting on a down app keeps refreshing it, and a worker with a long-running job is excluded via `inFlightJobs > 0`.

## How was this tested?

- **New regression test** in `packages/server/worker/test/lib/worker.test.ts` — stubs the health probe to never settle after the worker is up, then asserts the worker still polls, executes a job and reports completion. It fails against the unpatched code (times out) and passes in 5.3s with the fix.
- `npx turbo run build --filter=worker` — clean.
- `npm run lint-core` (the exact CI lint command) — 0 errors.
- Verified in prod: rolling `docker restart` across all 25 hosts took `active` 1 → 408 and drained the backlog 229,682 → 135,245 within minutes, confirming a fresh process is the only thing that re-arms the loop today.

Edition paths: this is worker-runtime only, with no UI, no branding and no edition-gated behaviour — identical on CE / EE / Cloud.

Two things worth flagging separately, both out of scope here:

1. **`packages/server/worker` is not in CI's test filter** (`turbo run test --filter=@activepieces/engine --filter=@activepieces/shared`), so `worker.test.ts` never runs in CI. It has accumulated pre-existing local failures as a result — 16 of 20 tests fail on `main` on my machine, unrelated to this change (they time out at the 15s boundary against a test server that never answers the health probe). Adding the worker package to CI would turn the pipeline red immediately, so it needs its own PR.
2. **The 1g memory limit** for `AP_WORKER_CONCURRENCY: 1` shared workers is what supplied this bug its 848 attempts per container. That is a `mrsk/prod/config/worker.yml` change, not a repo change.

Fixes # (issue)

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)

https://claude.ai/code/session_01MX3WFqJLmZ5QPGDDKahAy6
