### PR TITLE
fix(ai-providers): pin the Azure resource name to a single dns label

### DIFF
--- a/packages/core/piece-types/src/lib/ai-providers.ts
+++ b/packages/core/piece-types/src/lib/ai-providers.ts
@@ -1,4 +1,4 @@
-import { AIProviderName, isNil } from '@activepieces/core-utils'
+import { AIProviderName, formErrors, isNil } from '@activepieces/core-utils'
 import * as z from 'zod/mini'
 
 export enum AIProviderModelType {
@@ -61,8 +61,12 @@ export const CloudflareGatewayProviderConfig = z.object({
 })
 export type CloudflareGatewayProviderConfig = z.infer<typeof CloudflareGatewayProviderConfig>
 
+// The resource name is interpolated into `https://<resourceName>.openai.azure.com`, so it has to
+// stay a single DNS label. Azure allows alphanumerics and inner hyphens, up to 64 characters.
+export const AZURE_RESOURCE_NAME_PATTERN = /^[A-Za-z0-9](?:[A-Za-z0-9-]{0,62}[A-Za-z0-9])?$/
+
 export const AzureProviderConfig = z.object({
-    resourceName: z.string(),
+    resourceName: z.string().check(z.regex(AZURE_RESOURCE_NAME_PATTERN, formErrors.invalidAzureResourceName)),
     apiVersion: z.pipe(
         z.transform((v) => (typeof v === 'string' && v.trim().length === 0 ? undefined : v)),
         z.optional(z.string()),

--- a/packages/core/shared/src/lib/management/ai-providers/index.ts
+++ b/packages/core/shared/src/lib/management/ai-providers/index.ts
@@ -1,4 +1,5 @@
-import { AIProviderName, BaseModelSchema } from '@activepieces/core-utils'
+import { AZURE_RESOURCE_NAME_PATTERN } from '@activepieces/core-piece-types'
+import { AIProviderName, BaseModelSchema, formErrors } from '@activepieces/core-utils'
 import { z } from 'zod'
 
 export enum AIProviderModelType {
@@ -78,7 +79,7 @@ export const CloudflareGatewayProviderConfig = z.object({
 export type CloudflareGatewayProviderConfig = z.infer<typeof CloudflareGatewayProviderConfig>
 
 export const AzureProviderConfig = z.object({
-    resourceName: z.string(),
+    resourceName: z.string().regex(AZURE_RESOURCE_NAME_PATTERN, formErrors.invalidAzureResourceName),
     apiVersion: z.preprocess(
         (v) => (typeof v === 'string' && v.trim().length === 0 ? undefined : v),
         z.string().optional(),
@@ -347,6 +348,7 @@ export {
     ACTIVEPIECES_CHAT_TIERS,
     DEFAULT_CHAT_TIER_ID,
     AI_PROVIDER_CAPABILITIES,
+    AZURE_RESOURCE_NAME_PATTERN,
     aiProviderUtils,
 } from '@activepieces/core-piece-types'
 export type { ActivepiecesChatTier, AIProviderCapabilities, AIWebSearchMode } from '@activepieces/core-piece-types'

--- a/packages/core/utils/src/lib/form-errors.ts
+++ b/packages/core/utils/src/lib/form-errors.ts
@@ -4,6 +4,7 @@ export const formErrors = {
     invalidGitRepoBranch: 'invalidGitRepoBranch',
     invalidGitRepoRemoteUrl: 'invalidGitRepoRemoteUrl',
     invalidExternalId: 'invalidExternalId',
+    invalidAzureResourceName: 'invalidAzureResourceName',
     invalidFileName: 'invalidFileName',
     messageRequiresContentOrFiles: 'messageRequiresContentOrFiles',
 } as const

--- a/packages/server/api/src/app/ai/providers/azure-provider.ts
+++ b/packages/server/api/src/app/ai/providers/azure-provider.ts
@@ -1,5 +1,5 @@
 import { httpClient, HttpMethod } from '@activepieces/pieces-common'
-import { AIProviderModel, AIProviderModelType, AzureProviderAuthConfig, AzureProviderConfig } from '@activepieces/shared'
+import { AIProviderModel, AIProviderModelType, AZURE_RESOURCE_NAME_PATTERN, AzureProviderAuthConfig, AzureProviderConfig } from '@activepieces/shared'
 import { FastifyBaseLogger } from 'fastify'
 import { AIProviderStrategy } from './ai-provider'
 
@@ -9,12 +9,18 @@ export const azureProvider: AIProviderStrategy<AzureProviderAuthConfig, AzurePro
         await azureProvider.listModels(authConfig, config)
     },
     async listModels(authConfig: AzureProviderAuthConfig, config: AzureProviderConfig): Promise<AIProviderModel[]> {
-        const endpoint = `https://${config.resourceName}.openai.azure.com`
         const apiKey = authConfig.apiKey
 
-        if (!endpoint || !apiKey) {
+        if (!apiKey) {
             return []
         }
+
+        const resourceName = config.resourceName ?? ''
+        if (!AZURE_RESOURCE_NAME_PATTERN.test(resourceName)) {
+            throw new Error('Azure resource name must be alphanumerics and hyphens only, up to 64 characters')
+        }
+
+        const endpoint = `https://${resourceName}.openai.azure.com`
 
         const res = await httpClient.sendRequest<{ data: AzureDeployment[] }>({
             url: `${endpoint}/openai/deployments?api-version=${AZURE_DEPLOYMENTS_API_VERSION}`,

--- a/packages/server/api/test/unit/app/ai/providers/azure-provider.test.ts
+++ b/packages/server/api/test/unit/app/ai/providers/azure-provider.test.ts
@@ -38,4 +38,24 @@ describe('azureProvider.listModels', () => {
         const requestUrl = mockSendRequest.mock.calls[0][0].url
         expect(requestUrl).toContain('api-version=2023-03-15-preview')
     })
+
+    it('keeps the request on the resource own azure host', async () => {
+        await azureProvider.listModels({ apiKey: 'test-key' }, { resourceName: 'my-resource' })
+
+        const requestUrl = new URL(mockSendRequest.mock.calls[0][0].url)
+        expect(requestUrl.host).toBe('my-resource.openai.azure.com')
+    })
+
+    it.each([
+        ['host swap', 'example.com/#'],
+        ['path escape', 'my-resource.openai.azure.com/x?y='],
+        ['userinfo', 'user@example.com#'],
+        ['port', 'my-resource:8080#'],
+        ['empty', ''],
+    ])('rejects a resource name that is not a single dns label (%s) without sending a request', async (_case, resourceName) => {
+        await expect(azureProvider.listModels({ apiKey: 'test-key' }, { resourceName })).rejects.toThrow(
+            'Azure resource name must be alphanumerics and hyphens only, up to 64 characters',
+        )
+        expect(mockSendRequest).not.toHaveBeenCalled()
+    })
 })


### PR DESCRIPTION
## Description

`azureProvider.listModels` built its endpoint as `https://${config.resourceName}.openai.azure.com` and handed it to `httpClient.sendRequest` (`packages/server/api/src/app/ai/providers/azure-provider.ts:12-26`). `resourceName` was a free-form string in `AzureProviderConfig`, so a value carrying `/`, `#`, `?`, `:` or `@` moved the request off the Azure host, and the deployment ids in whatever answered came back as the provider's model list on `GET /v1/ai-providers/azure/models`.

Every other strategy in that folder points at a hardcoded host, so Azure is the only one whose endpoint depends on stored config. The repo already constrains user strings that reach a URL context this way: `SAFE_REMOTE_URL_PATTERN` and `SAFE_BRANCH_PATTERN` in `packages/core/shared/src/lib/ee/git-repo/index.ts:6-7`.

`AZURE_RESOURCE_NAME_PATTERN` (`packages/core/piece-types/src/lib/ai-providers.ts`) pins the field to a single DNS label: alphanumerics with inner hyphens, up to 64 characters, which is what Azure accepts for the resource itself. It is applied in both `AzureProviderConfig` copies (`core-piece-types` and `shared`, kept in sync as they are today) and again in the provider before the URL is built, so a config stored before this change cannot reach the request either. The web form validates through `zodResolver(CreateAIProviderRequest)`, so it picks the constraint up without a change.

Deliberately left alone:

- The `AIProviderConfig` union still ends in empty-object members, so `POST /v1/ai-providers/:id` with a rejected resource name falls through to `{}` and strips the config instead of answering 400. Nothing is sent in that state (the provider throws), but 400 is the better answer. Fixing it means restructuring that union, which reaches well past this change.
- `httpClient` stays instead of `safeHttp.axios`. Once the label is validated the host suffix is fixed to `openai.azure.com`, so the URL is no longer user-controlled. Say the word if you want `.claude/rules/safe-http.md` applied literally here as well.

Behaviour change: an Azure provider whose stored `resourceName` is not a valid label now fails with a clear message instead of issuing a request to wherever the value pointed. Valid Azure resource names are unaffected, which is why the breaking-change box below says no.

### References

GHSA-75q7-562h-f8h4 (reported privately, unpublished at time of writing)

## How was this tested?

CE code paths only; no EE or Cloud specific code is touched.

- `npx turbo run build --filter=api --filter=web`: green.
- `npx turbo run lint --filter=@activepieces/shared --filter=api --filter=@activepieces/core-utils --filter=@activepieces/core-piece-types`: 0 errors.
- `npx turbo run test --filter=@activepieces/shared --filter=@activepieces/core-utils`: 458 passed.
- `npm run test-unit` in `packages/server/api`: the six `azure-provider.test.ts` cases pass. Five test files plus `workerGroupService > getWorkerGroupId` fail with `getaddrinfo EAI_AGAIN redis` in my environment; the same set fails identically on unpatched `main`, so they are unrelated to this change.
- Manual, real HTTP path (no mock): called `azureProvider.listModels` with `resourceName: '127.0.0.1:8443/pwned#'` against a local TLS listener. Before the change the listener logged `GET /pwned` with the `api-key` header and its response body came back as the model list; after the change no request is made and the call throws. A normal name still resolves to `my-resource.openai.azure.com`, covered by a new unit test.
- Not run here: the ce/ee/cloud integration suites and e2e, which need postgres and redis.

Fixes # (issue): n/a

### Breaking change?  (required — CI fails if this is left unedited)

<!-- Tick exactly one box. If either "yes", apply the "⛓️‍💥 breaking-change" label AND add an entry to docs/install/reference/breaking-changes.mdx (what changed + the action self-hosters must take). -->

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

<!-- Tick exactly one box. "Security-sensitive" = touches authentication, secrets, permissions/roles, cryptography, SSRF / outbound HTTP, or file handling. -->

- [ ] no — reviewed, no security impact
- [x] yes — security-sensitive (call out the risk and mitigation in the description above)
