### PR TITLE
fix(templates): show project name instead of raw ID in Use Template dialog

### DIFF
--- a/packages/web/src/features/projects/components/projects-selector.tsx
+++ b/packages/web/src/features/projects/components/projects-selector.tsx
@@ -2,7 +2,10 @@ import { isNil } from '@activepieces/core-utils';
 import { t } from 'i18next';
 import { Control } from 'react-hook-form';
 
-import { projectCollectionUtils } from '@/features/projects/stores/project-collection';
+import {
+  getProjectName,
+  projectCollectionUtils,
+} from '@/features/projects/stores/project-collection';
 
 import { MultiSelectPieceProperty } from '../../../components/custom/multi-select-piece-property';
 import { FormField, FormItem, FormMessage } from '../../../components/ui/form';
@@ -28,7 +31,7 @@ export const ProjectSelector = ({
             options={
               projects?.map((project) => ({
                 value: project.id,
-                label: project.displayName,
+                label: getProjectName(project),
               })) ?? []
             }
             loading={!projects}

--- a/packages/web/src/features/templates/components/use-template-dialog.tsx
+++ b/packages/web/src/features/templates/components/use-template-dialog.tsx
@@ -31,7 +31,7 @@ import {
 } from '@/components/ui/select';
 import { flowHooks } from '@/features/flows';
 import { foldersApi, foldersHooks } from '@/features/folders';
-import { projectCollectionUtils } from '@/features/projects';
+import { getProjectName, projectCollectionUtils } from '@/features/projects';
 import { ApProjectDisplay } from '@/features/projects/components/ap-project-display';
 import { templatesTelemetryApi } from '@/features/templates';
 import { authenticationSession } from '@/lib/authentication-session';
@@ -165,7 +165,7 @@ export const UseTemplateDialog = ({
                 {projects?.map((project) => (
                   <SelectItem key={project.id} value={project.id}>
                     <ApProjectDisplay
-                      title={project.displayName}
+                      title={getProjectName(project)}
                       icon={project.icon}
                       projectType={project.type}
                     />


### PR DESCRIPTION
## Description

Fixes [GIT-1677](https://linear.app/activepieces/issue/GIT-1677)
Closes #14472

The "Use Template" modal (Flows → Create New → Start from Template) showed the raw project id in the Project dropdown for personal projects instead of the project name. Everywhere else in the app shows "Personal Project". The Folder dropdown was unaffected. Ref: Pylon 5473

Fix: the project option label now uses the app-wide `getProjectName()` helper ("Personal Project" for PERSONAL projects, `displayName` for TEAM) instead of raw `project.displayName`:
- `use-template-dialog.tsx` — the Use Template modal Project dropdown.
- `projects-selector.tsx` — the "Available for Projects" multi-select.

The header/switcher and `project-picker-card.tsx` already used the helper; these two were the only call sites bypassing it, which is why a personal project's raw stored `displayName` (an opaque id for embed/API-provisioned users) leaked here but nowhere else.

## How was this tested?

- lint: `turbo run lint --filter=web` — 0 errors (70 pre-existing warnings in untouched files).
- Visual (CE, real running dev stack): reproduced with a personal project — before showed the raw id `d80png58gpmc73dejmtg`, after shows "Personal Project". Before/after in the Visual verification comment.
- No unit test added: 4-line display-binding swap to an existing pure helper; behaviour is covered by `getProjectName` plus the before/after visual proof.
- Frontend-only: no server/API change, no migration, no `@activepieces/shared` change.

Visual: Use Template modal Project dropdown (personal project) — before/after.

Fixes #14472

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)
