### PR TITLE
fix(pieces): correct idempotent on 10 remote-render file-writing actions

### DIFF
--- a/packages/pieces/community/browserless/package.json
+++ b/packages/pieces/community/browserless/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-browserless",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/packages/pieces/community/browserless/src/lib/actions/capture-screenshot.ts
+++ b/packages/pieces/community/browserless/src/lib/actions/capture-screenshot.ts
@@ -8,7 +8,7 @@ export const captureScreenshot = createAction({
     displayName: 'Capture Screenshot',
     description: 'Take a screenshot of a web page',
     audience: 'both',
-    aiMetadata: { description: 'Renders a web page in a headless browser and returns a PNG or JPEG screenshot of it. Use to capture the visual state of a public URL; the page URL is required, and options like full-page capture, viewport size, clipping region, and waiting for a CSS selector control what is rendered. Read-only: re-running with the same input re-renders the page and produces an equivalent image without side effects.', idempotent: true },
+    aiMetadata: { description: 'Renders a web page in a headless browser and returns a PNG or JPEG screenshot of it. Use to capture the visual state of a public URL; the page URL is required, and options like full-page capture, viewport size, clipping region, and waiting for a CSS selector control what is rendered. Not idempotent: each call runs a fresh headless-browser render, so the returned image reflects the live page at the moment of the call.', idempotent: false },
     auth: browserlessAuth,
     props: {
         url: Property.ShortText({

--- a/packages/pieces/community/browserless/src/lib/actions/generate-pdf.ts
+++ b/packages/pieces/community/browserless/src/lib/actions/generate-pdf.ts
@@ -8,7 +8,7 @@ export const generatePdf = createAction({
     displayName: 'Generate PDF',
     description: 'Convert a web page to PDF',
     audience: 'both',
-    aiMetadata: { description: 'Renders content in a headless browser and returns it as a PDF file. Source the content either from a page URL or from a raw HTML string (provide exactly one, not both). Use to produce a printable PDF of a page or supplied markup, with control over paper format, orientation, margins, and headers/footers. Read-only: re-running with the same input re-renders an equivalent PDF without side effects.', idempotent: true },
+    aiMetadata: { description: 'Renders content in a headless browser and returns it as a PDF file. Source the content either from a page URL or from a raw HTML string (provide exactly one, not both). Use to produce a printable PDF of a page or supplied markup, with control over paper format, orientation, margins, and headers/footers. Not idempotent: each call runs a fresh headless-browser render, so repeating it produces a new PDF of the page or markup as it renders at that moment.', idempotent: false },
     auth: browserlessAuth,
     props: {
         url: Property.ShortText({

--- a/packages/pieces/community/filetopdf/package.json
+++ b/packages/pieces/community/filetopdf/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-filetopdf",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/packages/pieces/community/filetopdf/src/lib/actions/convert-file.ts
+++ b/packages/pieces/community/filetopdf/src/lib/actions/convert-file.ts
@@ -23,8 +23,8 @@ export const convertFile = createAction({
   audience: 'both',
   aiMetadata: {
     description:
-      'Converts an existing document to PDF, choosing the rendering engine from the file extension (Office formats, images, HTML, Markdown, or PDF passthrough). Operates in one of two source modes: upload binary file data, or pass a public http(s) file URL the server downloads (private/internal addresses are rejected). Choose this when the agent already has a source file or its URL, rather than raw HTML/Markdown text. The conversion is deterministic with no stored side effect, so re-running on the same input is safe and idempotent.',
-    idempotent: true,
+      'Converts an existing document to PDF, choosing the rendering engine from the file extension (Office formats, images, HTML, Markdown, or PDF passthrough). Operates in one of two source modes: upload binary file data, or pass a public http(s) file URL the server downloads (private/internal addresses are rejected). Choose this when the agent already has a source file or its URL, rather than raw HTML/Markdown text. Not idempotent: each call performs a fresh conversion on the FileToPDF service that produces a new file and consumes account credits.',
+    idempotent: false,
   },
   props: {
     source: Property.StaticDropdown({

--- a/packages/pieces/community/filetopdf/src/lib/actions/convert-html.ts
+++ b/packages/pieces/community/filetopdf/src/lib/actions/convert-html.ts
@@ -17,8 +17,8 @@ export const convertHtml = createAction({
   audience: 'both',
   aiMetadata: {
     description:
-      'Renders a raw HTML string (with optional injected CSS) to PDF via Chromium. Choose this when the agent holds HTML markup it generated or assembled in memory, rather than a file or URL. Requires the HTML content as input; rendering is deterministic with no stored side effect, so re-running on the same input is safe and idempotent.',
-    idempotent: true,
+      'Renders a raw HTML string (with optional injected CSS) to PDF via Chromium. Choose this when the agent holds HTML markup it generated or assembled in memory, rather than a file or URL. Requires the HTML content as input. Not idempotent: each call performs a fresh remote render on the FileToPDF service that produces a new file and consumes account credits.',
+    idempotent: false,
   },
   props: {
     html: Property.LongText({

--- a/packages/pieces/community/filetopdf/src/lib/actions/convert-markdown.ts
+++ b/packages/pieces/community/filetopdf/src/lib/actions/convert-markdown.ts
@@ -18,8 +18,8 @@ export const convertMarkdown = createAction({
   audience: 'both',
   aiMetadata: {
     description:
-      'Renders a raw Markdown string to PDF, applying a default stylesheet when no CSS is supplied (custom CSS overrides it). Choose this when the agent holds Markdown text it generated or assembled in memory, rather than a file, URL, or HTML. Requires the Markdown content as input; rendering is deterministic with no stored side effect, so re-running on the same input is safe and idempotent.',
-    idempotent: true,
+      'Renders a raw Markdown string to PDF, applying a default stylesheet when no CSS is supplied (custom CSS overrides it). Choose this when the agent holds Markdown text it generated or assembled in memory, rather than a file, URL, or HTML. Requires the Markdown content as input. Not idempotent: each call performs a fresh remote render on the FileToPDF service that produces a new file and consumes account credits.',
+    idempotent: false,
   },
   props: {
     markdown: Property.LongText({

--- a/packages/pieces/community/photoroom/package.json
+++ b/packages/pieces/community/photoroom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-photoroom",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {

--- a/packages/pieces/community/photoroom/src/lib/actions/remove-background.ts
+++ b/packages/pieces/community/photoroom/src/lib/actions/remove-background.ts
@@ -9,8 +9,8 @@ export const removeBackground = createAction({
   audience: 'both',
   aiMetadata: {
     description:
-      'Removes the background from an input image using the Photoroom segmentation API and writes the cutout to a file. Choose this to isolate a subject or produce a transparent-background version of a photo. Requires the raw image as a file input plus a filename for the generated output; the call is a pure transformation, so repeating it on the same image yields the same result with no extra side effect.',
-    idempotent: true,
+      'Removes the background from an input image using the Photoroom segmentation API and writes the cutout to a file. Choose this to isolate a subject or produce a transparent-background version of a photo. Requires the raw image as a file input plus a filename for the generated output. Not idempotent: each call performs a fresh server-side segmentation that produces a new file and consumes Photoroom account credits.',
+    idempotent: false,
   },
   auth: photoroomAuth,
   props: {

--- a/packages/pieces/community/polydoc/package.json
+++ b/packages/pieces/community/polydoc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-polydoc",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/packages/pieces/community/polydoc/src/lib/actions/capture-screenshot.ts
+++ b/packages/pieces/community/polydoc/src/lib/actions/capture-screenshot.ts
@@ -29,8 +29,8 @@ export const captureScreenshot = createAction({
   description: 'Capture a screenshot of a URL, inline HTML, or a saved template.',
   aiMetadata: {
     description:
-      'Captures a screenshot (PNG, JPEG, or WebP) of a URL, an inline HTML string, or a saved PolyDoc template. Supports full-page capture, custom viewport, and base64 or file output. Idempotent: the same input yields the same image.',
-    idempotent: true,
+      'Captures a screenshot (PNG, JPEG, or WebP) of a URL, an inline HTML string, or a saved PolyDoc template. Supports full-page capture, custom viewport, and base64 or file output. Not idempotent: each call performs a fresh capture on PolyDoc that produces a new file and consumes account credits, and a URL capture reflects the page as it is at capture time.',
+    idempotent: false,
   },
   props: {
     sourceType: sourceTypeProp('url'),

--- a/packages/pieces/community/polydoc/src/lib/actions/convert-pdf.ts
+++ b/packages/pieces/community/polydoc/src/lib/actions/convert-pdf.ts
@@ -29,8 +29,8 @@ export const convertToPdf = createAction({
   description: 'Convert HTML, a URL, or a saved template to a PDF.',
   aiMetadata: {
     description:
-      'Converts a URL, an inline HTML string, or a saved PolyDoc template into a PDF and returns the file (or delivers it to cloud storage / a webhook). Use it to render documents like invoices, reports, or contracts. Idempotent: the same input yields the same PDF.',
-    idempotent: true,
+      'Converts a URL, an inline HTML string, or a saved PolyDoc template into a PDF and returns the file (or delivers it to cloud storage / a webhook). Use it to render documents like invoices, reports, or contracts. Not idempotent: each call performs a fresh conversion on PolyDoc that produces a new file and consumes account credits, and the cloud-storage and webhook delivery modes send the file to an external destination.',
+    idempotent: false,
   },
   props: {
     sourceType: sourceTypeProp('url'),

--- a/packages/pieces/community/polydoc/src/lib/actions/generate-einvoice.ts
+++ b/packages/pieces/community/polydoc/src/lib/actions/generate-einvoice.ts
@@ -54,8 +54,8 @@ export const generateEinvoice = createAction({
   description: 'Generate a hybrid e-invoice PDF (Factur-X / ZUGFeRD, EN 16931) from a visual layout plus structured invoice data.',
   aiMetadata: {
     description:
-      'Generates a hybrid e-invoice PDF (Factur-X / ZUGFeRD, EN 16931) by embedding structured invoice XML into a visual PDF layout. EN 16931 requires payment terms or a due date, a seller tax ID for VAT category S, and consistent totals. Idempotent: the same input yields the same PDF.',
-    idempotent: true,
+      'Generates a hybrid e-invoice PDF (Factur-X / ZUGFeRD, EN 16931) by embedding structured invoice XML into a visual PDF layout. EN 16931 requires payment terms or a due date, a seller tax ID for VAT category S, and consistent totals. Not idempotent: each call performs a fresh generation on PolyDoc that produces a new file and consumes account credits, and the cloud-storage and webhook delivery modes send the file to an external destination.',
+    idempotent: false,
   },
   props: {
     sourceType: sourceTypeProp('html'),

--- a/packages/pieces/community/rendex/package.json
+++ b/packages/pieces/community/rendex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-rendex",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/packages/pieces/community/rendex/src/lib/actions/render-to-image.ts
+++ b/packages/pieces/community/rendex/src/lib/actions/render-to-image.ts
@@ -14,7 +14,7 @@ export const renderToImage = createAction({
   description:
     'Render raw HTML, a URL, or Markdown to an image (PNG, JPEG, WebP) or a PDF.',
   audience: 'both',
-  aiMetadata: { description: 'Renders source content into a downloadable image (PNG/JPEG/WebP) or PDF via the Rendex screenshot API, returning the rendered file. The Source mode determines what the content input means: raw HTML markup, a live page URL to capture, or Markdown. Use to turn HTML/Markdown or a webpage into a captured image or PDF; optionally capture the full scrollable page instead of just the viewport. Rendering is a pure transformation with no server-side state change, so repeating the same call produces the same output.', idempotent: true },
+  aiMetadata: { description: 'Renders source content into a downloadable image (PNG/JPEG/WebP) or PDF via the Rendex screenshot API, returning the rendered file. The Source mode determines what the content input means: raw HTML markup, a live page URL to capture, or Markdown. Use to turn HTML/Markdown or a webpage into a captured image or PDF; optionally capture the full scrollable page instead of just the viewport. Not idempotent: each call performs a fresh remote render that produces a new file, and in URL mode the capture reflects the live page at request time.', idempotent: false },
   props: {
     source_type: Property.StaticDropdown({
       displayName: 'Source',

--- a/packages/pieces/community/wafeq/package.json
+++ b/packages/pieces/community/wafeq/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-wafeq",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/packages/pieces/community/wafeq/src/lib/actions/download-invoice-pdf.ts
+++ b/packages/pieces/community/wafeq/src/lib/actions/download-invoice-pdf.ts
@@ -12,7 +12,7 @@ export const downloadInvoicePdf = createAction({
   audience: 'both',
   aiMetadata: {
     description:
-      'Fetches an existing Wafeq invoice as a PDF file for downstream use (email attachment, cloud storage, upload). Choose this when a flow needs the rendered invoice document rather than its data fields. Requires the invoice ID; the file name is optional. Read-only and idempotent — re-running returns the same PDF.',
+      'Fetches an existing Wafeq invoice as a PDF file for downstream use (email attachment, cloud storage, upload). Choose this when a flow needs the rendered invoice document rather than its data fields. Requires the invoice ID; the file name is optional. Read-only and idempotent — re-running downloads the invoice document again without changing anything in Wafeq (the PDF reflects the invoice as it stands at call time).',
     idempotent: true,
   },
   props: {


### PR DESCRIPTION
## Description

Ten curated community actions were marked `aiMetadata.idempotent: true` while actually performing a remote render or conversion job. Each call renders a new file server-side against a metered third-party API, so a retry is neither free nor equivalent. Agents read this flag to decide whether a retry is safe, so a wrong `true` is the harmful direction.

The corrected values match the actions with identical semantics already in the catalog, which all hold `idempotent: false`: `cloudconvert/capture-website`, `pdfcrowd/url_to_pdf` + `html_to_pdf`, `documerge` (3), `carbone/carbone_render_document`, `insta-charts/generate_chart_image`, and iloveapi's 15 conversion actions. `filetopdf`, `polydoc`, `browserless`, `photoroom` and `rendex` were the outliers.

Flipped to `false`:

| Piece | Actions |
|---|---|
| `filetopdf` | `convert_file`, `convert_html`, `convert_markdown` |
| `polydoc` | `capture_screenshot`, `convert_to_pdf`, `generate_einvoice` |
| `browserless` | `capture_screenshot`, `generate_pdf` |
| `photoroom` | `removeBackground` |
| `rendex` | `render_to_image` |

`polydoc/convert_to_pdf` and `generate_einvoice` additionally support presigned-URL and webhook delivery modes, which send the generated file to an external destination.

Descriptions that asserted idempotency or byte-determinism were reworded to match, since the description is read alongside the flag and would otherwise contradict it. One description-only change: `wafeq/download_invoice_pdf` keeps `idempotent: true` (it is an ordinary read of an existing document), but "re-running returns the same PDF" is now content-scoped.

Metadata only — no runtime behaviour changes. Each touched piece gets a patch version bump.

## How was this tested?

- `npx eslint` on all 11 changed `.ts` files: 0 errors (8 pre-existing `no-explicit-any` / unused-import warnings, untouched by this change).
- `npx tsc --noEmit` over the six touched pieces using the root `tsconfig.base.json` paths: 0 errors.
- Diff shape verified mechanically: 17 files, 24 insertions / 24 deletions, exactly 10 `idempotent: true` → `idempotent: false` transitions and no other value changes; no executable code touched.
- Values cross-checked against the equivalent merged actions listed above by reading each `run()` and its helpers.

Fixes # (issue)

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)