### PR TITLE
feat: add Postcards (Designmodo) email builder piece

### DIFF
--- a/packages/pieces/community/postcards/.eslintrc.json
+++ b/packages/pieces/community/postcards/.eslintrc.json
@@ -1,0 +1,47 @@
+{
+  "extends": [
+    "../../../../.eslintrc.base.json"
+  ],
+  "ignorePatterns": [
+    "!**/*"
+  ],
+  "overrides": [
+    {
+      "files": [
+        "*.ts",
+        "*.tsx",
+        "*.js",
+        "*.jsx"
+      ],
+      "rules": {}
+    },
+    {
+      "files": [
+        "*.ts",
+        "*.tsx"
+      ],
+      "rules": {
+        "no-restricted-imports": [
+          "error",
+          {
+            "patterns": [
+              "lodash",
+              "lodash/*",
+              "@activepieces/core-*",
+              "@activepieces/server*",
+              "@activepieces/engine",
+              "@activepieces/shared"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "files": [
+        "*.js",
+        "*.jsx"
+      ],
+      "rules": {}
+    }
+  ]
+}

--- a/packages/pieces/community/postcards/README.md
+++ b/packages/pieces/community/postcards/README.md
@@ -1,0 +1,5 @@
+# pieces-postcards
+
+## Building
+
+Run `turbo run build --filter=@activepieces/piece-postcards` to build the library.

--- a/packages/pieces/community/postcards/package.json
+++ b/packages/pieces/community/postcards/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@activepieces/piece-postcards",
+  "version": "0.0.1",
+  "main": "./dist/src/index.js",
+  "types": "./dist/src/index.d.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.lib.json && cp package.json dist/",
+    "bundle": "node ../../../../dist/packages/cli/src/index.js pieces bundle",
+    "lint": "eslint 'src/**/*.ts'"
+  },
+  "dependencies": {
+    "@activepieces/pieces-common": "workspace:*",
+    "@activepieces/pieces-framework": "workspace:*",
+    "@activepieces/core-piece-types": "workspace:*",
+    "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
+  }
+}

--- a/packages/pieces/community/postcards/src/index.ts
+++ b/packages/pieces/community/postcards/src/index.ts
@@ -14,7 +14,7 @@ export const postcards = createPiece({
   description:
     'Email Builder by Designmodo. List projects and folders, check export quota, and export email designs as hosted HTML or a ZIP bundle.',
   auth: postcardsAuth,
-  minimumSupportedRelease: '0.36.1',
+  minimumSupportedRelease: '0.82.0',
   logoUrl: 'https://cdn.activepieces.com/pieces/postcards.png',
   categories: [PieceCategory.MARKETING],
   authors: ['designmodo'],

--- a/packages/pieces/community/postcards/src/index.ts
+++ b/packages/pieces/community/postcards/src/index.ts
@@ -1,0 +1,37 @@
+import { createPiece } from '@activepieces/pieces-framework';
+import { createCustomApiCallAction } from '@activepieces/pieces-common';
+import { PieceCategory } from '@activepieces/pieces-framework';
+import { postcardsAuth, POSTCARDS_BASE_URL } from './lib/auth';
+import { listProjects } from './lib/actions/list-projects';
+import { getProject } from './lib/actions/get-project';
+import { exportProject } from './lib/actions/export-project';
+import { listFolders } from './lib/actions/list-folders';
+import { getFolder } from './lib/actions/get-folder';
+import { getUsage } from './lib/actions/get-usage';
+
+export const postcards = createPiece({
+  displayName: 'Postcards',
+  description:
+    'Email Builder by Designmodo. List projects and folders, check export quota, and export email designs as hosted HTML or a ZIP bundle.',
+  auth: postcardsAuth,
+  minimumSupportedRelease: '0.36.1',
+  logoUrl: 'https://cdn.activepieces.com/pieces/postcards.png',
+  categories: [PieceCategory.MARKETING],
+  authors: ['designmodo'],
+  actions: [
+    listProjects,
+    getProject,
+    exportProject,
+    listFolders,
+    getFolder,
+    getUsage,
+    createCustomApiCallAction({
+      baseUrl: () => `${POSTCARDS_BASE_URL}/api/v1`,
+      auth: postcardsAuth,
+      authMapping: async (auth) => ({
+        Authorization: `Bearer ${(auth as { secret_text: string }).secret_text}`,
+      }),
+    }),
+  ],
+  triggers: [],
+});

--- a/packages/pieces/community/postcards/src/lib/actions/export-project.ts
+++ b/packages/pieces/community/postcards/src/lib/actions/export-project.ts
@@ -1,0 +1,83 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+import { postcardsAuth, POSTCARDS_BASE_URL } from '../auth';
+
+export const exportProject = createAction({
+  auth: postcardsAuth,
+  name: 'export_project',
+  displayName: 'Export Project',
+  description:
+    'Export a project to HTML or ZIP. With Image Hosting off, returns a ZIP (base64) bundling index.html + assets. With Image Hosting on, returns hosted HTML as JSON or raw HTML. Counts against the monthly export quota.',
+  props: {
+    id: Property.ShortText({
+      displayName: 'Project ID',
+      description: 'Numeric id or obfuscated_id.',
+      required: true,
+    }),
+    imageHosting: Property.Checkbox({
+      displayName: 'Image Hosting',
+      description:
+        'Upload assets to Postcards hosting and reference them by URL. If off, assets are bundled into a ZIP.',
+      required: false,
+      defaultValue: false,
+    }),
+    cdn: Property.Checkbox({
+      displayName: 'Use CDN',
+      description: 'Serve assets from the Postcards CDN. Requires Image Hosting and the Pro plan.',
+      required: false,
+      defaultValue: false,
+    }),
+    minify: Property.Checkbox({
+      displayName: 'Minify HTML',
+      required: false,
+      defaultValue: false,
+    }),
+    format: Property.StaticDropdown({
+      displayName: 'Format',
+      description: 'Response shape when Image Hosting is on (ignored for ZIP).',
+      required: false,
+      defaultValue: 'json',
+      options: {
+        options: [
+          { label: 'JSON ({ "html": "..." })', value: 'json' },
+          { label: 'Raw HTML', value: 'html' },
+        ],
+      },
+    }),
+    variables: Property.Object({
+      displayName: 'Variables',
+      description:
+        'Map of {{key}} placeholder substitutions. Values must be scalar (string, number, boolean).',
+      required: false,
+    }),
+  },
+  async run(context) {
+    const { id, imageHosting, cdn, minify, format, variables } = context.propsValue;
+    const isZip = !imageHosting;
+
+    const res = await httpClient.sendRequest({
+      method: HttpMethod.POST,
+      url: `${POSTCARDS_BASE_URL}/api/v1/projects/${id}/export`,
+      headers: {
+        Authorization: `Bearer ${context.auth.secret_text}`,
+        'Content-Type': 'application/json',
+      },
+      body: {
+        imageHosting: imageHosting ?? false,
+        cdn: cdn ?? false,
+        minify: minify ?? false,
+        format: format ?? 'json',
+        variables: variables ?? {},
+      },
+      responseType: isZip ? 'arraybuffer' : 'json',
+    });
+
+    if (isZip) {
+      return {
+        format: 'zip',
+        zip_base64: Buffer.from(res.body as ArrayBuffer).toString('base64'),
+      };
+    }
+    return res.body;
+  },
+});

--- a/packages/pieces/community/postcards/src/lib/actions/get-folder.ts
+++ b/packages/pieces/community/postcards/src/lib/actions/get-folder.ts
@@ -1,0 +1,44 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+import { postcardsAuth, POSTCARDS_BASE_URL } from '../auth';
+
+export const getFolder = createAction({
+  auth: postcardsAuth,
+  name: 'get_folder',
+  displayName: 'Get Folder',
+  description:
+    'Get a single folder and the projects directly inside it. The ID is either the numeric id or the obfuscated_id. The projects array is paginated (50/page, max 100).',
+  props: {
+    id: Property.ShortText({
+      displayName: 'Folder ID',
+      description: 'Numeric id or obfuscated_id.',
+      required: true,
+    }),
+    page: Property.Number({
+      displayName: 'Page',
+      description: '1-based page number for the projects array.',
+      required: false,
+      defaultValue: 1,
+    }),
+    per_page: Property.Number({
+      displayName: 'Per Page',
+      description: 'Items per page for the projects array (max 100).',
+      required: false,
+      defaultValue: 50,
+    }),
+  },
+  async run(context) {
+    const { id, page, per_page } = context.propsValue;
+    const queryParams: Record<string, string> = {};
+    if (page != null) queryParams['page'] = String(page);
+    if (per_page != null) queryParams['per_page'] = String(per_page);
+
+    const res = await httpClient.sendRequest({
+      method: HttpMethod.GET,
+      url: `${POSTCARDS_BASE_URL}/api/v1/folders/${id}`,
+      headers: { Authorization: `Bearer ${context.auth.secret_text}` },
+      queryParams,
+    });
+    return res.body;
+  },
+});

--- a/packages/pieces/community/postcards/src/lib/actions/get-project.ts
+++ b/packages/pieces/community/postcards/src/lib/actions/get-project.ts
@@ -1,0 +1,26 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+import { postcardsAuth, POSTCARDS_BASE_URL } from '../auth';
+
+export const getProject = createAction({
+  auth: postcardsAuth,
+  name: 'get_project',
+  displayName: 'Get Project',
+  description:
+    'Get metadata for a single project. The ID is either the numeric id (e.g. 305876) or the obfuscated_id (e.g. 32b3f40e).',
+  props: {
+    id: Property.ShortText({
+      displayName: 'Project ID',
+      description: 'Numeric id or obfuscated_id.',
+      required: true,
+    }),
+  },
+  async run(context) {
+    const res = await httpClient.sendRequest({
+      method: HttpMethod.GET,
+      url: `${POSTCARDS_BASE_URL}/api/v1/projects/${context.propsValue.id}`,
+      headers: { Authorization: `Bearer ${context.auth.secret_text}` },
+    });
+    return res.body;
+  },
+});

--- a/packages/pieces/community/postcards/src/lib/actions/get-usage.ts
+++ b/packages/pieces/community/postcards/src/lib/actions/get-usage.ts
@@ -1,0 +1,20 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+import { postcardsAuth, POSTCARDS_BASE_URL } from '../auth';
+
+export const getUsage = createAction({
+  auth: postcardsAuth,
+  name: 'get_usage',
+  displayName: 'Get Usage',
+  description:
+    "Get the current export quota usage and active plan for the authenticated team. Returns plan name/period and exports used/limit (unlimited on Pro and Agency).",
+  props: {},
+  async run(context) {
+    const res = await httpClient.sendRequest({
+      method: HttpMethod.GET,
+      url: `${POSTCARDS_BASE_URL}/api/v1/usage`,
+      headers: { Authorization: `Bearer ${context.auth.secret_text}` },
+    });
+    return res.body;
+  },
+});

--- a/packages/pieces/community/postcards/src/lib/actions/list-folders.ts
+++ b/packages/pieces/community/postcards/src/lib/actions/list-folders.ts
@@ -1,0 +1,38 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+import { postcardsAuth, POSTCARDS_BASE_URL } from '../auth';
+
+export const listFolders = createAction({
+  auth: postcardsAuth,
+  name: 'list_folders',
+  displayName: 'List Folders',
+  description:
+    'List all folders in the authenticated team. Paginated (50/page, max 100). Folders can be nested via parent_id.',
+  props: {
+    page: Property.Number({
+      displayName: 'Page',
+      required: false,
+      defaultValue: 1,
+    }),
+    per_page: Property.Number({
+      displayName: 'Per Page',
+      description: 'Items per page (max 100).',
+      required: false,
+      defaultValue: 50,
+    }),
+  },
+  async run(context) {
+    const { page, per_page } = context.propsValue;
+    const queryParams: Record<string, string> = {};
+    if (page != null) queryParams['page'] = String(page);
+    if (per_page != null) queryParams['per_page'] = String(per_page);
+
+    const res = await httpClient.sendRequest({
+      method: HttpMethod.GET,
+      url: `${POSTCARDS_BASE_URL}/api/v1/folders`,
+      headers: { Authorization: `Bearer ${context.auth.secret_text}` },
+      queryParams,
+    });
+    return res.body;
+  },
+});

--- a/packages/pieces/community/postcards/src/lib/actions/list-projects.ts
+++ b/packages/pieces/community/postcards/src/lib/actions/list-projects.ts
@@ -1,0 +1,46 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+import { postcardsAuth, POSTCARDS_BASE_URL } from '../auth';
+
+export const listProjects = createAction({
+  auth: postcardsAuth,
+  name: 'list_projects',
+  displayName: 'List Projects',
+  description:
+    'List projects in the authenticated team, ordered by most-recently edited. Paginated (50/page, max 100).',
+  props: {
+    folder_id: Property.ShortText({
+      displayName: 'Folder ID',
+      description:
+        'Filter by folder (numeric id or obfuscated_id). Leave empty to list all projects.',
+      required: false,
+    }),
+    page: Property.Number({
+      displayName: 'Page',
+      description: '1-based page number.',
+      required: false,
+      defaultValue: 1,
+    }),
+    per_page: Property.Number({
+      displayName: 'Per Page',
+      description: 'Items per page (max 100).',
+      required: false,
+      defaultValue: 50,
+    }),
+  },
+  async run(context) {
+    const { folder_id, page, per_page } = context.propsValue;
+    const queryParams: Record<string, string> = {};
+    if (folder_id) queryParams['folder_id'] = folder_id;
+    if (page != null) queryParams['page'] = String(page);
+    if (per_page != null) queryParams['per_page'] = String(per_page);
+
+    const res = await httpClient.sendRequest({
+      method: HttpMethod.GET,
+      url: `${POSTCARDS_BASE_URL}/api/v1/projects`,
+      headers: { Authorization: `Bearer ${context.auth.secret_text}` },
+      queryParams,
+    });
+    return res.body;
+  },
+});

--- a/packages/pieces/community/postcards/src/lib/auth.ts
+++ b/packages/pieces/community/postcards/src/lib/auth.ts
@@ -1,0 +1,24 @@
+import { PieceAuth } from '@activepieces/pieces-framework';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+
+export const POSTCARDS_BASE_URL = 'https://api-postcards.designmodo.com';
+
+export const postcardsAuth = PieceAuth.SecretText({
+  displayName: 'API Key',
+  description:
+    'Postcards API key (format `sk-pcds-api03-...`). Create it in Postcards under Account → Workspace Settings → API.',
+  required: true,
+  // Inside validate, `auth` is the raw entered value — a plain string for SecretText.
+  validate: async ({ auth }) => {
+    try {
+      await httpClient.sendRequest({
+        method: HttpMethod.GET,
+        url: `${POSTCARDS_BASE_URL}/api/v1/usage`,
+        headers: { Authorization: `Bearer ${auth}` },
+      });
+      return { valid: true };
+    } catch {
+      return { valid: false, error: 'Invalid Postcards API key.' };
+    }
+  },
+});

--- a/packages/pieces/community/postcards/tsconfig.json
+++ b/packages/pieces/community/postcards/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/packages/pieces/community/postcards/tsconfig.lib.json
+++ b/packages/pieces/community/postcards/tsconfig.lib.json
@@ -1,0 +1,21 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "baseUrl": ".",
+    "paths": {},
+    "outDir": "./dist",
+    "declaration": true,
+    "types": [
+      "node"
+    ]
+  },
+  "include": [
+    "src/**/*.ts"
+  ],
+  "exclude": [
+    "jest.config.ts",
+    "src/**/*.spec.ts",
+    "src/**/*.test.ts"
+  ]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1013,6 +1013,9 @@
       "@activepieces/piece-poper": [
         "packages/pieces/community/poper/src/index.ts"
       ],
+      "@activepieces/piece-postcards": [
+        "packages/pieces/community/postcards/src/index.ts"
+      ],
       "@activepieces/piece-postgres": [
         "packages/pieces/community/postgres/src/index.ts"
       ],


### PR DESCRIPTION
## Description

Adds a new community piece: **Postcards** (Email Builder by Designmodo).

Works with Postcards email projects via the Postcards public API.

**Auth:** API key (`sk-pcds-api03-...`), stored as a secret. Created in Postcards under Account → Workspace Settings → API. Validated on connect via `GET /api/v1/usage`.

**Actions (6 + custom API call):**
- List Projects — list team projects, paginated
- Get Project — project metadata by id / obfuscated_id
- Export Project — export to hosted HTML or a ZIP bundle (base64); counts against the monthly export quota
- List Folders — list team folders, paginated
- Get Folder — folder + its projects
- Get Usage — current export quota and active plan
- Custom API Call — authenticated call against `https://api-postcards.designmodo.com/api/v1`

**Triggers:** none — the Postcards API has no webhooks.

Category: `MARKETING`. `minimumSupportedRelease: 0.82.0`.

## How was this tested?

- `turbo run build lint --filter=@activepieces/piece-postcards` — build (tsc) and lint (eslint) pass.
- Ran locally in dev mode (`AP_DEV_PIECES=postcards`, sqlite + in-memory queue) on the current release; the piece loads with its auth, 6 actions, and the custom API call.
- Manually tested every action against the live Postcards API with a real API key: List Projects, Get Project, Export Project (hosted HTML and ZIP), List Folders, Get Folder, Get Usage, and a Custom API Call — all returned the expected responses; invalid key is rejected on connect.

Edition paths: Cloud / CE (community piece, no EE-specific code).

Fixes # N/A — new community piece.

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)