### PR TITLE
chore(release): bump version to 0.87.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activepieces",
-  "version": "0.86.3",
+  "version": "0.87.0",
   "packageManager": "bun@1.3.3",
   "trustedDependencies": [
     "sqlite3",


### PR DESCRIPTION
## Description

Bumps the platform version to `0.87.0`.

`0.86.3` shipped on 2026-07-17 and is still the latest release, while 20 pieces on `main` declare a `minimumSupportedRelease` above it. `isSupportedRelease` filters those versions out of every read path (`fetchLatestPieces` and `findExactVersion`), so the catalog stores them and then serves the previous version instead. They are unservable by construction until a release exists that satisfies them.

Scanned all 1128 piece `index.ts` (729 declare a bound):

| Check | Result |
|---|---|
| Blocked at `0.86.3` | **20** — 15 at min `0.86.4`, 5 at min `0.87.0` |
| Still blocked after `0.87.0` | **0** — clears every declared minimum |
| Pushed *out* of range by `0.87.0` (max below target) | **0** — no piece caps below `0.87.0` |

Blocked pieces: airtable, apify, cody, discord, firecrawl, github, gmail, google-calendar, google-docs, google-drive, google-tasks, microsoft-outlook, microsoft-teams, microsoft-teams-bot, serp-api, slack, stripe, telegram-bot, todoist, trello.

`0.87.0` rather than `0.86.4` because 5 of the 20 declare `0.87.0`; releasing `0.86.4` would clear only 15 and leave those 5 needing a second release. Minor bumps are the norm here — `0.83.0`, `0.84.0`, `0.85.0`, `0.86.0` all shipped.

Once this is released and deployed, the next `Release Pieces` run picks these up with no manual list: `find-changed-pieces` diffs against the cloud registry, and because they are absent it re-adds them on every run already.

### One thing for the release owner to confirm

The 7 migrations queued for the next release are tagged `release = '0.86.4'`, not `0.87.0`:

`AddNotifyFlowOwnerOnFailureToProject`, `AddProjectExecutionDataRetentionDays`, `AddActiveFlowsLimitToProjectPlan`, `AddSampleDataFlowIdIndexToFile`, `AddTeamsBotInstallation`, `AddUserChatMemory`, `AddFieldPosition`

All 7 are `breaking = false`. Releasing `0.87.0` does not break them:

- `rollback-migrations.ts:55` selects with `semver.gt(m.release, targetVersion)`, so migrations tagged `0.86.4` are still picked up when rolling back below that — rollback behaves correctly.
- `check-release-migrations.ts` matches the release string exactly, so it will report "No migrations tagged for release 0.87.0" even though those 7 ship in it. Cosmetic only, and since none are breaking, no rollback note was due either way.

So the effect is bookkeeping, not behaviour. Flagging it because it is the one signal in the repo pointing at `0.86.4` as the intended next number — happy to switch this to `0.86.4` and follow up on the 5 pieces separately if that is the plan.

## How was this tested?

- `node --print "require('./package.json').version"` → `0.87.0`; JSON parses.
- Verified the full piece-bound scan above: no piece has a `maximumSupportedRelease` below `0.87.0`, and none declares a minimum above it, so nothing regresses at the top end.
- Confirmed `rollback-migrations.ts` uses a semver comparison rather than exact match, so the `0.86.4`-tagged migrations remain rollback-correct.
- Single-line change to root `package.json`, matching #14163 (`bump version to 0.86.3`), which touched only this file.

Fixes # (no GitHub issue)

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)
