### PR TITLE
fix(salesforce): cap Find Record FIELDS(ALL) query at LIMIT 200

### DIFF
--- a/packages/pieces/community/salesforce/package.json
+++ b/packages/pieces/community/salesforce/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-salesforce",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {

--- a/packages/pieces/community/salesforce/src/lib/action/find-record.ts
+++ b/packages/pieces/community/salesforce/src/lib/action/find-record.ts
@@ -9,7 +9,7 @@ export const findRecord = createAction({
     displayName: 'Find Record',
     description: 'Finds a record by a field value.',
     audience: 'both',
-    aiMetadata: { description: 'Look up records of a chosen Salesforce object where a single field equals an exact value (read-only, returns up to 2000 matches). Pick this for simple equality lookups by a known field such as Email or Name; for multi-condition filters, joins, or sorting use Run Query (SOQL) instead.', idempotent: true },
+    aiMetadata: { description: 'Look up records of a chosen Salesforce object where a single field equals an exact value (read-only, returns up to 200 matches). Pick this for simple equality lookups by a known field such as Email or Name; for multi-condition filters, joins, or sorting use Run Query (SOQL) instead.', idempotent: true },
     props: {
         object: salesforcesCommon.object,
         field: salesforcesCommon.field,
@@ -26,9 +26,9 @@ export const findRecord = createAction({
             throw new Error('Object and Field must be selected.');
         }
 
-        const escapedSearchValue = search_value.replace(/'/g, "\\'");
+        const escapedSearchValue = search_value.replace(/\\/g, '\\\\').replace(/'/g, "\\'");
 
-        const query = `SELECT FIELDS(ALL) FROM ${object} WHERE ${field} = '${escapedSearchValue}' LIMIT 2000`;
+        const query = `SELECT FIELDS(ALL) FROM ${object} WHERE ${field} = '${escapedSearchValue}' LIMIT 200`;
 
         const response = await querySalesforceApi(
             HttpMethod.GET,


### PR DESCRIPTION
## Description

`Find Record` failed on every call, for any object/field, since it shipped. Salesforce rejects SOQL `FIELDS(ALL)` queries with `LIMIT > 200` at parse time (`MALFORMED_QUERY: The SOQL FIELDS function must have a LIMIT of at most 200`) — the action used `LIMIT 2000`, which no Salesforce API version has ever accepted.

- `packages/pieces/community/salesforce/src/lib/action/find-record.ts`: `LIMIT 2000` → `LIMIT 200`, updated `aiMetadata` description to match.
- Also escaped backslashes in `search_value` before escaping single quotes, closing a SOQL-injection foothold (an input like `trailing\` produced an unterminated string literal).
- Bumped piece version to `0.7.7`.

All other `FIELDS(ALL)` queries elsewhere in the piece (`find-records-by-query.ts`, triggers, etc.) already used `LIMIT 200` — this action was the only outlier.

## How was this tested?

- Manually reproduced the reported `400 MALFORMED_QUERY` error against a live Salesforce connection with the old code, confirmed it's gone after the fix.
- Verified the escaping change by tracing values like `Test\'Injection` and `Test\` through the new `.replace(/\\/g, '\\\\').replace(/'/g, "\\'")` chain to confirm a well-formed, safely-terminated SOQL string literal.
- CE edition path only (Salesforce piece has no EE/Cloud-specific behavior).

Fixes #14521

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking

### Security impact?  (required — CI fails if this is left unedited)

- [x] yes — security-sensitive (fixes a SOQL-injection foothold: unescaped backslashes in a user-supplied search value could break out of the quoted string literal; now escaped before the quote-escaping step)