### PR TITLE
fix(schedule): Every X Minutes trigger no longer runs twice per hour

### DIFF
--- a/packages/pieces/core/schedule/package.json
+++ b/packages/pieces/core/schedule/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-schedule",
-  "version": "0.1.19",
+  "version": "0.1.20",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {


### PR DESCRIPTION
Fixes [GIT-1667](https://linear.app/activepieces/issue/GIT-1667)
Closes #14442

## Problem

"Every X Minutes" with an interval that doesn't divide 60 (e.g. 11) fires twice near the top of the hour (:55 and :00). The interval fix for this already merged, but was stranded: the re-apply (#14393) reused piece version `0.1.19`, which npm had already published as the reverted cron-only build (#14391). So the fixed build never shipped and every flow on the latest schedule piece still compiles to `*/N` cron.

## Fix

- `packages/pieces/core/schedule/package.json`: `0.1.19 → 0.1.20`, minting a fresh publishable version that carries the interval `onEnable` already in source. Flows on `0.1.20` schedule via a rolling interval, not a `*/N` cron, so they fire once per interval.

## Verification

- Unit: `packages/pieces/core/schedule` — 2/2 pass (`onEnable` emits `intervalMs` for 59 and 5). Interval logic is pre-existing and unchanged by this diff.
- Lint: clean (1 pre-existing unrelated warning in `cron-expression.trigger.ts`).
- /verify, /simplify, /code-review, /security-review, red-first regression: N/A — the diff is a single version-string bump, no logic or security surface.
- Visual: none - piece version bump only, no user-visible code/UI change.

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)