### PR TITLE
revert: expose core and universal-AI actions to agent discovery (#14413)

### DIFF
--- a/packages/pieces/community/ai/package.json
+++ b/packages/pieces/community/ai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-ai",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/packages/pieces/community/ai/src/lib/actions/agents/run-agent.ts
+++ b/packages/pieces/community/ai/src/lib/actions/agents/run-agent.ts
@@ -64,7 +64,7 @@ const agentToolArrayItems: ArraySubProps<boolean> = {
 }
 
 export const runAgent = createAction({
-  audience: 'both',
+  audience: 'human',
   name: 'run_agent',
   displayName: 'Run Agent',
   description: 'Handles complex, multi-step tasks by reasoning through problems, using tools accurately, and iterating until the job is done.',

--- a/packages/pieces/community/ai/src/lib/actions/image/generate-image.ts
+++ b/packages/pieces/community/ai/src/lib/actions/image/generate-image.ts
@@ -23,7 +23,7 @@ import { AIProviderName } from '@activepieces/pieces-framework';
 import { aiProps } from '../../common/props';
 
 export const generateImageAction = createAction({
-  audience: 'both',
+  audience: 'human',
   name: 'generateImage',
   displayName: 'Generate Image',
   description: 'Create unique, high-quality images from simple text descriptions using AI.',

--- a/packages/pieces/community/ai/src/lib/actions/text/ask-ai.ts
+++ b/packages/pieces/community/ai/src/lib/actions/text/ask-ai.ts
@@ -9,7 +9,7 @@ import { createAIModel } from '../../common/ai-sdk';
 import { buildWebSearchOptionsProperty, buildWebSearchConfig, WebSearchOptions } from '../../common/web-search';
 
 export const askAI = createAction({
-  audience: 'both',
+  audience: 'human',
   name: 'askAi',
   displayName: 'Ask AI',
   description: 'A flexible AI step. ask it to analyze data, explain, draft, or decide based on your flow\'s data.',

--- a/packages/pieces/community/ai/src/lib/actions/text/summarize-text.ts
+++ b/packages/pieces/community/ai/src/lib/actions/text/summarize-text.ts
@@ -5,7 +5,7 @@ import { generateText } from 'ai';
 import { aiProps } from '../../common/props';
 
 export const summarizeText = createAction({
-  audience: 'both',
+  audience: 'human',
   name: 'summarizeText',
   displayName: 'Summarize Text',
   description: 'Summarize long emails, articles, or documents into what matters.',

--- a/packages/pieces/community/ai/src/lib/actions/utility/classify-text.ts
+++ b/packages/pieces/community/ai/src/lib/actions/utility/classify-text.ts
@@ -5,7 +5,7 @@ import { aiProps } from '../../common/props';
 import { AIProviderName } from '@activepieces/pieces-framework';
 
 export const classifyText = createAction({
-  audience: 'both',
+  audience: 'human',
   name: 'classifyText',
   displayName: 'Classify Text',
   description: 'Categorize any text input using custom labels, so your flow knows what to do next.',

--- a/packages/pieces/community/ai/src/lib/actions/utility/extract-structured-data.ts
+++ b/packages/pieces/community/ai/src/lib/actions/utility/extract-structured-data.ts
@@ -7,7 +7,7 @@ import { aiProps } from '../../common/props';
 import { AIProviderName } from '@activepieces/pieces-framework';
 
 export const extractStructuredData = createAction({
-  audience: 'both',
+  audience: 'human',
 	name: 'extractStructuredData',
 	displayName: 'Extract Structured Data',
 	description: 'Accurately Pull names, amounts, and other structured data from emails, invoices, and scanned documents.',

--- a/packages/pieces/core/approval/package.json
+++ b/packages/pieces/core/approval/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-approval",
-  "version": "0.1.22",
+  "version": "0.1.23",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {

--- a/packages/pieces/core/approval/src/lib/actions/create-approval-link.ts
+++ b/packages/pieces/core/approval/src/lib/actions/create-approval-link.ts
@@ -2,7 +2,7 @@ import { createAction, PieceAuth, Property } from '@activepieces/pieces-framewor
 import { MarkdownVariant } from '@activepieces/pieces-framework';
 
 export const createApprovalLink = createAction({
-  audience: 'both',
+  audience: 'human',
   auth: PieceAuth.None(),
   name: 'create_approval_links',
   displayName: 'Create Approval Links',

--- a/packages/pieces/core/approval/src/lib/actions/wait-for-approval.ts
+++ b/packages/pieces/core/approval/src/lib/actions/wait-for-approval.ts
@@ -2,7 +2,7 @@ import { createAction, PieceAuth, Property } from '@activepieces/pieces-framewor
 import { ExecutionType, MarkdownVariant } from '@activepieces/pieces-framework';
 
 export const waitForApprovalLink = createAction({
-  audience: 'both',
+  audience: 'human',
   auth: PieceAuth.None(),
   name: 'wait_for_approval',
   displayName: 'Wait for Approval',

--- a/packages/pieces/core/connections/package.json
+++ b/packages/pieces/core/connections/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-connections",
-  "version": "0.5.6",
+  "version": "0.5.7",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {

--- a/packages/pieces/core/connections/src/lib/actions/read-connection.ts
+++ b/packages/pieces/core/connections/src/lib/actions/read-connection.ts
@@ -13,7 +13,7 @@ Use this piece if you are unsure which connection to use beforehand, such as whe
 `;
 
 export const readConnection = createAction({
-  audience: 'both',
+  audience: 'human',
   name: 'read_connection',
   displayName: 'Read Connection',
   description: 'Fetch connection by name',

--- a/packages/pieces/core/crypto/package.json
+++ b/packages/pieces/core/crypto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-crypto",
-  "version": "0.0.23",
+  "version": "0.0.24",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "dependencies": {

--- a/packages/pieces/core/crypto/src/lib/actions/base64-decode.ts
+++ b/packages/pieces/core/crypto/src/lib/actions/base64-decode.ts
@@ -1,7 +1,7 @@
 import { Property, createAction } from '@activepieces/pieces-framework';
 
 export const base64Decode = createAction({
-  audience: 'both',
+  audience: 'human',
   name: 'base64-decode',
   displayName: 'Base64 Decode',
   description:'Converts base64 text back to plain text.',

--- a/packages/pieces/core/crypto/src/lib/actions/base64-encode.ts
+++ b/packages/pieces/core/crypto/src/lib/actions/base64-encode.ts
@@ -1,7 +1,7 @@
 import { Property, createAction } from '@activepieces/pieces-framework';
 
 export const base64Encode = createAction({
-  audience: 'both',
+  audience: 'human',
   name: 'base64-encode',
   displayName: 'Base64 Encode',
   description: 'Converts plain text into base64 format.',

--- a/packages/pieces/core/crypto/src/lib/actions/generate-password.ts
+++ b/packages/pieces/core/crypto/src/lib/actions/generate-password.ts
@@ -6,7 +6,7 @@ import * as z from 'zod/mini'
 import { propsValidation } from '@activepieces/pieces-common';
 
 export const generatePassword = createAction({
-  audience: 'both',
+  audience: 'human',
   name: 'generate-password',
   description: 'Generates a random password with the specified length',
   displayName: 'Generate Password',

--- a/packages/pieces/core/crypto/src/lib/actions/hash-text.ts
+++ b/packages/pieces/core/crypto/src/lib/actions/hash-text.ts
@@ -2,7 +2,7 @@ import { Property, createAction } from '@activepieces/pieces-framework';
 import Crypto from 'crypto';
 
 export const hashText = createAction({
-  audience: 'both',
+  audience: 'human',
   name: 'hash-text',
   description: 'Converts text to a hash value using various hashing algorithms',
   displayName: 'Text to Hash',

--- a/packages/pieces/core/crypto/src/lib/actions/hmac-signature.ts
+++ b/packages/pieces/core/crypto/src/lib/actions/hmac-signature.ts
@@ -3,7 +3,7 @@ import Crypto from 'crypto';
 import { Buffer } from 'buffer';
 
 export const hmacSignature = createAction({
-  audience: 'both',
+  audience: 'human',
   name: 'hmac-signature',
   description:
     'Converts text to a HMAC signed hash value using various hashing algorithms',

--- a/packages/pieces/core/crypto/src/lib/actions/openpgp-encrypt.ts
+++ b/packages/pieces/core/crypto/src/lib/actions/openpgp-encrypt.ts
@@ -2,7 +2,7 @@ import { createAction, Property } from '@activepieces/pieces-framework';
 import * as openpgp from 'openpgp';
 
 export const openpgpEncrypt = createAction({
-  audience: 'both',
+  audience: 'human',
   name: 'openpgpEncrypt',
   displayName: 'OpenPGP Encrypt',
   description: 'Encrypt a file using OpenPGP public key',

--- a/packages/pieces/core/crypto/src/lib/actions/rsa-signature.ts
+++ b/packages/pieces/core/crypto/src/lib/actions/rsa-signature.ts
@@ -2,7 +2,7 @@ import { createAction, Property } from '@activepieces/pieces-framework';
 import Crypto from 'crypto';
 
 export const rsaSignature = createAction({
-  audience: 'both',
+  audience: 'human',
   name: 'rsa-signature',
   displayName: 'Generate RSA Signature',
   description:

--- a/packages/pieces/core/csv/package.json
+++ b/packages/pieces/core/csv/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-csv",
-  "version": "0.4.16",
+  "version": "0.4.17",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "dependencies": {

--- a/packages/pieces/core/csv/src/lib/actions/convert-csv-to-json.ts
+++ b/packages/pieces/core/csv/src/lib/actions/convert-csv-to-json.ts
@@ -3,7 +3,7 @@ import { isString } from '@activepieces/pieces-framework';
 import {parse} from 'csv-parse/sync';
 
 export const csvToJsonAction = createAction({
-  audience: 'both',
+  audience: 'human',
   name: 'convert_csv_to_json',
   displayName: 'Convert CSV to JSON',
   description:

--- a/packages/pieces/core/csv/src/lib/actions/convert-excel-to-csv.ts
+++ b/packages/pieces/core/csv/src/lib/actions/convert-excel-to-csv.ts
@@ -2,7 +2,7 @@ import { createAction, Property } from '@activepieces/pieces-framework';
 import * as XLSX from 'xlsx';
 
 export const excelToCsvAction = createAction({
-  audience: 'both',
+  audience: 'human',
   name: 'convert_excel_to_csv',
   displayName: 'Convert Excel to CSV',
   description: 'Converts an Excel file (.xlsx or .xls) into CSV text.',

--- a/packages/pieces/core/csv/src/lib/actions/convert-json-to-csv.ts
+++ b/packages/pieces/core/csv/src/lib/actions/convert-json-to-csv.ts
@@ -8,7 +8,7 @@ const markdown = `
 * The JSON object will be flattened If nested and the keys will be used as headers.
 `
 export const jsonToCsvAction = createAction({
-  audience: 'both',
+  audience: 'human',
   name: 'convert_json_to_csv',
   displayName: 'Convert JSON to CSV',
   description: 'This function reads a JSON array and converts it into CSV format.',

--- a/packages/pieces/core/data-mapper/package.json
+++ b/packages/pieces/core/data-mapper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-data-mapper",
-  "version": "0.3.17",
+  "version": "0.3.18",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {

--- a/packages/pieces/core/data-mapper/src/lib/actions/advanced-mapping.ts
+++ b/packages/pieces/core/data-mapper/src/lib/actions/advanced-mapping.ts
@@ -1,7 +1,7 @@
 import { createAction, Property } from '@activepieces/pieces-framework';
 
 export const advancedMapping = createAction({
-  audience: 'both',
+  audience: 'human',
   name: 'advanced_mapping',
   displayName: 'Advanced Mapping',
   description: 'Map data from one format to another',

--- a/packages/pieces/core/data-summarizer/package.json
+++ b/packages/pieces/core/data-summarizer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-data-summarizer",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {

--- a/packages/pieces/core/data-summarizer/src/lib/actions/calculate-average.ts
+++ b/packages/pieces/core/data-summarizer/src/lib/actions/calculate-average.ts
@@ -2,7 +2,7 @@ import { createAction, Property } from '@activepieces/pieces-framework';
 import { common } from '../common';
 
 export const calculateAverage = createAction({
-  audience: 'both',
+  audience: 'human',
   name: 'calculateAverage',
   displayName: 'Calculate Average',
   description: 'Calculates the average of a list of values.',

--- a/packages/pieces/core/data-summarizer/src/lib/actions/calculate-sum.ts
+++ b/packages/pieces/core/data-summarizer/src/lib/actions/calculate-sum.ts
@@ -2,7 +2,7 @@ import { createAction, Property } from '@activepieces/pieces-framework';
 import { common } from '../common';
 
 export const calculateSum = createAction({
-  audience: 'both',
+  audience: 'human',
   name: 'calculateSum',
   displayName: 'Calculate Sum',
   description: 'Calculates the sum of a list of values.',

--- a/packages/pieces/core/data-summarizer/src/lib/actions/count-uniques.ts
+++ b/packages/pieces/core/data-summarizer/src/lib/actions/count-uniques.ts
@@ -3,7 +3,7 @@ import { common } from '../common';
 import { isNil } from '@activepieces/pieces-framework';
 
 export const countUniques = createAction({
-  audience: 'both',
+  audience: 'human',
   name: 'countUniques',
   displayName: 'Count Uniques',
   description: 'Counts the number of unique values for multiple fields',

--- a/packages/pieces/core/data-summarizer/src/lib/actions/get-min-max.ts
+++ b/packages/pieces/core/data-summarizer/src/lib/actions/get-min-max.ts
@@ -2,7 +2,7 @@ import { createAction, Property } from '@activepieces/pieces-framework';
 import { common } from '../common';
 
 export const getMinMax = createAction({
-  audience: 'both',
+  audience: 'human',
   name: 'getMinMax',
   displayName: 'Find Min and Max',
   description: 'Get the smallest and greatest values from a list of numeric values.',

--- a/packages/pieces/core/date-helper/package.json
+++ b/packages/pieces/core/date-helper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-date-helper",
-  "version": "0.1.29",
+  "version": "0.1.30",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {

--- a/packages/pieces/core/date-helper/src/lib/actions/add-subtract-date.ts
+++ b/packages/pieces/core/date-helper/src/lib/actions/add-subtract-date.ts
@@ -14,7 +14,7 @@ import * as z from 'zod/mini'
 import { propsValidation } from '@activepieces/pieces-common';
 
 export const addSubtractDateAction = createAction({
-  audience: 'both',
+  audience: 'human',
   name: 'add_subtract_date',
   displayName: 'Add/Subtract Time',
   description: 'Add or subtract time from a date',

--- a/packages/pieces/core/date-helper/src/lib/actions/date-difference.ts
+++ b/packages/pieces/core/date-helper/src/lib/actions/date-difference.ts
@@ -10,7 +10,7 @@ import {
 } from '../common';
 
 export const dateDifferenceAction = createAction({
-  audience: 'both',
+  audience: 'human',
   name: 'date_difference',
   displayName: 'Date Difference',
   description: 'Get the difference between two dates',

--- a/packages/pieces/core/date-helper/src/lib/actions/extract-date-parts.ts
+++ b/packages/pieces/core/date-helper/src/lib/actions/extract-date-parts.ts
@@ -9,7 +9,7 @@ import {
 } from '../common';
 
 export const extractDateParts = createAction({
-  audience: 'both',
+  audience: 'human',
   name: 'extract_date_parts',
   displayName: 'Extract Date Units',
   description:

--- a/packages/pieces/core/date-helper/src/lib/actions/first-day-of-prior-month.ts
+++ b/packages/pieces/core/date-helper/src/lib/actions/first-day-of-prior-month.ts
@@ -11,7 +11,7 @@ import * as z from 'zod/mini'
 import { propsValidation } from '@activepieces/pieces-common';
 
 export const firstDayOfPreviousMonthAction = createAction({
-  audience: 'both',
+  audience: 'human',
   name: 'first_day_of_previous_month',
   displayName: 'First Day of Previous Month',
   description: 'Get the date and time of the first day of the previous month',

--- a/packages/pieces/core/date-helper/src/lib/actions/format-date.ts
+++ b/packages/pieces/core/date-helper/src/lib/actions/format-date.ts
@@ -9,7 +9,7 @@ import {
 } from '../common';
 
 export const formatDateAction = createAction({
-  audience: 'both',
+  audience: 'human',
   name: 'format_date',
   displayName: 'Format Date',
   description: 'Converts a date from one format to another',

--- a/packages/pieces/core/date-helper/src/lib/actions/get-current-date.ts
+++ b/packages/pieces/core/date-helper/src/lib/actions/get-current-date.ts
@@ -9,7 +9,7 @@ import {
 } from '../common';
 
 export const getCurrentDate = createAction({
-  audience: 'both',
+  audience: 'human',
   name: 'get_current_date',
   displayName: 'Get Current Date',
   description: 'Get the current date',

--- a/packages/pieces/core/date-helper/src/lib/actions/last-day-of-prior-month.ts
+++ b/packages/pieces/core/date-helper/src/lib/actions/last-day-of-prior-month.ts
@@ -11,7 +11,7 @@ import * as z from 'zod/mini'
 import { propsValidation } from '@activepieces/pieces-common';
 
 export const lastDayOfPreviousMonthAction = createAction({
-  audience: 'both',
+  audience: 'human',
   name: 'last_day_of_previous_month',
   displayName: 'Last Day of Previous Month',
   description: 'Get the date and time of the last day of the previous month',

--- a/packages/pieces/core/date-helper/src/lib/actions/next-day-of-week.ts
+++ b/packages/pieces/core/date-helper/src/lib/actions/next-day-of-week.ts
@@ -14,7 +14,7 @@ import * as z from 'zod/mini'
 import { propsValidation } from '@activepieces/pieces-common';
 
 export const nextDayofWeek = createAction({
-  audience: 'both',
+  audience: 'human',
   name: 'next_day_of_week',
   displayName: 'Next Day of Week',
   description: 'Get the date and time of the next day of the week',

--- a/packages/pieces/core/date-helper/src/lib/actions/next-day-of-year.ts
+++ b/packages/pieces/core/date-helper/src/lib/actions/next-day-of-year.ts
@@ -14,7 +14,7 @@ import * as z from 'zod/mini'
 import { propsValidation } from '@activepieces/pieces-common';
 
 export const nextDayofYear = createAction({
-  audience: 'both',
+  audience: 'human',
   name: 'next_day_of_year',
   displayName: 'Next Day of Year',
   description: 'Get the date and time of the next day of the year',

--- a/packages/pieces/core/delay/package.json
+++ b/packages/pieces/core/delay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-delay",
-  "version": "0.3.29",
+  "version": "0.3.30",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {

--- a/packages/pieces/core/delay/src/lib/actions/delay-for-action.ts
+++ b/packages/pieces/core/delay/src/lib/actions/delay-for-action.ts
@@ -15,7 +15,7 @@ enum TimeUnit {
 }
 
 export const delayForAction = createAction({
-  audience: 'both',
+  audience: 'human',
   name: 'delayFor',
   displayName: 'Delay For',
   description: 'Delays the execution of the next action for a given duration',

--- a/packages/pieces/core/delay/src/lib/actions/delay-until-action.ts
+++ b/packages/pieces/core/delay/src/lib/actions/delay-until-action.ts
@@ -4,7 +4,7 @@ import dayjs from 'dayjs';
 import { markdownDescription } from '../common';
 
 export const delayUntilAction = createAction({
-  audience: 'both',
+  audience: 'human',
   name: 'delay_until',
   displayName: 'Delay Until',
   description:

--- a/packages/pieces/core/file-helper/package.json
+++ b/packages/pieces/core/file-helper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-file-helper",
-  "version": "0.1.25",
+  "version": "0.1.26",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "dependencies": {

--- a/packages/pieces/core/file-helper/src/lib/actions/change-file-encoding.ts
+++ b/packages/pieces/core/file-helper/src/lib/actions/change-file-encoding.ts
@@ -2,7 +2,7 @@ import { Property, createAction } from '@activepieces/pieces-framework';
 import { encodings } from '../common/encodings';
 
 export const changeFileEncoding = createAction({
-  audience: 'both',
+  audience: 'human',
   name: 'change_file_encoding',
   displayName: 'Change File Encoding',
   description: 'Changes the encoding of a file',

--- a/packages/pieces/core/file-helper/src/lib/actions/check-file-type.ts
+++ b/packages/pieces/core/file-helper/src/lib/actions/check-file-type.ts
@@ -3,7 +3,7 @@ import { predefinedMimeTypes } from '../common/mimeTypes';
 import mime from 'mime-types';
 
 export const checkFileType = createAction({
-  audience: 'both',
+  audience: 'human',
   name: 'checkFileType',
   displayName: 'Check file type',
   description: 'Check MIME type of a file and filter based on selected types',

--- a/packages/pieces/core/file-helper/src/lib/actions/create-file.ts
+++ b/packages/pieces/core/file-helper/src/lib/actions/create-file.ts
@@ -2,7 +2,7 @@ import { createAction, Property } from '@activepieces/pieces-framework';
 import { encodings } from '../common/encodings';
 
 export const createFile = createAction({
-  audience: 'both',
+  audience: 'human',
   // auth: check https://www.activepieces.com/docs/developers/piece-reference/authentication,
   name: 'createFile',
   displayName: 'Create file',

--- a/packages/pieces/core/file-helper/src/lib/actions/get-file-name.ts
+++ b/packages/pieces/core/file-helper/src/lib/actions/get-file-name.ts
@@ -1,7 +1,7 @@
 import { Property, createAction } from '@activepieces/pieces-framework';
 
 export const getFileName = createAction({
-  audience: 'both',
+  audience: 'human',
   name: 'get_file_name',
   displayName: 'Get File Name',
   description: 'Get the name of a file',

--- a/packages/pieces/core/file-helper/src/lib/actions/read-file.ts
+++ b/packages/pieces/core/file-helper/src/lib/actions/read-file.ts
@@ -7,7 +7,7 @@ export const filesOutput = {
 };
 
 export const readFileAction = createAction({
-  audience: 'both',
+  audience: 'human',
   name: 'read_file',
   displayName: 'Read File',
   description: 'Read a file from the file system',

--- a/packages/pieces/core/file-helper/src/lib/actions/unzip-file.ts
+++ b/packages/pieces/core/file-helper/src/lib/actions/unzip-file.ts
@@ -23,7 +23,7 @@ Throw an error if zip file has more than expected entries.
 `;
 
 export const unzipFile = createAction({
-  audience: 'both',
+  audience: 'human',
   name: 'unzipFile',
   displayName: 'Unzip File',
   description: 'Unzip compressed zip file',

--- a/packages/pieces/core/file-helper/src/lib/actions/zip-files.ts
+++ b/packages/pieces/core/file-helper/src/lib/actions/zip-files.ts
@@ -28,7 +28,7 @@ const encryptionMethodDescription = `
 `;
 
 export const zipFiles = createAction({
-  audience: 'both',
+  audience: 'human',
   name: 'zipFiles',
   displayName: 'Zip Files',
   description: 'Create compressed zip file from one or many files',

--- a/packages/pieces/core/forms/package.json
+++ b/packages/pieces/core/forms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-forms",
-  "version": "0.4.16",
+  "version": "0.4.17",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {

--- a/packages/pieces/core/forms/src/lib/actions/return-response.ts
+++ b/packages/pieces/core/forms/src/lib/actions/return-response.ts
@@ -4,7 +4,7 @@ import { StatusCodes } from 'http-status-codes';
 import mime from 'mime-types';
 
 export const returnResponse = createAction({
-  audience: 'both',
+  audience: 'human',
   name: 'return_response',
   displayName: 'Respond on UI',
   description: 'Return a file or text (markdown) as a response.',

--- a/packages/pieces/core/graphql/package.json
+++ b/packages/pieces/core/graphql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-graphql",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "dependencies": {

--- a/packages/pieces/core/graphql/src/lib/actions/query.ts
+++ b/packages/pieces/core/graphql/src/lib/actions/query.ts
@@ -17,7 +17,7 @@ import { HttpsProxyAgent } from 'https-proxy-agent';
 import axios from 'axios';
 
 export const query = createAction({
-  audience: 'both',
+  audience: 'human',
   name: 'send_request',
   displayName: 'Send Request',
   description: 'Makes a GraphQL request.',

--- a/packages/pieces/core/http/package.json
+++ b/packages/pieces/core/http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-http",
-  "version": "0.11.12",
+  "version": "0.11.13",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "dependencies": {

--- a/packages/pieces/core/http/src/lib/actions/parse-url.ts
+++ b/packages/pieces/core/http/src/lib/actions/parse-url.ts
@@ -1,7 +1,7 @@
 import { createAction, Property } from '@activepieces/pieces-framework';
 
 export const parseUrl = createAction({
-  audience: 'both',
+  audience: 'human',
   name: 'parse_url',
   displayName: 'Parse URL',
   description: 'Extract the domain, path, and query parameters from a URL.',

--- a/packages/pieces/core/http/src/lib/actions/send-http-request-action.ts
+++ b/packages/pieces/core/http/src/lib/actions/send-http-request-action.ts
@@ -25,7 +25,7 @@ enum AuthType {
 }
 
 export const httpSendRequestAction = createAction({
-  audience: 'both',
+  audience: 'human',
   name: 'send_request',
   displayName: 'Send HTTP request',
   description: 'Send HTTP request',

--- a/packages/pieces/core/image-helper/package.json
+++ b/packages/pieces/core/image-helper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-image-helper",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "dependencies": {

--- a/packages/pieces/core/image-helper/src/lib/actions/compress-image.actions.ts
+++ b/packages/pieces/core/image-helper/src/lib/actions/compress-image.actions.ts
@@ -2,7 +2,7 @@ import { Property, createAction } from '@activepieces/pieces-framework';
 import jimp from 'jimp';
 
 export const compressImage = createAction({
-  audience: 'both',
+  audience: 'human',
   name: 'compress_image',
   description: 'Compresses an image',
   displayName: 'Compresses an image',

--- a/packages/pieces/core/image-helper/src/lib/actions/convert-image.action.ts
+++ b/packages/pieces/core/image-helper/src/lib/actions/convert-image.action.ts
@@ -5,7 +5,7 @@ import jimp from 'jimp';
 import * as mime from 'mime-types';
 
 export const convertImageFormat = createAction({
-  audience: 'both',
+  audience: 'human',
   name: 'convert_image_format',
   displayName: 'Image Conversion Helper',
   description: 'Converts a image to supported formats',

--- a/packages/pieces/core/image-helper/src/lib/actions/crop-image.action.ts
+++ b/packages/pieces/core/image-helper/src/lib/actions/crop-image.action.ts
@@ -2,7 +2,7 @@ import { Property, createAction } from '@activepieces/pieces-framework';
 import jimp from 'jimp';
 
 export const cropImage = createAction({
-  audience: 'both',
+  audience: 'human',
   name: 'crop_image',
   description: 'Crops an image',
   displayName: 'Crop an image',

--- a/packages/pieces/core/image-helper/src/lib/actions/get-metadata.action.ts
+++ b/packages/pieces/core/image-helper/src/lib/actions/get-metadata.action.ts
@@ -2,7 +2,7 @@ import { Property, createAction } from '@activepieces/pieces-framework';
 import * as ExifReader from 'exifreader';
 
 export const getMetaData = createAction({
-  audience: 'both',
+  audience: 'human',
   name: 'get_meta_data',
   description: 'Gets metadata from an image',
   displayName: 'Get image metadata',

--- a/packages/pieces/core/image-helper/src/lib/actions/image-to-base64.action.ts
+++ b/packages/pieces/core/image-helper/src/lib/actions/image-to-base64.action.ts
@@ -2,7 +2,7 @@ import { Property, createAction } from '@activepieces/pieces-framework';
 import mime from 'mime-types';
 
 export const imageToBase64 = createAction({
-  audience: 'both',
+  audience: 'human',
   name: 'image_to_base64',
   description: 'Converts an image to an url-like Base64 string',
   displayName: 'Image to Base64',

--- a/packages/pieces/core/image-helper/src/lib/actions/resize-Image.action.ts
+++ b/packages/pieces/core/image-helper/src/lib/actions/resize-Image.action.ts
@@ -2,7 +2,7 @@ import { Property, createAction } from '@activepieces/pieces-framework';
 import jimp from 'jimp';
 
 export const resizeImage = createAction({
-  audience: 'both',
+  audience: 'human',
   name: 'resize_image',
   description: 'Resizes an image',
   displayName: 'Resize an image',

--- a/packages/pieces/core/image-helper/src/lib/actions/rotate-image.action.ts
+++ b/packages/pieces/core/image-helper/src/lib/actions/rotate-image.action.ts
@@ -2,7 +2,7 @@ import { Property, createAction } from '@activepieces/pieces-framework';
 import jimp from 'jimp';
 
 export const rotateImage = createAction({
-  audience: 'both',
+  audience: 'human',
   name: 'rotate_image',
   description: 'Rotates an image',
   displayName: 'Rotate an image',

--- a/packages/pieces/core/math-helper/package.json
+++ b/packages/pieces/core/math-helper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-math-helper",
-  "version": "0.0.25",
+  "version": "0.0.26",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "bundleDeps": true,

--- a/packages/pieces/core/math-helper/src/lib/actions/addition.ts
+++ b/packages/pieces/core/math-helper/src/lib/actions/addition.ts
@@ -5,7 +5,7 @@ import {
 } from '@activepieces/pieces-framework';
 
 export const addition = createAction({
-  audience: 'both',
+  audience: 'human',
   name: 'addition_math',
   auth: PieceAuth.None(),
   displayName: 'Addition',

--- a/packages/pieces/core/math-helper/src/lib/actions/division.ts
+++ b/packages/pieces/core/math-helper/src/lib/actions/division.ts
@@ -7,7 +7,7 @@ import { propsValidation } from '@activepieces/pieces-common';
 import * as z from 'zod/mini';
 
 export const division = createAction({
-  audience: 'both',
+  audience: 'human',
   name: 'division_math',
   auth: PieceAuth.None(),
   displayName: 'Division',

--- a/packages/pieces/core/math-helper/src/lib/actions/generateRandom.ts
+++ b/packages/pieces/core/math-helper/src/lib/actions/generateRandom.ts
@@ -5,7 +5,7 @@ import {
 } from '@activepieces/pieces-framework';
 
 export const generateRandom = createAction({
-  audience: 'both',
+  audience: 'human',
   name: 'generateRandom_math',
   auth: PieceAuth.None(),
   displayName: 'Generate Random Number',

--- a/packages/pieces/core/math-helper/src/lib/actions/modulo.ts
+++ b/packages/pieces/core/math-helper/src/lib/actions/modulo.ts
@@ -5,7 +5,7 @@ import {
 } from '@activepieces/pieces-framework';
 
 export const modulo = createAction({
-  audience: 'both',
+  audience: 'human',
   name: 'modulo_math',
   auth: PieceAuth.None(),
   displayName: 'Modulo',

--- a/packages/pieces/core/math-helper/src/lib/actions/multiplication.ts
+++ b/packages/pieces/core/math-helper/src/lib/actions/multiplication.ts
@@ -5,7 +5,7 @@ import {
 } from '@activepieces/pieces-framework';
 
 export const multiplication = createAction({
-  audience: 'both',
+  audience: 'human',
   name: 'multiplication_math',
   auth: PieceAuth.None(),
   displayName: 'Multiplication',

--- a/packages/pieces/core/math-helper/src/lib/actions/subtraction.ts
+++ b/packages/pieces/core/math-helper/src/lib/actions/subtraction.ts
@@ -5,7 +5,7 @@ import {
 } from '@activepieces/pieces-framework';
 
 export const subtraction = createAction({
-  audience: 'both',
+  audience: 'human',
   name: 'subtraction_math',
   auth: PieceAuth.None(),
   displayName: 'Subtraction',

--- a/packages/pieces/core/pdf/package.json
+++ b/packages/pieces/core/pdf/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-pdf",
-  "version": "0.5.6",
+  "version": "0.5.7",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "dependencies": {

--- a/packages/pieces/core/pdf/src/lib/actions/add-image-to-pdf.ts
+++ b/packages/pieces/core/pdf/src/lib/actions/add-image-to-pdf.ts
@@ -4,7 +4,7 @@ import { getTargetPages, mapVisualToIntrinsic } from '../common';
 import mime from 'mime-types';
 
 export const addImageToPdf = createAction({
-  audience: 'both',
+  audience: 'human',
   name: 'addImageToPdf',
   displayName: 'Add Image to PDF',
   description: 'Stamps one or more images (PNG or JPG) at exact pixel distances from the top-left corner.',

--- a/packages/pieces/core/pdf/src/lib/actions/add-text-to-pdf.ts
+++ b/packages/pieces/core/pdf/src/lib/actions/add-text-to-pdf.ts
@@ -8,7 +8,7 @@ const fontOptions = Object.entries(StandardFonts).map(([key, value]) => {
 });
 
 export const addTextToPdf = createAction({
-  audience: 'both',
+  audience: 'human',
   name: 'addTextToPdf',
   displayName: 'Add Text to PDF',
   description: 'Stamps one or more text strings at exact pixel distances from the top-left corner.',

--- a/packages/pieces/core/pdf/src/lib/actions/convert-to-image.ts
+++ b/packages/pieces/core/pdf/src/lib/actions/convert-to-image.ts
@@ -67,7 +67,7 @@ async function concatImagesVertically(imageBuffers: Buffer[]): Promise<Buffer> {
 }
 
 export const convertToImage = createAction({
-  audience: 'both',
+  audience: 'human',
     name: 'convertToImage',
     displayName: 'Convert to Image',
     description: 'Convert a PDF file or URL to an image',

--- a/packages/pieces/core/pdf/src/lib/actions/extract-pdf-pages.ts
+++ b/packages/pieces/core/pdf/src/lib/actions/extract-pdf-pages.ts
@@ -60,7 +60,7 @@ This action can extract or rearrange the pages in a PDF.
 `;
 
 export const extractPdfPages = createAction({
-  audience: 'both',
+  audience: 'human',
   name: 'extractPdfPages',
   displayName: 'Extract PDF Pages',
   description: 'Extract or rearrange page(s)from PDF File.',

--- a/packages/pieces/core/pdf/src/lib/actions/extract-text.ts
+++ b/packages/pieces/core/pdf/src/lib/actions/extract-text.ts
@@ -2,7 +2,7 @@ import { createAction, Property } from '@activepieces/pieces-framework';
 import { extractText as pdfExtractText, getDocumentProxy } from 'unpdf';
 
 export const extractText = createAction({
-  audience: 'both',
+  audience: 'human',
   name: 'extractText',
   displayName: 'Extract Text',
   description: 'Extract text from PDF file or url',

--- a/packages/pieces/core/pdf/src/lib/actions/image-to-pdf.ts
+++ b/packages/pieces/core/pdf/src/lib/actions/image-to-pdf.ts
@@ -2,7 +2,7 @@ import { createAction, Property } from '@activepieces/pieces-framework';
 import { PDFDocument, PDFImage, RotationTypes, PageSizes } from 'pdf-lib';
 
 export const imageToPdf = createAction({
-  audience: 'both',
+  audience: 'human',
 	name: 'imageToPdf',
 	displayName: 'Image to PDF',
 	description: 'Convert image to PDF',

--- a/packages/pieces/core/pdf/src/lib/actions/merge-pdfs.ts
+++ b/packages/pieces/core/pdf/src/lib/actions/merge-pdfs.ts
@@ -2,7 +2,7 @@ import { createAction, Property } from '@activepieces/pieces-framework';
 import { PDFDocument } from 'pdf-lib';
 
 export const mergePdfs = createAction({
-  audience: 'both',
+  audience: 'human',
   name: 'mergePdfs',
   displayName: 'Merge PDFs',
   description: 'Merges multiple PDF files into a single PDF document.',

--- a/packages/pieces/core/pdf/src/lib/actions/pdf-page-count.ts
+++ b/packages/pieces/core/pdf/src/lib/actions/pdf-page-count.ts
@@ -2,7 +2,7 @@ import { createAction, Property } from '@activepieces/pieces-framework';
 import { PDFDocument } from 'pdf-lib';
 
 export const pdfPageCount = createAction({
-  audience: 'both',
+  audience: 'human',
   name: 'pdfPageCount',
   displayName: 'PDF Page Count',
   description: 'Get page count of PDF file.',

--- a/packages/pieces/core/pdf/src/lib/actions/text-to-pdf.ts
+++ b/packages/pieces/core/pdf/src/lib/actions/text-to-pdf.ts
@@ -2,7 +2,7 @@ import { createAction, Property } from '@activepieces/pieces-framework';
 import { PDFDocument, StandardFonts } from 'pdf-lib';
 
 export const textToPdf = createAction({
-  audience: 'both',
+  audience: 'human',
   name: 'textToPdf',
   displayName: 'Text to PDF',
   description: 'Convert text to PDF',

--- a/packages/pieces/core/qrcode/package.json
+++ b/packages/pieces/core/qrcode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-qrcode",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "devDependencies": {

--- a/packages/pieces/core/qrcode/src/lib/actions/output-qrcode-action.ts
+++ b/packages/pieces/core/qrcode/src/lib/actions/output-qrcode-action.ts
@@ -2,7 +2,7 @@ import { createAction, Property } from '@activepieces/pieces-framework';
 import { toBuffer } from 'qrcode';
 
 export const outputQrcodeAction = createAction({
-  audience: 'both',
+  audience: 'human',
   name: 'text_to_qrcode',
   displayName: 'Text to QR Code',
   description: 'Convert text to QR code',

--- a/packages/pieces/core/sftp/package.json
+++ b/packages/pieces/core/sftp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-sftp",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "dependencies": {

--- a/packages/pieces/core/sftp/src/lib/actions/create-file.ts
+++ b/packages/pieces/core/sftp/src/lib/actions/create-file.ts
@@ -28,7 +28,7 @@ async function createFileWithFTP(client: FTPClient, fileName: string, fileConten
 }
 
 export const createFile = createAction({
-  audience: 'both',
+  audience: 'human',
     auth: sftpAuth,
     name: 'create_file',
     displayName: 'Create File from Text',

--- a/packages/pieces/core/sftp/src/lib/actions/create-folder.ts
+++ b/packages/pieces/core/sftp/src/lib/actions/create-folder.ts
@@ -6,7 +6,7 @@ import { Client as FTPClient, FTPError } from 'basic-ftp';
 import { getSftpError } from './common';
 
 export const createFolderAction = createAction({
-  audience: 'both',
+  audience: 'human',
   auth: sftpAuth,
   name: 'createFolder',
   displayName: 'Create Folder',

--- a/packages/pieces/core/sftp/src/lib/actions/delete-file.ts
+++ b/packages/pieces/core/sftp/src/lib/actions/delete-file.ts
@@ -14,7 +14,7 @@ async function deleteFileFromSFTP(client: Client, filePath: string) {
 }
 
 export const deleteFileAction = createAction({
-  audience: 'both',
+  audience: 'human',
   auth: sftpAuth,
   name: 'deleteFile',
   displayName: 'Delete file',

--- a/packages/pieces/core/sftp/src/lib/actions/delete-folder.ts
+++ b/packages/pieces/core/sftp/src/lib/actions/delete-folder.ts
@@ -18,7 +18,7 @@ async function deleteFolderSFTP(client: Client, directoryPath: string, recursive
 }
 
 export const deleteFolderAction = createAction({
-  audience: 'both',
+  audience: 'human',
   auth: sftpAuth,
   name: 'deleteFolder',
   displayName: 'Delete Folder',

--- a/packages/pieces/core/sftp/src/lib/actions/list-files.ts
+++ b/packages/pieces/core/sftp/src/lib/actions/list-files.ts
@@ -31,7 +31,7 @@ async function listFTP(client: FTPClient, directoryPath: string) {
 }
 
 export const listFolderContentsAction = createAction({
-  audience: 'both',
+  audience: 'human',
   auth: sftpAuth,
   name: 'listFolderContents',
   displayName: 'List Folder Contents',

--- a/packages/pieces/core/sftp/src/lib/actions/read-file.ts
+++ b/packages/pieces/core/sftp/src/lib/actions/read-file.ts
@@ -25,7 +25,7 @@ async function readSFTP(client: Client, filePath: string) {
 }
 
 export const readFileContent = createAction({
-  audience: 'both',
+  audience: 'human',
   auth: sftpAuth,
   name: 'read_file_content',
   displayName: 'Read File Content',

--- a/packages/pieces/core/sftp/src/lib/actions/rename-file-or-folder.ts
+++ b/packages/pieces/core/sftp/src/lib/actions/rename-file-or-folder.ts
@@ -16,7 +16,7 @@ async function renameSFTP(client: Client, oldPath: string, newPath: string) {
 }
 
 export const renameFileOrFolderAction = createAction({
-  audience: 'both',
+  audience: 'human',
   auth: sftpAuth,
   name: 'renameFileOrFolder',
   displayName: 'Rename File or Folder',

--- a/packages/pieces/core/sftp/src/lib/actions/upload-file.ts
+++ b/packages/pieces/core/sftp/src/lib/actions/upload-file.ts
@@ -23,7 +23,7 @@ async function uploadFileToSFTP(client: Client, fileName: string, fileContent: {
 }
 
 export const uploadFileAction = createAction({
-  audience: 'both',
+  audience: 'human',
   auth: sftpAuth,
   name: 'upload_file',
   displayName: 'Upload File',

--- a/packages/pieces/core/smtp/package.json
+++ b/packages/pieces/core/smtp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-smtp",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {

--- a/packages/pieces/core/smtp/src/lib/actions/send-email.ts
+++ b/packages/pieces/core/smtp/src/lib/actions/send-email.ts
@@ -5,7 +5,7 @@ import { Attachment, Headers } from 'nodemailer/lib/mailer';
 import mime from 'mime-types';
 
 export const sendEmail = createAction({
-  audience: 'both',
+  audience: 'human',
   auth: smtpAuth,
   name: 'send-email',
   displayName: 'Send Email',

--- a/packages/pieces/core/store/package.json
+++ b/packages/pieces/core/store/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-store",
-  "version": "0.6.16",
+  "version": "0.6.17",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {

--- a/packages/pieces/core/store/src/lib/actions/store-add-to-list.ts
+++ b/packages/pieces/core/store/src/lib/actions/store-add-to-list.ts
@@ -55,7 +55,7 @@ import { common, getScopeAndKey, PieceStoreScope } from './common';
 }
 
 export const storageAddtoList = createAction({
-  audience: 'both',
+  audience: 'human',
 	name: 'add_to_list',
 	displayName: 'Add To List',
 	description: 'Add Items to a list.',

--- a/packages/pieces/core/store/src/lib/actions/store-append-action.ts
+++ b/packages/pieces/core/store/src/lib/actions/store-append-action.ts
@@ -43,7 +43,7 @@ async function executeStorageAppend(context: ActionContext<PieceAuthProperty | u
 }
 
 export const storageAppendAction = createAction({
-  audience: 'both',
+  audience: 'human',
   name: 'append',
   displayName: 'Append',
   description: 'Append to a value in storage',

--- a/packages/pieces/core/store/src/lib/actions/store-get-action.ts
+++ b/packages/pieces/core/store/src/lib/actions/store-get-action.ts
@@ -32,7 +32,7 @@ async function executeStorageGet(context: ActionContext<PieceAuthProperty | unde
 }
 
 export const storageGetAction = createAction({
-  audience: 'both',
+  audience: 'human',
   name: 'get',
   displayName: 'Get',
   description: 'Get a value from storage',

--- a/packages/pieces/core/store/src/lib/actions/store-put-action.ts
+++ b/packages/pieces/core/store/src/lib/actions/store-put-action.ts
@@ -33,7 +33,7 @@ async function executeStoragePut(context: ActionContext<PieceAuthProperty | unde
 }
 
 export const storagePutAction = createAction({
-  audience: 'both',
+  audience: 'human',
   name: 'put',
   displayName: 'Put',
   description: 'Put a value in storage',

--- a/packages/pieces/core/store/src/lib/actions/store-remove-from-list.ts
+++ b/packages/pieces/core/store/src/lib/actions/store-remove-from-list.ts
@@ -55,7 +55,7 @@ async function executeStorageRemoveFromList(context: ActionContext<PieceAuthProp
 }
 
 export const storageRemoveFromList = createAction({
-  audience: 'both',
+  audience: 'human',
   name: 'remove_from_list',
   displayName: 'Remove from List',
   description: 'Remove Item from a list',

--- a/packages/pieces/core/store/src/lib/actions/store-remove-value.ts
+++ b/packages/pieces/core/store/src/lib/actions/store-remove-value.ts
@@ -31,7 +31,7 @@ async function executeStorageRemoveValue(context: ActionContext<PieceAuthPropert
 }
 
 export const storageRemoveValue = createAction({
-  audience: 'both',
+  audience: 'human',
   name: 'remove_value',
   displayName: 'Remove',
   description: 'Remove a value from storage',

--- a/packages/pieces/core/subflows/package.json
+++ b/packages/pieces/core/subflows/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-subflows",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {

--- a/packages/pieces/core/subflows/src/lib/actions/call-flow.ts
+++ b/packages/pieces/core/subflows/src/lib/actions/call-flow.ts
@@ -9,7 +9,7 @@ import { ExecutionType, FAIL_PARENT_ON_FAILURE_HEADER, FlowStatus, isNil, PARENT
 import { CallableFlowRequest, CallableFlowResponse, findFlowByExternalIdOrThrow, listFlowsWithSubflowTrigger } from '../common';
 
 export const callFlow = createAction({
-  audience: 'both',
+  audience: 'human',
   name: 'callFlow',
   displayName: 'Call Flow',
   description: 'Call a flow that has "Callable Flow" trigger',

--- a/packages/pieces/core/subflows/src/lib/actions/respond.ts
+++ b/packages/pieces/core/subflows/src/lib/actions/respond.ts
@@ -4,7 +4,7 @@ import { httpClient, HttpMethod } from '@activepieces/pieces-common';
 import { isNil } from '@activepieces/pieces-framework';
 
 export const response = createAction({
-  audience: 'both',
+  audience: 'human',
   name: 'returnResponse',
   displayName: 'Return Response',
   description: 'Return response to the original flow',

--- a/packages/pieces/core/tables/package.json
+++ b/packages/pieces/core/tables/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-tables",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {

--- a/packages/pieces/core/tables/src/lib/actions/clear-table.ts
+++ b/packages/pieces/core/tables/src/lib/actions/clear-table.ts
@@ -3,7 +3,7 @@ import { tablesCommon } from '../common';
 import { AuthenticationType, httpClient, HttpMethod } from '@activepieces/pieces-common';
 
 export const clearTable = createAction({
-  audience: 'both',
+  audience: 'human',
   name: 'tables-clear-table',
   displayName: 'Clear Table',
   description: 'Delete all records from a table',

--- a/packages/pieces/core/tables/src/lib/actions/create-records.ts
+++ b/packages/pieces/core/tables/src/lib/actions/create-records.ts
@@ -4,7 +4,7 @@ import { CreateRecordsRequest } from '@activepieces/pieces-framework';
 import { tablesCommon } from '../common';
 
 export const createRecords = createAction({
-  audience: 'both',
+  audience: 'human',
   name: 'tables-create-records',
   displayName: 'Create Record(s)',
   description: 'Insert one or more new records to a table.',

--- a/packages/pieces/core/tables/src/lib/actions/create-table.ts
+++ b/packages/pieces/core/tables/src/lib/actions/create-table.ts
@@ -3,7 +3,7 @@ import { apId, createAction, FieldType, PieceAuth, Property, Table } from '@acti
 import * as z from 'zod/mini';
 
 export const createTable = createAction({
-  audience: 'both',
+  audience: 'human',
   name: 'tables-create-table',
   displayName: 'Create Table',
   description: 'Create a new table, optionally with fields.',

--- a/packages/pieces/core/tables/src/lib/actions/delete-record.ts
+++ b/packages/pieces/core/tables/src/lib/actions/delete-record.ts
@@ -3,7 +3,7 @@ import { tablesCommon } from '../common';
 import { AuthenticationType, httpClient, HttpMethod } from '@activepieces/pieces-common';
 
 export const deleteRecord = createAction({
-  audience: 'both',
+  audience: 'human',
   name: 'tables-delete-record',
   displayName: 'Delete Record(s)',
   description: 'Delete record(s) from a table',

--- a/packages/pieces/core/tables/src/lib/actions/delete-table.ts
+++ b/packages/pieces/core/tables/src/lib/actions/delete-table.ts
@@ -3,7 +3,7 @@ import { createAction, PieceAuth } from '@activepieces/pieces-framework';
 import { tablesCommon } from '../common';
 
 export const deleteTable = createAction({
-  audience: 'both',
+  audience: 'human',
   name: 'tables-delete-table',
   displayName: 'Delete Table',
   description: 'Delete a table and all of its records.',

--- a/packages/pieces/core/tables/src/lib/actions/download-table.ts
+++ b/packages/pieces/core/tables/src/lib/actions/download-table.ts
@@ -12,7 +12,7 @@ import {
 import { ExportTableResponse } from '@activepieces/pieces-framework';
 
 export const downloadTable = createAction({
-  audience: 'both',
+  audience: 'human',
   name: 'tables-download-table',
   displayName: 'Download Table',
   description: 'Export a table as a CSV file.',

--- a/packages/pieces/core/tables/src/lib/actions/find-records.ts
+++ b/packages/pieces/core/tables/src/lib/actions/find-records.ts
@@ -11,7 +11,7 @@ type FieldInfo = {
 };
 
 export const findRecords = createAction({
-  audience: 'both',
+  audience: 'human',
   name: 'tables-find-records',
   displayName: 'Find Records',
   description: 'Find records in a table with filters.',

--- a/packages/pieces/core/tables/src/lib/actions/get-record.ts
+++ b/packages/pieces/core/tables/src/lib/actions/get-record.ts
@@ -4,7 +4,7 @@ import { AuthenticationType, httpClient, HttpMethod } from '@activepieces/pieces
 import { PopulatedRecord } from '@activepieces/pieces-framework';
 
 export const getRecord = createAction({
-  audience: 'both',
+  audience: 'human',
   name: 'tables-get-record',
   displayName: 'Get Record',
   description: 'Get single record by its id.',

--- a/packages/pieces/core/tables/src/lib/actions/update-record.ts
+++ b/packages/pieces/core/tables/src/lib/actions/update-record.ts
@@ -4,7 +4,7 @@ import { AuthenticationType, httpClient, HttpMethod, propsValidation } from '@ac
 import { PopulatedRecord, UpdateRecordRequest } from '@activepieces/pieces-framework';
 
 export const updateRecord = createAction({
-  audience: 'both',
+  audience: 'human',
   name: 'tables-update-record',
   displayName: 'Update Record',
   description: 'Update values in an existing record',

--- a/packages/pieces/core/tags/package.json
+++ b/packages/pieces/core/tags/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-tags",
-  "version": "0.0.19",
+  "version": "0.0.20",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {

--- a/packages/pieces/core/tags/src/lib/add-tag.ts
+++ b/packages/pieces/core/tags/src/lib/add-tag.ts
@@ -8,7 +8,7 @@ This action add a tag to the current execution, this tag can be used to filter t
 `;
 
 export const addTag = createAction({
-  audience: 'both',
+  audience: 'human',
   name: 'add_tag',
   displayName: 'Add Tag',
   description: 'Add a tag to the current execution',

--- a/packages/pieces/core/text-helper/package.json
+++ b/packages/pieces/core/text-helper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-text-helper",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "dependencies": {

--- a/packages/pieces/core/text-helper/src/lib/actions/concat.ts
+++ b/packages/pieces/core/text-helper/src/lib/actions/concat.ts
@@ -1,7 +1,7 @@
 import { Property, createAction } from '@activepieces/pieces-framework';
 
 export const concat = createAction({
-  audience: 'both',
+  audience: 'human',
   description: 'Concatenate two or more texts',
   displayName: 'Concatenate',
   name: 'concat',

--- a/packages/pieces/core/text-helper/src/lib/actions/default-value.ts
+++ b/packages/pieces/core/text-helper/src/lib/actions/default-value.ts
@@ -2,7 +2,7 @@ import { createAction, Property } from '@activepieces/pieces-framework';
 import { isEmpty } from '@activepieces/pieces-framework';
 
 export const defaultValue = createAction({
-  audience: 'both',
+  audience: 'human',
   // auth: check https://www.activepieces.com/docs/developers/piece-reference/authentication,
   name: 'defaultValue',
   errorHandlingOptions: {

--- a/packages/pieces/core/text-helper/src/lib/actions/extract-from-html.ts
+++ b/packages/pieces/core/text-helper/src/lib/actions/extract-from-html.ts
@@ -2,7 +2,7 @@ import { createAction, Property } from '@activepieces/pieces-framework';
 import { JSDOM, VirtualConsole } from 'jsdom';
 
 export const extractFromHtml = createAction({
-  audience: 'both',
+  audience: 'human',
   name: 'extract_from_html',
   displayName: 'Extract from HTML',
   description: 'Extract specific elements or data from an HTML document.',

--- a/packages/pieces/core/text-helper/src/lib/actions/find-all.ts
+++ b/packages/pieces/core/text-helper/src/lib/actions/find-all.ts
@@ -1,7 +1,7 @@
 import { Property, createAction } from '@activepieces/pieces-framework';
 
 export const findAll = createAction({
-  audience: 'both',
+  audience: 'human',
   description: 'Find all substrings matching a regex or text pattern.',
   displayName: 'Find All',
   name: 'find_all',

--- a/packages/pieces/core/text-helper/src/lib/actions/find.ts
+++ b/packages/pieces/core/text-helper/src/lib/actions/find.ts
@@ -1,7 +1,7 @@
 import { Property, createAction } from '@activepieces/pieces-framework';
 
 export const find = createAction({
-  audience: 'both',
+  audience: 'human',
   description: 'Find substring (Regex or Text).',
   displayName: 'Find',
   name: 'find',

--- a/packages/pieces/core/text-helper/src/lib/actions/html-to-markdown.ts
+++ b/packages/pieces/core/text-helper/src/lib/actions/html-to-markdown.ts
@@ -5,7 +5,7 @@ import { gfm } from '@joplin/turndown-plugin-gfm';
 import turndownPluginTableNormalizer from '../utilities/html-to-markdown/turndown-table-normalizer-plugin';
 
 export const htmlToMarkdown = createAction({
-  audience: 'both',
+  audience: 'human',
   name: 'html_to_markdown',
   displayName: 'HTML to Markdown',
   description: 'Convert HTML to Markdown',

--- a/packages/pieces/core/text-helper/src/lib/actions/json-to-ascii-table.ts
+++ b/packages/pieces/core/text-helper/src/lib/actions/json-to-ascii-table.ts
@@ -1,7 +1,7 @@
 import { Property, createAction } from '@activepieces/pieces-framework';
 
 export const jsonToAsciiTable = createAction({
-  audience: 'both',
+  audience: 'human',
   description: 'Convert a list of items to a text table',
   displayName: 'List to Text Table',
   name: 'json_to_ascii_table',

--- a/packages/pieces/core/text-helper/src/lib/actions/markdown-to-html.ts
+++ b/packages/pieces/core/text-helper/src/lib/actions/markdown-to-html.ts
@@ -4,7 +4,7 @@ import { propsValidation } from '@activepieces/pieces-common';
 import { z, type ZodTypeAny } from 'zod';
 
 export const markdownToHTML = createAction({
-  audience: 'both',
+  audience: 'human',
   name: 'markdown_to_html',
   displayName: 'Markdown to HTML',
   description: 'Convert markdown to HTML',

--- a/packages/pieces/core/text-helper/src/lib/actions/replace.ts
+++ b/packages/pieces/core/text-helper/src/lib/actions/replace.ts
@@ -1,7 +1,7 @@
 import { Property, createAction } from '@activepieces/pieces-framework';
 
 export const replace = createAction({
-  audience: 'both',
+  audience: 'human',
   description:
     'Replaces all instances of any word, character or phrase in text, with another.',
   displayName: 'Replace',

--- a/packages/pieces/core/text-helper/src/lib/actions/slugify.ts
+++ b/packages/pieces/core/text-helper/src/lib/actions/slugify.ts
@@ -2,7 +2,7 @@ import slugify from 'slugify';
 import { Property, createAction } from '@activepieces/pieces-framework';
 
 export const slugifyAction = createAction({
-  audience: 'both',
+  audience: 'human',
   description: 'Slugifies strings.',
   displayName: 'Slugify',
   name: 'slugify',

--- a/packages/pieces/core/text-helper/src/lib/actions/split.ts
+++ b/packages/pieces/core/text-helper/src/lib/actions/split.ts
@@ -1,7 +1,7 @@
 import { Property, createAction } from '@activepieces/pieces-framework';
 
 export const split = createAction({
-  audience: 'both',
+  audience: 'human',
   description: 'Split a text by a delimiter',
   displayName: 'Split',
   name: 'split',

--- a/packages/pieces/core/text-helper/src/lib/actions/strip-html.ts
+++ b/packages/pieces/core/text-helper/src/lib/actions/strip-html.ts
@@ -2,7 +2,7 @@ import { stripHtml } from 'string-strip-html';
 import { createAction, Property } from '@activepieces/pieces-framework';
 
 export const stripHtmlContent = createAction({
-  audience: 'both',
+  audience: 'human',
   name: 'stripHtml',
   displayName: 'Remove HTML Tags',
   description: 'Removes every HTML tag and returns plain text',

--- a/packages/pieces/core/webhook/package.json
+++ b/packages/pieces/core/webhook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-webhook",
-  "version": "0.1.37",
+  "version": "0.1.38",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {

--- a/packages/pieces/core/webhook/src/lib/actions/return-response-and-wait-for-next-webhook.ts
+++ b/packages/pieces/core/webhook/src/lib/actions/return-response-and-wait-for-next-webhook.ts
@@ -18,7 +18,7 @@ import {
 
   const RESUME_WEBHOOK_HEADER = 'x-activepieces-resume-webhook-url';
   export const returnResponseAndWaitForNextWebhook = createAction({
-    audience: 'both',
+    audience: 'human',
     name: 'return_response_and_wait_for_next_webhook',
     displayName: 'Respond and Wait for Next Webhook',
     description: 'return a response and wait for the next webhook to resume the flow',

--- a/packages/pieces/core/webhook/src/lib/actions/return-response.ts
+++ b/packages/pieces/core/webhook/src/lib/actions/return-response.ts
@@ -21,7 +21,7 @@ enum FlowExecution {
 }
 
 export const returnResponse = createAction({
-  audience: 'both',
+  audience: 'human',
   name: 'return_response',
   displayName: 'Return Response',
   description: 'return a response',

--- a/packages/pieces/core/xml/package.json
+++ b/packages/pieces/core/xml/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-xml",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "dependencies": {

--- a/packages/pieces/core/xml/src/lib/actions/convert-json-to-xml.ts
+++ b/packages/pieces/core/xml/src/lib/actions/convert-json-to-xml.ts
@@ -2,7 +2,7 @@ import { createAction, Property } from '@activepieces/pieces-framework';
 import js2xml from 'json2xml';
 
 export const convertJsonToXml = createAction({
-  audience: 'both',
+  audience: 'human',
   name: 'convert-json-to-xml',
   displayName: 'Convert JSON to XML',
   description: 'Convert JSON to XML',

--- a/packages/pieces/core/xml/src/lib/actions/convert-xml-to-json.ts
+++ b/packages/pieces/core/xml/src/lib/actions/convert-xml-to-json.ts
@@ -2,7 +2,7 @@ import { createAction, Property } from '@activepieces/pieces-framework';
 import { XMLParser } from 'fast-xml-parser';
 
 export const convertXmlToJson = createAction({
-  audience: 'both',
+  audience: 'human',
   name: 'convert-xml-to-json',
   displayName: 'Convert XML to JSON',
   description: 'Convert XML to JSON',


### PR DESCRIPTION
## Description

Reverts #14413, which changed `audience: 'human'` to `audience: 'both'` on core and universal-AI piece actions, exposing them to agent tool discovery.

Each affected piece's `package.json` patch version is bumped one step past what #14413 already published (rather than reset back to the pre-#14413 version), since that version number is already in use with different content.

## How was this tested?

Manual review of the revert diff against #14413. Not run against a live builder session.

Fixes # (issue)

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)