### PR TITLE
perf(engine): track flow log size incrementally instead of re-walking all steps

### DIFF
--- a/packages/server/engine/src/lib/handler/context/flow-execution-context.ts
+++ b/packages/server/engine/src/lib/handler/context/flow-execution-context.ts
@@ -2,12 +2,15 @@ import { apId, assertEqual, isNil } from '@activepieces/core-utils'
 import { BaseStepOutput, EngineGenericError, executionJournal, FailedStep, FileType, FlowActionType, FlowRunStatus, GenericStepOutput, LogSliceRef, LoopStepOutput, LoopStepResult, RespondResponse, StepOutput, StepOutputStatus, StepOutputType } from '@activepieces/shared'
 import { engineFileApi } from '../../api/engine-file-api'
 import { loggingUtils } from '../../helper/logging-utils'
+import { sizeofUtils } from '../../helper/sizeof'
 import { StepExecutionPath } from './step-execution-path'
 
 const DEFAULT_THRESHOLD_KB = 32
 const SLICE_THRESHOLD_BYTES = Number(
     process.env.AP_FLOW_RUN_LOG_SLICE_THRESHOLD_KB ?? DEFAULT_THRESHOLD_KB,
 ) * 1024
+
+const EMPTY_STEPS_SIZE_BYTES = sizeofUtils.recursiveSizeof({})
 
 export class FlowExecutorContext {
     tags: readonly string[]
@@ -19,6 +22,7 @@ export class FlowExecutorContext {
     engineApi?: EngineApiConfig
     resolvedStepOutputCache: Map<string, Promise<unknown>>
     slicingEnabled: boolean
+    logSizeBytes: number
 
     /**
      * Execution time in milliseconds
@@ -36,6 +40,7 @@ export class FlowExecutorContext {
         this.engineApi = copyFrom?.engineApi
         this.resolvedStepOutputCache  = copyFrom?.resolvedStepOutputCache  ?? new Map()
         this.slicingEnabled = copyFrom?.slicingEnabled ?? true
+        this.logSizeBytes = copyFrom?.logSizeBytes ?? EMPTY_STEPS_SIZE_BYTES
     }
 
     static empty(params?: FlowExecutorContextInit): FlowExecutorContext {
@@ -125,10 +130,12 @@ export class FlowExecutorContext {
                 errorMessage: truncated.errorMessage,
             })
         }
+        const previousStep = executionJournal.getStep({ stepName, path: this.currentPath.path, steps: this.steps })
         const steps = executionJournal.upsertStep({ stepName, stepOutput: finalized, path: this.currentPath.path, steps: this.steps })
         return new FlowExecutorContext({
             ...this,
             steps,
+            logSizeBytes: this.logSizeBytes + sizeofUtils.upsertStepDelta({ stepName, previousStep, nextStep: finalized }),
         })
     }
 

--- a/packages/server/engine/src/lib/handler/flow-executor.ts
+++ b/packages/server/engine/src/lib/handler/flow-executor.ts
@@ -166,7 +166,7 @@ const applyLogSizeLimitIfExceeded = async (
     flowExecutionContext: FlowExecutorContext,
     action: FlowAction | FlowTrigger,
 ): Promise<FlowExecutorContext> => {
-    if (loggingUtils.isWithinSizeLimit(flowExecutionContext.steps)) {
+    if (loggingUtils.isWithinSizeLimit(flowExecutionContext.logSizeBytes)) {
         return flowExecutionContext
     }
     const failed = await flowExecutionContext

--- a/packages/server/engine/src/lib/helper/logging-utils.ts
+++ b/packages/server/engine/src/lib/helper/logging-utils.ts
@@ -1,6 +1,4 @@
-import { StepOutput } from '@activepieces/shared'
 import { utils } from '../utils'
-import { sizeofUtils } from './sizeof'
 
 const DEFAULT_INPUT_TRUNCATE_THRESHOLD_KB = 2
 const INPUT_TRUNCATE_THRESHOLD_BYTES = Number(
@@ -40,7 +38,7 @@ export const loggingUtils = {
         return copy ?? input
     },
     maxLogSizeMb: MAX_LOG_SIZE / (1024 * 1024),
-    isWithinSizeLimit(steps: Record<string, StepOutput>, maxSize: number = MAX_SIZE_FOR_ALL_ENTRIES): boolean {
-        return sizeofUtils.recursiveSizeof(steps) <= maxSize
+    isWithinSizeLimit(logSizeBytes: number, maxSize: number = MAX_SIZE_FOR_ALL_ENTRIES): boolean {
+        return logSizeBytes <= maxSize
     },
 }

--- a/packages/server/engine/src/lib/helper/sizeof.ts
+++ b/packages/server/engine/src/lib/helper/sizeof.ts
@@ -1,3 +1,4 @@
+import { isNil } from '@activepieces/core-utils'
 import { StepOutputType } from '@activepieces/shared'
 import { utils } from '../utils'
 
@@ -45,6 +46,21 @@ function isSliceRefShape(value: unknown): value is { size: number } {
     )
 }
 
+function upsertStepDelta({ stepName, previousStep, nextStep }: UpsertStepDeltaParams): number {
+    const nextSize = recursiveSizeof(nextStep)
+    if (isNil(previousStep)) {
+        return utils.sizeof(stepName) + 2 + nextSize
+    }
+    return nextSize - recursiveSizeof(previousStep)
+}
+
 export const sizeofUtils = {
     recursiveSizeof,
+    upsertStepDelta,
+}
+
+type UpsertStepDeltaParams = {
+    stepName: string
+    previousStep: unknown
+    nextStep: unknown
 }

--- a/packages/server/engine/test/handler/context/flow-execution-context-log-size.test.ts
+++ b/packages/server/engine/test/handler/context/flow-execution-context-log-size.test.ts
@@ -1,0 +1,57 @@
+import { FlowActionType, GenericStepOutput, LoopStepOutput, StepOutputStatus, StepOutputType } from '@activepieces/shared'
+import { describe, expect, it } from 'vitest'
+import { FlowExecutorContext } from '../../../src/lib/handler/context/flow-execution-context'
+import { sizeofUtils } from '../../../src/lib/helper/sizeof'
+
+function pieceStep(output: unknown): GenericStepOutput<FlowActionType.PIECE, unknown> {
+    return GenericStepOutput.create({
+        type: FlowActionType.PIECE,
+        status: StepOutputStatus.SUCCEEDED,
+        input: { key: 'value' },
+    }).setOutput(output)
+}
+
+describe('FlowExecutorContext.logSizeBytes', () => {
+    it('starts at the size of an empty steps record', () => {
+        const ctx = FlowExecutorContext.empty()
+        expect(ctx.logSizeBytes).toBe(sizeofUtils.recursiveSizeof(ctx.steps))
+    })
+
+    it('matches a full recursive walk across inserts, overwrites and nested loop steps', async () => {
+        let ctx = FlowExecutorContext.empty()
+
+        ctx = await ctx.upsertStep('trigger', pieceStep({ payload: 'x'.repeat(100) }))
+        ctx = await ctx.upsertStep('trigger', pieceStep({ payload: 'tiny' }))
+
+        let loopOutput = LoopStepOutput.init({ input: { items: [1, 2] } })
+        ctx = await ctx.upsertStep('loop', loopOutput)
+
+        for (let iteration = 0; iteration < 2; iteration++) {
+            loopOutput = loopOutput.setItemAndIndex({ item: iteration, index: iteration + 1 }).addIteration()
+            ctx = (await ctx.upsertStep('loop', loopOutput))
+                .setCurrentPath(ctx.currentPath.loopIteration({ loopName: 'loop', iteration }))
+            ctx = await ctx.upsertStep('inner', pieceStep({ nested: ['a', 'b', iteration] }))
+            ctx = await ctx.upsertStep('inner', pieceStep({ nested: 'overwritten'.repeat(iteration + 1) }))
+            ctx = ctx.setCurrentPath(ctx.currentPath.removeLast())
+        }
+
+        ctx = await ctx.upsertStep('last', pieceStep(undefined))
+
+        expect(ctx.logSizeBytes).toBe(sizeofUtils.recursiveSizeof(ctx.steps))
+    })
+
+    it('counts the referenced size of sliced steps, not the ref payload', async () => {
+        const sliced = new GenericStepOutput({
+            type: FlowActionType.CODE,
+            status: StepOutputStatus.SUCCEEDED,
+            input: {},
+            outputType: StepOutputType.SLICE,
+            output: { fileId: 'file-1', size: 4_096, url: 'http://example.com/file-1' },
+        })
+
+        const ctx = await FlowExecutorContext.empty().upsertStep('echo_step', sliced)
+
+        expect(ctx.logSizeBytes).toBe(sizeofUtils.recursiveSizeof(ctx.steps))
+        expect(ctx.logSizeBytes).toBeGreaterThan(4_096)
+    })
+})

--- a/packages/server/engine/test/helper/logging-utils.test.ts
+++ b/packages/server/engine/test/helper/logging-utils.test.ts
@@ -1,8 +1,3 @@
-import {
-    FlowActionType,
-    GenericStepOutput,
-    StepOutputStatus,
-} from '@activepieces/shared'
 import { loggingUtils } from '../../src/lib/helper/logging-utils'
 
 describe('loggingUtils.maybeTruncateInput', () => {
@@ -59,25 +54,11 @@ describe('loggingUtils.maybeTruncateInput', () => {
 })
 
 describe('loggingUtils.isWithinSizeLimit', () => {
-    it('returns true when steps fit under the cap', () => {
-        const steps = {
-            step1: GenericStepOutput.create({
-                type: FlowActionType.PIECE,
-                status: StepOutputStatus.SUCCEEDED,
-                input: { tiny: 'ok' },
-            }),
-        }
-        expect(loggingUtils.isWithinSizeLimit(steps, 10 * 1024)).toBe(true)
+    it('returns true when the tracked size fits under the cap', () => {
+        expect(loggingUtils.isWithinSizeLimit(1024, 10 * 1024)).toBe(true)
     })
 
-    it('returns false when steps blow the cap', () => {
-        const steps = {
-            step1: GenericStepOutput.create({
-                type: FlowActionType.PIECE,
-                status: StepOutputStatus.SUCCEEDED,
-                input: { large: 'x'.repeat(4096) },
-            }),
-        }
-        expect(loggingUtils.isWithinSizeLimit(steps, 128)).toBe(false)
+    it('returns false when the tracked size blows the cap', () => {
+        expect(loggingUtils.isWithinSizeLimit(4096, 128)).toBe(false)
     })
 })


### PR DESCRIPTION
## Description

`applyLogSizeLimitIfExceeded` called `loggingUtils.isWithinSizeLimit(steps)` after every executed action, which ran `recursiveSizeof` over the entire steps tree — stringifying every leaf — to answer a question `upsertStep` already knows the delta for.

`FlowExecutorContext` now carries a running `logSizeBytes`:

- `upsertStep` reads the step it is about to replace at the current path and adds `sizeofUtils.upsertStepDelta` (size of the new step minus size of the replaced one, plus key overhead for inserts) to the running total.
- `loggingUtils.isWithinSizeLimit` takes the tracked byte count and becomes an O(1) comparison against the cap.

The per-action cost drops from O(total log size) to O(size of the upserted step). Slice refs keep counting their referenced `size` exactly as `recursiveSizeof` did.

## How was this tested?

- New `flow-execution-context-log-size.test.ts` asserts the incremental total stays byte-identical to a full `recursiveSizeof` walk across inserts, overwrites, nested loop iterations, and sliced steps.
- Existing `flow-log-size.test.ts` (end-to-end `LOG_SIZE_EXCEEDED` verdicts, including loops and trigger output) and `flow-looping.test.ts` pass unchanged.

Fixes # (issue)

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)