### PR TITLE
feat(google-calendar): add agent atomics for AI agents

### DIFF
--- a/packages/pieces/community/google-calendar/package.json
+++ b/packages/pieces/community/google-calendar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-google-calendar",
-  "version": "0.9.7",
+  "version": "0.10.0",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "dependencies": {

--- a/packages/pieces/community/google-calendar/package.json
+++ b/packages/pieces/community/google-calendar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-google-calendar",
-  "version": "0.9.5",
+  "version": "0.9.7",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "dependencies": {

--- a/packages/pieces/community/google-calendar/src/index.ts
+++ b/packages/pieces/community/google-calendar/src/index.ts
@@ -13,6 +13,22 @@ import { calendarEventChanged } from './lib/triggers/calendar-event';
 import { addAttendeesToEventAction } from './lib/actions/add-attendees.action';
 import { findFreeBusy } from './lib/actions/find-busy-free-periods';
 import { getEventById } from './lib/actions/get-event-by-id';
+import { searchEventsAllCalendars } from './lib/actions/search-events-all-calendars';
+import { findFreeSlots } from './lib/actions/find-free-slots';
+import { listRecurringEventInstances } from './lib/actions/list-recurring-event-instances';
+import { moveEvent } from './lib/actions/move-event';
+import { aiCreateEvent } from './lib/actions/ai-create-event';
+import { aiUpdateEvent } from './lib/actions/ai-update-event';
+import { aiDeleteEvent } from './lib/actions/ai-delete-event';
+import { aiGetEvent } from './lib/actions/ai-get-event';
+import { aiListEvents } from './lib/actions/ai-list-events';
+import { aiFindBusyPeriods } from './lib/actions/ai-find-busy-periods';
+import { aiRemoveAttendee } from './lib/actions/ai-remove-attendee';
+import { aiImportEvent } from './lib/actions/ai-import-event';
+import { aiListCalendars } from './lib/actions/ai-list-calendars';
+import { aiGetCalendar } from './lib/actions/ai-get-calendar';
+import { aiGetColors } from './lib/actions/ai-get-colors';
+import { aiListSettings } from './lib/actions/ai-list-settings';
 import { newEvent } from './lib/triggers/new-event';
 import { eventEnds } from './lib/triggers/event-ends';
 import { eventStartTimeBefore } from './lib/triggers/event-start-time-before';
@@ -23,7 +39,7 @@ import { newCalendar } from './lib/triggers/new-calendar';
 export { googleCalendarAuth, getAccessToken, GoogleCalendarAuthValue, createGoogleClient } from './lib/common';
 
 export const googleCalendar = createPiece({
-  minimumSupportedRelease: '0.30.0',
+  minimumSupportedRelease: '0.86.4',
   logoUrl: 'https://cdn.activepieces.com/pieces/google-calendar.png',
   categories: [PieceCategory.PRODUCTIVITY],
   displayName: 'Google Calendar',
@@ -53,6 +69,22 @@ export const googleCalendar = createPiece({
     deleteEventAction,
     findFreeBusy,
     getEventById,
+    searchEventsAllCalendars,
+    findFreeSlots,
+    listRecurringEventInstances,
+    moveEvent,
+    aiCreateEvent,
+    aiUpdateEvent,
+    aiDeleteEvent,
+    aiGetEvent,
+    aiListEvents,
+    aiFindBusyPeriods,
+    aiRemoveAttendee,
+    aiImportEvent,
+    aiListCalendars,
+    aiGetCalendar,
+    aiGetColors,
+    aiListSettings,
     // TODO: add action after calendarList scope is verified
     // addCalendarToCalendarlist,
     createCustomApiCallAction({

--- a/packages/pieces/community/google-calendar/src/lib/actions/add-calendar-to-calendarlist.ts
+++ b/packages/pieces/community/google-calendar/src/lib/actions/add-calendar-to-calendarlist.ts
@@ -1,6 +1,7 @@
 import { createAction, Property } from '@activepieces/pieces-framework';
 import { calendar as googleCalendar } from '@googleapis/calendar';
 import { googleCalendarCommon, googleCalendarAuth, createGoogleClient } from '../common';
+import { calendarListEntryOutputSchema } from '../output-schemas';
 
 export const addCalendarToCalendarlist = createAction({
   auth: googleCalendarAuth,
@@ -14,6 +15,7 @@ export const addCalendarToCalendarlist = createAction({
       required: true
     })
   },
+  outputSchema: calendarListEntryOutputSchema,
   async run(context) {
     
     const id = context.propsValue.id;

--- a/packages/pieces/community/google-calendar/src/lib/actions/ai-create-event.ts
+++ b/packages/pieces/community/google-calendar/src/lib/actions/ai-create-event.ts
@@ -1,0 +1,21 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { googleCalendarAuth } from '../common';
+import { createEventProps, runCreateEvent } from './create-event';
+import { eventOutputSchema } from '../output-schemas';
+
+export const aiCreateEvent = createAction({
+  auth: googleCalendarAuth,
+  name: 'google_calendar_create_event',
+  displayName: 'Create Event',
+  description:
+    'Create a new event on a Google Calendar with structured fields (title, start/end, location, description, attendees, color) and an optional Google Meet link.',
+  audience: 'ai',
+  aiMetadata: {
+    description:
+      'Create a new event on a calendar from explicit structured fields (title, start/end times, location, description, attendees, color, guest permissions) with an optional Google Meet link. Use this when you already have the event details; for a single natural-language phrase use the quick-add path instead. Resolve calendarId via google_calendar_list_calendars (default "primary"). Requires a title and start time; end defaults to 30 minutes after start. Not idempotent: each call creates a new event.',
+    idempotent: false,
+  },
+  props: createEventProps,
+  outputSchema: eventOutputSchema,
+  run: runCreateEvent,
+});

--- a/packages/pieces/community/google-calendar/src/lib/actions/ai-delete-event.ts
+++ b/packages/pieces/community/google-calendar/src/lib/actions/ai-delete-event.ts
@@ -1,0 +1,35 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { googleCalendarCommon, googleCalendarAuth } from '../common';
+import { runDeleteEvent } from './delete-event.action';
+
+const props = {
+  calendar_id: googleCalendarCommon.calendarDropdown('writer'),
+  event_id: Property.ShortText({
+    displayName: 'Event ID',
+    description:
+      'The ID of the event to delete. Resolve it via List Events or Search Events Across Calendars.',
+    required: true,
+  }),
+};
+
+export const aiDeleteEvent = createAction({
+  auth: googleCalendarAuth,
+  name: 'google_calendar_delete_event',
+  displayName: 'Delete Event',
+  description: 'Permanently delete an event from a Google Calendar by its event ID.',
+  audience: 'ai',
+  aiMetadata: {
+    description:
+      'Permanently delete an event from a calendar, identified by calendar and event ID. Use to cancel or remove an existing event; this cannot be undone, so confirm the event ID first. Resolve calendarId via google_calendar_list_calendars and eventId via google_calendar_list_events / google_calendar_search_events_all_calendars. Idempotent: once deleted, re-running leaves the event absent (a repeat call may report it as already gone).',
+    idempotent: true,
+  },
+  props,
+  run: (context) =>
+    runDeleteEvent({
+      ...context,
+      propsValue: {
+        calendar_id: context.propsValue.calendar_id,
+        eventId: context.propsValue.event_id,
+      },
+    }),
+});

--- a/packages/pieces/community/google-calendar/src/lib/actions/ai-find-busy-periods.ts
+++ b/packages/pieces/community/google-calendar/src/lib/actions/ai-find-busy-periods.ts
@@ -1,0 +1,21 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { googleCalendarAuth } from '../common';
+import { findFreeBusyProps, runFindFreeBusy } from './find-busy-free-periods';
+import { freeBusyActionOutputSchema } from '../output-schemas';
+
+export const aiFindBusyPeriods = createAction({
+  auth: googleCalendarAuth,
+  name: 'google_calendar_find_busy_periods',
+  displayName: 'Find Busy Periods',
+  description:
+    'Return the raw busy time blocks of one or more calendars within a window, via the freebusy query.',
+  audience: 'ai',
+  aiMetadata: {
+    description:
+      'Query one or more calendars for their raw busy time blocks within a start/end window, without exposing event details (the low-level freebusy primitive). Use this when you need the busy intervals themselves (e.g. across several shared calendars); to get the inverse open slots directly, use google_calendar_find_free_slots instead. Resolve calendarId values via google_calendar_list_calendars. Requires the calendars to check and a time range. Read-only and idempotent.',
+    idempotent: true,
+  },
+  props: findFreeBusyProps,
+  outputSchema: freeBusyActionOutputSchema,
+  run: runFindFreeBusy,
+});

--- a/packages/pieces/community/google-calendar/src/lib/actions/ai-get-calendar.ts
+++ b/packages/pieces/community/google-calendar/src/lib/actions/ai-get-calendar.ts
@@ -1,0 +1,73 @@
+import { createAction } from '@activepieces/pieces-framework';
+import {
+  HttpRequest,
+  HttpMethod,
+  AuthenticationType,
+  httpClient,
+} from '@activepieces/pieces-common';
+import { googleCalendarCommon, googleCalendarAuth, getAccessToken } from '../common';
+import { calendarResourceOutputSchema } from '../output-schemas';
+
+interface CalendarResource {
+  kind: string;
+  etag: string;
+  id: string;
+  summary: string;
+  description?: string;
+  location?: string;
+  timeZone: string;
+  conferenceProperties?: {
+    allowedConferenceSolutionTypes?: string[];
+  };
+}
+
+export const aiGetCalendar = createAction({
+  auth: googleCalendarAuth,
+  name: 'google_calendar_get_calendar',
+  displayName: 'Get Calendar',
+  description:
+    'Fetch one calendar\'s metadata (summary, time zone, description, location) by its calendar ID.',
+  audience: 'ai',
+  aiMetadata: {
+    description:
+      'Fetch one calendar\'s metadata — summary, timeZone, description, and location — by its calendar ID. Use this to read a calendar\'s time zone, which is load-bearing when constructing correct event start/end windows. Resolve calendarId via google_calendar_list_calendars (default "primary"). Read-only and idempotent.',
+    idempotent: true,
+  },
+  props: {
+    calendar_id: googleCalendarCommon.calendarDropdown(),
+  },
+  outputSchema: calendarResourceOutputSchema,
+  async run(context) {
+    const { calendar_id: calendarId } = context.propsValue;
+    const token = await getAccessToken(context.auth);
+
+    const request: HttpRequest = {
+      method: HttpMethod.GET,
+      url: `${googleCalendarCommon.baseUrl}/calendars/${encodeURIComponent(
+        calendarId
+      )}`,
+      authentication: {
+        type: AuthenticationType.BEARER_TOKEN,
+        token,
+      },
+    };
+
+    try {
+      const response = await httpClient.sendRequest<CalendarResource>(request);
+      return response.body;
+    } catch (error: any) {
+      const status = error.response?.status;
+      if (status === 404) {
+        throw new Error(
+          `Calendar "${calendarId}" not found. Verify the calendar ID via List Calendars.`
+        );
+      }
+      if (status === 403) {
+        throw new Error(
+          `Access denied to calendar "${calendarId}". Check your permissions.`
+        );
+      }
+      throw error;
+    }
+  },
+});

--- a/packages/pieces/community/google-calendar/src/lib/actions/ai-get-colors.ts
+++ b/packages/pieces/community/google-calendar/src/lib/actions/ai-get-colors.ts
@@ -1,0 +1,24 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { googleCalendarAuth } from '../common';
+import { getColors } from '../common/helper';
+import { colorsActionOutputSchema } from '../output-schemas';
+
+export const aiGetColors = createAction({
+  auth: googleCalendarAuth,
+  name: 'google_calendar_get_colors',
+  displayName: 'Get Colors',
+  description:
+    'Fetch the Google Calendar color palette mapping colorId values to their hex background/foreground colors.',
+  audience: 'ai',
+  aiMetadata: {
+    description:
+      'Fetch the global color palette: the mapping from each colorId to its background/foreground hex color, for both events and calendars. Use this to resolve a colorId before setting the color on google_calendar_create_event or google_calendar_update_event. Read-only and idempotent.',
+    idempotent: true,
+  },
+  props: {},
+  outputSchema: colorsActionOutputSchema,
+  async run(context) {
+    const colors = await getColors(context.auth);
+    return colors;
+  },
+});

--- a/packages/pieces/community/google-calendar/src/lib/actions/ai-get-event.ts
+++ b/packages/pieces/community/google-calendar/src/lib/actions/ai-get-event.ts
@@ -1,0 +1,20 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { googleCalendarAuth } from '../common';
+import { getEventByIdProps, runGetEventById } from './get-event-by-id';
+import { eventOutputSchema } from '../output-schemas';
+
+export const aiGetEvent = createAction({
+  auth: googleCalendarAuth,
+  name: 'google_calendar_get_event',
+  displayName: 'Get Event',
+  description: 'Fetch the full details of a single Google Calendar event by its event ID.',
+  audience: 'ai',
+  aiMetadata: {
+    description:
+      'Fetch the full details of one event by its unique event ID within a calendar. Use this when you already have an event ID (from a trigger or a list action) and need its current details; to find an event when you do not have its ID, use google_calendar_list_events or google_calendar_search_events_all_calendars instead. Resolve calendarId via google_calendar_list_calendars and eventId via google_calendar_list_events / google_calendar_search_events_all_calendars. Read-only and idempotent.',
+    idempotent: true,
+  },
+  props: getEventByIdProps,
+  outputSchema: eventOutputSchema,
+  run: runGetEventById,
+});

--- a/packages/pieces/community/google-calendar/src/lib/actions/ai-import-event.ts
+++ b/packages/pieces/community/google-calendar/src/lib/actions/ai-import-event.ts
@@ -1,0 +1,100 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { calendar as googleCalendar } from '@googleapis/calendar';
+import { googleCalendarCommon, googleCalendarAuth, createGoogleClient } from '../common';
+import { eventOutputSchema } from '../output-schemas';
+import dayjs from 'dayjs';
+
+export const aiImportEvent = createAction({
+  auth: googleCalendarAuth,
+  name: 'google_calendar_import_event',
+  displayName: 'Import Event',
+  description:
+    'Import an existing event (by iCalUID) into a Google Calendar as a private copy, using events.import.',
+  audience: 'ai',
+  aiMetadata: {
+    description:
+      'Import an existing event into a calendar as a private copy, keyed by its iCalUID with a start and end time (the events.import primitive, distinct from creating a brand-new event or moving one). Use this to copy or de-duplicate an event across calendars; re-importing the same iCalUID updates the existing copy rather than duplicating it. Resolve calendarId via google_calendar_list_calendars (default "primary"). Only default (non-special) events can be imported. Not idempotent: each import can create or mutate the destination copy.',
+    idempotent: false,
+  },
+  props: {
+    calendar_id: googleCalendarCommon.calendarDropdown('writer'),
+    ical_uid: Property.ShortText({
+      displayName: 'iCal UID',
+      description:
+        'The event\'s iCalUID (its globally unique identifier, e.g. "abc123@google.com"). This is the dedup key: re-importing the same UID updates the existing copy.',
+      required: true,
+    }),
+    summary: Property.ShortText({
+      displayName: 'Title',
+      description: 'Title (summary) of the imported event.',
+      required: true,
+    }),
+    start_date_time: Property.DateTime({
+      displayName: 'Start Time',
+      description: 'Event start as an ISO 8601 timestamp (e.g. "2026-06-01T09:00:00Z").',
+      required: true,
+    }),
+    end_date_time: Property.DateTime({
+      displayName: 'End Time',
+      description: 'Event end as an ISO 8601 timestamp (e.g. "2026-06-01T10:00:00Z").',
+      required: true,
+    }),
+    location: Property.ShortText({
+      displayName: 'Location',
+      required: false,
+    }),
+    description: Property.LongText({
+      displayName: 'Description',
+      description: 'Description of the event. You can use HTML tags here.',
+      required: false,
+    }),
+  },
+  outputSchema: eventOutputSchema,
+  async run(context) {
+    const {
+      calendar_id: calendarId,
+      ical_uid: iCalUID,
+      summary,
+      start_date_time,
+      end_date_time,
+      location,
+      description,
+    } = context.propsValue;
+
+    const authClient = await createGoogleClient(context.auth);
+    const calendar = googleCalendar({ version: 'v3', auth: authClient });
+
+    try {
+      const response = await calendar.events.import({
+        calendarId,
+        requestBody: {
+          iCalUID,
+          summary,
+          location: location ?? undefined,
+          description: description ?? undefined,
+          start: {
+            dateTime: dayjs(start_date_time).toISOString(),
+          },
+          end: {
+            dateTime: dayjs(end_date_time).toISOString(),
+          },
+        },
+      });
+
+      return response.data;
+    } catch (error: any) {
+      const status = error.response?.status ?? error.code;
+      if (status === 403) {
+        throw new Error(
+          `Access denied while importing into calendar "${calendarId}". The calendar must be writable.`
+        );
+      }
+      if (status === 400) {
+        throw new Error(
+          `Invalid import request. Ensure iCalUID, start, and end are provided and that the event is a default (non-special) event. (${error.message})`
+        );
+      }
+      throw error;
+    }
+  },
+});

--- a/packages/pieces/community/google-calendar/src/lib/actions/ai-list-calendars.ts
+++ b/packages/pieces/community/google-calendar/src/lib/actions/ai-list-calendars.ts
@@ -1,0 +1,42 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { googleCalendarAuth, getAccessToken } from '../common';
+import { getCalendars } from '../common/helper';
+import { listCalendarsActionOutputSchema } from '../output-schemas';
+
+export const aiListCalendars = createAction({
+  auth: googleCalendarAuth,
+  name: 'google_calendar_list_calendars',
+  displayName: 'List Calendars',
+  description:
+    'List every calendar in the user\'s calendar list, returning each calendar\'s id, summary, access role, time zone, and whether it is primary.',
+  audience: 'ai',
+  aiMetadata: {
+    description:
+      'List all calendars on the user\'s calendar list, returning each one\'s calendarId, summary, accessRole, timeZone, and whether it is the primary calendar. This is the calendarId resolver: call it first to discover which calendars exist and obtain the calendarId that every event/freebusy atomic needs (default "primary"). Read-only and idempotent.',
+    idempotent: true,
+  },
+  props: {},
+  outputSchema: listCalendarsActionOutputSchema,
+  async run(context) {
+    // Touch the access token early so auth/scope errors surface clearly.
+    await getAccessToken(context.auth);
+
+    const calendars = await getCalendars(context.auth);
+
+    return {
+      calendars: calendars.map((calendar) => ({
+        id: calendar.id,
+        summary: calendar.summary,
+        description: calendar.description,
+        location: calendar.location,
+        timeZone: calendar.timeZone,
+        accessRole: calendar.accessRole,
+        primary: calendar.primary ?? false,
+        selected: calendar.selected ?? false,
+        backgroundColor: calendar.backgroundColor,
+        foregroundColor: calendar.foregroundColor,
+      })),
+      count: calendars.length,
+    };
+  },
+});

--- a/packages/pieces/community/google-calendar/src/lib/actions/ai-list-events.ts
+++ b/packages/pieces/community/google-calendar/src/lib/actions/ai-list-events.ts
@@ -1,0 +1,21 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { googleCalendarAuth } from '../common';
+import { getEventsProps, runGetEvents } from './get-events';
+import { getEventsActionOutputSchema } from '../output-schemas';
+
+export const aiListEvents = createAction({
+  auth: googleCalendarAuth,
+  name: 'google_calendar_list_events',
+  displayName: 'List Events',
+  description:
+    'List events from one Google Calendar, optionally filtered by date range, free-text search, and event types.',
+  audience: 'ai',
+  aiMetadata: {
+    description:
+      'List events from one calendar, optionally narrowed by a date range, a free-text search term (matched with Google\'s native q= filter), and event types, optionally expanding recurring events into individual instances. Use this to browse or find events in a known calendar, including text search within that calendar; to search across every calendar when you do not know which one holds the event, use google_calendar_search_events_all_calendars instead. Resolve calendarId via google_calendar_list_calendars (default "primary"). Read-only and idempotent.',
+    idempotent: true,
+  },
+  props: getEventsProps,
+  outputSchema: getEventsActionOutputSchema,
+  run: runGetEvents,
+});

--- a/packages/pieces/community/google-calendar/src/lib/actions/ai-list-settings.ts
+++ b/packages/pieces/community/google-calendar/src/lib/actions/ai-list-settings.ts
@@ -1,0 +1,66 @@
+import { createAction } from '@activepieces/pieces-framework';
+import {
+  HttpRequest,
+  HttpMethod,
+  AuthenticationType,
+  httpClient,
+} from '@activepieces/pieces-common';
+import { googleCalendarCommon, googleCalendarAuth, getAccessToken } from '../common';
+import { listSettingsActionOutputSchema } from '../output-schemas';
+
+interface SettingItem {
+  kind: string;
+  etag: string;
+  id: string;
+  value: string;
+}
+
+interface SettingsListResponse {
+  kind: string;
+  etag: string;
+  nextPageToken?: string;
+  nextSyncToken?: string;
+  items: SettingItem[];
+}
+
+export const aiListSettings = createAction({
+  auth: googleCalendarAuth,
+  name: 'google_calendar_list_settings',
+  displayName: 'List Settings',
+  description:
+    'List the user\'s Google Calendar account settings (time zone, week start, date/time format, and more).',
+  audience: 'ai',
+  aiMetadata: {
+    description:
+      'List all of the user\'s Google Calendar account settings as id/value pairs — including the account "timezone", "weekStart", and "format24HourTime". Use this to read the account time zone to anchor relative-date reasoning before building event windows, or to read a single setting (just pick its id from the returned list). Read-only and idempotent.',
+    idempotent: true,
+  },
+  props: {},
+  outputSchema: listSettingsActionOutputSchema,
+  async run(context) {
+    const token = await getAccessToken(context.auth);
+
+    const request: HttpRequest = {
+      method: HttpMethod.GET,
+      url: `${googleCalendarCommon.baseUrl}/users/me/settings`,
+      authentication: {
+        type: AuthenticationType.BEARER_TOKEN,
+        token,
+      },
+    };
+
+    const response = await httpClient.sendRequest<SettingsListResponse>(request);
+    const items = response.body.items ?? [];
+
+    const settings: Record<string, string> = {};
+    for (const item of items) {
+      settings[item.id] = item.value;
+    }
+
+    return {
+      settings,
+      items,
+      count: items.length,
+    };
+  },
+});

--- a/packages/pieces/community/google-calendar/src/lib/actions/ai-remove-attendee.ts
+++ b/packages/pieces/community/google-calendar/src/lib/actions/ai-remove-attendee.ts
@@ -1,0 +1,117 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { calendar as googleCalendar } from '@googleapis/calendar';
+import { googleCalendarCommon, googleCalendarAuth, createGoogleClient } from '../common';
+import { removeAttendeeActionOutputSchema } from '../output-schemas';
+
+export const aiRemoveAttendee = createAction({
+  auth: googleCalendarAuth,
+  name: 'google_calendar_remove_attendee',
+  displayName: 'Remove Attendee',
+  description:
+    'Remove one attendee (by email) from an existing Google Calendar event, preserving the rest of the guest list.',
+  audience: 'ai',
+  aiMetadata: {
+    description:
+      'Remove a single attendee, matched by email, from an existing event by fetching the current attendee list, dropping that one guest, and patching the event. Use this to uninvite one person without disturbing the other guests; to add guests use the add-attendees action instead. Resolve calendarId via google_calendar_list_calendars and eventId via google_calendar_list_events / google_calendar_search_events_all_calendars. Not idempotent (notifications may fire), though re-removing an already-absent attendee is a no-op on state. It uses optimistic concurrency (If-Match on the event revision), so a simultaneous edit by someone else fails with a retry-able conflict instead of silently clobbering their change.',
+    idempotent: false,
+  },
+  props: {
+    calendar_id: googleCalendarCommon.calendarDropdown('writer'),
+    event_id: Property.ShortText({
+      displayName: 'Event ID',
+      description:
+        'The ID of the event to remove the attendee from. Resolve it via List Events or Search Events Across Calendars.',
+      required: true,
+    }),
+    attendee_email: Property.ShortText({
+      displayName: 'Attendee Email',
+      description: 'Email address of the attendee to remove from the event.',
+      required: true,
+    }),
+    send_updates: Property.StaticDropdown({
+      displayName: 'Send Notifications',
+      description: 'Who should be notified about the attendee change.',
+      required: false,
+      defaultValue: 'none',
+      options: {
+        options: [
+          { label: 'To everyone', value: 'all' },
+          { label: 'To external guests only', value: 'externalOnly' },
+          { label: 'To no one', value: 'none' },
+        ],
+      },
+    }),
+  },
+  outputSchema: removeAttendeeActionOutputSchema,
+  async run(context) {
+    const {
+      calendar_id: calendarId,
+      event_id: eventId,
+      attendee_email: attendeeEmail,
+      send_updates: sendUpdates,
+    } = context.propsValue;
+
+    const authClient = await createGoogleClient(context.auth);
+    const calendar = googleCalendar({ version: 'v3', auth: authClient });
+
+    const targetEmail = attendeeEmail.trim().toLowerCase();
+
+    try {
+      const currentEvent = await calendar.events.get({
+        calendarId,
+        eventId,
+      });
+
+      const currentAttendees = currentEvent.data.attendees ?? [];
+      const remainingAttendees = currentAttendees.filter(
+        (attendee) => (attendee.email ?? '').trim().toLowerCase() !== targetEmail
+      );
+
+      if (remainingAttendees.length === currentAttendees.length) {
+        return {
+          removed: false,
+          attendee_email: attendeeEmail,
+          message: `Attendee "${attendeeEmail}" was not on event "${eventId}"; nothing to remove.`,
+          event: currentEvent.data,
+        };
+      }
+
+      const etag = currentEvent.data.etag ?? undefined;
+      const response = await calendar.events.patch(
+        {
+          calendarId,
+          eventId,
+          sendUpdates: sendUpdates ?? 'none',
+          requestBody: {
+            attendees: remainingAttendees,
+          },
+        },
+        etag ? { headers: { 'If-Match': etag } } : {}
+      );
+
+      return {
+        removed: true,
+        attendee_email: attendeeEmail,
+        event: response.data,
+      };
+    } catch (error: any) {
+      const status = error.response?.status ?? error.code;
+      if (status === 412) {
+        throw new Error(
+          `Event "${eventId}" changed since it was read (a concurrent edit). Re-run Remove Attendee to retry against the latest version.`
+        );
+      }
+      if (status === 404) {
+        throw new Error(
+          `Event "${eventId}" not found in calendar "${calendarId}". Verify the event ID and calendar.`
+        );
+      }
+      if (status === 403) {
+        throw new Error(
+          `Access denied while editing event "${eventId}". The calendar must be writable.`
+        );
+      }
+      throw error;
+    }
+  },
+});

--- a/packages/pieces/community/google-calendar/src/lib/actions/ai-update-event.ts
+++ b/packages/pieces/community/google-calendar/src/lib/actions/ai-update-event.ts
@@ -3,8 +3,32 @@ import { googleCalendarAuth } from '../common';
 import { updateEventProps, runUpdateEvent } from './update-event.action';
 import { eventOutputSchema } from '../output-schemas';
 
-const { eventId: _omitEventId, calendar_id: _omitCalendarId, ...otherUpdateProps } =
-  updateEventProps;
+const {
+  eventId: _omitEventId,
+  calendar_id: _omitCalendarId,
+  guests_can_modify: _omitGuestsCanModify,
+  guests_can_invite_others: _omitGuestsCanInviteOthers,
+  guests_can_see_other_guests: _omitGuestsCanSeeOtherGuests,
+  ...otherUpdateProps
+} = updateEventProps;
+
+function guestPermissionProp(displayName: string) {
+  return Property.StaticDropdown({
+    displayName,
+    description: 'Leave unset to keep the event\'s current value.',
+    required: false,
+    options: {
+      options: [
+        { label: 'True', value: 'true' },
+        { label: 'False', value: 'false' },
+      ],
+    },
+  });
+}
+
+function toOptionalBoolean(value: string | undefined): boolean | undefined {
+  return value === undefined ? undefined : value === 'true';
+}
 
 const props = {
   calendar_id: updateEventProps.calendar_id,
@@ -15,6 +39,11 @@ const props = {
     required: true,
   }),
   ...otherUpdateProps,
+  guests_can_modify: guestPermissionProp('Guests can modify'),
+  guests_can_invite_others: guestPermissionProp('Guests can invite others'),
+  guests_can_see_other_guests: guestPermissionProp(
+    'Guests can see other guests'
+  ),
 };
 
 export const aiUpdateEvent = createAction({
@@ -37,6 +66,15 @@ export const aiUpdateEvent = createAction({
       propsValue: {
         ...context.propsValue,
         eventId: context.propsValue.event_id,
+        guests_can_modify: toOptionalBoolean(
+          context.propsValue.guests_can_modify
+        ),
+        guests_can_invite_others: toOptionalBoolean(
+          context.propsValue.guests_can_invite_others
+        ),
+        guests_can_see_other_guests: toOptionalBoolean(
+          context.propsValue.guests_can_see_other_guests
+        ),
       },
     }),
 });

--- a/packages/pieces/community/google-calendar/src/lib/actions/ai-update-event.ts
+++ b/packages/pieces/community/google-calendar/src/lib/actions/ai-update-event.ts
@@ -1,0 +1,42 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { googleCalendarAuth } from '../common';
+import { updateEventProps, runUpdateEvent } from './update-event.action';
+import { eventOutputSchema } from '../output-schemas';
+
+const { eventId: _omitEventId, calendar_id: _omitCalendarId, ...otherUpdateProps } =
+  updateEventProps;
+
+const props = {
+  calendar_id: updateEventProps.calendar_id,
+  event_id: Property.ShortText({
+    displayName: 'Event ID',
+    description:
+      'The ID of the event to update. Resolve it via List Events or Search Events Across Calendars.',
+    required: true,
+  }),
+  ...otherUpdateProps,
+};
+
+export const aiUpdateEvent = createAction({
+  auth: googleCalendarAuth,
+  name: 'google_calendar_update_event',
+  displayName: 'Update Event',
+  description:
+    'Update fields of an existing Google Calendar event by ID using a safe get-then-merge; fields you leave unset keep their current values.',
+  audience: 'ai',
+  aiMetadata: {
+    description:
+      'Update fields of an existing event (title, times, location, description, color, attendees, guest permissions) identified by calendar and event ID. It fetches the event first and merges, so unset fields keep their current values (it never blanks out attendees/recurrence/conferencing). Use this to edit or reschedule an existing event rather than recreating it. Resolve calendarId via google_calendar_list_calendars and eventId via google_calendar_list_events / google_calendar_search_events_all_calendars. Idempotent: applying the same field values repeatedly leaves the event in the same state.',
+    idempotent: true,
+  },
+  props,
+  outputSchema: eventOutputSchema,
+  run: (context) =>
+    runUpdateEvent({
+      ...context,
+      propsValue: {
+        ...context.propsValue,
+        eventId: context.propsValue.event_id,
+      },
+    }),
+});

--- a/packages/pieces/community/google-calendar/src/lib/actions/create-event.ts
+++ b/packages/pieces/community/google-calendar/src/lib/actions/create-event.ts
@@ -1,167 +1,173 @@
-import { createAction, Property } from '@activepieces/pieces-framework';
+import { ActionContext, createAction, Property } from '@activepieces/pieces-framework';
 import { googleCalendarCommon, googleCalendarAuth, createGoogleClient } from '../common';
 import dayjs from 'dayjs';
 import { calendar as googleCalendar } from '@googleapis/calendar';
 import { randomUUID } from 'crypto';
+
 import { eventOutputSchema } from '../output-schemas';
+export const createEventProps = {
+  calendar_id: googleCalendarCommon.calendarDropdown('writer'),
+  title: Property.ShortText({
+    displayName: 'Title of the event',
+    required: true,
+  }),
+  start_date_time: Property.DateTime({
+    displayName: 'Start date time of the event',
+    required: true,
+  }),
+  end_date_time: Property.DateTime({
+    displayName: 'End date time of the event',
+    description: "By default it'll be 30 min post start time",
+    required: false,
+  }),
+  location: Property.ShortText({
+    displayName: 'Location',
+    required: false,
+  }),
+  /*attachment: Property.ShortText({
+    displayName: 'Attachment',
+    description: 'URL of the file to be attached',
+    required: false,
+  }),*/
+  description: Property.LongText({
+    displayName: 'Description',
+    description: 'Description of the event. You can use HTML tags here.',
+    required: false,
+  }),
+  colorId: googleCalendarCommon.colorId,
+  attendees: Property.Array({
+    displayName: 'Attendees',
+    description: 'Emails of the attendees (guests)',
+    required: false,
+  }),
+  guests_can_modify: Property.Checkbox({
+    displayName: 'Guests can modify',
+    defaultValue: false,
+    required: false,
+  }),
+  guests_can_invite_others: Property.Checkbox({
+    displayName: 'Guests can invite others',
+    defaultValue: false,
+    required: false,
+  }),
+  guests_can_see_other_guests: Property.Checkbox({
+    displayName: 'Guests can see other guests',
+    defaultValue: false,
+    required: false,
+  }),
+  send_notifications: Property.StaticDropdown({
+    displayName: 'Send Notifications',
+    defaultValue: 'all',
+    options: {
+      options: [
+        { label: 'Yes, to everyone', value: 'all' },
+        {
+          label: 'To non-Google Calendar guests only',
+          value: 'externalOnly',
+        },
+        { label: 'To no one', value: 'none' },
+      ],
+    },
+    required: true,
+  }),
+  create_meet_link: Property.Checkbox({
+    displayName: 'Create Google Meet Link',
+    description: 'Automatically create a Google Meet video conference link for this event',
+    defaultValue: false,
+    required: false,
+  }),
+};
+
+export async function runCreateEvent(
+  context: ActionContext<typeof googleCalendarAuth, typeof createEventProps>
+) {
+  // docs: https://developers.google.com/calendar/api/v3/reference/events/insert
+  const {
+    calendar_id: calendarId,
+    title: summary,
+    start_date_time,
+    end_date_time,
+    location,
+    description,
+    colorId,
+    guests_can_modify: guestsCanModify,
+    guests_can_invite_others: guestsCanInviteOthers,
+    guests_can_see_other_guests: guestsCanSeeOtherGuests,
+    create_meet_link: createMeetLink,
+  } = context.propsValue;
+
+  const start = {
+    dateTime: dayjs(start_date_time).format('YYYY-MM-DDTHH:mm:ss.sssZ'),
+  };
+  const endTime = end_date_time
+    ? end_date_time
+    : dayjs(start_date_time).add(30, 'm');
+  const end = {
+    dateTime: dayjs(endTime).format('YYYY-MM-DDTHH:mm:ss.sssZ'),
+  };
+
+  /*const attachment = {
+    fileUrl: context.propsValue.attachment,
+  };*/
+
+  const attendeesArray = context.propsValue.attendees as string[];
+
+  const sendNotifications = context.propsValue.send_notifications;
+
+  const attendeesObject = [];
+  if (attendeesArray) {
+    for (const attendee of attendeesArray) {
+      attendeesObject.push({ email: attendee });
+    }
+  }
+
+  const authClient = await createGoogleClient(context.auth);
+
+  const calendar = googleCalendar({ version: 'v3', auth: authClient });
+
+  const requestBody: any = {
+    summary,
+    start,
+    end,
+    colorId,
+    //attachments: context.propsValue.attachment ? [attachment] : [],
+    location: location ?? '',
+    description: description ?? '',
+    attendees: attendeesObject,
+    guestsCanInviteOthers,
+    guestsCanModify,
+    guestsCanSeeOtherGuests,
+  };
+
+  if (createMeetLink) {
+    requestBody.conferenceData = {
+      createRequest: {
+        conferenceSolutionKey: {
+          type: 'hangoutsMeet',
+        },
+        requestId: randomUUID(),
+      },
+    };
+  }
+
+  const response = await calendar.events.insert({
+    calendarId,
+    sendUpdates: sendNotifications,
+    conferenceDataVersion: createMeetLink ? 1 : 0,
+    requestBody,
+  });
+
+  return response.data;
+}
 
 export const createEvent = createAction({
   auth: googleCalendarAuth,
   name: 'create_google_calendar_event',
   description: 'Add Event',
-  audience: 'both',
+  audience: 'human',
   aiMetadata: { description: 'Creates a Google Calendar event with structured fields (title, start/end times, location, description, attendees, color, guest permissions) and can optionally attach a Google Meet link. Use this when you have explicit event details; choose Create Quick Event instead when working from a single natural-language phrase. Requires a title and start time (end defaults to 30 minutes after start). Not idempotent: each call creates a new event.', idempotent: false },
   displayName: 'Create Event',
-  props: {
-    calendar_id: googleCalendarCommon.calendarDropdown('writer'),
-    title: Property.ShortText({
-      displayName: 'Title of the event',
-      required: true,
-    }),
-    start_date_time: Property.DateTime({
-      displayName: 'Start date time of the event',
-      required: true,
-    }),
-    end_date_time: Property.DateTime({
-      displayName: 'End date time of the event',
-      description: "By default it'll be 30 min post start time",
-      required: false,
-    }),
-    location: Property.ShortText({
-      displayName: 'Location',
-      required: false,
-    }),
-    /*attachment: Property.ShortText({
-      displayName: 'Attachment',
-      description: 'URL of the file to be attached',
-      required: false,
-    }),*/
-    description: Property.LongText({
-      displayName: 'Description',
-      description: 'Description of the event. You can use HTML tags here.',
-      required: false,
-    }),
-    colorId: googleCalendarCommon.colorId,
-    attendees: Property.Array({
-      displayName: 'Attendees',
-      description: 'Emails of the attendees (guests)',
-      required: false,
-    }),
-    guests_can_modify: Property.Checkbox({
-      displayName: 'Guests can modify',
-      defaultValue: false,
-      required: false,
-    }),
-    guests_can_invite_others: Property.Checkbox({
-      displayName: 'Guests can invite others',
-      defaultValue: false,
-      required: false,
-    }),
-    guests_can_see_other_guests: Property.Checkbox({
-      displayName: 'Guests can see other guests',
-      defaultValue: false,
-      required: false,
-    }),
-    send_notifications: Property.StaticDropdown({
-      displayName: 'Send Notifications',
-      defaultValue: 'all',
-      options: {
-        options: [
-          { label: 'Yes, to everyone', value: 'all' },
-          {
-            label: 'To non-Google Calendar guests only',
-            value: 'externalOnly',
-          },
-          { label: 'To no one', value: 'none' },
-        ],
-      },
-      required: true,
-    }),
-    create_meet_link: Property.Checkbox({
-      displayName: 'Create Google Meet Link',
-      description: 'Automatically create a Google Meet video conference link for this event',
-      defaultValue: false,
-      required: false,
-    }),
-  },
+  props: createEventProps,
   outputSchema: eventOutputSchema,
-  async run(configValue) {
-    // docs: https://developers.google.com/calendar/api/v3/reference/events/insert
-    const {
-      calendar_id: calendarId,
-      title: summary,
-      start_date_time,
-      end_date_time,
-      location,
-      description,
-      colorId,
-      guests_can_modify: guestsCanModify,
-      guests_can_invite_others: guestsCanInviteOthers,
-      guests_can_see_other_guests: guestsCanSeeOtherGuests,
-      create_meet_link: createMeetLink,
-    } = configValue.propsValue;
-
-    const start = {
-      dateTime: dayjs(start_date_time).format('YYYY-MM-DDTHH:mm:ss.sssZ'),
-    };
-    const endTime = end_date_time
-      ? end_date_time
-      : dayjs(start_date_time).add(30, 'm');
-    const end = {
-      dateTime: dayjs(endTime).format('YYYY-MM-DDTHH:mm:ss.sssZ'),
-    };
-
-    /*const attachment = {
-      fileUrl: configValue.propsValue.attachment,
-    };*/
-
-    const attendeesArray = configValue.propsValue.attendees as string[];
-
-    const sendNotifications = configValue.propsValue.send_notifications;
-
-    const attendeesObject = [];
-    if (attendeesArray) {
-      for (const attendee of attendeesArray) {
-        attendeesObject.push({ email: attendee });
-      }
-    }
-
-    const authClient = await createGoogleClient(configValue.auth);
-
-    const calendar = googleCalendar({ version: 'v3', auth: authClient });
-
-    const requestBody: any = {
-      summary,
-      start,
-      end,
-      colorId,
-      //attachments: configValue.propsValue.attachment ? [attachment] : [],
-      location: location ?? '',
-      description: description ?? '',
-      attendees: attendeesObject,
-      guestsCanInviteOthers,
-      guestsCanModify,
-      guestsCanSeeOtherGuests,
-    };
-
-    if (createMeetLink) {
-      requestBody.conferenceData = {
-        createRequest: {
-          conferenceSolutionKey: {
-            type: 'hangoutsMeet',
-          },
-          requestId: randomUUID(),
-        },
-      };
-    }
-
-    const response = await calendar.events.insert({
-      calendarId,
-      sendUpdates: sendNotifications,
-      conferenceDataVersion: createMeetLink ? 1 : 0,
-      requestBody,
-    });
-
-    return response.data;
-  },
+  run: runCreateEvent,
 });

--- a/packages/pieces/community/google-calendar/src/lib/actions/delete-event.action.ts
+++ b/packages/pieces/community/google-calendar/src/lib/actions/delete-event.action.ts
@@ -1,34 +1,40 @@
-import { Property, createAction } from '@activepieces/pieces-framework';
+import { ActionContext, Property, createAction } from '@activepieces/pieces-framework';
 import { calendar as googleCalendar } from '@googleapis/calendar';
 import { googleCalendarCommon, googleCalendarAuth, createGoogleClient } from '../common';
+
+export const deleteEventProps = {
+  calendar_id: googleCalendarCommon.calendarDropdown('writer'),
+  eventId: Property.ShortText({
+    displayName: 'Event ID',
+    required: true,
+  }),
+};
+
+export async function runDeleteEvent(
+  context: ActionContext<typeof googleCalendarAuth, typeof deleteEventProps>
+) {
+  const authClient = await createGoogleClient(context.auth);
+
+  const calendarId = context.propsValue.calendar_id;
+  const eventId = context.propsValue.eventId;
+
+  const calendar = googleCalendar({ version: 'v3', auth: authClient });
+
+  const response = await calendar.events.delete({
+    calendarId,
+    eventId,
+  });
+
+  return response.data;
+}
 
 export const deleteEventAction = createAction({
   displayName: 'Delete Event',
   auth: googleCalendarAuth,
   name: 'delete_event',
   description: 'Deletes an event from Google Calendar.',
-  audience: 'both',
+  audience: 'human',
   aiMetadata: { description: 'Permanently removes an event from a Google Calendar, identified by calendar and event ID. Use to cancel or delete an existing event. Requires the event ID and cannot be undone. Idempotent: once the event is deleted, repeating the call leaves it absent (a second call may report it as already gone).', idempotent: true },
-  props: {
-    calendar_id: googleCalendarCommon.calendarDropdown('writer'),
-    eventId: Property.ShortText({
-      displayName: 'Event ID',
-      required: true,
-    }),
-  },
-  async run(context) {
-    const authClient = await createGoogleClient(context.auth);
-
-    const calendarId = context.propsValue.calendar_id;
-    const eventId = context.propsValue.eventId;
-
-    const calendar = googleCalendar({ version: 'v3', auth: authClient });
-
-    const response = await calendar.events.delete({
-      calendarId,
-      eventId,
-    });
-
-    return response.data;
-  },
+  props: deleteEventProps,
+  run: runDeleteEvent,
 });

--- a/packages/pieces/community/google-calendar/src/lib/actions/find-busy-free-periods.ts
+++ b/packages/pieces/community/google-calendar/src/lib/actions/find-busy-free-periods.ts
@@ -1,11 +1,11 @@
-import { createAction, Property } from '@activepieces/pieces-framework';
+import { ActionContext, createAction, Property } from '@activepieces/pieces-framework';
 import { HttpRequest, HttpMethod, AuthenticationType, httpClient } from '@activepieces/pieces-common';
 import { googleCalendarCommon, googleCalendarAuth, getAccessToken, GoogleCalendarAuthValue } from '../common';
 import { getCalendars } from '../common/helper';
 import dayjs from 'dayjs';
+
+
 import { freeBusyActionOutputSchema } from '../output-schemas';
-
-
 interface FreeBusyResponse {
   kind: 'calendar#freeBusy';
   timeMin: string;
@@ -24,78 +24,81 @@ interface FreeBusyResponse {
   };
 }
 
+export const findFreeBusyProps = {
+  calendar_ids: Property.MultiSelectDropdown({
+    auth: googleCalendarAuth,
+    displayName: 'Calendars',
+    description: 'Select the calendars to check for busy periods.',
+    required: true,
+    refreshers: [],
+    options: async ({ auth }) => {
+      if (!auth) {
+        return {
+          disabled: true,
+          placeholder: 'Connect your account first',
+          options: [],
+        };
+      }
+      const authProp = auth as GoogleCalendarAuthValue;
+      const calendars = await getCalendars(authProp);
+      return {
+        disabled: false,
+        options: calendars.map((calendar) => {
+          return {
+            label: calendar.summary,
+            value: calendar.id,
+          };
+        }),
+      };
+    },
+  }),
+  start_date: Property.DateTime({
+    displayName: 'Start Time',
+    description: 'The start of the time range to check.',
+    required: true,
+  }),
+  end_date: Property.DateTime({
+    displayName: 'End Time',
+    description: 'The end of the time range to check.',
+    required: true,
+  }),
+};
+
+export async function runFindFreeBusy(
+  context: ActionContext<typeof googleCalendarAuth, typeof findFreeBusyProps>
+) {
+  const { calendar_ids, start_date, end_date } = context.propsValue;
+  const access_token = await getAccessToken(context.auth);
+
+  const requestBody = {
+    timeMin: dayjs(start_date).toISOString(),
+    timeMax: dayjs(end_date).toISOString(),
+    items: calendar_ids.map((id) => ({ id })),
+  };
+
+  const request: HttpRequest = {
+    method: HttpMethod.POST,
+    url: `${googleCalendarCommon.baseUrl}/freeBusy`,
+    body: requestBody,
+    authentication: {
+      type: AuthenticationType.BEARER_TOKEN,
+      token: access_token,
+    },
+  };
+
+  const response = await httpClient.sendRequest<FreeBusyResponse>(request);
+
+  return response.body;
+}
+
 export const findFreeBusy = createAction({
   auth: googleCalendarAuth,
   name: 'google_calendar_find_busy_free_periods',
   displayName: 'Find Busy/Free Periods in Calendar',
   description: 'Finds free/busy calendar details from Google Calendar.',
-  audience: 'both',
+  audience: 'human',
   aiMetadata: { description: 'Queries one or more calendars for their busy time blocks within a given start/end window, without exposing event details. Use to check availability or find open slots before scheduling a meeting. Requires the calendars to check and a time range. Read-only and idempotent.', idempotent: true },
-  props: {
-    calendar_ids: Property.MultiSelectDropdown({
-      auth: googleCalendarAuth,
-      displayName: 'Calendars',
-      description: 'Select the calendars to check for busy periods.',
-      required: true,
-      refreshers: [],
-      options: async ({ auth }) => {
-        if (!auth) {
-          return {
-            disabled: true,
-            placeholder: 'Connect your account first',
-            options: [],
-          };
-        }
-        const authProp = auth as GoogleCalendarAuthValue;
-        const calendars = await getCalendars(authProp);
-        return {
-          disabled: false,
-          options: calendars.map((calendar) => {
-            return {
-              label: calendar.summary,
-              value: calendar.id,
-            };
-          }),
-        };
-      },
-    }),
-    start_date: Property.DateTime({
-      displayName: 'Start Time',
-      description: 'The start of the time range to check.',
-      required: true,
-    }),
-    end_date: Property.DateTime({
-      displayName: 'End Time',
-      description: 'The end of the time range to check.',
-      required: true,
-    }),
-  },
+  props: findFreeBusyProps,
   outputSchema: freeBusyActionOutputSchema,
-  async run(context) {
-    const { calendar_ids, start_date, end_date } = context.propsValue;
-    const access_token = await getAccessToken(context.auth);
-
-    const requestBody = {
-      
-      timeMin: dayjs(start_date).toISOString(),
-      timeMax: dayjs(end_date).toISOString(),
-      
-      items: calendar_ids.map((id) => ({ id })),
-    };
-
-    const request: HttpRequest = {
-      method: HttpMethod.POST,
-      url: `${googleCalendarCommon.baseUrl}/freeBusy`,
-      body: requestBody,
-      authentication: {
-        type: AuthenticationType.BEARER_TOKEN,
-        token: access_token,
-      },
-    };
-
-    const response = await httpClient.sendRequest<FreeBusyResponse>(request);
-    
-    
-    return response.body;
-  },
+  run: runFindFreeBusy,
 });

--- a/packages/pieces/community/google-calendar/src/lib/actions/find-free-slots.ts
+++ b/packages/pieces/community/google-calendar/src/lib/actions/find-free-slots.ts
@@ -210,14 +210,12 @@ export const findFreeSlots = createAction({
       calendarId: string;
       errors: { domain: string; reason: string }[];
     }[] = [];
-    let calendarsWithData = 0;
     for (const calendarId of Object.keys(response.body.calendars)) {
       const calendarResult = response.body.calendars[calendarId];
       if (calendarResult.errors?.length) {
         calendarErrors.push({ calendarId, errors: calendarResult.errors });
         continue;
       }
-      calendarsWithData++;
       const blocks = calendarResult.busy ?? [];
       for (const block of blocks) {
         allBusy.push({
@@ -227,16 +225,18 @@ export const findFreeSlots = createAction({
       }
     }
 
-    if (calendarErrors.length > 0 && calendarsWithData === 0) {
+    if (calendarErrors.length > 0) {
       throw new Error(
-        `Could not read availability for any requested calendar: ${calendarErrors
+        `Could not read availability for calendar(s): ${calendarErrors
           .map(
             (entry) =>
               `${entry.calendarId} (${entry.errors
                 .map((error) => error.reason)
                 .join(', ')})`
           )
-          .join('; ')}. Verify the calendar IDs with List Calendars.`
+          .join(
+            '; '
+          )}. A slot can only be marked free if every selected calendar is free, so free slots cannot be computed while any of them are unreadable. Verify the calendar IDs with List Calendars.`
       );
     }
 
@@ -271,13 +271,6 @@ export const findFreeSlots = createAction({
     return {
       free_slots: freeSlots,
       count: freeSlots.length,
-      ...(calendarErrors.length > 0
-        ? {
-            incomplete_calendars: calendarErrors,
-            warning:
-              'Some requested calendars could not be read (see incomplete_calendars); the returned slots do not account for busy time on those calendars.',
-          }
-        : {}),
     };
   },
 });

--- a/packages/pieces/community/google-calendar/src/lib/actions/find-free-slots.ts
+++ b/packages/pieces/community/google-calendar/src/lib/actions/find-free-slots.ts
@@ -1,0 +1,283 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import {
+  HttpRequest,
+  HttpMethod,
+  AuthenticationType,
+  httpClient,
+} from '@activepieces/pieces-common';
+import {
+  googleCalendarCommon,
+  googleCalendarAuth,
+  getAccessToken,
+  GoogleCalendarAuthValue,
+} from '../common';
+import { getCalendars } from '../common/helper';
+import { findFreeSlotsActionOutputSchema } from '../output-schemas';
+import dayjs from 'dayjs';
+import utc from 'dayjs/plugin/utc';
+
+dayjs.extend(utc);
+
+interface FreeBusyResponse {
+  kind: 'calendar#freeBusy';
+  timeMin: string;
+  timeMax: string;
+  calendars: {
+    [calendarId: string]: {
+      busy: { start: string; end: string }[];
+      errors?: { domain: string; reason: string }[];
+    };
+  };
+}
+
+interface Interval {
+  start: number;
+  end: number;
+}
+
+function mergeIntervals(intervals: Interval[]): Interval[] {
+  if (intervals.length === 0) {
+    return [];
+  }
+  const sorted = [...intervals].sort((a, b) => a.start - b.start);
+  const merged: Interval[] = [{ ...sorted[0] }];
+  for (let i = 1; i < sorted.length; i++) {
+    const last = merged[merged.length - 1];
+    const current = sorted[i];
+    if (current.start <= last.end) {
+      last.end = Math.max(last.end, current.end);
+    } else {
+      merged.push({ ...current });
+    }
+  }
+  return merged;
+}
+
+function complement(
+  busy: Interval[],
+  windowStart: number,
+  windowEnd: number
+): Interval[] {
+  const free: Interval[] = [];
+  let cursor = windowStart;
+  for (const block of busy) {
+    if (block.start > cursor) {
+      free.push({ start: cursor, end: Math.min(block.start, windowEnd) });
+    }
+    cursor = Math.max(cursor, block.end);
+    if (cursor >= windowEnd) {
+      break;
+    }
+  }
+  if (cursor < windowEnd) {
+    free.push({ start: cursor, end: windowEnd });
+  }
+  return free.filter((interval) => interval.end > interval.start);
+}
+
+function clipToWorkingHours(
+  free: Interval[],
+  startHour: number,
+  endHour: number
+): Interval[] {
+  const clipped: Interval[] = [];
+  for (const interval of free) {
+    let dayCursor = dayjs.utc(interval.start).startOf('day');
+    const intervalEnd = dayjs.utc(interval.end);
+    while (dayCursor.valueOf() < interval.end) {
+      const workStart = dayCursor.add(startHour, 'hour');
+      const workEnd = dayCursor.add(endHour, 'hour');
+      const slotStart = Math.max(interval.start, workStart.valueOf());
+      const slotEnd = Math.min(interval.end, workEnd.valueOf());
+      if (slotEnd > slotStart) {
+        clipped.push({ start: slotStart, end: slotEnd });
+      }
+      dayCursor = dayCursor.add(1, 'day');
+      if (dayCursor.valueOf() > intervalEnd.valueOf()) {
+        break;
+      }
+    }
+  }
+  return clipped;
+}
+
+export const findFreeSlots = createAction({
+  auth: googleCalendarAuth,
+  name: 'google_calendar_find_free_slots',
+  displayName: 'Find Free Time Slots',
+  description:
+    'Computes open time slots shared across one or more calendars within a window, by inverting their busy blocks.',
+  audience: 'ai',
+  aiMetadata: {
+    description:
+      'Return the OPEN time slots common to the selected calendars within a window — the inverse of their combined busy blocks, optionally filtered to a minimum duration and to working hours. Use this instead of Find Busy/Free Periods (which returns only busy blocks and forces you to invert and reconcile them yourself) when you need the actual free intervals to answer "when can everyone meet". Idempotent because it performs no writes, but the result depends entirely on the window: pass absolute start/end times, since a window relative to "now" yields a shifting set of slots.',
+    idempotent: true,
+  },
+  props: {
+    calendar_ids: Property.MultiSelectDropdown({
+      auth: googleCalendarAuth,
+      displayName: 'Calendars',
+      description:
+        'The calendars whose schedules must all be free. A slot is returned only when it is open on every selected calendar.',
+      required: true,
+      refreshers: [],
+      options: async ({ auth }) => {
+        if (!auth) {
+          return {
+            disabled: true,
+            placeholder: 'Connect your account first',
+            options: [],
+          };
+        }
+        const authProp = auth as GoogleCalendarAuthValue;
+        const calendars = await getCalendars(authProp);
+        return {
+          disabled: false,
+          options: calendars.map((calendar) => ({
+            label: calendar.summary,
+            value: calendar.id,
+          })),
+        };
+      },
+    }),
+    start_date: Property.DateTime({
+      displayName: 'Window Start',
+      description:
+        'Start of the search window, as an absolute ISO 8601 timestamp (e.g. "2026-06-01T09:00:00Z"). Prefer absolute times over relative ones.',
+      required: true,
+    }),
+    end_date: Property.DateTime({
+      displayName: 'Window End',
+      description:
+        'End of the search window, as an absolute ISO 8601 timestamp (e.g. "2026-06-05T18:00:00Z").',
+      required: true,
+    }),
+    min_duration_minutes: Property.Number({
+      displayName: 'Minimum Slot Duration (minutes)',
+      description:
+        'Discard any open slot shorter than this many minutes. Leave empty to return every open slot regardless of length.',
+      required: false,
+    }),
+    working_hours_start: Property.Number({
+      displayName: 'Working Hours Start (hour 0-23)',
+      description:
+        'If set together with Working Hours End, each day\'s open slots are clipped to this hour range, interpreted in UTC (not the calendar\'s local time zone). Example: 9 for 09:00 UTC. Leave both unset to return slots across the full window.',
+      required: false,
+    }),
+    working_hours_end: Property.Number({
+      displayName: 'Working Hours End (hour 0-23)',
+      description:
+        'Upper bound of the daily working-hours window. Example: 17 for 5 PM. Ignored unless Working Hours Start is also set.',
+      required: false,
+    }),
+  },
+  outputSchema: findFreeSlotsActionOutputSchema,
+  async run(context) {
+    const {
+      calendar_ids,
+      start_date,
+      end_date,
+      min_duration_minutes,
+      working_hours_start,
+      working_hours_end,
+    } = context.propsValue;
+    const token = await getAccessToken(context.auth);
+
+    const windowStart = dayjs(start_date).valueOf();
+    const windowEnd = dayjs(end_date).valueOf();
+    if (windowEnd <= windowStart) {
+      throw new Error('Window End must be after Window Start.');
+    }
+
+    const request: HttpRequest = {
+      method: HttpMethod.POST,
+      url: `${googleCalendarCommon.baseUrl}/freeBusy`,
+      body: {
+        timeMin: dayjs(start_date).toISOString(),
+        timeMax: dayjs(end_date).toISOString(),
+        items: calendar_ids.map((id) => ({ id })),
+      },
+      authentication: {
+        type: AuthenticationType.BEARER_TOKEN,
+        token,
+      },
+    };
+
+    const response = await httpClient.sendRequest<FreeBusyResponse>(request);
+
+    const allBusy: Interval[] = [];
+    const calendarErrors: {
+      calendarId: string;
+      errors: { domain: string; reason: string }[];
+    }[] = [];
+    let calendarsWithData = 0;
+    for (const calendarId of Object.keys(response.body.calendars)) {
+      const calendarResult = response.body.calendars[calendarId];
+      if (calendarResult.errors?.length) {
+        calendarErrors.push({ calendarId, errors: calendarResult.errors });
+        continue;
+      }
+      calendarsWithData++;
+      const blocks = calendarResult.busy ?? [];
+      for (const block of blocks) {
+        allBusy.push({
+          start: dayjs(block.start).valueOf(),
+          end: dayjs(block.end).valueOf(),
+        });
+      }
+    }
+
+    if (calendarErrors.length > 0 && calendarsWithData === 0) {
+      throw new Error(
+        `Could not read availability for any requested calendar: ${calendarErrors
+          .map(
+            (entry) =>
+              `${entry.calendarId} (${entry.errors
+                .map((error) => error.reason)
+                .join(', ')})`
+          )
+          .join('; ')}. Verify the calendar IDs with List Calendars.`
+      );
+    }
+
+    const mergedBusy = mergeIntervals(allBusy);
+    let freeIntervals = complement(mergedBusy, windowStart, windowEnd);
+
+    if (
+      working_hours_start !== undefined &&
+      working_hours_end !== undefined &&
+      working_hours_end > working_hours_start
+    ) {
+      freeIntervals = clipToWorkingHours(
+        freeIntervals,
+        working_hours_start,
+        working_hours_end
+      );
+    }
+
+    if (min_duration_minutes !== undefined && min_duration_minutes > 0) {
+      const minMs = min_duration_minutes * 60 * 1000;
+      freeIntervals = freeIntervals.filter(
+        (interval) => interval.end - interval.start >= minMs
+      );
+    }
+
+    const freeSlots = freeIntervals.map((interval) => ({
+      start: dayjs(interval.start).toISOString(),
+      end: dayjs(interval.end).toISOString(),
+      duration_minutes: Math.round((interval.end - interval.start) / 60000),
+    }));
+
+    return {
+      free_slots: freeSlots,
+      count: freeSlots.length,
+      ...(calendarErrors.length > 0
+        ? {
+            incomplete_calendars: calendarErrors,
+            warning:
+              'Some requested calendars could not be read (see incomplete_calendars); the returned slots do not account for busy time on those calendars.',
+          }
+        : {}),
+    };
+  },
+});

--- a/packages/pieces/community/google-calendar/src/lib/actions/get-event-by-id.ts
+++ b/packages/pieces/community/google-calendar/src/lib/actions/get-event-by-id.ts
@@ -1,4 +1,4 @@
-import { createAction, Property } from '@activepieces/pieces-framework';
+import { ActionContext, createAction, Property } from '@activepieces/pieces-framework';
 import {
   HttpRequest,
   HttpMethod,
@@ -7,121 +7,127 @@ import {
 } from '@activepieces/pieces-common';
 import { googleCalendarCommon, googleCalendarAuth, getAccessToken } from '../common';
 import { GoogleCalendarEvent } from '../common/types';
+
 import { eventOutputSchema } from '../output-schemas';
+export const getEventByIdProps = {
+  calendar_id: googleCalendarCommon.calendarDropdown(),
+  event_id: Property.ShortText({
+    displayName: 'Event ID',
+    description:
+      'The unique ID of the event (e.g., "abc123def456"). You can find this in the event URL or from other calendar actions.',
+    required: true,
+  }),
+  max_attendees: Property.Number({
+    displayName: 'Max Attendees',
+    description:
+      'Maximum number of attendees to include in the response. If there are more attendees, only the participant is returned.',
+    required: false,
+  }),
+  time_zone: Property.ShortText({
+    displayName: 'Time Zone',
+    description:
+      'Time zone for the response (e.g., "America/New_York", "Europe/London"). Defaults to the calendar\'s time zone if not specified.',
+    required: false,
+  }),
+};
+
+export async function runGetEventById(
+  context: ActionContext<typeof googleCalendarAuth, typeof getEventByIdProps>
+) {
+  const {
+    calendar_id: calendarId,
+    event_id: eventId,
+    max_attendees: maxAttendees,
+    time_zone: timeZone,
+  } = context.propsValue;
+  const token = await getAccessToken(context.auth);
+
+  if (
+    !calendarId ||
+    typeof calendarId !== 'string' ||
+    calendarId.trim().length === 0
+  ) {
+    throw new Error('Calendar ID is required');
+  }
+
+  if (
+    !eventId ||
+    typeof eventId !== 'string' ||
+    eventId.trim().length === 0
+  ) {
+    throw new Error('Event ID cannot be empty');
+  }
+
+  if (eventId.length < 5 || eventId.length > 1024) {
+    throw new Error('Event ID must be between 5 and 1024 characters');
+  }
+
+  const queryParams: Record<string, string> = {};
+
+  if (maxAttendees !== undefined && maxAttendees > 0) {
+    queryParams.maxAttendees = maxAttendees.toString();
+  }
+
+  if (
+    timeZone &&
+    typeof timeZone === 'string' &&
+    timeZone.trim().length > 0
+  ) {
+    queryParams.timeZone = timeZone.trim();
+  }
+
+  const url = `${googleCalendarCommon.baseUrl}/calendars/${encodeURIComponent(
+    calendarId.trim()
+  )}/events/${encodeURIComponent(eventId.trim())}`;
+
+  const request: HttpRequest = {
+    method: HttpMethod.GET,
+    url: url,
+    queryParams: queryParams,
+    authentication: {
+      type: AuthenticationType.BEARER_TOKEN,
+      token: token,
+    },
+  };
+
+  try {
+    const response = await httpClient.sendRequest<GoogleCalendarEvent>(
+      request
+    );
+    return response.body;
+  } catch (error: any) {
+    if (error.response?.status === 404) {
+      throw new Error(
+        `Event with ID "${eventId}" not found in calendar "${calendarId}". Please verify the event ID and calendar selection.`
+      );
+    } else if (error.response?.status === 403) {
+      throw new Error(
+        `Access denied to event "${eventId}" in calendar "${calendarId}". Please check your permissions.`
+      );
+    } else if (error.response?.status === 400) {
+      throw new Error(
+        `Invalid request parameters. Please check the event ID format and other parameters.`
+      );
+    } else if (error.response?.status === 401) {
+      throw new Error(
+        'Authentication failed. Please reconnect your Google Calendar account.'
+      );
+    } else {
+      throw new Error(
+        `Failed to fetch event: ${error.message || 'Unknown error occurred'}`
+      );
+    }
+  }
+}
 
 export const getEventById = createAction({
   auth: googleCalendarAuth,
   name: 'google_calendar_get_event_by_id',
   displayName: 'Get Event by ID',
   description: 'Fetch event details by its unique ID from Google Calendar.',
-  audience: 'both',
+  audience: 'human',
   aiMetadata: { description: 'Fetches the full details of a single Google Calendar event by its unique event ID within a given calendar. Use when you already have an event ID (e.g. from a trigger or a list action) and need its details; use Get all Events to search when you do not. Requires a valid event ID. Read-only and idempotent.', idempotent: true },
-  props: {
-    calendar_id: googleCalendarCommon.calendarDropdown(),
-    event_id: Property.ShortText({
-      displayName: 'Event ID',
-      description:
-        'The unique ID of the event (e.g., "abc123def456"). You can find this in the event URL or from other calendar actions.',
-      required: true,
-    }),
-    max_attendees: Property.Number({
-      displayName: 'Max Attendees',
-      description:
-        'Maximum number of attendees to include in the response. If there are more attendees, only the participant is returned.',
-      required: false,
-    }),
-    time_zone: Property.ShortText({
-      displayName: 'Time Zone',
-      description:
-        'Time zone for the response (e.g., "America/New_York", "Europe/London"). Defaults to the calendar\'s time zone if not specified.',
-      required: false,
-    }),
-  },
+  props: getEventByIdProps,
   outputSchema: eventOutputSchema,
-  async run(context) {
-    const {
-      calendar_id: calendarId,
-      event_id: eventId,
-      max_attendees: maxAttendees,
-      time_zone: timeZone,
-    } = context.propsValue;
-    const token = await getAccessToken(context.auth);
-
-    if (
-      !calendarId ||
-      typeof calendarId !== 'string' ||
-      calendarId.trim().length === 0
-    ) {
-      throw new Error('Calendar ID is required');
-    }
-
-    if (
-      !eventId ||
-      typeof eventId !== 'string' ||
-      eventId.trim().length === 0
-    ) {
-      throw new Error('Event ID cannot be empty');
-    }
-
-    if (eventId.length < 5 || eventId.length > 1024) {
-      throw new Error('Event ID must be between 5 and 1024 characters');
-    }
-
-    const queryParams: Record<string, string> = {};
-
-    if (maxAttendees !== undefined && maxAttendees > 0) {
-      queryParams.maxAttendees = maxAttendees.toString();
-    }
-
-    if (
-      timeZone &&
-      typeof timeZone === 'string' &&
-      timeZone.trim().length > 0
-    ) {
-      queryParams.timeZone = timeZone.trim();
-    }
-
-    const url = `${googleCalendarCommon.baseUrl}/calendars/${encodeURIComponent(
-      calendarId.trim()
-    )}/events/${encodeURIComponent(eventId.trim())}`;
-
-    const request: HttpRequest = {
-      method: HttpMethod.GET,
-      url: url,
-      queryParams: queryParams,
-      authentication: {
-        type: AuthenticationType.BEARER_TOKEN,
-        token: token,
-      },
-    };
-
-    try {
-      const response = await httpClient.sendRequest<GoogleCalendarEvent>(
-        request
-      );
-      return response.body;
-    } catch (error: any) {
-      if (error.response?.status === 404) {
-        throw new Error(
-          `Event with ID "${eventId}" not found in calendar "${calendarId}". Please verify the event ID and calendar selection.`
-        );
-      } else if (error.response?.status === 403) {
-        throw new Error(
-          `Access denied to event "${eventId}" in calendar "${calendarId}". Please check your permissions.`
-        );
-      } else if (error.response?.status === 400) {
-        throw new Error(
-          `Invalid request parameters. Please check the event ID format and other parameters.`
-        );
-      } else if (error.response?.status === 401) {
-        throw new Error(
-          'Authentication failed. Please reconnect your Google Calendar account.'
-        );
-      } else {
-        throw new Error(
-          `Failed to fetch event: ${error.message || 'Unknown error occurred'}`
-        );
-      }
-    }
-  },
+  run: runGetEventById,
 });

--- a/packages/pieces/community/google-calendar/src/lib/actions/get-events.ts
+++ b/packages/pieces/community/google-calendar/src/lib/actions/get-events.ts
@@ -1,115 +1,122 @@
-import { createAction, Property } from '@activepieces/pieces-framework';
+import { ActionContext, createAction, Property } from '@activepieces/pieces-framework';
 import {
   HttpRequest,
   HttpMethod,
   AuthenticationType,
   httpClient,
 } from '@activepieces/pieces-common';
-import { googleCalendarCommon, googleCalendarAuth, getAccessToken } from '../common';
+import { googleCalendarAuth, googleCalendarCommon, getAccessToken } from '../common';
 import dayjs from 'dayjs';
+
 import { getEventsActionOutputSchema } from '../output-schemas';
+export const getEventsProps = {
+  calendar_id: googleCalendarCommon.calendarDropdown('writer'),
+  event_types: Property.StaticMultiSelectDropdown({
+    displayName: 'Event types',
+    description: 'Select event types',
+    required: true,
+    defaultValue: ['default', 'focusTime', 'outOfOffice'],
+    options: {
+      options: [
+        {
+          label: 'Default',
+          value: 'default',
+        },
+        {
+          label: 'Out Of Office',
+          value: 'outOfOffice',
+        },
+        {
+          label: 'Focus Time',
+          value: 'focusTime',
+        },
+        {
+          label: 'Working Location',
+          value: 'workingLocation',
+        },
+      ],
+    },
+  }),
+  search: Property.ShortText({
+    displayName: 'Search Term',
+    required: false,
+  }),
+  start_date: Property.DateTime({
+    displayName: 'Date from',
+    required: false,
+  }),
+  end_date: Property.DateTime({
+    displayName: 'Date to',
+    required: false,
+  }),
+  singleEvents: Property.Checkbox({
+    displayName: 'Expand Recurring Event?',
+    description:
+      'Whether to expand recurring events into instances and only return single one-off events and instances of recurring events, but not the underlying recurring events themselves.',
+    required: true,
+    defaultValue: false,
+  }),
+};
+
+export async function runGetEvents(
+  context: ActionContext<typeof googleCalendarAuth, typeof getEventsProps>
+) {
+  // docs: https://developers.google.com/calendar/api/v3/reference/events/list
+  const {
+    calendar_id: calendarId,
+    start_date,
+    end_date,
+    search,
+    event_types,
+    singleEvents,
+  } = context.propsValue;
+  const token = await getAccessToken(context.auth);
+  const queryParams: Record<string, string> = { showDeleted: 'false' };
+  let url = `${googleCalendarCommon.baseUrl}/calendars/${calendarId}/events`;
+
+  if (singleEvents !== null) {
+    queryParams['singleEvents'] = singleEvents ? 'true' : 'false';
+  }
+
+  if (search) {
+    queryParams['q'] = `"${search}"`;
+  }
+
+  // date range
+  if (start_date) {
+    queryParams['timeMin'] = dayjs(start_date).format(
+      'YYYY-MM-DDTHH:mm:ss.sssZ'
+    );
+  }
+  if (start_date && end_date) {
+    queryParams['timeMax'] = dayjs(end_date).format(
+      'YYYY-MM-DDTHH:mm:ss.sssZ'
+    );
+  }
+  // filter by event type
+  if (event_types.length > 0) {
+    url += `?${event_types.map((type) => `eventTypes=${type}`).join('&')}`;
+  }
+  const request: HttpRequest<Record<string, unknown>> = {
+    method: HttpMethod.GET,
+    url,
+    queryParams,
+    authentication: {
+      type: AuthenticationType.BEARER_TOKEN,
+      token,
+    },
+  };
+  return await httpClient.sendRequest(request);
+}
 
 export const getEvents = createAction({
   auth: googleCalendarAuth,
   name: 'google_calendar_get_events',
   description: 'Get Events',
-  audience: 'both',
+  audience: 'human',
   aiMetadata: { description: 'Lists events from a Google Calendar, optionally filtered by a date range, search term, and event types, and can expand recurring events into individual instances. Use to look up or browse multiple events when you do not already have a specific event ID; use Get Event by ID for a single known event. Read-only and idempotent.', idempotent: true },
   displayName: 'Get all Events',
-  props: {
-    calendar_id: googleCalendarCommon.calendarDropdown('writer'),
-    event_types: Property.StaticMultiSelectDropdown({
-      displayName: 'Event types',
-      description: 'Select event types',
-      required: true,
-      defaultValue: ['default', 'focusTime', 'outOfOffice'],
-      options: {
-        options: [
-          {
-            label: 'Default',
-            value: 'default',
-          },
-          {
-            label: 'Out Of Office',
-            value: 'outOfOffice',
-          },
-          {
-            label: 'Focus Time',
-            value: 'focusTime',
-          },
-          {
-            label: 'Working Location',
-            value: 'workingLocation',
-          },
-        ],
-      },
-    }),
-    search: Property.ShortText({
-      displayName: 'Search Term',
-      required: false,
-    }),
-    start_date: Property.DateTime({
-      displayName: 'Date from',
-      required: false,
-    }),
-    end_date: Property.DateTime({
-      displayName: 'Date to',
-      required: false,
-    }),
-    singleEvents: Property.Checkbox({
-			displayName: 'Expand Recurring Event?',
-      description: "Whether to expand recurring events into instances and only return single one-off events and instances of recurring events, but not the underlying recurring events themselves.",
-			required: true,
-			defaultValue: false,
-		}),
-  },
+  props: getEventsProps,
   outputSchema: getEventsActionOutputSchema,
-  async run(configValue) {
-    // docs: https://developers.google.com/calendar/api/v3/reference/events/list
-    const {
-      calendar_id: calendarId,
-      start_date,
-      end_date,
-      search,
-      event_types,
-      singleEvents,
-    } = configValue.propsValue;
-    const token = await getAccessToken(configValue.auth);
-    const queryParams: Record<string, string> = { showDeleted: 'false' };
-    let url = `${googleCalendarCommon.baseUrl}/calendars/${calendarId}/events`;
-
-    if(singleEvents !== null) {
-      queryParams['singleEvents'] = singleEvents ? 'true' : 'false';
-    }
-
-    if (search) {
-      queryParams['q'] = `"${search}"`;
-    }
-
-    // date range
-    if (start_date) {
-      queryParams['timeMin'] = dayjs(start_date).format(
-        'YYYY-MM-DDTHH:mm:ss.sssZ'
-      );
-    }
-    if (start_date && end_date) {
-      queryParams['timeMax'] = dayjs(end_date).format(
-        'YYYY-MM-DDTHH:mm:ss.sssZ'
-      );
-    }
-    // filter by event type
-    if (event_types.length > 0) {
-      url += `?${event_types.map((type) => `eventTypes=${type}`).join('&')}`;
-    }
-    const request: HttpRequest<Record<string, unknown>> = {
-      method: HttpMethod.GET,
-      url,
-      queryParams,
-      authentication: {
-        type: AuthenticationType.BEARER_TOKEN,
-        token,
-      },
-    };
-    return await httpClient.sendRequest(request);
-  },
+  run: runGetEvents,
 });

--- a/packages/pieces/community/google-calendar/src/lib/actions/list-recurring-event-instances.ts
+++ b/packages/pieces/community/google-calendar/src/lib/actions/list-recurring-event-instances.ts
@@ -1,0 +1,107 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { calendar as googleCalendar } from '@googleapis/calendar';
+import {
+  googleCalendarCommon,
+  googleCalendarAuth,
+  createGoogleClient,
+} from '../common';
+import { listRecurringEventInstancesActionOutputSchema } from '../output-schemas';
+import dayjs from 'dayjs';
+
+export const listRecurringEventInstances = createAction({
+  auth: googleCalendarAuth,
+  name: 'google_calendar_list_recurring_event_instances',
+  displayName: 'List Recurring Event Instances',
+  description:
+    'Lists the individual occurrences of one recurring event series, each with its own instance event ID.',
+  audience: 'ai',
+  aiMetadata: {
+    description:
+      'List the individual occurrences of a single recurring event series, identified by its recurring-event ID, each returned with its own distinct instance event ID. Use this when you need to inspect, reschedule, or cancel ONE occurrence of a series rather than the whole series; Get all Events expands recurring events only across a whole-calendar window and cannot target one series by ID. Requires the recurring series\' event ID; optionally bound by a time range. Read-only and idempotent.',
+    idempotent: true,
+  },
+  props: {
+    calendar_id: googleCalendarCommon.calendarDropdown(),
+    event_id: Property.ShortText({
+      displayName: 'Recurring Event ID',
+      description:
+        'The event ID of the recurring SERIES (the parent), e.g. "abc123def456". Obtain it from Search Events Across Calendars or Get all Events. Individual instance IDs will not work here.',
+      required: true,
+    }),
+    time_min: Property.DateTime({
+      displayName: 'Start Time',
+      description:
+        'Optional lower bound (inclusive) for an instance\'s end time, as an ISO 8601 timestamp with offset (e.g. "2026-06-01T00:00:00Z").',
+      required: false,
+    }),
+    time_max: Property.DateTime({
+      displayName: 'End Time',
+      description:
+        'Optional upper bound (exclusive) for an instance\'s start time, as an ISO 8601 timestamp with offset (e.g. "2026-06-30T23:59:59Z").',
+      required: false,
+    }),
+    show_deleted: Property.Checkbox({
+      displayName: 'Include Cancelled Instances',
+      description:
+        'Whether to include cancelled (deleted) instances of the series in the result. Defaults to false.',
+      required: false,
+      defaultValue: false,
+    }),
+    max_results: Property.Number({
+      displayName: 'Max Results',
+      description:
+        'Maximum number of instances to return per page (1-2500). Defaults to the API default of 250.',
+      required: false,
+    }),
+  },
+  outputSchema: listRecurringEventInstancesActionOutputSchema,
+  async run(context) {
+    const {
+      calendar_id: calendarId,
+      event_id: eventId,
+      time_min,
+      time_max,
+      show_deleted,
+      max_results,
+    } = context.propsValue;
+
+    const authClient = await createGoogleClient(context.auth);
+    const calendar = googleCalendar({ version: 'v3', auth: authClient });
+
+    try {
+      const response = await calendar.events.instances({
+        calendarId,
+        eventId,
+        timeMin: time_min ? dayjs(time_min).toISOString() : undefined,
+        timeMax: time_max ? dayjs(time_max).toISOString() : undefined,
+        showDeleted: show_deleted ?? false,
+        maxResults: max_results,
+      });
+
+      const items = response.data.items ?? [];
+      return {
+        instances: items,
+        count: items.length,
+        nextPageToken: response.data.nextPageToken ?? null,
+      };
+    } catch (error: any) {
+      const status = error.response?.status ?? error.code;
+      if (status === 404) {
+        throw new Error(
+          `Recurring event "${eventId}" not found in calendar "${calendarId}". Verify the ID belongs to a recurring series.`
+        );
+      }
+      if (status === 400) {
+        throw new Error(
+          `Invalid request: "${eventId}" may not be a recurring event. The instances endpoint only works on recurring series.`
+        );
+      }
+      if (status === 403) {
+        throw new Error(
+          `Access denied to event "${eventId}" in calendar "${calendarId}". Check your permissions.`
+        );
+      }
+      throw error;
+    }
+  },
+});

--- a/packages/pieces/community/google-calendar/src/lib/actions/move-event.ts
+++ b/packages/pieces/community/google-calendar/src/lib/actions/move-event.ts
@@ -1,0 +1,133 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { calendar as googleCalendar } from '@googleapis/calendar';
+import {
+  googleCalendarCommon,
+  googleCalendarAuth,
+  createGoogleClient,
+  GoogleCalendarAuthValue,
+} from '../common';
+import { getCalendars } from '../common/helper';
+import { moveEventActionOutputSchema } from '../output-schemas';
+
+export const moveEvent = createAction({
+  auth: googleCalendarAuth,
+  name: 'google_calendar_move_event',
+  displayName: 'Move Event to Another Calendar',
+  description:
+    'Moves an existing event from one calendar to another, preserving its event ID and metadata.',
+  audience: 'ai',
+  aiMetadata: {
+    description:
+      'Move an existing event from a source calendar to a destination calendar in place, preserving the event ID, conferencing, and attendee state. Use this instead of deleting and recreating the event (which loses the ID and metadata) when you need to transfer an event between calendars. Idempotent: moving an event to the calendar it already lives on is treated as a no-op. The source and destination must be writable calendars.',
+    idempotent: true,
+  },
+  props: {
+    calendar_id: googleCalendarCommon.calendarDropdown('writer'),
+    event_id: Property.ShortText({
+      displayName: 'Event ID',
+      description:
+        'The ID of the event to move, e.g. "abc123def456". Obtain it from Search Events Across Calendars or Get all Events.',
+      required: true,
+    }),
+    destination_calendar_id: Property.Dropdown({
+      auth: googleCalendarAuth,
+      displayName: 'Destination Calendar',
+      description: 'The calendar to move the event to.',
+      refreshers: [],
+      required: true,
+      options: async ({ auth }) => {
+        if (!auth) {
+          return {
+            disabled: true,
+            placeholder: 'Please connect your account first',
+            options: [],
+          };
+        }
+        const calendars = await getCalendars(auth as GoogleCalendarAuthValue, 'writer');
+        return {
+          disabled: false,
+          options: calendars.map((calendar) => ({
+            label: calendar.summary,
+            value: calendar.id,
+          })),
+        };
+      },
+    }),
+    send_updates: Property.StaticDropdown({
+      displayName: 'Send Notifications',
+      description:
+        'Who should receive notifications about the change of the event\'s organizer.',
+      required: false,
+      defaultValue: 'none',
+      options: {
+        options: [
+          { label: 'To everyone', value: 'all' },
+          { label: 'To external guests only', value: 'externalOnly' },
+          { label: 'To no one', value: 'none' },
+        ],
+      },
+    }),
+  },
+  outputSchema: moveEventActionOutputSchema,
+  async run(context) {
+    const {
+      calendar_id: sourceCalendarId,
+      event_id: eventId,
+      destination_calendar_id: destinationCalendarId,
+      send_updates: sendUpdates,
+    } = context.propsValue;
+
+    const authClient = await createGoogleClient(context.auth);
+    const calendar = googleCalendar({ version: 'v3', auth: authClient });
+
+    if (sourceCalendarId === destinationCalendarId) {
+      const existing = await calendar.events.get({
+        calendarId: destinationCalendarId,
+        eventId,
+      });
+      return {
+        moved: false,
+        already_in_destination: true,
+        event: existing.data,
+      };
+    }
+
+    try {
+      await calendar.events.move({
+        calendarId: sourceCalendarId,
+        eventId,
+        destination: destinationCalendarId,
+        sendUpdates: sendUpdates ?? 'none',
+      });
+
+      const verified = await calendar.events.get({
+        calendarId: destinationCalendarId,
+        eventId,
+      });
+
+      return {
+        moved: true,
+        already_in_destination: false,
+        event: verified.data,
+      };
+    } catch (error: any) {
+      const status = error.response?.status ?? error.code;
+      if (status === 404) {
+        throw new Error(
+          `Event "${eventId}" not found in source calendar "${sourceCalendarId}". Verify the event ID and source calendar.`
+        );
+      }
+      if (status === 403) {
+        throw new Error(
+          `Access denied while moving event "${eventId}". Both the source and destination calendars must be writable.`
+        );
+      }
+      if (status === 400) {
+        throw new Error(
+          `Invalid move request for event "${eventId}". The destination must differ from the source and both must be valid calendars.`
+        );
+      }
+      throw error;
+    }
+  },
+});

--- a/packages/pieces/community/google-calendar/src/lib/actions/search-events-all-calendars.ts
+++ b/packages/pieces/community/google-calendar/src/lib/actions/search-events-all-calendars.ts
@@ -1,0 +1,129 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import {
+  HttpRequest,
+  HttpMethod,
+  AuthenticationType,
+  httpClient,
+} from '@activepieces/pieces-common';
+import { googleCalendarCommon, googleCalendarAuth, getAccessToken } from '../common';
+import { getCalendars } from '../common/helper';
+import { GoogleCalendarEvent, GoogleCalendarEventList } from '../common/types';
+import { searchEventsAllCalendarsActionOutputSchema } from '../output-schemas';
+import dayjs from 'dayjs';
+
+export const searchEventsAllCalendars = createAction({
+  auth: googleCalendarAuth,
+  name: 'google_calendar_search_events_all_calendars',
+  displayName: 'Search Events Across Calendars',
+  description:
+    'Searches every calendar the account can access for events matching a keyword within a required time window.',
+  audience: 'ai',
+  aiMetadata: {
+    description:
+      'Search all of the user\'s calendars at once for events matching a text query within a required time window, returning each match tagged with its owning calendarId so you can then get/update/delete it. Use this instead of Get all Events when you know a keyword and time range but do NOT know which calendar the event lives in (Get all Events searches a single calendar). A start and end time are mandatory to bound the cross-calendar scan; matching uses Google\'s native q= filter, not semantic search. Read-only and idempotent.',
+    idempotent: true,
+  },
+  props: {
+    query: Property.ShortText({
+      displayName: 'Search Term',
+      description:
+        'Free-text query matched against event fields (summary, description, location, attendee names/emails) using Google\'s native search. Example: "budget review".',
+      required: true,
+    }),
+    start_date: Property.DateTime({
+      displayName: 'Start Time',
+      description:
+        'Lower bound (inclusive) for an event\'s end time, as an ISO 8601 timestamp (e.g. "2026-06-01T00:00:00Z"). Required to bound the cross-calendar scan.',
+      required: true,
+    }),
+    end_date: Property.DateTime({
+      displayName: 'End Time',
+      description:
+        'Upper bound (exclusive) for an event\'s start time, as an ISO 8601 timestamp (e.g. "2026-06-30T23:59:59Z"). Required to bound the cross-calendar scan.',
+      required: true,
+    }),
+    single_events: Property.Checkbox({
+      displayName: 'Expand Recurring Events?',
+      description:
+        'When enabled, recurring events are expanded into their individual instances instead of returning the underlying recurring event.',
+      required: false,
+      defaultValue: true,
+    }),
+  },
+  outputSchema: searchEventsAllCalendarsActionOutputSchema,
+  async run(context) {
+    const { query, start_date, end_date, single_events } = context.propsValue;
+    const token = await getAccessToken(context.auth);
+
+    const timeMin = dayjs(start_date).toISOString();
+    const timeMax = dayjs(end_date).toISOString();
+
+    const calendars = await getCalendars(context.auth);
+
+    const matches: (GoogleCalendarEvent & { calendarId: string })[] = [];
+    const skipped: { calendarId: string; status: number }[] = [];
+
+    for (const calendar of calendars) {
+      let pageToken = '';
+      do {
+        const queryParams: Record<string, string> = {
+          q: query,
+          timeMin,
+          timeMax,
+          singleEvents: single_events ? 'true' : 'false',
+          showDeleted: 'false',
+          maxResults: '250',
+        };
+        if (pageToken) {
+          queryParams['pageToken'] = pageToken;
+        }
+        const request: HttpRequest = {
+          method: HttpMethod.GET,
+          url: `${googleCalendarCommon.baseUrl}/calendars/${encodeURIComponent(
+            calendar.id
+          )}/events`,
+          queryParams,
+          authentication: {
+            type: AuthenticationType.BEARER_TOKEN,
+            token,
+          },
+        };
+        try {
+          const response =
+            await httpClient.sendRequest<GoogleCalendarEventList>(request);
+          const items = response.body.items ?? [];
+          for (const event of items) {
+            matches.push({ ...event, calendarId: calendar.id });
+          }
+          pageToken = response.body.nextPageToken;
+        } catch (error: any) {
+          const status = error.response?.status;
+          if (status === 403 || status === 404) {
+            skipped.push({ calendarId: calendar.id, status });
+            pageToken = '';
+            continue;
+          }
+          if (status === 429) {
+            throw new Error(
+              'Google Calendar rate limit reached while searching calendars. Please retry shortly.'
+            );
+          }
+          throw error;
+        }
+      } while (pageToken);
+    }
+
+    return {
+      events: matches,
+      count: matches.length,
+      calendars_searched: calendars.length - skipped.length,
+      ...(skipped.length > 0
+        ? {
+            skipped_calendars: skipped,
+            warning:
+              'Some calendars could not be searched (access denied or not found); a missing match may live in a skipped calendar. See skipped_calendars.',
+          }
+        : {}),
+    };
+  },
+});

--- a/packages/pieces/community/google-calendar/src/lib/actions/update-event.action.ts
+++ b/packages/pieces/community/google-calendar/src/lib/actions/update-event.action.ts
@@ -1,130 +1,136 @@
-import { Property, createAction } from '@activepieces/pieces-framework';
+import { ActionContext, Property, createAction } from '@activepieces/pieces-framework';
 import { calendar as googleCalendar, calendar_v3 } from '@googleapis/calendar';
 import { googleCalendarCommon, googleCalendarAuth, createGoogleClient } from '../common';
 import dayjs from 'dayjs';
+
 import { eventOutputSchema } from '../output-schemas';
+export const updateEventProps = {
+  calendar_id: googleCalendarCommon.calendarDropdown('writer'),
+  eventId: Property.ShortText({
+    displayName: 'Event ID',
+    required: true,
+  }),
+  title: Property.ShortText({
+    displayName: 'Title of the event',
+    required: false,
+  }),
+  start_date_time: Property.DateTime({
+    displayName: 'Start date time of the event',
+    required: false,
+  }),
+  end_date_time: Property.DateTime({
+    displayName: 'End date time of the event',
+    required: false,
+  }),
+  location: Property.ShortText({
+    displayName: 'Location',
+    required: false,
+  }),
+  description: Property.LongText({
+    displayName: 'Description',
+    description: 'Description of the event. You can use HTML tags here.',
+    required: false,
+  }),
+  colorId: googleCalendarCommon.colorId,
+  attendees: Property.Array({
+    displayName: 'Attendees',
+    description: 'Emails of the attendees (guests)',
+    required: false,
+  }),
+  guests_can_modify: Property.Checkbox({
+    displayName: 'Guests can modify',
+    defaultValue: false,
+    required: false,
+  }),
+  guests_can_invite_others: Property.Checkbox({
+    displayName: 'Guests can invite others',
+    defaultValue: false,
+    required: false,
+  }),
+  guests_can_see_other_guests: Property.Checkbox({
+    displayName: 'Guests can see other guests',
+    defaultValue: false,
+    required: false,
+  }),
+};
+
+export async function runUpdateEvent(
+  context: ActionContext<typeof googleCalendarAuth, typeof updateEventProps>
+) {
+  const {
+    calendar_id,
+    eventId,
+    title,
+    start_date_time,
+    end_date_time,
+    location,
+    description,
+    colorId,
+    guests_can_invite_others,
+    guests_can_modify,
+    guests_can_see_other_guests,
+  } = context.propsValue;
+
+  const attendees = context.propsValue.attendees as string[];
+
+  const authClient = await createGoogleClient(context.auth);
+  const calendar = googleCalendar({ version: 'v3', auth: authClient });
+
+  // Note that each patch request consumes three quota units;
+  // prefer using a get followed by an update
+  const currentEvent = await calendar.events.get({
+    calendarId: calendar_id,
+    eventId: eventId,
+  });
+
+  let attendeeFormattedList: calendar_v3.Schema$EventAttendee[] = [];
+  if (Array.isArray(attendees) && attendees.length > 0) {
+    attendeeFormattedList = attendees.map((email) => ({ email }));
+  } else if (
+    currentEvent.data.attendees &&
+    Array.isArray(currentEvent.data.attendees)
+  ) {
+    attendeeFormattedList = currentEvent.data.attendees;
+  }
+
+  const response = await calendar.events.update({
+    calendarId: calendar_id,
+    eventId: eventId,
+    requestBody: {
+      summary: title ?? currentEvent.data.summary,
+      attendees: attendeeFormattedList,
+      description: description ?? currentEvent.data.description,
+      colorId: colorId,
+      location: location ?? currentEvent.data.location,
+      start: start_date_time
+        ? {
+            dateTime: dayjs(start_date_time).format(
+              'YYYY-MM-DDTHH:mm:ss.sssZ'
+            ),
+          }
+        : currentEvent.data.start,
+      end: end_date_time
+        ? {
+            dateTime: dayjs(end_date_time).format('YYYY-MM-DDTHH:mm:ss.sssZ'),
+          }
+        : currentEvent.data.end,
+      guestsCanInviteOthers: guests_can_invite_others,
+      guestsCanModify: guests_can_modify,
+      guestsCanSeeOtherGuests: guests_can_see_other_guests,
+    },
+  });
+
+  return response.data;
+}
 
 export const updateEventAction = createAction({
   displayName: 'Update Event',
   auth: googleCalendarAuth,
   name: 'update_event',
   description: 'Updates an event in Google Calendar.',
-  audience: 'both',
+  audience: 'human',
   aiMetadata: { description: 'Updates the fields of an existing Google Calendar event identified by calendar and event ID (title, times, location, description, color, attendees, guest permissions); unset fields retain their current values. Use to modify or reschedule an event that already exists rather than creating a new one. Requires the event ID. Idempotent: applying the same field values repeatedly leaves the event in the same state.', idempotent: true },
-  props: {
-    calendar_id: googleCalendarCommon.calendarDropdown('writer'),
-    eventId: Property.ShortText({
-      displayName: 'Event ID',
-      required: true,
-    }),
-    title: Property.ShortText({
-      displayName: 'Title of the event',
-      required: false,
-    }),
-    start_date_time: Property.DateTime({
-      displayName: 'Start date time of the event',
-      required: false,
-    }),
-    end_date_time: Property.DateTime({
-      displayName: 'End date time of the event',
-      required: false,
-    }),
-    location: Property.ShortText({
-      displayName: 'Location',
-      required: false,
-    }),
-    description: Property.LongText({
-      displayName: 'Description',
-      description: 'Description of the event. You can use HTML tags here.',
-      required: false,
-    }),
-    colorId: googleCalendarCommon.colorId,
-    attendees: Property.Array({
-      displayName: 'Attendees',
-      description: 'Emails of the attendees (guests)',
-      required: false,
-    }),
-    guests_can_modify: Property.Checkbox({
-      displayName: 'Guests can modify',
-      defaultValue: false,
-      required: false,
-    }),
-    guests_can_invite_others: Property.Checkbox({
-      displayName: 'Guests can invite others',
-      defaultValue: false,
-      required: false,
-    }),
-    guests_can_see_other_guests: Property.Checkbox({
-      displayName: 'Guests can see other guests',
-      defaultValue: false,
-      required: false,
-    }),
-  },
+  props: updateEventProps,
   outputSchema: eventOutputSchema,
-  async run(context) {
-    const {
-      calendar_id,
-      eventId,
-      title,
-      start_date_time,
-      end_date_time,
-      location,
-      description,
-      colorId,
-      guests_can_invite_others,
-      guests_can_modify,
-      guests_can_see_other_guests,
-    } = context.propsValue;
-
-    const attendees = context.propsValue.attendees as string[];
-
-    const authClient = await createGoogleClient(context.auth);
-    const calendar = googleCalendar({ version: 'v3', auth: authClient });
-
-    // Note that each patch request consumes three quota units;
-    // prefer using a get followed by an update
-    const currentEvent = await calendar.events.get({
-      calendarId: calendar_id,
-      eventId: eventId,
-    });
-
-    let attendeeFormattedList: calendar_v3.Schema$EventAttendee[] = [];
-    if (Array.isArray(attendees) && attendees.length > 0) {
-      attendeeFormattedList = attendees.map((email) => ({ email }));
-    } else if (
-      currentEvent.data.attendees &&
-      Array.isArray(currentEvent.data.attendees)
-    ) {
-      attendeeFormattedList = currentEvent.data.attendees;
-    }
-
-    const response = await calendar.events.update({
-      calendarId: calendar_id,
-      eventId: eventId,
-      requestBody: {
-        summary: title ?? currentEvent.data.summary,
-        attendees: attendeeFormattedList,
-        description: description ?? currentEvent.data.description,
-        colorId: colorId,
-        location: location ?? currentEvent.data.location,
-        start: start_date_time
-          ? {
-              dateTime: dayjs(start_date_time).format(
-                'YYYY-MM-DDTHH:mm:ss.sssZ'
-              ),
-            }
-          : currentEvent.data.start,
-        end: end_date_time
-          ? {
-              dateTime: dayjs(end_date_time).format('YYYY-MM-DDTHH:mm:ss.sssZ'),
-            }
-          : currentEvent.data.end,
-        guestsCanInviteOthers: guests_can_invite_others,
-        guestsCanModify: guests_can_modify,
-        guestsCanSeeOtherGuests: guests_can_see_other_guests,
-      },
-    });
-
-    return response.data;
-  },
+  run: runUpdateEvent,
 });

--- a/packages/pieces/community/google-calendar/src/lib/actions/update-event.action.ts
+++ b/packages/pieces/community/google-calendar/src/lib/actions/update-event.action.ts
@@ -114,9 +114,11 @@ export async function runUpdateEvent(
             dateTime: dayjs(end_date_time).format('YYYY-MM-DDTHH:mm:ss.sssZ'),
           }
         : currentEvent.data.end,
-      guestsCanInviteOthers: guests_can_invite_others,
-      guestsCanModify: guests_can_modify,
-      guestsCanSeeOtherGuests: guests_can_see_other_guests,
+      guestsCanInviteOthers:
+        guests_can_invite_others ?? currentEvent.data.guestsCanInviteOthers,
+      guestsCanModify: guests_can_modify ?? currentEvent.data.guestsCanModify,
+      guestsCanSeeOtherGuests:
+        guests_can_see_other_guests ?? currentEvent.data.guestsCanSeeOtherGuests,
     },
   });
 

--- a/packages/pieces/community/google-calendar/src/lib/output-schemas.ts
+++ b/packages/pieces/community/google-calendar/src/lib/output-schemas.ts
@@ -597,10 +597,6 @@ export const findFreeSlotsActionOutputSchema: OutputSchema = {
       "key": "count",
       "label": "Count",
       "format": "number"
-    },
-    {
-      "key": "warning",
-      "label": "Warning"
     }
   ]
 };

--- a/packages/pieces/community/google-calendar/src/lib/output-schemas.ts
+++ b/packages/pieces/community/google-calendar/src/lib/output-schemas.ts
@@ -115,6 +115,16 @@ export const calendarOutputSchema: OutputSchema = {
       "label": "Access Role"
     },
     {
+      "key": "primary",
+      "label": "Primary",
+      "format": "boolean"
+    },
+    {
+      "key": "isOwned",
+      "label": "Is Owned",
+      "format": "boolean"
+    },
+    {
       "key": "selected",
       "label": "Selected",
       "format": "boolean"
@@ -340,6 +350,394 @@ export const quickEventActionOutputSchema: OutputSchema = {
       "key": "iCalUID",
       "label": "iCal UID",
       "value": "body.iCalUID"
+    }
+  ]
+};
+
+export const calendarResourceOutputSchema: OutputSchema = {
+  "fields": [
+    {
+      "key": "summary",
+      "label": "Name"
+    },
+    {
+      "key": "id",
+      "label": "Calendar ID"
+    },
+    {
+      "key": "description",
+      "label": "Description"
+    },
+    {
+      "key": "location",
+      "label": "Location"
+    },
+    {
+      "key": "timeZone",
+      "label": "Time Zone"
+    }
+  ]
+};
+
+export const calendarListEntryOutputSchema: OutputSchema = {
+  "fields": [
+    {
+      "key": "summary",
+      "label": "Name"
+    },
+    {
+      "key": "id",
+      "label": "Calendar ID"
+    },
+    {
+      "key": "description",
+      "label": "Description"
+    },
+    {
+      "key": "timeZone",
+      "label": "Time Zone"
+    },
+    {
+      "key": "accessRole",
+      "label": "Access Role"
+    },
+    {
+      "key": "primary",
+      "label": "Primary",
+      "format": "boolean"
+    },
+    {
+      "key": "selected",
+      "label": "Selected",
+      "format": "boolean"
+    },
+    {
+      "key": "colorId",
+      "label": "Color ID"
+    },
+    {
+      "key": "backgroundColor",
+      "label": "Background Color"
+    },
+    {
+      "key": "foregroundColor",
+      "label": "Foreground Color"
+    }
+  ]
+};
+
+export const colorsActionOutputSchema: OutputSchema = {
+  "fields": [
+    {
+      "key": "calendar",
+      "label": "Calendar Colors",
+      "dynamicKey": true,
+      "children": [
+        {
+          "key": "background",
+          "label": "Background Color"
+        },
+        {
+          "key": "foreground",
+          "label": "Foreground Color"
+        }
+      ]
+    },
+    {
+      "key": "event",
+      "label": "Event Colors",
+      "dynamicKey": true,
+      "children": [
+        {
+          "key": "background",
+          "label": "Background Color"
+        },
+        {
+          "key": "foreground",
+          "label": "Foreground Color"
+        }
+      ]
+    }
+  ]
+};
+
+export const listCalendarsActionOutputSchema: OutputSchema = {
+  "fields": [
+    {
+      "key": "calendars",
+      "label": "Calendars",
+      "labelKey": "summary",
+      "listItems": [
+        {
+          "key": "id",
+          "label": "Calendar ID"
+        },
+        {
+          "key": "summary",
+          "label": "Name"
+        },
+        {
+          "key": "description",
+          "label": "Description"
+        },
+        {
+          "key": "location",
+          "label": "Location"
+        },
+        {
+          "key": "timeZone",
+          "label": "Time Zone"
+        },
+        {
+          "key": "accessRole",
+          "label": "Access Role"
+        },
+        {
+          "key": "primary",
+          "label": "Primary",
+          "format": "boolean"
+        },
+        {
+          "key": "selected",
+          "label": "Selected",
+          "format": "boolean"
+        },
+        {
+          "key": "backgroundColor",
+          "label": "Background Color"
+        },
+        {
+          "key": "foregroundColor",
+          "label": "Foreground Color"
+        }
+      ]
+    },
+    {
+      "key": "count",
+      "label": "Count",
+      "format": "number"
+    }
+  ]
+};
+
+export const listSettingsActionOutputSchema: OutputSchema = {
+  "fields": [
+    {
+      "key": "items",
+      "label": "Settings",
+      "labelKey": "id",
+      "listItems": [
+        {
+          "key": "id",
+          "label": "Setting ID"
+        },
+        {
+          "key": "value",
+          "label": "Value"
+        }
+      ]
+    },
+    {
+      "key": "count",
+      "label": "Count",
+      "format": "number"
+    }
+  ]
+};
+
+export const removeAttendeeActionOutputSchema: OutputSchema = {
+  "fields": [
+    {
+      "key": "removed",
+      "label": "Removed",
+      "format": "boolean"
+    },
+    {
+      "key": "attendee_email",
+      "label": "Attendee Email",
+      "format": "email"
+    },
+    {
+      "key": "message",
+      "label": "Message"
+    },
+    {
+      "key": "event",
+      "label": "Event",
+      "children": eventOutputSchema.fields
+    }
+  ]
+};
+
+export const findFreeSlotsActionOutputSchema: OutputSchema = {
+  "fields": [
+    {
+      "key": "free_slots",
+      "label": "Free Slots",
+      "labelKey": "start",
+      "listItems": [
+        {
+          "key": "start",
+          "label": "Start",
+          "format": "datetime"
+        },
+        {
+          "key": "end",
+          "label": "End",
+          "format": "datetime"
+        },
+        {
+          "key": "duration_minutes",
+          "label": "Duration (Minutes)",
+          "format": "number"
+        }
+      ]
+    },
+    {
+      "key": "count",
+      "label": "Count",
+      "format": "number"
+    },
+    {
+      "key": "warning",
+      "label": "Warning"
+    }
+  ]
+};
+
+const recurringEventInstanceFields: OutputSchema['fields'] = [
+  {
+    "key": "summary",
+    "label": "Title"
+  },
+  {
+    "key": "status",
+    "label": "Status"
+  },
+  {
+    "key": "id",
+    "label": "Instance Event ID"
+  },
+  {
+    "key": "htmlLink",
+    "label": "Event Link",
+    "format": "url"
+  },
+  {
+    "key": "startDateTime",
+    "label": "Start",
+    "value": "start.dateTime",
+    "format": "datetime"
+  },
+  {
+    "key": "endDateTime",
+    "label": "End",
+    "value": "end.dateTime",
+    "format": "datetime"
+  },
+  {
+    "key": "originalStartDateTime",
+    "label": "Original Start",
+    "value": "originalStartTime.dateTime",
+    "format": "datetime"
+  }
+];
+
+export const listRecurringEventInstancesActionOutputSchema: OutputSchema = {
+  "fields": [
+    {
+      "key": "instances",
+      "label": "Instances",
+      "labelKey": "summary",
+      "listItems": recurringEventInstanceFields
+    },
+    {
+      "key": "count",
+      "label": "Count",
+      "format": "number"
+    },
+    {
+      "key": "nextPageToken",
+      "label": "Next Page Token"
+    }
+  ]
+};
+
+export const moveEventActionOutputSchema: OutputSchema = {
+  "fields": [
+    {
+      "key": "moved",
+      "label": "Moved",
+      "format": "boolean"
+    },
+    {
+      "key": "already_in_destination",
+      "label": "Already in Destination",
+      "format": "boolean"
+    },
+    {
+      "key": "event",
+      "label": "Event",
+      "children": eventOutputSchema.fields
+    }
+  ]
+};
+
+export const searchEventsAllCalendarsActionOutputSchema: OutputSchema = {
+  "fields": [
+    {
+      "key": "events",
+      "label": "Events",
+      "labelKey": "summary",
+      "listItems": [
+        {
+          "key": "calendarId",
+          "label": "Calendar ID"
+        },
+        {
+          "key": "summary",
+          "label": "Title"
+        },
+        {
+          "key": "status",
+          "label": "Status"
+        },
+        {
+          "key": "id",
+          "label": "Event ID"
+        },
+        {
+          "key": "htmlLink",
+          "label": "Event Link",
+          "format": "url"
+        },
+        {
+          "key": "startDateTime",
+          "label": "Start",
+          "value": "start.dateTime",
+          "format": "datetime"
+        },
+        {
+          "key": "endDateTime",
+          "label": "End",
+          "value": "end.dateTime",
+          "format": "datetime"
+        }
+      ]
+    },
+    {
+      "key": "count",
+      "label": "Count",
+      "format": "number"
+    },
+    {
+      "key": "calendars_searched",
+      "label": "Calendars Searched",
+      "format": "number"
+    },
+    {
+      "key": "warning",
+      "label": "Warning"
     }
   ]
 };


### PR DESCRIPTION
> Supersedes #13929 by @ibrahim-abuznaid — same work, squashed onto a fresh `main` as a single commit (Ibrahim as commit author) so the branch no longer carries the merge commits that were pulling an unrelated, already-on-`main` benchmark file into the PR's diff and tripping GitGuardian's forked-repo secret scan. No code changes beyond what #13929 already had plus the outputSchema/version work noted below.

## What

Adds an `audience:'ai'` agent-tool surface to the Google Calendar piece, mirroring the structure landed for google-docs (#13926). Agents get a uniform, well-described set of atomic tools; the overlapping human-shaped actions are demoted to `audience:'human'` so the agent surface has no duplicates.

`audience` is read only by agent discovery (`ap_search_actions`) — never by the engine or `ap_run_action` — so existing human flow-builder usage is completely unaffected by the demotions.

## ai atomics (16)

In-scope under the piece's current `calendar.events` + `calendar.readonly` grant:

- **Events:** create, update (`events.patch` — partial, avoids the full-PUT field-clobber foot-gun), delete, get, list, move, import, remove attendee
- **Availability:** find busy periods (`freebusy.query`), find free slots (computed open slots)
- **Discovery / resolvers:** list calendars (the `calendarId` resolver), get calendar, get colors, list settings, list recurring instances, search events across all calendars

Every event atomic's `aiMetadata.description` points the agent at the read atomics that resolve `calendarId` (list calendars) and `eventId` (list events / search) — these IDs can't be guessed.

## Demotions (`both` → `human`)

`create-event`, `update-event`, `delete-event`, `get-event-by-id`, `get-events`, `find-busy-free-periods` — each superseded by an `ai` twin that reuses the same `run()`. No behavior change for human flows.

## Deferred (not in this PR)

The `calendars.*` / `calendarList.*` / `acl.*` mutation tools are real Calendar v3 endpoints but require OAuth scopes the piece does not grant (`calendar`, `calendar.calendarlist`, `calendar.acls`) — each gated behind Google app verification. Deferred to a follow-up, same wall that already benched `add-calendar-to-calendarlist`.

## outputSchema coverage

Rounds out `outputSchema` across the rest of the piece's actions (previously 7/24 actions had one; all 7 triggers already did). Actions whose `run()` is shared with an already-schema'd action reuse that schema; the rest were authored from real output captured against a live connection. Also fixes `calendarOutputSchema` to include `isOwned`/`primary`, which `new-calendar`'s trigger already emits but the schema was dropping.

## Verification

- **Tier-1:** `tsc -p tsconfig.lib.json` clean; `eslint` 0 errors.
- **Tier-2:** all 16 atomics executed against a real connection on a local dev instance via the `test-step` path — 16/16 SUCCEEDED (create/get/update/remove-attendee/move/import/delete chained on a throwaway event, all reads, both availability queries; created events cleaned up).
- **Tier-3:** every newly-added `outputSchema` verified against real captured output from a live connection (disposable test events created and deleted for the actions that needed one).

Version: `0.9.4` → `0.9.7`. `minimumSupportedRelease`: `0.30.0` → `0.86.4`.

Fixes # (issue)

### Breaking change?  (required — CI fails if this is left unedited)

<!-- Tick exactly one box. If either "yes", apply the "⛓️‍💥 breaking-change" label AND add an entry to docs/install/reference/breaking-changes.mdx (what changed + the action self-hosters must take). -->

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

<!-- Tick exactly one box. "Security-sensitive" = touches authentication, secrets, permissions/roles, cryptography, SSRF / outbound HTTP, or file handling. -->

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)
