### PR TITLE
fix(pieces): correct minimumSupportedRelease for apify and firecrawl

### DIFF
--- a/packages/pieces/community/apify/package.json
+++ b/packages/pieces/community/apify/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-apify",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {

--- a/packages/pieces/community/apify/src/index.ts
+++ b/packages/pieces/community/apify/src/index.ts
@@ -79,7 +79,7 @@ export const apify = createPiece({
   displayName: 'Apify',
   description: 'Access Apify tools for web scraping, data extraction, and automation.',
   auth: apifyAuth,
-  minimumSupportedRelease: '0.84.6',
+  minimumSupportedRelease: '0.86.4',
   logoUrl: 'https://cdn.activepieces.com/pieces/apify.png',
   categories: [PieceCategory.BUSINESS_INTELLIGENCE],
   authors: ['buttonsbond'],

--- a/packages/pieces/community/firecrawl/package.json
+++ b/packages/pieces/community/firecrawl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-firecrawl",
-  "version": "0.3.11",
+  "version": "0.3.12",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {

--- a/packages/pieces/community/firecrawl/src/index.ts
+++ b/packages/pieces/community/firecrawl/src/index.ts
@@ -28,7 +28,7 @@ import { firecrawlAuth } from './lib/auth';
 export const firecrawl = createPiece({
   displayName: 'Firecrawl',
   description: 'Extract structured data from websites using AI with natural language prompts',
-  minimumSupportedRelease: '0.84.6',
+  minimumSupportedRelease: '0.86.4',
   logoUrl: 'https://cdn.activepieces.com/pieces/firecrawl.png',
   categories: [PieceCategory.ARTIFICIAL_INTELLIGENCE],
   authors: ["geekyme-fsmk", "geekyme", "arinmakk"],


### PR DESCRIPTION
## Description

`minimumSupportedRelease` on the `apify` and `firecrawl` pieces was mistakenly set to `0.84.6` — an already-shipped release — in #14378. Since `isSupportedRelease()` only hides a piece while the running server release is below `minimumSupportedRelease`, this had no gating effect and the new AI-agent actions were immediately visible everywhere instead of only on servers running `>= 0.86.4`.

This corrects the value to `0.86.4` and bumps both piece versions (`apify` 0.2.8→0.2.9, `firecrawl` 0.3.11→0.3.12) so `release-pieces.yml` republishes them with the fixed metadata.

## How was this tested?

Verified `isSupportedRelease` (`packages/server/api/src/app/pieces/metadata/utils/piece-cache-utils.ts`) compares the running release against `minimumSupportedRelease` via semver, and that `release-pieces.yml`'s `find-changed-pieces.ts` only republishes a piece when its `package.json` version changes vs. the cloud registry — confirming the version bump is required for this fix to actually reach npm/Cloud.

Fixes # (issue)

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact