### PR TITLE
ci(pr-size): count only the PR's own changes under stacked PRs

### DIFF
--- a/tools/scripts/pr-size-check.test.ts
+++ b/tools/scripts/pr-size-check.test.ts
@@ -28,6 +28,16 @@ describe('resolveRenamePath', () => {
     })
 })
 
+describe('diffRange', () => {
+    it('diffs the merge commit parents on a PR checkout so stacked PRs only count their own changes', () => {
+        expect(prSizeCheck.diffRange({ baseRef: 'feat/base', parentCount: 2 })).toBe('HEAD^1...HEAD^2')
+    })
+
+    it('falls back to the base ref on a non-merge (local) checkout', () => {
+        expect(prSizeCheck.diffRange({ baseRef: 'main', parentCount: 1 })).toBe('origin/main...HEAD')
+    })
+})
+
 describe('bucketFor', () => {
     it('folds engine, worker and execution into one bucket', () => {
         const areas = [

--- a/tools/scripts/pr-size-check.ts
+++ b/tools/scripts/pr-size-check.ts
@@ -43,6 +43,16 @@ function resolveRenamePath({ raw }: { raw: string }): string {
     return to ?? raw
 }
 
+// On a `pull_request` run the checkout is the base←head merge commit, so its two
+// parents are the true base (HEAD^1) and the PR head (HEAD^2); diffing them isolates
+// the PR's own changes. This matters for stacked PRs: GitHub folds the ancestor PRs
+// into the merge's base parent, so `origin/<base>...HEAD` collapses the merge-base to
+// main and re-counts the whole stack. A non-merge checkout (local run) has no HEAD^2,
+// so it falls back to diffing against the base ref.
+function diffRange({ baseRef, parentCount }: { baseRef: string, parentCount: number }): string {
+    return parentCount >= 2 ? 'HEAD^1...HEAD^2' : `origin/${baseRef}...HEAD`
+}
+
 function isExcluded({ path }: { path: string }): boolean {
     return EXCLUDE_PATTERNS.some((pattern) => pattern.test(path))
 }
@@ -131,7 +141,9 @@ function main(): void {
     const labels: string[] = JSON.parse(process.env.PR_LABELS ?? '[]')
     const title = process.env.PR_TITLE ?? ''
 
-    const numstat = execSync(`git diff --numstat "origin/${baseRef}...HEAD"`, {
+    const parentCount = execSync('git rev-list --parents -n 1 HEAD', { encoding: 'utf-8' })
+        .trim().split(/\s+/).length - 1
+    const numstat = execSync(`git diff --numstat ${diffRange({ baseRef, parentCount })}`, {
         encoding: 'utf-8',
         maxBuffer: 256 * 1024 * 1024,
     })
@@ -173,7 +185,7 @@ type SizeReport = {
     excludedTotal: number
 }
 
-export const prSizeCheck = { collectSizes, renderSummary, bucketFor, resolveRenamePath, isBlocked }
+export const prSizeCheck = { collectSizes, renderSummary, bucketFor, resolveRenamePath, isBlocked, diffRange }
 
 if (import.meta.main) {
     main()


### PR DESCRIPTION
## Description

Fixes the **PR size gate** for stacked PRs (GitHub's stacked-PR feature).

With stacking enabled, GitHub builds a PR's merge ref as `merge(head, merge(ancestors, main))` — it folds the ancestor PRs into the merge commit's **base parent**. The size check diffed `origin/<base>...HEAD`, and because that merge-base now collapses to `main`, the diff **re-counted the entire stack**: e.g. the middle PR of a 3-PR stack was reported at `packages/web 2,027 / 1,200` (its own ~1,026 lines **plus** the base PR's ~1,001, including the base PR's `engine`/`pieces` changes) and was wrongly blocked.

**Fix:** diff the merge commit's two parents directly — `HEAD^1` (the true base) vs `HEAD^2` (the PR head) — via `git diff HEAD^1...HEAD^2`. That isolates the PR's own changes regardless of how GitHub folds ancestors into the base, and works for normal, stacked, and fork PRs. A non-merge checkout (local run) falls back to `origin/<base>...HEAD`.

No workflow change needed — the merge commit's parents are already present under the existing `fetch-depth: 0` checkout.

## How was this tested?
- `bun test tools/scripts/pr-size-check.test.ts` — 21 pass (added 2 cases for `diffRange`).
- Verified against the real failing run's merge commit: `git diff HEAD^1...HEAD^2` returns the stacked PR's own `web=1,026` (not `2,027`), with `engine=0`/`pieces=0`.

Fixes # (n/a — CI infra)

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)
