### PR TITLE
fix(tool-search): re-run the reconcile when the catalog changes mid-run

### DIFF
--- a/packages/server/api/src/app/app.ts
+++ b/packages/server/api/src/app/app.ts
@@ -224,6 +224,10 @@ export const setupApp = async (app: FastifyInstance): Promise<FastifyInstance> =
     // embedded (a populated deployment fires no sync delta, and a build that failed midway leaves rows
     // unembedded). Fire-and-forget — a no-op once fully built, and must never block or fail boot.
     rejectedPromiseHandler(toolSearchReindexJob(app.log).backfillIfNeeded(), app.log)
+    // Safety net: a periodic reconcile, so a catalog change stranded at the edge of a running reconcile —
+    // or a stale index the boot backfill cannot detect — is repaired within one interval instead of
+    // waiting for the next publish. A no-op against an unchanged catalog.
+    rejectedPromiseHandler(toolSearchReindexJob(app.log).scheduleRecurringReconcile(), app.log)
     await pieceMetadataService(app.log).setup()
     await app.register(pieceModule)
     await app.register(collaborativeModule)

--- a/packages/server/api/src/app/app.ts
+++ b/packages/server/api/src/app/app.ts
@@ -224,7 +224,7 @@ export const setupApp = async (app: FastifyInstance): Promise<FastifyInstance> =
     // embedded (a populated deployment fires no sync delta, and a build that failed midway leaves rows
     // unembedded). Fire-and-forget — a no-op once fully built, and must never block or fail boot.
     rejectedPromiseHandler(toolSearchReindexJob(app.log).backfillIfNeeded(), app.log)
-    rejectedPromiseHandler(toolSearchReindexJob(app.log).scheduleRecurringReconcile(), app.log)
+    await toolSearchReindexJob(app.log).scheduleRecurringReconcile()
     await pieceMetadataService(app.log).setup()
     await app.register(pieceModule)
     await app.register(collaborativeModule)

--- a/packages/server/api/src/app/app.ts
+++ b/packages/server/api/src/app/app.ts
@@ -224,9 +224,6 @@ export const setupApp = async (app: FastifyInstance): Promise<FastifyInstance> =
     // embedded (a populated deployment fires no sync delta, and a build that failed midway leaves rows
     // unembedded). Fire-and-forget — a no-op once fully built, and must never block or fail boot.
     rejectedPromiseHandler(toolSearchReindexJob(app.log).backfillIfNeeded(), app.log)
-    // Safety net: a periodic reconcile, so a catalog change stranded at the edge of a running reconcile —
-    // or a stale index the boot backfill cannot detect — is repaired within one interval instead of
-    // waiting for the next publish. A no-op against an unchanged catalog.
     rejectedPromiseHandler(toolSearchReindexJob(app.log).scheduleRecurringReconcile(), app.log)
     await pieceMetadataService(app.log).setup()
     await app.register(pieceModule)

--- a/packages/server/api/src/app/tool-search/tool-search-reindex.job.ts
+++ b/packages/server/api/src/app/tool-search/tool-search-reindex.job.ts
@@ -25,10 +25,15 @@ const REINDEX_LOCK_TIMEOUT_SECONDS = 300
  * anything stranded is picked up within one interval, whatever stranded it.
  *
  * Cheap by construction: the reconcile is hash-gated, so an unchanged catalog embeds nothing, deletes
- * nothing and writes no rows — the steady-state cost is one catalog read. Fixed pattern rather than a
- * per-replica random one so repeated boots re-upsert the same schedule instead of rewriting it.
+ * nothing and writes no rows — the steady-state cost is one catalog read (measured at ~0.4 s against a
+ * 700-piece / 7 000-object catalog). Hourly is well inside the window that matters, since the failure it
+ * covers is rare and only costs stale search text while it lasts.
+ *
+ * Runs at minute 30 for two reasons: it staggers against `PIECES_SYNC` (minutes 0–4), whose own delta
+ * already enqueues a reconcile, and a fixed pattern rather than a per-replica random one means repeated
+ * boots re-upsert the same schedule instead of rewriting it.
  */
-const REINDEX_CRON_PATTERN = '*/30 * * * *'
+const REINDEX_CRON_PATTERN = '30 * * * *'
 
 /**
  * Stable BullMQ jobId per scope. The global reconcile always enqueues under one id so a burst of

--- a/packages/server/api/src/app/tool-search/tool-search-reindex.job.ts
+++ b/packages/server/api/src/app/tool-search/tool-search-reindex.job.ts
@@ -17,6 +17,20 @@ import { ReindexScope, toolSearchIndexCoverage, toolSearchReindexService, toolSe
 const REINDEX_LOCK_TIMEOUT_SECONDS = 300
 
 /**
+ * Cadence of the safety-net reconcile. Every trigger the index has otherwise is a catalog *event*, and
+ * an event that arrives while a reconcile is running can still be missed at the edges: the reindex
+ * service's trailing pass covers a write that lands mid-run, but a bounded pass count still defers the
+ * write its last pass detects, and a stale-but-fully-embedded index reports nothing to do at boot
+ * (`backfillIfNeeded` counts NULL embeddings, not staleness). This is the out-of-band guarantee that
+ * anything stranded is picked up within one interval, whatever stranded it.
+ *
+ * Cheap by construction: the reconcile is hash-gated, so an unchanged catalog embeds nothing, deletes
+ * nothing and writes no rows — the steady-state cost is one catalog read. Fixed pattern rather than a
+ * per-replica random one so repeated boots re-upsert the same schedule instead of rewriting it.
+ */
+const REINDEX_CRON_PATTERN = '*/30 * * * *'
+
+/**
  * Stable BullMQ jobId per scope. The global reconcile always enqueues under one id so a burst of
  * catalog changes collapses to a single pending job (dedup); each platform gets its own id so a
  * tenant install isn't starved by — and doesn't cancel — the global job.
@@ -54,9 +68,19 @@ export function shouldSkipReindexOnCloud(): boolean {
 }
 
 export const toolSearchReindexJob = (log: FastifyBaseLogger) => ({
-    /** Register the worker handler. Called once at boot; the job only ever runs via {@link enqueue}. */
+    /**
+     * Register the worker handler. Called once at boot; the job runs via {@link enqueue} or the repeated
+     * schedule from {@link scheduleRecurringReconcile}.
+     */
     register(): void {
         systemJobHandlers.registerJobHandler(SystemJobName.TOOL_SEARCH_REINDEX, async (data) => {
+            // The enqueue sites all gate on the flag, but a repeated schedule is persisted in the queue
+            // and outlives a flag flip — so the flag has to be honoured here too, or turning tool-search
+            // off would leave the index (and its embedding spend) being maintained anyway.
+            if (!isToolSearchEnabled()) {
+                log.info('[toolSearchReindexJob] Tool-search is disabled — skipping the reconcile.')
+                return
+            }
             await distributedLock(log).runExclusive({
                 key: reindexLockKey(data.scope),
                 timeoutInSeconds: REINDEX_LOCK_TIMEOUT_SECONDS,
@@ -93,6 +117,31 @@ export const toolSearchReindexJob = (log: FastifyBaseLogger) => ({
             schedule: {
                 type: 'one-time',
                 date: apDayjs(),
+            },
+        })
+    },
+
+    /**
+     * Register the periodic safety-net reconcile (see {@link REINDEX_CRON_PATTERN}). Called at boot
+     * alongside {@link backfillIfNeeded}; `upsertJobScheduler` is keyed on the job name, so every replica
+     * converges on one schedule rather than each adding its own.
+     *
+     * Only the *registration* is flag-gated — a schedule already in the queue survives the flag being
+     * turned off, which is why the handler re-checks the flag as well.
+     */
+    async scheduleRecurringReconcile(): Promise<void> {
+        if (!isToolSearchEnabled()) {
+            return
+        }
+        await systemJobsSchedule(log).upsertJob({
+            job: {
+                name: SystemJobName.TOOL_SEARCH_REINDEX,
+                data: { scope: { type: 'all' } },
+                jobId: reindexJobId({ type: 'all' }),
+            },
+            schedule: {
+                type: 'repeated',
+                cron: REINDEX_CRON_PATTERN,
             },
         })
     },

--- a/packages/server/api/src/app/tool-search/tool-search-reindex.job.ts
+++ b/packages/server/api/src/app/tool-search/tool-search-reindex.job.ts
@@ -16,23 +16,6 @@ import { ReindexScope, toolSearchIndexCoverage, toolSearchReindexService, toolSe
 // comfortably larger than a single embed round-trip — a full re-embed (model swap) keeps extending.
 const REINDEX_LOCK_TIMEOUT_SECONDS = 300
 
-/**
- * Cadence of the safety-net reconcile. Every trigger the index has otherwise is a catalog *event*, and
- * an event that arrives while a reconcile is running can still be missed at the edges: the reindex
- * service's trailing pass covers a write that lands mid-run, but a bounded pass count still defers the
- * write its last pass detects, and a stale-but-fully-embedded index reports nothing to do at boot
- * (`backfillIfNeeded` counts NULL embeddings, not staleness). This is the out-of-band guarantee that
- * anything stranded is picked up within one interval, whatever stranded it.
- *
- * Cheap by construction: the reconcile is hash-gated, so an unchanged catalog embeds nothing, deletes
- * nothing and writes no rows — the steady-state cost is one catalog read (measured at ~0.4 s against a
- * 700-piece / 7 000-object catalog). Hourly is well inside the window that matters, since the failure it
- * covers is rare and only costs stale search text while it lasts.
- *
- * Runs at minute 30 for two reasons: it staggers against `PIECES_SYNC` (minutes 0–4), whose own delta
- * already enqueues a reconcile, and a fixed pattern rather than a per-replica random one means repeated
- * boots re-upsert the same schedule instead of rewriting it.
- */
 const REINDEX_CRON_PATTERN = '30 * * * *'
 
 /**
@@ -73,15 +56,8 @@ export function shouldSkipReindexOnCloud(): boolean {
 }
 
 export const toolSearchReindexJob = (log: FastifyBaseLogger) => ({
-    /**
-     * Register the worker handler. Called once at boot; the job runs via {@link enqueue} or the repeated
-     * schedule from {@link scheduleRecurringReconcile}.
-     */
     register(): void {
         systemJobHandlers.registerJobHandler(SystemJobName.TOOL_SEARCH_REINDEX, async (data) => {
-            // The enqueue sites all gate on the flag, but a repeated schedule is persisted in the queue
-            // and outlives a flag flip — so the flag has to be honoured here too, or turning tool-search
-            // off would leave the index (and its embedding spend) being maintained anyway.
             if (!isToolSearchEnabled()) {
                 log.info('[toolSearchReindexJob] Tool-search is disabled — skipping the reconcile.')
                 return
@@ -126,14 +102,6 @@ export const toolSearchReindexJob = (log: FastifyBaseLogger) => ({
         })
     },
 
-    /**
-     * Register the periodic safety-net reconcile (see {@link REINDEX_CRON_PATTERN}). Called at boot
-     * alongside {@link backfillIfNeeded}; `upsertJobScheduler` is keyed on the job name, so every replica
-     * converges on one schedule rather than each adding its own.
-     *
-     * Only the *registration* is flag-gated — a schedule already in the queue survives the flag being
-     * turned off, which is why the handler re-checks the flag as well.
-     */
     async scheduleRecurringReconcile(): Promise<void> {
         if (!isToolSearchEnabled()) {
             return

--- a/packages/server/api/src/app/tool-search/tool-search-reindex.service.ts
+++ b/packages/server/api/src/app/tool-search/tool-search-reindex.service.ts
@@ -10,6 +10,14 @@ import { buildRetrievalDoc, computeEmbeddingInputHash } from './retrieval-doc'
 
 const EMBED_BATCH_SIZE = 256
 
+/**
+ * Upper bound on reconcile passes in one job run (see {@link catalogFingerprint} for why a second pass
+ * exists at all). A pass after the first only touches what changed, so the cap is about refusing to
+ * chase a catalog that is being written continuously — not about cost. On hitting it we stop and log:
+ * the pending work is not lost, the next catalog change enqueues a fresh reconcile.
+ */
+const MAX_RECONCILE_PASSES = 3
+
 export const toolSearchReindexService = (log: FastifyBaseLogger) => ({
     /**
      * Reconcile `tool_search_index` against the live catalog — an idempotent, hash-gated incremental
@@ -24,6 +32,12 @@ export const toolSearchReindexService = (log: FastifyBaseLogger) => ({
      * touches the shared base catalog. A `model_version` change rebuilds under the new version while
      * old-version rows keep serving reads until cutover.
      *
+     * A catalog change that lands *while* this reconcile is running would otherwise be lost — the
+     * enqueue that announced it collapses onto the already-running job (stable jobId) and the snapshot
+     * was read before it committed. So the run re-checks the catalog fingerprint after each pass and
+     * runs a trailing pass when it moved: the debounce keeps collapsing a burst, but now executes on
+     * the trailing edge instead of dropping it.
+     *
      * The embedder is injectable so tests can drive a deterministic fake with no key/network. In
      * production `platformId` names the platform whose OpenAI key funds the embedding; when neither
      * an embedder nor a resolvable key is available the reindex is a no-op (keyword floor serves).
@@ -35,48 +49,106 @@ export const toolSearchReindexService = (log: FastifyBaseLogger) => ({
             : await resolveEmbedder({ platformId: params.platformId, log }))
         if (isNil(embedder)) {
             log.info('[toolSearchReindexService#reindex] No embedder resolved — skipping reindex (keyword floor serves).')
-            return { status: 'no-embedder', objectsIndexed: 0, objectsEmbedded: 0, objectsDeleted: 0, objectsPending: 0 }
+            return { status: 'no-embedder', passes: 0, objectsIndexed: 0, objectsEmbedded: 0, objectsDeleted: 0, objectsPending: 0 }
         }
         // The migration no-ops when pgvector is absent, so the table can be missing even with the flag
         // on. Degrade gracefully (keyword floor) instead of throwing "relation does not exist" on every
         // catalog-change reconcile.
         if (!await toolSearchTableExists()) {
             log.warn('[toolSearchReindexService#reindex] tool_search_index is absent (pgvector not installed) — skipping reindex; keyword floor serves.')
-            return { status: 'no-table', objectsIndexed: 0, objectsEmbedded: 0, objectsDeleted: 0, objectsPending: 0 }
+            return { status: 'no-table', passes: 0, objectsIndexed: 0, objectsEmbedded: 0, objectsDeleted: 0, objectsPending: 0 }
         }
 
-        const currentRelease = apVersionUtil.getCurrentRelease()
-        const pieces = await fetchLatestCompatiblePiecesFromDB(currentRelease)
-        const desired = pieces
-            .flatMap((piece) => explodePiece(piece, embedder.modelVersion))
-            .filter((record) => scopeMatches(record, scope))
+        let objectsIndexed = 0
+        let objectsPending = 0
+        let objectsEmbedded = 0
+        let objectsDeleted = 0
+        let passes = 0
+        // Read BEFORE the first snapshot, and re-read after every pass: any write that lands from here
+        // on moves the fingerprint, so "changed after we read the catalog" can never be missed.
+        let fingerprint = await catalogFingerprint()
 
-        // Upsert the desired rows by unique key, batched into chunked multi-row statements rather than
-        // one round-trip per row (~6k on a cold-start backfill). A new row lands with embedding=NULL; an
-        // existing row keeps its embedding unless the retrieval text (→ hash) changed, in which case it
-        // is nulled to force a re-embed. Rows whose content is unchanged are not touched at all (idempotent).
-        await upsertDesired(desired, embedder.modelVersion)
+        while (passes < MAX_RECONCILE_PASSES) {
+            passes++
+            const pass = await reconcileOnce(embedder, scope, log)
+            // A pass fully supersedes the previous one's view of the catalog, so the desired-state and
+            // still-pending counts are the latest pass's; the work counters accumulate across passes.
+            objectsIndexed = pass.objectsIndexed
+            objectsPending = pass.objectsPending
+            objectsEmbedded += pass.objectsEmbedded
+            objectsDeleted += pass.objectsDeleted
 
-        // Remove rows whose object key is no longer in the desired catalog (deleted pieces, removed
-        // actions, superseded old versions). Done before embedding so a row that is both pending and
-        // gone is never wastefully embedded.
-        const objectsDeleted = await deleteRemovedRows(desired, embedder.modelVersion, scope)
-
-        // Embed only the rows still missing an embedding (the new + changed ones, plus any that failed
-        // a previous run). Embedding is batched and never blocks the upsert diff above.
-        const { embedded: objectsEmbedded, pending: objectsPending } = await embedPendingRows(embedder, scope, log)
+            const fingerprintAfterPass = await catalogFingerprint()
+            if (fingerprintAfterPass === fingerprint) {
+                break
+            }
+            fingerprint = fingerprintAfterPass
+            if (passes < MAX_RECONCILE_PASSES) {
+                log.info({ scope: scope.type, passes }, '[toolSearchReindexService#reindex] Catalog changed while the reconcile was running — running a trailing pass so the change is not dropped.')
+            }
+            else {
+                log.warn({ scope: scope.type, passes }, '[toolSearchReindexService#reindex] Catalog still changing after the trailing-pass cap — stopping; the next catalog change enqueues a fresh reconcile.')
+            }
+        }
 
         // Rows left unembedded after a reconcile mean the embedder failed or was rate-limited on those
         // batches: a NULL-embedding row is invisible to semantic ranking, so search silently under-serves
         // until they are re-embedded. Surface it loudly — both the boot backfill and the sync hook retry.
         if (objectsPending > 0) {
-            log.warn({ scope: scope.type, objectsIndexed: desired.length, objectsEmbedded, objectsPending, objectsDeleted }, '[toolSearchReindexService#reindex] Reindex left rows unembedded — embedding degraded; search partially served until the next boot or catalog sync retries.')
+            log.warn({ scope: scope.type, passes, objectsIndexed, objectsEmbedded, objectsPending, objectsDeleted }, '[toolSearchReindexService#reindex] Reindex left rows unembedded — embedding degraded; search partially served until the next boot or catalog sync retries.')
         }
 
-        log.info({ scope: scope.type, objectsIndexed: desired.length, objectsEmbedded, objectsPending, objectsDeleted }, '[toolSearchReindexService#reindex] Reindex complete.')
-        return { status: 'done', objectsIndexed: desired.length, objectsEmbedded, objectsDeleted, objectsPending }
+        log.info({ scope: scope.type, passes, objectsIndexed, objectsEmbedded, objectsPending, objectsDeleted }, '[toolSearchReindexService#reindex] Reindex complete.')
+        return { status: 'done', passes, objectsIndexed, objectsEmbedded, objectsDeleted, objectsPending }
     },
 })
+
+/**
+ * One reconcile pass: re-derive the desired state from the catalog as it is *now*, diff it into the
+ * index, and embed what is missing. Every pass re-reads the catalog, so a trailing pass sees writes the
+ * previous pass's snapshot could not.
+ */
+async function reconcileOnce(embedder: ToolSearchEmbedder, scope: ReindexScope, log: FastifyBaseLogger): Promise<ReconcilePassResult> {
+    const currentRelease = apVersionUtil.getCurrentRelease()
+    const pieces = await fetchLatestCompatiblePiecesFromDB(currentRelease)
+    const desired = pieces
+        .flatMap((piece) => explodePiece(piece, embedder.modelVersion))
+        .filter((record) => scopeMatches(record, scope))
+
+    // Upsert the desired rows by unique key, batched into chunked multi-row statements rather than
+    // one round-trip per row (~6k on a cold-start backfill). A new row lands with embedding=NULL; an
+    // existing row keeps its embedding unless the retrieval text (→ hash) changed, in which case it
+    // is nulled to force a re-embed. Rows whose content is unchanged are not touched at all (idempotent).
+    await upsertDesired(desired, embedder.modelVersion)
+
+    // Remove rows whose object key is no longer in the desired catalog (deleted pieces, removed
+    // actions, superseded old versions). Done before embedding so a row that is both pending and
+    // gone is never wastefully embedded.
+    const objectsDeleted = await deleteRemovedRows(desired, embedder.modelVersion, scope)
+
+    // Embed only the rows still missing an embedding (the new + changed ones, plus any that failed
+    // a previous run). Embedding is batched and never blocks the upsert diff above.
+    const { embedded: objectsEmbedded, pending: objectsPending } = await embedPendingRows(embedder, scope, log)
+
+    return { objectsIndexed: desired.length, objectsEmbedded, objectsDeleted, objectsPending }
+}
+
+/**
+ * A cheap change-detector for the piece catalog, compared across a reconcile pass rather than read for
+ * its own sake. Every write to `piece_metadata` moves either the row count (insert/delete) or the newest
+ * write timestamp (insert/update — TypeORM stamps `updated` on both), so an unchanged fingerprint means
+ * no catalog write committed while the pass was running.
+ *
+ * Deliberately unfiltered: it covers rows a scoped or release-incompatible reconcile ignores, so it can
+ * over-report a change. That direction is free — a spurious trailing pass is a hash-gated no-op — while
+ * under-reporting would silently strand a publish, which is the bug this guards.
+ */
+async function catalogFingerprint(): Promise<string> {
+    const result = await databaseConnection().query(
+        'SELECT count(*)::int AS count, max(GREATEST("created", "updated"))::text AS "lastWrite" FROM "piece_metadata"',
+    )
+    return `${result?.[0]?.count ?? 0}@${result?.[0]?.lastWrite ?? ''}`
+}
 
 /** A platform-scoped reconcile only owns that tenant's custom pieces; `all` owns the whole index. */
 function scopeMatches(record: DesiredRecord, scope: ReindexScope): boolean {
@@ -365,15 +437,19 @@ type ReindexParams = {
 
 type ReindexResult = {
     status: 'done' | 'no-embedder' | 'no-table'
-    /** desired-state object count (latest version per piece, exploded into actions + triggers). */
+    /** reconcile passes this run took — >1 means the catalog changed mid-run and a trailing pass caught it. */
+    passes: number
+    /** desired-state object count as of the LAST pass (latest version per piece, actions + triggers). */
     objectsIndexed: number
-    /** rows that were (re)embedded this run — 0 when nothing changed. */
+    /** rows that were (re)embedded this run, summed over passes — 0 when nothing changed. */
     objectsEmbedded: number
-    /** rows removed because their key is no longer in the desired catalog. */
+    /** rows removed because their key is no longer in the desired catalog, summed over passes. */
     objectsDeleted: number
-    /** rows still lacking an embedding after this run — non-zero means embedding is degraded. */
+    /** rows still lacking an embedding after the last pass — non-zero means embedding is degraded. */
     objectsPending: number
 }
+
+type ReconcilePassResult = Omit<ReindexResult, 'status' | 'passes'>
 
 type EmbedResult = {
     embedded: number

--- a/packages/server/api/src/app/tool-search/tool-search-reindex.service.ts
+++ b/packages/server/api/src/app/tool-search/tool-search-reindex.service.ts
@@ -10,12 +10,6 @@ import { buildRetrievalDoc, computeEmbeddingInputHash } from './retrieval-doc'
 
 const EMBED_BATCH_SIZE = 256
 
-/**
- * Upper bound on reconcile passes in one job run (see {@link catalogFingerprint} for why a second pass
- * exists at all). A pass after the first only touches what changed, so the cap is about refusing to
- * chase a catalog that is being written continuously — not about cost. On hitting it we stop and log:
- * the pending work is not lost, the next catalog change enqueues a fresh reconcile.
- */
 const MAX_RECONCILE_PASSES = 3
 
 export const toolSearchReindexService = (log: FastifyBaseLogger) => ({
@@ -31,12 +25,6 @@ export const toolSearchReindexService = (log: FastifyBaseLogger) => ({
      * `platform` reconciles only one tenant's custom pieces (the custom-piece install hook) and never
      * touches the shared base catalog. A `model_version` change rebuilds under the new version while
      * old-version rows keep serving reads until cutover.
-     *
-     * A catalog change that lands *while* this reconcile is running would otherwise be lost — the
-     * enqueue that announced it collapses onto the already-running job (stable jobId) and the snapshot
-     * was read before it committed. So the run re-checks the catalog fingerprint after each pass and
-     * runs a trailing pass when it moved: the debounce keeps collapsing a burst, but now executes on
-     * the trailing edge instead of dropping it.
      *
      * The embedder is injectable so tests can drive a deterministic fake with no key/network. In
      * production `platformId` names the platform whose OpenAI key funds the embedding; when neither
@@ -64,15 +52,11 @@ export const toolSearchReindexService = (log: FastifyBaseLogger) => ({
         let objectsEmbedded = 0
         let objectsDeleted = 0
         let passes = 0
-        // Read BEFORE the first snapshot, and re-read after every pass: any write that lands from here
-        // on moves the fingerprint, so "changed after we read the catalog" can never be missed.
         let fingerprint = await catalogFingerprint()
 
         while (passes < MAX_RECONCILE_PASSES) {
             passes++
             const pass = await reconcileOnce(embedder, scope, log)
-            // A pass fully supersedes the previous one's view of the catalog, so the desired-state and
-            // still-pending counts are the latest pass's; the work counters accumulate across passes.
             objectsIndexed = pass.objectsIndexed
             objectsPending = pass.objectsPending
             objectsEmbedded += pass.objectsEmbedded
@@ -103,11 +87,6 @@ export const toolSearchReindexService = (log: FastifyBaseLogger) => ({
     },
 })
 
-/**
- * One reconcile pass: re-derive the desired state from the catalog as it is *now*, diff it into the
- * index, and embed what is missing. Every pass re-reads the catalog, so a trailing pass sees writes the
- * previous pass's snapshot could not.
- */
 async function reconcileOnce(embedder: ToolSearchEmbedder, scope: ReindexScope, log: FastifyBaseLogger): Promise<ReconcilePassResult> {
     const currentRelease = apVersionUtil.getCurrentRelease()
     const pieces = await fetchLatestCompatiblePiecesFromDB(currentRelease)
@@ -115,34 +94,15 @@ async function reconcileOnce(embedder: ToolSearchEmbedder, scope: ReindexScope, 
         .flatMap((piece) => explodePiece(piece, embedder.modelVersion))
         .filter((record) => scopeMatches(record, scope))
 
-    // Upsert the desired rows by unique key, batched into chunked multi-row statements rather than
-    // one round-trip per row (~6k on a cold-start backfill). A new row lands with embedding=NULL; an
-    // existing row keeps its embedding unless the retrieval text (→ hash) changed, in which case it
-    // is nulled to force a re-embed. Rows whose content is unchanged are not touched at all (idempotent).
     await upsertDesired(desired, embedder.modelVersion)
 
-    // Remove rows whose object key is no longer in the desired catalog (deleted pieces, removed
-    // actions, superseded old versions). Done before embedding so a row that is both pending and
-    // gone is never wastefully embedded.
     const objectsDeleted = await deleteRemovedRows(desired, embedder.modelVersion, scope)
 
-    // Embed only the rows still missing an embedding (the new + changed ones, plus any that failed
-    // a previous run). Embedding is batched and never blocks the upsert diff above.
     const { embedded: objectsEmbedded, pending: objectsPending } = await embedPendingRows(embedder, scope, log)
 
     return { objectsIndexed: desired.length, objectsEmbedded, objectsDeleted, objectsPending }
 }
 
-/**
- * A cheap change-detector for the piece catalog, compared across a reconcile pass rather than read for
- * its own sake. Every write to `piece_metadata` moves either the row count (insert/delete) or the newest
- * write timestamp (insert/update — TypeORM stamps `updated` on both), so an unchanged fingerprint means
- * no catalog write committed while the pass was running.
- *
- * Deliberately unfiltered: it covers rows a scoped or release-incompatible reconcile ignores, so it can
- * over-report a change. That direction is free — a spurious trailing pass is a hash-gated no-op — while
- * under-reporting would silently strand a publish, which is the bug this guards.
- */
 async function catalogFingerprint(): Promise<string> {
     const result = await databaseConnection().query(
         'SELECT count(*)::int AS count, max(GREATEST("created", "updated"))::text AS "lastWrite" FROM "piece_metadata"',
@@ -437,15 +397,10 @@ type ReindexParams = {
 
 type ReindexResult = {
     status: 'done' | 'no-embedder' | 'no-table'
-    /** reconcile passes this run took — >1 means the catalog changed mid-run and a trailing pass caught it. */
     passes: number
-    /** desired-state object count as of the LAST pass (latest version per piece, actions + triggers). */
     objectsIndexed: number
-    /** rows that were (re)embedded this run, summed over passes — 0 when nothing changed. */
     objectsEmbedded: number
-    /** rows removed because their key is no longer in the desired catalog, summed over passes. */
     objectsDeleted: number
-    /** rows still lacking an embedding after the last pass — non-zero means embedding is degraded. */
     objectsPending: number
 }
 

--- a/packages/server/api/test/integration/ce/tool-search/tool-search-publish-burst.test.ts
+++ b/packages/server/api/test/integration/ce/tool-search/tool-search-publish-burst.test.ts
@@ -1,0 +1,198 @@
+import { createServer, Server } from 'node:http'
+import { ActionBase, PieceAuth } from '@activepieces/pieces-framework'
+import { PackageType, PieceType } from '@activepieces/shared'
+import { FastifyInstance } from 'fastify'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { databaseConnection } from '../../../../src/app/database/database-connection'
+import { SystemJobName } from '../../../../src/app/helper/system-jobs/common'
+import { OPENAI_3_SMALL_DIMENSIONS } from '../../../../src/app/tool-search/embedder'
+import { toolSearchReindexJob } from '../../../../src/app/tool-search/tool-search-reindex.job'
+import { db } from '../../../helpers/db'
+import { createMockPieceMetadata, mockAndSaveBasicSetup } from '../../../helpers/mocks'
+import { setupTestEnvironment, teardownTestEnvironment } from '../../../helpers/test-setup'
+
+// End-to-end reproduction of the production failure, through the REAL pipeline: a publish writes
+// piece_metadata and fires toolSearchReindexJob.enqueue (what admin-platform.controller.ts does), BullMQ
+// dedups on the stable jobId, the worker runs the registered handler, and the handler resolves a real
+// OpenAI embedder over HTTP. Nothing is injected — unlike tool-search.test.ts, which calls reindex()
+// directly and so cannot show that the *collapse* is what drops a publish.
+//
+// The embedder is real code pointed at a local stub via OPENAI_BASE_URL (honoured by @ai-sdk/openai), so
+// resolveEmbedder → createOpenAiEmbedder → embed → pgvector all execute with no key and no network.
+let app: FastifyInstance
+let stub: Server
+let stubPort: number
+let embedCalls = 0
+
+// Deliberate latency on the embed call. It widens the window in which the reconcile is running, which is
+// what makes the race deterministic — a real embed round-trip is this slow or slower.
+const EMBED_DELAY_MS = 600
+
+function startEmbeddingStub(): Promise<void> {
+    stub = createServer((req, res) => {
+        let body = ''
+        req.on('data', (c) => (body += c))
+        req.on('end', () => {
+            const inputs: string[] = JSON.parse(body).input
+            embedCalls++
+            // Deterministic unit-ish vectors, distinct per input, in the OpenAI embeddings response shape.
+            const data = inputs.map((text, index) => ({
+                object: 'embedding',
+                index,
+                embedding: Array.from({ length: OPENAI_3_SMALL_DIMENSIONS }, (_, d) =>
+                    ((text.charCodeAt(d % text.length) % 13) + 1) / 100),
+            }))
+            setTimeout(() => {
+                res.writeHead(200, { 'content-type': 'application/json' })
+                res.end(JSON.stringify({ object: 'list', data, model: 'text-embedding-3-small', usage: { prompt_tokens: 1, total_tokens: 1 } }))
+            }, EMBED_DELAY_MS)
+        })
+    })
+    return new Promise((resolve) => {
+        stub.listen(0, '127.0.0.1', () => {
+            stubPort = (stub.address() as { port: number }).port
+            resolve()
+        })
+    })
+}
+
+const pieceAuth = PieceAuth.SecretText({ displayName: 'API Key', required: true })
+
+function piece(name: string, version: string, description: string): ReturnType<typeof createMockPieceMetadata> {
+    return createMockPieceMetadata({
+        name: `@activepieces/piece-${name}`,
+        displayName: name,
+        version,
+        auth: pieceAuth,
+        pieceType: PieceType.OFFICIAL,
+        packageType: PackageType.REGISTRY,
+        actions: {
+            run: {
+                name: 'run',
+                displayName: 'Run',
+                description,
+                props: {},
+                requireAuth: true,
+                audience: 'both',
+            } as ActionBase,
+        },
+        triggers: {},
+    })
+}
+
+/** Exactly what POST /v1/admin/pieces does: write the metadata, then fire the reindex hook. */
+async function publish(name: string, version: string, description: string): Promise<void> {
+    await db.save('piece_metadata', piece(name, version, description))
+    await toolSearchReindexJob(app.log).enqueue({ type: 'all' })
+}
+
+async function retrievalDocFor(name: string): Promise<string | undefined> {
+    const rows = await databaseConnection().query(
+        'SELECT "retrievalDoc", "embedding" IS NULL AS "unembedded" FROM "tool_search_index" WHERE "pieceName" = $1',
+        [`@activepieces/piece-${name}`],
+    )
+    return rows[0]?.retrievalDoc
+}
+
+async function unembeddedCount(): Promise<number> {
+    const [{ count }] = await databaseConnection().query('SELECT COUNT(*)::int AS count FROM "tool_search_index" WHERE "embedding" IS NULL')
+    return count
+}
+
+/** Wait until the reindex queue is idle — no job running and none waiting to run. */
+async function waitForReconcileToSettle(timeoutMs = 60_000): Promise<void> {
+    const { systemJobsQueue } = await import('../../../../src/app/helper/system-jobs/system-job')
+    const deadline = Date.now() + timeoutMs
+    let idleStreak = 0
+    // `delayed` is deliberately excluded: the hourly safety-net scheduler always has one delayed job
+    // queued for the next run, so counting it would mean the queue is never idle.
+    while (Date.now() < deadline) {
+        const counts = await systemJobsQueue.getJobCounts('active', 'waiting', 'prioritized')
+        const busy = (counts.active ?? 0) + (counts.waiting ?? 0) + (counts.prioritized ?? 0)
+        idleStreak = busy === 0 ? idleStreak + 1 : 0
+        // Three consecutive idle polls — a trailing pass runs inside one job, but a re-enqueue would
+        // briefly show waiting, so don't call it settled on the first idle read.
+        if (idleStreak >= 3) {
+            return
+        }
+        await new Promise((resolve) => setTimeout(resolve, 250))
+    }
+    const counts = await systemJobsQueue.getJobCounts()
+    const failed = await systemJobsQueue.getJobs(['failed'], 0, 5)
+    throw new Error(`reindex queue never settled — counts=${JSON.stringify(counts)} failed=${JSON.stringify(failed.map((j) => j.failedReason))}`)
+}
+
+beforeAll(async () => {
+    await startEmbeddingStub()
+    process.env.AP_TOOL_SEARCH_ENABLED = 'true'
+    process.env.AP_OPENAI_API_KEY = 'sk-local-stub'
+    process.env.OPENAI_BASE_URL = `http://127.0.0.1:${stubPort}`
+    app = await setupTestEnvironment()
+    // The handler funds embedding via getOldestPlatform() and returns early when there is none, so a
+    // platform has to exist for the job path to run at all. (With AP_OPENAI_API_KEY set, resolveEmbedder
+    // short-circuits to the env key — the platform only supplies an id.)
+    await mockAndSaveBasicSetup()
+}, 300_000)
+
+afterAll(async () => {
+    // Booting with the flag on registers the hourly safety-net schedule; drop it so it can't fire a
+    // reconcile inside another suite sharing this queue.
+    const { systemJobsQueue } = await import('../../../../src/app/helper/system-jobs/system-job')
+    for (const scheduler of await systemJobsQueue.getJobSchedulers()) {
+        if (scheduler.name === SystemJobName.TOOL_SEARCH_REINDEX) {
+            await systemJobsQueue.removeJobScheduler(scheduler.id ?? scheduler.key)
+        }
+    }
+    delete process.env.AP_TOOL_SEARCH_ENABLED
+    delete process.env.AP_OPENAI_API_KEY
+    delete process.env.OPENAI_BASE_URL
+    await new Promise((resolve) => stub.close(resolve))
+    await teardownTestEnvironment()
+})
+
+describe('Tool Search — publish burst through the real enqueue → BullMQ → reindex path', () => {
+    it('indexes every piece of a burst that lands while the reconcile is running', async () => {
+        // 1. First publish. Its enqueue creates the job; the worker starts it within milliseconds and it
+        //    reads its catalog snapshot, then blocks on the (slow) embed call.
+        await publish('first', '1.0.0', 'Original first description')
+        await new Promise((resolve) => setTimeout(resolve, 400))
+
+        // 2. The rest of the batch commits while that job is mid-run — concurrently, as the publish script
+        //    does (chunks of 30 via Promise.all). Every one of these enqueues collapses onto the active
+        //    job and is a silent no-op. On main they are dropped outright.
+        const stragglers = ['second', 'third', 'fourth', 'fifth', 'sixth']
+        await Promise.all(stragglers.map((name) => publish(name, '1.0.0', `Original ${name} description`)))
+
+        await waitForReconcileToSettle()
+
+        // 3. Every piece in the burst must be in the index, embedded.
+        for (const name of ['first', ...stragglers]) {
+            const doc = await retrievalDocFor(name)
+            expect(doc, `${name} missing from the index — its publish was dropped`).toBeDefined()
+            expect(doc).toContain(`Original ${name === 'first' ? 'first' : name} description`)
+        }
+        expect(await unembeddedCount()).toBe(0)
+        expect(embedCalls).toBeGreaterThan(1)
+    }, 300_000)
+
+    // Runs after the test above and re-publishes the pieces it created — keep them in this order.
+    it('refreshes descriptions republished mid-reconcile — no stale text survives', async () => {
+        // The reported symptom: a re-publish (new version, rewritten action text) landing inside a running
+        // reconcile keeps serving its pre-publish description.
+        await publish('first', '1.0.1', 'Rewritten first description')
+        await new Promise((resolve) => setTimeout(resolve, 400))
+        const stragglers = ['second', 'third', 'fourth']
+        await Promise.all(stragglers.map((name) => publish(name, '1.0.1', `Rewritten ${name} description`)))
+
+        await waitForReconcileToSettle()
+
+        for (const name of ['first', ...stragglers]) {
+            const doc = await retrievalDocFor(name)
+            // Assert the OLD text is gone — "new text present" passes trivially on whichever piece won
+            // the snapshot race and hides the ones that did not.
+            expect(doc, `${name} still serves its pre-publish description`).not.toContain(`Original ${name} description`)
+            expect(doc).toContain(`Rewritten ${name} description`)
+        }
+        expect(await unembeddedCount()).toBe(0)
+    }, 300_000)
+})

--- a/packages/server/api/test/integration/ce/tool-search/tool-search-publish-burst.test.ts
+++ b/packages/server/api/test/integration/ce/tool-search/tool-search-publish-burst.test.ts
@@ -11,21 +11,11 @@ import { db } from '../../../helpers/db'
 import { createMockPieceMetadata, mockAndSaveBasicSetup } from '../../../helpers/mocks'
 import { setupTestEnvironment, teardownTestEnvironment } from '../../../helpers/test-setup'
 
-// End-to-end reproduction of the production failure, through the REAL pipeline: a publish writes
-// piece_metadata and fires toolSearchReindexJob.enqueue (what admin-platform.controller.ts does), BullMQ
-// dedups on the stable jobId, the worker runs the registered handler, and the handler resolves a real
-// OpenAI embedder over HTTP. Nothing is injected — unlike tool-search.test.ts, which calls reindex()
-// directly and so cannot show that the *collapse* is what drops a publish.
-//
-// The embedder is real code pointed at a local stub via OPENAI_BASE_URL (honoured by @ai-sdk/openai), so
-// resolveEmbedder → createOpenAiEmbedder → embed → pgvector all execute with no key and no network.
 let app: FastifyInstance
 let stub: Server
 let stubPort: number
 let embedCalls = 0
 
-// Deliberate latency on the embed call. It widens the window in which the reconcile is running, which is
-// what makes the race deterministic — a real embed round-trip is this slow or slower.
 const EMBED_DELAY_MS = 600
 
 function startEmbeddingStub(): Promise<void> {
@@ -35,7 +25,6 @@ function startEmbeddingStub(): Promise<void> {
         req.on('end', () => {
             const inputs: string[] = JSON.parse(body).input
             embedCalls++
-            // Deterministic unit-ish vectors, distinct per input, in the OpenAI embeddings response shape.
             const data = inputs.map((text, index) => ({
                 object: 'embedding',
                 index,
@@ -80,7 +69,6 @@ function piece(name: string, version: string, description: string): ReturnType<t
     })
 }
 
-/** Exactly what POST /v1/admin/pieces does: write the metadata, then fire the reindex hook. */
 async function publish(name: string, version: string, description: string): Promise<void> {
     await db.save('piece_metadata', piece(name, version, description))
     await toolSearchReindexJob(app.log).enqueue({ type: 'all' })
@@ -99,19 +87,14 @@ async function unembeddedCount(): Promise<number> {
     return count
 }
 
-/** Wait until the reindex queue is idle — no job running and none waiting to run. */
 async function waitForReconcileToSettle(timeoutMs = 60_000): Promise<void> {
     const { systemJobsQueue } = await import('../../../../src/app/helper/system-jobs/system-job')
     const deadline = Date.now() + timeoutMs
     let idleStreak = 0
-    // `delayed` is deliberately excluded: the hourly safety-net scheduler always has one delayed job
-    // queued for the next run, so counting it would mean the queue is never idle.
     while (Date.now() < deadline) {
         const counts = await systemJobsQueue.getJobCounts('active', 'waiting', 'prioritized')
         const busy = (counts.active ?? 0) + (counts.waiting ?? 0) + (counts.prioritized ?? 0)
         idleStreak = busy === 0 ? idleStreak + 1 : 0
-        // Three consecutive idle polls — a trailing pass runs inside one job, but a re-enqueue would
-        // briefly show waiting, so don't call it settled on the first idle read.
         if (idleStreak >= 3) {
             return
         }
@@ -128,15 +111,10 @@ beforeAll(async () => {
     process.env.AP_OPENAI_API_KEY = 'sk-local-stub'
     process.env.OPENAI_BASE_URL = `http://127.0.0.1:${stubPort}`
     app = await setupTestEnvironment()
-    // The handler funds embedding via getOldestPlatform() and returns early when there is none, so a
-    // platform has to exist for the job path to run at all. (With AP_OPENAI_API_KEY set, resolveEmbedder
-    // short-circuits to the env key — the platform only supplies an id.)
     await mockAndSaveBasicSetup()
 }, 300_000)
 
 afterAll(async () => {
-    // Booting with the flag on registers the hourly safety-net schedule; drop it so it can't fire a
-    // reconcile inside another suite sharing this queue.
     const { systemJobsQueue } = await import('../../../../src/app/helper/system-jobs/system-job')
     for (const scheduler of await systemJobsQueue.getJobSchedulers()) {
         if (scheduler.name === SystemJobName.TOOL_SEARCH_REINDEX) {
@@ -152,20 +130,14 @@ afterAll(async () => {
 
 describe('Tool Search — publish burst through the real enqueue → BullMQ → reindex path', () => {
     it('indexes every piece of a burst that lands while the reconcile is running', async () => {
-        // 1. First publish. Its enqueue creates the job; the worker starts it within milliseconds and it
-        //    reads its catalog snapshot, then blocks on the (slow) embed call.
         await publish('first', '1.0.0', 'Original first description')
         await new Promise((resolve) => setTimeout(resolve, 400))
 
-        // 2. The rest of the batch commits while that job is mid-run — concurrently, as the publish script
-        //    does (chunks of 30 via Promise.all). Every one of these enqueues collapses onto the active
-        //    job and is a silent no-op. On main they are dropped outright.
         const stragglers = ['second', 'third', 'fourth', 'fifth', 'sixth']
         await Promise.all(stragglers.map((name) => publish(name, '1.0.0', `Original ${name} description`)))
 
         await waitForReconcileToSettle()
 
-        // 3. Every piece in the burst must be in the index, embedded.
         for (const name of ['first', ...stragglers]) {
             const doc = await retrievalDocFor(name)
             expect(doc, `${name} missing from the index — its publish was dropped`).toBeDefined()
@@ -175,10 +147,7 @@ describe('Tool Search — publish burst through the real enqueue → BullMQ → 
         expect(embedCalls).toBeGreaterThan(1)
     }, 300_000)
 
-    // Runs after the test above and re-publishes the pieces it created — keep them in this order.
-    it('refreshes descriptions republished mid-reconcile — no stale text survives', async () => {
-        // The reported symptom: a re-publish (new version, rewritten action text) landing inside a running
-        // reconcile keeps serving its pre-publish description.
+    it('refreshes descriptions republished mid-reconcile — no stale text survives (runs after the burst test and republishes its pieces)', async () => {
         await publish('first', '1.0.1', 'Rewritten first description')
         await new Promise((resolve) => setTimeout(resolve, 400))
         const stragglers = ['second', 'third', 'fourth']
@@ -188,8 +157,6 @@ describe('Tool Search — publish burst through the real enqueue → BullMQ → 
 
         for (const name of ['first', ...stragglers]) {
             const doc = await retrievalDocFor(name)
-            // Assert the OLD text is gone — "new text present" passes trivially on whichever piece won
-            // the snapshot race and hides the ones that did not.
             expect(doc, `${name} still serves its pre-publish description`).not.toContain(`Original ${name} description`)
             expect(doc).toContain(`Rewritten ${name} description`)
         }

--- a/packages/server/api/test/integration/ce/tool-search/tool-search-publish-burst.test.ts
+++ b/packages/server/api/test/integration/ce/tool-search/tool-search-publish-burst.test.ts
@@ -15,8 +15,7 @@ let app: FastifyInstance
 let stub: Server
 let stubPort: number
 let embedCalls = 0
-
-const EMBED_DELAY_MS = 600
+let onNextEmbedCall: (() => Promise<void>) | null = null
 
 function startEmbeddingStub(): Promise<void> {
     stub = createServer((req, res) => {
@@ -25,16 +24,26 @@ function startEmbeddingStub(): Promise<void> {
         req.on('end', () => {
             const inputs: string[] = JSON.parse(body).input
             embedCalls++
-            const data = inputs.map((text, index) => ({
-                object: 'embedding',
-                index,
-                embedding: Array.from({ length: OPENAI_3_SMALL_DIMENSIONS }, (_, d) =>
-                    ((text.charCodeAt(d % text.length) % 13) + 1) / 100),
-            }))
-            setTimeout(() => {
+            const hook = onNextEmbedCall
+            onNextEmbedCall = null
+            const respond = (): void => {
+                const data = inputs.map((text, index) => ({
+                    object: 'embedding',
+                    index,
+                    embedding: Array.from({ length: OPENAI_3_SMALL_DIMENSIONS }, (_, d) =>
+                        ((text.charCodeAt(d % text.length) % 13) + 1) / 100),
+                }))
                 res.writeHead(200, { 'content-type': 'application/json' })
                 res.end(JSON.stringify({ object: 'list', data, model: 'text-embedding-3-small', usage: { prompt_tokens: 1, total_tokens: 1 } }))
-            }, EMBED_DELAY_MS)
+            }
+            if (hook) {
+                hook().then(respond).catch((error) => {
+                    res.writeHead(500, { 'content-type': 'text/plain' })
+                    res.end(String(error))
+                })
+                return
+            }
+            respond()
         })
     })
     return new Promise((resolve) => {
@@ -92,6 +101,10 @@ async function waitForReconcileToSettle(timeoutMs = 60_000): Promise<void> {
     const deadline = Date.now() + timeoutMs
     let idleStreak = 0
     while (Date.now() < deadline) {
+        const failedJobs = await systemJobsQueue.getJobs(['failed'], 0, 5)
+        if (failedJobs.length > 0) {
+            throw new Error(`reindex job failed — ${JSON.stringify(failedJobs.map((j) => j.failedReason))}`)
+        }
         const counts = await systemJobsQueue.getJobCounts('active', 'waiting', 'prioritized')
         const busy = (counts.active ?? 0) + (counts.waiting ?? 0) + (counts.prioritized ?? 0)
         idleStreak = busy === 0 ? idleStreak + 1 : 0
@@ -130,11 +143,12 @@ afterAll(async () => {
 
 describe('Tool Search — publish burst through the real enqueue → BullMQ → reindex path', () => {
     it('indexes every piece of a burst that lands while the reconcile is running', async () => {
-        await publish('first', '1.0.0', 'Original first description')
-        await new Promise((resolve) => setTimeout(resolve, 400))
-
         const stragglers = ['second', 'third', 'fourth', 'fifth', 'sixth']
-        await Promise.all(stragglers.map((name) => publish(name, '1.0.0', `Original ${name} description`)))
+        onNextEmbedCall = async (): Promise<void> => {
+            await Promise.all(stragglers.map((name) => publish(name, '1.0.0', `Original ${name} description`)))
+        }
+
+        await publish('first', '1.0.0', 'Original first description')
 
         await waitForReconcileToSettle()
 
@@ -148,10 +162,12 @@ describe('Tool Search — publish burst through the real enqueue → BullMQ → 
     }, 300_000)
 
     it('refreshes descriptions republished mid-reconcile — no stale text survives (runs after the burst test and republishes its pieces)', async () => {
-        await publish('first', '1.0.1', 'Rewritten first description')
-        await new Promise((resolve) => setTimeout(resolve, 400))
         const stragglers = ['second', 'third', 'fourth']
-        await Promise.all(stragglers.map((name) => publish(name, '1.0.1', `Rewritten ${name} description`)))
+        onNextEmbedCall = async (): Promise<void> => {
+            await Promise.all(stragglers.map((name) => publish(name, '1.0.1', `Rewritten ${name} description`)))
+        }
+
+        await publish('first', '1.0.1', 'Rewritten first description')
 
         await waitForReconcileToSettle()
 

--- a/packages/server/api/test/integration/ce/tool-search/tool-search-reindex-job.test.ts
+++ b/packages/server/api/test/integration/ce/tool-search/tool-search-reindex-job.test.ts
@@ -69,7 +69,8 @@ describe('Tool Search recurring reconcile (safety net)', () => {
 
         const scheduled = await reindexSchedulers()
         expect(scheduled).toHaveLength(1)
-        expect(scheduled[0].pattern).toBe('*/30 * * * *')
+        // Minute 30 — staggered against PIECES_SYNC (minutes 0–4), which enqueues its own reconcile.
+        expect(scheduled[0].pattern).toBe('30 * * * *')
     })
 
     it('is idempotent across replica boots — a second call does not add a second schedule', async () => {

--- a/packages/server/api/test/integration/ce/tool-search/tool-search-reindex-job.test.ts
+++ b/packages/server/api/test/integration/ce/tool-search/tool-search-reindex-job.test.ts
@@ -1,7 +1,8 @@
 import { FastifyInstance } from 'fastify'
-import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest'
 import { SystemJobName } from '../../../../src/app/helper/system-jobs/common'
 import { systemJobHandlers } from '../../../../src/app/helper/system-jobs/job-handlers'
+import { systemJobsQueue } from '../../../../src/app/helper/system-jobs/system-job'
 import { toolSearchReindexJob } from '../../../../src/app/tool-search/tool-search-reindex.job'
 import { setupTestEnvironment, teardownTestEnvironment } from '../../../helpers/test-setup'
 
@@ -9,6 +10,11 @@ import { setupTestEnvironment, teardownTestEnvironment } from '../../../helpers/
 // toolSearchReindexJob(app.log).register(). The MEMORY redis is a real redis-memory-server binary,
 // so BullMQ + the RedLock distributed lock genuinely run here.
 let app: FastifyInstance
+
+async function reindexSchedulers(): Promise<{ name: string, pattern?: string | null, id?: string | null, key: string }[]> {
+    const schedulers = await systemJobsQueue.getJobSchedulers()
+    return schedulers.filter((scheduler) => scheduler.name === SystemJobName.TOOL_SEARCH_REINDEX)
+}
 
 beforeAll(async () => {
     app = await setupTestEnvironment()
@@ -18,6 +24,13 @@ afterAll(async () => {
     await teardownTestEnvironment()
 })
 
+afterEach(async () => {
+    delete process.env.AP_TOOL_SEARCH_ENABLED
+    for (const scheduler of await reindexSchedulers()) {
+        await systemJobsQueue.removeJobScheduler(scheduler.id ?? scheduler.key)
+    }
+})
+
 describe('Tool Search reindex job (Phase 3 — async wiring)', () => {
     it('registers the TOOL_SEARCH_REINDEX handler at boot', () => {
         // Throws "No handler for job ..." if app.ts never called register() — guards the boot wiring.
@@ -25,9 +38,16 @@ describe('Tool Search reindex job (Phase 3 — async wiring)', () => {
     })
 
     it('the registered handler runs end-to-end (acquires the lock, resolves the platform, invokes reindex) and no-ops cleanly with no AI key', async () => {
+        process.env.AP_TOOL_SEARCH_ENABLED = 'true'
         const handler = systemJobHandlers.getJobHandler(SystemJobName.TOOL_SEARCH_REINDEX)
         // Real RedLock + getOldestPlatform + reindex. No OpenAI key is configured in tests, so the
         // reconcile resolves no embedder and no-ops — but the lock/platform/reindex glue all execute.
+        await expect(handler({ scope: { type: 'all' } })).resolves.toBeUndefined()
+    })
+
+    it('the handler no-ops when the flag is off, so a schedule that outlived the flip does no work', async () => {
+        delete process.env.AP_TOOL_SEARCH_ENABLED
+        const handler = systemJobHandlers.getJobHandler(SystemJobName.TOOL_SEARCH_REINDEX)
         await expect(handler({ scope: { type: 'all' } })).resolves.toBeUndefined()
     })
 
@@ -35,5 +55,39 @@ describe('Tool Search reindex job (Phase 3 — async wiring)', () => {
         // The worker is running (app.ts startWorker), so an enqueued one-time job is picked up and the
         // handler runs (no-op without a key). We only assert the enqueue itself integrates cleanly.
         await expect(toolSearchReindexJob(app.log).enqueue({ type: 'platform', platformId: 'platform-xyz' })).resolves.toBeUndefined()
+    })
+})
+
+// The periodic safety net. Event triggers can strand a catalog change at the edge of a running
+// reconcile, and the boot backfill only detects NULL embeddings — never staleness — so without a
+// repeated schedule a stranded change waits for the next publish.
+describe('Tool Search recurring reconcile (safety net)', () => {
+    it('registers one repeated reconcile when the flag is on', async () => {
+        process.env.AP_TOOL_SEARCH_ENABLED = 'true'
+
+        await toolSearchReindexJob(app.log).scheduleRecurringReconcile()
+
+        const scheduled = await reindexSchedulers()
+        expect(scheduled).toHaveLength(1)
+        expect(scheduled[0].pattern).toBe('*/30 * * * *')
+    })
+
+    it('is idempotent across replica boots — a second call does not add a second schedule', async () => {
+        process.env.AP_TOOL_SEARCH_ENABLED = 'true'
+
+        await toolSearchReindexJob(app.log).scheduleRecurringReconcile()
+        await toolSearchReindexJob(app.log).scheduleRecurringReconcile()
+
+        // Keyed on the job name, so every replica converges on the one schedule instead of each adding
+        // its own — N replicas must not mean N reconciles per interval.
+        expect(await reindexSchedulers()).toHaveLength(1)
+    })
+
+    it('registers nothing when the flag is off', async () => {
+        delete process.env.AP_TOOL_SEARCH_ENABLED
+
+        await toolSearchReindexJob(app.log).scheduleRecurringReconcile()
+
+        expect(await reindexSchedulers()).toHaveLength(0)
     })
 })

--- a/packages/server/api/test/integration/ce/tool-search/tool-search-reindex-job.test.ts
+++ b/packages/server/api/test/integration/ce/tool-search/tool-search-reindex-job.test.ts
@@ -58,9 +58,6 @@ describe('Tool Search reindex job (Phase 3 — async wiring)', () => {
     })
 })
 
-// The periodic safety net. Event triggers can strand a catalog change at the edge of a running
-// reconcile, and the boot backfill only detects NULL embeddings — never staleness — so without a
-// repeated schedule a stranded change waits for the next publish.
 describe('Tool Search recurring reconcile (safety net)', () => {
     it('registers one repeated reconcile when the flag is on', async () => {
         process.env.AP_TOOL_SEARCH_ENABLED = 'true'
@@ -69,7 +66,6 @@ describe('Tool Search recurring reconcile (safety net)', () => {
 
         const scheduled = await reindexSchedulers()
         expect(scheduled).toHaveLength(1)
-        // Minute 30 — staggered against PIECES_SYNC (minutes 0–4), which enqueues its own reconcile.
         expect(scheduled[0].pattern).toBe('30 * * * *')
     })
 
@@ -79,8 +75,6 @@ describe('Tool Search recurring reconcile (safety net)', () => {
         await toolSearchReindexJob(app.log).scheduleRecurringReconcile()
         await toolSearchReindexJob(app.log).scheduleRecurringReconcile()
 
-        // Keyed on the job name, so every replica converges on the one schedule instead of each adding
-        // its own — N replicas must not mean N reconciles per interval.
         expect(await reindexSchedulers()).toHaveLength(1)
     })
 

--- a/packages/server/api/test/integration/ce/tool-search/tool-search.test.ts
+++ b/packages/server/api/test/integration/ce/tool-search/tool-search.test.ts
@@ -97,11 +97,11 @@ async function nullEmbeddingCount(): Promise<number> {
     return count
 }
 
-type IndexRowProbe = { pieceVersion: string, embeddingInputHash: string, embedding: string | null, modelVersion: string }
+type IndexRowProbe = { pieceVersion: string, embeddingInputHash: string, embedding: string | null, modelVersion: string, retrievalDoc: string }
 
 async function getIndexRow(pieceName: string, objectName: string): Promise<IndexRowProbe | undefined> {
     const rows = await databaseConnection().query(
-        `SELECT "pieceVersion", "embeddingInputHash", "embedding"::text AS embedding, "modelVersion"
+        `SELECT "pieceVersion", "embeddingInputHash", "embedding"::text AS embedding, "modelVersion", "retrievalDoc"
          FROM "tool_search_index" WHERE "pieceName" = $1 AND "objectName" = $2`,
         [pieceName, objectName],
     )
@@ -445,7 +445,108 @@ describe('Tool Search Engine (Phase 3 — incremental catalog sync)', () => {
         expect(second.objectsIndexed).toBe(4)
         expect(second.objectsEmbedded).toBe(0)
         expect(second.objectsDeleted).toBe(0)
+        // An unchanged catalog never triggers a trailing pass — the fingerprint check costs one pass, not two.
+        expect(second.passes).toBe(1)
         expect(await indexRowCount()).toBe(4)
+    })
+})
+
+describe('Tool Search Engine (Phase 3 — trailing edge: catalog changes landing mid-reconcile)', () => {
+    // A burst of publishes collapses onto one reindex job (stable jobId), so a piece published after that
+    // job read its catalog snapshot has no job of its own left to run in. These tests reproduce that by
+    // writing to piece_metadata from inside embed() — which runs after the snapshot is taken — and assert
+    // the reconcile notices and runs a trailing pass instead of silently stranding the write.
+    function embedderPublishingMidRun(publish: (call: number) => Promise<unknown>, calls = 1): ToolSearchEmbedder {
+        let call = 0
+        return {
+            ...fakeEmbedder,
+            embed: async (texts) => {
+                if (call < calls) {
+                    call++
+                    await publish(call)
+                }
+                return texts.map(bagOfWords)
+            },
+        }
+    }
+
+    function trelloPiece(version: string): ReturnType<typeof createMockPieceMetadata> {
+        return createMockPieceMetadata({
+            name: '@activepieces/piece-trello',
+            displayName: 'Trello',
+            version,
+            pieceType: PieceType.OFFICIAL,
+            packageType: PackageType.REGISTRY,
+            actions: { create_card: action({ name: 'create_card', displayName: 'Create Card', description: 'Create a new card on a Trello board' }) },
+            triggers: {},
+        })
+    }
+
+    it('indexes a piece published after the snapshot was taken instead of dropping it', async () => {
+        await seedCatalog()
+        const embedder = embedderPublishingMidRun(() => db.save('piece_metadata', trelloPiece('1.0.0')))
+
+        const result = await toolSearchReindexService(log).reindex({ embedder })
+
+        // Pass 1 indexes the 4 seeded objects; Trello lands while they embed and pass 2 picks it up.
+        expect(result.passes).toBe(2)
+        expect(result.objectsIndexed).toBe(5)
+        expect(result.objectsEmbedded).toBe(5)
+        expect(await indexRowCount()).toBe(5)
+        expect((await getIndexRow('@activepieces/piece-trello', 'create_card'))?.embedding).not.toBeNull()
+    })
+
+    it('refreshes a description republished mid-reconcile — the stale text is gone from the index', async () => {
+        // The reported failure: two publishes inside one reconcile window. The first (Trello) is what the
+        // running job is embedding; the second (Gmail, with rewritten action text) commits mid-run and
+        // must not keep serving its pre-publish description. Asserting the NEW text is present would pass
+        // trivially on the rows that did update — so assert the OLD text is absent.
+        await seedCatalog()
+        await toolSearchReindexService(log).reindex({ embedder: fakeEmbedder })
+        expect((await getIndexRow('@activepieces/piece-gmail', 'send_email'))?.retrievalDoc).toContain('Send an email via Gmail')
+
+        await db.save('piece_metadata', trelloPiece('1.0.0'))
+        const embedder = embedderPublishingMidRun(() => db.save('piece_metadata', createMockPieceMetadata({
+            name: '@activepieces/piece-gmail',
+            displayName: 'Gmail',
+            version: '1.0.1',
+            pieceType: PieceType.OFFICIAL,
+            packageType: PackageType.REGISTRY,
+            actions: { send_email: action({ name: 'send_email', displayName: 'Send Email', description: 'Create and send a new email message via Gmail' }) },
+            triggers: {},
+        })))
+
+        const result = await toolSearchReindexService(log).reindex({ embedder })
+
+        expect(result.passes).toBe(2)
+        const gmail = await getIndexRow('@activepieces/piece-gmail', 'send_email')
+        expect(gmail?.retrievalDoc).not.toContain('Send an email via Gmail')
+        expect(gmail?.retrievalDoc).toContain('Create and send a new email message via Gmail')
+        expect(gmail?.pieceVersion).toBe('1.0.1')
+        expect(gmail?.embedding).not.toBeNull()
+    })
+
+    it('stops at the trailing-pass cap when the catalog keeps changing, rather than looping', async () => {
+        await seedCatalog()
+        // Every pass finds something to embed and publishes again, so the fingerprint never settles.
+        const embedder = embedderPublishingMidRun((call) => db.save('piece_metadata', createMockPieceMetadata({
+            name: `@activepieces/piece-churn-${call}`,
+            displayName: `Churn ${call}`,
+            version: '1.0.0',
+            pieceType: PieceType.OFFICIAL,
+            packageType: PackageType.REGISTRY,
+            actions: { send_message: action({ name: 'send_message', displayName: 'Send Message', description: `Send message number ${call}` }) },
+            triggers: {},
+        })), Number.MAX_SAFE_INTEGER)
+
+        const result = await toolSearchReindexService(log).reindex({ embedder })
+
+        // 3 passes: seeded 4 → +churn-1 → +churn-2. churn-3 is published during pass 3 and left for the
+        // next enqueued reconcile; the run terminates rather than chasing the catalog.
+        expect(result.passes).toBe(3)
+        expect(result.objectsIndexed).toBe(6)
+        expect(await indexRowCount()).toBe(6)
+        expect(await nullEmbeddingCount()).toBe(0)
     })
 })
 

--- a/packages/server/api/test/integration/ce/tool-search/tool-search.test.ts
+++ b/packages/server/api/test/integration/ce/tool-search/tool-search.test.ts
@@ -445,17 +445,12 @@ describe('Tool Search Engine (Phase 3 — incremental catalog sync)', () => {
         expect(second.objectsIndexed).toBe(4)
         expect(second.objectsEmbedded).toBe(0)
         expect(second.objectsDeleted).toBe(0)
-        // An unchanged catalog never triggers a trailing pass — the fingerprint check costs one pass, not two.
         expect(second.passes).toBe(1)
         expect(await indexRowCount()).toBe(4)
     })
 })
 
 describe('Tool Search Engine (Phase 3 — trailing edge: catalog changes landing mid-reconcile)', () => {
-    // A burst of publishes collapses onto one reindex job (stable jobId), so a piece published after that
-    // job read its catalog snapshot has no job of its own left to run in. These tests reproduce that by
-    // writing to piece_metadata from inside embed() — which runs after the snapshot is taken — and assert
-    // the reconcile notices and runs a trailing pass instead of silently stranding the write.
     function embedderPublishingMidRun(publish: (call: number) => Promise<unknown>, calls = 1): ToolSearchEmbedder {
         let call = 0
         return {
@@ -488,7 +483,6 @@ describe('Tool Search Engine (Phase 3 — trailing edge: catalog changes landing
 
         const result = await toolSearchReindexService(log).reindex({ embedder })
 
-        // Pass 1 indexes the 4 seeded objects; Trello lands while they embed and pass 2 picks it up.
         expect(result.passes).toBe(2)
         expect(result.objectsIndexed).toBe(5)
         expect(result.objectsEmbedded).toBe(5)
@@ -497,10 +491,6 @@ describe('Tool Search Engine (Phase 3 — trailing edge: catalog changes landing
     })
 
     it('refreshes a description republished mid-reconcile — the stale text is gone from the index', async () => {
-        // The reported failure: two publishes inside one reconcile window. The first (Trello) is what the
-        // running job is embedding; the second (Gmail, with rewritten action text) commits mid-run and
-        // must not keep serving its pre-publish description. Asserting the NEW text is present would pass
-        // trivially on the rows that did update — so assert the OLD text is absent.
         await seedCatalog()
         await toolSearchReindexService(log).reindex({ embedder: fakeEmbedder })
         expect((await getIndexRow('@activepieces/piece-gmail', 'send_email'))?.retrievalDoc).toContain('Send an email via Gmail')
@@ -528,7 +518,6 @@ describe('Tool Search Engine (Phase 3 — trailing edge: catalog changes landing
 
     it('stops at the trailing-pass cap when the catalog keeps changing, rather than looping', async () => {
         await seedCatalog()
-        // Every pass finds something to embed and publishes again, so the fingerprint never settles.
         const embedder = embedderPublishingMidRun((call) => db.save('piece_metadata', createMockPieceMetadata({
             name: `@activepieces/piece-churn-${call}`,
             displayName: `Churn ${call}`,
@@ -541,8 +530,6 @@ describe('Tool Search Engine (Phase 3 — trailing edge: catalog changes landing
 
         const result = await toolSearchReindexService(log).reindex({ embedder })
 
-        // 3 passes: seeded 4 → +churn-1 → +churn-2. churn-3 is published during pass 3 and left for the
-        // next enqueued reconcile; the run terminates rather than chasing the catalog.
         expect(result.passes).toBe(3)
         expect(result.objectsIndexed).toBe(6)
         expect(await indexRowCount()).toBe(6)


### PR DESCRIPTION
Plan: [PIE-371](https://linear.app/activepieces/issue/PIE-371/fix-tool-search-reindex-dropping-pieces-published-mid-reconcile) — goal, happy path, unhappy scenarios, trade-offs and breaking-change assessment.

## Description

A piece published **while a tool-search reindex is running** never reaches `tool_search_index`. Search keeps serving that action's pre-publish description until some later, unrelated publish happens to schedule a fresh reconcile.

Observed on cloud after a 6-piece publish burst: `piece_metadata` was correct for all six, `tool_search_index` had picked up **one**. The other five still served their old descriptions hours later — repeat probes returned byte-identical cosine scores, so those rows were untouched, not slowly re-embedded.

This is not an edge case of one unusually large PR. `tools/scripts/pieces/update-pieces-metadata.ts:52-58` publishes the changed set in **concurrent batches of 30**, 5s apart — so on any release run touching more than one piece, whichever POST commits first creates the reindex job, and its siblings commit after that job has already read its snapshot. Self-hosted `OFFICIAL_AUTO` sync is not exposed (`piece-sync-service.ts:72` enqueues once, after all inserts complete).

### Why

The debounce has no trailing edge:

1. Every publish (`POST /v1/admin/pieces`) fires `toolSearchReindexJob.enqueue({ type: 'all' })`.
2. `enqueue` uses a deliberately stable jobId, `tool-search-reindex`, so a burst of catalog changes collapses to one pending job.
3. `upsertJob` is a silent no-op when a job with that id already exists — including while it is **active**.
4. The reconcile reads the catalog **once**, at job start.

So a publish that commits after the running job's snapshot is collapsed into a job that has already read its input, and is dropped. Collapsing the burst is right; collapsing into an already-started job is the bug.

Nothing recovered it. The boot backfill skips when `coverage.pending === 0`, and `pending` counts NULL embeddings only — a stale row keeps its old, non-NULL vector, so a fully-embedded-but-stale index reports "fully built, nothing to reconcile" on every restart. Because `removeOnComplete` evicts the finished job, the stranded rows did eventually clear on the *next* publish, which is why this was intermittent rather than wedged.

### How it works

Two layers, because an event-driven trigger alone cannot close this.

**1. Trailing pass (`tool-search-reindex.service.ts`).** Fingerprint `piece_metadata` (row count + newest write timestamp) **before** the catalog snapshot and again after each reconcile pass. If it moved, a write landed that the pass could not see — so run a trailing pass.

- That pass is the same idempotent, hash-gated diff, so it only touches what actually changed.
- An unchanged catalog still costs exactly **one** pass (two cheap aggregates).
- Capped at 3 passes, so a catalog under continuous writes is not chased while holding the reconcile lock.
- The fingerprint is deliberately unfiltered. It can over-report a change (a spurious trailing pass is a hash-gated no-op); under-reporting would strand a publish, which is the failure this guards.

No BullMQ introspection and no cross-process dirty marker, so it behaves the same on every queue/redis configuration — and it also catches catalog writes that never called `enqueue`. The module-internal `ReindexResult` gains `passes` so the behaviour is assertable.

**2. Periodic reconcile (`tool-search-reindex.job.ts`, hourly at minute 30).** A bounded loop still defers the write its *last* pass detects, and that write's own enqueue was already collapsed into the running job — so the trailing pass alone leaves a hole, as does the boot backfill (it counts NULL embeddings, never staleness). The repeated schedule is the out-of-band guarantee that anything stranded is repaired within one interval, whatever stranded it. It follows the existing `PIECES_SYNC` pattern, and is staggered to minute 30 because that job (minutes 0-4) already enqueues a reconcile off its own catalog delta. Cheap by construction: the reconcile is hash-gated, so an unchanged catalog embeds nothing, deletes nothing and writes no rows — each pass does still re-read the full piece catalog to recompute hashes, and that read plus two fingerprint aggregates is the whole per-tick cost. Measured against a 700-piece / 7,000-object catalog, a no-op reconcile is **~0.4s**. Keyed on the job name, so N replicas converge on one schedule rather than N.

Registration is flag-gated, but a repeated schedule is persisted in the queue and outlives a flag flip, so the handler now checks `isToolSearchEnabled()` as well — otherwise turning tool-search off would leave the index, and its embedding spend, being maintained anyway.

### Still open, deliberately

Fixing the boot staleness test (compare desired-vs-stored `embeddingInputHash` instead of counting NULLs) so a restart also repairs stale rows. The periodic reconcile now covers that case within one interval (hourly at minute 30, so up to ~an hour), which makes this an optimisation rather than a gap.

## How was this tested?

Three new integration tests in `tool-search.test.ts` write to `piece_metadata` from inside `embed()` — which runs *after* the snapshot is taken — to reproduce a publish landing mid-reconcile:

- a piece published after the snapshot is indexed and embedded rather than dropped;
- a description republished mid-reconcile is refreshed, asserting the **old** text is absent (asserting the new text is present passes trivially on rows that did update, and hides the ones that did not);
- a catalog that keeps changing stops at the pass cap instead of looping.

All three were verified red against `main`: 4 index rows instead of 5, and Gmail still serving `Send an email via Gmail`. A `passes === 1` assertion was added to the existing unchanged-catalog no-op test so the fingerprint check can't silently start double-reconciling.

One end-to-end test in `tool-search-publish-burst.test.ts` exercises the drop through the real path — the reconcile tests above call `reindex()` directly, so they never cross the enqueue collapse, which is where the loss actually happens. It publishes through the real `enqueue` -> BullMQ -> handler chain with a genuine OpenAI embedder pointed at a local stub via `OPENAI_BASE_URL` (no key, no network, runs on PG16 in CI). Verified red on `main` the same way: the second publish was absent from the index entirely, and a republished description kept serving its pre-publish text.

Four more in `tool-search-reindex-job.test.ts`, against real BullMQ on `redis-memory-server`: the repeated schedule is registered once with the expected pattern when the flag is on, a second call (another replica booting) does not add a second schedule, nothing is registered when the flag is off, and the handler no-ops when the flag is off. The pre-existing "handler runs end-to-end" test now enables the flag so it still exercises the lock/platform/reindex glue it is there to guard.

Ran locally on CE (PGlite): `packages/server/api` tool-search unit + integration suites, **97/97 pass**, including the two full-server-boot suites. `tsc -p tsconfig.app.json` clean; `eslint` 0 errors. The `tool-search (postgres)` CI job covers the PG16 path. Server-side only, no edition-specific branches.

Fixes PIE-371

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)


