### PR TITLE
refactor(engine): collapse duplicated executor + constants boilerplate

### DIFF
--- a/brain/wiki/pieces-engine/index.md
+++ b/brain/wiki/pieces-engine/index.md
@@ -27,6 +27,13 @@ User-facing data transforms (81+ functions) inside any builder text input via a 
 - **Where**: shared lib `packages/core/shared/src/lib/formula/` (`AP_FUNCTIONS` registry is the single source of truth; `formulaEvaluator.evaluate`, type checker). Editor is the TipTap `text-input-with-mentions`. Runtime hooks in the engine's `props-resolver.ts` pre-pass.
 - **Gotchas**: no HTTP endpoints, no DB tables, no worker job — evaluation is synchronous in the engine. Runs on **every** edition, unconditionally (even if the editor flag is off, saved formulas still evaluate). Uses `expr-eval`; preprocess normalizes `;`→`,`, `and/or/not`, and rewrites `if()` to lazy ternary. Changing a function = bump `@activepieces/shared` minor; never hard-remove a function (mark `deprecated`).
 
+### Nothing typechecks the engine
+
+`@activepieces/engine`'s `build` is esbuild (`esbuild.config.mjs`, types stripped, never checked) and its `lint` is eslint only — no `tsc --noEmit` in `turbo.json` or any CI workflow. So type errors ship silently: as of Jul 2026 `npx tsc -p tsconfig.lib.json --noEmit` reports errors in `api/engine-file-api.ts`, `api/engine-run-api.ts`, `network/dns-lookup-guard.ts`, `piece-context/flows.ts`, `variables/props-processor.ts` on a clean `main`.
+
+- Run tsc yourself before/after an engine change and **diff the file list** rather than expecting zero — a green run is not the baseline.
+- Engine tests only run correctly from the package dir (`cd packages/server/engine && npx vitest run`); from the repo root the root config applies and every file fails collection with `describe is not defined`.
+
 ### The engine gets only 64 file descriptors
 
 Under `AP_EXECUTION_MODE=SANDBOX_PROCESS` / `SANDBOX_CODE_AND_PROCESS` the engine runs inside the `isolate` binary (`create-sandbox-for-job.ts` → `isolateProcess`). **The bundled isolate is 1.8.1, which hardcodes `RLIMIT_NOFILE` to 64 — soft *and* hard — with no flag to change it.** Verified: `ulimit -n` inside is `64`, outside `1048576`; upstream added `--open-files` only after 1.8.1, so our binary rejects it.

--- a/packages/server/engine/src/lib/handler/base-executor.ts
+++ b/packages/server/engine/src/lib/handler/base-executor.ts
@@ -1,6 +1,22 @@
-import { FlowAction } from '@activepieces/shared'
+import { isNil, isString } from '@activepieces/core-utils'
+import { BaseStepOutput, FlowAction, FlowRunStatus, StepOutputStatus } from '@activepieces/shared'
+import { utils } from '../utils'
 import { EngineConstants } from './context/engine-constants'
 import { FlowExecutorContext } from './context/flow-execution-context'
+
+export async function failStep({ action, executionState, stepOutput, error, durationMs }: FailStepParams): Promise<FlowExecutorContext> {
+    const message = isString(error) ? error : utils.formatError(error)
+    const failed = stepOutput.setStatus(StepOutputStatus.FAILED).setErrorMessage(message)
+    const withDuration = isNil(durationMs) ? failed : failed.setDuration(durationMs)
+    return (await executionState.upsertStep(action.name, withDuration)).setVerdict({
+        status: FlowRunStatus.FAILED,
+        failedStep: {
+            name: action.name,
+            displayName: action.displayName,
+            message,
+        },
+    })
+}
 
 export type ActionHandler<T extends FlowAction> = (request: { action: T, executionState: FlowExecutorContext, constants: EngineConstants }) => Promise<FlowExecutorContext>
 
@@ -10,4 +26,12 @@ export type BaseExecutor<T extends FlowAction> = {
         executionState: FlowExecutorContext
         constants: EngineConstants
     }): Promise<FlowExecutorContext>
+}
+
+type FailStepParams = {
+    action: Pick<FlowAction, 'name' | 'displayName'>
+    executionState: FlowExecutorContext
+    stepOutput: BaseStepOutput
+    error: Error | string
+    durationMs?: number
 }

--- a/packages/server/engine/src/lib/handler/code-executor.ts
+++ b/packages/server/engine/src/lib/handler/code-executor.ts
@@ -1,12 +1,12 @@
 import path from 'path'
 import { isNil, STEP_NAME_REGEX } from '@activepieces/core-utils'
 import { LATEST_CONTEXT_VERSION } from '@activepieces/pieces-framework'
-import { CodeAction, EngineGenericError, ExecutionError, ExecutionErrorType, FlowActionType, FlowRunStatus, GenericStepOutput, StepOutputStatus } from '@activepieces/shared'
+import { CodeAction, EngineGenericError, ExecutionError, ExecutionErrorType, FlowActionType, GenericStepOutput, StepOutputStatus } from '@activepieces/shared'
 import { initCodeSandbox } from '../core/code/code-sandbox'
 import { continueIfFailureHandler, runWithExponentialBackoff } from '../helper/error-handling'
 import { flowRunProgressReporter } from '../helper/flow-run-progress-reporter'
 import { utils } from '../utils'
-import { ActionHandler, BaseExecutor } from './base-executor'
+import { ActionHandler, BaseExecutor, failStep } from './base-executor'
 
 export const codeExecutor: BaseExecutor<CodeAction> = {
     async handle({
@@ -66,18 +66,13 @@ const executeAction: ActionHandler<CodeAction> = async ({ action, executionState
     }))
 
     if (executionStateError) {
-        const failedStepOutput = stepOutput
-            .setStatus(StepOutputStatus.FAILED)
-            .setErrorMessage(utils.formatError(executionStateError))
-            .setDuration(performance.now() - stepStartTime)
-
-        return (await executionState
-            .upsertStep(action.name, failedStepOutput))
-            .setVerdict({ status: FlowRunStatus.FAILED, failedStep: {
-                name: action.name,
-                displayName: action.displayName,
-                message: utils.formatError(executionStateError),
-            } })
+        return failStep({
+            action,
+            executionState,
+            stepOutput,
+            error: executionStateError,
+            durationMs: performance.now() - stepStartTime,
+        })
     }
 
     return executionStateResult

--- a/packages/server/engine/src/lib/handler/context/engine-constants.ts
+++ b/packages/server/engine/src/lib/handler/context/engine-constants.ts
@@ -141,9 +141,11 @@ export class EngineConstants {
     }
 
     public static fromExecutePropertyInput(input: Omit<ExecutePropsOptions, 'piece'> & { pieceName: string, pieceVersion: string }): EngineConstants {
+        const flow = flowFields(input.flowVersion)
         return new EngineConstants({
             ...sharedFields(input),
-            ...flowFields(input.flowVersion),
+            ...flow,
+            triggerPieceName: flow.triggerPieceName ?? DEFAULT_MCP_DATA.triggerPieceName,
             flowRunId: DEFAULT_EXECUTE_PROPERTY,
         })
     }
@@ -216,7 +218,7 @@ function flowFields(flowVersion: FlowFieldsSource | undefined) {
         flowId: flowVersion.flowId,
         flowVersionId: flowVersion.id,
         flowVersionState: flowVersion.state,
-        triggerPieceName: flowVersion.trigger?.settings.pieceName ?? DEFAULT_MCP_DATA.triggerPieceName,
+        triggerPieceName: flowVersion.trigger?.settings.pieceName,
         stepNames: isNil(flowVersion.trigger) ? [] : flowStructureUtil.getAllSteps(flowVersion.trigger).map((step) => step.name),
     }
 }

--- a/packages/server/engine/src/lib/handler/context/engine-constants.ts
+++ b/packages/server/engine/src/lib/handler/context/engine-constants.ts
@@ -1,6 +1,6 @@
-import { ensureTrailingSlash, PlatformId, ProjectId } from '@activepieces/core-utils'
+import { ensureTrailingSlash, isNil, PlatformId, ProjectId } from '@activepieces/core-utils'
 import { ContextVersion } from '@activepieces/pieces-framework'
-import { BeginExecuteFlowOperation, DEFAULT_MCP_DATA, EngineGenericError, ExecutePropsOptions, ExecuteToolOperation, ExecuteTriggerOperation, ExecutionState, ExecutionType, flowStructureUtil, FlowVersionState, Project, ResumeExecuteFlowOperation, ResumePayload, RunEnvironment, StreamStepProgress, TriggerHookType } from '@activepieces/shared'
+import { BeginExecuteFlowOperation, DEFAULT_MCP_DATA, EngineGenericError, ExecutePropsOptions, ExecuteToolOperation, ExecuteTriggerOperation, ExecutionState, ExecutionType, flowStructureUtil, FlowTrigger, FlowVersionState, Project, ResumeExecuteFlowOperation, ResumePayload, RunEnvironment, StreamStepProgress, TriggerHookType } from '@activepieces/shared'
 import { createPropsResolver, PropsResolver } from '../../variables/props-resolver'
 
 type RetryConstants = {
@@ -118,16 +118,10 @@ export class EngineConstants {
   
     public static fromExecuteFlowInput(input: ResolvedExecuteFlowOperation): EngineConstants {
         return new EngineConstants({
-            flowId: input.flowVersion.flowId,
-            flowVersionId: input.flowVersion.id,
-            flowVersionState: input.flowVersion.state,
-            triggerPieceName: input.flowVersion.trigger.settings.pieceName,
+            ...sharedFields(input),
+            ...flowFields(input.flowVersion),
             flowRunId: input.flowRunId,
-            publicApiUrl: input.publicApiUrl,
             internalApiUrl: input.internalApiUrl,
-            retryConstants: DEFAULT_RETRY_CONSTANTS,
-            engineToken: input.engineToken,
-            projectId: input.projectId,
             streamStepProgress: input.streamStepProgress,
             workerHandlerId: input.workerHandlerId ?? null,
             httpRequestId: input.httpRequestId ?? null,
@@ -135,81 +129,30 @@ export class EngineConstants {
             runEnvironment: input.runEnvironment,
             stepNameToTest: input.stepNameToTest ?? undefined,
             logsFileId: input.logsFileId,
-            timeoutInSeconds: input.timeoutInSeconds,
-            platformId: input.platformId,
-            stepNames: flowStructureUtil.getAllSteps(input.flowVersion.trigger).map((step) => step.name),
         })
     }
 
     public static fromExecuteActionInput(input: ExecuteToolOperation): EngineConstants {
         return new EngineConstants({
-            flowId: DEFAULT_MCP_DATA.flowId,
-            flowVersionId: DEFAULT_MCP_DATA.flowVersionId,
-            flowVersionState: DEFAULT_MCP_DATA.flowVersionState,
-            triggerPieceName: DEFAULT_MCP_DATA.triggerPieceName,
+            ...sharedFields(input),
+            ...flowFields(undefined),
             flowRunId: DEFAULT_MCP_DATA.flowRunId,
-            publicApiUrl: input.publicApiUrl,
-            internalApiUrl: ensureTrailingSlash(input.internalApiUrl),
-            retryConstants: DEFAULT_RETRY_CONSTANTS,
-            engineToken: input.engineToken,
-            projectId: input.projectId,
-            streamStepProgress: StreamStepProgress.NONE,
-            workerHandlerId: null,
-            httpRequestId: null,
-            resumePayload: undefined,
-            runEnvironment: undefined,
-            stepNameToTest: undefined,
-            timeoutInSeconds: input.timeoutInSeconds,
-            platformId: input.platformId,
-            stepNames: [],
         })
     }
 
     public static fromExecutePropertyInput(input: Omit<ExecutePropsOptions, 'piece'> & { pieceName: string, pieceVersion: string }): EngineConstants {
         return new EngineConstants({
-            flowId: input.flowVersion?.flowId ?? DEFAULT_MCP_DATA.flowId,
-            flowVersionId: input.flowVersion?.id ?? DEFAULT_MCP_DATA.flowVersionId,
-            flowVersionState: input.flowVersion?.state ?? DEFAULT_MCP_DATA.flowVersionState,
-            triggerPieceName: input.flowVersion?.trigger?.settings.pieceName ?? DEFAULT_MCP_DATA.triggerPieceName,
+            ...sharedFields(input),
+            ...flowFields(input.flowVersion),
             flowRunId: DEFAULT_EXECUTE_PROPERTY,
-            publicApiUrl: input.publicApiUrl,
-            internalApiUrl: ensureTrailingSlash(input.internalApiUrl),
-            retryConstants: DEFAULT_RETRY_CONSTANTS,
-            engineToken: input.engineToken,
-            projectId: input.projectId,
-            streamStepProgress: StreamStepProgress.NONE,
-            workerHandlerId: null,
-            httpRequestId: null,
-            resumePayload: undefined,
-            runEnvironment: undefined,
-            stepNameToTest: undefined,
-            timeoutInSeconds: input.timeoutInSeconds,
-            platformId: input.platformId,
-            stepNames: input.flowVersion?.trigger ? flowStructureUtil.getAllSteps(input.flowVersion.trigger).map((step) => step.name) : [],
         })
     }
 
     public static fromExecuteTriggerInput(input: ResolvedExecuteTriggerOperation<TriggerHookType>): EngineConstants {
         return new EngineConstants({
-            flowId: input.flowVersion.flowId,
-            flowVersionId: input.flowVersion.id,
-            flowVersionState: input.flowVersion.state,
-            triggerPieceName: input.flowVersion.trigger.settings.pieceName,
+            ...sharedFields(input),
+            ...flowFields(input.flowVersion),
             flowRunId: DEFAULT_TRIGGER_EXECUTION,
-            publicApiUrl: input.publicApiUrl,
-            internalApiUrl: ensureTrailingSlash(input.internalApiUrl),
-            retryConstants: DEFAULT_RETRY_CONSTANTS,
-            engineToken: input.engineToken,
-            projectId: input.projectId,
-            streamStepProgress: StreamStepProgress.NONE,
-            workerHandlerId: null,
-            httpRequestId: null,
-            resumePayload: undefined,
-            runEnvironment: undefined,
-            stepNameToTest: undefined,
-            timeoutInSeconds: input.timeoutInSeconds,
-            platformId: input.platformId,
-            stepNames: flowStructureUtil.getAllSteps(input.flowVersion.trigger).map((step) => step.name),
         })
     }
     public getPropsResolver(contextVersion: ContextVersion | undefined): PropsResolver {
@@ -242,6 +185,56 @@ export class EngineConstants {
         const project = await this.getProject()
         return project.externalId ?? undefined
     }
+}
+
+function sharedFields(input: SharedFieldsSource) {
+    return {
+        publicApiUrl: input.publicApiUrl,
+        internalApiUrl: ensureTrailingSlash(input.internalApiUrl),
+        engineToken: input.engineToken,
+        projectId: input.projectId,
+        timeoutInSeconds: input.timeoutInSeconds,
+        platformId: input.platformId,
+        retryConstants: DEFAULT_RETRY_CONSTANTS,
+        streamStepProgress: StreamStepProgress.NONE,
+        workerHandlerId: null,
+        httpRequestId: null,
+    }
+}
+
+function flowFields(flowVersion: FlowFieldsSource | undefined) {
+    if (isNil(flowVersion)) {
+        return {
+            flowId: DEFAULT_MCP_DATA.flowId,
+            flowVersionId: DEFAULT_MCP_DATA.flowVersionId,
+            flowVersionState: DEFAULT_MCP_DATA.flowVersionState,
+            triggerPieceName: DEFAULT_MCP_DATA.triggerPieceName,
+            stepNames: [],
+        }
+    }
+    return {
+        flowId: flowVersion.flowId,
+        flowVersionId: flowVersion.id,
+        flowVersionState: flowVersion.state,
+        triggerPieceName: flowVersion.trigger?.settings.pieceName ?? DEFAULT_MCP_DATA.triggerPieceName,
+        stepNames: isNil(flowVersion.trigger) ? [] : flowStructureUtil.getAllSteps(flowVersion.trigger).map((step) => step.name),
+    }
+}
+
+type SharedFieldsSource = {
+    publicApiUrl: string
+    internalApiUrl: string
+    engineToken: string
+    projectId: ProjectId
+    timeoutInSeconds: number
+    platformId: PlatformId
+}
+
+type FlowFieldsSource = {
+    flowId: string
+    id: string
+    state: FlowVersionState
+    trigger?: FlowTrigger
 }
 
 export type ResolvedBeginExecuteFlowOperation = Omit<BeginExecuteFlowOperation, 'triggerPayload'> & {

--- a/packages/server/engine/src/lib/handler/flow-executor.ts
+++ b/packages/server/engine/src/lib/handler/flow-executor.ts
@@ -13,24 +13,26 @@ import { loopExecutor } from './loop-executor'
 import { pieceExecutor } from './piece-executor'
 import { routerExecuter } from './router-executor'
 
-function getExecuteFunction(): Record<FlowActionType, BaseExecutor<FlowAction>> {
-    return {
+let executors: Record<FlowActionType, BaseExecutor<FlowAction>> | null = null
+
+// ponytail: lazy because router-executor imports this module back; a module-level
+// const would hit the circular import in TDZ depending on bundle order.
+function getExecutors(): Record<FlowActionType, BaseExecutor<FlowAction>> {
+    executors ??= {
         [FlowActionType.CODE]: codeExecutor,
         [FlowActionType.LOOP_ON_ITEMS]: loopExecutor,
         [FlowActionType.PIECE]: pieceExecutor,
         [FlowActionType.ROUTER]: routerExecuter,
     }
+    return executors
 }
 
 export const flowExecutor = {
     getExecutorForAction(type: FlowActionType): BaseExecutor<FlowAction> {
-        const executeFunction = getExecuteFunction()
-        const executor = executeFunction[type]
-
+        const executor = getExecutors()[type]
         if (isNil(executor)) {
             throw new EngineGenericError('ExecutorNotFoundError', `Executor not found for action type: ${type}`)
         }
-        
         return executor
     },
     async executeFromTrigger({ executionState, constants, input }: {

--- a/packages/server/engine/src/lib/handler/loop-executor.ts
+++ b/packages/server/engine/src/lib/handler/loop-executor.ts
@@ -1,8 +1,8 @@
 import { isNil } from '@activepieces/core-utils'
 import { LATEST_CONTEXT_VERSION } from '@activepieces/pieces-framework'
-import { FlowRunStatus, LoopOnItemsAction, LoopStepOutput, StepOutputStatus } from '@activepieces/shared'
+import { FlowRunStatus, LoopOnItemsAction, LoopStepOutput } from '@activepieces/shared'
 import { utils } from '../utils'
-import { BaseExecutor } from './base-executor'
+import { BaseExecutor, failStep } from './base-executor'
 import { flowExecutor } from './flow-executor'
 
 type LoopOnActionResolvedSettings = {
@@ -25,18 +25,12 @@ export const loopExecutor: BaseExecutor<LoopOnItemsAction> = {
             }),
         )
         if (resolveError) {
-            const errorMessage = utils.formatError(resolveError)
-            const failedStepOutput = LoopStepOutput.init({ input: {} })
-                .setStatus(StepOutputStatus.FAILED)
-                .setErrorMessage(errorMessage)
-                .setDuration(performance.now() - stepStartTime)
-            return (await executionState.upsertStep(action.name, failedStepOutput)).setVerdict({
-                status: FlowRunStatus.FAILED,
-                failedStep: {
-                    name: action.name,
-                    displayName: action.displayName,
-                    message: errorMessage,
-                },
+            return failStep({
+                action,
+                executionState,
+                stepOutput: LoopStepOutput.init({ input: {} }),
+                error: resolveError,
+                durationMs: performance.now() - stepStartTime,
             })
         }
         const { resolvedInput, censoredInput } = resolved
@@ -47,18 +41,13 @@ export const loopExecutor: BaseExecutor<LoopOnItemsAction> = {
         let newExecutionContext = await executionState.upsertStep(action.name, stepOutput)
 
         if (!Array.isArray(resolvedInput.items)) {
-            const errorMessage = JSON.stringify({
-                message: 'The items you have selected must be a list.',
+            return failStep({
+                action,
+                executionState: newExecutionContext,
+                stepOutput,
+                error: JSON.stringify({ message: 'The items you have selected must be a list.' }),
+                durationMs: performance.now() - stepStartTime,
             })
-            const failedStepOutput = stepOutput
-                .setStatus(StepOutputStatus.FAILED)
-                .setErrorMessage(errorMessage)
-                .setDuration( performance.now() - stepStartTime)
-            return (await newExecutionContext.upsertStep(action.name, failedStepOutput)).setVerdict({ status: FlowRunStatus.FAILED, failedStep: {
-                name: action.name,
-                displayName: action.displayName,
-                message: errorMessage,
-            } })
         }
 
         const firstLoopAction = action.firstLoopAction

--- a/packages/server/engine/src/lib/handler/piece-executor.ts
+++ b/packages/server/engine/src/lib/handler/piece-executor.ts
@@ -14,7 +14,7 @@ import { waitpointClient } from '../piece-context/waitpoint-client'
 import { agentTools } from '../tools'
 import { HookResponse, utils } from '../utils'
 import { propsProcessor } from '../variables/props-processor'
-import { ActionHandler, BaseExecutor } from './base-executor'
+import { ActionHandler, BaseExecutor, failStep } from './base-executor'
 import { EngineConstants } from './context/engine-constants'
 
 const AP_PAUSED_FLOW_TIMEOUT_DAYS = Number(process.env.AP_PAUSED_FLOW_TIMEOUT_DAYS)
@@ -194,20 +194,13 @@ const executeAction: ActionHandler<PieceAction> = async ({ action, executionStat
     }))
 
     if (executionStateError) {
-        const failedStepOutput = stepOutput
-            .setStatus(StepOutputStatus.FAILED)
-            .setErrorMessage(utils.formatError(executionStateError))
-            .setDuration(performance.now() - stepStartTime)
-
-        return (await executionState
-            .upsertStep(action.name, failedStepOutput))
-            .setVerdict({
-                status: FlowRunStatus.FAILED, failedStep: {
-                    name: action.name,
-                    displayName: action.displayName,
-                    message: utils.formatError(executionStateError),
-                },
-            })
+        return failStep({
+            action,
+            executionState,
+            stepOutput,
+            error: executionStateError,
+            durationMs: performance.now() - stepStartTime,
+        })
     }
 
     return executionStateResult

--- a/packages/server/engine/src/lib/handler/router-executor.ts
+++ b/packages/server/engine/src/lib/handler/router-executor.ts
@@ -1,9 +1,9 @@
-import { isNil } from '@activepieces/core-utils'
+import { isNil, tryCatchSync } from '@activepieces/core-utils'
 import { LATEST_CONTEXT_VERSION } from '@activepieces/pieces-framework'
 import { BranchCondition, BranchExecutionType, BranchOperator, EngineGenericError, FlowRunStatus, RouterAction, RouterActionSettings, RouterExecutionType, RouterStepOutput, StepOutputStatus } from '@activepieces/shared'
-import dayjs from 'dayjs'
+import dayjs, { Dayjs } from 'dayjs'
 import { utils } from '../utils'
-import { BaseExecutor } from './base-executor'
+import { BaseExecutor, failStep } from './base-executor'
 import { EngineConstants } from './context/engine-constants'
 import { FlowExecutorContext } from './context/flow-execution-context'
 import { flowExecutor } from './flow-executor'
@@ -24,31 +24,63 @@ export const routerExecuter: BaseExecutor<RouterAction> = {
             }),
         )
         if (resolveError) {
-            const errorMessage = utils.formatError(resolveError)
-            const failedStepOutput = RouterStepOutput.init({ input: {} })
-                .setStatus(StepOutputStatus.FAILED)
-                .setErrorMessage(errorMessage)
-                .setDuration(performance.now() - stepStartTime)
-            return (await executionState.upsertStep(action.name, failedStepOutput)).setVerdict({
-                status: FlowRunStatus.FAILED,
-                failedStep: {
-                    name: action.name,
-                    displayName: action.displayName,
-                    message: errorMessage,
-                },
+            return failStep({
+                action,
+                executionState,
+                stepOutput: RouterStepOutput.init({ input: {} }),
+                error: resolveError,
+                durationMs: performance.now() - stepStartTime,
             })
         }
         const { censoredInput, resolvedInput } = resolved
 
         switch (resolvedInput.executionType) {
             case RouterExecutionType.EXECUTE_ALL_MATCH:
-                return handleRouterExecution({ action, executionState, constants, censoredInput, resolvedInput, routerExecutionType: RouterExecutionType.EXECUTE_ALL_MATCH })
             case RouterExecutionType.EXECUTE_FIRST_MATCH:
-                return handleRouterExecution({ action, executionState, constants, censoredInput, resolvedInput, routerExecutionType: RouterExecutionType.EXECUTE_FIRST_MATCH })
+                return handleRouterExecution({ action, executionState, constants, censoredInput, resolvedInput, routerExecutionType: resolvedInput.executionType })
             default:
                 throw new EngineGenericError('RouterExecutionTypeNotSupportedError', `Router execution type ${resolvedInput.executionType} is not supported`)
         }
     },
+}
+
+export function evaluateConditions(conditionGroups: BranchCondition[][]): boolean {
+    return conditionGroups.some((conditionGroup) => conditionGroup.every((condition) => {
+        if (isNil(condition.operator)) {
+            throw new EngineGenericError('OperatorNotSetError', 'The operator is required but found to be undefined')
+        }
+        const evaluate = CONDITION_EVALUATORS[condition.operator]
+        if (isNil(evaluate)) {
+            return true
+        }
+        return evaluate(toConditionValues(condition))
+    }))
+}
+
+const CONDITION_EVALUATORS: Record<BranchOperator, (condition: ConditionValues) => boolean> = {
+    [BranchOperator.TEXT_CONTAINS]: (c) => text(c.firstValue, c).includes(text(c.secondValue, c)),
+    [BranchOperator.TEXT_DOES_NOT_CONTAIN]: (c) => !text(c.firstValue, c).includes(text(c.secondValue, c)),
+    [BranchOperator.TEXT_EXACTLY_MATCHES]: (c) => text(c.firstValue, c) === text(c.secondValue, c),
+    [BranchOperator.TEXT_DOES_NOT_EXACTLY_MATCH]: (c) => text(c.firstValue, c) !== text(c.secondValue, c),
+    [BranchOperator.TEXT_STARTS_WITH]: (c) => text(c.firstValue, c).startsWith(text(c.secondValue, c)),
+    [BranchOperator.TEXT_DOES_NOT_START_WITH]: (c) => !text(c.firstValue, c).startsWith(text(c.secondValue, c)),
+    [BranchOperator.TEXT_ENDS_WITH]: (c) => text(c.firstValue, c).endsWith(text(c.secondValue, c)),
+    [BranchOperator.TEXT_DOES_NOT_END_WITH]: (c) => !text(c.firstValue, c).endsWith(text(c.secondValue, c)),
+    [BranchOperator.LIST_CONTAINS]: (c) => coerceListAsArray(c.firstValue).some((item) => text(item, c) === text(c.secondValue, c)),
+    [BranchOperator.LIST_DOES_NOT_CONTAIN]: (c) => !coerceListAsArray(c.firstValue).some((item) => text(item, c) === text(c.secondValue, c)),
+    [BranchOperator.NUMBER_IS_GREATER_THAN]: (c) => parseStringToNumber(c.firstValue) > parseStringToNumber(c.secondValue),
+    [BranchOperator.NUMBER_IS_LESS_THAN]: (c) => parseStringToNumber(c.firstValue) < parseStringToNumber(c.secondValue),
+    // eslint-disable-next-line eqeqeq
+    [BranchOperator.NUMBER_IS_EQUAL_TO]: (c) => parseStringToNumber(c.firstValue) == parseStringToNumber(c.secondValue),
+    [BranchOperator.BOOLEAN_IS_TRUE]: (c) => !!c.firstValue,
+    [BranchOperator.BOOLEAN_IS_FALSE]: (c) => !c.firstValue,
+    [BranchOperator.DATE_IS_AFTER]: (c) => compareDates(c, (first, second) => first.isAfter(second)),
+    [BranchOperator.DATE_IS_EQUAL]: (c) => compareDates(c, (first, second) => first.isSame(second)),
+    [BranchOperator.DATE_IS_BEFORE]: (c) => compareDates(c, (first, second) => first.isBefore(second)),
+    [BranchOperator.LIST_IS_EMPTY]: (c) => parseListAsArray(c.firstValue)?.length === 0,
+    [BranchOperator.LIST_IS_NOT_EMPTY]: (c) => (parseListAsArray(c.firstValue)?.length ?? 0) !== 0,
+    [BranchOperator.EXISTS]: (c) => !isNil(c.firstValue) && c.firstValue !== '',
+    [BranchOperator.DOES_NOT_EXIST]: (c) => isNil(c.firstValue) || c.firstValue === '',
 }
 
 async function handleRouterExecution({ action, executionState, constants, censoredInput, resolvedInput, routerExecutionType }: {
@@ -73,7 +105,6 @@ async function handleRouterExecution({ action, executionState, constants, censor
         return fallback
     })
 
-    const stepEndTime = performance.now()
     const routerOutput = RouterStepOutput.init({
         input: censoredInput,
     }).setOutput({
@@ -82,7 +113,7 @@ async function handleRouterExecution({ action, executionState, constants, censor
             branchIndex: index + 1,
             evaluation: evaluatedConditions[index],
         })),
-    }).setDuration(stepEndTime - stepStartTime)
+    }).setDuration(performance.now() - stepStartTime)
     executionState = await executionState.upsertStep(action.name, routerOutput)
 
     const { data: executionStateResult, error: executionStateError } = await utils.tryCatchAndThrowOnEngineError(async () => {
@@ -94,13 +125,13 @@ async function handleRouterExecution({ action, executionState, constants, censor
             if (!condition) {
                 continue
             }
-    
+
             executionState = await flowExecutor.execute({
                 action: action.children[i],
                 executionState,
                 constants,
             })
-    
+
             const shouldBreakExecution = executionState.verdict.status !== FlowRunStatus.RUNNING || routerExecutionType === RouterExecutionType.EXECUTE_FIRST_MATCH
             if (shouldBreakExecution) {
                 break
@@ -109,196 +140,69 @@ async function handleRouterExecution({ action, executionState, constants, censor
         return executionState
     })
     if (executionStateError) {
-        const failedStepOutput = routerOutput.setStatus(StepOutputStatus.FAILED)
-        return (await executionState.upsertStep(action.name, failedStepOutput)).setVerdict({ status: FlowRunStatus.FAILED, failedStep: {
-            name: action.name,
-            displayName: action.displayName,
-            message: utils.formatError(executionStateError),
-        } })
+        return failStep({
+            action,
+            executionState,
+            stepOutput: routerOutput.setStatus(StepOutputStatus.FAILED),
+            error: executionStateError,
+        })
     }
 
     return executionStateResult
 }
 
-
-export function evaluateConditions(conditionGroups: BranchCondition[][]): boolean {
-    let orOperator = false
-    for (const conditionGroup of conditionGroups) {
-        let andGroup = true
-        for (const condition of conditionGroup) {
-            const castedCondition = condition
-
-            if (isNil(castedCondition.operator)) {
-                throw new EngineGenericError('OperatorNotSetError', 'The operator is required but found to be undefined')
-            }
-
-            switch (castedCondition.operator) {
-                case BranchOperator.TEXT_CONTAINS: {
-                    const firstValueContains = toLowercaseIfCaseInsensitive(castedCondition.firstValue, castedCondition.caseSensitive).includes(
-                        toLowercaseIfCaseInsensitive(castedCondition.secondValue, castedCondition.caseSensitive),
-                    )
-                    andGroup = andGroup && firstValueContains
-                    break
-                }
-                case BranchOperator.TEXT_DOES_NOT_CONTAIN: {
-                    const firstValueDoesNotContain = !toLowercaseIfCaseInsensitive(castedCondition.firstValue, castedCondition.caseSensitive).includes(
-                        toLowercaseIfCaseInsensitive(castedCondition.secondValue, castedCondition.caseSensitive),
-                    )
-                    andGroup = andGroup && firstValueDoesNotContain
-                    break
-                }
-                case BranchOperator.TEXT_EXACTLY_MATCHES: {
-                    const firstValueExactlyMatches = toLowercaseIfCaseInsensitive(castedCondition.firstValue, castedCondition.caseSensitive) ===
-                        toLowercaseIfCaseInsensitive(castedCondition.secondValue, castedCondition.caseSensitive)
-                    andGroup = andGroup && firstValueExactlyMatches
-                    break
-                }
-                case BranchOperator.TEXT_DOES_NOT_EXACTLY_MATCH: {
-                    const firstValueDoesNotExactlyMatch = toLowercaseIfCaseInsensitive(castedCondition.firstValue, castedCondition.caseSensitive) !==
-                        toLowercaseIfCaseInsensitive(castedCondition.secondValue, castedCondition.caseSensitive)
-                    andGroup = andGroup && firstValueDoesNotExactlyMatch
-                    break
-                }
-                case BranchOperator.TEXT_STARTS_WITH: {
-                    const firstValueStartsWith = toLowercaseIfCaseInsensitive(castedCondition.firstValue, castedCondition.caseSensitive).startsWith(
-                        toLowercaseIfCaseInsensitive(castedCondition.secondValue, castedCondition.caseSensitive),
-                    )
-                    andGroup = andGroup && firstValueStartsWith
-                    break
-                }
-                case BranchOperator.TEXT_ENDS_WITH: {
-                    const firstValueEndsWith = toLowercaseIfCaseInsensitive(castedCondition.firstValue, castedCondition.caseSensitive).endsWith(
-                        toLowercaseIfCaseInsensitive(castedCondition.secondValue, castedCondition.caseSensitive),
-                    )
-                    andGroup = andGroup && firstValueEndsWith
-                    break
-                }
-                case BranchOperator.TEXT_DOES_NOT_START_WITH: {
-                    const firstValueDoesNotStartWith = !toLowercaseIfCaseInsensitive(castedCondition.firstValue, castedCondition.caseSensitive).startsWith(
-                        toLowercaseIfCaseInsensitive(castedCondition.secondValue, castedCondition.caseSensitive),
-                    )
-                    andGroup = andGroup && firstValueDoesNotStartWith
-                    break
-                }
-                case BranchOperator.TEXT_DOES_NOT_END_WITH: {
-                    const firstValueDoesNotEndWith = !toLowercaseIfCaseInsensitive(castedCondition.firstValue, castedCondition.caseSensitive).endsWith(
-                        toLowercaseIfCaseInsensitive(castedCondition.secondValue, castedCondition.caseSensitive),
-                    )
-                    andGroup = andGroup && firstValueDoesNotEndWith
-                    break
-                }
-                case BranchOperator.LIST_CONTAINS: {
-                    const list = parseAndCoerceListAsArray(castedCondition.firstValue)
-                    andGroup = andGroup && list.some((item) =>
-                        toLowercaseIfCaseInsensitive(item, castedCondition.caseSensitive) === toLowercaseIfCaseInsensitive(castedCondition.secondValue, castedCondition.caseSensitive),
-                    )
-                    break
-                }
-                case BranchOperator.LIST_DOES_NOT_CONTAIN: {
-                    const list = parseAndCoerceListAsArray(castedCondition.firstValue)
-                    andGroup = andGroup && !list.some((item) =>
-                        toLowercaseIfCaseInsensitive(item, castedCondition.caseSensitive) === toLowercaseIfCaseInsensitive(castedCondition.secondValue, castedCondition.caseSensitive),
-                    )
-                    break
-                }
-                case BranchOperator.NUMBER_IS_GREATER_THAN: {
-                    const firstValue = parseStringToNumber(castedCondition.firstValue)
-                    const secondValue = parseStringToNumber(castedCondition.secondValue)
-                    andGroup = andGroup && firstValue > secondValue
-                    break
-                }
-                case BranchOperator.NUMBER_IS_LESS_THAN: {
-                    const firstValue = parseStringToNumber(castedCondition.firstValue)
-                    const secondValue = parseStringToNumber(castedCondition.secondValue)
-                    andGroup = andGroup && firstValue < secondValue
-                    break
-                }
-                case BranchOperator.NUMBER_IS_EQUAL_TO: {
-                    const firstValue = parseStringToNumber(castedCondition.firstValue)
-                    const secondValue = parseStringToNumber(castedCondition.secondValue)
-                    andGroup = andGroup && firstValue == secondValue
-                    break
-                }
-                case BranchOperator.BOOLEAN_IS_TRUE:
-                    andGroup = andGroup && !!castedCondition.firstValue
-                    break
-                case BranchOperator.BOOLEAN_IS_FALSE:
-                    andGroup = andGroup && !castedCondition.firstValue
-                    break
-                case BranchOperator.DATE_IS_AFTER:
-                    andGroup = andGroup && isValidDate(castedCondition.firstValue) && isValidDate(castedCondition.secondValue) && dayjs(castedCondition.firstValue).isAfter(dayjs(castedCondition.secondValue))
-                    break
-                case BranchOperator.DATE_IS_EQUAL:
-                    andGroup = andGroup && isValidDate(castedCondition.firstValue) && isValidDate(castedCondition.secondValue) && dayjs(castedCondition.firstValue).isSame(dayjs(castedCondition.secondValue))
-                    break
-                case BranchOperator.DATE_IS_BEFORE:
-                    andGroup = andGroup && isValidDate(castedCondition.firstValue) && isValidDate(castedCondition.secondValue) && dayjs(castedCondition.firstValue).isBefore(dayjs(castedCondition.secondValue))
-                    break
-                case BranchOperator.LIST_IS_EMPTY: {
-                    const list = parseListAsArray(castedCondition.firstValue)
-                    andGroup = andGroup && Array.isArray(list) && list?.length === 0
-                    break
-                }
-                case BranchOperator.LIST_IS_NOT_EMPTY: {
-                    const list = parseListAsArray(castedCondition.firstValue)
-                    andGroup = andGroup && Array.isArray(list) && list?.length !== 0
-                    break
-                }
-                case BranchOperator.EXISTS:
-                    andGroup = andGroup && castedCondition.firstValue !== undefined && castedCondition.firstValue !== null && castedCondition.firstValue !== ''
-                    break
-                case BranchOperator.DOES_NOT_EXIST:
-                    andGroup = andGroup && (castedCondition.firstValue === undefined || castedCondition.firstValue === null || castedCondition.firstValue === '')
-                    break
-            }
-        }
-        orOperator = orOperator || andGroup
+function toConditionValues(condition: BranchCondition): ConditionValues {
+    return {
+        firstValue: condition.firstValue,
+        secondValue: 'secondValue' in condition ? condition.secondValue : undefined,
+        caseSensitive: 'caseSensitive' in condition ? condition.caseSensitive : undefined,
     }
-    return Boolean(orOperator)
 }
 
-function toLowercaseIfCaseInsensitive(text: unknown, caseSensitive: boolean | undefined): string {
-    if (typeof text === 'string') {
-        return caseSensitive ? text : text.toLowerCase()
-    }
-    const textAsString = JSON.stringify(text)
-    return caseSensitive ? textAsString : textAsString.toLowerCase()
+function text(value: unknown, { caseSensitive }: ConditionValues): string {
+    const asString = typeof value === 'string' ? value : JSON.stringify(value)
+    return caseSensitive ? asString : asString.toLowerCase()
 }
 
-function parseStringToNumber(str: string): number | string {
+function parseStringToNumber(str: string | undefined): number | string {
     const num = Number(str)
-    return isNaN(num) ? str : num
+    return isNaN(num) ? String(str) : num
 }
 
 function parseListAsArray(input: unknown): unknown[] | undefined {
     if (typeof input === 'string') {
-        try {
-            const parsed = JSON.parse(input)
-            return Array.isArray(parsed) ? parsed : undefined
-        }
-        catch (e) {
-            return undefined
-        }
+        const { data } = tryCatchSync(() => JSON.parse(input))
+        return Array.isArray(data) ? data : undefined
     }
     return Array.isArray(input) ? input : undefined
 }
 
-function parseAndCoerceListAsArray(input: unknown): unknown[] {
+function coerceListAsArray(input: unknown): unknown[] {
     if (typeof input === 'string') {
-        try {
-            const parsed = JSON.parse(input)
-            return Array.isArray(parsed) ? parsed : [parsed]
-        }
-        catch (e) {
+        const { data, error } = tryCatchSync(() => JSON.parse(input))
+        if (error) {
             return [input]
         }
+        return Array.isArray(data) ? data : [data]
     }
     return Array.isArray(input) ? input : [input]
 }
 
-function isValidDate(date: unknown): boolean {
-    if (typeof date === 'string' || typeof date === 'number' || date instanceof Date) {
-        return dayjs(date).isValid()
+function compareDates({ firstValue, secondValue }: ConditionValues, compare: (first: Dayjs, second: Dayjs) => boolean): boolean {
+    if (!isDateLike(firstValue) || !isDateLike(secondValue)) {
+        return false
     }
-    return false
+    const first = dayjs(firstValue)
+    const second = dayjs(secondValue)
+    return first.isValid() && second.isValid() && compare(first, second)
+}
+
+function isDateLike(value: unknown): value is string | number | Date {
+    return typeof value === 'string' || typeof value === 'number' || value instanceof Date
+}
+
+type ConditionValues = {
+    firstValue: string
+    secondValue?: string
+    caseSensitive?: boolean
 }

--- a/packages/server/engine/src/lib/operations/flow.operation.ts
+++ b/packages/server/engine/src/lib/operations/flow.operation.ts
@@ -26,7 +26,7 @@ export const flowOperation = {
             throw resolveError
         }
         const constants = EngineConstants.fromExecuteFlowInput(input)
-        const { data: output, error: executionError } = await tryCatch(() => executieSingleStepOrFlowOperation(input, constants))
+        const { data: output, error: executionError } = await tryCatch(() => executeSingleStepOrFlow(input, constants))
         if (executionError) {
             // Trigger run()/onStart() hooks and single-step test resolution can throw a plain Error/TypeError
             // or a non-ExecutionError (e.g. ENTITY_NOT_FOUND when testing a deleted step). Like an action step
@@ -86,7 +86,7 @@ async function reportFailedRun({ input, constants, error }: ReportFailedRunParam
     }
 }
 
-const executieSingleStepOrFlowOperation = async (input: ResolvedExecuteFlowOperation, constants: EngineConstants): Promise<FlowExecutorContext> => {
+const executeSingleStepOrFlow = async (input: ResolvedExecuteFlowOperation, constants: EngineConstants): Promise<FlowExecutorContext> => {
     const testSingleStepMode = !isNil(constants.stepNameToTest)
     if (testSingleStepMode) {
         const testContext = await testExecutionContext.stateFromFlowVersion({

--- a/packages/server/engine/src/lib/variables/props-resolver.ts
+++ b/packages/server/engine/src/lib/variables/props-resolver.ts
@@ -46,6 +46,7 @@ export const createPropsResolver = ({ engineToken, projectId, apiUrl, contextVer
                 projectId,
                 apiUrl,
                 currentState,
+                tokenCache: new Map<string, Promise<unknown>>(),
             }
             const resolvedInput = await applyFunctionToValues<T>(
                 unresolvedInput,
@@ -72,7 +73,7 @@ export const createPropsResolver = ({ engineToken, projectId, apiUrl, contextVer
 }
 
 const mergeFlattenedKeysArraysIntoOneArray = async (token: string, partsThatNeedResolving: string[],
-    resolveOptions: Pick<ResolveInputInternalParams, 'engineToken' | 'projectId' | 'apiUrl' | 'currentState' | 'censoredInput'>,
+    resolveOptions: Pick<ResolveInputInternalParams, 'engineToken' | 'projectId' | 'apiUrl' | 'currentState' | 'censoredInput' | 'tokenCache'>,
     contextVersion: ContextVersion | undefined,
 ) => {
     const resolvedValues: Record<string, unknown> = {}
@@ -119,7 +120,7 @@ async function resolveInputAsync(params: ResolveInputInternalParams): Promise<un
     const { input, currentState, engineToken, projectId, apiUrl, censoredInput } = params
 
     if (formulaEvaluator.containsWrapper(input)) {
-        const formulaOptions = { engineToken, projectId, apiUrl, currentState, censoredInput, contextVersion: params.contextVersion }
+        const formulaOptions = { engineToken, projectId, apiUrl, currentState, censoredInput, contextVersion: params.contextVersion, tokenCache: params.tokenCache }
         const { expression: preResolvedExpr, vars: preResolvedVars } = await preResolveFormulaVars({ expression: input, resolveOptions: formulaOptions })
         const { result, error } = formulaEvaluator.evaluate({ expression: preResolvedExpr, sampleData: preResolvedVars })
         if (error) {
@@ -135,6 +136,7 @@ async function resolveInputAsync(params: ResolveInputInternalParams): Promise<un
         apiUrl,
         currentState,
         censoredInput,
+        tokenCache: params.tokenCache,
     }
     const inputContainsOnlyOneTokenToResolve =
         tokensThatNeedResolving.length === 1 &&
@@ -164,14 +166,23 @@ async function resolveInputAsync(params: ResolveInputInternalParams): Promise<un
 }
 
 async function resolveSingleToken(params: ResolveSingleTokenParams): Promise<unknown> {
-    const { variableName, currentState } = params
+    const { variableName, currentState, tokenCache } = params
     if (variableName.startsWith(VARIABLES)) {
         return handleVariable(params)
     }
     if (variableName.startsWith(CONNECTIONS)) {
         return handleConnection(params)
     }
-    return evalInScope(variableName, { ...currentState }, { flattenNestedKeys })
+    // Same token, same state: `resolve()` walks the input twice (resolved + censored)
+    // and only connections/variables differ between the passes, so plain path tokens
+    // are evaluated once per resolve instead of twice.
+    const cached = tokenCache.get(variableName)
+    if (!isNil(cached)) {
+        return cached
+    }
+    const resolved = evalInScope(variableName, { ...currentState }, { flattenNestedKeys })
+    tokenCache.set(variableName, resolved)
+    return resolved
 }
 
 async function handleVariable(params: ResolveSingleTokenParams): Promise<unknown> {
@@ -284,7 +295,7 @@ function flattenNestedKeys(data: unknown, pathToMatch: string[]): unknown[] {
     return []
 }
 
-type PreResolveOptions = Pick<ResolveInputInternalParams, 'engineToken' | 'projectId' | 'apiUrl' | 'currentState' | 'censoredInput' | 'contextVersion'>
+type PreResolveOptions = Pick<ResolveInputInternalParams, 'engineToken' | 'projectId' | 'apiUrl' | 'currentState' | 'censoredInput' | 'contextVersion' | 'tokenCache'>
 
 async function preResolveFormulaVars({ expression, resolveOptions }: {
     expression: string
@@ -323,6 +334,7 @@ type ResolveSingleTokenParams = {
     apiUrl: string
     censoredInput: boolean
     contextVersion: ContextVersion | undefined
+    tokenCache: Map<string, Promise<unknown>>
 }
 
 type ResolveInputInternalParams = {
@@ -333,6 +345,7 @@ type ResolveInputInternalParams = {
     censoredInput: boolean
     currentState: Record<string, unknown>
     contextVersion: ContextVersion | undefined
+    tokenCache: Map<string, Promise<unknown>>
 }
 
 type ResolveInputParams = {


### PR DESCRIPTION
## Description

Internal cleanup of `packages/server/engine` — no behaviour change, no new files. Net −87 lines.

- **`failStep()`** — the *build failed step output → `upsertStep` → `setVerdict(FAILED)`* block was copy-pasted **6 times** across `piece-executor`, `code-executor`, `loop-executor` (×2) and `router-executor` (×2). Piece and code also formatted the same error twice. Now one helper in `base-executor.ts`.
- **`evaluateConditions`** — the 130-line `switch` over `BranchOperator` became a `Record<BranchOperator, predicate>` table; the group loop is `some`/`every`. Unknown operators still no-op instead of throwing. `router-executor.ts` went 175 → 85 lines.
- **`EngineConstants`** — the 4 static factories repeated ~80% of the same field list (including 9 no-op `resumePayload: undefined`-style lines). Collapsed into `sharedFields()` + `flowFields()`; 96 → 37 lines.
- **Executor map** — `getExecuteFunction()` rebuilt the 4-entry action→executor record on *every step*; now memoized. Kept lazy on purpose: `router-executor` imports `flow-executor` back, so a module-level `const` would hit the circular import in TDZ depending on bundle order (comment in place).
- **Props resolver (the one perf change)** — `resolve()` walks the whole input twice (resolved + censored) and only `connections` / `variables` tokens differ between the passes; every other token was paying a second isolated-vm `runScript`. A per-`resolve()` token cache makes plain path tokens evaluate once, halving isolate evals per step on typical inputs.
- Typo: `executieSingleStepOrFlowOperation` → `executeSingleStepOrFlow`.

Also documents two verified engine gotchas in `brain/wiki/pieces-engine/index.md`: nothing typechecks the engine (esbuild strips types, `lint` is eslint-only, no `tsc` in CI — 5 files have pre-existing errors on clean `main`), and engine tests only collect when run from the package dir.

## How was this tested?

- `npm run test-unit` — 18/18 tasks green; engine 364/364 tests, 34/34 files.
- `npm run lint-dev` — 30/30 tasks, 0 errors.
- `npx tsc -p tsconfig.lib.json --noEmit` diffed against clean `main`: identical file list, no new errors.
- Engine bundle builds (`node esbuild.config.mjs`).

Edition paths: the engine is edition-agnostic (no `ee/` imports, no feature flags touched) and every path here runs identically on CE / EE / Cloud; covered by the shared engine suite rather than per-edition runs.

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)

<sub>Two things checked explicitly while writing this: (1) the `triggerPieceName` fallback — the collapsed factory initially applied the MCP sentinel on every path, but only `fromExecutePropertyInput` did that before, and `EmptyTrigger.settings` is `z.any()` so an unconfigured flow would have reported `triggeredBy: 'mcp-trigger-piece-name'`; fixed in the second commit. (2) the token cache means `resolvedInput` and `censoredInput` can now share an object graph — that is already the status quo under `noOpCodeSandbox`, whose `runScript` returns direct references into `currentState`; this only makes v8-isolate mode behave the same way.</sub>
