### PR TITLE
feat(agent): carry a flow-step run in the agent job payload

### DIFF
--- a/packages/core/execution/src/lib/agents/index.ts
+++ b/packages/core/execution/src/lib/agents/index.ts
@@ -5,6 +5,11 @@ export * from './tools'
 export * from './mcp'
 export * from './mcp-tool-name-util'
 
+export enum AgentRunSource {
+    CHAT = 'CHAT',
+    FLOW_STEP = 'FLOW_STEP',
+}
+
 export enum AgentOutputFieldType {
     TEXT = 'text',
     NUMBER = 'number',

--- a/packages/core/execution/src/lib/workers/job-data.ts
+++ b/packages/core/execution/src/lib/workers/job-data.ts
@@ -1,6 +1,7 @@
 
 import { z } from 'zod'
 import { isNil } from '@activepieces/core-utils'
+import { AgentOutputField, AgentRunSource, AgentTool } from '../agents'
 import { ResumeReason, StreamStepProgress, TriggerHookType, TriggerPayload } from '../engine'
 import { ExecutionType } from '../flow-run/execution/execution-output'
 import { RunEnvironment } from '../flow-run/flow-run'
@@ -262,9 +263,25 @@ export const ChatPromptOverride = z.object({
 })
 export type ChatPromptOverride = z.infer<typeof ChatPromptOverride>
 
+export const AgentFlowStepRun = z.object({
+    flowRunId: z.string(),
+    stepName: z.string(),
+    resumeUrl: z.string(),
+    tools: z.array(AgentTool).default([]),
+    structuredOutput: z.array(AgentOutputField).optional(),
+    maxSteps: z.number(),
+    aiProviderModel: z.object({ provider: z.string(), model: z.string() }),
+    webSearch: z.boolean().optional(),
+})
+export type AgentFlowStepRun = z.infer<typeof AgentFlowStepRun>
+
 export const ExecuteAgentRunJobData = z.object({
     schemaVersion: z.number(),
     jobType: z.literal(WorkerJobType.EXECUTE_AGENT_RUN),
+    // Defaulted rather than required: jobs already queued when this shipped carry no source,
+    // and every one of them is a chat turn.
+    source: z.enum(AgentRunSource).default(AgentRunSource.CHAT),
+    flowStep: AgentFlowStepRun.optional(),
     conversationId: z.string(),
     runId: z.string().optional(),
     projectId: z.string().nullable(),

--- a/packages/core/shared/src/lib/ee/chat/index.ts
+++ b/packages/core/shared/src/lib/ee/chat/index.ts
@@ -1,4 +1,4 @@
-import { ChatPromptOverride } from '@activepieces/core-execution'
+import { AgentRunSource, ChatPromptOverride } from '@activepieces/core-execution'
 import { BaseModelSchema, Nullable } from '@activepieces/core-utils'
 import { z } from 'zod'
 import { formErrors } from '../../form-errors'
@@ -192,11 +192,6 @@ export enum ChatConversationStatus {
     IDLE = 'IDLE',
     STREAMING = 'STREAMING',
     ERROR = 'ERROR',
-}
-
-export enum AgentRunSource {
-    CHAT = 'CHAT',
-    FLOW_STEP = 'FLOW_STEP',
 }
 
 export const ChatConversation = z.object({

--- a/packages/server/api/src/app/ee/agent/agent-controller.ts
+++ b/packages/server/api/src/app/ee/agent/agent-controller.ts
@@ -1,5 +1,5 @@
 import { ActivepiecesError, AIProviderName, apId, ErrorCode, isNil, spreadIfDefined, tryCatch } from '@activepieces/core-utils'
-import { ChatConversationStatus, CreateChatConversationRequest, ImportChatMemoryRequest, InstructChatMemoryRequest, LATEST_JOB_DATA_SCHEMA_VERSION, PrincipalType, SendChatMessageRequest, SERVICE_KEY_SECURITY_OPENAPI, SetChatMessageFeedbackRequest, UpdateChatConversationRequest, UpdateChatMemoryRequest, WorkerJobType } from '@activepieces/shared'
+import { AgentRunSource, ChatConversationStatus, CreateChatConversationRequest, ImportChatMemoryRequest, InstructChatMemoryRequest, LATEST_JOB_DATA_SCHEMA_VERSION, PrincipalType, SendChatMessageRequest, SERVICE_KEY_SECURITY_OPENAPI, SetChatMessageFeedbackRequest, UpdateChatConversationRequest, UpdateChatMemoryRequest, WorkerJobType } from '@activepieces/shared'
 import { FastifyBaseLogger } from 'fastify'
 import { FastifyPluginAsyncZod } from 'fastify-type-provider-zod'
 import { StatusCodes } from 'http-status-codes'
@@ -157,6 +157,7 @@ export const agentController: FastifyPluginAsyncZod = async (app) => {
             data: {
                 schemaVersion: LATEST_JOB_DATA_SCHEMA_VERSION,
                 jobType: WorkerJobType.EXECUTE_AGENT_RUN,
+                source: AgentRunSource.CHAT,
                 conversationId,
                 runId,
                 projectId: conversation.projectId ?? null,

--- a/packages/server/api/src/app/ee/agent/agent-eval-controller.ts
+++ b/packages/server/api/src/app/ee/agent/agent-eval-controller.ts
@@ -1,5 +1,5 @@
 import { apId, isNil } from '@activepieces/core-utils'
-import { ChatConversationStatus, ChatPromptOverride, LATEST_JOB_DATA_SCHEMA_VERSION, PersistedChatRole, SimulateChatRequest, WorkerJobType } from '@activepieces/shared'
+import { AgentRunSource, ChatConversationStatus, ChatPromptOverride, LATEST_JOB_DATA_SCHEMA_VERSION, PersistedChatRole, SimulateChatRequest, WorkerJobType } from '@activepieces/shared'
 import { FastifyBaseLogger, FastifyReply, FastifyRequest } from 'fastify'
 import { FastifyPluginAsyncZod } from 'fastify-type-provider-zod'
 import { StatusCodes } from 'http-status-codes'
@@ -78,6 +78,7 @@ const agentEvalController: FastifyPluginAsyncZod = async (app) => {
                 data: {
                     schemaVersion: LATEST_JOB_DATA_SCHEMA_VERSION,
                     jobType: WorkerJobType.EXECUTE_AGENT_RUN,
+                    source: AgentRunSource.CHAT,
                     conversationId: conversation.id,
                     runId: lastRunId,
                     projectId: null,
@@ -154,6 +155,7 @@ const agentEvalController: FastifyPluginAsyncZod = async (app) => {
             data: {
                 schemaVersion: LATEST_JOB_DATA_SCHEMA_VERSION,
                 jobType: WorkerJobType.EXECUTE_AGENT_RUN,
+                source: AgentRunSource.CHAT,
                 conversationId: convId,
                 runId,
                 projectId: null,


### PR DESCRIPTION
> **Closed as speculative.** A cleanup review found this has zero producers and zero consumers: nothing writes `FLOW_STEP`, nothing reads `source`, and the job payload still requires `conversationId` / `userMessage` / `userId`, which a flow-step run has none of — so whoever wires the real producer would rewrite the shape anyway.

A better design surfaced while reviewing it: put `flowRunId` and `stepName` on the conversation (both nullable, no backfill, no `NOT NULL`) and derive the source from `flowRunId IS NOT NULL`. That deletes the enum, the migration, and the cross-package move, and keeps a run traceable after its job is gone — which the current shape does not.

Re-opening with the producer that needs it.

---

> **Stacked on #14553.** Groundwork for running the Agent step through the same path chat uses.

## Description

Extends the agent job payload with the two things a flow-step run needs and a chat turn does not:

- `source` — which surface started the run.
- `flowStep` — the configured `tools`, `structuredOutput`, `maxSteps` and `aiProviderModel`, plus the `flowRunId` / `stepName` / `resumeUrl` the server calls when the turn finishes.

**Nothing enqueues a `FLOW_STEP` job yet.** This is the payload contract on its own, so the PR that adds the endpoint and the runner has something typed to build against.

### Two details worth a look

`source` is `.default(CHAT)` on parse, so a job already sitting in BullMQ when this deploys still decodes. But every enqueue site passes it explicitly — a missing `source` should be a type error at the call site, not a silent `CHAT` two hops away.

`AgentRunSource` is defined in `core-execution`, not `core/shared`. The job payload lives in `core-execution`, which cannot import the thicker package; `core/shared` already re-exports `core-execution`, so the enum reaches every existing consumer unchanged.

## How was this tested?

- Typecheck 0 errors on `server/api` and `server/worker`.
- API agent unit tests 56 passed; worker chat + eval harness 109 passed, 1 skipped.
- Lint 0 errors.

Fixes # (issue)

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

Additive fields on a job payload that still decodes older queued jobs.

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)