### PR TITLE
feat(agent): make the AI Agent step recover from failures automatically

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -10577,6 +10577,7 @@
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
+        "@ai-sdk/provider": "^3.0.0",
         "ai": "^6.0.0",
         "semver": "7.6.0",
         "zod": "4.3.6",
@@ -10727,6 +10728,7 @@
       "name": "@activepieces/engine",
       "version": "0.7.0",
       "dependencies": {
+        "@activepieces/core-agent-runtime": "workspace:*",
         "@activepieces/core-formula": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
         "@activepieces/pieces-common": "workspace:*",

--- a/packages/pieces/community/ai/package.json
+++ b/packages/pieces/community/ai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-ai",
-  "version": "0.4.9",
+  "version": "0.5.0",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/packages/pieces/community/ai/src/lib/actions/agents/run-agent.ts
+++ b/packages/pieces/community/ai/src/lib/actions/agents/run-agent.ts
@@ -7,7 +7,6 @@ import {
 import { isNil } from '@activepieces/pieces-framework';
 import { AgentToolType } from '@activepieces/pieces-framework';
 import { AgentOutputField, AgentPieceProps, AgentTaskStatus, AgentTool, TASK_COMPLETION_TOOL_NAME, AIProviderName, AgentProviderModel, ExecutionToolStatus, AgentKnowledgeBaseTool, KnowledgeBaseSourceType, normalizeToolOutputToExecuteResponse, spreadIfDefined, getEffectiveProviderAndModel } from '@activepieces/pieces-framework';
-import { hasToolCall, stepCountIs, streamText } from 'ai';
 import { agentOutputBuilder } from './agent-output-builder';
 import { createAIModel, createEmbeddingModel } from '../../common/ai-sdk';
 import { inspect } from 'util';
@@ -199,19 +198,16 @@ export const runAgent = createAction({
 
     try {
       const prompts = agentUtils.getPrompts(prompt, { hasKnowledgeBaseTools });
-      const stream = streamText({
-        model: model,
+      const runResult = await context.agent.run({
+        model,
+        provider,
         system: prompts.system,
         prompt: prompts.prompt,
         tools: allTools,
-        stopWhen: [stepCountIs(maxSteps), hasToolCall(TASK_COMPLETION_TOOL_NAME)],
+        maxSteps,
         providerOptions,
-        onFinish: async () => {
-          await Promise.all(mcpClients.map(async (client) => client.close()));
-        },
-      });
-
-      for await (const chunk of stream.fullStream) {
+        stopOnToolName: TASK_COMPLETION_TOOL_NAME,
+        onChunk: async (chunk) => {
         try {
           switch (chunk.type) {
             case 'text-delta': {
@@ -228,7 +224,7 @@ export const runAgent = createAction({
             }
             case 'tool-call': {
               if (agentUtils.isTaskCompletionToolCall(chunk.toolName)) {
-                continue;
+                return;
               }
               outputBuilder.startToolCall({
                 toolName: chunk.toolName,
@@ -239,7 +235,7 @@ export const runAgent = createAction({
             }
             case 'tool-result': {
               if (agentUtils.isTaskCompletionToolCall(chunk.toolName)) {
-                continue;
+                return;
               }
               const rawOutput = chunk.output;
               const toolOutput = normalizeToolOutputToExecuteResponse(rawOutput);
@@ -302,18 +298,29 @@ export const runAgent = createAction({
             details: detailsStr,
           });
         }
-      }
+        },
+      });
 
-      if (!outputBuilder.hasTextContent()) {
-        try {
-          const accumulatedText = await stream.text;
-          if (accumulatedText?.trim()) {
-            outputBuilder.addMarkdown(accumulatedText);
-            await context.output.update({ data: outputBuilder.build() });
-          }
-        } catch {
-          // ignore
-        }
+      await Promise.all(mcpClients.map(async (client) => client.close()));
+
+      if (runResult.streamError) {
+        errors.push({
+          type: 'stream-error',
+          message: 'Error during streaming',
+          details: inspect(runResult.streamError),
+        });
+      }
+      if (runResult.truncatedAfterRetries) {
+        errors.push({
+          type: 'truncated',
+          message: `Response was still cut off by the output token limit after ${runResult.continuations} auto-continuations`,
+        });
+      }
+      if (runResult.budgetExceeded) {
+        errors.push({
+          type: 'budget-exceeded',
+          message: 'Stopped early after hitting the per-run token budget',
+        });
       }
 
       if (errors.length > 0) {

--- a/packages/pieces/framework/package.json
+++ b/packages/pieces/framework/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@activepieces/core-utils": "workspace:*",
     "@activepieces/core-piece-types": "workspace:*",
+    "@ai-sdk/provider": "^3.0.0",
     "zod": "4.3.6",
     "ai": "^6.0.0",
     "semver": "7.6.0"

--- a/packages/pieces/framework/src/lib/context/index.ts
+++ b/packages/pieces/framework/src/lib/context/index.ts
@@ -11,9 +11,11 @@ import {
   PauseMetadata,
   WebhookPauseMetadata,
 } from '@activepieces/core-piece-types';
+import type { AIProviderName } from '@activepieces/core-utils';
 import type { SeekPage } from '@activepieces/core-utils';
 import type { FlowRunId, ProjectId } from '@activepieces/core-utils';
-import { LanguageModel, Tool } from 'ai'
+import type { SharedV3ProviderOptions } from '@ai-sdk/provider'
+import { LanguageModel, TextStreamPart, Tool, ToolSet } from 'ai'
 import type { Readable } from 'node:stream'
 
 import {
@@ -266,8 +268,30 @@ export type ConstructToolParams = {
   model: LanguageModel,
 }
 
+export type RunAgentParams = {
+  model: LanguageModel;
+  provider: AIProviderName;
+  system: string;
+  prompt: string;
+  tools: Record<string, Tool>;
+  maxSteps: number;
+  providerOptions?: SharedV3ProviderOptions;
+  stopOnToolName?: string;
+  onChunk: (chunk: AgentStreamChunk) => Promise<void> | void;
+};
+
+export type AgentStreamChunk = TextStreamPart<ToolSet>;
+
+export type RunAgentResult = {
+  streamError: Error | null;
+  truncatedAfterRetries: boolean;
+  budgetExceeded: boolean;
+  continuations: number;
+};
+
 export interface AgentContext {
   tools: (params: ConstructToolParams) => Promise<Record<string, Tool>>;
+  run: (params: RunAgentParams) => Promise<RunAgentResult>;
 }
 
 export interface FilesService {

--- a/packages/pieces/framework/src/lib/test/index.ts
+++ b/packages/pieces/framework/src/lib/test/index.ts
@@ -45,6 +45,12 @@ export function createMockActionContext<
     },
     agent: {
       tools: async () => ({}),
+      run: async () => ({
+        streamError: null,
+        truncatedAfterRetries: false,
+        budgetExceeded: false,
+        continuations: 0,
+      }),
     },
     run: {
       id: 'test-run-id' as string,

--- a/packages/server/engine/package.json
+++ b/packages/server/engine/package.json
@@ -9,6 +9,7 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "@activepieces/core-agent-runtime": "workspace:*",
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "@activepieces/shared": "workspace:*",

--- a/packages/server/engine/src/lib/agent/run.ts
+++ b/packages/server/engine/src/lib/agent/run.ts
@@ -1,0 +1,56 @@
+import { runAgentTurn } from '@activepieces/core-agent-runtime'
+import { tryCatchSync } from '@activepieces/core-utils'
+import { RunAgentParams, RunAgentResult } from '@activepieces/pieces-framework'
+import { hasToolCall } from 'ai'
+
+export const agentRunner = {
+    async run({ model, provider, system, prompt, tools, maxSteps, providerOptions, stopOnToolName, onChunk }: RunAgentParams): Promise<RunAgentResult> {
+        const result = await runAgentTurn({
+            model,
+            provider,
+            systemPrompt: system,
+            messages: [{ role: 'user', content: prompt }],
+            tools,
+            ...(providerOptions ? { providerOptions } : {}),
+            log: agentStepLogger,
+            maxSteps,
+            ...(stopOnToolName ? { stopWhen: [hasToolCall(stopOnToolName)] } : {}),
+            drainStream: async (stream, markVisibleOutput) => {
+                for await (const chunk of stream.fullStream) {
+                    // Deltas reach the step's output builder as they arrive, so a stream that dies
+                    // after emitting some must not be retried — the retry would append a second
+                    // copy of the text the user can already see.
+                    if (chunk.type === 'text-delta' || chunk.type === 'tool-call') {
+                        markVisibleOutput()
+                    }
+                    await onChunk(chunk)
+                }
+            },
+        })
+
+        return {
+            streamError: result.streamError,
+            truncatedAfterRetries: result.truncatedAfterRetries,
+            budgetExceeded: result.budgetExceeded,
+            continuations: result.continuations,
+        }
+    },
+}
+
+
+// `console` IS the engine's logger — `worker-socket.ts` patches it to forward to the worker as run
+// stdout/stderr, joining its args with a space. Fields therefore have to be serialized here or
+// they reach the run log as "[object Object]"; Errors need unwrapping too, since JSON.stringify
+// renders them as "{}" and would drop the message that makes the log worth reading.
+function serializeFields(obj: Record<string, unknown>): string {
+    const { data } = tryCatchSync(() => JSON.stringify(obj, (_key, value) =>
+        value instanceof Error ? { message: value.message, stack: value.stack } : value,
+    ))
+    return data ?? ''
+}
+
+const agentStepLogger = {
+    info: (obj: Record<string, unknown>, msg: string) => console.log(msg, serializeFields(obj)),
+    warn: (obj: Record<string, unknown>, msg: string) => console.warn(msg, serializeFields(obj)),
+    error: (obj: Record<string, unknown>, msg: string) => console.error(msg, serializeFields(obj)),
+}

--- a/packages/server/engine/src/lib/handler/piece-executor.ts
+++ b/packages/server/engine/src/lib/handler/piece-executor.ts
@@ -1,8 +1,9 @@
 import { isNil } from '@activepieces/core-utils'
-import { ActionContext, backwardCompatabilityContextUtils, ConstructToolParams, CreateWaitpointHook, CreateWaitpointParams, CreateWaitpointResult, InputPropertyMap, PieceAuthProperty, PiecePropertyMap, RespondHook, RespondHookParams, StaticPropsValue, StopHook, StopHookParams, TagsManager, WaitForWaitpointHook } from '@activepieces/pieces-framework'
+import { ActionContext, backwardCompatabilityContextUtils, ConstructToolParams, CreateWaitpointHook, CreateWaitpointParams, CreateWaitpointResult, InputPropertyMap, PieceAuthProperty, PiecePropertyMap, RespondHook, RespondHookParams, RunAgentParams, RunAgentResult, StaticPropsValue, StopHook, StopHookParams, TagsManager, WaitForWaitpointHook } from '@activepieces/pieces-framework'
 import { AUTHENTICATION_PROPERTY_NAME, EngineGenericError, ExecutionType, FlowActionType, FlowRunStatus, GenericStepOutput, PausedFlowTimeoutError, PieceAction, RespondResponse, StepOutputStatus } from '@activepieces/shared'
 import type { ToolSet } from 'ai'
 import dayjs from 'dayjs'
+import { agentRunner } from '../agent/run'
 import { engineRunApi } from '../api/engine-run-api'
 import { continueIfFailureHandler, runWithExponentialBackoff } from '../helper/error-handling'
 import { flowRunProgressReporter } from '../helper/flow-run-progress-reporter'
@@ -121,6 +122,7 @@ const executeAction: ActionHandler<PieceAction> = async ({ action, executionStat
                     tools: params.tools,
                     model: params.model,
                 }),
+                run: async (params: RunAgentParams): Promise<RunAgentResult> => agentRunner.run(params),
             },
             propsValue: processedInput,
             tags: createTagsManager(params),

--- a/packages/server/engine/test/agent/run.test.ts
+++ b/packages/server/engine/test/agent/run.test.ts
@@ -1,0 +1,76 @@
+import { AIProviderName } from '@activepieces/core-utils'
+import { AgentStreamChunk } from '@activepieces/pieces-framework'
+import { simulateReadableStream } from 'ai/test'
+import { MockLanguageModelV3 } from 'ai/test'
+import { describe, expect, it } from 'vitest'
+import { agentRunner } from '../../src/lib/agent/run'
+
+const COMPLETION_TOOL = 'updateTaskStatus'
+
+function textModel(chunks: string[], finishReason = 'stop') {
+    return new MockLanguageModelV3({
+        doStream: async () => ({
+            stream: simulateReadableStream({
+                chunks: [
+                    { type: 'stream-start', warnings: [] },
+                    { type: 'text-start', id: '0' },
+                    ...chunks.map((text) => ({ type: 'text-delta' as const, id: '0', delta: text })),
+                    { type: 'text-end', id: '0' },
+                    { type: 'finish', finishReason: { unified: finishReason, raw: finishReason }, usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 } },
+                ],
+            }),
+        }),
+    })
+}
+
+async function runWith(model: MockLanguageModelV3, maxSteps = 5) {
+    const chunks: AgentStreamChunk[] = []
+    const result = await agentRunner.run({
+        model,
+        provider: AIProviderName.OPENAI,
+        system: 'you are a test agent',
+        prompt: 'do the thing',
+        tools: {},
+        maxSteps,
+        stopOnToolName: COMPLETION_TOOL,
+        onChunk: (chunk) => {
+            chunks.push(chunk)
+        },
+    })
+    return { result, chunks }
+}
+
+describe('agentRunner.run', () => {
+    it('streams every chunk to onChunk and reports produced text', async () => {
+        const { result, chunks } = await runWith(textModel(['Hello', ' world']))
+
+        const text = chunks
+            .filter((chunk) => chunk.type === 'text-delta')
+            .map((chunk) => 'text' in chunk ? chunk.text : '')
+            .join('')
+
+        expect(text).toBe('Hello world')
+        expect(result.streamError).toBeNull()
+        expect(result.truncatedAfterRetries).toBe(false)
+    })
+
+    it('reports truncation after exhausting auto-continuations instead of silently stopping', async () => {
+        const { result } = await runWith(textModel(['partial'], 'length'))
+
+        expect(result.truncatedAfterRetries).toBe(true)
+        expect(result.continuations).toBeGreaterThan(0)
+    })
+
+    it('surfaces a stream error rather than throwing', async () => {
+        const failing = new MockLanguageModelV3({
+            doStream: async () => {
+                throw new Error('provider exploded')
+            },
+        })
+
+        const { result, chunks } = await runWith(failing)
+
+        expect(result.streamError).toBeInstanceOf(Error)
+        expect(chunks.filter((chunk) => chunk.type === 'text-delta')).toHaveLength(0)
+    })
+})


### PR DESCRIPTION
> **Superseded and closed.** This built a shared runtime with two execution hosts (chat in the worker, the agent step in the engine). We are replacing that with a single server-side execution: the Agent step becomes a thin client that suspends on a waitpoint while the server runs the same path chat uses. The engine-side agent code is being deleted rather than shared. Rebuilding against that design.

---

<!-- merge-order:start -->
> Part of **stack #14549** — GitHub shows the order and lets you page through the chain, so it is not repeated here. Merge bottom-up; each PR retargets to `main` automatically as its parent lands.
>
> #14480 (contract dedup) and #14484 (agents become enterprise-only, breaking, draft) are **not** in the stack — they branch off `main` and can merge independently, in any order.
<!-- merge-order:end -->

> **Stacked on #14481** — review that first. This PR's own diff is 8 files.

## Description

The **Run Agent** step had its own `streamText` loop inside the piece bundle. It had no retry, no handling for a response truncated by the output-token limit, no brake on a tool that keeps failing the same way, and MCP connection failures were swallowed into an empty tool set. None of the hardening chat had accumulated could reach it, because the two loops shared no code.

The loop now runs in the **engine**, through a new `AgentContext.run()` that sits beside the `AgentContext.tools()` seam the piece already delegates to.

**Why the engine and not a worker job.** A piece action that blocks waiting on a *separate* worker job still holds its own worker slot. At 1–5 concurrency per replica (`brain/decisions/000001`), every replica can end up blocked on agent steps with nobody free to run the loops they are waiting for. Hosting the loop where `tools()` already runs needs no new job type, no queue and no RPC layer.

**Streaming is preserved exactly.** `buildParts` only fires at step end, but the agent step updates its timeline on every delta. The engine drains `fullStream` and forwards each chunk to the piece's `onChunk`, so `context.output.update()` still runs per delta as before. The piece and engine share a JS heap, so the callback costs nothing.

### What users get

The agent step now recovers from things that used to just fail the step:

- a dropped stream retried once, with rate-limit / 5xx / timeout classified as transient
- a response cut off by the output limit continued automatically instead of returning half-finished work
- a malformed tool call repaired instead of erroring
- a tool that returns the same failure or the same empty result twice short-circuited with a "change approach" directive, instead of burning steps and credits on a loop
- oversized tool history collapsed in-loop instead of overflowing the context window
- a per-run token ceiling as a runaway-cost backstop

## How was this tested?

- New `packages/server/engine/test/agent/run.test.ts` — 3 tests against a mock model: chunk streaming reaches `onChunk`, truncation auto-continue actually fires (`truncatedAfterRetries` + `continuations > 0`), and a provider error surfaces as `streamError` rather than throwing.
- Typecheck: `piece-ai` **0 errors**; engine at its pre-existing 14 (all in `engine-file-api.ts` / `engine-run-api.ts` / `dns-lookup-guard.ts`, none in files this PR touches — verified against a clean tree).
- Full engine suite: 26 failed / 341 passed, identical failure set to a clean-tree baseline of 26 failed / 338 passed (+3 from this PR). Those failures are pre-existing and depend on locally-built pieces.
- Lint 0 errors.
- **Note for reviewers:** AI SDK v6 carries `finishReason` as `{ unified, raw }`, not a string. My first mock used a plain string and silently got `'other'`, which would have made the truncation test a false negative. I verified against raw `streamText` that this was the mock, not our code.

Fixes # (issue)

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

Existing agent steps keep the same settings, the same system prompt and the same `AgentResult` output shape. Locked flow versions pin their piece version (`brain/decisions/000005`), so a published flow does not even load this code until it is next edited and re-locked.

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)

Connection resolution, credential handling and tool execution are unchanged — the piece still builds its own model and tool set and passes them in. Only the loop that drives them moved.
