### PR TITLE
fix(flows): only re-render the condition being edited in a router branch

### DIFF
--- a/packages/web/AGENTS.md
+++ b/packages/web/AGENTS.md
@@ -63,7 +63,9 @@ You are working in the Activepieces web application (`packages/web`).
   );
   ```
 - **Always use `<FormField>` + `render` prop** — Wrap every field in `<FormField name="..." render={({ field }) => <FormItem>...</FormItem>} />`. Always include `<FormMessage />` inside `<FormItem>` to surface validation errors.
-- **Use `form.watch()` for conditional rendering** — When a field value controls what other fields or UI is shown, use `form.watch('fieldName')`. Do not mirror form values into separate `useState`.
+- **Subscribe to a field for conditional rendering; never read it with `form.getValues()`** — When a field value controls what other fields or UI is shown, subscribe to it. `form.getValues()` returns a non-reactive snapshot, so the derived UI keeps showing the old state until something unrelated happens to re-render the component. Do not mirror form values into separate `useState` either.
+  - In the component that calls `useForm`, use `form.watch('fieldName')`.
+  - In any component **below** that one (anything reaching the form through `useFormContext`), use `useWatch({ control: form.control, name: 'fieldName' })`. `form.watch()` does work there, but it re-renders the `useForm` owner and with it every `useFormContext` consumer in the form, not just the component that asked for the value.
 - **Use `form.setValue()` for cascading field updates** — When changing one field should reset or update related fields (e.g. selecting a provider resets its config), call `form.setValue()` inside the `onValueChange` handler.
 - **Server errors go to `root.serverError`** — Set API errors with `form.setError('root.serverError', { type: 'manual', message: '...' })`. Clear it at the top of `handleSubmit` with `form.clearErrors('root.serverError')`. Render it below the fields, outside `<ScrollArea>`.
 - **Wrap the `<form>` element in `<Form {...form}>`** — Always spread the form instance onto the Shadcn `<Form>` wrapper, and use `form.handleSubmit(handleSubmit)` on the native `<form>`. The submit button must be inside the `<form>` with `type="submit"`. Cancel buttons must always have `type="button"` to prevent accidental form submission.

--- a/packages/web/src/app/builder/step-settings/branch-settings/branch-single-condition.tsx
+++ b/packages/web/src/app/builder/step-settings/branch-settings/branch-single-condition.tsx
@@ -6,7 +6,7 @@ import {
 } from '@activepieces/shared';
 import { t } from 'i18next';
 import { Trash } from 'lucide-react';
-import { useFormContext } from 'react-hook-form';
+import { useFormContext, useWatch } from 'react-hook-form';
 
 import { SearchableSelect } from '@/components/custom/searchable-select';
 import { Button } from '@/components/ui/button';
@@ -74,9 +74,10 @@ const BranchSingleCondition = ({
 }: BranchSingleConditionProps) => {
   const form = useFormContext<RouterAction>();
 
-  const condition = form.watch(
-    `settings.branches.${branchIndex}.conditions.${groupIndex}.${conditionIndex}`,
-  );
+  const condition = useWatch({
+    control: form.control,
+    name: `settings.branches.${branchIndex}.conditions.${groupIndex}.${conditionIndex}`,
+  });
 
   const isTextCondition =
     condition.operator && textConditions.includes(condition?.operator);

--- a/packages/web/test/app/builder/step-settings/branch-settings/branch-single-condition.test.tsx
+++ b/packages/web/test/app/builder/step-settings/branch-settings/branch-single-condition.test.tsx
@@ -9,12 +9,13 @@
  * component read the condition with a non-subscribing form.getValues()
  * snapshot, so isSingleValueCondition never recomputed on operator change.
  *
- * The component is rendered for real with a real react-hook-form. Only the
- * leaf UI components (SearchableSelect, TextInputWithMentions, icons, tooltip)
- * are stubbed; the stubbed SearchableSelect captures the component's real
- * onChange and invokes it, exactly as picking an option would. This file uses
- * raw react-dom + React's act rather than @testing-library/react (not a
- * dependency of this package).
+ * The component is rendered for real with a real react-hook-form. Only
+ * SearchableSelect and TextInputWithMentions are stubbed, the first so the
+ * test can invoke the component's real onChange exactly as picking an option
+ * would, the second because the mentions editor is a tiptap instance. Every
+ * other child renders for real, including the InvalidStepIcon whose visibility
+ * is one of the flags this bug affected. This file uses raw react-dom + React's
+ * act rather than @testing-library/react (not a dependency of this package).
  */
 /* eslint-disable testing-library/no-unnecessary-act */
 import { BranchOperator } from '@activepieces/shared';
@@ -29,8 +30,6 @@ const selectMock = vi.hoisted(() => ({
 }));
 
 vi.mock('i18next', () => ({ t: (key: string) => key }));
-
-vi.mock('lucide-react', () => ({ Trash: () => null }));
 
 vi.mock('@/components/custom/searchable-select', () => ({
   SearchableSelect: ({
@@ -47,26 +46,6 @@ vi.mock('@/components/custom/searchable-select', () => ({
 
 vi.mock('@/app/builder/piece-properties/text-input-with-mentions', () => ({
   TextInputWithMentions: () => <input data-testid="mentions-input" />,
-}));
-
-vi.mock('@/components/custom/alert-icon', () => ({
-  InvalidStepIcon: () => null,
-}));
-
-vi.mock('@/components/ui/tooltip', () => ({
-  Tooltip: ({ children }: React.PropsWithChildren) => <>{children}</>,
-  TooltipTrigger: ({ children }: React.PropsWithChildren) => <>{children}</>,
-  TooltipContent: ({ children }: React.PropsWithChildren) => <>{children}</>,
-}));
-
-vi.mock('@/components/ui/switch', () => ({
-  Switch: () => null,
-}));
-
-vi.mock('@/components/ui/button', () => ({
-  Button: ({ children, ...props }: React.ComponentProps<'button'>) => (
-    <button {...props}>{children}</button>
-  ),
 }));
 
 // eslint-disable-next-line import/first
@@ -95,12 +74,18 @@ let container: HTMLDivElement;
 let root: Root;
 let formApi: UseFormReturn<ConditionFormShape> | undefined;
 
-function Harness({ operator }: { operator: BranchOperator }) {
+function Harness({
+  operator,
+  secondValue = '',
+}: {
+  operator: BranchOperator;
+  secondValue?: string;
+}) {
   const form = useForm<ConditionFormShape>({
     defaultValues: {
       settings: {
         branches: [
-          { conditions: [[{ operator, firstValue: '', secondValue: '' }]] },
+          { conditions: [[{ operator, firstValue: '', secondValue }]] },
         ],
       },
     },
@@ -121,12 +106,12 @@ function Harness({ operator }: { operator: BranchOperator }) {
   );
 }
 
-function setup(operator: BranchOperator) {
+function setup(operator: BranchOperator, secondValue?: string) {
   container = document.createElement('div');
   document.body.appendChild(container);
   root = createRoot(container);
   act(() => {
-    root.render(<Harness operator={operator} />);
+    root.render(<Harness operator={operator} secondValue={secondValue} />);
   });
 }
 
@@ -165,17 +150,17 @@ describe('BranchSingleCondition (issue 13900)', () => {
     selectOperator(BranchOperator.EXISTS);
 
     expect(hasSecondValueField()).toBe(false);
-    expect(
-      formApi?.getValues('settings.branches.0.conditions.0.0.secondValue'),
-    ).toBe('');
   });
 
-  it('restores the Second value field when switching back to a two-value operator', () => {
-    setup(BranchOperator.EXISTS);
+  it('restores the Second value field when switching back to a two-value operator, and clears the value it was hiding', () => {
+    setup(BranchOperator.EXISTS, 'stale');
     expect(hasSecondValueField()).toBe(false);
 
     selectOperator(BranchOperator.TEXT_EXACTLY_MATCHES);
 
     expect(hasSecondValueField()).toBe(true);
+    expect(
+      formApi?.getValues('settings.branches.0.conditions.0.0.secondValue'),
+    ).toBe('');
   });
 });


### PR DESCRIPTION
## Description

Follow-up to #14489. Those changes came out of reviewing it but were not pushed before it merged, so its description ended up describing them while `main` has the earlier version. Fixing #14489's description separately.

Three things, none of them user visible. #14489 already fixed the bug; this is about how.

**Scope the subscription to the condition row.** `BranchSingleCondition` reaches the form through `useFormContext`, so `form.watch(...)` there re-renders the `useForm` owner in `step-settings/index.tsx` and every `useFormContext` consumer under it, on each keystroke in the condition rather than only on operator change. `useWatch({ control: form.control, name })` produces the same visible behaviour and re-renders just this row. Measured both with a throwaway harness: `form.watch` in a descendant took the form root from 2 renders to 3 on a `setValue`, `useWatch` left the root untouched and re-rendered only the leaf.

**Split the forms rule by tree position.** `packages/web/AGENTS.md` said "use `form.watch()` for conditional rendering" without saying where you are in the tree, which is what pointed #14489 at the wider option. It now says `form.watch` in the component that calls `useForm`, `useWatch` in anything below it, and spells out why `getValues` is wrong for this in the first place.

**Two test fixes.** The `secondValue` assertion sat on the switch *to* a single-value operator, where the component's clearing branch never runs, so it was asserting against an untouched `''` default and could not fail. Moved to the switch back, seeded with `secondValue: 'stale'`. That covers the `form.setValue` block (the one behind `//TODO: fix this` / `@ts-expect-ignore`) for the first time. Separately, five of the eight `vi.mock` calls were unnecessary: `alert-icon`, `tooltip`, `switch`, `button` and `lucide-react` all render fine in jsdom. Dropping them lets the test exercise the real `InvalidStepIcon`, whose visibility is one of the flags the original bug affected, and `Button` was being mocked but never rendered since the harness passes `showDelete={false}`.

## How was this tested?

- `packages/web`: 3/3 in the file, 407/407 across the suite, `npx turbo run lint --filter=web` clean, all on top of merged `main`.
- Confirmed the reworked assertion actually bites: disabling the `form.setValue` clearing block makes it fail with `expected 'stale' to be ''`.
- Behaviour is unchanged from what shipped in #14489, so no edition paths are affected. Rendering only.

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)
