### PR TITLE
feat(agent): make the AI Agent step an enterprise feature

### DIFF
--- a/docs/install/reference/breaking-changes.mdx
+++ b/docs/install/reference/breaking-changes.mdx
@@ -5,6 +5,19 @@ icon: "hammer"
 ---
 
 
+## 0.87.0
+
+### What has changed?
+
+#### The AI Agent step is now an enterprise feature
+The **Run Agent** step is now gated behind the `agentsEnabled` plan entitlement, alongside the rest of the AI agent surface. It was previously available on Community and on the standard Cloud plan; on both, `agentsEnabled` now defaults to off. Platforms with an enterprise license or a Cloud plan that includes agents are unaffected.
+
+Flows that already contain an agent step keep their configuration — the step is not removed or rewritten — but on a platform without the entitlement it will no longer execute, and the step is hidden from the piece selector when adding new steps.
+
+### Do you need to take action?
+- Only if you run Community or standard Cloud **and** have flows that use the Run Agent step. Those steps stop executing on upgrade. Either move the platform to a plan that includes agents, or replace the step — the **Ask AI** / **Extract Structured Data** actions in the same AI piece cover many single-shot use cases and are not gated.
+- To check before upgrading, search your flows for the `run_agent` action of the `@activepieces/piece-ai` piece.
+
 ## 0.86.0
 
 ### What has changed?

--- a/docs/install/reference/breaking-changes.mdx
+++ b/docs/install/reference/breaking-changes.mdx
@@ -17,6 +17,7 @@ Flows that already contain an agent step keep their configuration — the step i
 ### Do you need to take action?
 - Only if you run Community or standard Cloud **and** have flows that use the Run Agent step. Those steps stop executing on upgrade. Either move the platform to a plan that includes agents, or replace the step — the **Ask AI** / **Extract Structured Data** actions in the same AI piece cover many single-shot use cases and are not gated.
 - To check before upgrading, search your flows for the `run_agent` action of the `@activepieces/piece-ai` piece.
+- **Cloud platforms with an already-persisted plan row keep agent access until their plan is next reconciled.** Changing the default only affects platforms that fall back to it; an existing `platform_plan` row with `agentsEnabled: true` is returned as stored. Self-hosted Community platforms are affected immediately.
 
 ## 0.86.0
 

--- a/packages/core/shared/package.json
+++ b/packages/core/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/shared",
-  "version": "0.123.0",
+  "version": "0.124.0",
   "type": "commonjs",
   "sideEffects": false,
   "main": "./dist/src/index.js",

--- a/packages/core/shared/src/lib/ee/billing/index.ts
+++ b/packages/core/shared/src/lib/ee/billing/index.ts
@@ -80,7 +80,7 @@ export const STANDARD_CLOUD_PLAN: PlatformPlanWithOnlyLimits = {
     projectsLimit: 1,
     aiCreditsAutoTopUpState: AiCreditsAutoTopUpState.DISABLED,
     embeddingEnabled: false,
-    agentsEnabled: true,
+    agentsEnabled: false,
     aiProvidersEnabled: false,
     chatEnabled: false,
     workerGroupsEnabled: false,
@@ -107,7 +107,7 @@ export const STANDARD_CLOUD_PLAN: PlatformPlanWithOnlyLimits = {
 export const OPEN_SOURCE_PLAN: PlatformPlanWithOnlyLimits = {
     tablesEnabled: true,
     embeddingEnabled: false,
-    agentsEnabled: true,
+    agentsEnabled: false,
     aiProvidersEnabled: true,
     chatEnabled: false,
     workerGroupsEnabled: false,


### PR DESCRIPTION
<!-- merge-order:start -->
> Independent of **stack #14549** (#14481 → #14485 → #14482 → #14483). This PR branches off `main` and can merge on its own, in any order relative to the stack.
<!-- merge-order:end -->

> **Draft on purpose.** This revokes a working feature from Community and standard-Cloud platforms. It is independent of the other agent PRs (#14480–#14483) and can merge whenever the product decision is confirmed — mark ready when that is settled.

## Description

Makes the **Run Agent** step an enterprise feature, gated by the existing `agentsEnabled` plan entitlement, alongside the rest of the AI agent surface.

Today both defaults are on:

```
OPEN_SOURCE_PLAN.agentsEnabled    = true
STANDARD_CLOUD_PLAN.agentsEnabled = true
```

Both become `false`. Platforms with an enterprise license, or a Cloud plan that includes agents, are unaffected.

Flows keep their agent step configuration — nothing is removed or rewritten — but on a platform without the entitlement the step no longer executes, and it is hidden from the piece selector when adding new steps.

**Please read this bit before approving.** Community self-hosters and standard-Cloud customers have working agent steps in published, scheduled flows *today*. On upgrade those steps stop executing. That is the intended outcome here, but it is a real revocation rather than a gate on something new, so it deserves an explicit product sign-off and probably customer comms rather than just a code review.

Includes the required `docs/install/reference/breaking-changes.mdx` entry under `0.87.0`, with how to find affected flows before upgrading (search for the `run_agent` action of `@activepieces/piece-ai`) and what to move to (`Ask AI` / `Extract Structured Data` in the same piece are not gated).

`@activepieces/shared` bumped `0.123.0` → `0.124.0`.

## How was this tested?

- Typecheck 0 errors on `core/shared`, `server/api`, `web`.
- `core/shared` unit tests: 443 passed.
- The change is two boolean literals plus docs; the behaviour it drives (`platformMustHaveFeatureEnabled`, the piece-selector gate at `packages/web/src/app/builder/pieces-selector/index.tsx`) is existing, already-tested machinery.
- Edition matrix to confirm before merge: **CE** and **Cloud standard** → agent step hidden in the selector and existing agent steps stop executing; **EE** / **Cloud enterprise** → unchanged.

Fixes # (issue)

### Breaking change?  (required — CI fails if this is left unedited)

- [ ] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [x] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)

Restricts access to a feature; it does not change authentication, permissions enforcement, secrets or outbound HTTP.
