### PR TITLE
docs: document the configurable Store value size limit

### DIFF
--- a/docs/install/configure-operate/production-setup.mdx
+++ b/docs/install/configure-operate/production-setup.mdx
@@ -68,6 +68,7 @@ Full methodology and the ratio comparison: [Benchmark](../architecture/benchmark
 | Max webhook payload | 25 MB | `AP_MAX_WEBHOOK_PAYLOAD_SIZE_MB` |
 | Step file size | 25 MB | `AP_MAX_FILE_SIZE_MB` |
 | Flow run log size | 50 MB | `AP_MAX_FLOW_RUN_LOG_SIZE_MB` |
+| Max store value | 512 KB | `AP_MAX_STORE_ENTRY_VALUE_SIZE_KB` |
 
 The complete table lives in [Limits](/install/reference/limits).
 

--- a/docs/install/reference/environment-variables.mdx
+++ b/docs/install/reference/environment-variables.mdx
@@ -165,6 +165,7 @@ run data is kept. The **Cloud** values and how these interact are covered in
 | `AP_PAUSED_FLOW_TIMEOUT_DAYS` | Maximum pause duration for a paused flow, in days. Cannot exceed `AP_EXECUTION_DATA_RETENTION_DAYS`. | `30` |
 | `AP_ISSUE_ARCHIVE_DAYS` | Issues not updated for this many days are automatically archived. | `7` |
 | `AP_MAX_FILE_SIZE_MB` | Maximum size (MB) for files uploaded in steps or triggers. Larger files are rejected. | `25` |
+| `AP_MAX_STORE_ENTRY_VALUE_SIZE_KB` | Maximum size (KB) of a single value written by the Store piece or `context.store`. Larger writes are rejected with HTTP 413. | `512` |
 | `AP_MAX_FLOW_RUN_LOG_SIZE_MB` | Maximum combined size (MB) of all step inputs and outputs in a single run. Exceeding it ends the run with `LOG_SIZE_EXCEEDED`. | `50` |
 | `AP_FLOW_RUN_LOG_SLICE_THRESHOLD_KB` | Step outputs larger than this (KB) are offloaded to object storage instead of inlined in the run log. | `32` |
 | `AP_FLOW_RUN_LOG_INPUT_TRUNCATE_THRESHOLD_KB` | Step inputs larger than this (KB) are replaced with a placeholder in the run log; the step still receives the full value at runtime. | `2` |

--- a/docs/install/reference/limits.mdx
+++ b/docs/install/reference/limits.mdx
@@ -125,10 +125,18 @@ memory; smaller payloads stay inline for the fastest path.
 ### Key / value storage
 
 Used by the built-in **Store** piece and any piece that calls `context.store`.
+Values are stored directly in Postgres (`jsonb`), so unlike files and run logs
+they are **not** offloaded to object storage. Every stored value counts toward
+your database size and is read and written in full on each access.
 
-| Limit | Value |
-|---|---|
-| Maximum key length | 128 characters |
-| Maximum value size | 512 KB |
+| Limit | Cloud | Env var | Self-hosted default |
+|---|---|---|---|
+| Maximum key length | 128 characters | not configurable | `128` |
+| Maximum value size | 512 KB | `AP_MAX_STORE_ENTRY_VALUE_SIZE_KB` | `512` |
 
-These limits are not configurable.
+<Tip>
+Raising the value size lets a flow stash bigger payloads (for example, data
+gathered inside router branches and re-read after the branches join). But large
+values live in the database with no object-storage offload. For payloads in the
+MB range, prefer the **Tables** piece or pass data as files between steps.
+</Tip>


### PR DESCRIPTION
Fixes [GIT-1666](https://linear.app/activepieces/issue/GIT-1666)
Closes #14441

## Description
The Store value size limit (512 KB) was documented as "not configurable", while the other three size limits each document their `AP_MAX_*` env var and default. This documents the Store limit becoming configurable and makes the four size limits consistent across the reference docs.

- `docs/install/reference/limits.mdx` — Key/value storage section: the value-size row now lists the env var and self-hosted default, adds the Postgres-`jsonb` / no-offload note and a `<Tip>`, and drops the "not configurable" line.
- `docs/install/reference/environment-variables.mdx` — new `AP_MAX_STORE_ENTRY_VALUE_SIZE_KB` row (default `512`).
- `docs/install/configure-operate/production-setup.mdx` — new "Max store value" row in the limits table.

Do NOT merge before the backend change (SRE-201) ships: `AP_MAX_STORE_ENTRY_VALUE_SIZE_KB` does not exist in code yet, so merging first would document a knob with no effect.

## How was this tested?
Docs-only (3 mdx files, no code). Mintlify link-rot + vale-spellcheck checks pass. Code gates (lint-dev, unit/api tests, /verify, /simplify, /code-review, /security-review) N/A — nothing executable changed.

Visual: none - documentation pages only, no application UI change.

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)