### PR TITLE
feat(gmail): add agent atomics for AI agents (read/draft/thread surface)

### DIFF
--- a/packages/pieces/community/gmail/package.json
+++ b/packages/pieces/community/gmail/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-gmail",
-  "version": "0.12.8",
+  "version": "0.12.9",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "dependencies": {

--- a/packages/pieces/community/gmail/src/index.ts
+++ b/packages/pieces/community/gmail/src/index.ts
@@ -12,6 +12,25 @@ import { gmailNewLabelTrigger } from './lib/triggers/new-label';
 import { gmailSearchMailAction } from './lib/actions/search-email-action';
 import { gmailGetEmailAction } from './lib/actions/get-mail-action';
 import { gmailAuth, getAccessToken, GmailAuthValue } from './lib/auth';
+import { gmailAiSendEmailAction } from './lib/actions/ai-send-email-action';
+import { gmailAiReplyToThreadAction } from './lib/actions/ai-reply-to-thread-action';
+import { gmailAiGetMessageAction } from './lib/actions/ai-get-message-action';
+import { gmailAiSearchEmailAction } from './lib/actions/ai-search-email-action';
+import { gmailGetThread } from './lib/actions/get-thread-action';
+import { gmailCreateDraftAction } from './lib/actions/create-draft-action';
+import { gmailUpdateDraftAction } from './lib/actions/update-draft-action';
+import { gmailSendDraftAction } from './lib/actions/send-draft-action';
+import { gmailGetDraftAction } from './lib/actions/get-draft-action';
+import { gmailListDraftsAction } from './lib/actions/list-drafts-action';
+import { gmailDeleteDraftAction } from './lib/actions/delete-draft-action';
+import { gmailListThreadsAction } from './lib/actions/list-threads-action';
+import { gmailGetAttachmentAction } from './lib/actions/get-attachment-action';
+import { gmailForwardMessageAction } from './lib/actions/forward-message-action';
+import { gmailListLabelsAction } from './lib/actions/list-labels-action';
+import { gmailGetLabelAction } from './lib/actions/get-label-action';
+import { gmailGetProfileAction } from './lib/actions/get-profile-action';
+import { gmailListHistoryAction } from './lib/actions/list-history-action';
+import { gmailStopWatchAction } from './lib/actions/stop-watch-action';
 
 export {
   gmailAuth,
@@ -34,6 +53,25 @@ export const gmail = createPiece({
     gmailCreateDraftReplyAction,
     gmailGetEmailAction,
     gmailSearchMailAction,
+    gmailAiSendEmailAction,
+    gmailAiReplyToThreadAction,
+    gmailAiGetMessageAction,
+    gmailAiSearchEmailAction,
+    gmailGetThread,
+    gmailCreateDraftAction,
+    gmailUpdateDraftAction,
+    gmailSendDraftAction,
+    gmailGetDraftAction,
+    gmailListDraftsAction,
+    gmailDeleteDraftAction,
+    gmailListThreadsAction,
+    gmailGetAttachmentAction,
+    gmailForwardMessageAction,
+    gmailListLabelsAction,
+    gmailGetLabelAction,
+    gmailGetProfileAction,
+    gmailListHistoryAction,
+    gmailStopWatchAction,
     createCustomApiCallAction({
       baseUrl: () => 'https://gmail.googleapis.com/gmail/v1',
       auth: gmailAuth,

--- a/packages/pieces/community/gmail/src/lib/actions/ai-get-message-action.ts
+++ b/packages/pieces/community/gmail/src/lib/actions/ai-get-message-action.ts
@@ -1,0 +1,20 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { gmailAuth } from '../auth';
+import { gmailGetEmailAction } from './get-mail-action';
+import { gmailAiGetMessageActionOutputSchema } from '../output-schemas';
+
+export const gmailAiGetMessageAction = createAction({
+  auth: gmailAuth,
+  name: 'gmail_get_message',
+  displayName: 'Get Message',
+  description: 'Get a single email message by its ID.',
+  audience: 'ai',
+  aiMetadata: {
+    description:
+      'Fetches a single email by its Gmail message ID and returns its parsed contents, including headers, body, and decoded attachments (each attachment is returned with its downloaded content directly, so a separate Get Attachment call is normally unnecessary). Use this to read the full details of a specific known message; obtain the message ID from Search Email. Idempotent: a read-only lookup that does not modify the mailbox.',
+    idempotent: true,
+  },
+  outputSchema: gmailAiGetMessageActionOutputSchema,
+  props: gmailGetEmailAction.props,
+  run: gmailGetEmailAction.run,
+});

--- a/packages/pieces/community/gmail/src/lib/actions/ai-reply-to-thread-action.ts
+++ b/packages/pieces/community/gmail/src/lib/actions/ai-reply-to-thread-action.ts
@@ -1,0 +1,20 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { gmailAuth } from '../auth';
+import { gmailReplyToEmailAction } from './reply-to-email-action';
+import { gmailAiReplyToThreadActionOutputSchema } from '../output-schemas';
+
+export const gmailAiReplyToThreadAction = createAction({
+  auth: gmailAuth,
+  name: 'gmail_reply_to_thread',
+  displayName: 'Reply to Thread',
+  description: 'Reply to an existing email thread.',
+  audience: 'ai',
+  aiMetadata: {
+    description:
+      'Sends a reply to an existing email, preserving the thread and subject and addressing the original sender (reply) or all participants (reply all). Use this to respond within a known conversation; requires the Gmail message ID of the email being answered (obtain it from Search Email or Get Thread). Not idempotent: each call sends a new reply into the thread.',
+    idempotent: false,
+  },
+  outputSchema: gmailAiReplyToThreadActionOutputSchema,
+  props: gmailReplyToEmailAction.props,
+  run: gmailReplyToEmailAction.run,
+});

--- a/packages/pieces/community/gmail/src/lib/actions/ai-search-email-action.ts
+++ b/packages/pieces/community/gmail/src/lib/actions/ai-search-email-action.ts
@@ -1,0 +1,21 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { gmailAuth } from '../auth';
+import { gmailSearchMailAction } from './search-email-action';
+import { gmailAiSearchEmailActionOutputSchema } from '../output-schemas';
+
+export const gmailAiSearchEmailAction = createAction({
+  auth: gmailAuth,
+  name: 'gmail_search_email',
+  displayName: 'Search Email',
+  description:
+    'Search emails using advanced criteria. If no filters are provided, the latest emails are returned.',
+  audience: 'ai',
+  aiMetadata: {
+    description:
+      'Searches the mailbox for emails matching combinable filters (sender, recipient, subject, body text, label, category, date range, attachment presence/name) and returns the matched messages with parsed contents and their message IDs. Use this as the primary resolver to locate messages or discover their message IDs before reading or replying to them; with no filters it returns the most recent emails. Bound results with Max Results (1-500, default 10). Idempotent: a read-only search that does not modify the mailbox.',
+    idempotent: true,
+  },
+  outputSchema: gmailAiSearchEmailActionOutputSchema,
+  props: gmailSearchMailAction.props,
+  run: gmailSearchMailAction.run,
+});

--- a/packages/pieces/community/gmail/src/lib/actions/ai-send-email-action.ts
+++ b/packages/pieces/community/gmail/src/lib/actions/ai-send-email-action.ts
@@ -1,0 +1,20 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { gmailAuth } from '../auth';
+import { gmailSendEmailAction } from './send-email-action';
+import { gmailAiSendEmailActionOutputSchema } from '../output-schemas';
+
+export const gmailAiSendEmailAction = createAction({
+  auth: gmailAuth,
+  name: 'gmail_send_email',
+  displayName: 'Send Email',
+  description: 'Send an email through a Gmail account',
+  audience: 'ai',
+  aiMetadata: {
+    description:
+      'Composes and sends a new email from the connected Gmail account to one or more recipients, with optional CC/BCC, attachments, and a plain-text or HTML body. Use this to originate a fresh message; to answer an existing conversation prefer Reply to Thread, and to save an unsent message use Create Draft. Not idempotent: each call sends a separate message.',
+    idempotent: false,
+  },
+  outputSchema: gmailAiSendEmailActionOutputSchema,
+  props: gmailSendEmailAction.props,
+  run: gmailSendEmailAction.run,
+});

--- a/packages/pieces/community/gmail/src/lib/actions/create-draft-action.ts
+++ b/packages/pieces/community/gmail/src/lib/actions/create-draft-action.ts
@@ -1,0 +1,148 @@
+import { ApFile, createAction, Property } from '@activepieces/pieces-framework';
+import { gmailAuth, createGoogleClient, getUserEmail } from '../auth';
+import { gmail as googleGmail } from '@googleapis/gmail';
+import { GmailMime } from '../common/mime';
+import { gmailCreateDraftActionOutputSchema } from '../output-schemas';
+
+export const gmailCreateDraftAction = createAction({
+  auth: gmailAuth,
+  name: 'gmail_create_draft',
+  displayName: 'Create Draft',
+  description:
+    'Create a new draft email (optionally inside an existing thread).',
+  audience: 'ai',
+  aiMetadata: {
+    description:
+      'Creates an unsent draft email with the given recipients, subject, body, and optional attachments, optionally placing it inside an existing thread. Use this when a message should be saved for later review or sending rather than sent immediately; send it afterwards with Send Draft. To attach the draft to a conversation, pass a thread ID from Search Email or Get Thread. Not idempotent: each call creates a separate draft.',
+    idempotent: false,
+  },
+  props: {
+    receiver: Property.Array({
+      displayName: 'Receiver Email (To)',
+      required: false,
+    }),
+    cc: Property.Array({
+      displayName: 'CC Email',
+      required: false,
+    }),
+    bcc: Property.Array({
+      displayName: 'BCC Email',
+      required: false,
+    }),
+    subject: Property.ShortText({
+      displayName: 'Subject',
+      required: true,
+    }),
+    body_type: Property.StaticDropdown({
+      displayName: 'Body Type',
+      required: true,
+      defaultValue: 'plain_text',
+      options: {
+        disabled: false,
+        options: [
+          { label: 'plain text', value: 'plain_text' },
+          { label: 'html', value: 'html' },
+        ],
+      },
+    }),
+    body: Property.LongText({
+      displayName: 'Body',
+      description: 'Body for the draft email.',
+      required: true,
+    }),
+    sender_name: Property.ShortText({
+      displayName: 'Sender Name',
+      required: false,
+    }),
+    from: Property.ShortText({
+      displayName: 'Sender Email',
+      description:
+        "The address must be listed in your Gmail account's settings.",
+      required: false,
+    }),
+    thread_id: Property.ShortText({
+      displayName: 'Thread ID',
+      description:
+        'Optional thread ID to attach this draft to an existing conversation (obtain from Search Email or Get Thread).',
+      required: false,
+    }),
+    attachments: Property.Array({
+      displayName: 'Attachments',
+      required: false,
+      properties: {
+        file: Property.File({
+          displayName: 'File',
+          description: 'File to attach to the draft.',
+          required: true,
+        }),
+        name: Property.ShortText({
+          displayName: 'Attachment Name',
+          description: 'Optional name to override the attachment filename.',
+          required: false,
+        }),
+      },
+    }),
+  },
+  outputSchema: gmailCreateDraftActionOutputSchema,
+  async run(context) {
+    const authClient = await createGoogleClient(context.auth);
+    const gmail = googleGmail({ version: 'v1', auth: authClient });
+
+    try {
+      const receiver = (
+        context.propsValue.receiver as string[] | undefined
+      )?.filter((email) => email !== '');
+      const cc = (context.propsValue.cc as string[] | undefined)?.filter(
+        (email) => email !== ''
+      );
+      const bcc = (context.propsValue.bcc as string[] | undefined)?.filter(
+        (email) => email !== ''
+      );
+
+      const senderEmail =
+        context.propsValue.from ||
+        (await getUserEmail(context.auth, authClient));
+      const from = senderEmail
+        ? context.propsValue.sender_name
+          ? `${context.propsValue.sender_name} <${senderEmail}>`
+          : senderEmail
+        : undefined;
+
+      const raw = await GmailMime.buildRawMessage({
+        to: receiver,
+        cc,
+        bcc,
+        from,
+        subject: context.propsValue.subject,
+        bodyType: context.propsValue.body_type as 'plain_text' | 'html',
+        body: context.propsValue.body,
+        attachments: context.propsValue.attachments as
+          | { file: ApFile; name?: string }[]
+          | undefined,
+      });
+
+      const response = await gmail.users.drafts.create({
+        userId: 'me',
+        requestBody: {
+          message: {
+            raw,
+            threadId: context.propsValue.thread_id || undefined,
+          },
+        },
+      });
+
+      return response.data;
+    } catch (error: any) {
+      if (error.code === 403) {
+        throw new Error(
+          'Insufficient permissions to create a draft. Ensure the gmail.compose scope is granted.'
+        );
+      } else if (error.code === 429) {
+        throw new Error(
+          'Gmail API rate limit exceeded. Please try again later.'
+        );
+      }
+      throw new Error(`Failed to create draft: ${error.message}`);
+    }
+  },
+});

--- a/packages/pieces/community/gmail/src/lib/actions/create-draft-reply-action.ts
+++ b/packages/pieces/community/gmail/src/lib/actions/create-draft-reply-action.ts
@@ -11,7 +11,7 @@ export const gmailCreateDraftReplyAction = createAction({
   auth: gmailAuth,
   name: 'create_draft_reply',
   description: 'Creates a draft reply to an existing email.',
-  audience: 'both',
+  audience: 'human',
   aiMetadata: {
     description:
       'Builds a draft reply to an existing email and saves it (unsent) in the thread, addressing the original sender (reply) or all participants (reply all) and optionally quoting the original message. Use this when a human should review and send the response rather than sending it automatically; requires the Gmail message ID of the email being replied to. Not idempotent: each call creates a new draft.',

--- a/packages/pieces/community/gmail/src/lib/actions/delete-draft-action.ts
+++ b/packages/pieces/community/gmail/src/lib/actions/delete-draft-action.ts
@@ -1,0 +1,57 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { gmailAuth, createGoogleClient } from '../auth';
+import { gmail as googleGmail } from '@googleapis/gmail';
+
+export const gmailDeleteDraftAction = createAction({
+  auth: gmailAuth,
+  name: 'gmail_delete_draft',
+  displayName: 'Delete Draft',
+  description: 'Permanently delete a draft email by its ID.',
+  audience: 'ai',
+  aiMetadata: {
+    description:
+      'Permanently removes a draft email by its draft ID. This only deletes the unsent draft (not a sent message) but the draft itself is not recoverable. Obtain the draft ID from List Drafts. Idempotent: if no draft matches the ID (already removed, or an invalid ID) it returns deleted:false instead of failing — check that flag rather than assuming a delete happened.',
+    idempotent: true,
+  },
+  props: {
+    draft_id: Property.ShortText({
+      displayName: 'Draft ID',
+      description: 'The ID of the draft to delete (obtain from List Drafts).',
+      required: true,
+    }),
+  },
+  async run(context) {
+    const authClient = await createGoogleClient(context.auth);
+    const gmail = googleGmail({ version: 'v1', auth: authClient });
+
+    try {
+      await gmail.users.drafts.delete({
+        userId: 'me',
+        id: context.propsValue.draft_id,
+      });
+      return {
+        success: true,
+        deleted: true,
+        draftId: context.propsValue.draft_id,
+      };
+    } catch (error: any) {
+      if (error.code === 403) {
+        throw new Error(
+          'Insufficient permissions to delete a draft. Ensure the gmail.compose scope is granted.'
+        );
+      } else if (error.code === 404) {
+        return {
+          success: true,
+          deleted: false,
+          draftId: context.propsValue.draft_id,
+          message: `No draft with ID "${context.propsValue.draft_id}" was found — it may already be deleted, or the ID is invalid. Verify with List Drafts.`,
+        };
+      } else if (error.code === 429) {
+        throw new Error(
+          'Gmail API rate limit exceeded. Please try again later.'
+        );
+      }
+      throw new Error(`Failed to delete draft: ${error.message}`);
+    }
+  },
+});

--- a/packages/pieces/community/gmail/src/lib/actions/delete-draft-action.ts
+++ b/packages/pieces/community/gmail/src/lib/actions/delete-draft-action.ts
@@ -41,7 +41,7 @@ export const gmailDeleteDraftAction = createAction({
         );
       } else if (error.code === 404) {
         return {
-          success: true,
+          success: false,
           deleted: false,
           draftId: context.propsValue.draft_id,
           message: `No draft with ID "${context.propsValue.draft_id}" was found — it may already be deleted, or the ID is invalid. Verify with List Drafts.`,

--- a/packages/pieces/community/gmail/src/lib/actions/forward-message-action.ts
+++ b/packages/pieces/community/gmail/src/lib/actions/forward-message-action.ts
@@ -1,0 +1,159 @@
+import { ApFile, createAction, Property } from '@activepieces/pieces-framework';
+import { gmailAuth, createGoogleClient, getUserEmail } from '../auth';
+import { gmail as googleGmail } from '@googleapis/gmail';
+import { GmailMime } from '../common/mime';
+import { parseStream } from '../common/data';
+import { gmailForwardMessageActionOutputSchema } from '../output-schemas';
+
+export const gmailForwardMessageAction = createAction({
+  auth: gmailAuth,
+  name: 'gmail_forward_message',
+  displayName: 'Forward Message',
+  description: 'Forward an existing email to new recipients.',
+  audience: 'ai',
+  aiMetadata: {
+    description:
+      'Forwards an existing email to one or more new recipients, quoting the original sender, subject, and body beneath an optional added note. Requires the Gmail message ID of the email to forward (obtain from Search Email or Get Message). Performs two calls: it fetches the original message, then sends the forwarded copy. Not idempotent: each call sends a new forwarded message.',
+    idempotent: false,
+  },
+  props: {
+    message_id: Property.ShortText({
+      displayName: 'Message ID',
+      description:
+        'The Gmail message ID to forward (obtain from Search Email or Get Message).',
+      required: true,
+    }),
+    receiver: Property.Array({
+      displayName: 'Receiver Email (To)',
+      description: 'One or more recipients to forward the email to.',
+      required: true,
+    }),
+    cc: Property.Array({
+      displayName: 'CC Email',
+      required: false,
+    }),
+    bcc: Property.Array({
+      displayName: 'BCC Email',
+      required: false,
+    }),
+    note: Property.LongText({
+      displayName: 'Note',
+      description: 'Optional message to add above the forwarded content.',
+      required: false,
+    }),
+    sender_name: Property.ShortText({
+      displayName: 'Sender Name',
+      required: false,
+    }),
+  },
+  outputSchema: gmailForwardMessageActionOutputSchema,
+  async run(context) {
+    const authClient = await createGoogleClient(context.auth);
+    const gmail = googleGmail({ version: 'v1', auth: authClient });
+
+    try {
+      const original = await gmail.users.messages.get({
+        userId: 'me',
+        id: context.propsValue.message_id,
+        format: 'raw',
+      });
+
+      if (!original.data.raw) {
+        throw new Error('Could not fetch the original message to forward.');
+      }
+
+      const parsed = await parseStream(
+        Buffer.from(original.data.raw, 'base64').toString('utf-8')
+      );
+
+      const originalSubject = parsed.subject || '';
+      const forwardSubject = originalSubject.toLowerCase().startsWith('fwd:')
+        ? originalSubject
+        : `Fwd: ${originalSubject}`;
+
+      const originalFrom =
+        typeof parsed.from?.text === 'string' ? parsed.from.text : '';
+      const originalTo =
+        parsed.to && !Array.isArray(parsed.to) ? parsed.to.text : '';
+      const originalDate = parsed.date ? parsed.date.toUTCString() : '';
+
+      const note = context.propsValue.note
+        ? `${context.propsValue.note}\n\n`
+        : '';
+      const htmlAsText = parsed.html ? parsed.html.replace(/<[^>]*>/g, '') : '';
+      const originalBody = parsed.text || htmlAsText || '';
+      const quotedBody = originalBody
+        .split('\n')
+        .map((line) => `> ${line}`)
+        .join('\n');
+      const forwardedBody =
+        `${note}---------- Forwarded message ----------\n` +
+        `From: ${originalFrom}\n` +
+        `Date: ${originalDate}\n` +
+        `Subject: ${originalSubject}\n` +
+        `To: ${originalTo}\n\n` +
+        `${quotedBody}`;
+
+      const receiver = (context.propsValue.receiver as string[]).filter(
+        (email) => email !== ''
+      );
+      const cc = (context.propsValue.cc as string[] | undefined)?.filter(
+        (email) => email !== ''
+      );
+      const bcc = (context.propsValue.bcc as string[] | undefined)?.filter(
+        (email) => email !== ''
+      );
+
+      const senderEmail = await getUserEmail(context.auth, authClient);
+      const from = senderEmail
+        ? context.propsValue.sender_name
+          ? `${context.propsValue.sender_name} <${senderEmail}>`
+          : senderEmail
+        : undefined;
+
+      const forwardedAttachments = (parsed.attachments || [])
+        .filter((attachment) => attachment.content)
+        .map((attachment) => ({
+          file: new ApFile(
+            attachment.filename ?? `attachment-${Date.now()}`,
+            Buffer.from(attachment.content),
+            attachment.filename?.split('.').pop()
+          ),
+          name: attachment.filename ?? undefined,
+        }));
+
+      const raw = await GmailMime.buildRawMessage({
+        to: receiver,
+        cc,
+        bcc,
+        from,
+        subject: forwardSubject,
+        bodyType: 'plain_text',
+        body: forwardedBody,
+        attachments: forwardedAttachments,
+      });
+
+      const response = await gmail.users.messages.send({
+        userId: 'me',
+        requestBody: { raw },
+      });
+
+      return response.data;
+    } catch (error: any) {
+      if (error.code === 403) {
+        throw new Error(
+          'Insufficient permissions to forward the message. Ensure the gmail.send and gmail.readonly scopes are granted.'
+        );
+      } else if (error.code === 404) {
+        throw new Error(
+          `Original message not found: "${context.propsValue.message_id}". Use Search Email to find a valid message ID.`
+        );
+      } else if (error.code === 429) {
+        throw new Error(
+          'Gmail API rate limit exceeded. Please try again later.'
+        );
+      }
+      throw new Error(`Failed to forward message: ${error.message}`);
+    }
+  },
+});

--- a/packages/pieces/community/gmail/src/lib/actions/get-attachment-action.ts
+++ b/packages/pieces/community/gmail/src/lib/actions/get-attachment-action.ts
@@ -1,0 +1,83 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { gmailAuth, createGoogleClient } from '../auth';
+import { gmail as googleGmail } from '@googleapis/gmail';
+import { gmailGetAttachmentActionOutputSchema } from '../output-schemas';
+
+export const gmailGetAttachmentAction = createAction({
+  auth: gmailAuth,
+  name: 'gmail_get_attachment',
+  displayName: 'Get Attachment',
+  description: 'Download an email attachment by message ID and attachment ID.',
+  audience: 'ai',
+  aiMetadata: {
+    description:
+      "Fetches one email attachment's raw bytes by message ID + attachment ID, returning a stored file plus size. Note: Get Message already returns each attachment's downloaded content directly, so prefer that; use this only when you separately hold a raw Gmail attachment ID (from the message payload parts) and need the bytes on their own. Get the message ID from Search Email. Idempotent: a read-only fetch that does not modify the mailbox.",
+    idempotent: true,
+  },
+  props: {
+    message_id: Property.ShortText({
+      displayName: 'Message ID',
+      description:
+        'The Gmail message ID the attachment belongs to (obtain from Search Email or Get Message).',
+      required: true,
+    }),
+    attachment_id: Property.ShortText({
+      displayName: 'Attachment ID',
+      description:
+        'The raw Gmail attachment ID, taken from the message payload parts (parts[].body.attachmentId of a full-format message). Note: Get Message returns attachment content directly, so this field is only needed for the raw-ID fetch path.',
+      required: true,
+    }),
+    file_name: Property.ShortText({
+      displayName: 'File Name',
+      description: 'Optional name to give the downloaded file.',
+      required: false,
+    }),
+  },
+  outputSchema: gmailGetAttachmentActionOutputSchema,
+  async run(context) {
+    const authClient = await createGoogleClient(context.auth);
+    const gmail = googleGmail({ version: 'v1', auth: authClient });
+
+    try {
+      const response = await gmail.users.messages.attachments.get({
+        userId: 'me',
+        messageId: context.propsValue.message_id,
+        id: context.propsValue.attachment_id,
+      });
+
+      const data = response.data.data;
+      if (!data) {
+        throw new Error('Attachment returned no data.');
+      }
+
+      const fileName =
+        context.propsValue.file_name ||
+        `attachment-${context.propsValue.attachment_id}`;
+      const fileUrl = await context.files.write({
+        fileName,
+        data: Buffer.from(data, 'base64'),
+      });
+
+      return {
+        fileName,
+        size: response.data.size,
+        data: fileUrl,
+      };
+    } catch (error: any) {
+      if (error.code === 403) {
+        throw new Error(
+          'Insufficient permissions to read the attachment. Ensure the gmail.readonly scope is granted.'
+        );
+      } else if (error.code === 404) {
+        throw new Error(
+          'Attachment or message not found. Verify the message ID and attachment ID via Get Message.'
+        );
+      } else if (error.code === 429) {
+        throw new Error(
+          'Gmail API rate limit exceeded. Please try again later.'
+        );
+      }
+      throw new Error(`Failed to get attachment: ${error.message}`);
+    }
+  },
+});

--- a/packages/pieces/community/gmail/src/lib/actions/get-draft-action.ts
+++ b/packages/pieces/community/gmail/src/lib/actions/get-draft-action.ts
@@ -1,0 +1,53 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { gmailAuth, createGoogleClient } from '../auth';
+import { gmail as googleGmail } from '@googleapis/gmail';
+import { gmailGetDraftActionOutputSchema } from '../output-schemas';
+
+export const gmailGetDraftAction = createAction({
+  auth: gmailAuth,
+  name: 'gmail_get_draft',
+  displayName: 'Get Draft',
+  description: 'Get a single draft email by its ID.',
+  audience: 'ai',
+  aiMetadata: {
+    description:
+      'Fetches a single draft email by its draft ID, returning the draft and its underlying message. Use this to inspect a draft before sending or updating it; obtain the draft ID from List Drafts. Idempotent: a read-only lookup that does not modify the mailbox.',
+    idempotent: true,
+  },
+  props: {
+    draft_id: Property.ShortText({
+      displayName: 'Draft ID',
+      description: 'The ID of the draft to read (obtain from List Drafts).',
+      required: true,
+    }),
+  },
+  outputSchema: gmailGetDraftActionOutputSchema,
+  async run(context) {
+    const authClient = await createGoogleClient(context.auth);
+    const gmail = googleGmail({ version: 'v1', auth: authClient });
+
+    try {
+      const response = await gmail.users.drafts.get({
+        userId: 'me',
+        id: context.propsValue.draft_id,
+        format: 'full',
+      });
+      return response.data;
+    } catch (error: any) {
+      if (error.code === 403) {
+        throw new Error(
+          'Insufficient permissions to read drafts. Ensure the gmail.readonly scope is granted.'
+        );
+      } else if (error.code === 404) {
+        throw new Error(
+          `Draft not found: "${context.propsValue.draft_id}". Use List Drafts to find a valid draft ID.`
+        );
+      } else if (error.code === 429) {
+        throw new Error(
+          'Gmail API rate limit exceeded. Please try again later.'
+        );
+      }
+      throw new Error(`Failed to get draft: ${error.message}`);
+    }
+  },
+});

--- a/packages/pieces/community/gmail/src/lib/actions/get-label-action.ts
+++ b/packages/pieces/community/gmail/src/lib/actions/get-label-action.ts
@@ -1,0 +1,53 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { gmailAuth, createGoogleClient } from '../auth';
+import { gmail as googleGmail } from '@googleapis/gmail';
+import { gmailGetLabelActionOutputSchema } from '../output-schemas';
+
+export const gmailGetLabelAction = createAction({
+  auth: gmailAuth,
+  name: 'gmail_get_label',
+  displayName: 'Get Label',
+  description:
+    'Get a single label by its ID, including message and thread counts.',
+  audience: 'ai',
+  aiMetadata: {
+    description:
+      'Fetches a single label by its label ID, returning its name, type, visibility, color, and message/thread counts. Use this to inspect a label or read how many messages carry it; obtain the label ID from List Labels. Idempotent: a read-only lookup that does not modify the mailbox.',
+    idempotent: true,
+  },
+  props: {
+    label_id: Property.ShortText({
+      displayName: 'Label ID',
+      description: 'The ID of the label to read (obtain from List Labels).',
+      required: true,
+    }),
+  },
+  outputSchema: gmailGetLabelActionOutputSchema,
+  async run(context) {
+    const authClient = await createGoogleClient(context.auth);
+    const gmail = googleGmail({ version: 'v1', auth: authClient });
+
+    try {
+      const response = await gmail.users.labels.get({
+        userId: 'me',
+        id: context.propsValue.label_id,
+      });
+      return response.data;
+    } catch (error: any) {
+      if (error.code === 403) {
+        throw new Error(
+          'Insufficient permissions to read the label. Ensure the gmail.readonly scope is granted.'
+        );
+      } else if (error.code === 404) {
+        throw new Error(
+          `Label not found: "${context.propsValue.label_id}". Use List Labels to find a valid label ID.`
+        );
+      } else if (error.code === 429) {
+        throw new Error(
+          'Gmail API rate limit exceeded. Please try again later.'
+        );
+      }
+      throw new Error(`Failed to get label: ${error.message}`);
+    }
+  },
+});

--- a/packages/pieces/community/gmail/src/lib/actions/get-mail-action.ts
+++ b/packages/pieces/community/gmail/src/lib/actions/get-mail-action.ts
@@ -8,7 +8,7 @@ export const gmailGetEmailAction = createAction({
   auth: gmailAuth,
   name: 'gmail_get_mail',
   description: 'Get an email via Id.',
-  audience: 'both',
+  audience: 'human',
   aiMetadata: {
     description:
       'Fetches a single email by its Gmail message ID and returns its parsed contents, including headers, body, and decoded attachments. Use this to read the full details of a specific known message, typically after a trigger or search yields its ID. Idempotent: a read-only lookup that does not modify the mailbox.',

--- a/packages/pieces/community/gmail/src/lib/actions/get-profile-action.ts
+++ b/packages/pieces/community/gmail/src/lib/actions/get-profile-action.ts
@@ -1,0 +1,39 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { gmailAuth, createGoogleClient } from '../auth';
+import { gmail as googleGmail } from '@googleapis/gmail';
+import { gmailGetProfileActionOutputSchema } from '../output-schemas';
+
+export const gmailGetProfileAction = createAction({
+  auth: gmailAuth,
+  name: 'gmail_get_profile',
+  displayName: 'Get Profile',
+  description: 'Get the connected mailbox profile.',
+  audience: 'ai',
+  aiMetadata: {
+    description:
+      'Returns the connected mailbox profile: the account email address, total message and thread counts, and the current history ID. Use this to confirm which account is connected or to obtain the starting history ID for List History. Idempotent: a read-only lookup that does not modify the mailbox.',
+    idempotent: true,
+  },
+  props: {},
+  outputSchema: gmailGetProfileActionOutputSchema,
+  async run(context) {
+    const authClient = await createGoogleClient(context.auth);
+    const gmail = googleGmail({ version: 'v1', auth: authClient });
+
+    try {
+      const response = await gmail.users.getProfile({ userId: 'me' });
+      return response.data;
+    } catch (error: any) {
+      if (error.code === 403) {
+        throw new Error(
+          'Insufficient permissions to read the profile. Ensure a read scope (e.g. gmail.readonly) is granted.'
+        );
+      } else if (error.code === 429) {
+        throw new Error(
+          'Gmail API rate limit exceeded. Please try again later.'
+        );
+      }
+      throw new Error(`Failed to get profile: ${error.message}`);
+    }
+  },
+});

--- a/packages/pieces/community/gmail/src/lib/actions/get-thread-action.ts
+++ b/packages/pieces/community/gmail/src/lib/actions/get-thread-action.ts
@@ -2,12 +2,19 @@ import { createAction, Property } from '@activepieces/pieces-framework';
 import { GmailRequests } from '../common/data';
 import { GmailMessageFormat } from '../common/models';
 import { gmailAuth, getAccessToken } from '../auth';
+import { gmailGetThreadActionOutputSchema } from '../output-schemas';
 
 export const gmailGetThread = createAction({
   auth: gmailAuth,
   name: 'gmail_get_thread',
   description: 'Get a thread from your Gmail account via Id',
   displayName: 'Get Thread',
+  audience: 'ai',
+  aiMetadata: {
+    description:
+      'Fetches an entire email conversation by its Gmail thread ID, returning every message in the thread. Use this to read a full conversation or to discover the message IDs within a thread before replying; obtain the thread ID from Search Email or List Threads. Idempotent: a read-only lookup that does not modify the mailbox.',
+    idempotent: true,
+  },
   props: {
     thread_id: Property.ShortText({
       displayName: 'Thread ID',
@@ -30,6 +37,7 @@ export const gmailGetThread = createAction({
       },
     }),
   },
+  outputSchema: gmailGetThreadActionOutputSchema,
   run: async ({ auth, propsValue: { format, thread_id } }) =>
     await GmailRequests.getThread({
       access_token: await getAccessToken(auth),

--- a/packages/pieces/community/gmail/src/lib/actions/list-drafts-action.ts
+++ b/packages/pieces/community/gmail/src/lib/actions/list-drafts-action.ts
@@ -1,0 +1,72 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { gmailAuth, createGoogleClient } from '../auth';
+import { gmail as googleGmail } from '@googleapis/gmail';
+import { gmailListDraftsActionOutputSchema } from '../output-schemas';
+
+export const gmailListDraftsAction = createAction({
+  auth: gmailAuth,
+  name: 'gmail_list_drafts',
+  displayName: 'List Drafts',
+  description: 'List draft emails in the mailbox.',
+  audience: 'ai',
+  aiMetadata: {
+    description:
+      'Lists draft emails in the connected mailbox, returning each draft ID and its associated message. This is the resolver for obtaining draft IDs used by Get Draft, Update Draft, Send Draft, and Delete Draft. Optionally narrow with a Gmail search query and bound with Max Results. Idempotent: a read-only listing that does not modify the mailbox.',
+    idempotent: true,
+  },
+  props: {
+    query: Property.ShortText({
+      displayName: 'Search Query',
+      description:
+        'Optional Gmail search query to filter drafts (e.g. "subject:invoice").',
+      required: false,
+    }),
+    max_results: Property.Number({
+      displayName: 'Max Results',
+      description: 'Maximum number of drafts to return (1-500).',
+      required: false,
+      defaultValue: 20,
+    }),
+  },
+  outputSchema: gmailListDraftsActionOutputSchema,
+  async run(context) {
+    const authClient = await createGoogleClient(context.auth);
+    const gmail = googleGmail({ version: 'v1', auth: authClient });
+
+    const maxResults = Math.min(
+      Math.max(context.propsValue.max_results || 20, 1),
+      500
+    );
+
+    try {
+      const response = await gmail.users.drafts.list({
+        userId: 'me',
+        maxResults,
+        ...(context.propsValue.query?.trim()
+          ? { q: context.propsValue.query.trim() }
+          : {}),
+      });
+
+      const drafts = response.data.drafts || [];
+      return {
+        drafts,
+        count: drafts.length,
+        resultSizeEstimate: response.data.resultSizeEstimate,
+        ...(response.data.nextPageToken
+          ? { nextPageToken: response.data.nextPageToken }
+          : {}),
+      };
+    } catch (error: any) {
+      if (error.code === 403) {
+        throw new Error(
+          'Insufficient permissions to list drafts. Ensure the gmail.readonly scope is granted.'
+        );
+      } else if (error.code === 429) {
+        throw new Error(
+          'Gmail API rate limit exceeded. Please try again later.'
+        );
+      }
+      throw new Error(`Failed to list drafts: ${error.message}`);
+    }
+  },
+});

--- a/packages/pieces/community/gmail/src/lib/actions/list-history-action.ts
+++ b/packages/pieces/community/gmail/src/lib/actions/list-history-action.ts
@@ -1,0 +1,83 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { gmailAuth, createGoogleClient } from '../auth';
+import { gmail as googleGmail } from '@googleapis/gmail';
+import { gmailListHistoryActionOutputSchema } from '../output-schemas';
+
+export const gmailListHistoryAction = createAction({
+  auth: gmailAuth,
+  name: 'gmail_list_history',
+  displayName: 'List History',
+  description: 'List mailbox changes since a given history ID.',
+  audience: 'ai',
+  aiMetadata: {
+    description:
+      'Returns the incremental change log (messages added, deleted, or relabeled) since a given starting history ID. Use this to detect what changed in the mailbox since a previous checkpoint; obtain the starting history ID from Get Profile (or a prior run). Idempotent: a read-only listing that does not modify the mailbox.',
+    idempotent: true,
+  },
+  props: {
+    start_history_id: Property.ShortText({
+      displayName: 'Start History ID',
+      description:
+        'Return changes after this history ID (obtain from Get Profile or a previous history result).',
+      required: true,
+    }),
+    history_types: Property.StaticMultiSelectDropdown({
+      displayName: 'History Types',
+      description: 'Limit results to these change types (leave empty for all).',
+      required: false,
+      options: {
+        disabled: false,
+        options: [
+          { label: 'Message Added', value: 'messageAdded' },
+          { label: 'Message Deleted', value: 'messageDeleted' },
+          { label: 'Label Added', value: 'labelAdded' },
+          { label: 'Label Removed', value: 'labelRemoved' },
+        ],
+      },
+    }),
+    max_results: Property.Number({
+      displayName: 'Max Results',
+      description: 'Maximum number of history records to return (1-500).',
+      required: false,
+      defaultValue: 100,
+    }),
+  },
+  outputSchema: gmailListHistoryActionOutputSchema,
+  async run(context) {
+    const authClient = await createGoogleClient(context.auth);
+    const gmail = googleGmail({ version: 'v1', auth: authClient });
+
+    const maxResults = Math.min(
+      Math.max(context.propsValue.max_results || 100, 1),
+      500
+    );
+    const historyTypes = context.propsValue.history_types as
+      | string[]
+      | undefined;
+
+    try {
+      const response = await gmail.users.history.list({
+        userId: 'me',
+        startHistoryId: context.propsValue.start_history_id,
+        maxResults,
+        ...(historyTypes && historyTypes.length > 0 ? { historyTypes } : {}),
+      });
+      return response.data;
+    } catch (error: any) {
+      if (error.code === 403) {
+        throw new Error(
+          'Insufficient permissions to read history. Ensure the gmail.readonly scope is granted.'
+        );
+      } else if (error.code === 404) {
+        throw new Error(
+          'The start history ID is too old or invalid. Fetch a fresh history ID from Get Profile.'
+        );
+      } else if (error.code === 429) {
+        throw new Error(
+          'Gmail API rate limit exceeded. Please try again later.'
+        );
+      }
+      throw new Error(`Failed to list history: ${error.message}`);
+    }
+  },
+});

--- a/packages/pieces/community/gmail/src/lib/actions/list-labels-action.ts
+++ b/packages/pieces/community/gmail/src/lib/actions/list-labels-action.ts
@@ -1,0 +1,43 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { gmailAuth, createGoogleClient } from '../auth';
+import { gmail as googleGmail } from '@googleapis/gmail';
+import { gmailListLabelsActionOutputSchema } from '../output-schemas';
+
+export const gmailListLabelsAction = createAction({
+  auth: gmailAuth,
+  name: 'gmail_list_labels',
+  displayName: 'List Labels',
+  description: 'List all labels in the mailbox.',
+  audience: 'ai',
+  aiMetadata: {
+    description:
+      'Lists every label in the mailbox (both system labels like INBOX/UNREAD/STARRED and user-created labels) with their IDs, names, and types. This is the primary resolver for label IDs — look up a label ID by name here before passing it to Get Label or any label-aware action. Idempotent: a read-only listing that does not modify the mailbox.',
+    idempotent: true,
+  },
+  props: {},
+  outputSchema: gmailListLabelsActionOutputSchema,
+  async run(context) {
+    const authClient = await createGoogleClient(context.auth);
+    const gmail = googleGmail({ version: 'v1', auth: authClient });
+
+    try {
+      const response = await gmail.users.labels.list({ userId: 'me' });
+      const labels = response.data.labels || [];
+      return {
+        labels,
+        count: labels.length,
+      };
+    } catch (error: any) {
+      if (error.code === 403) {
+        throw new Error(
+          'Insufficient permissions to list labels. Ensure the gmail.readonly scope is granted.'
+        );
+      } else if (error.code === 429) {
+        throw new Error(
+          'Gmail API rate limit exceeded. Please try again later.'
+        );
+      }
+      throw new Error(`Failed to list labels: ${error.message}`);
+    }
+  },
+});

--- a/packages/pieces/community/gmail/src/lib/actions/list-threads-action.ts
+++ b/packages/pieces/community/gmail/src/lib/actions/list-threads-action.ts
@@ -1,0 +1,89 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { gmailAuth, createGoogleClient } from '../auth';
+import { gmail as googleGmail } from '@googleapis/gmail';
+import { gmailListThreadsActionOutputSchema } from '../output-schemas';
+
+export const gmailListThreadsAction = createAction({
+  auth: gmailAuth,
+  name: 'gmail_list_threads',
+  displayName: 'List Threads',
+  description: 'List email conversation threads in the mailbox.',
+  audience: 'ai',
+  aiMetadata: {
+    description:
+      'Lists email conversation threads matching an optional Gmail search query and label filter, returning each thread ID and snippet. This is the resolver for obtaining thread IDs used by Get Thread and Reply to Thread. Resolve label IDs with List Labels. Idempotent: a read-only listing that does not modify the mailbox.',
+    idempotent: true,
+  },
+  props: {
+    query: Property.ShortText({
+      displayName: 'Search Query',
+      description:
+        'Optional Gmail search query to filter threads (e.g. "from:boss@example.com is:unread").',
+      required: false,
+    }),
+    label_ids: Property.Array({
+      displayName: 'Label IDs',
+      description:
+        'Optional list of label IDs to filter by (resolve via List Labels; system labels like INBOX, UNREAD are valid).',
+      required: false,
+    }),
+    include_spam_trash: Property.Checkbox({
+      displayName: 'Include Spam & Trash',
+      description: 'Include threads from Spam and Trash in the results.',
+      required: false,
+      defaultValue: false,
+    }),
+    max_results: Property.Number({
+      displayName: 'Max Results',
+      description: 'Maximum number of threads to return (1-500).',
+      required: false,
+      defaultValue: 20,
+    }),
+  },
+  outputSchema: gmailListThreadsActionOutputSchema,
+  async run(context) {
+    const authClient = await createGoogleClient(context.auth);
+    const gmail = googleGmail({ version: 'v1', auth: authClient });
+
+    const maxResults = Math.min(
+      Math.max(context.propsValue.max_results || 20, 1),
+      500
+    );
+    const labelIds = (
+      context.propsValue.label_ids as string[] | undefined
+    )?.filter((id) => id !== '');
+
+    try {
+      const response = await gmail.users.threads.list({
+        userId: 'me',
+        maxResults,
+        includeSpamTrash: context.propsValue.include_spam_trash,
+        ...(context.propsValue.query?.trim()
+          ? { q: context.propsValue.query.trim() }
+          : {}),
+        ...(labelIds && labelIds.length > 0 ? { labelIds } : {}),
+      });
+
+      const threads = response.data.threads || [];
+      return {
+        threads,
+        count: threads.length,
+        resultSizeEstimate: response.data.resultSizeEstimate,
+        ...(response.data.nextPageToken
+          ? { nextPageToken: response.data.nextPageToken }
+          : {}),
+      };
+    } catch (error: any) {
+      if (error.code === 403) {
+        throw new Error(
+          'Insufficient permissions to list threads. Ensure the gmail.readonly scope is granted.'
+        );
+      } else if (error.code === 429) {
+        throw new Error(
+          'Gmail API rate limit exceeded. Please try again later.'
+        );
+      }
+      throw new Error(`Failed to list threads: ${error.message}`);
+    }
+  },
+});

--- a/packages/pieces/community/gmail/src/lib/actions/reply-to-email-action.ts
+++ b/packages/pieces/community/gmail/src/lib/actions/reply-to-email-action.ts
@@ -12,7 +12,7 @@ export const gmailReplyToEmailAction = createAction({
   name: 'reply_to_email',
   displayName: 'Reply to Email',
   description: 'Reply to an existing email.',
-  audience: 'both',
+  audience: 'human',
   aiMetadata: {
     description:
       'Sends a reply to an existing email, preserving the thread and subject and addressing the original sender (reply) or all participants (reply all). Use this to respond within a known conversation; requires the Gmail message ID of the email being answered. Not idempotent: each call sends a new reply message into the thread.',

--- a/packages/pieces/community/gmail/src/lib/actions/search-email-action.ts
+++ b/packages/pieces/community/gmail/src/lib/actions/search-email-action.ts
@@ -12,7 +12,7 @@ export const gmailSearchMailAction = createAction({
   displayName: 'Find Email',
   description:
     'Find emails using advanced search criteria. If no filters are provided, the latest emails are returned.',
-  audience: 'both',
+  audience: 'human',
   aiMetadata: {
     description:
       'Searches the mailbox for emails matching combinable filters (sender, recipient, subject, body text, label, category, date range, attachment presence/name) and returns the matched messages with parsed contents. Use this to locate messages or discover their IDs before reading or replying; with no filters it returns the most recent emails. Bound results with Max Results (1-500, default 10). Idempotent: a read-only search that does not modify the mailbox.',

--- a/packages/pieces/community/gmail/src/lib/actions/send-draft-action.ts
+++ b/packages/pieces/community/gmail/src/lib/actions/send-draft-action.ts
@@ -1,0 +1,54 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { gmailAuth, createGoogleClient } from '../auth';
+import { gmail as googleGmail } from '@googleapis/gmail';
+import { gmailSendDraftActionOutputSchema } from '../output-schemas';
+
+export const gmailSendDraftAction = createAction({
+  auth: gmailAuth,
+  name: 'gmail_send_draft',
+  displayName: 'Send Draft',
+  description: 'Send an existing draft email by its ID.',
+  audience: 'ai',
+  aiMetadata: {
+    description:
+      'Sends an existing draft email identified by its draft ID, delivering it to its recipients. Use this after creating or editing a draft with Create Draft / Update Draft; obtain the draft ID from List Drafts. Not idempotent: each call sends the draft as a message.',
+    idempotent: false,
+  },
+  props: {
+    draft_id: Property.ShortText({
+      displayName: 'Draft ID',
+      description: 'The ID of the draft to send (obtain from List Drafts).',
+      required: true,
+    }),
+  },
+  outputSchema: gmailSendDraftActionOutputSchema,
+  async run(context) {
+    const authClient = await createGoogleClient(context.auth);
+    const gmail = googleGmail({ version: 'v1', auth: authClient });
+
+    try {
+      const response = await gmail.users.drafts.send({
+        userId: 'me',
+        requestBody: {
+          id: context.propsValue.draft_id,
+        },
+      });
+      return response.data;
+    } catch (error: any) {
+      if (error.code === 403) {
+        throw new Error(
+          'Insufficient permissions to send a draft. Ensure the gmail.send scope is granted.'
+        );
+      } else if (error.code === 404) {
+        throw new Error(
+          `Draft not found: "${context.propsValue.draft_id}". Use List Drafts to find a valid draft ID.`
+        );
+      } else if (error.code === 429) {
+        throw new Error(
+          'Gmail API rate limit exceeded. Please try again later.'
+        );
+      }
+      throw new Error(`Failed to send draft: ${error.message}`);
+    }
+  },
+});

--- a/packages/pieces/community/gmail/src/lib/actions/send-email-action.ts
+++ b/packages/pieces/community/gmail/src/lib/actions/send-email-action.ts
@@ -10,7 +10,7 @@ export const gmailSendEmailAction = createAction({
   auth: gmailAuth,
   name: 'send_email',
   description: 'Send an email through a Gmail account',
-  audience: 'both',
+  audience: 'human',
   aiMetadata: {
     description:
       'Composes and sends a new email from the connected Gmail account to one or more recipients, with optional CC/BCC, attachments, and plain-text or HTML body. Use this to originate a fresh message; to answer an existing thread prefer Reply to Email instead, or pass an original Message-ID to send this message into that existing thread. Set the draft flag to save it as a draft instead of sending. Not idempotent: each call sends (or drafts) a separate message.',

--- a/packages/pieces/community/gmail/src/lib/actions/stop-watch-action.ts
+++ b/packages/pieces/community/gmail/src/lib/actions/stop-watch-action.ts
@@ -1,0 +1,37 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { gmailAuth, createGoogleClient } from '../auth';
+import { gmail as googleGmail } from '@googleapis/gmail';
+
+export const gmailStopWatchAction = createAction({
+  auth: gmailAuth,
+  name: 'gmail_stop_watch',
+  displayName: 'Stop Watch',
+  description: 'Stop push notifications on the mailbox.',
+  audience: 'ai',
+  aiMetadata: {
+    description:
+      'Stops any active push (Cloud Pub/Sub) notifications for the connected mailbox. Use this to cancel a previously started watch. Takes no parameters. Idempotent: stopping when no watch is active is a no-op.',
+    idempotent: true,
+  },
+  props: {},
+  async run(context) {
+    const authClient = await createGoogleClient(context.auth);
+    const gmail = googleGmail({ version: 'v1', auth: authClient });
+
+    try {
+      await gmail.users.stop({ userId: 'me' });
+      return { success: true };
+    } catch (error: any) {
+      if (error.code === 403) {
+        throw new Error(
+          'Insufficient permissions to stop the watch. Ensure a read scope (e.g. gmail.readonly) is granted.'
+        );
+      } else if (error.code === 429) {
+        throw new Error(
+          'Gmail API rate limit exceeded. Please try again later.'
+        );
+      }
+      throw new Error(`Failed to stop watch: ${error.message}`);
+    }
+  },
+});

--- a/packages/pieces/community/gmail/src/lib/actions/update-draft-action.ts
+++ b/packages/pieces/community/gmail/src/lib/actions/update-draft-action.ts
@@ -1,0 +1,186 @@
+import { ApFile, createAction, Property } from '@activepieces/pieces-framework';
+import { gmailAuth, createGoogleClient, getUserEmail } from '../auth';
+import { gmail as googleGmail } from '@googleapis/gmail';
+import { GmailMime } from '../common/mime';
+import { gmailUpdateDraftActionOutputSchema } from '../output-schemas';
+
+export const gmailUpdateDraftAction = createAction({
+  auth: gmailAuth,
+  name: 'gmail_update_draft',
+  displayName: 'Update Draft',
+  description: 'Replace the content of an existing draft email.',
+  audience: 'ai',
+  aiMetadata: {
+    description:
+      'Updates an existing draft (subject, body, recipients, attachments) by its draft ID. Subject and body are required and replace the previous values; omitted recipients (To/CC) and the thread association are preserved from the existing draft rather than cleared. Obtain the draft ID from List Drafts. Not idempotent in effect: each call rewrites the draft with the supplied content.',
+    idempotent: false,
+  },
+  props: {
+    draft_id: Property.ShortText({
+      displayName: 'Draft ID',
+      description: 'The ID of the draft to update (obtain from List Drafts).',
+      required: true,
+    }),
+    receiver: Property.Array({
+      displayName: 'Receiver Email (To)',
+      required: false,
+    }),
+    cc: Property.Array({
+      displayName: 'CC Email',
+      required: false,
+    }),
+    bcc: Property.Array({
+      displayName: 'BCC Email',
+      required: false,
+    }),
+    subject: Property.ShortText({
+      displayName: 'Subject',
+      required: true,
+    }),
+    body_type: Property.StaticDropdown({
+      displayName: 'Body Type',
+      required: true,
+      defaultValue: 'plain_text',
+      options: {
+        disabled: false,
+        options: [
+          { label: 'plain text', value: 'plain_text' },
+          { label: 'html', value: 'html' },
+        ],
+      },
+    }),
+    body: Property.LongText({
+      displayName: 'Body',
+      description: 'New body for the draft email.',
+      required: true,
+    }),
+    sender_name: Property.ShortText({
+      displayName: 'Sender Name',
+      required: false,
+    }),
+    from: Property.ShortText({
+      displayName: 'Sender Email',
+      description:
+        "The address must be listed in your Gmail account's settings.",
+      required: false,
+    }),
+    thread_id: Property.ShortText({
+      displayName: 'Thread ID',
+      description:
+        'Optional thread ID to keep this draft attached to a conversation (obtain from Search Email or Get Thread).',
+      required: false,
+    }),
+    attachments: Property.Array({
+      displayName: 'Attachments',
+      required: false,
+      properties: {
+        file: Property.File({
+          displayName: 'File',
+          description: 'File to attach to the draft.',
+          required: true,
+        }),
+        name: Property.ShortText({
+          displayName: 'Attachment Name',
+          description: 'Optional name to override the attachment filename.',
+          required: false,
+        }),
+      },
+    }),
+  },
+  outputSchema: gmailUpdateDraftActionOutputSchema,
+  async run(context) {
+    const authClient = await createGoogleClient(context.auth);
+    const gmail = googleGmail({ version: 'v1', auth: authClient });
+
+    try {
+      let receiver = (
+        context.propsValue.receiver as string[] | undefined
+      )?.filter((email) => email !== '');
+      let cc = (context.propsValue.cc as string[] | undefined)?.filter(
+        (email) => email !== ''
+      );
+      const bcc = (context.propsValue.bcc as string[] | undefined)?.filter(
+        (email) => email !== ''
+      );
+      let threadId = context.propsValue.thread_id || undefined;
+
+      // A draft update replaces the whole message, so recover the recipients
+      // and thread link from the existing draft when the caller omits them —
+      // otherwise editing only the body would silently strip the To/CC list
+      // and detach the draft from its conversation.
+      if (!receiver?.length || !cc?.length || !threadId) {
+        const existing = await gmail.users.drafts.get({
+          userId: 'me',
+          id: context.propsValue.draft_id,
+          format: 'metadata',
+        });
+        const message = existing.data.message;
+        threadId = threadId ?? message?.threadId ?? undefined;
+        const headerValues = (name: string) =>
+          (message?.payload?.headers ?? [])
+            .filter((header) => (header.name ?? '').toLowerCase() === name)
+            .flatMap((header) => (header.value ?? '').split(','))
+            .map((value) => value.trim())
+            .filter((value) => value !== '');
+        if (!receiver?.length) {
+          const existingTo = headerValues('to');
+          if (existingTo.length) receiver = existingTo;
+        }
+        if (!cc?.length) {
+          const existingCc = headerValues('cc');
+          if (existingCc.length) cc = existingCc;
+        }
+      }
+
+      const senderEmail =
+        context.propsValue.from ||
+        (await getUserEmail(context.auth, authClient));
+      const from = senderEmail
+        ? context.propsValue.sender_name
+          ? `${context.propsValue.sender_name} <${senderEmail}>`
+          : senderEmail
+        : undefined;
+
+      const raw = await GmailMime.buildRawMessage({
+        to: receiver,
+        cc,
+        bcc,
+        from,
+        subject: context.propsValue.subject,
+        bodyType: context.propsValue.body_type as 'plain_text' | 'html',
+        body: context.propsValue.body,
+        attachments: context.propsValue.attachments as
+          | { file: ApFile; name?: string }[]
+          | undefined,
+      });
+
+      const response = await gmail.users.drafts.update({
+        userId: 'me',
+        id: context.propsValue.draft_id,
+        requestBody: {
+          message: {
+            raw,
+            threadId,
+          },
+        },
+      });
+
+      return response.data;
+    } catch (error: any) {
+      if (error.code === 403) {
+        throw new Error(
+          'Insufficient permissions to update a draft. Ensure the gmail.compose scope is granted.'
+        );
+      } else if (error.code === 404) {
+        throw new Error(
+          `Draft not found: "${context.propsValue.draft_id}". Use List Drafts to find a valid draft ID.`
+        );
+      } else if (error.code === 429) {
+        throw new Error(
+          'Gmail API rate limit exceeded. Please try again later.'
+        );
+      }
+      throw new Error(`Failed to update draft: ${error.message}`);
+    }
+  },
+});

--- a/packages/pieces/community/gmail/src/lib/actions/update-draft-action.ts
+++ b/packages/pieces/community/gmail/src/lib/actions/update-draft-action.ts
@@ -1,8 +1,10 @@
 import { ApFile, createAction, Property } from '@activepieces/pieces-framework';
 import { gmailAuth, createGoogleClient, getUserEmail } from '../auth';
 import { gmail as googleGmail } from '@googleapis/gmail';
-import { GmailMime } from '../common/mime';
+import { GmailMime, RawMimeAttachment } from '../common/mime';
 import { gmailUpdateDraftActionOutputSchema } from '../output-schemas';
+import { parseStream } from '../common/data';
+import { AddressObject } from 'mailparser';
 
 export const gmailUpdateDraftAction = createAction({
   auth: gmailAuth,
@@ -12,7 +14,7 @@ export const gmailUpdateDraftAction = createAction({
   audience: 'ai',
   aiMetadata: {
     description:
-      'Updates an existing draft (subject, body, recipients, attachments) by its draft ID. Subject and body are required and replace the previous values; omitted recipients (To/CC) and the thread association are preserved from the existing draft rather than cleared. Obtain the draft ID from List Drafts. Not idempotent in effect: each call rewrites the draft with the supplied content.',
+      'Updates an existing draft (subject, body, recipients, attachments) by its draft ID. Subject and body are required and replace the previous values; omitted recipients (To/CC/BCC), attachments, and the thread association are preserved from the existing draft rather than cleared. Obtain the draft ID from List Drafts. Not idempotent in effect: each call rewrites the draft with the supplied content.',
     idempotent: false,
   },
   props: {
@@ -99,36 +101,50 @@ export const gmailUpdateDraftAction = createAction({
       let cc = (context.propsValue.cc as string[] | undefined)?.filter(
         (email) => email !== ''
       );
-      const bcc = (context.propsValue.bcc as string[] | undefined)?.filter(
+      let bcc = (context.propsValue.bcc as string[] | undefined)?.filter(
         (email) => email !== ''
       );
       let threadId = context.propsValue.thread_id || undefined;
+      const newAttachments = context.propsValue.attachments as
+        | { file: ApFile; name?: string }[]
+        | undefined;
+      let preservedAttachments: RawMimeAttachment[] = [];
 
-      // A draft update replaces the whole message, so recover the recipients
-      // and thread link from the existing draft when the caller omits them —
-      // otherwise editing only the body would silently strip the To/CC list
-      // and detach the draft from its conversation.
-      if (!receiver?.length || !cc?.length || !threadId) {
+      // A draft update replaces the whole message, so recover the recipients,
+      // attachments, and thread link from the existing draft when the caller
+      // omits them — otherwise editing only the body would silently strip the
+      // BCC list or attachments and detach the draft from its conversation.
+      // BCC is stripped from `metadata`/`full` responses, so recovering it
+      // (and the attachment content) requires the raw MIME of the draft.
+      if (
+        !receiver?.length ||
+        !cc?.length ||
+        !bcc?.length ||
+        !threadId ||
+        !newAttachments?.length
+      ) {
         const existing = await gmail.users.drafts.get({
           userId: 'me',
           id: context.propsValue.draft_id,
-          format: 'metadata',
+          format: 'raw',
         });
         const message = existing.data.message;
         threadId = threadId ?? message?.threadId ?? undefined;
-        const headerValues = (name: string) =>
-          (message?.payload?.headers ?? [])
-            .filter((header) => (header.name ?? '').toLowerCase() === name)
-            .flatMap((header) => (header.value ?? '').split(','))
-            .map((value) => value.trim())
-            .filter((value) => value !== '');
-        if (!receiver?.length) {
-          const existingTo = headerValues('to');
-          if (existingTo.length) receiver = existingTo;
-        }
-        if (!cc?.length) {
-          const existingCc = headerValues('cc');
-          if (existingCc.length) cc = existingCc;
+
+        if (message?.raw) {
+          const parsed = await parseStream(
+            Buffer.from(message.raw, 'base64').toString('utf-8')
+          );
+          if (!receiver?.length) receiver = addressesOf(parsed.to);
+          if (!cc?.length) cc = addressesOf(parsed.cc);
+          if (!bcc?.length) bcc = addressesOf(parsed.bcc);
+          if (!newAttachments?.length) {
+            preservedAttachments = parsed.attachments.map((attachment) => ({
+              filename: attachment.filename,
+              content: attachment.content,
+              contentType: attachment.contentType,
+            }));
+          }
         }
       }
 
@@ -149,9 +165,9 @@ export const gmailUpdateDraftAction = createAction({
         subject: context.propsValue.subject,
         bodyType: context.propsValue.body_type as 'plain_text' | 'html',
         body: context.propsValue.body,
-        attachments: context.propsValue.attachments as
-          | { file: ApFile; name?: string }[]
-          | undefined,
+        attachments: newAttachments?.length
+          ? newAttachments
+          : preservedAttachments,
       });
 
       const response = await gmail.users.drafts.update({
@@ -184,3 +200,12 @@ export const gmailUpdateDraftAction = createAction({
     }
   },
 });
+
+function addressesOf(
+  address: AddressObject | AddressObject[] | undefined
+): string[] {
+  return (Array.isArray(address) ? address : address ? [address] : [])
+    .flatMap((addressObject) => addressObject.value)
+    .map((emailAddress) => emailAddress.address)
+    .filter((emailAddress): emailAddress is string => !!emailAddress);
+}

--- a/packages/pieces/community/gmail/src/lib/common/mime.ts
+++ b/packages/pieces/community/gmail/src/lib/common/mime.ts
@@ -1,0 +1,60 @@
+import mime from 'mime-types';
+import MailComposer from 'nodemailer/lib/mail-composer';
+import Mail, { Attachment } from 'nodemailer/lib/mailer';
+import { ApFile } from '@activepieces/pieces-framework';
+
+interface BuildRawMessageProps {
+  to?: string[];
+  cc?: string[];
+  bcc?: string[];
+  from?: string;
+  subject: string;
+  bodyType: 'plain_text' | 'html';
+  body: string;
+  headers?: { key: string; value: string }[];
+  attachments?: { file: ApFile; name?: string }[];
+}
+
+async function buildRawMessage(props: BuildRawMessageProps): Promise<string> {
+  const subjectBase64 = Buffer.from(props.subject).toString('base64');
+  const mailOptions: Mail.Options = {
+    to: props.to && props.to.length > 0 ? props.to.join(', ') : undefined,
+    cc: props.cc && props.cc.length > 0 ? props.cc.join(', ') : undefined,
+    bcc: props.bcc && props.bcc.length > 0 ? props.bcc.join(', ') : undefined,
+    from: props.from,
+    subject: `=?UTF-8?B?${subjectBase64}?=`,
+    text: props.bodyType === 'plain_text' ? props.body : undefined,
+    html: props.bodyType === 'html' ? props.body : undefined,
+    attachments: [],
+    headers: props.headers,
+  };
+
+  if (props.attachments && props.attachments.length > 0) {
+    const attachmentOption: Attachment[] = props.attachments.map(
+      ({ file, name }) => {
+        const lookupResult = mime.lookup(file.extension ? file.extension : '');
+        return {
+          filename: name ?? file.filename,
+          content: file?.base64,
+          contentType: lookupResult ? lookupResult : undefined,
+          encoding: 'base64',
+        };
+      }
+    );
+    mailOptions.attachments = attachmentOption;
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const mail: any = new MailComposer(mailOptions).compile();
+  mail.keepBcc = true;
+  const mailBody = await mail.build();
+
+  return Buffer.from(mailBody)
+    .toString('base64')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_');
+}
+
+export const GmailMime = {
+  buildRawMessage,
+};

--- a/packages/pieces/community/gmail/src/lib/common/mime.ts
+++ b/packages/pieces/community/gmail/src/lib/common/mime.ts
@@ -3,6 +3,12 @@ import MailComposer from 'nodemailer/lib/mail-composer';
 import Mail, { Attachment } from 'nodemailer/lib/mailer';
 import { ApFile } from '@activepieces/pieces-framework';
 
+export interface RawMimeAttachment {
+  filename?: string;
+  content: Buffer;
+  contentType?: string;
+}
+
 interface BuildRawMessageProps {
   to?: string[];
   cc?: string[];
@@ -12,7 +18,13 @@ interface BuildRawMessageProps {
   bodyType: 'plain_text' | 'html';
   body: string;
   headers?: { key: string; value: string }[];
-  attachments?: { file: ApFile; name?: string }[];
+  attachments?: ({ file: ApFile; name?: string } | RawMimeAttachment)[];
+}
+
+function isFileAttachment(
+  attachment: { file: ApFile; name?: string } | RawMimeAttachment
+): attachment is { file: ApFile; name?: string } {
+  return 'file' in attachment;
 }
 
 async function buildRawMessage(props: BuildRawMessageProps): Promise<string> {
@@ -31,13 +43,23 @@ async function buildRawMessage(props: BuildRawMessageProps): Promise<string> {
 
   if (props.attachments && props.attachments.length > 0) {
     const attachmentOption: Attachment[] = props.attachments.map(
-      ({ file, name }) => {
-        const lookupResult = mime.lookup(file.extension ? file.extension : '');
+      (attachment) => {
+        if (isFileAttachment(attachment)) {
+          const { file, name } = attachment;
+          const lookupResult = mime.lookup(
+            file.extension ? file.extension : ''
+          );
+          return {
+            filename: name ?? file.filename,
+            content: file?.base64,
+            contentType: lookupResult ? lookupResult : undefined,
+            encoding: 'base64',
+          };
+        }
         return {
-          filename: name ?? file.filename,
-          content: file?.base64,
-          contentType: lookupResult ? lookupResult : undefined,
-          encoding: 'base64',
+          filename: attachment.filename,
+          content: attachment.content,
+          contentType: attachment.contentType,
         };
       }
     );

--- a/packages/pieces/community/gmail/src/lib/output-schemas.ts
+++ b/packages/pieces/community/gmail/src/lib/output-schemas.ts
@@ -1,5 +1,93 @@
 import { OutputSchema } from '@activepieces/pieces-framework';
 
+const addressObjectFields: OutputSchema['fields'] = [
+  { key: 'text', label: 'Text' },
+  {
+    key: 'value',
+    label: 'Addresses',
+    labelKey: 'name',
+    listItems: [
+      { key: 'address', label: 'Email', format: 'email' },
+      { key: 'name', label: 'Name' },
+    ],
+  },
+];
+
+const attachmentFields: OutputSchema['fields'] = [
+  { key: 'fileName', label: 'File Name' },
+  { key: 'mimeType', label: 'MIME Type' },
+  { key: 'size', label: 'Size', format: 'filesize' },
+  { key: 'data', label: 'Download URL', format: 'url' },
+];
+
+const parsedMessageFields: OutputSchema['fields'] = [
+  { key: 'id', label: 'Message ID' },
+  { key: 'subject', label: 'Subject' },
+  { key: 'from', label: 'From', children: addressObjectFields },
+  { key: 'to', label: 'To', children: addressObjectFields },
+  { key: 'cc', label: 'Cc', children: addressObjectFields },
+  { key: 'date', label: 'Date', format: 'datetime' },
+  { key: 'messageId', label: 'RFC Message-ID' },
+  { key: 'text', label: 'Text Body' },
+  { key: 'html', label: 'HTML Body', format: 'html' },
+  {
+    key: 'attachments',
+    label: 'Attachments',
+    labelKey: 'fileName',
+    listItems: attachmentFields,
+  },
+];
+
+const messageSendResultFields: OutputSchema['fields'] = [
+  { key: 'id', label: 'Message ID' },
+  { key: 'threadId', label: 'Thread ID' },
+  { key: 'labelIds', label: 'Labels' },
+];
+
+const gmailMessageResourceFields: OutputSchema['fields'] = [
+  { key: 'id', label: 'Message ID' },
+  { key: 'threadId', label: 'Thread ID' },
+  { key: 'labelIds', label: 'Labels' },
+  { key: 'snippet', label: 'Snippet' },
+  { key: 'internalDate', label: 'Internal Date', format: 'datetime' },
+  { key: 'sizeEstimate', label: 'Size Estimate', format: 'filesize' },
+];
+
+const draftMutationFields: OutputSchema['fields'] = [
+  { key: 'id', label: 'Draft ID' },
+  {
+    key: 'message',
+    label: 'Message',
+    children: [
+      { key: 'id', label: 'Message ID' },
+      { key: 'threadId', label: 'Thread ID' },
+      { key: 'labelIds', label: 'Labels' },
+    ],
+  },
+];
+
+const gmailLabelBaseFields: OutputSchema['fields'] = [
+  { key: 'id', label: 'Label ID' },
+  { key: 'name', label: 'Name' },
+  { key: 'type', label: 'Type' },
+  { key: 'messageListVisibility', label: 'Message List Visibility' },
+  { key: 'labelListVisibility', label: 'Label List Visibility' },
+  {
+    key: 'color',
+    label: 'Color',
+    children: [
+      { key: 'textColor', label: 'Text Color' },
+      { key: 'backgroundColor', label: 'Background Color' },
+    ],
+  },
+];
+
+const historyRecordMessageFields: OutputSchema['fields'] = [
+  { key: 'id', label: 'Message ID' },
+  { key: 'threadId', label: 'Thread ID' },
+  { key: 'labelIds', label: 'Labels' },
+];
+
 export const sendEmailActionOutputSchema: OutputSchema = {
   fields: [
     {
@@ -734,6 +822,237 @@ export const newLabeledEmailTriggerOutputSchema: OutputSchema = {
               value: 'sizeEstimate',
               format: 'filesize',
             },
+          ],
+        },
+      ],
+    },
+  ],
+};
+
+export const gmailAiSendEmailActionOutputSchema: OutputSchema = {
+  fields: [
+    { key: 'data', label: 'Message', children: messageSendResultFields },
+    { key: 'status', label: 'Status Code', format: 'number' },
+    { key: 'statusText', label: 'Status Text' },
+  ],
+};
+
+export const gmailAiGetMessageActionOutputSchema: OutputSchema = {
+  fields: parsedMessageFields,
+};
+
+export const gmailAiSearchEmailActionOutputSchema: OutputSchema = {
+  fields: [
+    { key: 'found', label: 'Found', format: 'boolean' },
+    {
+      key: 'results',
+      label: 'Results',
+      children: [
+        { key: 'count', label: 'Count', format: 'number' },
+        {
+          key: 'messages',
+          label: 'Messages',
+          labelKey: 'subject',
+          listItems: parsedMessageFields,
+        },
+      ],
+    },
+  ],
+};
+
+export const gmailAiReplyToThreadActionOutputSchema: OutputSchema = {
+  fields: messageSendResultFields,
+};
+
+export const gmailForwardMessageActionOutputSchema: OutputSchema = {
+  fields: messageSendResultFields,
+};
+
+export const gmailSendDraftActionOutputSchema: OutputSchema = {
+  fields: messageSendResultFields,
+};
+
+export const gmailCreateDraftActionOutputSchema: OutputSchema = {
+  fields: draftMutationFields,
+};
+
+export const gmailUpdateDraftActionOutputSchema: OutputSchema = {
+  fields: draftMutationFields,
+};
+
+export const gmailGetDraftActionOutputSchema: OutputSchema = {
+  fields: [
+    { key: 'id', label: 'Draft ID' },
+    { key: 'message', label: 'Message', children: gmailMessageResourceFields },
+  ],
+};
+
+export const gmailListDraftsActionOutputSchema: OutputSchema = {
+  fields: [
+    {
+      key: 'drafts',
+      label: 'Drafts',
+      labelKey: 'id',
+      listItems: [
+        { key: 'id', label: 'Draft ID' },
+        {
+          key: 'message',
+          label: 'Message',
+          children: [
+            { key: 'id', label: 'Message ID' },
+            { key: 'threadId', label: 'Thread ID' },
+          ],
+        },
+      ],
+    },
+    { key: 'count', label: 'Count', format: 'number' },
+    {
+      key: 'resultSizeEstimate',
+      label: 'Result Size Estimate',
+      format: 'number',
+    },
+    { key: 'nextPageToken', label: 'Next Page Token' },
+  ],
+};
+
+export const gmailGetThreadActionOutputSchema: OutputSchema = {
+  fields: [
+    { key: 'id', label: 'Thread ID' },
+    { key: 'snippet', label: 'Snippet' },
+    { key: 'historyId', label: 'History ID' },
+    {
+      key: 'messages',
+      label: 'Messages',
+      labelKey: 'snippet',
+      listItems: gmailMessageResourceFields,
+    },
+  ],
+};
+
+export const gmailListThreadsActionOutputSchema: OutputSchema = {
+  fields: [
+    {
+      key: 'threads',
+      label: 'Threads',
+      labelKey: 'snippet',
+      listItems: [
+        { key: 'id', label: 'Thread ID' },
+        { key: 'snippet', label: 'Snippet' },
+        { key: 'historyId', label: 'History ID' },
+      ],
+    },
+    { key: 'count', label: 'Count', format: 'number' },
+    {
+      key: 'resultSizeEstimate',
+      label: 'Result Size Estimate',
+      format: 'number',
+    },
+    { key: 'nextPageToken', label: 'Next Page Token' },
+  ],
+};
+
+export const gmailListLabelsActionOutputSchema: OutputSchema = {
+  fields: [
+    {
+      key: 'labels',
+      label: 'Labels',
+      labelKey: 'name',
+      listItems: gmailLabelBaseFields,
+    },
+    { key: 'count', label: 'Count', format: 'number' },
+  ],
+};
+
+export const gmailGetLabelActionOutputSchema: OutputSchema = {
+  fields: [
+    ...gmailLabelBaseFields,
+    { key: 'messagesTotal', label: 'Messages Total', format: 'number' },
+    { key: 'messagesUnread', label: 'Messages Unread', format: 'number' },
+    { key: 'threadsTotal', label: 'Threads Total', format: 'number' },
+    { key: 'threadsUnread', label: 'Threads Unread', format: 'number' },
+  ],
+};
+
+export const gmailGetProfileActionOutputSchema: OutputSchema = {
+  fields: [
+    { key: 'emailAddress', label: 'Email Address', format: 'email' },
+    { key: 'messagesTotal', label: 'Messages Total', format: 'number' },
+    { key: 'threadsTotal', label: 'Threads Total', format: 'number' },
+    { key: 'historyId', label: 'History ID' },
+  ],
+};
+
+export const gmailGetAttachmentActionOutputSchema: OutputSchema = {
+  fields: [
+    { key: 'fileName', label: 'File Name' },
+    { key: 'size', label: 'Size', format: 'filesize' },
+    { key: 'data', label: 'File', format: 'url' },
+  ],
+};
+
+export const gmailListHistoryActionOutputSchema: OutputSchema = {
+  fields: [
+    { key: 'historyId', label: 'History ID' },
+    { key: 'nextPageToken', label: 'Next Page Token' },
+    {
+      key: 'history',
+      label: 'History Records',
+      labelKey: 'id',
+      listItems: [
+        { key: 'id', label: 'History ID' },
+        {
+          key: 'messages',
+          label: 'Messages',
+          labelKey: 'id',
+          listItems: [
+            { key: 'id', label: 'Message ID' },
+            { key: 'threadId', label: 'Thread ID' },
+          ],
+        },
+        {
+          key: 'messagesAdded',
+          label: 'Messages Added',
+          listItems: [
+            {
+              key: 'message',
+              label: 'Message',
+              children: historyRecordMessageFields,
+            },
+          ],
+        },
+        {
+          key: 'messagesDeleted',
+          label: 'Messages Deleted',
+          listItems: [
+            {
+              key: 'message',
+              label: 'Message',
+              children: historyRecordMessageFields,
+            },
+          ],
+        },
+        {
+          key: 'labelsAdded',
+          label: 'Labels Added',
+          listItems: [
+            {
+              key: 'message',
+              label: 'Message',
+              children: historyRecordMessageFields,
+            },
+            { key: 'labelIds', label: 'Added Label IDs' },
+          ],
+        },
+        {
+          key: 'labelsRemoved',
+          label: 'Labels Removed',
+          listItems: [
+            {
+              key: 'message',
+              label: 'Message',
+              children: historyRecordMessageFields,
+            },
+            { key: 'labelIds', label: 'Removed Label IDs' },
           ],
         },
       ],


### PR DESCRIPTION
## What

Adds an `audience:'ai'` agent-tool surface to the Gmail piece, mirroring google-docs (#13926) and google-calendar (#13929). This is **phase 1**: every atomic reachable under the piece's *current* OAuth scopes (`gmail.readonly` / `gmail.compose` / `gmail.send`) — no scope change, so no connection re-consent.

`audience` is read only by agent discovery (`ap_search_actions`), never by the engine or `ap_run_action`, so the demotions below do not affect human flow-builder usage.

## ai atomics (19)

- **Messages / threads:** send email, reply to thread, get message, get thread, search email, list threads, get attachment, forward message
- **Drafts (full lifecycle):** create, update, get, list, delete, send draft
- **Labels (read):** list labels, get label
- **Account:** get profile, list history, stop watch

Every ID-taking atomic's `aiMetadata.description` names the resolver atomic for the ID it needs (messageId ← search, draftId ← list drafts, threadId ← list threads, historyId ← get profile) — these can't be guessed.

## Demotions (`both` → `human`)

`send_email`, `reply_to_email`, `create_draft_reply`, `gmail_get_mail`, `gmail_search_mail` — each superseded by an `ai` twin that reuses the same `run()`. `request_approval_in_mail` stays `both` (human-in-the-loop approval gate; no agent equivalent). The previously-unregistered get-thread action is registered as the `ai` Get Thread.

## Deferred to a follow-up (scope-gated)

The label-mutation / trash / modify-labels / batch cluster and the settings + contacts tools are authored but **not** in this PR: they need broader scopes (`gmail.modify`, `gmail.labels`, `gmail.settings.*`, People-API contacts) that force **every existing Gmail connection to re-consent**. Splitting them keeps this PR scope-neutral and lets the scope expansion be reviewed on its own.

## Verification

- **Tier-1:** `tsc -p tsconfig.lib.json` clean; `eslint` 0 errors.
- **Tier-2:** 18/19 atomics executed against a real Gmail connection on a local dev instance via the `test-step` path and SUCCEEDED — including the `forward_message` and `reply_to_thread` composites and the full draft lifecycle (all test traffic was self→self). `get_attachment` is Tier-1-only: its raw `attachmentId` is not surfaced by Get Message (which returns attachment content directly), so it could not be chained in-account — its description was corrected to reflect this.

Version: `0.12.6` → `0.12.7`.


### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)
