### PR TITLE
chore(ci): stop the nightly canary redeploy from main

### DIFF
--- a/.github/workflows/continuous-delivery-canary.yml
+++ b/.github/workflows/continuous-delivery-canary.yml
@@ -3,8 +3,9 @@ name: Continuous Delivery — Canary
 on:
   workflow_dispatch:
   workflow_call:
-  schedule:
-    - cron: '0 9 * * *'  # Daily 9 AM UTC
+  # schedule:
+    # - cron: '0 9 * * *'  # Daily 9 AM UTC — scheduled runs always use the default branch,
+    #                        so this reverted canary to main and undid branch deployments
 
 jobs:
   build-image:


### PR DESCRIPTION
GitHub runs schedule triggers only from the default branch, so the daily 09:00 UTC cron rebuilt canary from main and silently undid any canary deployed from a feature branch. Canary now deploys only when dispatched or when the cloud CD pipeline calls it, both of which keep the branch the operator picked.


Fixes # (issue)

### Breaking change?  (required — CI fails if this is left unedited)

<!-- Tick exactly one box. If either "yes", apply the "⛓️‍💥 breaking-change" label AND add an entry to docs/install/reference/breaking-changes.mdx (what changed + the action self-hosters must take). -->

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

<!-- Tick exactly one box. "Security-sensitive" = touches authentication, secrets, permissions/roles, cryptography, SSRF / outbound HTTP, or file handling. -->

- [ ] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)
