### PR TITLE
fix(docker): honor the command passed to the entrypoint

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,5 +1,9 @@
 #!/bin/sh
 
+if [ "$#" -gt 0 ]; then
+    exec "$@"
+fi
+
 export AP_CONTAINER_TYPE="${AP_CONTAINER_TYPE:-WORKER_AND_APP}"
 export AP_PORT="${AP_PORT:-80}"
 


### PR DESCRIPTION
## Description

`docker-entrypoint.sh` never read `"$@"`, and the Dockerfile's `ENTRYPOINT` is exec-form — so a command passed at run time arrived as ignored arguments and the script always started PM2. `kamal app exec <cmd>` therefore booted a permanent worker instead of running `<cmd>`. One such call on 2026-07-09 left 412 orphan containers across the prod worker hosts holding ~86 GB, still running 18 days later.

Fix — exec the passed command, before any setup, so a one-off command skips the token generation and PM2 config write:

```sh
if [ "$#" -gt 0 ]; then
    exec "$@"
fi
```

Normal boot passes no arguments and is unchanged (there is no top-level `CMD`; the only one belongs to `HEALTHCHECK`).

Not breaking: nothing here passes a command — compose, Helm, Pulumi (`args:` are build args), `docs/install/options/docker.mdx` — and `rollback.mdx` uses `--entrypoint npm`, which bypasses the entrypoint and should stay that way. Flip to functional-breaking if `grep -rn "cmd:" mrsk/prod/config/` finds a stray role command, since that would now execute.

## How was this tested?

- `sh docker-entrypoint.sh echo hello` → `hello`, no setup, no PM2
- `sh docker-entrypoint.sh printf '[%s]\n' 'two words'` → `[two words]`, so quoted `"$@"` keeps argument boundaries
- `sh docker-entrypoint.sh` → unchanged: prints env and hands off to PM2

Inert unless a command is passed, so no edition path (CE / EE / Cloud) is affected.

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)
