### PR TITLE
fix(sandbox): enforce the sandbox memory limit in isolate modes and stop miscounting shutdown kills as OOMs

### DIFF
--- a/packages/server/sandbox/src/lib/sandbox/fork.ts
+++ b/packages/server/sandbox/src/lib/sandbox/fork.ts
@@ -1,4 +1,5 @@
 import { fork } from 'child_process'
+import { engineNodeArgs } from './node-args'
 import { SandboxProcessMaker } from './types'
 
 export function simpleProcess(enginePath: string, codeDirectory: string): SandboxProcessMaker {
@@ -10,12 +11,7 @@ export function simpleProcess(enginePath: string, codeDirectory: string): Sandbo
                 // of memory" aborts) that never travels over the RPC socket. Without this, a hard
                 // engine crash surfaces only as an opaque "Worker exited with code 1 ... standardError=".
                 silent: true,
-                execArgv: [
-                    // IMPORTANT DO NOT REMOVE THIS ARGUMENT: https://github.com/laverdet/isolated-vm/issues/424
-                    '--no-node-snapshot',
-                    '--expose-gc',
-                    `--max-old-space-size=${params.resourceLimits.memoryLimitMb}`,
-                ],
+                execArgv: engineNodeArgs(params.resourceLimits),
                 env: {
                     ...params.env,
                     AP_BASE_CODE_DIRECTORY: codeDirectory,

--- a/packages/server/sandbox/src/lib/sandbox/isolate.ts
+++ b/packages/server/sandbox/src/lib/sandbox/isolate.ts
@@ -3,6 +3,7 @@ import { mkdir } from 'fs/promises'
 import path from 'path'
 import { arch } from 'process'
 import { execPromise } from '../utils/exec'
+import { engineNodeArgs } from './node-args'
 import { CreateSandboxProcessParams, SandboxLogger, SandboxMount, SandboxProcessMaker } from './types'
 
 export function getIsolateExecutableName(nodeArch: NodeJS.Architecture = arch): string {
@@ -58,7 +59,7 @@ const etcDir = path.resolve(process.cwd(), 'packages/server/api/src/assets/etc')
 export function isolateProcess(log: SandboxLogger, enginePath: string, _codeDirectory: string, boxId: number): SandboxProcessMaker {
     return {
         create: async (params: CreateSandboxProcessParams) => {
-            const { sandboxId, mounts, env } = params
+            const { sandboxId, mounts, env, resourceLimits } = params
 
             for (const mount of mounts) {
                 assertMountInsideRoot(mount)
@@ -118,6 +119,7 @@ export function isolateProcess(log: SandboxLogger, enginePath: string, _codeDire
                 '--run',
                 '--',
                 process.execPath,
+                ...engineNodeArgs(resourceLimits),
                 engineSandboxPath,
             ]
 

--- a/packages/server/sandbox/src/lib/sandbox/node-args.ts
+++ b/packages/server/sandbox/src/lib/sandbox/node-args.ts
@@ -1,0 +1,16 @@
+import { SandboxResourceLimits } from './types'
+
+// Every engine child needs these, in every execution mode. isolate caps nothing itself (we pass
+// no --mem, no --cg-mem), so --max-old-space-size is the ONLY thing bounding engine memory —
+// without it the engine ran with V8's default heap, outgrew its container, and was SIGKILLed by
+// the kernel OOM killer with no diagnostics (isolate reports only "Caught fatal signal 9").
+// --expose-gc is equally load-bearing: the engine's periodic forced GC in worker-socket.ts is
+// silently a no-op when global.gc is undefined.
+export function engineNodeArgs(resourceLimits: SandboxResourceLimits): string[] {
+    return [
+        // IMPORTANT DO NOT REMOVE THIS ARGUMENT: https://github.com/laverdet/isolated-vm/issues/424
+        '--no-node-snapshot',
+        '--expose-gc',
+        `--max-old-space-size=${resourceLimits.memoryLimitMb}`,
+    ]
+}

--- a/packages/server/sandbox/src/lib/sandbox/sandbox.ts
+++ b/packages/server/sandbox/src/lib/sandbox/sandbox.ts
@@ -395,7 +395,17 @@ function handleProcessExit(log: SandboxLogger, params: ProcessExitParams): void 
         killedByTimeout: String(killedByTimeout),
         killedByShutdown: String(killedByShutdown),
     }, '[Sandbox] Process exit event fired')
-    const isRamIssue = stdError.includes('JavaScript heap out of memory') || stdError.includes('Allocation failed - JavaScript heap out of memory') || stdError.includes('Caught fatal signal 9') || (code === 134 || signal === 'SIGABRT' || (signal === 'SIGKILL' && !killedByShutdown))
+    // V8 saying it ran out of heap, or aborting, is unambiguous — nothing we do produces those, so
+    // they count as a RAM issue even mid-shutdown. A SIGKILL is NOT unambiguous: the kernel OOM
+    // killer sends one, but so does our own treeKill in shutdown(), and in isolate mode that makes
+    // isolate print "Caught fatal signal 9" itself. Attributing those to the flow reports every
+    // deploy-time abort as the user running out of memory, and a deploy disconnects all workers at
+    // once — enough to dominate the MEMORY_LIMIT_EXCEEDED count and bury the real OOMs in it. A real
+    // OOM racing a shutdown is indistinguishable from our own kill and is lost to the retry path;
+    // that is the safer way round, since shutdown-aborted runs are retried anyway.
+    const isUnambiguousRamIssue = stdError.includes('JavaScript heap out of memory') || stdError.includes('Allocation failed - JavaScript heap out of memory') || code === 134 || signal === 'SIGABRT'
+    const isAmbiguousKill = stdError.includes('Caught fatal signal 9') || signal === 'SIGKILL'
+    const isRamIssue = isUnambiguousRamIssue || (isAmbiguousKill && !killedByShutdown)
     const isLogSizeExceeded = stdError.includes('Flow run data size exceeded the maximum allowed size')
 
     if (killedByTimeout) {

--- a/packages/server/sandbox/test/lib/sandbox/isolate.test.ts
+++ b/packages/server/sandbox/test/lib/sandbox/isolate.test.ts
@@ -198,10 +198,16 @@ describe('isolateProcess', () => {
         it('runs node with engine path at /root/common/<basename>', async () => {
             await callCreate({ enginePath: '/any/where/engine-main.js' })
             const args: string[] = spawnMock.mock.calls[0][1]
-            expect(args[args.length - 2]).toBe(process.execPath)
-            expect(args[args.length - 1]).toBe('/root/common/engine-main.js')
-            expect(args[args.length - 3]).toBe('--')
-            expect(args[args.length - 4]).toBe('--run')
+            const runIndex = args.indexOf('--run')
+            expect(args.slice(runIndex)).toEqual([
+                '--run',
+                '--',
+                process.execPath,
+                '--no-node-snapshot',
+                '--expose-gc',
+                '--max-old-space-size=256',
+                '/root/common/engine-main.js',
+            ])
         })
 
         it('spawns with shell: false', async () => {

--- a/packages/server/sandbox/test/lib/sandbox/sandbox.test.ts
+++ b/packages/server/sandbox/test/lib/sandbox/sandbox.test.ts
@@ -733,6 +733,64 @@ describe('createSandbox', () => {
             }
         })
 
+        // We SIGKILL the sandbox ourselves on shutdown, and isolate prints the same "Caught fatal
+        // signal 9" it prints for an OOM kill — so a deploy-time abort must not be reported as the
+        // user's flow exhausting memory.
+        it('does NOT classify a shutdown-initiated SIGKILL as SANDBOX_MEMORY_ISSUE', async () => {
+            const { sandbox } = await startSandbox()
+            const client = testPM.getClient()
+            const child = testPM.getChild()
+
+            client.on('rpc', () => {
+                void sandbox.shutdown()
+                ;(child.stderr as unknown as EventEmitter).emit('data', Buffer.from('Caught fatal signal 9\n'))
+                setTimeout(() => child.emit('close', 1, null), 20)
+            })
+
+            const executePromise = sandbox.execute(
+                'EXECUTE_FLOW' as any,
+                {} as any,
+                { timeoutInSeconds: 10 },
+            )
+
+            await expect(executePromise).rejects.toThrow()
+            try {
+                await executePromise
+            }
+            catch (err) {
+                expect((err as ActivepiecesError).error.code).not.toBe(ErrorCode.SANDBOX_MEMORY_ISSUE)
+                expect((err as ActivepiecesError).error.code).toBe(ErrorCode.SANDBOX_INTERNAL_ERROR)
+            }
+        })
+
+        // A V8 heap-OOM message can only come from the engine actually exhausting memory — we never
+        // produce it — so a concurrent shutdown must not strip the memory classification off it.
+        it('still classifies a V8 heap-OOM as SANDBOX_MEMORY_ISSUE even during shutdown', async () => {
+            const { sandbox } = await startSandbox()
+            const client = testPM.getClient()
+            const child = testPM.getChild()
+
+            client.on('rpc', () => {
+                void sandbox.shutdown()
+                ;(child.stderr as unknown as EventEmitter).emit('data', Buffer.from('FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory\n'))
+                setTimeout(() => child.emit('close', 1, null), 20)
+            })
+
+            const executePromise = sandbox.execute(
+                'EXECUTE_FLOW' as any,
+                {} as any,
+                { timeoutInSeconds: 10 },
+            )
+
+            await expect(executePromise).rejects.toThrow()
+            try {
+                await executePromise
+            }
+            catch (err) {
+                expect((err as ActivepiecesError).error.code).toBe(ErrorCode.SANDBOX_MEMORY_ISSUE)
+            }
+        })
+
         it('cleans up listener, timeout, and event handlers in finally block', async () => {
             const { sandbox } = await startSandbox()
             const client = testPM.getClient()


### PR DESCRIPTION
## Description

Two defects in how sandbox memory failures are bounded and attributed.

**1. `AP_SANDBOX_MEMORY_LIMIT` did nothing in the isolate execution modes.** `isolateProcess` destructured only `{ sandboxId, mounts, env }` and dropped `resourceLimits`. isolate is spawned without `--mem`/`--cg-mem`, so `--max-old-space-size` is the *only* thing bounding engine memory — under `SANDBOX_PROCESS` and `SANDBOX_CODE_AND_PROCESS` the engine ran with V8's default heap (several GB) and the configured limit was dead config. It grew past its container and was SIGKILLed by the kernel OOM killer, which leaves no diagnostics: isolate reports only `Caught fatal signal 9`, so the run surfaced as `SANDBOX_INTERNAL_ERROR` (pages on-call) instead of `MEMORY_LIMIT_EXCEEDED`. A cap also makes V8 collect harder as it nears the limit, so some of these runs now complete instead of dying.

The same omission skipped `--expose-gc` (without which the engine's periodic forced GC in `worker-socket.ts` is a no-op — it guards on `typeof global.gc === 'function'`) and `--no-node-snapshot` (required wherever isolated-vm loads, [isolated-vm#424](https://github.com/laverdet/isolated-vm/issues/424) — including `SANDBOX_CODE_AND_PROCESS`, where code steps run in isolated-vm inside the sandbox). Both process makers now build their argv through one `engineNodeArgs()` helper. **Fork mode is unchanged** — identical flags and value.

**2. Our own shutdown kills were counted as flow memory failures.** The `!killedByShutdown` guard was bound to the bare `SIGKILL` clause only, so the `Caught fatal signal 9` string match fired unconditionally — and `shutdown()` sets that flag then `treeKill`s with SIGKILL, which makes isolate print exactly that string. So every deploy-time abort was reported as the user's flow running out of memory, in bursts proportional to deploy frequency. The guard now covers all evidence we could have produced ourselves; V8's own heap-OOM messages and its `SIGABRT`/134 abort stay unambiguous (`treeKill` never sends SIGABRT) and still classify as memory even mid-shutdown.

**Trade-off to review:** a real OOM racing a shutdown is now indistinguishable from our own kill and falls to the retry path. SIGKILL carries no attribution, so this is unavoidable one way or the other — I chose the direction where the cost is a mislabel on a run that reruns anyway, rather than burying genuine OOMs in deploy noise.

**Not in this PR:** reserving non-heap headroom when the limit is *derived* from container memory (the `AP_WORKER_CONCURRENCY=1` path). A cap at 100% of the container can't beat the OOM killer, since V8's old space is only part of RSS — so **signal 9 is reduced here, not eliminated.** Worth sizing that reserve from measurement rather than an estimate.

## How was this tested?

`npx vitest run --root packages/server/sandbox` — 171 passing, including three new assertions: the full isolate argv tail, a shutdown SIGKILL *not* classified as a memory issue, and a V8 heap-OOM *still* classified as one during shutdown. `npm run lint-dev` clean. Worker/sandbox-internal with no edition-gated surface, so CE/EE/Cloud are identical — the affected path is selected by `AP_EXECUTION_MODE`.

Fixes # (issue)

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

Makes a documented setting take effect where it silently did nothing; no env var added, removed, or renamed, and no configured value changes meaning. `UNSANDBOXED` (the default) and `SANDBOX_CODE_ONLY` are unaffected.

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)

Adds resource-limit flags to a process we already spawn, and narrows an error-classification branch. No change to isolation boundaries, mounts, env handling, or network policy.
