### PR TITLE
feat(pieces): add Wafly piece

### DIFF
--- a/packages/pieces/community/wafly/.eslintrc.json
+++ b/packages/pieces/community/wafly/.eslintrc.json
@@ -1,0 +1,47 @@
+{
+  "extends": [
+    "../../../../.eslintrc.json"
+  ],
+  "ignorePatterns": [
+    "!**/*"
+  ],
+  "overrides": [
+    {
+      "files": [
+        "*.ts",
+        "*.tsx",
+        "*.js",
+        "*.jsx"
+      ],
+      "rules": {}
+    },
+    {
+      "files": [
+        "*.ts",
+        "*.tsx"
+      ],
+      "rules": {
+        "no-restricted-imports": [
+          "error",
+          {
+            "patterns": [
+              "lodash",
+              "lodash/*",
+              "@activepieces/core-*",
+              "@activepieces/server*",
+              "@activepieces/engine",
+              "@activepieces/shared"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "files": [
+        "*.js",
+        "*.jsx"
+      ],
+      "rules": {}
+    }
+  ]
+}

--- a/packages/pieces/community/wafly/README.md
+++ b/packages/pieces/community/wafly/README.md
@@ -1,0 +1,55 @@
+# Wafly
+
+WhatsApp API built for automations and AI agents.
+
+Nobody writes a paragraph on WhatsApp. People send `hi`, then `you there?`, then
+`how much is it?` — three separate webhooks, so an agent replies three times and
+the first two replies were written before the person finished asking. Half the
+time the real question arrives as a voice note, which an LLM cannot hear at all.
+
+Wafly solves both in the pipe: consecutive messages from the same person are
+delivered as **one** event, and voice notes arrive already transcribed.
+
+## Actions
+
+| Action | What it does |
+|---|---|
+| Send Text Message | Text to a number or group |
+| Send Media | Image, video, audio or PDF |
+| Send Poll | Poll with two or more options |
+| Create Group | New group with participants |
+| Check Numbers on WhatsApp | Which numbers in a list have WhatsApp |
+| Get Instance Status | Whether the instance is connected |
+| Configure Message Buffer | Group split messages into one event |
+| Configure Audio Transcription | Transcribe incoming voice notes |
+
+The last two are **instance-level settings** — run once, not per message.
+
+## Trigger
+
+**New Message Received** — fires on every inbound message, already grouped and
+transcribed when those settings are on.
+
+> Wafly has no API to register a webhook URL. After enabling the trigger, copy
+> the webhook URL from Activepieces and paste it in the Wafly dashboard under
+> **Instance → Webhooks**. It is a one-time step.
+
+## Connection
+
+Get these from [wafly.com.br](https://wafly.com.br):
+
+| Field | Where |
+|---|---|
+| Base URL | `https://wafly.com.br/api-bridge-whats` (default) |
+| Client Token | Dashboard → Security |
+| Instance | The instance name |
+| Instance Token | That instance's token |
+
+Free 3-day trial, no card. Connect by QR Code.
+
+## Audio transcription uses your own OpenAI key
+
+The cost lands on your own OpenAI account and Wafly charges nothing on top. The
+key is stored encrypted and never returned by the API. Set a monthly cap so it
+cannot run away — and if the cap is hit or the provider refuses, **the message
+still arrives**, only without the transcript. Nothing is dropped.

--- a/packages/pieces/community/wafly/package.json
+++ b/packages/pieces/community/wafly/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@activepieces/piece-wafly",
+  "version": "0.1.0",
+  "main": "./dist/src/index.js",
+  "types": "./dist/src/index.d.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.lib.json && cp package.json dist/",
+    "bundle": "node ../../../../dist/packages/cli/src/index.js pieces bundle",
+    "lint": "eslint 'src/**/*.ts'"
+  },
+  "dependencies": {
+    "@activepieces/pieces-common": "workspace:*",
+    "@activepieces/pieces-framework": "workspace:*",
+    "@activepieces/core-piece-types": "workspace:*",
+    "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
+  }
+}

--- a/packages/pieces/community/wafly/src/index.ts
+++ b/packages/pieces/community/wafly/src/index.ts
@@ -1,0 +1,37 @@
+import { createPiece, PieceCategory } from '@activepieces/pieces-framework';
+
+import { waflyAuth } from './lib/common';
+import { sendText } from './lib/actions/send-text';
+import { sendMedia } from './lib/actions/send-media';
+import { sendPoll } from './lib/actions/send-poll';
+import { getInstanceStatus } from './lib/actions/get-instance-status';
+import { checkPhones } from './lib/actions/check-phones';
+import { createGroup } from './lib/actions/create-group';
+import { setMessageBuffer } from './lib/actions/set-message-buffer';
+import { setTranscription } from './lib/actions/set-transcription';
+import { newMessage } from './lib/triggers/new-message';
+
+export { waflyAuth };
+
+export const wafly = createPiece({
+  displayName: 'Wafly',
+  description:
+    'WhatsApp API that groups a person\'s split messages into one event and transcribes voice notes, so an AI agent answers once with the whole question.',
+  auth: waflyAuth,
+  minimumSupportedRelease: '0.36.1',
+  logoUrl:
+    'https://raw.githubusercontent.com/iagovelasco3/n8n-nodes-wafly/main/nodes/Wafly/wafly.svg',
+  categories: [PieceCategory.COMMUNICATION],
+  authors: ['iagovelasco3'],
+  actions: [
+    sendText,
+    sendMedia,
+    sendPoll,
+    createGroup,
+    checkPhones,
+    getInstanceStatus,
+    setMessageBuffer,
+    setTranscription,
+  ],
+  triggers: [newMessage],
+});

--- a/packages/pieces/community/wafly/src/lib/actions/check-phones.ts
+++ b/packages/pieces/community/wafly/src/lib/actions/check-phones.ts
@@ -1,0 +1,39 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { waflyAuth, waflyApiCall, normalizePhone } from '../common';
+
+export const checkPhones = createAction({
+  auth: waflyAuth,
+  name: 'check_phones',
+  displayName: 'Check Numbers on WhatsApp',
+  description: 'Check which of a list of phone numbers exist on WhatsApp.',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Checks a batch of phone numbers and reports which ones have a WhatsApp account. Read-only and idempotent. Useful for cleaning a list before a send, so messages are not attempted against numbers that cannot receive them.',
+    idempotent: true,
+  },
+  props: {
+    phones: Property.Array({
+      displayName: 'Phone Numbers',
+      description: 'International format, e.g. 5511999999999.',
+      required: true,
+    }),
+  },
+  async run(context) {
+    const phones = (context.propsValue.phones as string[])
+      .map((phone) => normalizePhone(String(phone)))
+      .filter((phone) => phone.length > 0);
+
+    if (phones.length === 0) {
+      throw new Error('Provide at least one phone number.');
+    }
+
+    return await waflyApiCall({
+      auth: context.auth,
+      method: HttpMethod.POST,
+      resourceUri: '/phone-exists-batch',
+      body: { phones },
+    });
+  },
+});

--- a/packages/pieces/community/wafly/src/lib/actions/create-group.ts
+++ b/packages/pieces/community/wafly/src/lib/actions/create-group.ts
@@ -1,0 +1,45 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { waflyAuth, waflyApiCall, normalizePhone } from '../common';
+
+export const createGroup = createAction({
+  auth: waflyAuth,
+  name: 'create_group',
+  displayName: 'Create Group',
+  description: 'Create a WhatsApp group with a list of participants.',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Creates a new WhatsApp group from a connected Wafly instance, with a name and an initial list of participant phone numbers, and returns the new group ID. Not idempotent: calling it twice creates two groups with the same name.',
+    idempotent: false,
+  },
+  props: {
+    groupName: Property.ShortText({
+      displayName: 'Group Name',
+      required: true,
+    }),
+    phones: Property.Array({
+      displayName: 'Participants',
+      description: 'Phone numbers in international format, e.g. 5511999999999.',
+      required: true,
+    }),
+  },
+  async run(context) {
+    const { groupName, phones } = context.propsValue;
+
+    const participants = (phones as string[])
+      .map((phone) => normalizePhone(String(phone)))
+      .filter((phone) => phone.length > 0);
+
+    if (participants.length === 0) {
+      throw new Error('Provide at least one participant.');
+    }
+
+    return await waflyApiCall({
+      auth: context.auth,
+      method: HttpMethod.POST,
+      resourceUri: '/create-group',
+      body: { groupName, phones: participants },
+    });
+  },
+});

--- a/packages/pieces/community/wafly/src/lib/actions/get-instance-status.ts
+++ b/packages/pieces/community/wafly/src/lib/actions/get-instance-status.ts
@@ -1,0 +1,24 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { waflyAuth, waflyApiCall } from '../common';
+
+export const getInstanceStatus = createAction({
+  auth: waflyAuth,
+  name: 'get_instance_status',
+  displayName: 'Get Instance Status',
+  description: 'Check whether the WhatsApp instance is connected.',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Reads the current connection state of the Wafly WhatsApp instance, including whether it is connected and which phone number is paired. Read-only and idempotent: safe to call repeatedly, typically before sending messages or to alert when a number drops.',
+    idempotent: true,
+  },
+  props: {},
+  async run(context) {
+    return await waflyApiCall({
+      auth: context.auth,
+      method: HttpMethod.GET,
+      resourceUri: '/status',
+    });
+  },
+});

--- a/packages/pieces/community/wafly/src/lib/actions/send-media.ts
+++ b/packages/pieces/community/wafly/src/lib/actions/send-media.ts
@@ -1,0 +1,90 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { waflyAuth, waflyApiCall, normalizePhone } from '../common';
+
+/**
+ * Image, video, audio and document are four routes with almost the same body,
+ * so they are one action with a Media Type dropdown instead of four actions
+ * cluttering the picker.
+ */
+const MEDIA_ROUTES = {
+  image: { uri: '/send-image', field: 'image' },
+  video: { uri: '/send-video', field: 'video' },
+  audio: { uri: '/send-audio', field: 'audio' },
+  document: { uri: '/send-document/pdf', field: 'document' },
+} as const;
+
+type MediaType = keyof typeof MEDIA_ROUTES;
+
+export const sendMedia = createAction({
+  auth: waflyAuth,
+  name: 'send_media',
+  displayName: 'Send Media',
+  description: 'Send an image, video, audio or document over WhatsApp.',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Sends a media file (image, video, audio or PDF document) over WhatsApp from a connected Wafly instance. The file is provided as a public URL or a base64 data URI. Captions apply to image, video and document. Not idempotent: each call delivers a new message.',
+    idempotent: false,
+  },
+  props: {
+    phone: Property.ShortText({
+      displayName: 'To',
+      description:
+        'Phone number in international format (e.g. 5511999999999) or a group ID.',
+      required: true,
+    }),
+    mediaType: Property.StaticDropdown({
+      displayName: 'Media Type',
+      required: true,
+      defaultValue: 'image',
+      options: {
+        options: [
+          { label: 'Image', value: 'image' },
+          { label: 'Video', value: 'video' },
+          { label: 'Audio', value: 'audio' },
+          { label: 'Document (PDF)', value: 'document' },
+        ],
+      },
+    }),
+    url: Property.ShortText({
+      displayName: 'File URL or Base64',
+      description: 'A publicly reachable URL, or a base64 data URI.',
+      required: true,
+    }),
+    caption: Property.LongText({
+      displayName: 'Caption',
+      description: 'Ignored for audio.',
+      required: false,
+    }),
+    fileName: Property.ShortText({
+      displayName: 'File Name',
+      description: 'Document only. Shown to the recipient.',
+      required: false,
+    }),
+  },
+  async run(context) {
+    const { phone, mediaType, url, caption, fileName } = context.propsValue;
+    const route = MEDIA_ROUTES[mediaType as MediaType];
+
+    const body: Record<string, unknown> = {
+      phone: normalizePhone(phone),
+      [route.field]: url,
+    };
+
+    // Audio carries no caption, and only the document route reads fileName.
+    if (mediaType !== 'audio' && caption) {
+      body['caption'] = caption;
+    }
+    if (mediaType === 'document' && fileName) {
+      body['fileName'] = fileName;
+    }
+
+    return await waflyApiCall({
+      auth: context.auth,
+      method: HttpMethod.POST,
+      resourceUri: route.uri,
+      body,
+    });
+  },
+});

--- a/packages/pieces/community/wafly/src/lib/actions/send-poll.ts
+++ b/packages/pieces/community/wafly/src/lib/actions/send-poll.ts
@@ -1,0 +1,63 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { waflyAuth, waflyApiCall, normalizePhone } from '../common';
+
+export const sendPoll = createAction({
+  auth: waflyAuth,
+  name: 'send_poll',
+  displayName: 'Send Poll',
+  description: 'Send a WhatsApp poll with two or more options.',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Sends a WhatsApp poll from a connected Wafly instance, with a question and a list of options, optionally allowing multiple selections. Not idempotent: each call posts a new poll.',
+    idempotent: false,
+  },
+  props: {
+    phone: Property.ShortText({
+      displayName: 'To',
+      description:
+        'Phone number in international format (e.g. 5511999999999) or a group ID.',
+      required: true,
+    }),
+    message: Property.ShortText({
+      displayName: 'Question',
+      required: true,
+    }),
+    options: Property.Array({
+      displayName: 'Options',
+      description: 'At least two.',
+      required: true,
+    }),
+    maxOptions: Property.Number({
+      displayName: 'Max Selectable Options',
+      description: 'How many options a person may pick. Defaults to 1.',
+      required: false,
+      defaultValue: 1,
+    }),
+  },
+  async run(context) {
+    const { phone, message, options, maxOptions } = context.propsValue;
+
+    const poll = (options as string[])
+      .map((option) => String(option).trim())
+      .filter((option) => option.length > 0)
+      .map((optionName) => ({ optionName }));
+
+    if (poll.length < 2) {
+      throw new Error('A poll needs at least two non-empty options.');
+    }
+
+    return await waflyApiCall({
+      auth: context.auth,
+      method: HttpMethod.POST,
+      resourceUri: '/send-poll',
+      body: {
+        phone: normalizePhone(phone),
+        message,
+        poll,
+        pollMaxOptions: maxOptions ?? 1,
+      },
+    });
+  },
+});

--- a/packages/pieces/community/wafly/src/lib/actions/send-text.ts
+++ b/packages/pieces/community/wafly/src/lib/actions/send-text.ts
@@ -1,0 +1,37 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { waflyAuth, waflyApiCall, normalizePhone } from '../common';
+
+export const sendText = createAction({
+  auth: waflyAuth,
+  name: 'send_text',
+  displayName: 'Send Text Message',
+  description: 'Send a WhatsApp text message to a phone number or group.',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Sends a WhatsApp text message from a connected Wafly instance to a single recipient, which can be a phone number in international format or a group ID. Requires the recipient and the message body. Not idempotent: each call delivers a new message, so repeating it sends duplicates.',
+    idempotent: false,
+  },
+  props: {
+    phone: Property.ShortText({
+      displayName: 'To',
+      description:
+        'Phone number in international format (e.g. 5511999999999) or a group ID.',
+      required: true,
+    }),
+    message: Property.LongText({
+      displayName: 'Message',
+      required: true,
+    }),
+  },
+  async run(context) {
+    const { phone, message } = context.propsValue;
+    return await waflyApiCall({
+      auth: context.auth,
+      method: HttpMethod.POST,
+      resourceUri: '/send-text',
+      body: { phone: normalizePhone(phone), message },
+    });
+  },
+});

--- a/packages/pieces/community/wafly/src/lib/actions/set-message-buffer.ts
+++ b/packages/pieces/community/wafly/src/lib/actions/set-message-buffer.ts
@@ -1,0 +1,81 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { waflyAuth, waflyApiCall } from '../common';
+
+export const setMessageBuffer = createAction({
+  auth: waflyAuth,
+  name: 'set_message_buffer',
+  displayName: 'Configure Message Buffer',
+  description:
+    'Group a person\'s consecutive messages into a single webhook call, so an agent answers once.',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Turns on or updates message buffering for a Wafly instance. When enabled, consecutive messages from the same person are delivered as one webhook event instead of one per message, so an AI agent replies once with the whole question. This is an instance-level setting, not a per-message step. Idempotent: applying the same values twice leaves the same configuration.',
+    idempotent: true,
+  },
+  props: {
+    windowSeconds: Property.Number({
+      displayName: 'Silence Window (seconds)',
+      description:
+        'Restarts on every new message, so delivery happens when the person stops typing. Max 20.',
+      required: true,
+      defaultValue: 8,
+    }),
+    maxWaitSeconds: Property.Number({
+      displayName: 'Max Wait (seconds)',
+      description:
+        'Hard ceiling from the first message, so non-stop typing cannot postpone delivery forever. Max 30.',
+      required: true,
+      defaultValue: 30,
+    }),
+    maxMessages: Property.Number({
+      displayName: 'Max Messages',
+      description: 'Deliver immediately once this many pile up. Max 50.',
+      required: true,
+      defaultValue: 10,
+    }),
+    mode: Property.StaticDropdown({
+      displayName: 'Mode',
+      description:
+        'Concat keeps the usual payload shape, so existing flows keep working. Batch adds a bufferedMessages array and changes it.',
+      required: true,
+      defaultValue: 'concat',
+      options: {
+        options: [
+          { label: 'Concat (same payload shape)', value: 'concat' },
+          { label: 'Batch (array of messages)', value: 'batch' },
+        ],
+      },
+    }),
+    includeGroups: Property.Checkbox({
+      displayName: 'Include Group Chats',
+      description:
+        'Grouping inside a group chat is per participant — different people are never merged together.',
+      required: false,
+      defaultValue: false,
+    }),
+  },
+  async run(context) {
+    const { windowSeconds, maxWaitSeconds, maxMessages, mode, includeGroups } =
+      context.propsValue;
+
+    // The API works in milliseconds; seconds is what makes sense to someone
+    // setting "how long to wait for the person to finish typing".
+    return await waflyApiCall({
+      auth: context.auth,
+      method: HttpMethod.PUT,
+      resourceUri: '/inbound-config',
+      body: {
+        buffer: {
+          enabled: true,
+          window_ms: windowSeconds * 1000,
+          max_wait_ms: maxWaitSeconds * 1000,
+          max_messages: maxMessages,
+          mode,
+          include_groups: includeGroups ?? false,
+        },
+      },
+    });
+  },
+});

--- a/packages/pieces/community/wafly/src/lib/actions/set-transcription.ts
+++ b/packages/pieces/community/wafly/src/lib/actions/set-transcription.ts
@@ -1,0 +1,59 @@
+import { createAction, Property, PieceAuth } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { waflyAuth, waflyApiCall } from '../common';
+
+export const setTranscription = createAction({
+  auth: waflyAuth,
+  name: 'set_transcription',
+  displayName: 'Configure Audio Transcription',
+  description:
+    'Have received voice notes arrive already transcribed in the webhook, using your own OpenAI key.',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Turns on or updates audio transcription for a Wafly instance, so incoming WhatsApp voice notes arrive with their text transcript in the webhook payload. Uses the customer\'s own OpenAI key, billed directly by OpenAI. This is an instance-level setting, not a per-message step. Idempotent.',
+    idempotent: true,
+  },
+  props: {
+    apiKey: PieceAuth.SecretText({
+      displayName: 'OpenAI API Key',
+      description:
+        'Yours — the cost lands on your own OpenAI account and Wafly adds nothing. Stored encrypted and never returned by the API. Leave empty to keep the key already saved and change only the limits.',
+      required: false,
+    }),
+    maxAudioSeconds: Property.Number({
+      displayName: 'Max Audio Length (seconds)',
+      description: 'Voice notes longer than this are delivered without a transcript.',
+      required: true,
+      defaultValue: 300,
+    }),
+    monthlyMinutesCap: Property.Number({
+      displayName: 'Monthly Cap (minutes)',
+      description:
+        'Once reached, messages still arrive — only without the transcript. Nothing is dropped.',
+      required: true,
+      defaultValue: 500,
+    }),
+  },
+  async run(context) {
+    const { apiKey, maxAudioSeconds, monthlyMinutesCap } = context.propsValue;
+    const key = (apiKey ?? '').trim();
+
+    return await waflyApiCall({
+      auth: context.auth,
+      method: HttpMethod.PUT,
+      resourceUri: '/ai-config',
+      body: {
+        provider: 'openai',
+        // Empty key means "keep the stored one", so the cap can be adjusted
+        // without pasting the secret into the flow again.
+        ...(key ? { api_key: key } : {}),
+        transcription: {
+          enabled: true,
+          max_audio_seconds: maxAudioSeconds,
+          monthly_minutes_cap: monthlyMinutesCap,
+        },
+      },
+    });
+  },
+});

--- a/packages/pieces/community/wafly/src/lib/common/index.ts
+++ b/packages/pieces/community/wafly/src/lib/common/index.ts
@@ -1,0 +1,120 @@
+import { PieceAuth, Property } from '@activepieces/pieces-framework';
+import {
+  httpClient,
+  HttpMethod,
+  HttpMessageBody,
+  QueryParams,
+} from '@activepieces/pieces-common';
+
+/**
+ * The four fields as configured in the connection. Note that a CustomAuth
+ * connection hands them over nested under `.props`, never at the top level.
+ */
+export type WaflyCredentials = {
+  baseUrl: string;
+  clientToken: string;
+  instance: string;
+  token: string;
+};
+
+export type WaflyAuthValue = { props: WaflyCredentials };
+
+export const waflyAuth = PieceAuth.CustomAuth({
+  description: `Get these from the Wafly dashboard at https://wafly.com.br — **Client Token** lives under Security, and **Instance** and **Token** under the instance you want to use.`,
+  required: true,
+  props: {
+    baseUrl: Property.ShortText({
+      displayName: 'Base URL',
+      description: 'Leave the default unless you run a dedicated Wafly host.',
+      required: true,
+      defaultValue: 'https://wafly.com.br/api-bridge-whats',
+    }),
+    clientToken: PieceAuth.SecretText({
+      displayName: 'Client Token',
+      description: 'Account-wide token, sent as the Client-Token header.',
+      required: true,
+    }),
+    instance: Property.ShortText({
+      displayName: 'Instance',
+      description: 'Name of the WhatsApp instance.',
+      required: true,
+    }),
+    token: PieceAuth.SecretText({
+      displayName: 'Instance Token',
+      description: 'Token of that specific instance.',
+      required: true,
+    }),
+  },
+  validate: async ({ auth }) => {
+    try {
+      // Asymmetry in the framework worth knowing about: `validate` receives the
+      // connection fields flat, while `run` receives them nested under `.props`.
+      // Wrapping here keeps waflyApiCall with a single shape to reason about.
+      await waflyApiCall({
+        auth: { props: auth },
+        method: HttpMethod.GET,
+        resourceUri: '/status',
+      });
+      return { valid: true };
+    } catch {
+      return {
+        valid: false,
+        error:
+          'Could not reach the instance. Check the Client Token, instance name and instance token.',
+      };
+    }
+  },
+});
+
+/**
+ * Every instance-scoped Wafly route lives under
+ * /instances/{instance}/token/{token}, with the account-wide Client-Token in
+ * the header. Keeping the URL assembly here means no action can accidentally
+ * leak the instance token into a log line or an error message.
+ */
+export async function waflyApiCall<T extends HttpMessageBody>({
+  auth,
+  method,
+  resourceUri,
+  body,
+  queryParams,
+}: {
+  auth: WaflyAuthValue;
+  method: HttpMethod;
+  resourceUri: string;
+  body?: unknown;
+  queryParams?: QueryParams;
+}): Promise<T> {
+  const { baseUrl, instance, token, clientToken } = auth.props;
+  const root = baseUrl.replace(/\/$/, '');
+  const basePath = `/instances/${encodeURIComponent(
+    instance
+  )}/token/${encodeURIComponent(token)}`;
+
+  const response = await httpClient.sendRequest<T>({
+    method,
+    url: `${root}${basePath}${resourceUri}`,
+    headers: {
+      'Client-Token': clientToken,
+      'Content-Type': 'application/json',
+    },
+    body,
+    queryParams,
+  });
+
+  return response.body;
+}
+
+/**
+ * Wafly wants a plain international number (e.g. 5511999999999), so a pasted
+ * "+55 (11) 99999-9999" is cleaned up. Group IDs also travel in this field and
+ * are NOT numbers — "120363...@g.us" would be mangled into digits and silently
+ * addressed to the wrong chat, so anything carrying an @ or a - is left alone.
+ */
+export function normalizePhone(recipient: string): string {
+  const value = recipient.trim();
+  if (value.includes('@') || value.includes('-')) {
+    return value;
+  }
+  return value.replace(/\D/g, '');
+}

--- a/packages/pieces/community/wafly/src/lib/triggers/new-message.ts
+++ b/packages/pieces/community/wafly/src/lib/triggers/new-message.ts
@@ -1,0 +1,60 @@
+import { createTrigger, TriggerStrategy } from '@activepieces/pieces-framework';
+import { waflyAuth } from '../common';
+
+export const newMessage = createTrigger({
+  auth: waflyAuth,
+  name: 'new_message',
+  displayName: 'New Message Received',
+  description:
+    'Fires when the instance receives a WhatsApp message — already grouped and with voice notes transcribed.',
+  type: TriggerStrategy.WEBHOOK,
+  aiMetadata: {
+    description:
+      'Fires when a connected Wafly WhatsApp instance receives an inbound message. If the message buffer is enabled, consecutive messages from the same person arrive as one event with a "buffered" field; if transcription is enabled, voice notes arrive with their text under "transcription". The payload carries the sender phone, the message body and the instance identifier.',
+  },
+  props: {},
+  sampleData: {
+    instanceId: 'my-instance',
+    phone: '5511999999999',
+    senderName: 'Maria',
+    fromMe: false,
+    isGroup: false,
+    momment: 1754006400000,
+    messageId: '3EB0C767D26B8A3B1F2A',
+    text: {
+      message: 'hi\nyou there?\nhow much is it?',
+    },
+    buffered: {
+      count: 3,
+      messageIds: [
+        '3EB0C767D26B8A3B1F2A',
+        '3EB0C767D26B8A3B1F2B',
+        '3EB0C767D26B8A3B1F2C',
+      ],
+      waitedMs: 8012,
+    },
+    transcription: {
+      status: 'ok',
+      text: "I'd like two units, please",
+      latency_ms: 1180,
+    },
+  },
+  /**
+   * Wafly has no public endpoint to register a webhook URL — it is set in the
+   * dashboard, under Instance -> Webhooks. So there is nothing to subscribe or
+   * unsubscribe here, and the URL is pasted by hand once. Doing it silently in
+   * onEnable would be worse than doing nothing: the flow would look armed and
+   * never fire.
+   */
+  async onEnable(context) {
+    // Intentionally empty — see the note above. `context` is kept so the
+    // generic parameters stay inferable from this literal.
+    void context;
+  },
+  async onDisable(context) {
+    void context;
+  },
+  async run(context) {
+    return [context.payload.body];
+  },
+});

--- a/packages/pieces/community/wafly/tsconfig.json
+++ b/packages/pieces/community/wafly/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/packages/pieces/community/wafly/tsconfig.lib.json
+++ b/packages/pieces/community/wafly/tsconfig.lib.json
@@ -1,0 +1,15 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "rootDir": ".",
+    "baseUrl": ".",
+    "paths": {},
+    "outDir": "./dist",
+    "declaration": true,
+    "declarationMap": true,
+    "types": ["node"]
+  },
+  "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"],
+  "include": ["src/**/*.ts"]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1450,6 +1450,9 @@
       "@activepieces/piece-wafeq": [
         "packages/pieces/community/wafeq/src/index.ts"
       ],
+      "@activepieces/piece-wafly": [
+        "packages/pieces/community/wafly/src/index.ts"
+      ],
       "@activepieces/piece-wealthbox": [
         "packages/pieces/community/wealthbox/src/index.ts"
       ],


### PR DESCRIPTION
## What this adds

A piece for **Wafly**, a WhatsApp API aimed at automations and AI agents.

Two things set its payload apart, and both are instance-level settings exposed here as actions:

- **Message buffer** — consecutive messages from the same person arrive as a *single* webhook event, so an agent answers once with the whole question instead of three times mid-sentence.
- **Audio transcription** — incoming voice notes arrive with their transcript, using the customer's own OpenAI key (billed by OpenAI, not by Wafly).

## Actions

| Action | |
|---|---|
| Send Text Message | text to a number or group |
| Send Media | image, video, audio or PDF |
| Send Poll | poll with two or more options |
| Create Group | new group with participants |
| Check Numbers on WhatsApp | which numbers in a list have WhatsApp |
| Get Instance Status | whether the instance is connected |
| Configure Message Buffer | group split messages into one event |
| Configure Audio Transcription | transcribe incoming voice notes |

## Trigger

**New Message Received** — fires on every inbound message.

## One decision worth flagging

The trigger's `onEnable`/`onDisable` are intentionally empty. Wafly has no endpoint to register a webhook URL — it is configured in the Wafly dashboard. There is genuinely nothing to subscribe or unsubscribe to.

Failing silently in `onEnable` seemed worse than doing nothing: the flow would look armed and never fire. The piece README documents the one-time manual step of pasting the webhook URL. Happy to change the approach if you would rather it be handled differently.

## Notes

- Auth is `CustomAuth`: base URL, Client-Token (header), instance name and instance token. `validate` pings `/status`.
- The logo currently points at an SVG on GitHub — glad to send a square PNG for your CDN if that is preferred.
- Free 3-day trial at https://wafly.com.br if you want to exercise the actions during review.
