### PR TITLE
fix(web): search piece sets by package name

### DIFF
--- a/packages/web/src/app/routes/platform/setup/pieces/piece-sets/piece-set-pieces-tab.test.ts
+++ b/packages/web/src/app/routes/platform/setup/pieces/piece-sets/piece-set-pieces-tab.test.ts
@@ -1,0 +1,35 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from 'vitest';
+import { matchesPieceSearch } from './piece-set-pieces-tab';
+
+const humanInput = {
+  displayName: 'Human Input',
+  name: '@activepieces/piece-forms',
+};
+
+describe('matchesPieceSearch', () => {
+  it('matches on the package name', () => {
+    expect(matchesPieceSearch(humanInput, '@activepieces/piece-forms')).toBe(
+      true
+    );
+    expect(matchesPieceSearch(humanInput, 'piece-forms')).toBe(true);
+  });
+
+  it('matches on the display name', () => {
+    expect(matchesPieceSearch(humanInput, 'Human Input')).toBe(true);
+    expect(matchesPieceSearch(humanInput, 'human')).toBe(true);
+  });
+
+  it('ignores case and surrounding whitespace', () => {
+    expect(matchesPieceSearch(humanInput, '  PIECE-FORMS  ')).toBe(true);
+  });
+
+  it('keeps every piece when the search is empty', () => {
+    expect(matchesPieceSearch(humanInput, '')).toBe(true);
+    expect(matchesPieceSearch(humanInput, '   ')).toBe(true);
+  });
+
+  it('does not match unrelated searches', () => {
+    expect(matchesPieceSearch(humanInput, 'slack')).toBe(false);
+  });
+});

--- a/packages/web/src/app/routes/platform/setup/pieces/piece-sets/piece-set-pieces-tab.tsx
+++ b/packages/web/src/app/routes/platform/setup/pieces/piece-sets/piece-set-pieces-tab.tsx
@@ -40,7 +40,7 @@ import { PieceComponentVisibilitySheet } from '../piece-component-visibility-she
 function setPieceVisible(
   pieces: PieceSelection,
   name: string,
-  visible: boolean,
+  visible: boolean
 ): PieceSelection {
   const isException = pieces.exceptions.includes(name);
   const shouldBeException =
@@ -59,11 +59,11 @@ function setPieceVisible(
 function setPiecesVisible(
   pieces: PieceSelection,
   names: string[],
-  visible: boolean,
+  visible: boolean
 ): PieceSelection {
   return names.reduce(
     (acc, name) => setPieceVisible(acc, name, visible),
-    pieces,
+    pieces
   );
 }
 
@@ -88,10 +88,10 @@ const BulkPieceSetActions = ({
 
   const selectedNames = selectedPieces.map((p) => p.name);
   const allIncluded = selectedPieces.every((p) =>
-    isPieceVisible({ pieces: pieceSet.config.pieces, name: p.name }),
+    isPieceVisible({ pieces: pieceSet.config.pieces, name: p.name })
   );
   const allExcluded = selectedPieces.every(
-    (p) => !isPieceVisible({ pieces: pieceSet.config.pieces, name: p.name }),
+    (p) => !isPieceVisible({ pieces: pieceSet.config.pieces, name: p.name })
   );
 
   const pendingRequest = (variables as { request: UpdatePieceSetRequestBody })
@@ -112,11 +112,11 @@ const BulkPieceSetActions = ({
                 pieces: setPiecesVisible(
                   pieceSet.config.pieces,
                   selectedNames,
-                  true,
+                  true
                 ),
               },
             },
-            { onSuccess: resetSelection },
+            { onSuccess: resetSelection }
           )
         }
       >
@@ -136,11 +136,11 @@ const BulkPieceSetActions = ({
                 pieces: setPiecesVisible(
                   pieceSet.config.pieces,
                   selectedNames,
-                  false,
+                  false
                 ),
               },
             },
-            { onSuccess: resetSelection },
+            { onSuccess: resetSelection }
           )
         }
       >
@@ -148,6 +148,23 @@ const BulkPieceSetActions = ({
         {t('Exclude')}
       </Button>
     </>
+  );
+};
+
+/**
+ * The pieces page can be searched by package name, so the piece set
+ * configuration table matches either the display name ("Human Input") or the
+ * package name ("@activepieces/piece-forms").
+ */
+export const matchesPieceSearch = (
+  piece: Pick<PieceMetadataModelSummary, 'displayName' | 'name'>,
+  search: string
+): boolean => {
+  const query = search.trim().toLowerCase();
+  if (query === '') return true;
+  return (
+    (piece.displayName ?? '').toLowerCase().includes(query) ||
+    (piece.name ?? '').toLowerCase().includes(query)
   );
 };
 
@@ -172,12 +189,12 @@ export const PieceSetPiecesTab = ({ pieceSet }: PieceSetPiecesTabProps) => {
           pieces: setPieceVisible(
             pieceSet.config.pieces,
             pieceName,
-            !currentlyIncluded,
+            !currentlyIncluded
           ),
         },
       });
     },
-    [updateSet, pieceSet.id, pieceSet.config.pieces],
+    [updateSet, pieceSet.id, pieceSet.config.pieces]
   );
 
   const filteredPieces = useMemo(() => {
@@ -198,6 +215,10 @@ export const PieceSetPiecesTab = ({ pieceSet }: PieceSetPiecesTabProps) => {
         {
           accessorKey: 'displayName',
           size: 300,
+          filterFn: (row, _columnId, filterValue) =>
+            typeof filterValue === 'string'
+              ? matchesPieceSearch(row.original, filterValue)
+              : true,
           header: ({ column }) => (
             <DataTableColumnHeader
               column={column}
@@ -221,7 +242,7 @@ export const PieceSetPiecesTab = ({ pieceSet }: PieceSetPiecesTabProps) => {
           ),
         },
         {
-          accessorKey: 'packageName',
+          accessorKey: 'name',
           size: 250,
           header: ({ column }) => (
             <DataTableColumnHeader
@@ -284,7 +305,7 @@ export const PieceSetPiecesTab = ({ pieceSet }: PieceSetPiecesTabProps) => {
                       setManagingComponentsPiece(row.original.name)
                     }
                     className={cn(
-                      'cursor-pointer disabled:cursor-not-allowed disabled:opacity-50',
+                      'cursor-pointer disabled:cursor-not-allowed disabled:opacity-50'
                     )}
                   >
                     <Badge variant={curated ? 'default' : 'accent'}>
@@ -326,7 +347,7 @@ export const PieceSetPiecesTab = ({ pieceSet }: PieceSetPiecesTabProps) => {
           },
         },
       ],
-      [pieceSet, togglePiece, isPending],
+      [pieceSet, togglePiece, isPending]
     );
 
   const managingPieceDisplayName = useMemo(
@@ -334,7 +355,7 @@ export const PieceSetPiecesTab = ({ pieceSet }: PieceSetPiecesTabProps) => {
       pieces?.find((p) => p.name === managingComponentsPiece)?.displayName ??
       managingComponentsPiece ??
       '',
-    [pieces, managingComponentsPiece],
+    [pieces, managingComponentsPiece]
   );
 
   return (
@@ -342,7 +363,7 @@ export const PieceSetPiecesTab = ({ pieceSet }: PieceSetPiecesTabProps) => {
       <DataTable
         emptyStateTextTitle={t('No pieces found')}
         emptyStateTextDescription={t(
-          'Start by installing pieces that you want to use in your automations',
+          'Start by installing pieces that you want to use in your automations'
         )}
         emptyStateIcon={<Package className="size-14" />}
         columns={columns}


### PR DESCRIPTION
Fixes #14392

## Problem

The pieces page (`/platform/setup/pieces`) can be searched by package name, but the piece set configuration table only filtered on `displayName`. Searching `@activepieces/piece-forms` there returns nothing, because that piece is called `Human Input`.

The two tables differ: the pieces page passes a `searchQuery` to `usePieces` and its input filter targets `accessorKey: 'name'`, while the piece set tab uses `clientFiltering` with `accessorKey: 'displayName'`.

## Change

Added a `filterFn` to the `displayName` column that matches either the display name or the package name, extracted as `matchesPieceSearch` so the behavior is unit tested.

While in there: the `Package Name` column used `accessorKey: 'packageName'`, but that field does not exist on `PieceMetadataModelSummary` (the cell renders `row.original.name`). Sorting and filtering on that column could not work, so it now points at `name`.

I left the filter label as `Piece Name` to avoid introducing an untranslated string. Happy to relabel it if you would prefer it to say the search covers package names.

## Testing

- Added `piece-set-pieces-tab.test.ts`, 5 cases: package name (full and partial), display name, case/whitespace insensitivity, empty search, and a non-match. Verified it fails when the package-name branch is removed and passes with it.
- `bunx vitest run` on that file: 5 passed.
- `tsc -p tsconfig.app.json --noEmit`: 16 errors in this file before and after my change, all pre-existing `pieceSet.config is of type 'unknown'` on lines I did not touch. No new errors.
- `prettier --write` applied.
- I could not run `eslint` locally because it needs the workspace packages built (`@activepieces/pieces-framework` dist missing), so I am relying on CI for lint.