### PR TITLE
fix(github): bump minimumSupportedRelease to 0.86.4

### DIFF
--- a/packages/pieces/community/github/package.json
+++ b/packages/pieces/community/github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-github",
-  "version": "0.8.7",
+  "version": "0.8.8",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {

--- a/packages/pieces/community/github/src/index.ts
+++ b/packages/pieces/community/github/src/index.ts
@@ -105,7 +105,7 @@ export const github = createPiece({
   description:
     'Developer platform that allows developers to create, store, manage and share their code',
 
-  minimumSupportedRelease: '0.30.0',
+  minimumSupportedRelease: '0.86.4',
   logoUrl: 'https://cdn.activepieces.com/pieces/github.png',
   categories: [PieceCategory.DEVELOPER_TOOLS],
   auth: githubAuth,


### PR DESCRIPTION
## Description

Bumps the GitHub piece's `minimumSupportedRelease` from `0.30.0` to `0.86.4`. The piece now depends on engine features added after `0.30.0` (agent atomics, #13972); the stale value let older, incompatible engines load the piece. Bumping it ensures only engines that actually support the piece pick it up.

## How was this tested?

Ran `npx turbo run lint --filter=github`. Single-value config change — no runtime behaviour to test.

Fixes # (issue)

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)
