### PR TITLE
chore(release): revert version bump to 0.87.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activepieces",
-  "version": "0.87.0",
+  "version": "0.86.3",
   "packageManager": "bun@1.3.3",
   "trustedDependencies": [
     "sqlite3",


### PR DESCRIPTION
## Description

Reverts #14542, restoring the platform version to `0.86.3`.

Single-line change to root `package.json`; no other file is touched.

### Operational notes

- **Staging will redeploy to `0.86.3`.** `continuous-delivery-stg.yml` triggers on push to `main`, and staging is currently running `0.87.0` (deployed 16:30 UTC from #14542). Cloud and canary are manual-dispatch only and were never deployed, so production is unaffected either way.
- **Already-applied migrations are not rolled back and do not need to be.** The 7 migrations queued for the next release are tagged `0.86.4` and all are `breaking = false` (additive columns/indexes), so a `0.86.3` build runs correctly against a database that already has them.
- **Expect a brief worker-idle window during the staging rollout.** `apVersionUtil.versionsAreCompatible` is fail-closed on any version mismatch, so workers still on `0.87.0` will idle until the app and workers converge on `0.86.3`. This is the intended behaviour of the dispatch gate and self-heals when the rollout completes.
- **The 20 release-gated pieces stay gated.** They declare `minimumSupportedRelease` of `0.86.4` (15) or `0.87.0` (5); at `0.86.3` `isSupportedRelease` filters those versions out of every read path and the catalog continues serving each piece's previous version. That is the pre-#14542 status quo, unchanged by this revert.

## How was this tested?

- `node --print "require('./package.json').version"` → `0.86.3`; JSON parses.
- `git revert` of the squash commit `d19ac9d1`, producing a diff that is exactly the inverse of #14542 — one line, one file.
- No behavioural code touched, so no edition-specific paths (CE / EE / Cloud) are affected.

Fixes # (no GitHub issue)

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)
