### PR TITLE
feat(google-docs): add agent atomics for AI agents

### DIFF
--- a/packages/pieces/community/google-docs/package.json
+++ b/packages/pieces/community/google-docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-google-docs",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "dependencies": {

--- a/packages/pieces/community/google-docs/src/index.ts
+++ b/packages/pieces/community/google-docs/src/index.ts
@@ -7,6 +7,43 @@ import { createDocumentBasedOnTemplate } from './lib/actions/create-document-bas
 import { readDocument } from './lib/actions/read-document.action';
 import { appendText } from './lib/actions/append-text';
 import { findDocumentAction } from './lib/actions/find-document';
+import { getDocumentPlaintext } from './lib/actions/get-document-plaintext.action';
+import { replaceAllText } from './lib/actions/replace-all-text.action';
+import { searchDocuments } from './lib/actions/search-documents.action';
+import { copyDocument } from './lib/actions/copy-document.action';
+import { getDocument } from './lib/actions/get-document.action';
+import { createTextDocument } from './lib/actions/create-text-document.action';
+import { getDocumentEndIndex } from './lib/actions/get-document-end-index.action';
+import { insertText } from './lib/actions/insert-text.action';
+import { deleteContentRange } from './lib/actions/delete-content-range.action';
+import { createDocumentFromMarkdown } from './lib/actions/create-document-from-markdown.action';
+import { createFooter } from './lib/actions/create-footer.action';
+import { createFootnote } from './lib/actions/create-footnote.action';
+import { createHeader } from './lib/actions/create-header.action';
+import { createNamedRange } from './lib/actions/create-named-range.action';
+import { createParagraphBullets } from './lib/actions/create-paragraph-bullets.action';
+import { deleteFooter } from './lib/actions/delete-footer.action';
+import { deleteHeader } from './lib/actions/delete-header.action';
+import { deleteNamedRange } from './lib/actions/delete-named-range.action';
+import { deleteParagraphBullets } from './lib/actions/delete-paragraph-bullets.action';
+import { deleteTableColumn } from './lib/actions/delete-table-column.action';
+import { deleteTableRow } from './lib/actions/delete-table-row.action';
+import { insertTable } from './lib/actions/insert-table.action';
+import { insertTableColumn } from './lib/actions/insert-table-column.action';
+import { insertTableRow } from './lib/actions/insert-table-row.action';
+import { insertTextInTableCell } from './lib/actions/insert-text-in-table-cell.action';
+import { insertImageInTableCell } from './lib/actions/insert-image-in-table-cell.action';
+import { unmergeTableCells } from './lib/actions/unmerge-table-cells.action';
+import { updateTableRowStyle } from './lib/actions/update-table-row-style.action';
+import { insertInlineImage } from './lib/actions/insert-inline-image.action';
+import { insertPageBreak } from './lib/actions/insert-page-break.action';
+import { replaceImage } from './lib/actions/replace-image.action';
+import { updateDocumentStyle } from './lib/actions/update-document-style.action';
+import { exportAsPdf } from './lib/actions/export-as-pdf.action';
+import { createAndPopulateTable } from './lib/actions/create-and-populate-table.action';
+import { replaceBodyWithMarkdown } from './lib/actions/replace-body-with-markdown.action';
+import { replaceSectionWithMarkdown } from './lib/actions/replace-section-with-markdown.action';
+import { batchUpdate } from './lib/actions/batch-update.action';
 import { newDocumentTrigger } from './lib/triggers/new-document';
 import { googleDocsAuth, getAccessToken, GoogleDocsAuthValue } from './lib/auth';
 
@@ -33,6 +70,43 @@ export const googleDocs = createPiece({
 		createDocumentBasedOnTemplate,
 		readDocument,
 		findDocumentAction,
+		getDocumentPlaintext,
+		replaceAllText,
+		searchDocuments,
+		copyDocument,
+		getDocumentEndIndex,
+		insertText,
+		deleteContentRange,
+		createDocumentFromMarkdown,
+		getDocument,
+		createTextDocument,
+		createFooter,
+		createFootnote,
+		createHeader,
+		createNamedRange,
+		createParagraphBullets,
+		deleteFooter,
+		deleteHeader,
+		deleteNamedRange,
+		deleteParagraphBullets,
+		deleteTableColumn,
+		deleteTableRow,
+		insertTable,
+		insertTableColumn,
+		insertTableRow,
+		insertTextInTableCell,
+		insertImageInTableCell,
+		unmergeTableCells,
+		updateTableRowStyle,
+		insertInlineImage,
+		insertPageBreak,
+		replaceImage,
+		updateDocumentStyle,
+		exportAsPdf,
+		createAndPopulateTable,
+		replaceBodyWithMarkdown,
+		replaceSectionWithMarkdown,
+		batchUpdate,
 		createCustomApiCallAction({
 			baseUrl: () => 'https://docs.googleapis.com/v1',
 			auth: googleDocsAuth,

--- a/packages/pieces/community/google-docs/src/index.ts
+++ b/packages/pieces/community/google-docs/src/index.ts
@@ -52,7 +52,7 @@ export { googleDocsAuth, getAccessToken, GoogleDocsAuthValue } from './lib/auth'
 export const googleDocs = createPiece({
 	displayName: 'Google Docs',
 	description: 'Create and edit documents online',
-	minimumSupportedRelease: '0.30.0',
+	minimumSupportedRelease: '0.86.4',
 	logoUrl: 'https://cdn.activepieces.com/pieces/google-docs.png',
 	categories: [PieceCategory.CONTENT_AND_FILES],
 	authors: [

--- a/packages/pieces/community/google-docs/src/lib/actions/append-text.ts
+++ b/packages/pieces/community/google-docs/src/lib/actions/append-text.ts
@@ -7,7 +7,7 @@ export const appendText = createAction({
     auth: googleDocsAuth,
     name: 'append_text',
     description: 'Appends text to google docs',
-    audience: 'both',
+    audience: 'human',
     aiMetadata: {
       description:
         'Appends text to the end of an existing Google Docs document identified by its ID. Use when an agent needs to add content to a known document without altering its existing text. Requires the document ID; not idempotent, since each call inserts the text again, accumulating duplicates.',

--- a/packages/pieces/community/google-docs/src/lib/actions/batch-update.action.ts
+++ b/packages/pieces/community/google-docs/src/lib/actions/batch-update.action.ts
@@ -1,0 +1,58 @@
+import { googleDocsAuth, createGoogleClient } from '../auth';
+import { docsCommon } from '../common';
+import { Property, createAction } from '@activepieces/pieces-framework';
+import { docs as googleDocs, docs_v1 } from '@googleapis/docs';
+import { batchUpdateActionOutputSchema } from '../output-schemas';
+
+export const batchUpdate = createAction({
+  auth: googleDocsAuth,
+  name: 'batch_update',
+  displayName: 'Batch Update (Advanced)',
+  description: 'Send a raw Google Docs batchUpdate requests array to a document',
+  audience: 'ai',
+  aiMetadata: {
+    description:
+      'Advanced escape hatch that sends a raw array of Google Docs API batchUpdate request objects directly to documents.batchUpdate. Only for callers who know the Google Docs API and need a request kind not covered by a dedicated atomic — prefer the specific atomics (Insert Text, Create Header, Insert Table, Delete Content Range, etc.) for common operations, as they validate inputs and resolve indices for you. Each request is a Docs API Request object, e.g. {"insertText":{"text":"hi","location":{"index":1}}}; requests run in order and indices must already account for prior edits in the same call. Not idempotent in general (depends on the requests supplied).',
+    idempotent: false,
+  },
+  outputSchema: batchUpdateActionOutputSchema,
+  props: {
+    documentId: Property.ShortText({
+      displayName: 'Document ID',
+      description: 'The ID of the document to update.',
+      required: true,
+    }),
+    requests: Property.Json({
+      displayName: 'Requests',
+      description:
+        'An array of raw Google Docs batchUpdate request objects, e.g. [{"insertText":{"text":"hi","location":{"index":1}}}]. See the Google Docs API documents.batchUpdate reference for the available request kinds.',
+      required: true,
+    }),
+  },
+  async run(context) {
+    const { documentId, requests } = context.propsValue;
+
+    if (!Array.isArray(requests)) {
+      throw new Error('Requests must be an array of Google Docs batchUpdate request objects.');
+    }
+    const docsRequests = requests as docs_v1.Schema$Request[];
+
+    const authClient = await createGoogleClient(context.auth);
+    const docs = googleDocs({ version: 'v1', auth: authClient });
+
+    try {
+      const response = await docs.documents.batchUpdate({
+        documentId,
+        requestBody: { requests: docsRequests },
+      });
+      return {
+        success: true,
+        documentId,
+        appliedRequests: docsRequests.length,
+        replies: response.data.replies ?? [],
+      };
+    } catch (error) {
+      throw new Error(docsCommon.formatError(error, 'apply a batch update to'));
+    }
+  },
+});

--- a/packages/pieces/community/google-docs/src/lib/actions/copy-document.action.ts
+++ b/packages/pieces/community/google-docs/src/lib/actions/copy-document.action.ts
@@ -1,0 +1,74 @@
+import { googleDocsAuth, createGoogleClient } from '../auth';
+import { Property, createAction } from '@activepieces/pieces-framework';
+import { drive as googleDrive } from '@googleapis/drive';
+import { folderIdProp } from '../common/props';
+import { copyDocumentActionOutputSchema } from '../output-schemas';
+
+export const copyDocument = createAction({
+	auth: googleDocsAuth,
+	name: 'copy_document',
+	displayName: 'Copy Document',
+	description: 'Create a copy of an existing Google Docs document.',
+	audience: 'ai',
+	aiMetadata: {
+		description:
+			'Duplicates an existing Google Docs document into a new file with the given title. Pick this to spin a working copy off a template or snapshot a version before editing; it is distinct from Edit Template File, which merges data in place. Each call creates a new file, so it is not idempotent (retries produce duplicates).',
+		idempotent: false,
+	},
+	outputSchema: copyDocumentActionOutputSchema,
+	props: {
+		fileId: Property.ShortText({
+			displayName: 'Source Document ID',
+			description:
+				"The ID of the document to copy, found in its URL: 'https://docs.google.com/document/d/<documentId>/edit'.",
+			required: true,
+		}),
+		title: Property.ShortText({
+			displayName: 'New Document Title',
+			description: 'The name to give the copied document.',
+			required: true,
+		}),
+		// Destination folder maps directly to the native Drive files.copy
+		// endpoint (the requestBody.parents field), letting the copy be placed in
+		// a chosen folder instead of defaulting to the source document's location.
+		parents: folderIdProp,
+	},
+	async run(context) {
+		const { fileId, title, parents } = context.propsValue;
+
+		const authClient = await createGoogleClient(context.auth);
+		const drive = googleDrive({ version: 'v3', auth: authClient });
+
+		try {
+			const response = await drive.files.copy({
+				fileId,
+				supportsAllDrives: true,
+				fields: 'id, name, webViewLink, parents',
+				requestBody: {
+					name: title,
+					...(parents ? { parents: [parents] } : {}),
+				},
+			});
+
+			return {
+				id: response.data.id ?? '',
+				name: response.data.name ?? '',
+				webViewLink: response.data.webViewLink ?? '',
+				parents: response.data.parents ?? [],
+			};
+		} catch (e) {
+			const error = e as { code?: number; message?: string };
+			if (error.code === 403) {
+				throw new Error(
+					'Permission denied copying the document. Ensure the connected account has access to the source document and the destination folder.'
+				);
+			}
+			if (error.code === 404) {
+				throw new Error(
+					`Source document not found for ID '${fileId}'. Verify the document ID.`
+				);
+			}
+			throw e;
+		}
+	},
+});

--- a/packages/pieces/community/google-docs/src/lib/actions/create-and-populate-table.action.ts
+++ b/packages/pieces/community/google-docs/src/lib/actions/create-and-populate-table.action.ts
@@ -102,7 +102,14 @@ export const createAndPopulateTable = createAction({
       try {
         await docs.documents.batchUpdate({
           documentId,
-          requestBody: { requests: cellInserts },
+          requestBody: {
+            requests: cellInserts,
+            // Fail loudly instead of misplacing text if the document changed
+            // between the read-back above and this write.
+            writeControl: reloaded.revisionId
+              ? { requiredRevisionId: reloaded.revisionId }
+              : undefined,
+          },
         });
       } catch (error) {
         throw new Error(docsCommon.formatError(error, 'populate the new table in'));

--- a/packages/pieces/community/google-docs/src/lib/actions/create-and-populate-table.action.ts
+++ b/packages/pieces/community/google-docs/src/lib/actions/create-and-populate-table.action.ts
@@ -1,0 +1,134 @@
+import { googleDocsAuth, createGoogleClient } from '../auth';
+import { docsCommon } from '../common';
+import { Property, createAction } from '@activepieces/pieces-framework';
+import { docs as googleDocs, docs_v1 } from '@googleapis/docs';
+import { createAndPopulateTableActionOutputSchema } from '../output-schemas';
+
+export const createAndPopulateTable = createAction({
+  auth: googleDocsAuth,
+  name: 'create_and_populate_table',
+  displayName: 'Create and Populate Table',
+  description: 'Insert a table into a Google Docs document and fill its cells with text',
+  audience: 'ai',
+  aiMetadata: {
+    description:
+      'Inserts a new table at the end of a Google Docs document, sized to the supplied 2D array of strings, and writes each value into its cell in one operation — so an agent can drop a fully-populated table without computing cell indices. The column count is the width of the widest row; shorter rows leave their trailing cells empty. Not idempotent: each call adds another table.',
+    idempotent: false,
+  },
+  outputSchema: createAndPopulateTableActionOutputSchema,
+  props: {
+    documentId: Property.ShortText({
+      displayName: 'Document ID',
+      description: 'The ID of the document to insert the table into.',
+      required: true,
+    }),
+    data: Property.Json({
+      displayName: 'Table Data',
+      description:
+        'A 2D array of strings (rows of columns), e.g. [["Name","Age"],["Alice","30"]]. Each string is written into its matching cell. The table width is the widest row; shorter rows leave trailing cells empty.',
+      required: true,
+    }),
+  },
+  async run(context) {
+    const { documentId, data } = context.propsValue;
+
+    const rowsData = data as unknown;
+    if (!Array.isArray(rowsData) || rowsData.length === 0 || !rowsData.every((row) => Array.isArray(row))) {
+      throw new Error('Table Data must be a non-empty 2D array of strings (rows of columns).');
+    }
+    const tableData = rowsData as string[][];
+    const rows = tableData.length;
+    const columns = Math.max(...tableData.map((row) => row.length));
+    if (columns === 0) {
+      throw new Error('Table Data rows must contain at least one column.');
+    }
+
+    const authClient = await createGoogleClient(context.auth);
+    const docs = googleDocs({ version: 'v1', auth: authClient });
+
+    // Append at the end of the body so the new table is unambiguously the last
+    // one in the document when we read back to resolve its cell indices.
+    const insertTableRequest: docs_v1.Schema$Request = {
+      insertTable: { rows, columns, endOfSegmentLocation: {} },
+    };
+
+    try {
+      await docs.documents.batchUpdate({
+        documentId,
+        requestBody: { requests: [insertTableRequest] },
+      });
+    } catch (error) {
+      throw new Error(docsCommon.formatError(error, 'insert a table into'));
+    }
+
+    let reloaded: docs_v1.Schema$Document;
+    try {
+      const response = await docs.documents.get({ documentId });
+      reloaded = response.data;
+    } catch (error) {
+      throw new Error(docsCommon.formatError(error, 'read back the new table in'));
+    }
+
+    const content = reloaded.body?.content ?? [];
+    const tableElement = findLastTable(content);
+    if (!tableElement?.table) {
+      throw new Error('Could not locate the inserted table when reading the document back.');
+    }
+
+    const cellInserts: docs_v1.Schema$Request[] = [];
+    const tableRows = tableElement.table.tableRows ?? [];
+    for (let r = 0; r < tableRows.length; r++) {
+      const cells = tableRows[r].tableCells ?? [];
+      for (let c = 0; c < cells.length; c++) {
+        const value = tableData[r]?.[c];
+        if (value === undefined || value === null || value === '') {
+          continue;
+        }
+        const cellContent = cells[c].content ?? [];
+        const firstParagraph = cellContent[0];
+        const insertIndex = firstParagraph?.startIndex;
+        if (insertIndex === undefined || insertIndex === null) {
+          continue;
+        }
+        cellInserts.push({ insertText: { text: String(value), location: { index: insertIndex } } });
+      }
+    }
+
+    // Apply highest-index inserts first so earlier (lower) indices stay valid as
+    // text shifts the document; each insert below an applied one is unaffected.
+    cellInserts.sort((a, b) => (b.insertText?.location?.index ?? 0) - (a.insertText?.location?.index ?? 0));
+
+    if (cellInserts.length > 0) {
+      try {
+        await docs.documents.batchUpdate({
+          documentId,
+          requestBody: { requests: cellInserts },
+        });
+      } catch (error) {
+        throw new Error(docsCommon.formatError(error, 'populate the new table in'));
+      }
+    }
+
+    return {
+      success: true,
+      documentId,
+      rows,
+      columns,
+      cellsPopulated: cellInserts.length,
+    };
+  },
+});
+
+// The table appended at end-of-body has the greatest startIndex, so the last
+// table element in document order is unambiguously the one just inserted.
+function findLastTable(
+  content: docs_v1.Schema$StructuralElement[]
+): docs_v1.Schema$StructuralElement | undefined {
+  let match: docs_v1.Schema$StructuralElement | undefined;
+  for (const element of content) {
+    if (element.table) {
+      match = element;
+    }
+  }
+  return match;
+}

--- a/packages/pieces/community/google-docs/src/lib/actions/create-document-from-markdown.action.ts
+++ b/packages/pieces/community/google-docs/src/lib/actions/create-document-from-markdown.action.ts
@@ -1,0 +1,63 @@
+import { googleDocsAuth, createGoogleClient } from '../auth';
+import { docsCommon } from '../common';
+import { Property, createAction } from '@activepieces/pieces-framework';
+import { docs as googleDocs } from '@googleapis/docs';
+import { createDocumentFromMarkdownActionOutputSchema } from '../output-schemas';
+
+export const createDocumentFromMarkdown = createAction({
+  auth: googleDocsAuth,
+  name: 'create_document_from_markdown',
+  displayName: 'Create Document from Markdown',
+  description: 'Create a Google Docs document from Markdown content',
+  audience: 'ai',
+  aiMetadata: {
+    description:
+      'Creates a new Google Docs document and populates it from Markdown text, converting headings (#, ##, ###), bullet lists (-, *, +), and paragraphs into native Google Docs formatting. Use when an agent has Markdown content (the format LLMs produce natively) and wants a formatted document in one call. Inline styling such as bold/italic is inserted as plain text. Not idempotent: each call creates a new document.',
+    idempotent: false,
+  },
+  outputSchema: createDocumentFromMarkdownActionOutputSchema,
+  props: {
+    title: Property.ShortText({
+      displayName: 'Title',
+      description: 'The title (and file name) of the new document.',
+      required: true,
+    }),
+    markdown: Property.LongText({
+      displayName: 'Markdown Content',
+      description: 'Markdown text. Supports headings (#/##/###), bullet lists (-/*/+), and paragraphs.',
+      required: true,
+    }),
+  },
+  async run(context) {
+    const { title, markdown } = context.propsValue;
+    const authClient = await createGoogleClient(context.auth);
+    const docs = googleDocs({ version: 'v1', auth: authClient });
+
+    let documentId: string;
+    try {
+      const created = await docs.documents.create({ requestBody: { title } });
+      if (!created.data.documentId) {
+        throw new Error('Google Docs did not return a document ID for the new document.');
+      }
+      documentId = created.data.documentId;
+    } catch (error) {
+      throw new Error(docsCommon.formatError(error, 'create'));
+    }
+
+    const requests = docsCommon.markdownToBatchRequests(markdown);
+    if (requests.length > 0) {
+      try {
+        await docs.documents.batchUpdate({ documentId, requestBody: { requests } });
+      } catch (error) {
+        throw new Error(docsCommon.formatError(error, 'populate the new'));
+      }
+    }
+
+    return {
+      success: true,
+      documentId,
+      title,
+      url: `https://docs.google.com/document/d/${documentId}/edit`,
+    };
+  },
+});

--- a/packages/pieces/community/google-docs/src/lib/actions/create-document.ts
+++ b/packages/pieces/community/google-docs/src/lib/actions/create-document.ts
@@ -7,7 +7,7 @@ export const createDocument = createAction({
   auth: googleDocsAuth,
   name: 'create_document',
   description: 'Create a document on Google Docs',
-  audience: 'both',
+  audience: 'human',
   aiMetadata: {
     description:
       'Creates a brand-new Google Docs document with the given title and writes the provided text into it. Use when an agent needs to generate a fresh document from content it has produced; to add to an existing document use Append Text instead. Not idempotent: every call creates a separate new document.',

--- a/packages/pieces/community/google-docs/src/lib/actions/create-footer.action.ts
+++ b/packages/pieces/community/google-docs/src/lib/actions/create-footer.action.ts
@@ -1,0 +1,59 @@
+import { googleDocsAuth, createGoogleClient } from '../auth';
+import { docsCommon } from '../common';
+import { Property, createAction } from '@activepieces/pieces-framework';
+import { docs as googleDocs, docs_v1 } from '@googleapis/docs';
+import { createFooterActionOutputSchema } from '../output-schemas';
+
+export const createFooter = createAction({
+  auth: googleDocsAuth,
+  name: 'create_footer',
+  displayName: 'Create Footer',
+  description: 'Create a footer section in a Google Docs document',
+  audience: 'ai',
+  aiMetadata: {
+    description:
+      'Creates a footer section in a Google Docs document and returns the new footerId. Use this when you need to add a footer to a document before inserting footer text — the footerId returned here is required by any subsequent Insert Text call targeting the footer segment. Each call creates a new footer; not idempotent.',
+    idempotent: false,
+  },
+  outputSchema: createFooterActionOutputSchema,
+  props: {
+    documentId: Property.ShortText({
+      displayName: 'Document ID',
+      description: 'The ID of the document to add a footer to (from the document URL or Search Documents).',
+      required: true,
+    }),
+    type: Property.StaticDropdown({
+      displayName: 'Footer Type',
+      description: 'The type of footer to create. DEFAULT is the standard document footer.',
+      required: false,
+      defaultValue: 'DEFAULT',
+      options: {
+        options: [
+          { label: 'Default', value: 'DEFAULT' },
+        ],
+      },
+    }),
+  },
+  async run(context) {
+    const { documentId, type } = context.propsValue;
+    const authClient = await createGoogleClient(context.auth);
+    const docs = googleDocs({ version: 'v1', auth: authClient });
+
+    const request: docs_v1.Schema$Request = {
+      createFooter: {
+        type: (type ?? 'DEFAULT') as docs_v1.Schema$CreateFooterRequest['type'],
+      },
+    };
+
+    try {
+      const response = await docs.documents.batchUpdate({
+        documentId,
+        requestBody: { requests: [request] },
+      });
+      const footerId = response.data.replies?.[0]?.createFooter?.footerId ?? null;
+      return { success: true, documentId, footerId };
+    } catch (error) {
+      throw new Error(docsCommon.formatError(error, 'create the footer in'));
+    }
+  },
+});

--- a/packages/pieces/community/google-docs/src/lib/actions/create-footnote.action.ts
+++ b/packages/pieces/community/google-docs/src/lib/actions/create-footnote.action.ts
@@ -1,0 +1,53 @@
+import { googleDocsAuth, createGoogleClient } from '../auth';
+import { docsCommon } from '../common';
+import { Property, createAction } from '@activepieces/pieces-framework';
+import { docs as googleDocs, docs_v1 } from '@googleapis/docs';
+import { createFootnoteActionOutputSchema } from '../output-schemas';
+
+export const createFootnote = createAction({
+  auth: googleDocsAuth,
+  name: 'create_footnote',
+  displayName: 'Create Footnote',
+  description: 'Insert a footnote at a character index in a Google Docs document',
+  audience: 'ai',
+  aiMetadata: {
+    description:
+      'Inserts a footnote at a specific character index inside an existing paragraph in a Google Docs document, or at the end of the body segment if no index is provided. Returns the new footnoteId, which can then be used to insert text into the footnote segment via Insert Text. The index must fall inside an existing paragraph — obtain a valid index from Get Document End Index or Read Document (cannot be guessed). Not idempotent.',
+    idempotent: false,
+  },
+  outputSchema: createFootnoteActionOutputSchema,
+  props: {
+    documentId: Property.ShortText({
+      displayName: 'Document ID',
+      description: 'The ID of the document to insert a footnote into (from the document URL or Search Documents).',
+      required: true,
+    }),
+    index: Property.Number({
+      displayName: 'Index',
+      description:
+        'Character index inside an existing paragraph where the footnote anchor is inserted. Leave empty to append at the end of the body segment. Obtain a valid index from Get Document End Index or Read Document — cannot be guessed.',
+      required: false,
+    }),
+  },
+  async run(context) {
+    const { documentId, index } = context.propsValue;
+    const authClient = await createGoogleClient(context.auth);
+    const docs = googleDocs({ version: 'v1', auth: authClient });
+
+    const request: docs_v1.Schema$Request =
+      index === undefined || index === null
+        ? { createFootnote: { endOfSegmentLocation: {} } }
+        : { createFootnote: { location: { index } } };
+
+    try {
+      const response = await docs.documents.batchUpdate({
+        documentId,
+        requestBody: { requests: [request] },
+      });
+      const footnoteId = response.data.replies?.[0]?.createFootnote?.footnoteId ?? null;
+      return { success: true, documentId, footnoteId };
+    } catch (error) {
+      throw new Error(docsCommon.formatError(error, 'create the footnote in'));
+    }
+  },
+});

--- a/packages/pieces/community/google-docs/src/lib/actions/create-header.action.ts
+++ b/packages/pieces/community/google-docs/src/lib/actions/create-header.action.ts
@@ -1,0 +1,59 @@
+import { googleDocsAuth, createGoogleClient } from '../auth';
+import { docsCommon } from '../common';
+import { Property, createAction } from '@activepieces/pieces-framework';
+import { docs as googleDocs, docs_v1 } from '@googleapis/docs';
+import { createHeaderActionOutputSchema } from '../output-schemas';
+
+export const createHeader = createAction({
+  auth: googleDocsAuth,
+  name: 'create_header',
+  displayName: 'Create Header',
+  description: 'Create a header section in a Google Docs document',
+  audience: 'ai',
+  aiMetadata: {
+    description:
+      'Creates a header section in a Google Docs document and returns the new headerId. Use this when you need to add a header to a document before inserting header text — the headerId returned here is required by any subsequent Insert Text call targeting the header segment. Each call creates a new header; not idempotent.',
+    idempotent: false,
+  },
+  outputSchema: createHeaderActionOutputSchema,
+  props: {
+    documentId: Property.ShortText({
+      displayName: 'Document ID',
+      description: 'The ID of the document to add a header to (from the document URL or Search Documents).',
+      required: true,
+    }),
+    type: Property.StaticDropdown({
+      displayName: 'Header Type',
+      description: 'The type of header to create. DEFAULT is the standard document header.',
+      required: false,
+      defaultValue: 'DEFAULT',
+      options: {
+        options: [
+          { label: 'Default', value: 'DEFAULT' },
+        ],
+      },
+    }),
+  },
+  async run(context) {
+    const { documentId, type } = context.propsValue;
+    const authClient = await createGoogleClient(context.auth);
+    const docs = googleDocs({ version: 'v1', auth: authClient });
+
+    const request: docs_v1.Schema$Request = {
+      createHeader: {
+        type: (type ?? 'DEFAULT') as docs_v1.Schema$CreateHeaderRequest['type'],
+      },
+    };
+
+    try {
+      const response = await docs.documents.batchUpdate({
+        documentId,
+        requestBody: { requests: [request] },
+      });
+      const headerId = response.data.replies?.[0]?.createHeader?.headerId ?? null;
+      return { success: true, documentId, headerId };
+    } catch (error) {
+      throw new Error(docsCommon.formatError(error, 'create the header in'));
+    }
+  },
+});

--- a/packages/pieces/community/google-docs/src/lib/actions/create-named-range.action.ts
+++ b/packages/pieces/community/google-docs/src/lib/actions/create-named-range.action.ts
@@ -1,0 +1,70 @@
+import { googleDocsAuth, createGoogleClient } from '../auth';
+import { docsCommon } from '../common';
+import { Property, createAction } from '@activepieces/pieces-framework';
+import { docs as googleDocs, docs_v1 } from '@googleapis/docs';
+import { createNamedRangeActionOutputSchema } from '../output-schemas';
+
+export const createNamedRange = createAction({
+  auth: googleDocsAuth,
+  name: 'create_named_range',
+  displayName: 'Create Named Range',
+  description: 'Create a named range over a character range in a Google Docs document',
+  audience: 'ai',
+  aiMetadata: {
+    description:
+      'Creates a named range over a specified character range in a Google Docs document body and returns the new namedRangeId. Named ranges let you bookmark a region for later operations (e.g. deletion, styling) by ID or by name. The startIndex and endIndex must be valid character positions inside the document body — obtain them from Get Document End Index or Read Document (cannot be guessed). Not idempotent.',
+    idempotent: false,
+  },
+  outputSchema: createNamedRangeActionOutputSchema,
+  props: {
+    documentId: Property.ShortText({
+      displayName: 'Document ID',
+      description: 'The ID of the document to add a named range to (from the document URL or Search Documents).',
+      required: true,
+    }),
+    name: Property.ShortText({
+      displayName: 'Range Name',
+      description: 'A human-readable name for the range. Multiple named ranges in the same document can share the same name.',
+      required: true,
+    }),
+    startIndex: Property.Number({
+      displayName: 'Start Index',
+      description:
+        'Inclusive start character index of the range. Obtain from Get Document End Index or Read Document — cannot be guessed.',
+      required: true,
+    }),
+    endIndex: Property.Number({
+      displayName: 'End Index',
+      description:
+        'Exclusive end character index of the range. Must be greater than Start Index. Obtain from Get Document End Index or Read Document — cannot be guessed.',
+      required: true,
+    }),
+  },
+  async run(context) {
+    const { documentId, name, startIndex, endIndex } = context.propsValue;
+    if (endIndex <= startIndex) {
+      throw new Error('End Index must be greater than Start Index.');
+    }
+
+    const authClient = await createGoogleClient(context.auth);
+    const docs = googleDocs({ version: 'v1', auth: authClient });
+
+    const request: docs_v1.Schema$Request = {
+      createNamedRange: {
+        name,
+        range: { startIndex, endIndex },
+      },
+    };
+
+    try {
+      const response = await docs.documents.batchUpdate({
+        documentId,
+        requestBody: { requests: [request] },
+      });
+      const namedRangeId = response.data.replies?.[0]?.createNamedRange?.namedRangeId ?? null;
+      return { success: true, documentId, name, namedRangeId };
+    } catch (error) {
+      throw new Error(docsCommon.formatError(error, 'create the named range in'));
+    }
+  },
+});

--- a/packages/pieces/community/google-docs/src/lib/actions/create-paragraph-bullets.action.ts
+++ b/packages/pieces/community/google-docs/src/lib/actions/create-paragraph-bullets.action.ts
@@ -1,0 +1,95 @@
+import { googleDocsAuth, createGoogleClient } from '../auth';
+import { docsCommon } from '../common';
+import { Property, createAction } from '@activepieces/pieces-framework';
+import { docs as googleDocs, docs_v1 } from '@googleapis/docs';
+import { createParagraphBulletsActionOutputSchema } from '../output-schemas';
+
+export const createParagraphBullets = createAction({
+  auth: googleDocsAuth,
+  name: 'create_paragraph_bullets',
+  displayName: 'Create Paragraph Bullets',
+  description: 'Apply a bullet list preset to paragraphs in a character range in a Google Docs document',
+  audience: 'ai',
+  aiMetadata: {
+    description:
+      'Applies a bullet list style (e.g. BULLET_DISC_CIRCLE_SQUARE) to all paragraphs within a character range in a Google Docs document. Use this to convert existing paragraphs into a bulleted or numbered list. The startIndex and endIndex must span the paragraphs to bullet — obtain valid indices from Get Document End Index or Read Document (cannot be guessed). Not idempotent (re-running with a different preset changes the glyph style).',
+    idempotent: false,
+  },
+  outputSchema: createParagraphBulletsActionOutputSchema,
+  props: {
+    documentId: Property.ShortText({
+      displayName: 'Document ID',
+      description: 'The ID of the document to apply bullets to (from the document URL or Search Documents).',
+      required: true,
+    }),
+    startIndex: Property.Number({
+      displayName: 'Start Index',
+      description:
+        'Inclusive start character index of the range of paragraphs to bullet. Obtain from Get Document End Index or Read Document — cannot be guessed.',
+      required: true,
+    }),
+    endIndex: Property.Number({
+      displayName: 'End Index',
+      description:
+        'Exclusive end character index of the range of paragraphs to bullet. Must be greater than Start Index. Obtain from Get Document End Index or Read Document — cannot be guessed.',
+      required: true,
+    }),
+    bulletPreset: Property.StaticDropdown({
+      displayName: 'Bullet Preset',
+      description: 'The bullet list glyph preset to apply to the paragraphs.',
+      required: false,
+      defaultValue: 'BULLET_DISC_CIRCLE_SQUARE',
+      options: {
+        options: [
+          { label: 'Disc / Circle / Square (default)', value: 'BULLET_DISC_CIRCLE_SQUARE' },
+          { label: 'Diamond / Circle / Square', value: 'BULLET_DIAMONDX_ARROW3D_SQUARE' },
+          { label: 'Checkbox', value: 'BULLET_CHECKBOX' },
+          { label: 'Arrow / Diamond / Disc', value: 'BULLET_ARROW_DIAMOND_DISC' },
+          { label: 'Star / Circle / Square', value: 'BULLET_STAR_CIRCLE_SQUARE' },
+          { label: 'Arrow3D / Circle / Square', value: 'BULLET_ARROW3D_CIRCLE_SQUARE' },
+          { label: 'Left Triangle / Diamond / Disc', value: 'BULLET_LEFTTRIANGLE_DIAMOND_DISC' },
+          { label: 'Diamond / Circle / Disc', value: 'BULLET_DIAMONDX_HOLLOWDIAMOND_SQUARE' },
+          { label: 'Diamond / Diamond / Square', value: 'BULLET_DIAMOND_DISC_CIRCLE' },
+          { label: 'Numbered: Decimal / Alpha Lower / Roman Lower', value: 'NUMBERED_DECIMAL_ALPHA_ROMAN' },
+          { label: 'Numbered: Decimal / Alpha Lower / Roman Lower (parenthesis)', value: 'NUMBERED_DECIMAL_ALPHA_ROMAN_PARENS' },
+          { label: 'Numbered: Decimal nested', value: 'NUMBERED_DECIMAL_NESTED' },
+          { label: 'Numbered: Upper Alpha / Alpha Lower / Roman Lower', value: 'NUMBERED_UPPERALPHA_ALPHA_ROMAN' },
+          { label: 'Numbered: Upper Roman / Roman Lower / Alpha Lower', value: 'NUMBERED_UPPERROMAN_UPPERALPHA_DECIMAL' },
+          { label: 'Numbered: Zero Decimal / Alpha Lower / Roman Lower', value: 'NUMBERED_ZERODECIMAL_ALPHA_ROMAN' },
+        ],
+      },
+    }),
+  },
+  async run(context) {
+    const { documentId, startIndex, endIndex, bulletPreset } = context.propsValue;
+    if (endIndex <= startIndex) {
+      throw new Error('End Index must be greater than Start Index.');
+    }
+
+    const authClient = await createGoogleClient(context.auth);
+    const docs = googleDocs({ version: 'v1', auth: authClient });
+
+    const request: docs_v1.Schema$Request = {
+      createParagraphBullets: {
+        range: { startIndex, endIndex },
+        bulletPreset: (bulletPreset ?? 'BULLET_DISC_CIRCLE_SQUARE') as docs_v1.Schema$CreateParagraphBulletsRequest['bulletPreset'],
+      },
+    };
+
+    try {
+      await docs.documents.batchUpdate({
+        documentId,
+        requestBody: { requests: [request] },
+      });
+      return {
+        success: true,
+        documentId,
+        startIndex,
+        endIndex,
+        bulletPreset: bulletPreset ?? 'BULLET_DISC_CIRCLE_SQUARE',
+      };
+    } catch (error) {
+      throw new Error(docsCommon.formatError(error, 'create paragraph bullets in'));
+    }
+  },
+});

--- a/packages/pieces/community/google-docs/src/lib/actions/create-text-document.action.ts
+++ b/packages/pieces/community/google-docs/src/lib/actions/create-text-document.action.ts
@@ -1,0 +1,35 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { docsCommon } from '../common';
+import { googleDocsAuth, getAccessToken } from '../auth';
+import { appendTextActionOutputSchema } from '../output-schemas';
+
+export const createTextDocument = createAction({
+  auth: googleDocsAuth,
+  name: 'create_text_document',
+  displayName: 'Create Text Document',
+  description: 'Create a new Google Docs document with a title and plain text',
+  audience: 'ai',
+  aiMetadata: {
+    description:
+      'Creates a new Google Docs document with the given title and writes the provided plain text into it, returning the new document metadata (including its ID). Use when an agent has plain text to put in a fresh document; for Markdown-formatted content use Create Document from Markdown instead. Not idempotent: each call creates a separate new document.',
+    idempotent: false,
+  },
+  outputSchema: appendTextActionOutputSchema,
+  props: {
+    title: Property.ShortText({
+      displayName: 'Title',
+      description: 'The title (and file name) of the new document.',
+      required: true,
+    }),
+    body: Property.LongText({
+      displayName: 'Content',
+      description: 'The plain text to write into the new document.',
+      required: true,
+    }),
+  },
+  async run(context) {
+    const accessToken = await getAccessToken(context.auth);
+    const document = await docsCommon.createDocument(context.propsValue.title, accessToken);
+    return await docsCommon.writeToDocument(document.documentId, context.propsValue.body, accessToken);
+  },
+});

--- a/packages/pieces/community/google-docs/src/lib/actions/delete-content-range.action.ts
+++ b/packages/pieces/community/google-docs/src/lib/actions/delete-content-range.action.ts
@@ -1,0 +1,59 @@
+import { googleDocsAuth, createGoogleClient } from '../auth';
+import { docsCommon } from '../common';
+import { Property, createAction } from '@activepieces/pieces-framework';
+import { docs as googleDocs, docs_v1 } from '@googleapis/docs';
+import { deleteContentRangeActionOutputSchema } from '../output-schemas';
+
+export const deleteContentRange = createAction({
+  auth: googleDocsAuth,
+  name: 'delete_content_range',
+  displayName: 'Delete Content Range',
+  description: 'Delete a range of content from a Google Docs document',
+  audience: 'ai',
+  aiMetadata: {
+    description:
+      'Deletes all content between a start and end character index in a Google Docs document body. Obtain valid indices from Get Document End Index / Read Document first — indices cannot be guessed. Note that every Google Docs segment ends in a newline that cannot be deleted, so the end index must not exceed the body end index minus one. Destructive and not idempotent.',
+    idempotent: false,
+  },
+  outputSchema: deleteContentRangeActionOutputSchema,
+  props: {
+    documentId: Property.ShortText({
+      displayName: 'Document ID',
+      description: 'The ID of the document to edit.',
+      required: true,
+    }),
+    startIndex: Property.Number({
+      displayName: 'Start Index',
+      description: 'Inclusive start character index. Obtain from Get Document End Index / Read Document.',
+      required: true,
+    }),
+    endIndex: Property.Number({
+      displayName: 'End Index',
+      description: 'Exclusive end character index. Must be greater than Start Index and not exceed the body end index.',
+      required: true,
+    }),
+  },
+  async run(context) {
+    const { documentId, startIndex, endIndex } = context.propsValue;
+    if (endIndex <= startIndex) {
+      throw new Error('End Index must be greater than Start Index.');
+    }
+
+    const authClient = await createGoogleClient(context.auth);
+    const docs = googleDocs({ version: 'v1', auth: authClient });
+
+    const request: docs_v1.Schema$Request = {
+      deleteContentRange: { range: { startIndex, endIndex } },
+    };
+
+    try {
+      await docs.documents.batchUpdate({
+        documentId,
+        requestBody: { requests: [request] },
+      });
+      return { success: true, documentId, deletedFrom: startIndex, deletedTo: endIndex };
+    } catch (error) {
+      throw new Error(docsCommon.formatError(error, 'delete content from'));
+    }
+  },
+});

--- a/packages/pieces/community/google-docs/src/lib/actions/delete-footer.action.ts
+++ b/packages/pieces/community/google-docs/src/lib/actions/delete-footer.action.ts
@@ -1,0 +1,51 @@
+import { googleDocsAuth, createGoogleClient } from '../auth';
+import { docsCommon } from '../common';
+import { Property, createAction } from '@activepieces/pieces-framework';
+import { docs as googleDocs, docs_v1 } from '@googleapis/docs';
+import { deleteFooterActionOutputSchema } from '../output-schemas';
+
+export const deleteFooter = createAction({
+  auth: googleDocsAuth,
+  name: 'delete_footer',
+  displayName: 'Delete Footer',
+  description: 'Delete a footer from a Google Docs document',
+  audience: 'ai',
+  aiMetadata: {
+    description:
+      'Permanently deletes a footer section from a Google Docs document by its footer ID. The footer ID is a hidden identifier — obtain it from the Read Document (gdocs_get_document) response under the document\'s named styles or sections; it cannot be guessed. Destructive and not idempotent: the footer content is unrecoverable once deleted.',
+    idempotent: false,
+  },
+  outputSchema: deleteFooterActionOutputSchema,
+  props: {
+    documentId: Property.ShortText({
+      displayName: 'Document ID',
+      description: 'The ID of the document to edit.',
+      required: true,
+    }),
+    footerId: Property.ShortText({
+      displayName: 'Footer ID',
+      description: 'The ID of the footer to delete. Obtain from Read Document (gdocs_get_document) — cannot be guessed.',
+      required: true,
+    }),
+  },
+  async run(context) {
+    const { documentId, footerId } = context.propsValue;
+
+    const authClient = await createGoogleClient(context.auth);
+    const docs = googleDocs({ version: 'v1', auth: authClient });
+
+    const request: docs_v1.Schema$Request = {
+      deleteFooter: { footerId },
+    };
+
+    try {
+      await docs.documents.batchUpdate({
+        documentId,
+        requestBody: { requests: [request] },
+      });
+      return { success: true, documentId, deletedFooterId: footerId };
+    } catch (error) {
+      throw new Error(docsCommon.formatError(error, 'delete the footer from'));
+    }
+  },
+});

--- a/packages/pieces/community/google-docs/src/lib/actions/delete-header.action.ts
+++ b/packages/pieces/community/google-docs/src/lib/actions/delete-header.action.ts
@@ -1,0 +1,51 @@
+import { googleDocsAuth, createGoogleClient } from '../auth';
+import { docsCommon } from '../common';
+import { Property, createAction } from '@activepieces/pieces-framework';
+import { docs as googleDocs, docs_v1 } from '@googleapis/docs';
+import { deleteHeaderActionOutputSchema } from '../output-schemas';
+
+export const deleteHeader = createAction({
+  auth: googleDocsAuth,
+  name: 'delete_header',
+  displayName: 'Delete Header',
+  description: 'Delete a header from a Google Docs document',
+  audience: 'ai',
+  aiMetadata: {
+    description:
+      'Permanently deletes a header section from a Google Docs document by its header ID. The header ID is a hidden identifier — obtain it from the Read Document (gdocs_get_document) response under the document\'s named styles or sections; it cannot be guessed. Destructive and not idempotent: the header content is unrecoverable once deleted.',
+    idempotent: false,
+  },
+  outputSchema: deleteHeaderActionOutputSchema,
+  props: {
+    documentId: Property.ShortText({
+      displayName: 'Document ID',
+      description: 'The ID of the document to edit.',
+      required: true,
+    }),
+    headerId: Property.ShortText({
+      displayName: 'Header ID',
+      description: 'The ID of the header to delete. Obtain from Read Document (gdocs_get_document) — cannot be guessed.',
+      required: true,
+    }),
+  },
+  async run(context) {
+    const { documentId, headerId } = context.propsValue;
+
+    const authClient = await createGoogleClient(context.auth);
+    const docs = googleDocs({ version: 'v1', auth: authClient });
+
+    const request: docs_v1.Schema$Request = {
+      deleteHeader: { headerId },
+    };
+
+    try {
+      await docs.documents.batchUpdate({
+        documentId,
+        requestBody: { requests: [request] },
+      });
+      return { success: true, documentId, deletedHeaderId: headerId };
+    } catch (error) {
+      throw new Error(docsCommon.formatError(error, 'delete the header from'));
+    }
+  },
+});

--- a/packages/pieces/community/google-docs/src/lib/actions/delete-named-range.action.ts
+++ b/packages/pieces/community/google-docs/src/lib/actions/delete-named-range.action.ts
@@ -1,0 +1,65 @@
+import { googleDocsAuth, createGoogleClient } from '../auth';
+import { docsCommon } from '../common';
+import { Property, createAction } from '@activepieces/pieces-framework';
+import { docs as googleDocs, docs_v1 } from '@googleapis/docs';
+import { deleteNamedRangeActionOutputSchema } from '../output-schemas';
+
+export const deleteNamedRange = createAction({
+  auth: googleDocsAuth,
+  name: 'delete_named_range',
+  displayName: 'Delete Named Range',
+  description: 'Delete a named range from a Google Docs document by ID or name',
+  audience: 'ai',
+  aiMetadata: {
+    description:
+      'Deletes a named range from a Google Docs document. Provide either namedRangeId (targets one specific range — obtain from Read Document gdocs_get_document, cannot be guessed) or name (deletes all named ranges with that name). Re-deleting an already-gone range or name is a no-op, so this call is idempotent.',
+    idempotent: true,
+  },
+  outputSchema: deleteNamedRangeActionOutputSchema,
+  props: {
+    documentId: Property.ShortText({
+      displayName: 'Document ID',
+      description: 'The ID of the document to edit.',
+      required: true,
+    }),
+    namedRangeId: Property.ShortText({
+      displayName: 'Named Range ID',
+      description: 'The ID of the named range to delete. Obtain from Read Document (gdocs_get_document) — cannot be guessed. Provide this OR Name, not both.',
+      required: false,
+    }),
+    name: Property.ShortText({
+      displayName: 'Name',
+      description: 'The name of the named range(s) to delete. All ranges with this name will be removed. Provide this OR Named Range ID, not both.',
+      required: false,
+    }),
+  },
+  async run(context) {
+    const { documentId, namedRangeId, name } = context.propsValue;
+
+    if (!namedRangeId && !name) {
+      throw new Error('Provide either Named Range ID or Name — at least one is required.');
+    }
+
+    const authClient = await createGoogleClient(context.auth);
+    const docs = googleDocs({ version: 'v1', auth: authClient });
+
+    const request: docs_v1.Schema$Request = namedRangeId
+      ? { deleteNamedRange: { namedRangeId } }
+      : { deleteNamedRange: { name } };
+
+    try {
+      await docs.documents.batchUpdate({
+        documentId,
+        requestBody: { requests: [request] },
+      });
+      return {
+        success: true,
+        documentId,
+        deletedNamedRangeId: namedRangeId ?? null,
+        deletedName: name ?? null,
+      };
+    } catch (error) {
+      throw new Error(docsCommon.formatError(error, 'delete the named range from'));
+    }
+  },
+});

--- a/packages/pieces/community/google-docs/src/lib/actions/delete-paragraph-bullets.action.ts
+++ b/packages/pieces/community/google-docs/src/lib/actions/delete-paragraph-bullets.action.ts
@@ -1,0 +1,62 @@
+import { googleDocsAuth, createGoogleClient } from '../auth';
+import { docsCommon } from '../common';
+import { Property, createAction } from '@activepieces/pieces-framework';
+import { docs as googleDocs, docs_v1 } from '@googleapis/docs';
+import { deleteParagraphBulletsActionOutputSchema } from '../output-schemas';
+
+export const deleteParagraphBullets = createAction({
+  auth: googleDocsAuth,
+  name: 'delete_paragraph_bullets',
+  displayName: 'Delete Paragraph Bullets',
+  description: 'Remove bullet list formatting from paragraphs in a range of a Google Docs document',
+  audience: 'ai',
+  aiMetadata: {
+    description:
+      'Removes bullet or numbered list formatting from all paragraphs within the given character index range in a Google Docs document. The paragraphs\' text content is preserved; only the list nesting and bullet glyphs are removed. Obtain valid startIndex and endIndex from Get Document End Index (gdocs_get_document_end_index) — indices cannot be guessed. Idempotent: re-running on already plain paragraphs is a no-op.',
+    idempotent: true,
+  },
+  outputSchema: deleteParagraphBulletsActionOutputSchema,
+  props: {
+    documentId: Property.ShortText({
+      displayName: 'Document ID',
+      description: 'The ID of the document to edit.',
+      required: true,
+    }),
+    startIndex: Property.Number({
+      displayName: 'Start Index',
+      description: 'Inclusive start character index of the range. Obtain from Get Document End Index (gdocs_get_document_end_index).',
+      required: true,
+    }),
+    endIndex: Property.Number({
+      displayName: 'End Index',
+      description: 'Exclusive end character index of the range. Must be greater than Start Index. Obtain from Get Document End Index (gdocs_get_document_end_index).',
+      required: true,
+    }),
+  },
+  async run(context) {
+    const { documentId, startIndex, endIndex } = context.propsValue;
+
+    if (endIndex <= startIndex) {
+      throw new Error('End Index must be greater than Start Index.');
+    }
+
+    const authClient = await createGoogleClient(context.auth);
+    const docs = googleDocs({ version: 'v1', auth: authClient });
+
+    const request: docs_v1.Schema$Request = {
+      deleteParagraphBullets: {
+        range: { startIndex, endIndex },
+      },
+    };
+
+    try {
+      await docs.documents.batchUpdate({
+        documentId,
+        requestBody: { requests: [request] },
+      });
+      return { success: true, documentId, rangeStart: startIndex, rangeEnd: endIndex };
+    } catch (error) {
+      throw new Error(docsCommon.formatError(error, 'delete paragraph bullets from'));
+    }
+  },
+});

--- a/packages/pieces/community/google-docs/src/lib/actions/delete-table-column.action.ts
+++ b/packages/pieces/community/google-docs/src/lib/actions/delete-table-column.action.ts
@@ -1,0 +1,67 @@
+import { googleDocsAuth, createGoogleClient } from '../auth';
+import { docsCommon } from '../common';
+import { Property, createAction } from '@activepieces/pieces-framework';
+import { docs as googleDocs, docs_v1 } from '@googleapis/docs';
+import { deleteTableColumnActionOutputSchema } from '../output-schemas';
+
+export const deleteTableColumn = createAction({
+  auth: googleDocsAuth,
+  name: 'delete_table_column',
+  displayName: 'Delete Table Column',
+  description: 'Delete a column from a table in a Google Docs document',
+  audience: 'ai',
+  aiMetadata: {
+    description:
+      'Permanently deletes a column from a table in a Google Docs document. The column to delete is addressed by the table\'s start index plus the row and column coordinates of any cell in that column. All three index values (tableStartIndex, rowIndex, columnIndex) must be obtained from Read Document (gdocs_get_document) — they cannot be guessed. Destructive and not idempotent: all content in the column is permanently removed.',
+    idempotent: false,
+  },
+  outputSchema: deleteTableColumnActionOutputSchema,
+  props: {
+    documentId: Property.ShortText({
+      displayName: 'Document ID',
+      description: 'The ID of the document to edit.',
+      required: true,
+    }),
+    tableStartIndex: Property.Number({
+      displayName: 'Table Start Index',
+      description: 'The character index of the start of the table in the document body. Obtain from Read Document (gdocs_get_document) — cannot be guessed.',
+      required: true,
+    }),
+    rowIndex: Property.Number({
+      displayName: 'Row Index',
+      description: 'Zero-based row index of any cell in the column to delete. Obtain from Read Document (gdocs_get_document).',
+      required: true,
+    }),
+    columnIndex: Property.Number({
+      displayName: 'Column Index',
+      description: 'Zero-based column index of the column to delete. Obtain from Read Document (gdocs_get_document).',
+      required: true,
+    }),
+  },
+  async run(context) {
+    const { documentId, tableStartIndex, rowIndex, columnIndex } = context.propsValue;
+
+    const authClient = await createGoogleClient(context.auth);
+    const docs = googleDocs({ version: 'v1', auth: authClient });
+
+    const request: docs_v1.Schema$Request = {
+      deleteTableColumn: {
+        tableCellLocation: {
+          tableStartLocation: { index: tableStartIndex },
+          rowIndex,
+          columnIndex,
+        },
+      },
+    };
+
+    try {
+      await docs.documents.batchUpdate({
+        documentId,
+        requestBody: { requests: [request] },
+      });
+      return { success: true, documentId, tableStartIndex, deletedColumnIndex: columnIndex };
+    } catch (error) {
+      throw new Error(docsCommon.formatError(error, 'delete the table column from'));
+    }
+  },
+});

--- a/packages/pieces/community/google-docs/src/lib/actions/delete-table-row.action.ts
+++ b/packages/pieces/community/google-docs/src/lib/actions/delete-table-row.action.ts
@@ -1,0 +1,67 @@
+import { googleDocsAuth, createGoogleClient } from '../auth';
+import { docsCommon } from '../common';
+import { Property, createAction } from '@activepieces/pieces-framework';
+import { docs as googleDocs, docs_v1 } from '@googleapis/docs';
+import { deleteTableRowActionOutputSchema } from '../output-schemas';
+
+export const deleteTableRow = createAction({
+  auth: googleDocsAuth,
+  name: 'delete_table_row',
+  displayName: 'Delete Table Row',
+  description: 'Delete a row from a table in a Google Docs document',
+  audience: 'ai',
+  aiMetadata: {
+    description:
+      'Permanently deletes a row from a table in a Google Docs document. The row to delete is addressed by the table\'s start index plus the row and column coordinates of any cell in that row. All three index values (tableStartIndex, rowIndex, columnIndex) must be obtained from Read Document (gdocs_get_document) — they cannot be guessed. Destructive and not idempotent: all content in the row is permanently removed.',
+    idempotent: false,
+  },
+  outputSchema: deleteTableRowActionOutputSchema,
+  props: {
+    documentId: Property.ShortText({
+      displayName: 'Document ID',
+      description: 'The ID of the document to edit.',
+      required: true,
+    }),
+    tableStartIndex: Property.Number({
+      displayName: 'Table Start Index',
+      description: 'The character index of the start of the table in the document body. Obtain from Read Document (gdocs_get_document) — cannot be guessed.',
+      required: true,
+    }),
+    rowIndex: Property.Number({
+      displayName: 'Row Index',
+      description: 'Zero-based row index of the row to delete. Obtain from Read Document (gdocs_get_document).',
+      required: true,
+    }),
+    columnIndex: Property.Number({
+      displayName: 'Column Index',
+      description: 'Zero-based column index of any cell in the row to delete. Obtain from Read Document (gdocs_get_document).',
+      required: true,
+    }),
+  },
+  async run(context) {
+    const { documentId, tableStartIndex, rowIndex, columnIndex } = context.propsValue;
+
+    const authClient = await createGoogleClient(context.auth);
+    const docs = googleDocs({ version: 'v1', auth: authClient });
+
+    const request: docs_v1.Schema$Request = {
+      deleteTableRow: {
+        tableCellLocation: {
+          tableStartLocation: { index: tableStartIndex },
+          rowIndex,
+          columnIndex,
+        },
+      },
+    };
+
+    try {
+      await docs.documents.batchUpdate({
+        documentId,
+        requestBody: { requests: [request] },
+      });
+      return { success: true, documentId, tableStartIndex, deletedRowIndex: rowIndex };
+    } catch (error) {
+      throw new Error(docsCommon.formatError(error, 'delete the table row from'));
+    }
+  },
+});

--- a/packages/pieces/community/google-docs/src/lib/actions/export-as-pdf.action.ts
+++ b/packages/pieces/community/google-docs/src/lib/actions/export-as-pdf.action.ts
@@ -1,0 +1,59 @@
+import { googleDocsAuth, createGoogleClient } from '../auth';
+import { docsCommon } from '../common';
+import { Property, createAction } from '@activepieces/pieces-framework';
+import { drive as googleDrive } from '@googleapis/drive';
+import { docs as googleDocs } from '@googleapis/docs';
+import { exportAsPdfActionOutputSchema } from '../output-schemas';
+
+export const exportAsPdf = createAction({
+	auth: googleDocsAuth,
+	name: 'export_as_pdf',
+	displayName: 'Export as PDF',
+	description: 'Export a Google Docs document as a PDF file.',
+	audience: 'ai',
+	aiMetadata: {
+		description:
+			'Exports a Google Docs document as a PDF and returns the file for use in later steps (e.g. sending via email or uploading to storage). Uses the Drive export endpoint, so the document must not exceed the Drive 10 MB export limit. Read-only and idempotent — it never modifies the document.',
+		idempotent: true,
+	},
+	outputSchema: exportAsPdfActionOutputSchema,
+	props: {
+		documentId: Property.ShortText({
+			displayName: 'Document ID',
+			description: 'The ID of the document to export as PDF.',
+			required: true,
+		}),
+	},
+	async run(context) {
+		const { documentId } = context.propsValue;
+		const authClient = await createGoogleClient(context.auth);
+
+		// Fetch document title for the file name
+		const docs = googleDocs({ version: 'v1', auth: authClient });
+		let title = documentId;
+		try {
+			const docResponse = await docs.documents.get({ documentId, fields: 'title' });
+			title = docResponse.data.title ?? documentId;
+		} catch {
+			// Fall back to documentId as the file name if the title fetch fails
+		}
+
+		const drive = googleDrive({ version: 'v3', auth: authClient });
+
+		try {
+			const response = await drive.files.export(
+				{ fileId: documentId, mimeType: 'application/pdf' },
+				{ responseType: 'arraybuffer' }
+			);
+
+			const file = await context.files.write({
+				fileName: `${title}.pdf`,
+				data: Buffer.from(response.data as ArrayBuffer),
+			});
+
+			return { success: true, documentId, file };
+		} catch (error) {
+			throw new Error(docsCommon.formatError(error, 'export'));
+		}
+	},
+});

--- a/packages/pieces/community/google-docs/src/lib/actions/find-document.ts
+++ b/packages/pieces/community/google-docs/src/lib/actions/find-document.ts
@@ -14,7 +14,7 @@ export const findDocumentAction = createAction({
 	name: 'google-docs-find-document',
 	displayName: 'Find Document',
 	description: 'Search for document by name.',
-	audience: 'both',
+	audience: 'human',
 	aiMetadata: {
 		description:
 			'Searches Google Drive for a Google Docs document whose name contains the given text, optionally scoped to a folder, and returns the first match. Use when an agent has a document name but not its ID and needs to resolve it. Idempotent only when used purely for lookup; enabling "Create a new document if not found" makes it create (and optionally move) a new document on each miss, which is a mutating side effect.',

--- a/packages/pieces/community/google-docs/src/lib/actions/get-document-end-index.action.ts
+++ b/packages/pieces/community/google-docs/src/lib/actions/get-document-end-index.action.ts
@@ -1,0 +1,47 @@
+import { googleDocsAuth, createGoogleClient } from '../auth';
+import { docsCommon } from '../common';
+import { Property, createAction } from '@activepieces/pieces-framework';
+import { docs as googleDocs } from '@googleapis/docs';
+import { getDocumentEndIndexActionOutputSchema } from '../output-schemas';
+
+export const getDocumentEndIndex = createAction({
+  auth: googleDocsAuth,
+  name: 'get_document_end_index',
+  displayName: 'Get Document End Index',
+  description: 'Get the end index of a Google Docs document body',
+  audience: 'ai',
+  aiMetadata: {
+    description:
+      'Returns the end index of a Google Docs document body (the highest character position) so an agent can compute where to insert, delete, or style content. Call this FIRST before any index-based editing atomic (Insert Text with an explicit index, Delete Content Range, etc.) — Google Docs edits are addressed by an integer character index that cannot be guessed. Requires the document ID; read-only and idempotent.',
+    idempotent: true,
+  },
+  outputSchema: getDocumentEndIndexActionOutputSchema,
+  props: {
+    documentId: Property.ShortText({
+      displayName: 'Document ID',
+      description: 'The ID of the document to inspect (from the document URL or Search Documents).',
+      required: true,
+    }),
+  },
+  async run(context) {
+    const { documentId } = context.propsValue;
+    const authClient = await createGoogleClient(context.auth);
+    const docs = googleDocs({ version: 'v1', auth: authClient });
+
+    try {
+      const response = await docs.documents.get({ documentId });
+      const content = response.data.body?.content ?? [];
+      const lastElement = content[content.length - 1];
+      const endIndex = lastElement?.endIndex ?? 1;
+
+      return {
+        documentId,
+        title: response.data.title ?? null,
+        endIndex,
+        maxInsertIndex: Math.max(1, endIndex - 1),
+      };
+    } catch (error) {
+      throw new Error(docsCommon.formatError(error, 'read'));
+    }
+  },
+});

--- a/packages/pieces/community/google-docs/src/lib/actions/get-document-plaintext.action.ts
+++ b/packages/pieces/community/google-docs/src/lib/actions/get-document-plaintext.action.ts
@@ -1,0 +1,74 @@
+import { googleDocsAuth, createGoogleClient } from '../auth';
+import { Property, createAction } from '@activepieces/pieces-framework';
+import { docs as googleDocs, docs_v1 } from '@googleapis/docs';
+import { getDocumentPlaintextActionOutputSchema } from '../output-schemas';
+
+// Minimal prose projection: only top-level body paragraph text runs are
+// flattened. Content inside tables, headers, footers, footnotes, and tabs is
+// intentionally NOT included — keep the contract unambiguous for agents that
+// just want the document prose. Use read_document for the full structural JSON.
+function flattenBodyToPlainText(body: docs_v1.Schema$Body | undefined): string {
+	const lines: string[] = [];
+	for (const element of body?.content ?? []) {
+		const paragraph = element.paragraph;
+		if (!paragraph) continue;
+		const text = (paragraph.elements ?? [])
+			.map((paragraphElement) => paragraphElement.textRun?.content ?? '')
+			.join('');
+		lines.push(text);
+	}
+	return lines.join('').replace(/\n+$/, '');
+}
+
+export const getDocumentPlaintext = createAction({
+	auth: googleDocsAuth,
+	name: 'get_document_plaintext',
+	displayName: 'Get Document Plain Text',
+	description: 'Get the plain text content of a Google Docs document.',
+	audience: 'ai',
+	aiMetadata: {
+		description:
+			'Returns just the body prose of a Google Docs document as a plain string, flattened from the document.get response. Pick this over Read Document when you only need the text to summarize/extract/classify and want to avoid the large nested structural JSON. Only top-level paragraph text is included — tables, headers, footers, footnotes, and tabs are omitted. Read-only and idempotent.',
+		idempotent: true,
+	},
+	outputSchema: getDocumentPlaintextActionOutputSchema,
+	props: {
+		documentId: Property.ShortText({
+			displayName: 'Document ID',
+			description:
+				"The ID of the document to read, found in its URL: 'https://docs.google.com/document/d/<documentId>/edit'. Obtain it from Search Documents or Find Document if you only have a name.",
+			required: true,
+		}),
+	},
+	async run(context) {
+		const authClient = await createGoogleClient(context.auth);
+		const docs = googleDocs({ version: 'v1', auth: authClient });
+
+		try {
+			const response = await docs.documents.get({
+				documentId: context.propsValue.documentId,
+			});
+
+			const plainText = flattenBodyToPlainText(response.data.body);
+
+			return {
+				documentId: response.data.documentId ?? context.propsValue.documentId,
+				title: response.data.title ?? '',
+				plainText,
+			};
+		} catch (e) {
+			const error = e as { code?: number; message?: string };
+			if (error.code === 403) {
+				throw new Error(
+					'Permission denied reading the document. Ensure the connected account has access to this document.'
+				);
+			}
+			if (error.code === 404) {
+				throw new Error(
+					`Document not found for ID '${context.propsValue.documentId}'. Verify the document ID.`
+				);
+			}
+			throw e;
+		}
+	},
+});

--- a/packages/pieces/community/google-docs/src/lib/actions/get-document.action.ts
+++ b/packages/pieces/community/google-docs/src/lib/actions/get-document.action.ts
@@ -1,0 +1,37 @@
+import { googleDocsAuth, createGoogleClient } from '../auth';
+import { docsCommon } from '../common';
+import { Property, createAction } from '@activepieces/pieces-framework';
+import { docs as googleDocs } from '@googleapis/docs';
+import { readDocumentActionOutputSchema } from '../output-schemas';
+
+export const getDocument = createAction({
+  auth: googleDocsAuth,
+  name: 'get_document',
+  displayName: 'Get Document',
+  description: 'Get the full content and structure of a Google Docs document',
+  audience: 'ai',
+  aiMetadata: {
+    description:
+      'Fetches the full content and structure of a Google Docs document by its ID — the raw document JSON including body elements and their character indices. Use when an agent needs the complete structure, e.g. to locate element indices before editing. For only the readable text use Get Document Plaintext; for just the body end index use Get Document End Index. Requires the document ID; read-only and idempotent.',
+    idempotent: true,
+  },
+  outputSchema: readDocumentActionOutputSchema,
+  props: {
+    documentId: Property.ShortText({
+      displayName: 'Document ID',
+      description: 'The ID of the document to read (from the document URL or Search Documents).',
+      required: true,
+    }),
+  },
+  async run(context) {
+    const { documentId } = context.propsValue;
+    const authClient = await createGoogleClient(context.auth);
+    const docs = googleDocs({ version: 'v1', auth: authClient });
+    try {
+      const response = await docs.documents.get({ documentId });
+      return response.data;
+    } catch (error) {
+      throw new Error(docsCommon.formatError(error, 'read'));
+    }
+  },
+});

--- a/packages/pieces/community/google-docs/src/lib/actions/insert-image-in-table-cell.action.ts
+++ b/packages/pieces/community/google-docs/src/lib/actions/insert-image-in-table-cell.action.ts
@@ -1,0 +1,139 @@
+import { googleDocsAuth, createGoogleClient } from '../auth';
+import { docsCommon } from '../common';
+import { Property, createAction } from '@activepieces/pieces-framework';
+import { docs as googleDocs, docs_v1 } from '@googleapis/docs';
+import { insertImageInTableCellActionOutputSchema } from '../output-schemas';
+
+export const insertImageInTableCell = createAction({
+  auth: googleDocsAuth,
+  name: 'insert_image_in_table_cell',
+  displayName: 'Insert Image in Table Cell',
+  description: 'Insert an inline image into a specific table cell in a Google Docs document',
+  audience: 'ai',
+  aiMetadata: {
+    description:
+      'Inserts an inline image at the start of a specific table cell in a Google Docs document. The action reads the document to resolve the correct character index for the target cell, then inserts the image from the given URI. Optionally accepts width and height in points. Requires the table start index (from Read Document — cannot be guessed). Not idempotent: each call inserts another image.',
+    idempotent: false,
+  },
+  outputSchema: insertImageInTableCellActionOutputSchema,
+  props: {
+    documentId: Property.ShortText({
+      displayName: 'Document ID',
+      description: 'The ID of the document containing the table.',
+      required: true,
+    }),
+    tableStartIndex: Property.Number({
+      displayName: 'Table Start Index',
+      description: 'Obtain the table start index from Read Document — cannot be guessed.',
+      required: true,
+    }),
+    rowIndex: Property.Number({
+      displayName: 'Row Index',
+      description: 'Zero-based row index of the target cell.',
+      required: true,
+    }),
+    columnIndex: Property.Number({
+      displayName: 'Column Index',
+      description: 'Zero-based column index of the target cell.',
+      required: true,
+    }),
+    uri: Property.ShortText({
+      displayName: 'Image URI',
+      description: 'Publicly accessible URL of the image to insert.',
+      required: true,
+    }),
+    width: Property.Number({
+      displayName: 'Width (points)',
+      description: 'Optional width of the image in points. If omitted, the image uses its natural size.',
+      required: false,
+    }),
+    height: Property.Number({
+      displayName: 'Height (points)',
+      description: 'Optional height of the image in points. If omitted, the image uses its natural size.',
+      required: false,
+    }),
+  },
+  async run(context) {
+    const { documentId, tableStartIndex, rowIndex, columnIndex, uri, width, height } = context.propsValue;
+    const authClient = await createGoogleClient(context.auth);
+    const docs = googleDocs({ version: 'v1', auth: authClient });
+
+    let cellContentIndex: number;
+    try {
+      const docResponse = await docs.documents.get({ documentId });
+      const content = docResponse.data.body?.content ?? [];
+
+      const tableElement = content.find(
+        (el) => el.table !== undefined && el.startIndex === tableStartIndex
+      );
+
+      if (!tableElement?.table) {
+        throw new Error(
+          `No table found at start index ${tableStartIndex}. Verify the table start index from Read Document.`
+        );
+      }
+
+      const tableRows = tableElement.table.tableRows ?? [];
+      const targetRow = tableRows[rowIndex];
+      if (!targetRow) {
+        throw new Error(`Row index ${rowIndex} is out of range — table has ${tableRows.length} row(s).`);
+      }
+
+      const targetCell = (targetRow.tableCells ?? [])[columnIndex];
+      if (!targetCell) {
+        throw new Error(
+          `Column index ${columnIndex} is out of range — row has ${(targetRow.tableCells ?? []).length} cell(s).`
+        );
+      }
+
+      const firstContent = (targetCell.content ?? [])[0];
+      if (firstContent?.startIndex === undefined || firstContent.startIndex === null) {
+        throw new Error('Could not resolve the content start index for the target cell.');
+      }
+
+      cellContentIndex = firstContent.startIndex;
+    } catch (error) {
+      if (error instanceof Error && error.message.startsWith('No table') ||
+          error instanceof Error && error.message.startsWith('Row index') ||
+          error instanceof Error && error.message.startsWith('Column index') ||
+          error instanceof Error && error.message.startsWith('Could not')) {
+        throw error;
+      }
+      throw new Error(docsCommon.formatError(error, 'read'));
+    }
+
+    const objectSize: docs_v1.Schema$Size | undefined =
+      width !== undefined || height !== undefined
+        ? {
+            width: width !== undefined ? { magnitude: width, unit: 'PT' } : undefined,
+            height: height !== undefined ? { magnitude: height, unit: 'PT' } : undefined,
+          }
+        : undefined;
+
+    const request: docs_v1.Schema$Request = {
+      insertInlineImage: {
+        uri,
+        location: { index: cellContentIndex },
+        ...(objectSize ? { objectSize } : {}),
+      },
+    };
+
+    try {
+      await docs.documents.batchUpdate({
+        documentId,
+        requestBody: { requests: [request] },
+      });
+      return {
+        success: true,
+        documentId,
+        tableStartIndex,
+        rowIndex,
+        columnIndex,
+        insertedAtIndex: cellContentIndex,
+        uri,
+      };
+    } catch (error) {
+      throw new Error(docsCommon.formatError(error, 'insert image into table cell in'));
+    }
+  },
+});

--- a/packages/pieces/community/google-docs/src/lib/actions/insert-inline-image.action.ts
+++ b/packages/pieces/community/google-docs/src/lib/actions/insert-inline-image.action.ts
@@ -1,0 +1,83 @@
+import { googleDocsAuth, createGoogleClient } from '../auth';
+import { docsCommon } from '../common';
+import { Property, createAction } from '@activepieces/pieces-framework';
+import { docs as googleDocs, docs_v1 } from '@googleapis/docs';
+import { insertInlineImageActionOutputSchema } from '../output-schemas';
+
+export const insertInlineImage = createAction({
+	auth: googleDocsAuth,
+	name: 'insert_inline_image',
+	displayName: 'Insert Inline Image',
+	description: 'Insert an inline image into a Google Docs document at a position or at the end.',
+	audience: 'ai',
+	aiMetadata: {
+		description:
+			'Inserts an inline image from a publicly fetchable URI into a Google Docs document. If "index" is omitted the image is placed at the end of the document body; if "index" is provided it is inserted at that character index — obtain a valid index from Get Document End Index first (indices cannot be guessed). The URI must be publicly accessible by Google at call time. Not idempotent: each call inserts another copy of the image.',
+		idempotent: false,
+	},
+	outputSchema: insertInlineImageActionOutputSchema,
+	props: {
+		documentId: Property.ShortText({
+			displayName: 'Document ID',
+			description: 'The ID of the document to insert the image into.',
+			required: true,
+		}),
+		uri: Property.ShortText({
+			displayName: 'Image URI',
+			description: 'A publicly accessible URL of the image to insert. Google must be able to fetch this URL at the time of the call.',
+			required: true,
+		}),
+		index: Property.Number({
+			displayName: 'Index',
+			description:
+				'Character index at which to insert the image. Leave empty to insert at the end of the document. Obtain a valid index from Get Document End Index.',
+			required: false,
+		}),
+		widthPt: Property.Number({
+			displayName: 'Width (pt)',
+			description: 'Desired width of the image in points. Leave empty to use the image\'s natural size.',
+			required: false,
+		}),
+		heightPt: Property.Number({
+			displayName: 'Height (pt)',
+			description: 'Desired height of the image in points. Leave empty to use the image\'s natural size.',
+			required: false,
+		}),
+	},
+	async run(context) {
+		const { documentId, uri, index, widthPt, heightPt } = context.propsValue;
+		const authClient = await createGoogleClient(context.auth);
+		const docs = googleDocs({ version: 'v1', auth: authClient });
+
+		const objectSize: docs_v1.Schema$Size | undefined =
+			widthPt !== undefined && widthPt !== null && heightPt !== undefined && heightPt !== null
+				? {
+						width: { magnitude: widthPt, unit: 'PT' },
+						height: { magnitude: heightPt, unit: 'PT' },
+					}
+				: undefined;
+
+		const location: docs_v1.Schema$InsertInlineImageRequest =
+			index === undefined || index === null
+				? { uri, endOfSegmentLocation: {}, ...(objectSize ? { objectSize } : {}) }
+				: { uri, location: { index }, ...(objectSize ? { objectSize } : {}) };
+
+		const request: docs_v1.Schema$Request = { insertInlineImage: location };
+
+		try {
+			const response = await docs.documents.batchUpdate({
+				documentId,
+				requestBody: { requests: [request] },
+			});
+			const insertedObjectId = response.data.replies?.[0]?.insertInlineImage?.objectId ?? null;
+			return {
+				success: true,
+				documentId,
+				insertedObjectId,
+				mode: index === undefined || index === null ? 'append' : 'insert_at_index',
+			};
+		} catch (error) {
+			throw new Error(docsCommon.formatError(error, 'insert inline image into'));
+		}
+	},
+});

--- a/packages/pieces/community/google-docs/src/lib/actions/insert-page-break.action.ts
+++ b/packages/pieces/community/google-docs/src/lib/actions/insert-page-break.action.ts
@@ -1,0 +1,56 @@
+import { googleDocsAuth, createGoogleClient } from '../auth';
+import { docsCommon } from '../common';
+import { Property, createAction } from '@activepieces/pieces-framework';
+import { docs as googleDocs, docs_v1 } from '@googleapis/docs';
+import { insertPageBreakActionOutputSchema } from '../output-schemas';
+
+export const insertPageBreak = createAction({
+	auth: googleDocsAuth,
+	name: 'insert_page_break',
+	displayName: 'Insert Page Break',
+	description: 'Insert a page break into a Google Docs document at a position or at the end.',
+	audience: 'ai',
+	aiMetadata: {
+		description:
+			'Inserts a page break into a Google Docs document. If "index" is omitted the page break is appended at the end of the document body; if "index" is provided it is inserted at that character index — obtain a valid index from Get Document End Index first (indices cannot be guessed and must fall inside an existing paragraph). Not idempotent: each call inserts another page break.',
+		idempotent: false,
+	},
+	outputSchema: insertPageBreakActionOutputSchema,
+	props: {
+		documentId: Property.ShortText({
+			displayName: 'Document ID',
+			description: 'The ID of the document to insert the page break into.',
+			required: true,
+		}),
+		index: Property.Number({
+			displayName: 'Index',
+			description:
+				'Character index at which to insert the page break. Leave empty to insert at the end of the document. Obtain a valid index from Get Document End Index.',
+			required: false,
+		}),
+	},
+	async run(context) {
+		const { documentId, index } = context.propsValue;
+		const authClient = await createGoogleClient(context.auth);
+		const docs = googleDocs({ version: 'v1', auth: authClient });
+
+		const request: docs_v1.Schema$Request =
+			index === undefined || index === null
+				? { insertPageBreak: { endOfSegmentLocation: {} } }
+				: { insertPageBreak: { location: { index } } };
+
+		try {
+			await docs.documents.batchUpdate({
+				documentId,
+				requestBody: { requests: [request] },
+			});
+			return {
+				success: true,
+				documentId,
+				mode: index === undefined || index === null ? 'append' : 'insert_at_index',
+			};
+		} catch (error) {
+			throw new Error(docsCommon.formatError(error, 'insert page break into'));
+		}
+	},
+});

--- a/packages/pieces/community/google-docs/src/lib/actions/insert-table-column.action.ts
+++ b/packages/pieces/community/google-docs/src/lib/actions/insert-table-column.action.ts
@@ -1,0 +1,80 @@
+import { googleDocsAuth, createGoogleClient } from '../auth';
+import { docsCommon } from '../common';
+import { Property, createAction } from '@activepieces/pieces-framework';
+import { docs as googleDocs, docs_v1 } from '@googleapis/docs';
+import { insertTableColumnActionOutputSchema } from '../output-schemas';
+
+export const insertTableColumn = createAction({
+  auth: googleDocsAuth,
+  name: 'insert_table_column',
+  displayName: 'Insert Table Column',
+  description: 'Insert a column into an existing table in a Google Docs document',
+  audience: 'ai',
+  aiMetadata: {
+    description:
+      'Inserts a new column into an existing table in a Google Docs document. The column is inserted to the left or right of the cell identified by rowIndex and columnIndex. Use "insertRight" to control the insertion side. Not idempotent: each call inserts another column.',
+    idempotent: false,
+  },
+  outputSchema: insertTableColumnActionOutputSchema,
+  props: {
+    documentId: Property.ShortText({
+      displayName: 'Document ID',
+      description: 'The ID of the document containing the table.',
+      required: true,
+    }),
+    tableStartIndex: Property.Number({
+      displayName: 'Table Start Index',
+      description: 'Obtain the table start index from Read Document — cannot be guessed.',
+      required: true,
+    }),
+    rowIndex: Property.Number({
+      displayName: 'Row Index',
+      description: 'Zero-based row index of the reference cell used to identify the column.',
+      required: true,
+    }),
+    columnIndex: Property.Number({
+      displayName: 'Column Index',
+      description: 'Zero-based column index of the reference cell.',
+      required: true,
+    }),
+    insertRight: Property.Checkbox({
+      displayName: 'Insert to the Right',
+      description: 'If true, the new column is inserted to the right of the reference cell; if false, to the left.',
+      required: false,
+      defaultValue: false,
+    }),
+  },
+  async run(context) {
+    const { documentId, tableStartIndex, rowIndex, columnIndex, insertRight } = context.propsValue;
+    const authClient = await createGoogleClient(context.auth);
+    const docs = googleDocs({ version: 'v1', auth: authClient });
+
+    const request: docs_v1.Schema$Request = {
+      insertTableColumn: {
+        tableCellLocation: {
+          tableStartLocation: { index: tableStartIndex },
+          rowIndex,
+          columnIndex,
+        },
+        insertRight: insertRight ?? false,
+      },
+    };
+
+    try {
+      await docs.documents.batchUpdate({
+        documentId,
+        requestBody: { requests: [request] },
+      });
+      return {
+        success: true,
+        documentId,
+        tableStartIndex,
+        rowIndex,
+        columnIndex,
+        insertRight: insertRight ?? false,
+      };
+    } catch (error) {
+      throw new Error(docsCommon.formatError(error, 'insert table column into'));
+    }
+  },
+});

--- a/packages/pieces/community/google-docs/src/lib/actions/insert-table-row.action.ts
+++ b/packages/pieces/community/google-docs/src/lib/actions/insert-table-row.action.ts
@@ -1,0 +1,80 @@
+import { googleDocsAuth, createGoogleClient } from '../auth';
+import { docsCommon } from '../common';
+import { Property, createAction } from '@activepieces/pieces-framework';
+import { docs as googleDocs, docs_v1 } from '@googleapis/docs';
+import { insertTableRowActionOutputSchema } from '../output-schemas';
+
+export const insertTableRow = createAction({
+  auth: googleDocsAuth,
+  name: 'insert_table_row',
+  displayName: 'Insert Table Row',
+  description: 'Insert a row into an existing table in a Google Docs document',
+  audience: 'ai',
+  aiMetadata: {
+    description:
+      'Inserts a new row into an existing table in a Google Docs document. The row is inserted above or below the cell identified by rowIndex and columnIndex. Use "insertBelow" to control the insertion side. Not idempotent: each call inserts another row.',
+    idempotent: false,
+  },
+  outputSchema: insertTableRowActionOutputSchema,
+  props: {
+    documentId: Property.ShortText({
+      displayName: 'Document ID',
+      description: 'The ID of the document containing the table.',
+      required: true,
+    }),
+    tableStartIndex: Property.Number({
+      displayName: 'Table Start Index',
+      description: 'Obtain the table start index from Read Document — cannot be guessed.',
+      required: true,
+    }),
+    rowIndex: Property.Number({
+      displayName: 'Row Index',
+      description: 'Zero-based row index of the reference cell used to identify the row.',
+      required: true,
+    }),
+    columnIndex: Property.Number({
+      displayName: 'Column Index',
+      description: 'Zero-based column index of the reference cell.',
+      required: true,
+    }),
+    insertBelow: Property.Checkbox({
+      displayName: 'Insert Below',
+      description: 'If true, the new row is inserted below the reference cell; if false, above.',
+      required: false,
+      defaultValue: false,
+    }),
+  },
+  async run(context) {
+    const { documentId, tableStartIndex, rowIndex, columnIndex, insertBelow } = context.propsValue;
+    const authClient = await createGoogleClient(context.auth);
+    const docs = googleDocs({ version: 'v1', auth: authClient });
+
+    const request: docs_v1.Schema$Request = {
+      insertTableRow: {
+        tableCellLocation: {
+          tableStartLocation: { index: tableStartIndex },
+          rowIndex,
+          columnIndex,
+        },
+        insertBelow: insertBelow ?? false,
+      },
+    };
+
+    try {
+      await docs.documents.batchUpdate({
+        documentId,
+        requestBody: { requests: [request] },
+      });
+      return {
+        success: true,
+        documentId,
+        tableStartIndex,
+        rowIndex,
+        columnIndex,
+        insertBelow: insertBelow ?? false,
+      };
+    } catch (error) {
+      throw new Error(docsCommon.formatError(error, 'insert table row into'));
+    }
+  },
+});

--- a/packages/pieces/community/google-docs/src/lib/actions/insert-table.action.ts
+++ b/packages/pieces/community/google-docs/src/lib/actions/insert-table.action.ts
@@ -1,0 +1,68 @@
+import { googleDocsAuth, createGoogleClient } from '../auth';
+import { docsCommon } from '../common';
+import { Property, createAction } from '@activepieces/pieces-framework';
+import { docs as googleDocs, docs_v1 } from '@googleapis/docs';
+import { insertTableActionOutputSchema } from '../output-schemas';
+
+export const insertTable = createAction({
+  auth: googleDocsAuth,
+  name: 'insert_table',
+  displayName: 'Insert Table',
+  description: 'Insert a new table into a Google Docs document',
+  audience: 'ai',
+  aiMetadata: {
+    description:
+      'Inserts a new table with the specified number of rows and columns into a Google Docs document. If "index" is omitted the table is inserted at the end of the document body; if provided the table is inserted at that character index — obtain a valid index from Get Document End Index first. Not idempotent: each call inserts another table.',
+    idempotent: false,
+  },
+  outputSchema: insertTableActionOutputSchema,
+  props: {
+    documentId: Property.ShortText({
+      displayName: 'Document ID',
+      description: 'The ID of the document to insert the table into.',
+      required: true,
+    }),
+    rows: Property.Number({
+      displayName: 'Rows',
+      description: 'Number of rows in the new table.',
+      required: true,
+    }),
+    columns: Property.Number({
+      displayName: 'Columns',
+      description: 'Number of columns in the new table.',
+      required: true,
+    }),
+    index: Property.Number({
+      displayName: 'Index',
+      description:
+        'Character index at which to insert the table. Leave empty to append at the end of the document. Obtain a valid index from Get Document End Index.',
+      required: false,
+    }),
+  },
+  async run(context) {
+    const { documentId, rows, columns, index } = context.propsValue;
+    const authClient = await createGoogleClient(context.auth);
+    const docs = googleDocs({ version: 'v1', auth: authClient });
+
+    const request: docs_v1.Schema$Request =
+      index === undefined || index === null
+        ? { insertTable: { rows, columns, endOfSegmentLocation: {} } }
+        : { insertTable: { rows, columns, location: { index } } };
+
+    try {
+      await docs.documents.batchUpdate({
+        documentId,
+        requestBody: { requests: [request] },
+      });
+      return {
+        success: true,
+        documentId,
+        rows,
+        columns,
+        mode: index === undefined || index === null ? 'append' : 'insert_at_index',
+      };
+    } catch (error) {
+      throw new Error(docsCommon.formatError(error, 'insert table into'));
+    }
+  },
+});

--- a/packages/pieces/community/google-docs/src/lib/actions/insert-text-in-table-cell.action.ts
+++ b/packages/pieces/community/google-docs/src/lib/actions/insert-text-in-table-cell.action.ts
@@ -1,0 +1,120 @@
+import { googleDocsAuth, createGoogleClient } from '../auth';
+import { docsCommon } from '../common';
+import { Property, createAction } from '@activepieces/pieces-framework';
+import { docs as googleDocs, docs_v1 } from '@googleapis/docs';
+import { insertTextInTableCellActionOutputSchema } from '../output-schemas';
+
+export const insertTextInTableCell = createAction({
+  auth: googleDocsAuth,
+  name: 'insert_text_in_table_cell',
+  displayName: 'Insert Text in Table Cell',
+  description: 'Insert text into a specific table cell in a Google Docs document',
+  audience: 'ai',
+  aiMetadata: {
+    description:
+      'Inserts text at the start of a specific table cell in a Google Docs document. The action reads the document to resolve the correct character index for the target cell, then inserts text there. Requires the table start index (from Read Document — cannot be guessed), plus the zero-based row and column index of the target cell. Not idempotent: each call inserts the text again.',
+    idempotent: false,
+  },
+  outputSchema: insertTextInTableCellActionOutputSchema,
+  props: {
+    documentId: Property.ShortText({
+      displayName: 'Document ID',
+      description: 'The ID of the document containing the table.',
+      required: true,
+    }),
+    tableStartIndex: Property.Number({
+      displayName: 'Table Start Index',
+      description: 'Obtain the table start index from Read Document — cannot be guessed.',
+      required: true,
+    }),
+    rowIndex: Property.Number({
+      displayName: 'Row Index',
+      description: 'Zero-based row index of the target cell.',
+      required: true,
+    }),
+    columnIndex: Property.Number({
+      displayName: 'Column Index',
+      description: 'Zero-based column index of the target cell.',
+      required: true,
+    }),
+    text: Property.LongText({
+      displayName: 'Text',
+      description: 'The text to insert into the table cell.',
+      required: true,
+    }),
+  },
+  async run(context) {
+    const { documentId, tableStartIndex, rowIndex, columnIndex, text } = context.propsValue;
+    const authClient = await createGoogleClient(context.auth);
+    const docs = googleDocs({ version: 'v1', auth: authClient });
+
+    let cellContentIndex: number;
+    try {
+      const docResponse = await docs.documents.get({ documentId });
+      const content = docResponse.data.body?.content ?? [];
+
+      const tableElement = content.find(
+        (el) => el.table !== undefined && el.startIndex === tableStartIndex
+      );
+
+      if (!tableElement?.table) {
+        throw new Error(
+          `No table found at start index ${tableStartIndex}. Verify the table start index from Read Document.`
+        );
+      }
+
+      const tableRows = tableElement.table.tableRows ?? [];
+      const targetRow = tableRows[rowIndex];
+      if (!targetRow) {
+        throw new Error(`Row index ${rowIndex} is out of range — table has ${tableRows.length} row(s).`);
+      }
+
+      const targetCell = (targetRow.tableCells ?? [])[columnIndex];
+      if (!targetCell) {
+        throw new Error(
+          `Column index ${columnIndex} is out of range — row has ${(targetRow.tableCells ?? []).length} cell(s).`
+        );
+      }
+
+      const firstContent = (targetCell.content ?? [])[0];
+      if (firstContent?.startIndex === undefined || firstContent.startIndex === null) {
+        throw new Error('Could not resolve the content start index for the target cell.');
+      }
+
+      cellContentIndex = firstContent.startIndex;
+    } catch (error) {
+      if (error instanceof Error && error.message.startsWith('No table') ||
+          error instanceof Error && error.message.startsWith('Row index') ||
+          error instanceof Error && error.message.startsWith('Column index') ||
+          error instanceof Error && error.message.startsWith('Could not')) {
+        throw error;
+      }
+      throw new Error(docsCommon.formatError(error, 'read'));
+    }
+
+    const request: docs_v1.Schema$Request = {
+      insertText: {
+        text,
+        location: { index: cellContentIndex },
+      },
+    };
+
+    try {
+      await docs.documents.batchUpdate({
+        documentId,
+        requestBody: { requests: [request] },
+      });
+      return {
+        success: true,
+        documentId,
+        tableStartIndex,
+        rowIndex,
+        columnIndex,
+        insertedAtIndex: cellContentIndex,
+        insertedCharacters: text.length,
+      };
+    } catch (error) {
+      throw new Error(docsCommon.formatError(error, 'insert text into table cell in'));
+    }
+  },
+});

--- a/packages/pieces/community/google-docs/src/lib/actions/insert-text.action.ts
+++ b/packages/pieces/community/google-docs/src/lib/actions/insert-text.action.ts
@@ -1,0 +1,62 @@
+import { googleDocsAuth, createGoogleClient } from '../auth';
+import { docsCommon } from '../common';
+import { Property, createAction } from '@activepieces/pieces-framework';
+import { docs as googleDocs, docs_v1 } from '@googleapis/docs';
+import { insertTextActionOutputSchema } from '../output-schemas';
+
+export const insertText = createAction({
+  auth: googleDocsAuth,
+  name: 'insert_text',
+  displayName: 'Insert Text',
+  description: 'Insert text into a Google Docs document at a position or at the end',
+  audience: 'ai',
+  aiMetadata: {
+    description:
+      'Inserts text into a Google Docs document. If "index" is omitted the text is appended to the end of the document body; if "index" is provided the text is inserted at that character index — obtain a valid index from Get Document End Index first (indices cannot be guessed, must fall inside an existing paragraph, and must be below the body end index). Not idempotent: each call inserts the text again.',
+    idempotent: false,
+  },
+  outputSchema: insertTextActionOutputSchema,
+  props: {
+    documentId: Property.ShortText({
+      displayName: 'Document ID',
+      description: 'The ID of the document to insert text into.',
+      required: true,
+    }),
+    text: Property.LongText({
+      displayName: 'Text',
+      description: 'The text to insert.',
+      required: true,
+    }),
+    index: Property.Number({
+      displayName: 'Index',
+      description:
+        'Character index to insert at. Leave empty to append to the end of the document. Get a valid index from Get Document End Index.',
+      required: false,
+    }),
+  },
+  async run(context) {
+    const { documentId, text, index } = context.propsValue;
+    const authClient = await createGoogleClient(context.auth);
+    const docs = googleDocs({ version: 'v1', auth: authClient });
+
+    const request: docs_v1.Schema$Request =
+      index === undefined || index === null
+        ? { insertText: { text, endOfSegmentLocation: {} } }
+        : { insertText: { text, location: { index } } };
+
+    try {
+      await docs.documents.batchUpdate({
+        documentId,
+        requestBody: { requests: [request] },
+      });
+      return {
+        success: true,
+        documentId,
+        insertedCharacters: text.length,
+        mode: index === undefined || index === null ? 'append' : 'insert_at_index',
+      };
+    } catch (error) {
+      throw new Error(docsCommon.formatError(error, 'insert text into'));
+    }
+  },
+});

--- a/packages/pieces/community/google-docs/src/lib/actions/read-document.action.ts
+++ b/packages/pieces/community/google-docs/src/lib/actions/read-document.action.ts
@@ -8,7 +8,7 @@ export const readDocument = createAction({
   auth: googleDocsAuth,
   name: 'read_document',
   description: 'Read a document from Google Docs',
-  audience: 'both',
+  audience: 'human',
   aiMetadata: {
     description:
       'Fetches the full content and structure of a Google Docs document by its ID. Use when an agent needs to inspect, summarize, or extract text from a known document. Requires the document ID (not a name or URL); read-only and idempotent.',

--- a/packages/pieces/community/google-docs/src/lib/actions/replace-all-text.action.ts
+++ b/packages/pieces/community/google-docs/src/lib/actions/replace-all-text.action.ts
@@ -1,0 +1,95 @@
+import { googleDocsAuth, createGoogleClient } from '../auth';
+import { Property, createAction } from '@activepieces/pieces-framework';
+import { docs as googleDocs } from '@googleapis/docs';
+import { replaceAllTextActionOutputSchema } from '../output-schemas';
+
+export const replaceAllText = createAction({
+	auth: googleDocsAuth,
+	name: 'replace_all_text',
+	displayName: 'Replace All Text in Document',
+	description:
+		'Replace every occurrence of a literal string in a Google Docs document with another string.',
+	audience: 'ai',
+	aiMetadata: {
+		// Idempotent matches the sibling create_document_based_on_template, which
+		// wraps the identical replaceAllText request and is labeled idempotent:true:
+		// re-running with the same find/replace leaves the same end state (the
+		// second run matches zero occurrences). Caveat noted below for the
+		// overlapping find/replace-literals edge case.
+		description:
+			'Find-and-replaces every occurrence of a literal string across a whole Google Docs document. Pick this for a bare ad-hoc text edit; use Edit Template File instead for placeholder-token merges or image swaps. Idempotent for normal use (a repeat run matches nothing and leaves the same end state); the exception is overlapping find/replace literals (e.g. replacing "a" with "ab"), which can re-match on a second run.',
+		idempotent: true,
+	},
+	outputSchema: replaceAllTextActionOutputSchema,
+	props: {
+		documentId: Property.ShortText({
+			displayName: 'Document ID',
+			description:
+				"The ID of the document to edit, found in its URL: 'https://docs.google.com/document/d/<documentId>/edit'.",
+			required: true,
+		}),
+		find_text: Property.ShortText({
+			displayName: 'Find Text',
+			description: 'The literal text to search for in the document.',
+			required: true,
+		}),
+		replace_text: Property.ShortText({
+			displayName: 'Replace With',
+			description: 'The text to replace every matched occurrence with.',
+			required: true,
+		}),
+		match_case: Property.Checkbox({
+			displayName: 'Match Case',
+			description: 'When enabled, the search is case-sensitive.',
+			required: false,
+			defaultValue: false,
+		}),
+	},
+	async run(context) {
+		const { documentId, find_text, replace_text, match_case } =
+			context.propsValue;
+
+		const authClient = await createGoogleClient(context.auth);
+		const docs = googleDocs({ version: 'v1', auth: authClient });
+
+		try {
+			const response = await docs.documents.batchUpdate({
+				documentId,
+				requestBody: {
+					requests: [
+						{
+							replaceAllText: {
+								containsText: {
+									text: find_text,
+									matchCase: match_case ?? false,
+								},
+								replaceText: replace_text,
+							},
+						},
+					],
+				},
+			});
+
+			const occurrencesChanged =
+				response.data.replies?.[0]?.replaceAllText?.occurrencesChanged ?? 0;
+
+			return {
+				documentId,
+				occurrencesChanged,
+			};
+		} catch (e) {
+			const error = e as { code?: number; message?: string };
+			if (error.code === 403) {
+				throw new Error(
+					'Permission denied editing the document. Ensure the connected account has edit access to this document.'
+				);
+			}
+			if (error.code === 404) {
+				throw new Error(
+					`Document not found for ID '${documentId}'. Verify the document ID.`
+				);
+			}
+			throw e;
+		}
+	},
+});

--- a/packages/pieces/community/google-docs/src/lib/actions/replace-body-with-markdown.action.ts
+++ b/packages/pieces/community/google-docs/src/lib/actions/replace-body-with-markdown.action.ts
@@ -1,0 +1,76 @@
+import { googleDocsAuth, createGoogleClient } from '../auth';
+import { docsCommon } from '../common';
+import { Property, createAction } from '@activepieces/pieces-framework';
+import { docs as googleDocs, docs_v1 } from '@googleapis/docs';
+import { replaceBodyWithMarkdownActionOutputSchema } from '../output-schemas';
+
+export const replaceBodyWithMarkdown = createAction({
+  auth: googleDocsAuth,
+  name: 'replace_body_with_markdown',
+  displayName: 'Replace Body with Markdown',
+  description: 'Replace the entire body of a Google Docs document with Markdown content',
+  audience: 'ai',
+  aiMetadata: {
+    description:
+      'Clears the entire body of an existing Google Docs document and repopulates it from Markdown text, converting headings (#, ##, ###), bullet lists (-, *, +), and paragraphs into native Google Docs formatting. Use when an agent wants to overwrite a document wholesale with freshly generated Markdown (the format LLMs produce natively) in one call. Inline styling such as bold/italic is inserted as plain text. Not supported when the body contains a table or table of contents — the action errors clearly instead of partially failing. Destructive and not idempotent: the previous body content is deleted.',
+    idempotent: false,
+  },
+  outputSchema: replaceBodyWithMarkdownActionOutputSchema,
+  props: {
+    documentId: Property.ShortText({
+      displayName: 'Document ID',
+      description: 'The ID of the document to overwrite.',
+      required: true,
+    }),
+    markdown: Property.LongText({
+      displayName: 'Markdown Content',
+      description: 'Markdown text. Supports headings (#/##/###), bullet lists (-/*/+), and paragraphs.',
+      required: true,
+    }),
+  },
+  async run(context) {
+    const { documentId, markdown } = context.propsValue;
+    const authClient = await createGoogleClient(context.auth);
+    const docs = googleDocs({ version: 'v1', auth: authClient });
+
+    let bodyEnd: number;
+    let hasStructuralElement = false;
+    try {
+      const response = await docs.documents.get({ documentId });
+      const content = response.data.body?.content ?? [];
+      const lastElement = content[content.length - 1];
+      bodyEnd = lastElement?.endIndex ?? 1;
+      // A single deleteContentRange cannot remove a table or table of contents
+      // that the range crosses, so a wholesale body replace is unsupported then.
+      hasStructuralElement = content.some((element) => element.table || element.tableOfContents);
+    } catch (error) {
+      throw new Error(docsCommon.formatError(error, 'read'));
+    }
+
+    if (hasStructuralElement) {
+      throw new Error(
+        'Cannot replace the body wholesale because it contains a table or table of contents, which deleteContentRange cannot remove. Remove those elements first, or edit the document with the targeted table/section atomics.'
+      );
+    }
+
+    const requests: docs_v1.Schema$Request[] = [];
+    // The body always ends in an undeletable trailing newline, so the deletable
+    // range is [1, bodyEnd-1); only delete when there is real content to remove.
+    if (bodyEnd > 2) {
+      requests.push({ deleteContentRange: { range: { startIndex: 1, endIndex: bodyEnd - 1 } } });
+    }
+    requests.push(...docsCommon.markdownToBatchRequests(markdown));
+
+    try {
+      await docs.documents.batchUpdate({ documentId, requestBody: { requests } });
+    } catch (error) {
+      throw new Error(docsCommon.formatError(error, 'replace the body of'));
+    }
+
+    return {
+      success: true,
+      documentId,
+      url: `https://docs.google.com/document/d/${documentId}/edit`,
+    };
+  },
+});

--- a/packages/pieces/community/google-docs/src/lib/actions/replace-image.action.ts
+++ b/packages/pieces/community/google-docs/src/lib/actions/replace-image.action.ts
@@ -1,0 +1,60 @@
+import { googleDocsAuth, createGoogleClient } from '../auth';
+import { docsCommon } from '../common';
+import { Property, createAction } from '@activepieces/pieces-framework';
+import { docs as googleDocs, docs_v1 } from '@googleapis/docs';
+import { replaceImageActionOutputSchema } from '../output-schemas';
+
+export const replaceImage = createAction({
+	auth: googleDocsAuth,
+	name: 'replace_image',
+	displayName: 'Replace Image',
+	description: 'Replace an existing inline image in a Google Docs document with a new image from a URI.',
+	audience: 'ai',
+	aiMetadata: {
+		description:
+			'Swaps an existing inline image (identified by its object ID) for a new image at the given URI. Use this to update a specific image in a document without altering surrounding content. The imageObjectId must come from the document\'s inlineObjects map — obtain it by calling Read Document first. Re-running with the same URI leaves the document in the same visual state, so it is idempotent.',
+		idempotent: true,
+	},
+	outputSchema: replaceImageActionOutputSchema,
+	props: {
+		documentId: Property.ShortText({
+			displayName: 'Document ID',
+			description: 'The ID of the document containing the image to replace.',
+			required: true,
+		}),
+		imageObjectId: Property.ShortText({
+			displayName: 'Image Object ID',
+			description:
+				'The object ID of the inline image to replace. This is a hidden ID found in the document\'s inlineObjects map — obtain it by calling Read Document and inspecting the inlineObjects field.',
+			required: true,
+		}),
+		uri: Property.ShortText({
+			displayName: 'New Image URI',
+			description: 'A publicly accessible URL of the replacement image. Google must be able to fetch this URL at the time of the call.',
+			required: true,
+		}),
+	},
+	async run(context) {
+		const { documentId, imageObjectId, uri } = context.propsValue;
+		const authClient = await createGoogleClient(context.auth);
+		const docs = googleDocs({ version: 'v1', auth: authClient });
+
+		const request: docs_v1.Schema$Request = {
+			replaceImage: {
+				imageObjectId,
+				uri,
+				imageReplaceMethod: 'CENTER_CROP',
+			},
+		};
+
+		try {
+			await docs.documents.batchUpdate({
+				documentId,
+				requestBody: { requests: [request] },
+			});
+			return { success: true, documentId, imageObjectId };
+		} catch (error) {
+			throw new Error(docsCommon.formatError(error, 'replace image in'));
+		}
+	},
+});

--- a/packages/pieces/community/google-docs/src/lib/actions/replace-section-with-markdown.action.ts
+++ b/packages/pieces/community/google-docs/src/lib/actions/replace-section-with-markdown.action.ts
@@ -52,18 +52,32 @@ export const replaceSectionWithMarkdown = createAction({
     // The body's terminal newline cannot be deleted, so if the caller passed an
     // end index at/after the body end (e.g. the value from Get Document End Index)
     // clamp it to one before the end — otherwise deleteContentRange 400s.
+    let content: docs_v1.Schema$StructuralElement[];
     try {
       const response = await docs.documents.get({ documentId });
-      const content = response.data.body?.content ?? [];
-      const bodyEnd = content[content.length - 1]?.endIndex ?? endIndex;
-      if (endIndex > bodyEnd - 1) {
-        endIndex = bodyEnd - 1;
-      }
+      content = response.data.body?.content ?? [];
     } catch (error) {
       throw new Error(docsCommon.formatError(error, 'read'));
     }
+    const bodyEnd = content[content.length - 1]?.endIndex ?? endIndex;
+    if (endIndex > bodyEnd - 1) {
+      endIndex = bodyEnd - 1;
+    }
     if (endIndex <= startIndex) {
       throw new Error('The section to replace is empty after clamping the end index to the document end.');
+    }
+    // A single deleteContentRange cannot remove a table or table of contents
+    // that the range crosses, so a section replace over one is unsupported.
+    const crossesStructuralElement = content.some(
+      (element) =>
+        (element.table || element.tableOfContents) &&
+        (element.startIndex ?? 0) < endIndex &&
+        (element.endIndex ?? 0) > startIndex
+    );
+    if (crossesStructuralElement) {
+      throw new Error(
+        'Cannot replace this section because it contains or overlaps a table or table of contents, which deleteContentRange cannot remove. Choose a range that excludes it, or edit it with the targeted table atomics.'
+      );
     }
 
     // Delete the section first, then insert the markdown at the now-empty

--- a/packages/pieces/community/google-docs/src/lib/actions/replace-section-with-markdown.action.ts
+++ b/packages/pieces/community/google-docs/src/lib/actions/replace-section-with-markdown.action.ts
@@ -1,0 +1,90 @@
+import { googleDocsAuth, createGoogleClient } from '../auth';
+import { docsCommon } from '../common';
+import { Property, createAction } from '@activepieces/pieces-framework';
+import { docs as googleDocs, docs_v1 } from '@googleapis/docs';
+import { replaceSectionWithMarkdownActionOutputSchema } from '../output-schemas';
+
+export const replaceSectionWithMarkdown = createAction({
+  auth: googleDocsAuth,
+  name: 'replace_section_with_markdown',
+  displayName: 'Replace Section with Markdown',
+  description: 'Replace a character range of a Google Docs document with Markdown content',
+  audience: 'ai',
+  aiMetadata: {
+    description:
+      'Deletes the content between a start and end character index and replaces it with text rendered from Markdown (headings #/##/###, bullet lists -/*/+, paragraphs converted to native Google Docs formatting). Use when an agent wants to overwrite one section of a document — not the whole body — with freshly generated Markdown. Obtain start and end indices from Read Document first; indices cannot be guessed. If the end index reaches the document end it is clamped to exclude the undeletable terminal newline. Inline styling such as bold/italic is inserted as plain text. Destructive and not idempotent.',
+    idempotent: false,
+  },
+  outputSchema: replaceSectionWithMarkdownActionOutputSchema,
+  props: {
+    documentId: Property.ShortText({
+      displayName: 'Document ID',
+      description: 'The ID of the document to edit.',
+      required: true,
+    }),
+    startIndex: Property.Number({
+      displayName: 'Start Index',
+      description: 'Inclusive start character index of the section to replace. Obtain from Read Document.',
+      required: true,
+    }),
+    endIndex: Property.Number({
+      displayName: 'End Index',
+      description:
+        'Exclusive end character index of the section to replace. Must be greater than Start Index and obtained from Read Document.',
+      required: true,
+    }),
+    markdown: Property.LongText({
+      displayName: 'Markdown Content',
+      description: 'Markdown text. Supports headings (#/##/###), bullet lists (-/*/+), and paragraphs.',
+      required: true,
+    }),
+  },
+  async run(context) {
+    const { documentId, startIndex, markdown } = context.propsValue;
+    let { endIndex } = context.propsValue;
+    if (endIndex <= startIndex) {
+      throw new Error('End Index must be greater than Start Index.');
+    }
+
+    const authClient = await createGoogleClient(context.auth);
+    const docs = googleDocs({ version: 'v1', auth: authClient });
+
+    // The body's terminal newline cannot be deleted, so if the caller passed an
+    // end index at/after the body end (e.g. the value from Get Document End Index)
+    // clamp it to one before the end — otherwise deleteContentRange 400s.
+    try {
+      const response = await docs.documents.get({ documentId });
+      const content = response.data.body?.content ?? [];
+      const bodyEnd = content[content.length - 1]?.endIndex ?? endIndex;
+      if (endIndex > bodyEnd - 1) {
+        endIndex = bodyEnd - 1;
+      }
+    } catch (error) {
+      throw new Error(docsCommon.formatError(error, 'read'));
+    }
+    if (endIndex <= startIndex) {
+      throw new Error('The section to replace is empty after clamping the end index to the document end.');
+    }
+
+    // Delete the section first, then insert the markdown at the now-empty
+    // startIndex; the converter builds its inserts from that base index.
+    const requests: docs_v1.Schema$Request[] = [
+      { deleteContentRange: { range: { startIndex, endIndex } } },
+      ...docsCommon.markdownToBatchRequests(markdown, startIndex),
+    ];
+
+    try {
+      await docs.documents.batchUpdate({ documentId, requestBody: { requests } });
+    } catch (error) {
+      throw new Error(docsCommon.formatError(error, 'replace a section of'));
+    }
+
+    return {
+      success: true,
+      documentId,
+      replacedFrom: startIndex,
+      replacedTo: endIndex,
+      url: `https://docs.google.com/document/d/${documentId}/edit`,
+    };
+  },
+});

--- a/packages/pieces/community/google-docs/src/lib/actions/search-documents.action.ts
+++ b/packages/pieces/community/google-docs/src/lib/actions/search-documents.action.ts
@@ -1,0 +1,129 @@
+import { googleDocsAuth, createGoogleClient } from '../auth';
+import { Property, createAction } from '@activepieces/pieces-framework';
+import { drive as googleDrive } from '@googleapis/drive';
+import { searchDocumentsActionOutputSchema } from '../output-schemas';
+
+export const searchDocuments = createAction({
+	auth: googleDocsAuth,
+	name: 'search_documents',
+	displayName: 'Search Documents',
+	description:
+		'Search Google Drive for Google Docs documents by name or full-text content.',
+	audience: 'ai',
+	aiMetadata: {
+		description:
+			"Searches Drive for Google Docs documents by name and/or full-text content, returning multiple ordered results with their IDs. Pick this over Find Document to discover documents by their content (not just an exact name) or to get more than one match; Find Document returns only the first name match and can also create-if-missing. Read-only and idempotent. At least one of name/content text is required.",
+		idempotent: true,
+	},
+	outputSchema: searchDocumentsActionOutputSchema,
+	props: {
+		name_contains: Property.ShortText({
+			displayName: 'Name Contains',
+			description:
+				'Return documents whose name contains this text. Provide this and/or Content Contains.',
+			required: false,
+		}),
+		full_text_contains: Property.ShortText({
+			displayName: 'Content Contains',
+			description:
+				'Return documents whose full text content contains this text. Provide this and/or Name Contains.',
+			required: false,
+		}),
+		max_results: Property.Number({
+			displayName: 'Max Results',
+			description: 'Maximum number of documents to return (1-100).',
+			required: false,
+			defaultValue: 10,
+		}),
+		order_by: Property.StaticDropdown({
+			displayName: 'Order By',
+			description: 'How to sort the results.',
+			required: false,
+			defaultValue: 'modifiedTime desc',
+			options: {
+				options: [
+					{ label: 'Last modified (newest first)', value: 'modifiedTime desc' },
+					{ label: 'Last modified (oldest first)', value: 'modifiedTime' },
+					{ label: 'Created (newest first)', value: 'createdTime desc' },
+					{ label: 'Created (oldest first)', value: 'createdTime' },
+					{ label: 'Name (A-Z)', value: 'name' },
+					{ label: 'Name (Z-A)', value: 'name desc' },
+				],
+			},
+		}),
+		page_token: Property.ShortText({
+			displayName: 'Page Token',
+			description:
+				'Token for the next page of results, taken from the nextPageToken of a previous call. Leave empty for the first page.',
+			required: false,
+		}),
+	},
+	async run(context) {
+		const { name_contains, full_text_contains, max_results, order_by, page_token } =
+			context.propsValue;
+
+		if (!name_contains && !full_text_contains) {
+			throw new Error(
+				'Provide at least one of "Name Contains" or "Content Contains" to search.'
+			);
+		}
+
+		const pageSize = Math.min(Math.max(max_results ?? 10, 1), 100);
+
+		const matchClauses: string[] = [];
+		if (name_contains) {
+			matchClauses.push(`name contains '${name_contains.replace(/'/g, "\\'")}'`);
+		}
+		if (full_text_contains) {
+			matchClauses.push(
+				`fullText contains '${full_text_contains.replace(/'/g, "\\'")}'`
+			);
+		}
+
+		const query = [
+			`mimeType='application/vnd.google-apps.document'`,
+			`(${matchClauses.join(' or ')})`,
+			'trashed=false',
+		].join(' and ');
+
+		const authClient = await createGoogleClient(context.auth);
+		const drive = googleDrive({ version: 'v3', auth: authClient });
+
+		try {
+			const response = await drive.files.list({
+				q: query,
+				orderBy: order_by ?? 'modifiedTime desc',
+				pageSize,
+				pageToken: page_token || undefined,
+				supportsAllDrives: true,
+				includeItemsFromAllDrives: true,
+				corpora: 'allDrives',
+				fields:
+					'nextPageToken, files(id, name, mimeType, createdTime, modifiedTime, webViewLink, owners(emailAddress))',
+			});
+
+			const documents = (response.data.files ?? []).map((file) => ({
+				id: file.id ?? '',
+				name: file.name ?? '',
+				createdTime: file.createdTime ?? '',
+				modifiedTime: file.modifiedTime ?? '',
+				webViewLink: file.webViewLink ?? '',
+				ownerEmail: file.owners?.[0]?.emailAddress ?? '',
+			}));
+
+			return {
+				documents,
+				count: documents.length,
+				nextPageToken: response.data.nextPageToken ?? null,
+			};
+		} catch (e) {
+			const error = e as { code?: number; message?: string };
+			if (error.code === 403) {
+				throw new Error(
+					'Permission denied searching Drive. Ensure the connected account has Drive access.'
+				);
+			}
+			throw e;
+		}
+	},
+});

--- a/packages/pieces/community/google-docs/src/lib/actions/search-documents.action.ts
+++ b/packages/pieces/community/google-docs/src/lib/actions/search-documents.action.ts
@@ -72,11 +72,13 @@ export const searchDocuments = createAction({
 
 		const matchClauses: string[] = [];
 		if (name_contains) {
-			matchClauses.push(`name contains '${name_contains.replace(/'/g, "\\'")}'`);
+			matchClauses.push(
+				`name contains '${name_contains.replace(/\\/g, '\\\\').replace(/'/g, "\\'")}'`
+			);
 		}
 		if (full_text_contains) {
 			matchClauses.push(
-				`fullText contains '${full_text_contains.replace(/'/g, "\\'")}'`
+				`fullText contains '${full_text_contains.replace(/\\/g, '\\\\').replace(/'/g, "\\'")}'`
 			);
 		}
 

--- a/packages/pieces/community/google-docs/src/lib/actions/unmerge-table-cells.action.ts
+++ b/packages/pieces/community/google-docs/src/lib/actions/unmerge-table-cells.action.ts
@@ -1,0 +1,88 @@
+import { googleDocsAuth, createGoogleClient } from '../auth';
+import { docsCommon } from '../common';
+import { Property, createAction } from '@activepieces/pieces-framework';
+import { docs as googleDocs, docs_v1 } from '@googleapis/docs';
+import { unmergeTableCellsActionOutputSchema } from '../output-schemas';
+
+export const unmergeTableCells = createAction({
+  auth: googleDocsAuth,
+  name: 'unmerge_table_cells',
+  displayName: 'Unmerge Table Cells',
+  description: 'Unmerge previously merged table cells in a Google Docs document',
+  audience: 'ai',
+  aiMetadata: {
+    description:
+      'Unmerges a range of previously merged table cells in a Google Docs document. The range is specified by the anchor cell (rowIndex, columnIndex) and the span (rowSpan, columnSpan) to unmerge. Requires the table start index from Read Document — cannot be guessed. Idempotent: unmerging already-unmerged cells is a no-op.',
+    idempotent: true,
+  },
+  outputSchema: unmergeTableCellsActionOutputSchema,
+  props: {
+    documentId: Property.ShortText({
+      displayName: 'Document ID',
+      description: 'The ID of the document containing the table.',
+      required: true,
+    }),
+    tableStartIndex: Property.Number({
+      displayName: 'Table Start Index',
+      description: 'Obtain the table start index from Read Document — cannot be guessed.',
+      required: true,
+    }),
+    rowIndex: Property.Number({
+      displayName: 'Row Index',
+      description: 'Zero-based row index of the top-left anchor cell of the merged region.',
+      required: true,
+    }),
+    columnIndex: Property.Number({
+      displayName: 'Column Index',
+      description: 'Zero-based column index of the top-left anchor cell of the merged region.',
+      required: true,
+    }),
+    rowSpan: Property.Number({
+      displayName: 'Row Span',
+      description: 'Number of rows covered by the merged region to unmerge.',
+      required: true,
+    }),
+    columnSpan: Property.Number({
+      displayName: 'Column Span',
+      description: 'Number of columns covered by the merged region to unmerge.',
+      required: true,
+    }),
+  },
+  async run(context) {
+    const { documentId, tableStartIndex, rowIndex, columnIndex, rowSpan, columnSpan } = context.propsValue;
+    const authClient = await createGoogleClient(context.auth);
+    const docs = googleDocs({ version: 'v1', auth: authClient });
+
+    const request: docs_v1.Schema$Request = {
+      unmergeTableCells: {
+        tableRange: {
+          tableCellLocation: {
+            tableStartLocation: { index: tableStartIndex },
+            rowIndex,
+            columnIndex,
+          },
+          rowSpan,
+          columnSpan,
+        },
+      },
+    };
+
+    try {
+      await docs.documents.batchUpdate({
+        documentId,
+        requestBody: { requests: [request] },
+      });
+      return {
+        success: true,
+        documentId,
+        tableStartIndex,
+        rowIndex,
+        columnIndex,
+        rowSpan,
+        columnSpan,
+      };
+    } catch (error) {
+      throw new Error(docsCommon.formatError(error, 'unmerge table cells in'));
+    }
+  },
+});

--- a/packages/pieces/community/google-docs/src/lib/actions/update-document-style.action.ts
+++ b/packages/pieces/community/google-docs/src/lib/actions/update-document-style.action.ts
@@ -1,0 +1,93 @@
+import { googleDocsAuth, createGoogleClient } from '../auth';
+import { docsCommon } from '../common';
+import { Property, createAction } from '@activepieces/pieces-framework';
+import { docs as googleDocs, docs_v1 } from '@googleapis/docs';
+import { updateDocumentStyleActionOutputSchema } from '../output-schemas';
+
+export const updateDocumentStyle = createAction({
+	auth: googleDocsAuth,
+	name: 'update_document_style',
+	displayName: 'Update Document Style',
+	description: 'Update the page margins or other document-level style properties of a Google Docs document.',
+	audience: 'ai',
+	aiMetadata: {
+		description:
+			'Updates document-level style properties such as page margins. Only the properties you provide are changed — leave any margin empty to leave it unchanged. Re-applying the same values leaves the document in the same state, so it is idempotent. Use this to set consistent page margins before exporting or sharing a document.',
+		idempotent: true,
+	},
+	outputSchema: updateDocumentStyleActionOutputSchema,
+	props: {
+		documentId: Property.ShortText({
+			displayName: 'Document ID',
+			description: 'The ID of the document whose style to update.',
+			required: true,
+		}),
+		marginTopPt: Property.Number({
+			displayName: 'Top Margin (pt)',
+			description: 'Top page margin in points. Leave empty to keep the current value.',
+			required: false,
+		}),
+		marginBottomPt: Property.Number({
+			displayName: 'Bottom Margin (pt)',
+			description: 'Bottom page margin in points. Leave empty to keep the current value.',
+			required: false,
+		}),
+		marginLeftPt: Property.Number({
+			displayName: 'Left Margin (pt)',
+			description: 'Left page margin in points. Leave empty to keep the current value.',
+			required: false,
+		}),
+		marginRightPt: Property.Number({
+			displayName: 'Right Margin (pt)',
+			description: 'Right page margin in points. Leave empty to keep the current value.',
+			required: false,
+		}),
+	},
+	async run(context) {
+		const { documentId, marginTopPt, marginBottomPt, marginLeftPt, marginRightPt } = context.propsValue;
+
+		const documentStyle: docs_v1.Schema$DocumentStyle = {};
+		const fieldPaths: string[] = [];
+
+		if (marginTopPt !== undefined && marginTopPt !== null) {
+			documentStyle.marginTop = { magnitude: marginTopPt, unit: 'PT' };
+			fieldPaths.push('marginTop');
+		}
+		if (marginBottomPt !== undefined && marginBottomPt !== null) {
+			documentStyle.marginBottom = { magnitude: marginBottomPt, unit: 'PT' };
+			fieldPaths.push('marginBottom');
+		}
+		if (marginLeftPt !== undefined && marginLeftPt !== null) {
+			documentStyle.marginLeft = { magnitude: marginLeftPt, unit: 'PT' };
+			fieldPaths.push('marginLeft');
+		}
+		if (marginRightPt !== undefined && marginRightPt !== null) {
+			documentStyle.marginRight = { magnitude: marginRightPt, unit: 'PT' };
+			fieldPaths.push('marginRight');
+		}
+
+		if (fieldPaths.length === 0) {
+			throw new Error('At least one style property must be provided.');
+		}
+
+		const request: docs_v1.Schema$Request = {
+			updateDocumentStyle: {
+				documentStyle,
+				fields: fieldPaths.join(','),
+			},
+		};
+
+		const authClient = await createGoogleClient(context.auth);
+		const docs = googleDocs({ version: 'v1', auth: authClient });
+
+		try {
+			await docs.documents.batchUpdate({
+				documentId,
+				requestBody: { requests: [request] },
+			});
+			return { success: true, documentId, updatedFields: fieldPaths };
+		} catch (error) {
+			throw new Error(docsCommon.formatError(error, 'update the style of'));
+		}
+	},
+});

--- a/packages/pieces/community/google-docs/src/lib/actions/update-table-row-style.action.ts
+++ b/packages/pieces/community/google-docs/src/lib/actions/update-table-row-style.action.ts
@@ -1,0 +1,73 @@
+import { googleDocsAuth, createGoogleClient } from '../auth';
+import { docsCommon } from '../common';
+import { Property, createAction } from '@activepieces/pieces-framework';
+import { docs as googleDocs, docs_v1 } from '@googleapis/docs';
+import { updateTableRowStyleActionOutputSchema } from '../output-schemas';
+
+export const updateTableRowStyle = createAction({
+  auth: googleDocsAuth,
+  name: 'update_table_row_style',
+  displayName: 'Update Table Row Style',
+  description: 'Update style properties of one or more rows in a Google Docs table',
+  audience: 'ai',
+  aiMetadata: {
+    description:
+      'Updates the minimum height of one or more rows in a Google Docs table. Requires the table start index from Read Document — cannot be guessed. (Google Docs does not support toggling a header row via this request.) Idempotent: applying the same height again is a no-op.',
+    idempotent: true,
+  },
+  outputSchema: updateTableRowStyleActionOutputSchema,
+  props: {
+    documentId: Property.ShortText({
+      displayName: 'Document ID',
+      description: 'The ID of the document containing the table.',
+      required: true,
+    }),
+    tableStartIndex: Property.Number({
+      displayName: 'Table Start Index',
+      description: 'Obtain the table start index from Read Document — cannot be guessed.',
+      required: true,
+    }),
+    rowIndices: Property.Array({
+      displayName: 'Row Indices',
+      description: 'Zero-based indices of the rows to update (e.g. [0, 1] to update the first two rows).',
+      required: true,
+    }),
+    minRowHeightPt: Property.Number({
+      displayName: 'Minimum Row Height (points)',
+      description: 'Minimum height of each selected row, in points.',
+      required: true,
+    }),
+  },
+  async run(context) {
+    const { documentId, tableStartIndex, rowIndices, minRowHeightPt } = context.propsValue;
+    const authClient = await createGoogleClient(context.auth);
+    const docs = googleDocs({ version: 'v1', auth: authClient });
+
+    const rowIndexNumbers = (rowIndices as unknown[]).map((v) => Number(v));
+
+    const request: docs_v1.Schema$Request = {
+      updateTableRowStyle: {
+        tableStartLocation: { index: tableStartIndex },
+        rowIndices: rowIndexNumbers,
+        tableRowStyle: { minRowHeight: { magnitude: minRowHeightPt, unit: 'PT' } },
+        fields: 'minRowHeight',
+      },
+    };
+
+    try {
+      await docs.documents.batchUpdate({
+        documentId,
+        requestBody: { requests: [request] },
+      });
+      return {
+        success: true,
+        documentId,
+        tableStartIndex,
+        rowIndices: rowIndexNumbers,
+        updatedFields: ['minRowHeight'],
+      };
+    } catch (error) {
+      throw new Error(docsCommon.formatError(error, 'update table row style in'));
+    }
+  },
+});

--- a/packages/pieces/community/google-docs/src/lib/common/index.ts
+++ b/packages/pieces/community/google-docs/src/lib/common/index.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { Property } from '@activepieces/pieces-framework';
 import { HttpMethod, httpClient, AuthenticationType } from '@activepieces/pieces-common';
+import { docs_v1 } from '@googleapis/docs';
 
 export const docsCommon = {
 	baseUrl: 'https://docs.googleapis.com/v1',
@@ -52,5 +53,74 @@ export const docsCommon = {
 		});
 
 		return writeRequest.body;
+	},
+
+	// Converts block-level Markdown into Google Docs batchUpdate requests.
+	// Inserts each line left-to-right at a running cursor (starting at baseIndex)
+	// so every index references the document state after the prior inserts in the
+	// same batch (indices stay stable because each insert is at the prior insert's
+	// end). Block-level only: headings and bullets; inline marks are left as literal
+	// text. baseIndex defaults to 1 (start of body); pass a section start index to
+	// insert markdown into a freshly-emptied range mid-document.
+	markdownToBatchRequests: (markdown: string, baseIndex = 1): docs_v1.Schema$Request[] => {
+		const lines = markdown.replace(/\r\n/g, '\n').split('\n');
+		const requests: docs_v1.Schema$Request[] = [];
+		const bulletRanges: Array<{ startIndex: number; endIndex: number }> = [];
+		let cursor = baseIndex;
+
+		for (const line of lines) {
+			const headingMatch = /^(#{1,3})\s+(.*)$/.exec(line);
+			const bulletMatch = /^\s*[-*+]\s+(.*)$/.exec(line);
+
+			let textToInsert = line;
+			let headingLevel = 0;
+			let isBullet = false;
+			if (headingMatch) {
+				headingLevel = headingMatch[1].length;
+				textToInsert = headingMatch[2];
+			} else if (bulletMatch) {
+				isBullet = true;
+				textToInsert = bulletMatch[1];
+			}
+
+			requests.push({ insertText: { text: textToInsert + '\n', location: { index: cursor } } });
+			const paragraphStart = cursor;
+			const paragraphEnd = cursor + textToInsert.length + 1;
+
+			if (headingLevel > 0) {
+				requests.push({
+					updateParagraphStyle: {
+						range: { startIndex: paragraphStart, endIndex: paragraphEnd },
+						paragraphStyle: { namedStyleType: `HEADING_${headingLevel}` },
+						fields: 'namedStyleType',
+					},
+				});
+			}
+			if (isBullet) {
+				bulletRanges.push({ startIndex: paragraphStart, endIndex: paragraphEnd });
+			}
+
+			cursor = paragraphEnd;
+		}
+
+		for (const range of bulletRanges) {
+			requests.push({
+				createParagraphBullets: { range, bulletPreset: 'BULLET_DISC_CIRCLE_SQUARE' },
+			});
+		}
+
+		return requests;
+	},
+
+	// Maps a Google API (Gaxios) error to a concise, agent-readable message.
+	formatError: (error: any, action: string): string => {
+		const status = error?.response?.status ?? error?.code;
+		const apiMessage = error?.response?.data?.error?.message ?? error?.message;
+		const suffix = apiMessage ? ` ${apiMessage}` : '';
+		if (status === 400) return `Invalid request trying to ${action} the document (400) — often a bad index or range.${suffix}`;
+		if (status === 403) return `Permission denied trying to ${action} the document (403) — check the connection has access.${suffix}`;
+		if (status === 404) return `Document not found trying to ${action} (404) — verify the document ID.${suffix}`;
+		if (status === 429) return `Rate limit exceeded trying to ${action} the document (429) — retry later.${suffix}`;
+		return `Failed to ${action} the document${status ? ` (${status})` : ''}:${suffix || ' unknown error'}`;
 	},
 };

--- a/packages/pieces/community/google-docs/src/lib/output-schemas.ts
+++ b/packages/pieces/community/google-docs/src/lib/output-schemas.ts
@@ -259,3 +259,335 @@ export const findDocumentActionOutputSchema: OutputSchema = {
 export const newDocumentTriggerOutputSchema: OutputSchema = {
   fields: driveFileFields,
 };
+
+export const insertTextActionOutputSchema: OutputSchema = {
+  fields: [
+    { key: 'success', label: 'Success', format: 'boolean' },
+    { key: 'documentId', label: 'Document ID' },
+    { key: 'insertedCharacters', label: 'Inserted Characters', format: 'number' },
+    { key: 'mode', label: 'Mode' },
+  ],
+};
+
+export const deleteContentRangeActionOutputSchema: OutputSchema = {
+  fields: [
+    { key: 'success', label: 'Success', format: 'boolean' },
+    { key: 'documentId', label: 'Document ID' },
+    { key: 'deletedFrom', label: 'Deleted From Index', format: 'number' },
+    { key: 'deletedTo', label: 'Deleted To Index', format: 'number' },
+  ],
+};
+
+export const replaceAllTextActionOutputSchema: OutputSchema = {
+  fields: [
+    { key: 'documentId', label: 'Document ID' },
+    { key: 'occurrencesChanged', label: 'Occurrences Changed', format: 'number' },
+  ],
+};
+
+export const createParagraphBulletsActionOutputSchema: OutputSchema = {
+  fields: [
+    { key: 'success', label: 'Success', format: 'boolean' },
+    { key: 'documentId', label: 'Document ID' },
+    { key: 'startIndex', label: 'Start Index', format: 'number' },
+    { key: 'endIndex', label: 'End Index', format: 'number' },
+    { key: 'bulletPreset', label: 'Bullet Preset' },
+  ],
+};
+
+export const deleteParagraphBulletsActionOutputSchema: OutputSchema = {
+  fields: [
+    { key: 'success', label: 'Success', format: 'boolean' },
+    { key: 'documentId', label: 'Document ID' },
+    { key: 'rangeStart', label: 'Range Start', format: 'number' },
+    { key: 'rangeEnd', label: 'Range End', format: 'number' },
+  ],
+};
+
+export const createFooterActionOutputSchema: OutputSchema = {
+  fields: [
+    { key: 'success', label: 'Success', format: 'boolean' },
+    { key: 'documentId', label: 'Document ID' },
+    { key: 'footerId', label: 'Footer ID' },
+  ],
+};
+
+export const createHeaderActionOutputSchema: OutputSchema = {
+  fields: [
+    { key: 'success', label: 'Success', format: 'boolean' },
+    { key: 'documentId', label: 'Document ID' },
+    { key: 'headerId', label: 'Header ID' },
+  ],
+};
+
+export const createFootnoteActionOutputSchema: OutputSchema = {
+  fields: [
+    { key: 'success', label: 'Success', format: 'boolean' },
+    { key: 'documentId', label: 'Document ID' },
+    { key: 'footnoteId', label: 'Footnote ID' },
+  ],
+};
+
+export const createNamedRangeActionOutputSchema: OutputSchema = {
+  fields: [
+    { key: 'success', label: 'Success', format: 'boolean' },
+    { key: 'documentId', label: 'Document ID' },
+    { key: 'name', label: 'Range Name' },
+    { key: 'namedRangeId', label: 'Named Range ID' },
+  ],
+};
+
+export const deleteFooterActionOutputSchema: OutputSchema = {
+  fields: [
+    { key: 'success', label: 'Success', format: 'boolean' },
+    { key: 'documentId', label: 'Document ID' },
+    { key: 'deletedFooterId', label: 'Deleted Footer ID' },
+  ],
+};
+
+export const deleteHeaderActionOutputSchema: OutputSchema = {
+  fields: [
+    { key: 'success', label: 'Success', format: 'boolean' },
+    { key: 'documentId', label: 'Document ID' },
+    { key: 'deletedHeaderId', label: 'Deleted Header ID' },
+  ],
+};
+
+export const deleteNamedRangeActionOutputSchema: OutputSchema = {
+  fields: [
+    { key: 'success', label: 'Success', format: 'boolean' },
+    { key: 'documentId', label: 'Document ID' },
+    { key: 'deletedNamedRangeId', label: 'Deleted Named Range ID' },
+    { key: 'deletedName', label: 'Deleted Range Name' },
+  ],
+};
+
+export const insertTableActionOutputSchema: OutputSchema = {
+  fields: [
+    { key: 'success', label: 'Success', format: 'boolean' },
+    { key: 'documentId', label: 'Document ID' },
+    { key: 'rows', label: 'Rows', format: 'number' },
+    { key: 'columns', label: 'Columns', format: 'number' },
+    { key: 'mode', label: 'Mode' },
+  ],
+};
+
+export const insertTableRowActionOutputSchema: OutputSchema = {
+  fields: [
+    { key: 'success', label: 'Success', format: 'boolean' },
+    { key: 'documentId', label: 'Document ID' },
+    { key: 'tableStartIndex', label: 'Table Start Index', format: 'number' },
+    { key: 'rowIndex', label: 'Row Index', format: 'number' },
+    { key: 'columnIndex', label: 'Column Index', format: 'number' },
+    { key: 'insertBelow', label: 'Inserted Below', format: 'boolean' },
+  ],
+};
+
+export const insertTableColumnActionOutputSchema: OutputSchema = {
+  fields: [
+    { key: 'success', label: 'Success', format: 'boolean' },
+    { key: 'documentId', label: 'Document ID' },
+    { key: 'tableStartIndex', label: 'Table Start Index', format: 'number' },
+    { key: 'rowIndex', label: 'Row Index', format: 'number' },
+    { key: 'columnIndex', label: 'Column Index', format: 'number' },
+    { key: 'insertRight', label: 'Inserted to the Right', format: 'boolean' },
+  ],
+};
+
+export const deleteTableRowActionOutputSchema: OutputSchema = {
+  fields: [
+    { key: 'success', label: 'Success', format: 'boolean' },
+    { key: 'documentId', label: 'Document ID' },
+    { key: 'tableStartIndex', label: 'Table Start Index', format: 'number' },
+    { key: 'deletedRowIndex', label: 'Deleted Row Index', format: 'number' },
+  ],
+};
+
+export const deleteTableColumnActionOutputSchema: OutputSchema = {
+  fields: [
+    { key: 'success', label: 'Success', format: 'boolean' },
+    { key: 'documentId', label: 'Document ID' },
+    { key: 'tableStartIndex', label: 'Table Start Index', format: 'number' },
+    { key: 'deletedColumnIndex', label: 'Deleted Column Index', format: 'number' },
+  ],
+};
+
+export const insertTextInTableCellActionOutputSchema: OutputSchema = {
+  fields: [
+    { key: 'success', label: 'Success', format: 'boolean' },
+    { key: 'documentId', label: 'Document ID' },
+    { key: 'tableStartIndex', label: 'Table Start Index', format: 'number' },
+    { key: 'rowIndex', label: 'Row Index', format: 'number' },
+    { key: 'columnIndex', label: 'Column Index', format: 'number' },
+    { key: 'insertedAtIndex', label: 'Inserted At Index', format: 'number' },
+    { key: 'insertedCharacters', label: 'Inserted Characters', format: 'number' },
+  ],
+};
+
+export const insertImageInTableCellActionOutputSchema: OutputSchema = {
+  fields: [
+    { key: 'success', label: 'Success', format: 'boolean' },
+    { key: 'documentId', label: 'Document ID' },
+    { key: 'tableStartIndex', label: 'Table Start Index', format: 'number' },
+    { key: 'rowIndex', label: 'Row Index', format: 'number' },
+    { key: 'columnIndex', label: 'Column Index', format: 'number' },
+    { key: 'insertedAtIndex', label: 'Inserted At Index', format: 'number' },
+    { key: 'uri', label: 'Image URI', format: 'url' },
+  ],
+};
+
+export const unmergeTableCellsActionOutputSchema: OutputSchema = {
+  fields: [
+    { key: 'success', label: 'Success', format: 'boolean' },
+    { key: 'documentId', label: 'Document ID' },
+    { key: 'tableStartIndex', label: 'Table Start Index', format: 'number' },
+    { key: 'rowIndex', label: 'Row Index', format: 'number' },
+    { key: 'columnIndex', label: 'Column Index', format: 'number' },
+    { key: 'rowSpan', label: 'Row Span', format: 'number' },
+    { key: 'columnSpan', label: 'Column Span', format: 'number' },
+  ],
+};
+
+export const updateTableRowStyleActionOutputSchema: OutputSchema = {
+  fields: [
+    { key: 'success', label: 'Success', format: 'boolean' },
+    { key: 'documentId', label: 'Document ID' },
+    { key: 'tableStartIndex', label: 'Table Start Index', format: 'number' },
+    { key: 'rowIndices', label: 'Row Indices' },
+    { key: 'updatedFields', label: 'Updated Fields' },
+  ],
+};
+
+export const updateDocumentStyleActionOutputSchema: OutputSchema = {
+  fields: [
+    { key: 'success', label: 'Success', format: 'boolean' },
+    { key: 'documentId', label: 'Document ID' },
+    { key: 'updatedFields', label: 'Updated Fields' },
+  ],
+};
+
+export const insertInlineImageActionOutputSchema: OutputSchema = {
+  fields: [
+    { key: 'success', label: 'Success', format: 'boolean' },
+    { key: 'documentId', label: 'Document ID' },
+    { key: 'insertedObjectId', label: 'Inserted Object ID' },
+    { key: 'mode', label: 'Mode' },
+  ],
+};
+
+export const insertPageBreakActionOutputSchema: OutputSchema = {
+  fields: [
+    { key: 'success', label: 'Success', format: 'boolean' },
+    { key: 'documentId', label: 'Document ID' },
+    { key: 'mode', label: 'Mode' },
+  ],
+};
+
+export const replaceImageActionOutputSchema: OutputSchema = {
+  fields: [
+    { key: 'success', label: 'Success', format: 'boolean' },
+    { key: 'documentId', label: 'Document ID' },
+    { key: 'imageObjectId', label: 'Image Object ID' },
+  ],
+};
+
+export const getDocumentEndIndexActionOutputSchema: OutputSchema = {
+  fields: [
+    { key: 'documentId', label: 'Document ID' },
+    { key: 'title', label: 'Title' },
+    { key: 'endIndex', label: 'End Index', format: 'number' },
+    { key: 'maxInsertIndex', label: 'Max Insert Index', format: 'number' },
+  ],
+};
+
+export const getDocumentPlaintextActionOutputSchema: OutputSchema = {
+  fields: [
+    { key: 'documentId', label: 'Document ID' },
+    { key: 'title', label: 'Title' },
+    { key: 'plainText', label: 'Plain Text' },
+  ],
+};
+
+export const copyDocumentActionOutputSchema: OutputSchema = {
+  fields: [
+    { key: 'id', label: 'Document ID' },
+    { key: 'name', label: 'Name' },
+    { key: 'webViewLink', label: 'Web View Link', format: 'url' },
+    { key: 'parents', label: 'Parent Folder IDs' },
+  ],
+};
+
+export const searchDocumentsActionOutputSchema: OutputSchema = {
+  fields: [
+    {
+      key: 'documents',
+      label: 'Documents',
+      value: 'documents',
+      labelKey: 'name',
+      listItems: [
+        { key: 'id', label: 'Document ID' },
+        { key: 'name', label: 'Name' },
+        { key: 'createdTime', label: 'Created Time', format: 'datetime' },
+        { key: 'modifiedTime', label: 'Modified Time', format: 'datetime' },
+        { key: 'webViewLink', label: 'Web View Link', format: 'url' },
+        { key: 'ownerEmail', label: 'Owner Email', format: 'email' },
+      ],
+    },
+    { key: 'count', label: 'Count', format: 'number' },
+    { key: 'nextPageToken', label: 'Next Page Token' },
+  ],
+};
+
+export const batchUpdateActionOutputSchema: OutputSchema = {
+  fields: [
+    { key: 'success', label: 'Success', format: 'boolean' },
+    { key: 'documentId', label: 'Document ID' },
+    { key: 'appliedRequests', label: 'Applied Requests', format: 'number' },
+    { key: 'replies', label: 'Replies' },
+  ],
+};
+
+export const createAndPopulateTableActionOutputSchema: OutputSchema = {
+  fields: [
+    { key: 'success', label: 'Success', format: 'boolean' },
+    { key: 'documentId', label: 'Document ID' },
+    { key: 'rows', label: 'Rows', format: 'number' },
+    { key: 'columns', label: 'Columns', format: 'number' },
+    { key: 'cellsPopulated', label: 'Cells Populated', format: 'number' },
+  ],
+};
+
+export const replaceSectionWithMarkdownActionOutputSchema: OutputSchema = {
+  fields: [
+    { key: 'success', label: 'Success', format: 'boolean' },
+    { key: 'documentId', label: 'Document ID' },
+    { key: 'replacedFrom', label: 'Replaced From Index', format: 'number' },
+    { key: 'replacedTo', label: 'Replaced To Index', format: 'number' },
+    { key: 'url', label: 'Document URL', format: 'url' },
+  ],
+};
+
+export const replaceBodyWithMarkdownActionOutputSchema: OutputSchema = {
+  fields: [
+    { key: 'success', label: 'Success', format: 'boolean' },
+    { key: 'documentId', label: 'Document ID' },
+    { key: 'url', label: 'Document URL', format: 'url' },
+  ],
+};
+
+export const createDocumentFromMarkdownActionOutputSchema: OutputSchema = {
+  fields: [
+    { key: 'success', label: 'Success', format: 'boolean' },
+    { key: 'documentId', label: 'Document ID' },
+    { key: 'title', label: 'Title' },
+    { key: 'url', label: 'Document URL', format: 'url' },
+  ],
+};
+
+export const exportAsPdfActionOutputSchema: OutputSchema = {
+  fields: [
+    { key: 'success', label: 'Success', format: 'boolean' },
+    { key: 'documentId', label: 'Document ID' },
+    { key: 'file', label: 'PDF File' },
+  ],
+};


### PR DESCRIPTION
## Description

Adds `audience: 'ai'` atomic actions to the Google Docs piece as part of the AI-ready effort, and curates `outputSchema` for the full action surface so the data selector, output viewer, and AI/MCP path map show typed, labelled fields instead of raw JSON.

**37 new `audience: 'ai'` actions** covering the agent-relevant Google Docs surface, each mapping 1:1 to a real Google Docs / Drive API call:

- **Reads / projections:** `get_document_plaintext`, `get_document_end_index`, `search_documents`, `copy_document`
- **Text & structure:** `insert_text`, `delete_content_range`, create/delete `header`/`footer`/`footnote`/`named_range`, create/delete `paragraph_bullets`, `insert_page_break`, `insert_inline_image`, `replace_image`, `replace_all_text`, `update_document_style`
- **Tables:** `insert_table`, insert/delete table `row`/`column`, `insert_text_in_table_cell`, `insert_image_in_table_cell`, `unmerge_table_cells`, `update_table_row_style`, `create_and_populate_table`
- **Markdown:** `create_document_from_markdown`, `replace_body_with_markdown`, `replace_section_with_markdown`
- **Export:** `export_as_pdf` (Drive)
- **Escape hatch:** `batch_update` (raw `batchUpdate`)

Index-based editors reference `get_document_end_index` / `read_document` in their descriptions for the character indices they need.

`append_text` is demoted to `audience: 'human'` (superseded by `insert_text`, which covers both append and indexed insert). The existing human-facing actions (create / read / find document, template) are unchanged.

**`outputSchema` added to all 37 of the above actions** (`src/lib/output-schemas.ts`), authored from each action's actual `run()` return statement and reusing shared field sets (`driveFileFields`, and direct reuse of `appendTextActionOutputSchema` / `readDocumentActionOutputSchema` where the return shape is identical) rather than duplicating. The piece's one trigger (`new_document`) already had a schema.

Version: google-docs `0.4.4` → `0.4.6`.

## How was this tested?

- **Tier-1:** `tsc -p tsconfig.lib.json` + `eslint`: 0 errors.
- **Tier-2 (atomics):** 35 of the 37 atomics were executed live against a real Google connection through the engine (the test-step path) — 35/35 succeeded, including the Markdown composites, table cell-index resolution (insert/delete row + column, cell text + image, populate-table), and the Drive PDF export. One field-mask issue (`update_table_row_style` passing an unsupported `tableHeader` field) was found and fixed during this pass. The remaining 2 — `replace_image` and `unmerge_table_cells` — are Tier-1-only: each requires a pre-existing artifact the agent surface itself doesn't create (an inline-image `objectId` / already-merged cells), so they can't be chained end-to-end in-account, but both run through the same verified `batchUpdate` path as the actions that passed.
- **Tier-2 (output schemas):** every schema was verified against real output captured live from a test document/token — including reply-derived fields (`footerId`, `headerId`, `footnoteId`, `namedRangeId`, `occurrencesChanged`, `insertInlineImage.objectId`) and the Drive `copy`/`search`/`export` shapes — then spot-checked that the curated tree renders correctly.
- Edition paths: this piece has no edition-specific branching (CE / EE / Cloud all load it identically via the piece registry); no UI/branding surface is touched.

Fixes # (issue)

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)
