### PR TITLE
fix(flows): run and step output downloads save as .json instead of .bin

### DIFF
--- a/packages/server/api/test/integration/ce/file/files-controller.test.ts
+++ b/packages/server/api/test/integration/ce/file/files-controller.test.ts
@@ -271,6 +271,39 @@ describe('Files Controller', () => {
             expect(getResponse?.rawPayload.toString('utf-8')).toBe('engine read')
         })
 
+        it('serves a named log slice as an attachment with the uploaded .json filename', async () => {
+            const { mockProject, mockPlatform } = await mockAndSaveBasicSetup()
+            const engineToken = await generateMockToken({
+                type: PrincipalType.ENGINE,
+                id: apId(),
+                projectId: mockProject.id,
+                platform: { id: mockPlatform.id },
+            })
+            const fileId = apId()
+
+            await app!.inject({
+                method: 'PUT',
+                url: `/api/v1/files/${fileId}`,
+                query: { token: engineToken },
+                headers: {
+                    'content-type': 'application/octet-stream',
+                    'x-ap-file-type': FileType.FLOW_RUN_LOG_SLICE,
+                    'x-ap-file-name': 'step_1.json',
+                },
+                payload: Buffer.from('{"rows":[]}', 'utf-8'),
+            })
+
+            const getResponse = await app!.inject({
+                method: 'GET',
+                url: `/api/v1/files/${fileId}`,
+                query: { token: engineToken },
+            })
+
+            expect(getResponse?.statusCode).toBe(StatusCodes.OK)
+            expect(getResponse?.headers['content-disposition']).toBe('attachment; filename="step_1.json"')
+            expect(getResponse?.headers['x-content-type-options']).toBe('nosniff')
+        })
+
         it('rejects a download with a read token bound to a different fileId', async () => {
             const otherFileReadUrl = await filesService.constructReadUrl({
                 fileId: apId(),

--- a/packages/server/engine/src/lib/handler/context/flow-execution-context.ts
+++ b/packages/server/engine/src/lib/handler/context/flow-execution-context.ts
@@ -119,7 +119,7 @@ export class FlowExecutorContext {
         }
         else {
             const sliced = this.slicingEnabled
-                ? await maybeSliceOutput({ value: truncated.output, engineApi: this.engineApi })
+                ? await maybeSliceOutput({ value: truncated.output, engineApi: this.engineApi, stepName })
                 : undefined
             finalized = new GenericStepOutput({
                 type: truncated.type,
@@ -209,7 +209,7 @@ async function extractStepView(steps: Record<string, StepOutput>, engineApi: Eng
     return result
 }
 
-async function maybeSliceOutput({ value, engineApi }: MaybeSliceOutputParams): Promise<{ ref: LogSliceRef } | undefined> {
+async function maybeSliceOutput({ value, engineApi, stepName }: MaybeSliceOutputParams): Promise<{ ref: LogSliceRef } | undefined> {
     if (isNil(value) || isNil(engineApi)) {
         return undefined
     }
@@ -227,6 +227,7 @@ async function maybeSliceOutput({ value, engineApi }: MaybeSliceOutputParams): P
         engineToken: engineApi.engineToken,
         fileId: apId(),
         type: FileType.FLOW_RUN_LOG_SLICE,
+        fileName: `${stepName}.json`,
         data,
     })
     return { ref: { fileId, size, url: readUrl } }
@@ -287,6 +288,7 @@ export type FlowExecutorContextInit = {
 type MaybeSliceOutputParams = {
     value: unknown
     engineApi?: EngineApiConfig
+    stepName: string
 }
 
 type SliceCache = {

--- a/packages/server/engine/test/handler/context/flow-execution-context-slice.test.ts
+++ b/packages/server/engine/test/handler/context/flow-execution-context-slice.test.ts
@@ -1,6 +1,13 @@
 import { FlowActionType, GenericStepOutput, StepOutputStatus, StepOutputType } from '@activepieces/shared'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
+import { engineFileApi } from '../../../src/lib/api/engine-file-api'
 import { FlowExecutorContext } from '../../../src/lib/handler/context/flow-execution-context'
+
+vi.mock('../../../src/lib/api/engine-file-api', () => ({
+    engineFileApi: {
+        upload: vi.fn().mockResolvedValue({ fileId: 'file-1', readUrl: 'http://example.com/file-1' }),
+    },
+}))
 
 describe('FlowExecutorContext.upsertStep — outputType: StepOutputType.SLICE preservation', () => {
     it('keeps the slice discriminant when upserting an already-sliced step (RESUME restore)', async () => {
@@ -24,5 +31,26 @@ describe('FlowExecutorContext.upsertStep — outputType: StepOutputType.SLICE pr
             size: 4_096,
             url: 'http://example.com/file-1',
         })
+    })
+})
+
+describe('FlowExecutorContext.upsertStep — slice upload file naming (GIT-1568)', () => {
+    it('uploads the offloaded output as <stepName>.json so the download saves with a .json extension', async () => {
+        const oversized = new GenericStepOutput({
+            type: FlowActionType.CODE,
+            status: StepOutputStatus.SUCCEEDED,
+            input: {},
+            output: { data: 'x'.repeat(64 * 1024) },
+        })
+
+        const ctx = FlowExecutorContext.empty({
+            engineApi: { engineToken: 'token', internalApiUrl: 'http://127.0.0.1:3000' },
+        })
+        const next = await ctx.upsertStep('echo_step', oversized)
+
+        expect(next.steps.echo_step.outputType).toBe(StepOutputType.SLICE)
+        expect(engineFileApi.upload).toHaveBeenCalledWith(
+            expect.objectContaining({ fileName: 'echo_step.json' }),
+        )
     })
 })

--- a/packages/web/src/components/custom/json-viewer.tsx
+++ b/packages/web/src/components/custom/json-viewer.tsx
@@ -62,15 +62,11 @@ const JsonViewer = React.memo(
         type: 'application/json',
       });
       const url = URL.createObjectURL(blob);
-      handleDownloadFile(url);
-    };
-
-    const handleDownloadFile = (fileUrl: string, ext = '') => {
       const link = document.createElement('a');
-      link.href = fileUrl;
-      link.download = `${typeof title === 'string' ? title : 'data'}${ext}`;
+      link.href = url;
+      link.download = `${typeof title === 'string' ? title : 'data'}.json`;
       link.click();
-      URL.revokeObjectURL(fileUrl);
+      URL.revokeObjectURL(url);
     };
     return (
       <div


### PR DESCRIPTION
Fixes [GIT-1568](https://linear.app/activepieces/issue/GIT-1568)
Closes #13752

## Description

Downloading a run or step output now saves a `.json` file instead of an extensionless one the browser names `.bin`.

Two separate paths produced the bug:
1. Inline JSON viewer (`Download JSON`): the saved file had no extension at all (`Output`).
2. Output too large to display inline (>32 KB, offloaded to a `FLOW_RUN_LOG_SLICE` file): `Download output` served `Content-Disposition: attachment; filename="<fileId>.bin"`, because the engine uploaded the slice with no `fileName` and the API falls back to `${file.id}.bin`.

Fix:
- `packages/web/src/components/custom/json-viewer.tsx` → build the anchor inline with `.json` appended; drop the single-caller `handleDownloadFile` helper whose `ext = ''` default was the bug.
- `packages/server/engine/.../flow-execution-context.ts` → `maybeSliceOutput` now passes a `fileName` of `<stepName>.json` to `engineFileApi.upload`, so both the API's `Content-Disposition` and the S3 signed-URL disposition name the file `<stepName>.json`.

Security note (see the ticked box below): the engine now puts a step name into a value that reaches a response header. Step names are constrained to `/^[a-zA-Z_][a-zA-Z0-9_]*$/` (`STEP_NAME_REGEX`, enforced by the zod schemas on every step-creating operation and by `assertImportedStepNamesAreSafe` for `IMPORT_FLOW`), so the filename cannot contain a quote, backslash, CRLF, slash, or dot. Both sinks escape independently anyway — `encodeURI` on the DB-stream path, the `content-disposition` package on the S3 path. No header injection, path traversal, or double-extension case; response stays `attachment` + `nosniff`.

## How was this tested?

Verified on Community Edition (`AP_EDITION=ce`); no edition-gated code paths are involved.

- Regression test `flow-execution-context-slice.test.ts`, red-first proven: fails against pre-fix engine code (`upload` called without `fileName`), passes with the fix.
- Sink-side API test added in `files-controller.test.ts`: a named `FLOW_RUN_LOG_SLICE` GET must return `attachment; filename="step_1.json"` + `nosniff`, so a future controller change can't silently restore the `.bin` fallback or flip to `inline`. `test/integration/ce/file` 11/11 pass.
- Full pre-push suite green: `lint-core`, `lint-affected`, `test-unit` (engine 442/442, shared 449/449, web 407/407, core-utils 9/9) and `test-api`. `npm run lint-dev` clean (0 errors), `tsc --noEmit` on web clean.
- Real app end-to-end (`npm run dev`, PGlite + Redis, published webhook flow with a 122.8 KB code-step output). Slice path before fix: `filename="NuUl8R5KNBJVYC0Ncasyh.bin"`; after: `filename="step_1.json"`. Inline viewer before fix: `download="Output"`; after: `download="Output.json"`. Both captured from the running page, not a harness.
- Inverse/adjacent drive: scalar output (`42`, bare `JsonViewer`), object output (trigger, `SmartOutputViewer` — unchanged, still `Output.json`), and the >32 KB slice panel.
- No unit test for the web leg: `packages/web` vitest runs in the `node` environment with no jsdom or testing-library, so a render test would mean new devDependencies for a one-line change. That leg is covered by the browser drive above.
- Visual: run-details Output panel driven in the real app for scalar output, object output, and the too-large slice notice; no rendered pixel change (filename-only fix) — captured download names in the `Visual verification` comment.
- Other affected paths: swept every `link.download` in `packages/web`. `smart-output-viewer/index.tsx`, `dom-utils.downloadFile`, `download-button.tsx`, `data-display-tabs.tsx` already append an extension; `step-file-download-button.tsx` deliberately defers to the server's `Content-Disposition` (the same mechanism the engine leg fixes). One left unfixed on purpose: `features/chat/chat-message/download-image.ts` sets `link.download = 'image'`, the same missing-extension class, but picking the right extension there means sniffing the image type — different surface, out of scope for this ticket.

### Breaking change?

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

No API field, column, env var, or setup step changes. Slice files created before this change keep the old `${file.id}.bin` fallback and age out with retention; nothing for a self-hoster to do.

### Security impact?

- [ ] no — reviewed, no security impact
- [x] yes — security-sensitive (call out the risk and mitigation in the description above)

Ticked yes because the change touches file handling: a step name now flows into a stored `fileName` that is emitted in `Content-Disposition`. Risk and mitigation are detailed in the Description above; a security review of this diff returned zero findings.

<details>
<summary>Plan & reasoning</summary>

## Plan
- The ticket pinned only `json-viewer.tsx`, but the reported trigger ("output too big to display") is the sliced-output path, which is server-named. Sibling sweep of every `link.download` in `packages/web` plus the file-serving controller found the second, load-bearing leg.
- Chose to name the slice file at upload time (`fileName` on the existing `engineFileApi.upload` param) rather than special-casing `FLOW_RUN_LOG_SLICE` in `files-controller.ts`: one choke point, and both the DB-stream and S3-signed-URL responses derive their disposition from `file.fileName`.
- Inlined the web anchor rather than passing `'.json'` into the helper — the helper had exactly one caller and its `ext = ''` default is what made the bug invisible.
- Did not reuse `dom-utils.downloadFile`: it prepends a UTF-8 BOM, which would change the downloaded bytes.

## Non-happy scenarios considered
- Non-string `title` in `JsonViewer` → existing `'data'` fallback kept, now yields `data.json`.
- Title already containing a dot → step names can't (regex), and viewer titles are i18n labels like `Output`/`Input`.
- Slice file read via S3 signed URL → `s3Helper.getS3SignedUrl(s3Key, file.fileName ?? file.id)` picks up the new name through the same field.
- Existing slice files created before this change → still fall back to `${file.id}.bin`; no migration, old runs age out with retention.
- `slicingEnabled: false` / no `engineApi` → `maybeSliceOutput` returns early as before, no filename computed.

## Alternatives rejected
- Hardcode `.json` in `files-controller.ts` for `FLOW_RUN_LOG_SLICE` → puts type-specific naming in the generic file route.
- Backfill `fileName` on existing slice rows → migration for cosmetic gain on data that expires.
- Set `metadata.mimetype` to `application/json` instead → the served filename comes from `file.fileName`, not the MIME type, so this would not fix the `.bin` name at all.
</details>
