### PR TITLE
fix(pieces): drop bundleDeps:false from amazon-s3 and image-helper

### DIFF
--- a/packages/pieces/community/amazon-s3/package.json
+++ b/packages/pieces/community/amazon-s3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-amazon-s3",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "dependencies": {
@@ -17,7 +17,6 @@
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
   },
-  "bundleDeps": false,
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",
     "bundle": "node ../../../../dist/packages/cli/src/index.js pieces bundle",

--- a/packages/pieces/core/image-helper/package.json
+++ b/packages/pieces/core/image-helper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-image-helper",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "dependencies": {
@@ -14,7 +14,6 @@
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
   },
-  "bundleDeps": false,
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",
     "bundle": "node ../../../../dist/packages/cli/src/index.js pieces bundle",


### PR DESCRIPTION
## Problem

`amazon-s3` and `image-helper` both had `"bundleDeps": false` in their `package.json`, originally added because the esbuild piece-bundler couldn't safely handle their native/`import.meta`-using deps (openpgp for amazon-s3, sharp for image-helper). #14230 fixed the bundler itself — it now correctly auto-externalizes only the specific deps that can't be inlined (transitive natives + `import.meta` users) instead of requiring a piece to fall back to externalizing everything.

But #14230 was bundler-only and explicitly deferred flipping `bundleDeps: false` back off on the affected pieces. Because it's still set, `bundleDeps: false` forces the bundler to externalize **every** third-party dependency — including `zod`, which these pieces need transitively via `@activepieces/pieces-framework`/`pieces-common`. Nothing re-installs deps between the release workflow's "Prepare pieces for publish" (bundling) step and "update pieces metadata" step, so that step's `load-piece-metadata-child.mjs` immediately fails with `Cannot find module 'zod/mini'` when it `require()`s the freshly-bundled dist.

This doesn't fail CI loudly: `loadPieceFromFolder` swallows the error (`console.error(ex); return null`), so the "update pieces metadata" step shows green while silently skipping these two pieces' metadata publish. See https://github.com/activepieces/activepieces/actions/runs/30329949047/job/90183336654.

## Fix

Drop `"bundleDeps": false` from both pieces' `package.json` so the bundler's default (inline everything, auto-externalize only what's unsafe) applies — matching #14230's own verification table:

| Piece | External (before) | External (after) |
|---|---|---|
| amazon-s3 | 13 packages incl. `zod` | `openpgp` only |
| image-helper | everything incl. `zod` | `sharp` only (native) |

Version bumped for both (patch) since the published bundle content changes.

## Verification

Ran the exact CI steps locally against real build output (not synthetic):
- `npx turbo run build --filter=<piece>` → `prepare-pieces-for-publish.ts` (scoped via `CHANGED_PIECES`) → confirmed `external=[openpgp]` / `external=[sharp]` only.
- `load-piece-metadata-child.mjs` (the exact script the failing CI step runs) loads both pieces successfully — full valid metadata returned, no errors.
- Simulated a **real production install**: copied each piece's published `dist/` into an isolated directory with no connection to the monorepo's `node_modules`, ran `npm install` there (mirrors what the engine does when installing a piece for a flow) — both installed cleanly.
- **Executed real actions** in that isolated install, not just metadata introspection:
  - amazon-s3: real `openpgp` encrypt → decrypt round-trip succeeded.
  - image-helper: real `sharp` PNG → AVIF conversion succeeded (437-byte output).

## Test plan

- [x] Piece builds and bundles with only the expected native/unsafe dep externalized
- [x] `update-pieces-metadata`'s loader succeeds against the built dist
- [x] Fresh isolated `npm install` of the published bundle succeeds
- [x] A representative action from each piece actually executes correctly post-install

### Breaking change?

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)
