### PR TITLE
fix(ai): use prefix matching for OpenAI image model classification

### DIFF
--- a/packages/server/api/src/app/ai/providers/openai-provider.ts
+++ b/packages/server/api/src/app/ai/providers/openai-provider.ts
@@ -3,6 +3,16 @@ import { AIProviderModel, AIProviderModelType, OpenAIProviderAuthConfig, OpenAIP
 import { FastifyBaseLogger } from 'fastify'
 import { AIProviderStrategy } from './ai-provider'
 
+/**
+ * Returns true for any OpenAI model whose primary capability is image
+ * generation. We match on well-established OpenAI naming prefixes rather
+ * than a hardcoded allowlist so that future variants (e.g. gpt-image-2,
+ * dall-e-4) are classified correctly without a code change.
+ */
+function isOpenAIImageModel(modelId: string): boolean {
+    return modelId.startsWith('gpt-image-') || modelId.startsWith('dall-e-')
+}
+
 export const openaiProvider: AIProviderStrategy<OpenAIProviderAuthConfig, OpenAIProviderConfig> = {
     name: 'OpenAI',
     async validateConnection(authConfig: OpenAIProviderAuthConfig, config: OpenAIProviderConfig, _log: FastifyBaseLogger): Promise<void> {
@@ -20,16 +30,10 @@ export const openaiProvider: AIProviderStrategy<OpenAIProviderAuthConfig, OpenAI
 
         const { data } = res.body
 
-        const openaiImageModels = [
-            'gpt-image-1',
-            'dall-e-3',
-            'dall-e-2',
-        ]
-
         return data.map((model: OpenAIModel) => ({
             id: model.id,
             name: model.id,
-            type: openaiImageModels.includes(model.id) ? AIProviderModelType.IMAGE : AIProviderModelType.TEXT,
+            type: isOpenAIImageModel(model.id) ? AIProviderModelType.IMAGE : AIProviderModelType.TEXT,
         }))
     },
 }

--- a/packages/server/api/test/unit/app/ai/providers/openai-provider.test.ts
+++ b/packages/server/api/test/unit/app/ai/providers/openai-provider.test.ts
@@ -1,0 +1,77 @@
+import { AIProviderModelType } from '@activepieces/shared'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { mockSendRequest } = vi.hoisted(() => ({ mockSendRequest: vi.fn() }))
+
+vi.mock('@activepieces/pieces-common', () => ({
+    httpClient: { sendRequest: mockSendRequest },
+    HttpMethod: { GET: 'GET' },
+}))
+
+import { openaiProvider } from '../../../../../src/app/ai/providers/openai-provider'
+
+const AUTH = { apiKey: 'test-key' }
+const CONFIG = {}
+
+function makeApiResponse(ids: string[]) {
+    return { body: { data: ids.map((id) => ({ id })) } }
+}
+
+describe('openaiProvider.listModels — image model classification', () => {
+    beforeEach(() => {
+        mockSendRequest.mockReset()
+    })
+
+    it('classifies known dall-e models as IMAGE', async () => {
+        mockSendRequest.mockResolvedValue(makeApiResponse(['dall-e-2', 'dall-e-3']))
+
+        const models = await openaiProvider.listModels(AUTH, CONFIG)
+
+        expect(models).toEqual([
+            { id: 'dall-e-2', name: 'dall-e-2', type: AIProviderModelType.IMAGE },
+            { id: 'dall-e-3', name: 'dall-e-3', type: AIProviderModelType.IMAGE },
+        ])
+    })
+
+    it('classifies gpt-image-1 as IMAGE', async () => {
+        mockSendRequest.mockResolvedValue(makeApiResponse(['gpt-image-1']))
+
+        const models = await openaiProvider.listModels(AUTH, CONFIG)
+
+        expect(models[0].type).toBe(AIProviderModelType.IMAGE)
+    })
+
+    it('classifies future gpt-image-* models as IMAGE (regression for #14475)', async () => {
+        // gpt-image-2 was silently typed as TEXT before this fix because it
+        // was not in the hardcoded allowlist.
+        mockSendRequest.mockResolvedValue(makeApiResponse(['gpt-image-2', 'gpt-image-3']))
+
+        const models = await openaiProvider.listModels(AUTH, CONFIG)
+
+        for (const model of models) {
+            expect(model.type).toBe(AIProviderModelType.IMAGE)
+        }
+    })
+
+    it('classifies text/chat models as TEXT', async () => {
+        mockSendRequest.mockResolvedValue(
+            makeApiResponse(['gpt-4o', 'gpt-4o-mini', 'gpt-4-turbo', 'o1', 'o3-mini']),
+        )
+
+        const models = await openaiProvider.listModels(AUTH, CONFIG)
+
+        for (const model of models) {
+            expect(model.type).toBe(AIProviderModelType.TEXT)
+        }
+    })
+
+    it('returns id and name both set to the model id', async () => {
+        mockSendRequest.mockResolvedValue(makeApiResponse(['gpt-4o', 'gpt-image-1']))
+
+        const models = await openaiProvider.listModels(AUTH, CONFIG)
+
+        for (const model of models) {
+            expect(model.id).toBe(model.name)
+        }
+    })
+})


### PR DESCRIPTION
## Summary

Fixes #14475

### Bug

OpenAI image models whose IDs are not in the hardcoded three-entry
allowlist are silently classified as `TEXT`:

```ts
// Before — only these three are ever IMAGE:
const openaiImageModels = [
    'gpt-image-1',
    'dall-e-3',
    'dall-e-2',
]
type: openaiImageModels.includes(model.id) ? AIProviderModelType.IMAGE : AIProviderModelType.TEXT
```

**Result:** `gpt-image-2` (and any future `gpt-image-*` variant) shows
up in the *Ask AI / Run Agent* text-model dropdown and is absent from
the *Generate Image* model dropdown.

### Root cause

`openai-provider.ts` → `listModels` — membership test against a
hardcoded string array instead of a naming-convention check.

### Fix

Replace the allowlist with a `startsWith`-based helper that matches
OpenAI's established naming conventions:

```ts
function isOpenAIImageModel(modelId: string): boolean {
    return modelId.startsWith('gpt-image-') || modelId.startsWith('dall-e-')
}
```

This correctly classifies every current model **and** any future
`gpt-image-*` / `dall-e-*` variant without requiring another code
change per release.

### Files changed

| File | Change |
|------|--------|
| `packages/server/api/src/app/ai/providers/openai-provider.ts` | Replace hardcoded allowlist with `isOpenAIImageModel()` prefix helper |
| `packages/server/api/test/unit/app/ai/providers/openai-provider.test.ts` | New: 5 unit tests covering known models, future variants, text models, and field shape |

### Test evidence

New unit tests (following the existing `azure-provider.test.ts` pattern):

| Test | Asserts |
|------|---------|
| `dall-e-2`, `dall-e-3` → IMAGE | known DALL-E models still work |
| `gpt-image-1` → IMAGE | existing flagship image model |
| `gpt-image-2`, `gpt-image-3` → IMAGE | **regression for #14475** |
| `gpt-4o`, `gpt-4o-mini`, `o1`, `o3-mini` → TEXT | chat models unaffected |
| `id === name` for all models | field shape preserved |