### PR TITLE
fix(slack): remove false-green test from channel_created trigger

### DIFF
--- a/packages/pieces/community/slack/src/lib/triggers/new-channel.ts
+++ b/packages/pieces/community/slack/src/lib/triggers/new-channel.ts
@@ -1,7 +1,6 @@
 import { TriggerStrategy, createTrigger } from '@activepieces/pieces-framework';
 import { slackAuth } from '../auth';
-import { WebClient } from '@slack/web-api';
-import { getBotToken, getTeamId, SlackAuthValue } from '../common/auth-helpers';
+import { getTeamId, SlackAuthValue } from '../common/auth-helpers';
 
 const sampleData = {
   type: 'channel_created',
@@ -35,29 +34,6 @@ export const channelCreated = createTrigger({
   onDisable: async (context) => {
     // Ignored
   },
-  test: async (context) => {
-    const client = new WebClient(getBotToken(context.auth as SlackAuthValue));
-    const response = await client.conversations.list({
-      exclude_archived: true,
-      limit: 10,
-      types: 'public_channel,private_channel',
-    });
-    if (!response.channels) {
-      return [];
-    }
-    return response.channels.map((channel) => {
-      return {
-        type: 'channel_created',
-        channel: {
-          id: channel.id,
-          name: channel.name,
-          created: channel.created,
-          creator: channel.creator,
-        },
-      };
-    });
-  },
-
   run: async (context) => {
     const payloadBody = context.payload.body as PayloadBody;
     return [payloadBody.event];


### PR DESCRIPTION
## Description

The Slack `channel_created` trigger is `APP_WEBHOOK`, but it defined a `test()` that called `conversations.list` and mapped existing channels. That made the trigger test a **false green**: it returned sample rows and passed even when the Slack app-webhook was completely unconfigured (Event Subscriptions off, no Request URL, `channel_created` not subscribed, Socket Mode on, no signing secret). Users saw a passing test but received zero runs.

This removes the misleading `test()` so the trigger falls back to its `sampleData`, exactly like every other `APP_WEBHOOK` Slack trigger in this piece (`new-message`, `new-reaction-added`, `new-command`, …), none of which define a `test()`. The now-unused `WebClient` and `getBotToken` imports are dropped.

Net change: 1 file, mostly deletions. No behaviour change to `run`/`onEnable`/`onDisable`; only the misleading test-button path is removed.

## How was this tested?

- `npx turbo run lint --filter=@activepieces/piece-slack` → 0 errors (the only remaining warning on the file is the pre-existing unused `context` in `onDisable`, shared by all sibling triggers).
- Reviewed against the sibling `APP_WEBHOOK` Slack triggers as the reference pattern (they rely on `sampleData`, no `test()`), so the test button now shows the sample payload shape instead of a false success.

Fixes #14464

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)
