### PR TITLE
fix(flows): name run and step output downloads .json instead of .bin

### DIFF
--- a/packages/server/api/src/app/file/file.service.ts
+++ b/packages/server/api/src/app/file/file.service.ts
@@ -347,6 +347,10 @@ export function getLocationForFile(type: FileType) {
     return FileLocation.DB
 }
 
+export function getDownloadName(file: Pick<File, 'id' | 'fileName' | 'type'>): string {
+    return file.fileName ?? `${file.id}.${file.type === FileType.FLOW_RUN_LOG_SLICE ? 'json' : 'bin'}`
+}
+
 export function getEffectiveExecutionDataRetentionDays(executionDataRetentionDays: number | null | undefined): number {
     if (isNil(executionDataRetentionDays)) {
         return EXECUTION_DATA_RETENTION_DAYS

--- a/packages/server/api/src/app/file/files-controller.ts
+++ b/packages/server/api/src/app/file/files-controller.ts
@@ -1,6 +1,7 @@
 import { Readable } from 'node:stream'
 import { ActivepiecesError, ApId, assertNotNullOrUndefined, ErrorCode, isNil } from '@activepieces/core-utils'
 import { ALL_PRINCIPAL_TYPES, EnginePrincipal, FileCompression, FileTransportQueryParams, FileType, Principal, PrincipalType } from '@activepieces/shared'
+import contentDisposition from 'content-disposition'
 import { FastifyPluginAsyncZod } from 'fastify-type-provider-zod'
 import { StatusCodes } from 'http-status-codes'
 import { z } from 'zod'
@@ -8,7 +9,7 @@ import { accessTokenManager } from '../authentication/lib/access-token-manager'
 import { securityAccess } from '../core/security/authorization/fastify-security'
 import { system } from '../helper/system/system'
 import { AppSystemProp } from '../helper/system/system-props'
-import { fileService } from './file.service'
+import { fileService, getDownloadName } from './file.service'
 import { enforceByteLimit, ENGINE_WRITABLE_FILE_TYPES, filesService, fileTransportHeaders } from './files-service'
 import { signedFileTransport } from './signed-file-transport'
 
@@ -133,7 +134,7 @@ export const filesController: FastifyPluginAsyncZod = async (app) => {
         return reply
             .type(mimeType)
             .header('X-Content-Type-Options', 'nosniff')
-            .header('Content-Disposition', `${disposition}; filename="${encodeURI(file.fileName ?? `${file.id}.bin`)}"`)
+            .header('Content-Disposition', contentDisposition(getDownloadName(file), { type: disposition }))
             .status(StatusCodes.OK)
             .send(data)
     })

--- a/packages/server/api/src/app/file/signed-file-transport.ts
+++ b/packages/server/api/src/app/file/signed-file-transport.ts
@@ -4,7 +4,7 @@ import { FastifyBaseLogger, FastifyReply } from 'fastify'
 import { StatusCodes } from 'http-status-codes'
 import { system } from '../helper/system/system'
 import { AppSystemProp } from '../helper/system/system-props'
-import { getLocationForFile } from './file.service'
+import { getDownloadName, getLocationForFile } from './file.service'
 import { s3Helper } from './s3-helper'
 
 const useS3SignedUrls = system.getBoolean(AppSystemProp.S3_USE_SIGNED_URLS) ?? false
@@ -37,7 +37,7 @@ export const signedFileTransport = {
             return false
         }
         assertNotNullOrUndefined(file.s3Key, 's3Key')
-        const url = await s3Helper(log).getS3SignedUrl(file.s3Key, file.fileName ?? file.id)
+        const url = await s3Helper(log).getS3SignedUrl(file.s3Key, getDownloadName(file))
         log.info({ s3Key: file.s3Key, fileId: file.id }, 'Redirecting GET to S3 signed URL')
         await reply
             .status(StatusCodes.TEMPORARY_REDIRECT)
@@ -59,5 +59,5 @@ type PutRedirectParams = {
 type GetRedirectParams = {
     reply: FastifyReply
     log: FastifyBaseLogger
-    file: Pick<File, 'id' | 'location' | 's3Key' | 'fileName'>
+    file: Pick<File, 'id' | 'location' | 's3Key' | 'fileName' | 'type'>
 }

--- a/packages/server/api/test/integration/ce/file/files-controller.test.ts
+++ b/packages/server/api/test/integration/ce/file/files-controller.test.ts
@@ -271,6 +271,72 @@ describe('Files Controller', () => {
             expect(getResponse?.rawPayload.toString('utf-8')).toBe('engine read')
         })
 
+        it.each([
+            { type: FileType.FLOW_RUN_LOG_SLICE, extension: 'json' },
+            { type: FileType.FLOW_STEP_FILE, extension: 'bin' },
+        ])('names an unnamed $type download <id>.$extension', async ({ type, extension }) => {
+            const { mockProject, mockPlatform } = await mockAndSaveBasicSetup()
+            const engineToken = await generateMockToken({
+                type: PrincipalType.ENGINE,
+                id: apId(),
+                projectId: mockProject.id,
+                platform: { id: mockPlatform.id },
+            })
+            const fileId = apId()
+
+            await app!.inject({
+                method: 'PUT',
+                url: `/api/v1/files/${fileId}`,
+                query: { token: engineToken },
+                headers: {
+                    'content-type': 'application/octet-stream',
+                    'x-ap-file-type': type,
+                },
+                payload: Buffer.from('{"rows":[]}', 'utf-8'),
+            })
+
+            const getResponse = await app!.inject({
+                method: 'GET',
+                url: `/api/v1/files/${fileId}`,
+                query: { token: engineToken },
+            })
+
+            expect(getResponse?.statusCode).toBe(StatusCodes.OK)
+            expect(getResponse?.headers['content-disposition']).toBe(`attachment; filename="${fileId}.${extension}"`)
+            expect(getResponse?.headers['x-content-type-options']).toBe('nosniff')
+        })
+
+        it('keeps the uploaded name when the file has one', async () => {
+            const { mockProject, mockPlatform } = await mockAndSaveBasicSetup()
+            const engineToken = await generateMockToken({
+                type: PrincipalType.ENGINE,
+                id: apId(),
+                projectId: mockProject.id,
+                platform: { id: mockPlatform.id },
+            })
+            const fileId = apId()
+
+            await app!.inject({
+                method: 'PUT',
+                url: `/api/v1/files/${fileId}`,
+                query: { token: engineToken },
+                headers: {
+                    'content-type': 'application/octet-stream',
+                    'x-ap-file-type': FileType.FLOW_STEP_FILE,
+                    'x-ap-file-name': 'invoice.pdf',
+                },
+                payload: Buffer.from('%PDF-1.4', 'utf-8'),
+            })
+
+            const getResponse = await app!.inject({
+                method: 'GET',
+                url: `/api/v1/files/${fileId}`,
+                query: { token: engineToken },
+            })
+
+            expect(getResponse?.headers['content-disposition']).toBe('attachment; filename="invoice.pdf"')
+        })
+
         it('rejects a download with a read token bound to a different fileId', async () => {
             const otherFileReadUrl = await filesService.constructReadUrl({
                 fileId: apId(),

--- a/packages/server/api/test/integration/ce/file/files-controller.test.ts
+++ b/packages/server/api/test/integration/ce/file/files-controller.test.ts
@@ -1,8 +1,9 @@
 import { apId } from '@activepieces/core-utils'
-import { FileType, PrincipalType } from '@activepieces/shared'
+import { FileCompression, FileType, PrincipalType } from '@activepieces/shared'
 import { FastifyInstance } from 'fastify'
 import { StatusCodes } from 'http-status-codes'
 import { vi } from 'vitest'
+import { fileService } from '../../../../src/app/file/file.service'
 import { filesService } from '../../../../src/app/file/files-service'
 import { generateMockToken } from '../../../helpers/auth'
 import { mockAndSaveBasicSetup } from '../../../helpers/mocks'
@@ -335,6 +336,37 @@ describe('Files Controller', () => {
             })
 
             expect(getResponse?.headers['content-disposition']).toBe('attachment; filename="invoice.pdf"')
+        })
+
+        it.each([
+            { fileName: 'résumé.pdf', expected: 'attachment; filename="résumé.pdf"' },
+            { fileName: '報告書.json', expected: 'attachment; filename="???.json"; filename*=UTF-8\'\'%E5%A0%B1%E5%91%8A%E6%9B%B8.json' },
+            { fileName: 'evil\r\nX-Injected: 1.json', expected: 'attachment; filename="evil??X-Injected: 1.json"; filename*=UTF-8\'\'evil%0D%0AX-Injected%3A%201.json' },
+        ])('escapes $fileName in the disposition header without emitting a raw newline', async ({ fileName, expected }) => {
+            const { mockProject, mockPlatform } = await mockAndSaveBasicSetup()
+            const file = await fileService(app!.log).save({
+                projectId: mockProject.id,
+                platformId: mockPlatform.id,
+                type: FileType.FLOW_STEP_FILE,
+                compression: FileCompression.NONE,
+                fileName,
+                data: Buffer.from('payload', 'utf-8'),
+            })
+            const readUrl = await filesService.constructReadUrl({
+                fileId: file.id,
+                fileType: FileType.FLOW_STEP_FILE,
+                platformId: mockPlatform.id,
+            })
+
+            const getResponse = await app!.inject({
+                method: 'GET',
+                url: `/api/v1/files/${file.id}`,
+                query: { token: new URL(readUrl).searchParams.get('token') as string },
+            })
+
+            expect(getResponse?.statusCode).toBe(StatusCodes.OK)
+            expect(getResponse?.headers['content-disposition']).toBe(expected)
+            expect(getResponse?.headers['content-disposition']).not.toMatch(/[\r\n]/)
         })
 
         it('rejects a download with a read token bound to a different fileId', async () => {

--- a/packages/web/src/components/custom/json-viewer.tsx
+++ b/packages/web/src/components/custom/json-viewer.tsx
@@ -62,15 +62,11 @@ const JsonViewer = React.memo(
         type: 'application/json',
       });
       const url = URL.createObjectURL(blob);
-      handleDownloadFile(url);
-    };
-
-    const handleDownloadFile = (fileUrl: string, ext = '') => {
       const link = document.createElement('a');
-      link.href = fileUrl;
-      link.download = `${typeof title === 'string' ? title : 'data'}${ext}`;
+      link.href = url;
+      link.download = `${typeof title === 'string' ? title : 'data'}.json`;
       link.click();
-      URL.revokeObjectURL(fileUrl);
+      URL.revokeObjectURL(url);
     };
     return (
       <div


### PR DESCRIPTION
## Description

Downloading a run or step output saved a file the browser named `.bin` — or, on S3-backed storage, an extensionless uuid.

The served filename comes from the `fileName` column, which is written once at upload time. `FLOW_RUN_LOG_SLICE` files (outputs over `AP_FLOW_RUN_LOG_SLICE_THRESHOLD_KB`, offloaded out of the run log) are uploaded **nameless**, so every download fell through to a fallback — and the two sinks had drifted apart:

| Sink | Fallback when `fileName` is null | Result |
|---|---|---|
| `files-controller.ts` (DB storage) | `` `${file.id}.bin` `` | `<uuid>.bin` |
| `signed-file-transport.ts` (S3 signed URL) | `file.id` | `<uuid>`, **no extension at all** |

**The fix derives the name at serve time from `file.type`, rather than naming the file at upload time.** That distinction is the point of the PR: every row ever written already carries `type`, so **runs that executed before this change are fixed too** — no migration, no backfill, and no engine change. Read tokens stay valid for the full `EXECUTION_DATA_RETENTION_DAYS` window (`files-service.ts`), so those older runs are still downloadable and were still serving the wrong name.

Changes:

- **`file.service.ts`** — one `getDownloadName(file)`, placed beside the existing `getLocationForFile`. `fileName` when present, otherwise `<id>.json` for slices and `<id>.bin` for anything else.
- **`files-controller.ts` / `signed-file-transport.ts`** — both sinks call it, collapsing the two divergent fallbacks into one. The controller also switches from hand-rolled `encodeURI` quoting to the `content-disposition` package that `s3-helper.ts` already used, so both transports escape filenames identically.
- **`json-viewer.tsx`** — the inline `Download JSON` button builds its blob anchor client-side and never reaches the server, so it needs its own `.json`. Drops the single-caller `handleDownloadFile` helper whose `ext = ''` default was that leg of the bug.

### Why not name the file in the engine

An earlier approach set `fileName: <stepName>.json` at upload. It can't reach rows that already exist, and `action.name` is the *machine* name — so it buys `step_1.json` over `<uuid>.json` while putting a step name into a response header and colliding across loop iterations. Serve-time derivation is a smaller diff that also covers the existing runs.

### Other file types

Swept the whole `FileType` enum against every path that emits a `Content-Disposition`. `FLOW_RUN_LOG_SLICE` is the only type that reaches a browser without a name — `FLOW_STEP_FILE` has `fileName` as a required param in both its writers (`file-uploader.ts`, `webhook-request-converter.ts`), and every other type is read internally by `id + type` and never passes through a disposition header. So `.bin` stays only as the defensive default for a branch nothing currently reaches.

Deliberately out of scope: `platform.controller.ts` serves `PLATFORM_ASSET` / `USER_PROFILE_PICTURE` with `filename="${encodeURI(fileName ?? '')}"` — an empty filename, same defect class. Different route, and it has `metadata.mimetype` in scope so it wants a `mime.extension()` fix instead. Separate ticket.

## How was this tested?

Verified on Community Edition (`AP_EDITION=ce`); no edition-gated code paths are involved.

- **Red-first proven.** Forcing `getDownloadName` back to `.bin` fails the new slice assertion while the `FLOW_STEP_FILE` case still passes — so both branches of the ternary are genuinely exercised, not riding along.
- Three tests added to `files-controller.test.ts`, all uploading **without** `x-ap-file-name` — the exact shape of every existing slice row. A test that sets the name would prove nothing about this bug. Nameless `FLOW_RUN_LOG_SLICE` → `<id>.json`; nameless `FLOW_STEP_FILE` → `<id>.bin`; a named file still keeps `invoice.pdf`.
- `test/integration/ce/file` 14/14 pass. `packages/web` 410/410 unit tests, `tsc --noEmit` clean. `npm run lint-dev` 0 errors.

**Not verified — worth a reviewer check:** the S3 signed-URL redirect header, and an end-to-end browser download. No S3-backed environment available here. This matters more than it sounds: `getLocationForFile(FLOW_RUN_LOG_SLICE)` resolves to `FILE_STORAGE_LOCATION`, so with `S3_USE_SIGNED_URLS=true` the download never reaches the controller the tests cover — it redirects through `signed-file-transport` instead. **The tested path is the self-hosted default; the untested one is cloud.** Same `getDownloadName` call on both, and `tsc` proves `file.type` reaches it, so the risk is low — but the branch is unexercised.

**One behaviour note for review:** switching the controller to `contentDisposition()` changes the header format for **named** files. Now pinned by tests:

| `fileName` | before (`encodeURI`) | after (`contentDisposition`) |
|---|---|---|
| `invoice.pdf` | `filename="invoice.pdf"` | unchanged |
| `résumé.pdf` | `filename="r%C3%A9sum%C3%A9.pdf"` | `filename="résumé.pdf"` |
| `報告書.json` | `filename="%E5%A0%B1..."` | `filename="???.json"; filename*=UTF-8''%E5%A0%B1...` |
| `evil\r\nX-Injected: 1.json` | `filename="evil%0D%0A..."` | `filename="evil??..."; filename*=UTF-8''evil%0D%0A...` |

Latin-1 names travel as a plain quoted string instead of percent-encoded; only non-Latin-1 names gain the RFC 5987 `filename*`. Both encoders neutralise CRLF, so neither can inject a header — asserted directly. It matches what the S3 path already did, but it is a change on a path this ticket didn't ask about; happy to keep `encodeURI` and touch only the fallback if reviewers prefer.

Fixes [GIT-1568](https://linear.app/activepieces/issue/GIT-1568)
Closes #13752

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

No API field, column, env var, or setup step changes. The only behaviour change is the filename in a `Content-Disposition` header, which requires no action from a self-hoster or API consumer.

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)

Touches file handling, but reduces rather than adds surface: no user-controlled value enters the response header (the fallback is a server-generated uuid plus a constant extension), and the hand-rolled `encodeURI` quoting is replaced by the `content-disposition` package's RFC 5987 escaping. Response stays `attachment` + `nosniff`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

