### PR TITLE
feat(pieces): add Drop to CDN community piece

### DIFF
--- a/packages/pieces/community/drop-to-cdn/.eslintrc.json
+++ b/packages/pieces/community/drop-to-cdn/.eslintrc.json
@@ -1,0 +1,47 @@
+{
+  "extends": [
+    "../../../../.eslintrc.base.json"
+  ],
+  "ignorePatterns": [
+    "!**/*"
+  ],
+  "overrides": [
+    {
+      "files": [
+        "*.ts",
+        "*.tsx",
+        "*.js",
+        "*.jsx"
+      ],
+      "rules": {}
+    },
+    {
+      "files": [
+        "*.ts",
+        "*.tsx"
+      ],
+      "rules": {
+        "no-restricted-imports": [
+          "error",
+          {
+            "patterns": [
+              "lodash",
+              "lodash/*",
+              "@activepieces/core-*",
+              "@activepieces/server*",
+              "@activepieces/engine",
+              "@activepieces/shared"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "files": [
+        "*.js",
+        "*.jsx"
+      ],
+      "rules": {}
+    }
+  ]
+}

--- a/packages/pieces/community/drop-to-cdn/README.md
+++ b/packages/pieces/community/drop-to-cdn/README.md
@@ -1,0 +1,17 @@
+# pieces-drop-to-cdn
+
+Community piece for [Drop to CDN](https://droptocdn.com) — upload files and get instant public CDN URLs.
+
+## Building
+
+Run `turbo run build --filter=@activepieces/piece-drop-to-cdn` to build the library.
+
+## Actions
+
+| Action | API |
+|--------|-----|
+| Upload File | `POST /v1/files` |
+| Get File Information | `GET /v1/files/:id` |
+| Delete File | `DELETE /v1/files/:id` |
+
+Auth: Bearer API key (`dtc_...`), validated via `GET /v1/profile`.

--- a/packages/pieces/community/drop-to-cdn/package.json
+++ b/packages/pieces/community/drop-to-cdn/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@activepieces/piece-drop-to-cdn",
+  "version": "0.1.0",
+  "main": "./dist/src/index.js",
+  "types": "./dist/src/index.d.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.lib.json && cp package.json dist/",
+    "bundle": "node ../../../../dist/packages/cli/src/index.js pieces bundle",
+    "lint": "eslint 'src/**/*.ts'"
+  },
+  "dependencies": {
+    "@activepieces/core-piece-types": "workspace:*",
+    "@activepieces/core-utils": "workspace:*",
+    "@activepieces/pieces-common": "workspace:*",
+    "@activepieces/pieces-framework": "workspace:*",
+    "form-data": "4.0.6"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
+  }
+}

--- a/packages/pieces/community/drop-to-cdn/src/i18n/translation.json
+++ b/packages/pieces/community/drop-to-cdn/src/i18n/translation.json
@@ -1,0 +1,18 @@
+{
+  "Upload files and get instant public CDN URLs on Cloudflare global edge.": "Upload files and get instant public CDN URLs on Cloudflare global edge.",
+  "Create an API key at [Drop to CDN → Settings → API keys](https://droptocdn.com/dashboard/settings). Keys start with `dtc_`.": "Create an API key at [Drop to CDN → Settings → API keys](https://droptocdn.com/dashboard/settings). Keys start with `dtc_`.",
+  "Upload File": "Upload File",
+  "Get File Information": "Get File Information",
+  "Delete File": "Delete File",
+  "Upload a file to Drop to CDN and get a public CDN URL.": "Upload a file to Drop to CDN and get a public CDN URL.",
+  "Get CDN URL and metadata for a file by ID.": "Get CDN URL and metadata for a file by ID.",
+  "Permanently delete a file by ID. This action cannot be undone.": "Permanently delete a file by ID. This action cannot be undone.",
+  "File": "File",
+  "The file to upload (upload directly or provide a URL).": "The file to upload (upload directly or provide a URL).",
+  "Retention (days)": "Retention (days)",
+  "Paid plans only. Leave empty to use your plan default (30 days on Free).": "Paid plans only. Leave empty to use your plan default (30 days on Free).",
+  "Never expire": "Never expire",
+  "Paid plans only. Skip automatic expiration for this file.": "Paid plans only. Skip automatic expiration for this file.",
+  "File ID": "File ID",
+  "The file ID from Upload File or your Drop to CDN dashboard.": "The file ID from Upload File or your Drop to CDN dashboard."
+}

--- a/packages/pieces/community/drop-to-cdn/src/index.ts
+++ b/packages/pieces/community/drop-to-cdn/src/index.ts
@@ -1,0 +1,18 @@
+import { createPiece, PieceCategory } from '@activepieces/pieces-framework';
+import { dropToCdnAuth } from './lib/auth';
+import { uploadFile } from './lib/actions/upload-file';
+import { getFile } from './lib/actions/get-file';
+import { deleteFile } from './lib/actions/delete-file';
+
+export const dropToCdn = createPiece({
+  displayName: 'Drop to CDN',
+  description:
+    'Upload files and get instant public CDN URLs on Cloudflare global edge.',
+  auth: dropToCdnAuth,
+  minimumSupportedRelease: '0.36.1',
+  logoUrl: 'https://cdn.activepieces.com/pieces/drop-to-cdn.png',
+  categories: [PieceCategory.CONTENT_AND_FILES],
+  authors: ['Nexus-JPF'],
+  actions: [uploadFile, getFile, deleteFile],
+  triggers: [],
+});

--- a/packages/pieces/community/drop-to-cdn/src/lib/actions/delete-file.ts
+++ b/packages/pieces/community/drop-to-cdn/src/lib/actions/delete-file.ts
@@ -1,0 +1,39 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { dropToCdnAuth } from '../auth';
+import { dropToCdnApiCall } from '../client';
+
+export const deleteFile = createAction({
+  auth: dropToCdnAuth,
+  name: 'delete_file',
+  displayName: 'Delete File',
+  description: 'Permanently delete a file by ID. This action cannot be undone.',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Permanently deletes a file from Drop to CDN by file ID. Use for pipeline cleanup after delivery. Idempotent for already-deleted files may return 404.',
+    idempotent: true,
+  },
+  props: {
+    file_id: Property.ShortText({
+      displayName: 'File ID',
+      description:
+        'The file ID from Upload File or your Drop to CDN dashboard.',
+      required: true,
+    }),
+  },
+  async run(context) {
+    const fileId = context.propsValue.file_id.trim();
+    if (!fileId) {
+      throw new Error('File ID is required.');
+    }
+
+    await dropToCdnApiCall({
+      apiKey: context.auth.secret_text,
+      method: HttpMethod.DELETE,
+      resourceUri: `/files/${encodeURIComponent(fileId)}`,
+    });
+
+    return { id: fileId, deleted: true };
+  },
+});

--- a/packages/pieces/community/drop-to-cdn/src/lib/actions/get-file.ts
+++ b/packages/pieces/community/drop-to-cdn/src/lib/actions/get-file.ts
@@ -1,0 +1,37 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { dropToCdnAuth } from '../auth';
+import { dropToCdnApiCall } from '../client';
+
+export const getFile = createAction({
+  auth: dropToCdnAuth,
+  name: 'get_file',
+  displayName: 'Get File Information',
+  description: 'Get CDN URL and metadata for a file by ID.',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Retrieves the public CDN URL, expiry, size, MIME type, and original name for an existing file by its Drop to CDN file ID. Read-only and idempotent.',
+    idempotent: true,
+  },
+  props: {
+    file_id: Property.ShortText({
+      displayName: 'File ID',
+      description:
+        'The file ID from Upload File or your Drop to CDN dashboard.',
+      required: true,
+    }),
+  },
+  async run(context) {
+    const fileId = context.propsValue.file_id.trim();
+    if (!fileId) {
+      throw new Error('File ID is required.');
+    }
+
+    return dropToCdnApiCall({
+      apiKey: context.auth.secret_text,
+      method: HttpMethod.GET,
+      resourceUri: `/files/${encodeURIComponent(fileId)}`,
+    });
+  },
+});

--- a/packages/pieces/community/drop-to-cdn/src/lib/actions/upload-file.ts
+++ b/packages/pieces/community/drop-to-cdn/src/lib/actions/upload-file.ts
@@ -1,0 +1,63 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { dropToCdnAuth } from '../auth';
+import { dropToCdnApiCall } from '../client';
+
+export const uploadFile = createAction({
+  auth: dropToCdnAuth,
+  name: 'upload_file',
+  displayName: 'Upload File',
+  description: 'Upload a file to Drop to CDN and get a public CDN URL.',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Uploads a file to Drop to CDN via multipart POST and returns the public CDN URL, file ID, expiry, size, and MIME type. Use when a previous step provides a file (upload or URL). Not idempotent: each call creates a new file.',
+    idempotent: false,
+  },
+  props: {
+    file: Property.File({
+      displayName: 'File',
+      description: 'The file to upload (upload directly or provide a URL).',
+      required: true,
+    }),
+    retention_days: Property.Number({
+      displayName: 'Retention (days)',
+      description:
+        'Paid plans only. Leave empty to use your plan default (30 days on Free).',
+      required: false,
+    }),
+    never_expire: Property.Checkbox({
+      displayName: 'Never expire',
+      description: 'Paid plans only. Skip automatic expiration for this file.',
+      required: false,
+      defaultValue: false,
+    }),
+  },
+  async run(context) {
+    const { file, retention_days, never_expire } = context.propsValue;
+    const FormData = (await import('form-data')).default;
+    const form = new FormData();
+
+    form.append('file', file.data, file.filename);
+
+    if (
+      typeof retention_days === 'number' &&
+      Number.isFinite(retention_days) &&
+      retention_days > 0
+    ) {
+      form.append('retention_days', String(retention_days));
+    }
+
+    if (never_expire) {
+      form.append('never_expire', 'true');
+    }
+
+    return dropToCdnApiCall({
+      apiKey: context.auth.secret_text,
+      method: HttpMethod.POST,
+      resourceUri: '/files',
+      body: form,
+      headers: form.getHeaders(),
+    });
+  },
+});

--- a/packages/pieces/community/drop-to-cdn/src/lib/auth.ts
+++ b/packages/pieces/community/drop-to-cdn/src/lib/auth.ts
@@ -1,0 +1,26 @@
+import { HttpMethod } from '@activepieces/pieces-common';
+import { PieceAuth } from '@activepieces/pieces-framework';
+import { dropToCdnApiCall } from './client';
+
+export const dropToCdnAuth = PieceAuth.SecretText({
+  displayName: 'API Key',
+  description:
+    'Create an API key at [Drop to CDN → Settings → API keys](https://droptocdn.com/dashboard/settings). Keys start with `dtc_`.',
+  required: true,
+  validate: async ({ auth }) => {
+    try {
+      await dropToCdnApiCall({
+        apiKey: auth,
+        method: HttpMethod.GET,
+        resourceUri: '/profile',
+      });
+      return { valid: true };
+    } catch {
+      return {
+        valid: false,
+        error:
+          'Invalid API key. Check your key in Drop to CDN → Settings → API keys.',
+      };
+    }
+  },
+});

--- a/packages/pieces/community/drop-to-cdn/src/lib/client.test.ts
+++ b/packages/pieces/community/drop-to-cdn/src/lib/client.test.ts
@@ -1,0 +1,61 @@
+import {
+  HttpMethod,
+  HttpRequest,
+  HttpResponse,
+  httpClient,
+} from '@activepieces/pieces-common';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { dropToCdnApiCall } from './client';
+
+function resp(body: unknown, status = 200): HttpResponse {
+  return { status, headers: {}, body };
+}
+
+let sendRequest: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  sendRequest = vi.spyOn(httpClient, 'sendRequest');
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('dropToCdnApiCall', () => {
+  it('sends Bearer auth and returns the response body on success', async () => {
+    sendRequest.mockResolvedValue(
+      resp({
+        id: 'abc123',
+        url: 'https://cdn.example.com/abc123',
+      })
+    );
+
+    const body = await dropToCdnApiCall({
+      apiKey: 'dtc_test_key',
+      method: HttpMethod.GET,
+      resourceUri: '/files/abc123',
+    });
+
+    expect(body).toEqual({
+      id: 'abc123',
+      url: 'https://cdn.example.com/abc123',
+    });
+
+    const req = sendRequest.mock.calls[0][0] as HttpRequest;
+    expect(req.method).toBe(HttpMethod.GET);
+    expect(req.url).toBe('https://api.droptocdn.com/v1/files/abc123');
+    expect(req.headers?.Authorization).toBe('Bearer dtc_test_key');
+  });
+
+  it('throws a readable error when the API returns 404', async () => {
+    sendRequest.mockResolvedValue(resp({ error: 'File not found' }, 404));
+
+    await expect(
+      dropToCdnApiCall({
+        apiKey: 'dtc_test_key',
+        method: HttpMethod.GET,
+        resourceUri: '/files/missing',
+      })
+    ).rejects.toThrow('File not found');
+  });
+});

--- a/packages/pieces/community/drop-to-cdn/src/lib/client.ts
+++ b/packages/pieces/community/drop-to-cdn/src/lib/client.ts
@@ -1,0 +1,44 @@
+import {
+  HttpMethod,
+  HttpMessageBody,
+  httpClient,
+} from '@activepieces/pieces-common';
+
+export const BASE_URL = 'https://api.droptocdn.com/v1';
+
+export type DropToCdnApiCallParams = {
+  apiKey: string;
+  method: HttpMethod;
+  resourceUri: string;
+  body?: unknown;
+  headers?: Record<string, string>;
+};
+
+export async function dropToCdnApiCall<T extends HttpMessageBody>({
+  apiKey,
+  method,
+  resourceUri,
+  body,
+  headers = {},
+}: DropToCdnApiCallParams): Promise<T> {
+  const response = await httpClient.sendRequest<T>({
+    method,
+    url: `${BASE_URL}${resourceUri}`,
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      ...headers,
+    },
+    body,
+  });
+
+  if (response.status >= 400) {
+    const errorBody = response.body as Record<string, unknown> | undefined;
+    const message =
+      (typeof errorBody?.error === 'string' && errorBody.error) ||
+      (typeof errorBody?.message === 'string' && errorBody.message) ||
+      `Drop to CDN API error: ${response.status}`;
+    throw new Error(message);
+  }
+
+  return response.body;
+}

--- a/packages/pieces/community/drop-to-cdn/tsconfig.json
+++ b/packages/pieces/community/drop-to-cdn/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "noPropertyAccessFromIndexSignature": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/packages/pieces/community/drop-to-cdn/tsconfig.lib.json
+++ b/packages/pieces/community/drop-to-cdn/tsconfig.lib.json
@@ -1,0 +1,15 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "rootDir": ".",
+    "baseUrl": ".",
+    "paths": {},
+    "outDir": "./dist",
+    "declaration": true,
+    "declarationMap": true,
+    "types": ["node"]
+  },
+  "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"],
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
## Description

Adds a **Drop to CDN** community piece for uploading files and receiving instant public CDN URLs on Cloudflare edge.

**Website:** https://droptocdn.com  
**API docs:** https://droptocdn.com/docs  
**OpenAPI:** https://api.droptocdn.com/v1/openapi.json

### Actions

| Action | API |
|--------|-----|
| Upload File | `POST /v1/files` (multipart) |
| Get File Information | `GET /v1/files/:id` |
| Delete File | `DELETE /v1/files/:id` |

**Auth:** API key (`dtc_...`) via `PieceAuth.SecretText`, validated with `GET /v1/profile`.

## Checklist

- [x] Tested piece structure matches community conventions
- [x] Unit tests for API client (`client.test.ts`)
- [x] i18n `translation.json` included
- [x] Lint/tsconfig aligned with other community pieces
- [ ] Logo uploaded to CDN as `drop-to-cdn.png` (can be done during review)

## Testing Instructions

1. Add **Drop to CDN** connection with API key from https://droptocdn.com/dashboard/settings
2. **Upload File** — upload a small PNG, confirm `url` and `id` in output
3. **Get File Information** — pass file ID from step 2
4. **Delete File** — pass same file ID, confirm `{ id, deleted: true }`
5. **Get File Information** with invalid ID — confirm readable 404 error

## Additional Notes

Piece source also lives in the Drop to CDN monorepo: https://github.com/Nexus-JPF/droptocdn/tree/main/integrations/activepieces/piece