### PR TITLE
fix(server): add platformId + created index migration for audit_event table (#14577)

### DIFF
--- a/packages/server/api/src/app/database/migration/postgres/1819000000000-AddAuditLogCreatedIndex.ts
+++ b/packages/server/api/src/app/database/migration/postgres/1819000000000-AddAuditLogCreatedIndex.ts
@@ -1,0 +1,57 @@
+import { ApEdition } from '@activepieces/shared'
+import { MigrationInterface, QueryRunner } from 'typeorm'
+import { system } from '../../../helper/system/system'
+import { AppSystemProp } from '../../../helper/system/system-props'
+import { isNotOneOfTheseEditions } from '../../database-common'
+import { DatabaseType } from '../../database-type'
+
+const log = system.globalLogger()
+const databaseType = system.get(AppSystemProp.DB_TYPE)
+const isPGlite = databaseType === DatabaseType.PGLITE
+
+export class AddAuditLogCreatedIndex1819000000000 implements MigrationInterface {
+    name = 'AddAuditLogCreatedIndex1819000000000'
+    transaction = false
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        if (isNotOneOfTheseEditions([ApEdition.CLOUD, ApEdition.ENTERPRISE])) {
+            return
+        }
+        log.info({
+            name: this.name,
+        }, 'up')
+        const concurrent = !isPGlite
+
+        if (concurrent) {
+            await queryRunner.query(`
+                CREATE INDEX CONCURRENTLY IF NOT EXISTS "audit_event_platform_id_created_idx" ON "audit_event" ("platformId", "created" DESC)
+            `)
+        }
+        else {
+            await queryRunner.query(`
+                CREATE INDEX IF NOT EXISTS "audit_event_platform_id_created_idx" ON "audit_event" ("platformId", "created" DESC)
+            `)
+        }
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        if (isNotOneOfTheseEditions([ApEdition.CLOUD, ApEdition.ENTERPRISE])) {
+            return
+        }
+        log.info({
+            name: this.name,
+        }, 'down')
+        const concurrent = !isPGlite
+
+        if (concurrent) {
+            await queryRunner.query(`
+                DROP INDEX CONCURRENTLY IF EXISTS "audit_event_platform_id_created_idx"
+            `)
+        }
+        else {
+            await queryRunner.query(`
+                DROP INDEX IF EXISTS "audit_event_platform_id_created_idx"
+            `)
+        }
+    }
+}

--- a/packages/server/api/src/app/ee/audit-logs/audit-event-entity.ts
+++ b/packages/server/api/src/app/ee/audit-logs/audit-event-entity.ts
@@ -53,6 +53,10 @@ export const AuditEventEntity = new EntitySchema<AuditEventSchema>({
             name: 'audit_event_platform_id_action_idx',
             columns: ['platformId', 'action'],
         },
+        {
+            name: 'audit_event_platform_id_created_idx',
+            columns: ['platformId', 'created'],
+        },
     ],
     relations: {
         platform: {


### PR DESCRIPTION
## Issue
Closes #14577

## Summary
Fixes Postgres statement timeout (57014) on the Audit Logs page by adding an index on (`platformId`, `created` DESC) to `audit_event` table.

## Changes
1. Added index `audit_event_platform_id_created_idx` on `["platformId", "created"]` in `packages/server/api/src/app/ee/audit-logs/audit-event-entity.ts`.
2. Added concurrent TypeORM database migration `AddAuditLogCreatedIndex1819000000000` under `packages/server/api/src/app/database/migration/postgres/1819000000000-AddAuditLogCreatedIndex.ts`.

## Acceptance criteria
- [x] Adds audit_event_platform_id_created_idx to AuditEventEntity indices
- [x] Adds non-blocking CREATE INDEX CONCURRENTLY migration for production Postgres databases
- [x] Eliminates full sequence scan on audit_event ORDER BY created DESC queries

/claim #14577