### PR TITLE
fix(web): correct malformed markdown link in install piece dialog

### DIFF
--- a/packages/web/src/features/pieces/components/install-piece-dialog.tsx
+++ b/packages/web/src/features/pieces/components/install-piece-dialog.tsx
@@ -182,7 +182,7 @@ const InstallPieceDialog = ({
           <DialogDescription>
             <ApMarkdown
               markdown={
-                'Use this to install a [custom piece]("https://www.activepieces.com/docs/build-pieces/building-pieces/create-action") that you (or someone else) created. Once the piece is installed, you can use it in the flow builder.\n\nWarning: Make sure you trust the author as the piece will have access to your flow data and it might not be compatible with the current version of Activepieces.'
+                'Use this to install a [custom piece](https://www.activepieces.com/docs/build-pieces/building-pieces/create-action) that you (or someone else) created. Once the piece is installed, you can use it in the flow builder.\n\nWarning: Make sure you trust the author as the piece will have access to your flow data and it might not be compatible with the current version of Activepieces.'
               }
             />
           </DialogDescription>


### PR DESCRIPTION
## Description

The "custom piece" docs link in the Install Piece dialog had malformed markdown syntax (`[text]("url")` instead of `[text](url)`), which made the rendered `href` start with a stray quote character. Browsers resolved that as a relative path against the current origin instead of an absolute URL, so on Cloud clicking the link fell through to the SPA catch-all route and redirected to the dashboard instead of opening the docs page.

Fix: removed the extra quotes so the link is valid markdown and correctly points to `https://www.activepieces.com/docs/build-pieces/building-pieces/create-action`.

## How was this tested?

Verified the markdown parses to a correct `href` (no wrapping quotes) using the same `remark-parse`/`remark-gfm` plugins `ApMarkdown` uses, and confirmed on Cloud that the link now opens the docs page instead of redirecting to the homepage.

Fixes #14560

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)
