### PR TITLE
fix(deploy): self-hosted restarts no longer cut off in-progress runs after 1.6 seconds

### DIFF
--- a/deploy/activepieces-helm/templates/deployment.yaml
+++ b/deploy/activepieces-helm/templates/deployment.yaml
@@ -33,6 +33,7 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds | default 40 }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/deploy/activepieces-helm/values.yaml
+++ b/deploy/activepieces-helm/values.yaml
@@ -5,7 +5,7 @@
 # This will set the replicaset count more information can be found here: https://kubernetes.io/docs/concepts/workloads/controllers/replicaset/
 replicaCount: 1
 
-# Pod termination grace period in seconds. Keep it above the image's PM2 kill_timeout (35s by default, PM2_KILL_TIMEOUT env) so the app and worker can finish draining in-flight runs before the pod is killed.
+# Pod termination grace period in seconds. Keep it above the image's PM2 kill timeout (worker: 35s; app: AP_WEBHOOK_TIMEOUT_SECONDS + 5s, minimum 35s; PM2_KILL_TIMEOUT overrides both) so the app and worker can finish draining in-flight work before the pod is killed.
 terminationGracePeriodSeconds: 40
 
 # This sets the container image more information can be found here: https://kubernetes.io/docs/concepts/containers/images/

--- a/deploy/activepieces-helm/values.yaml
+++ b/deploy/activepieces-helm/values.yaml
@@ -5,6 +5,9 @@
 # This will set the replicaset count more information can be found here: https://kubernetes.io/docs/concepts/workloads/controllers/replicaset/
 replicaCount: 1
 
+# Pod termination grace period in seconds. Keep it above the image's PM2 kill_timeout (35s by default, PM2_KILL_TIMEOUT env) so the app and worker can finish draining in-flight runs before the pod is killed.
+terminationGracePeriodSeconds: 40
+
 # This sets the container image more information can be found here: https://kubernetes.io/docs/concepts/containers/images/
 image:
   repository: ghcr.io/activepieces/activepieces

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,7 @@ services:
     image: ghcr.io/activepieces/activepieces:0.86.3
     container_name: activepieces-app
     restart: unless-stopped
+    stop_grace_period: 40s
     ports:
       - '8080:80'
     depends_on:
@@ -18,6 +19,7 @@ services:
   worker:
     image: ghcr.io/activepieces/activepieces:0.86.3
     restart: unless-stopped
+    stop_grace_period: 40s
     depends_on:
       - app
     env_file: .env

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -28,8 +28,22 @@ fi
 # Build PM2 ecosystem config
 KILL_TIMEOUT_MS="$PM2_KILL_TIMEOUT"
 case "$KILL_TIMEOUT_MS" in
-    ''|0*|*[!0-9]*) KILL_TIMEOUT_MS=35000 ;;
+    ''|0*|*[!0-9]*) KILL_TIMEOUT_MS="" ;;
 esac
+
+if [ -n "$KILL_TIMEOUT_MS" ]; then
+    APP_KILL_TIMEOUT_MS="$KILL_TIMEOUT_MS"
+else
+    WEBHOOK_TIMEOUT_S="$AP_WEBHOOK_TIMEOUT_SECONDS"
+    case "$WEBHOOK_TIMEOUT_S" in
+        ''|0*|*[!0-9]*) WEBHOOK_TIMEOUT_S=30 ;;
+    esac
+    APP_KILL_TIMEOUT_MS=$(( (WEBHOOK_TIMEOUT_S + 5) * 1000 ))
+    if [ "$APP_KILL_TIMEOUT_MS" -lt 35000 ]; then
+        APP_KILL_TIMEOUT_MS=35000
+    fi
+fi
+WORKER_KILL_TIMEOUT_MS="${KILL_TIMEOUT_MS:-35000}"
 
 APPS=""
 
@@ -41,7 +55,7 @@ if [ "$AP_CONTAINER_TYPE" = "APP" ] || [ "$AP_CONTAINER_TYPE" = "WORKER_AND_APP"
         node_args: '--enable-source-maps',
         instances: 1,
         exec_mode: 'fork',
-        kill_timeout: ${KILL_TIMEOUT_MS},
+        kill_timeout: ${APP_KILL_TIMEOUT_MS},
         env: { AP_CONTAINER_TYPE: 'APP' }
     },"
 fi
@@ -54,7 +68,7 @@ if [ "$AP_CONTAINER_TYPE" = "WORKER" ] || [ "$AP_CONTAINER_TYPE" = "WORKER_AND_A
         node_args: '--enable-source-maps',
         instances: 1,
         exec_mode: 'fork',
-        kill_timeout: ${KILL_TIMEOUT_MS}
+        kill_timeout: ${WORKER_KILL_TIMEOUT_MS}
     },"
 fi
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -28,7 +28,7 @@ fi
 # Build PM2 ecosystem config
 KILL_TIMEOUT_MS="$PM2_KILL_TIMEOUT"
 case "$KILL_TIMEOUT_MS" in
-    ''|*[!0-9]*) KILL_TIMEOUT_MS=35000 ;;
+    ''|0*|*[!0-9]*) KILL_TIMEOUT_MS=35000 ;;
 esac
 
 APPS=""

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -26,6 +26,11 @@ if [ -z "$AP_WORKER_TOKEN" ] && [ -n "$AP_JWT_SECRET" ]; then
 fi
 
 # Build PM2 ecosystem config
+KILL_TIMEOUT_MS="$PM2_KILL_TIMEOUT"
+case "$KILL_TIMEOUT_MS" in
+    ''|*[!0-9]*) KILL_TIMEOUT_MS=35000 ;;
+esac
+
 APPS=""
 
 if [ "$AP_CONTAINER_TYPE" = "APP" ] || [ "$AP_CONTAINER_TYPE" = "WORKER_AND_APP" ]; then
@@ -36,6 +41,7 @@ if [ "$AP_CONTAINER_TYPE" = "APP" ] || [ "$AP_CONTAINER_TYPE" = "WORKER_AND_APP"
         node_args: '--enable-source-maps',
         instances: 1,
         exec_mode: 'fork',
+        kill_timeout: ${KILL_TIMEOUT_MS},
         env: { AP_CONTAINER_TYPE: 'APP' }
     },"
 fi
@@ -47,7 +53,8 @@ if [ "$AP_CONTAINER_TYPE" = "WORKER" ] || [ "$AP_CONTAINER_TYPE" = "WORKER_AND_A
         script: 'packages/server/worker/dist/src/bootstrap.js',
         node_args: '--enable-source-maps',
         instances: 1,
-        exec_mode: 'fork'
+        exec_mode: 'fork',
+        kill_timeout: ${KILL_TIMEOUT_MS}
     },"
 fi
 

--- a/docs/install/reference/environment-variables.mdx
+++ b/docs/install/reference/environment-variables.mdx
@@ -150,6 +150,11 @@ run timeouts, and the network egress posture for user code. Read
 | `AP_PROJECT_RATE_LIMITER_ENABLED` | Enforce per-project rate limits to prevent excessive usage. | `false` |
 | `AP_NETWORK_MODE` | Egress posture for user code. `STRICT` installs the engine's in-process SSRF guard, blocking outbound connections to private, loopback, link-local, and cloud-metadata IPs across every Node egress path (`axios`, `fetch`, `undici`, raw `http`/`net`). This is best-effort, in-process protection — enforce the real boundary in infrastructure (see [Network Security](/install/architecture/network-security)). `UNRESTRICTED` disables the guard. | `UNRESTRICTED` |
 | `AP_SSRF_ALLOW_LIST` | Comma-separated IPs or CIDR ranges that bypass `AP_NETWORK_MODE=STRICT`, e.g. `10.0.0.5,10.10.0.0/24`. Only applies when `AP_NETWORK_MODE=STRICT`. | `None` |
+| `PM2_KILL_TIMEOUT` | Milliseconds PM2 (the process manager inside the official Docker image) waits after the stop signal before force-killing the app and worker processes. Overrides the derived defaults for both. | Derived, see below |
+
+<Note>
+On shutdown, the image gives each process time to finish gracefully: the worker gets 35 seconds (it drains in-flight runs for up to 25 seconds and force-exits at 30), and the app gets `AP_WEBHOOK_TIMEOUT_SECONDS` + 5 seconds (at least 35), so synchronous webhook requests it is still holding can complete. If you raise `AP_WEBHOOK_TIMEOUT_SECONDS`, also raise your orchestrator's stop grace period above the app's window — `terminationGracePeriodSeconds` on Kubernetes, `stop_grace_period` in Compose, `stopTimeout` on ECS, `--stop-timeout` for plain `docker run` — otherwise the container is killed before the processes finish shutting down.
+</Note>
 
 ---
 


### PR DESCRIPTION
Fixes activepieces/activepieces#14487<br>Closes activepieces/activepieces#14487

## Problem

1. PM2 in the official Docker image SIGKILLs the app/worker 1600ms after the stop signal (`kill_timeout` unset, pm2 6.0.10 default), so graceful shutdown (worker 25s drain + 30s force-exit guard) never completes on any deploy/restart. In-flight runs die mid-step (`SANDBOX_INTERNAL_ERROR: Worker exited with code 6 and signal null`), then retry from step one \~8 min later, duplicating non-idempotent side effects. Reported in [Pylon 5480](<https://app.usepylon.com/issues?issueNumber=5480>).
2. Even with (1) fixed, Docker's 10s / K8s' 30s default stop grace SIGKILLs the container before pm2's ceiling is reached.
3. The app can legitimately need longer than any flat default: it holds synchronous webhook responses open for up to `AP_WEBHOOK_TIMEOUT_SECONDS` (reporter runs 60s), and its `stop()` is `app.close()` with no inner timeout.

## Fix

* `docker-entrypoint.sh`: per-process pm2 `kill_timeout` — worker 35000ms (above its own 30s force-exit guard); app `(AP_WEBHOOK_TIMEOUT_SECONDS + 5) * 1000`, floored at 35000ms, so in-flight sync webhooks finish. A numeric `PM2_KILL_TIMEOUT` overrides both. Digits-only, no-leading-zero guards on both env vars because the values land in generated JS (leading zeros would parse as legacy octal; garbage would break container boot).
* `docker-compose.yml`: `stop_grace_period: 40s` on app + worker.
* `deploy/activepieces-helm`: `terminationGracePeriodSeconds` in values.yaml (default 40) + template.
* `docs/install/reference/environment-variables.mdx`: `PM2_KILL_TIMEOUT` row + a note on the shutdown ladder and raising the orchestrator grace period (k8s/compose/ECS/docker) when `AP_WEBHOOK_TIMEOUT_SECONDS` is raised.

Shutdown ladder at defaults: worker guard 30s < pm2 35s < orchestrator 40s. pm2's `kill_timeout` is a ceiling, not a wait — healthy shutdowns exit immediately (measured \~10.3s for a 10s drain).

## Verification

* Red-first proof, scripted against pm2 6.0.10 (the exact version pinned in `Dockerfile`): base entrypoint generates no `kill_timeout` in any `AP_CONTAINER_TYPE` mode and a 10s-drain process is SIGKILLed at exactly 1600ms mid-drain; patched entrypoint passes 13/13 config cases (per-mode defaults, webhook-derived app value `60s → 65000`, floor at 35000, garbage and leading-zero fallbacks for both env vars, explicit `PM2_KILL_TIMEOUT` precedence, valid generated JS). Behavioral run with real `pm2-runtime` on the entrypoint-generated config: 2/2 processes completed the full drain, 0 SIGKILLs, pm2 exited immediately after the drain finished.
* `npm run lint-dev` clean (0 errors; the 70 react-hooks warnings pre-exist on main, untouched).
* `sh -n` clean; compose + values.yaml YAML parse clean.
* UNVERIFIED: helm template render (helm unavailable locally); the added line follows the chart's existing `| default` idiom.
* No vitest harness exists for the entrypoint; the scripted red-first run above is the regression proof.
* Visual: none - infra entrypoint, deploy manifests, and a docs reference table row; no user-visible app surface.

Notes: `Dockerfile.worker` (direct `node`, no pm2) is unaffected by design — its shutdown is governed by the worker's own 30s guard plus orchestrator grace. Bare `docker run` users still need `--stop-timeout` (Docker's 10s default is outside the image's control; now documented). Setting `PM2_KILL_TIMEOUT` below the derived windows defeats the inner guards; explicit-override behavior, documented not guarded.

### Breaking change?  (required — CI fails if this is left unedited)

- [X] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

- [X] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)