### PR TITLE
fix(cli): fix TS narrowing bug that broke the CLI compile and generate-translations.yml

### DIFF
--- a/packages/cli/src/lib/commands/benchmark.ts
+++ b/packages/cli/src/lib/commands/benchmark.ts
@@ -681,7 +681,7 @@ function renderReport(report: BenchmarkReport): void {
 
     console.log(chalk.bold('\nProject'));
     console.log(`  throwaway project (auto-created, deleted after) : ${report.project.id}`);
-    if (report.project.limits.available) {
+    if (report.project.limits.available === true) {
         const cap = report.project.limits.maxConcurrentJobs;
         const capLabel = cap === null ? 'unset (platform default)' : `${cap} concurrent jobs`;
         // The benchmark project is uncapped on purpose, so these numbers can't throttle THIS run — they are


### PR DESCRIPTION
## Description

`generate-translations.yml` has failed on every scheduled run since 2026-07-21 (introduced by #14181).

The workflow runs `npm run cli pieces generate-translation-file-for-all-pieces` via `ts-node`, which type-checks the whole `packages/cli/src/index.ts` import graph — including the unrelated `benchmark` command. `packages/cli/tsconfig.json` doesn't set `strictNullChecks`; without it, TypeScript fails to narrow a discriminated union (`ProjectLimits`) via implicit boolean truthiness (`if (x.available) {} else {}`), so the `else` branch in `renderReport()` was still typed as the `available: true` shape, which has no `.reason` field — `TS2339: Property 'reason' does not exist on type 'ProjectLimits'`. That single error broke compilation of the entire CLI package, taking the unrelated translation-generation workflow down with it.

Fix: use an explicit `=== true` comparison, which narrows the union correctly regardless of `strictNullChecks`.

## How was this tested?

Reproduced the exact compile failure locally with the same `ts-node` invocation the workflow uses, confirmed the fix resolves it (CLI compiles and proceeds into translation generation). CLI-only change, not edition-specific (CE/EE/Cloud).

Fixes # (issue)

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)