### PR TITLE
fix(mcp): keep MCP OAuth sessions alive past 15 minutes

### DIFF
--- a/packages/server/api/src/app/mcp/oauth/token/mcp-oauth-token.service.ts
+++ b/packages/server/api/src/app/mcp/oauth/token/mcp-oauth-token.service.ts
@@ -101,6 +101,7 @@ export const mcpOAuthTokenService = {
             access_token: accessToken,
             token_type: 'Bearer',
             expires_in: ACCESS_TOKEN_TTL_15_MINUTES_SECONDS,
+            refresh_token: params.refreshToken,
         }
     },
 

--- a/packages/server/api/test/integration/ce/mcp/mcp-oauth-token.test.ts
+++ b/packages/server/api/test/integration/ce/mcp/mcp-oauth-token.test.ts
@@ -1,0 +1,81 @@
+import { createHash, randomBytes } from 'crypto'
+import { apId } from '@activepieces/core-utils'
+import { FastifyInstance } from 'fastify'
+import { beforeAll, describe, expect, it } from 'vitest'
+import { mcpOAuthClientService } from '../../../../src/app/mcp/oauth/client/mcp-oauth-client.service'
+import { mcpOAuthTokenService } from '../../../../src/app/mcp/oauth/token/mcp-oauth-token.service'
+import { setupTestEnvironment } from '../../../helpers/test-setup'
+
+let app: FastifyInstance
+
+function requireRefreshToken(response: { refresh_token?: string }): string {
+    if (response.refresh_token === undefined) {
+        throw new Error('expected a refresh_token in the token response')
+    }
+    return response.refresh_token
+}
+
+async function exchangeFreshCode(clientId: string): Promise<string> {
+    const codeVerifier = randomBytes(32).toString('base64url')
+    const codeChallenge = createHash('sha256').update(codeVerifier).digest().toString('base64url')
+    const tokens = await mcpOAuthTokenService.exchangeCode({
+        codeVerifier,
+        codeChallenge,
+        codeChallengeMethod: 'S256',
+        clientId,
+        userId: apId(),
+        projectId: apId(),
+        platformId: apId(),
+        scopes: ['mcp'],
+    })
+    return requireRefreshToken(tokens)
+}
+
+describe('MCP OAuth token refresh', () => {
+    beforeAll(async () => {
+        app = await setupTestEnvironment({ fresh: true })
+    })
+
+    it('echoes the presented refresh token back so clients cannot lose it', async () => {
+        const clientId = apId()
+        const refreshToken = await exchangeFreshCode(clientId)
+
+        const refreshed = await mcpOAuthTokenService.refreshAccessToken({ refreshToken, clientId })
+
+        expect(refreshed.access_token).toBeTypeOf('string')
+        expect(refreshed.refresh_token).toBe(refreshToken)
+    })
+
+    it('keeps refreshing indefinitely using the token from the previous response', async () => {
+        const clientId = apId()
+        const first = await exchangeFreshCode(clientId)
+
+        const second = await mcpOAuthTokenService.refreshAccessToken({ refreshToken: first, clientId })
+        const third = await mcpOAuthTokenService.refreshAccessToken({ refreshToken: requireRefreshToken(second), clientId })
+
+        expect(third.refresh_token).toBe(first)
+    })
+
+    it('returns the refresh token in the /token HTTP response a client persists', async () => {
+        const client = await mcpOAuthClientService.register({
+            redirectUris: ['https://example.com/callback'],
+            tokenEndpointAuthMethod: 'none',
+        })
+        const refreshToken = await exchangeFreshCode(client.client_id)
+
+        const res = await app.inject({
+            method: 'POST',
+            url: '/token',
+            payload: {
+                grant_type: 'refresh_token',
+                client_id: client.client_id,
+                refresh_token: refreshToken,
+            },
+        })
+
+        expect(res.statusCode).toBe(200)
+        const body = res.json()
+        expect(body.access_token).toBeTypeOf('string')
+        expect(body.refresh_token).toBe(refreshToken)
+    })
+})


### PR DESCRIPTION
Fixes [GIT-1663](https://linear.app/activepieces/issue/GIT-1663)
Closes #14411

## Problem
MCP OAuth refresh (`POST /token`, `grant_type=refresh_token`) returned `{ access_token, token_type, expires_in }` with no `refresh_token`, while the access token lives only 15 minutes. Clients that persist the token response verbatim (reported with OpenAI Codex) overwrote their stored refresh token with one that had none, then were forced to re-authorize roughly every 15 minutes, indefinitely. The discovery metadata advertises `refresh_token` in `grant_types_supported`, so clients reasonably expect refresh to keep working.

## Fix
`mcp-oauth-token.service.ts` (`refreshAccessToken`) now echoes the presented `refresh_token` back in the response (permitted by RFC 6749 section 6), so the value is re-asserted on every refresh and clients cannot lose it. `TokenResponse.refresh_token` was already optional, so it is a one-line change.

## Verification
- New CE integration test `mcp-oauth-token.test.ts`: service refresh returns the presented token, a chained refresh using the previous response keeps working, and the real `POST /token` HTTP response body carries `refresh_token`. Red-first confirmed: against pre-fix code the assertion sees `undefined` and all three cases fail.
- lint clean on both changed files.
- Manual code-review: single line on the already-validated success path (record exists, not revoked, unexpired, client matches); echoes the client's own presented token. Full persona panel skipped as disproportionate for a one-line change.
- Security: no new exposure. The echoed value is the exact token the client presented in the same request, returned only on the validated success path; token lifetime and (non-)rotation are unchanged. No findings.
- Visual: none, backend-only, no user-visible change.

### Breaking change?

- [x] no, reviewed and not breaking
- [ ] yes, technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes, functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?

- [ ] no, reviewed, no security impact
- [x] yes, security-sensitive. Touches the MCP OAuth token-refresh path. Risk: leaking a refresh token. Mitigation: the response only re-asserts the exact token the client already presented, on the validated success path (unrevoked, unexpired, matching client), so nothing new is exposed and lifetime/rotation are unchanged.