### PR TITLE
chore(pieces): revert mongodb & postgres bump to unblock the pieces release

### DIFF
--- a/packages/pieces/community/mongodb/package.json
+++ b/packages/pieces/community/mongodb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-mongodb",
-  "version": "0.1.6",
+  "version": "0.1.5",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "dependencies": {

--- a/packages/pieces/community/postgres/package.json
+++ b/packages/pieces/community/postgres/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-postgres",
-  "version": "0.2.7",
+  "version": "0.2.6",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "dependencies": {


### PR DESCRIPTION
## Description

Unblocks the **Release Pieces** workflow for `0.86.3`, which is currently failing for every piece.

`768bd919c9` patch-bumped all community pieces, making 722 pieces eligible for release. The run dies in the **Prepare pieces for publish** step:

```
Error: [preparePiece] external dependency "kerberos" has no resolvable version
  (not a direct dependency and not found under node_modules); publishing it
  would crash at runtime with a missing module
    at rewriteManifestForBundle (packages/cli/src/lib/utils/prepare-piece-utils.ts:67:19)
```

Two pieces bundle a driver that declares **optional native peers**, which are `optionalPeers` upstream and therefore installed nowhere in the workspace — so no version is resolvable and `rewriteManifestForBundle` throws:

| Piece | Unresolvable externals |
| --- | --- |
| `community/mongodb` | `kerberos`, `@mongodb-js/zstd`, `snappy`, `aws4`, `mongodb-client-encryption` |
| `community/postgres` | `pg-native` |

Because `prepare-pieces-for-publish.ts` fans out with `Promise.all`, the first rejection aborts the whole step — so **none** of the 722 pieces publish, and only the first error is ever visible in the logs.

This PR reverts those two pieces to their already-published versions (`0.1.5`, `0.2.6`) so they drop out of `CHANGED_PIECES` and the remaining **720 pieces can ship**. `768bd919c9` changed nothing but the `version` line in both, so no code changes are lost.

This is a deliberate stopgap, not the fix. The CLI fix (splitting required natives from guarded-optional peers so they're dropped from the manifest rather than fatal) plus a re-bump of both pieces follows in a separate PR.

## How was this tested?

- Reproduced the exact CI failure locally: `CHANGED_PIECES=packages/pieces/community/mongodb npx ts-node ... tools/scripts/pieces/prepare-pieces-for-publish.ts` → identical `kerberos` error.
- Swept **all 753 pieces** through the same bundle + dependency-resolution path used by `rewriteManifestForBundle` to confirm the failing set is *exactly* these two — nothing else fails, and no piece fails the esbuild safety gate. This matters because `Promise.all` hides every failure after the first, so reverting mongodb alone would have gone red again on `postgres`/`pg-native`.
- Confirmed against the cloud registry (`/v1/pieces/registry?release=0.86.3&edition=ee`) that `piece-mongodb@0.1.5` and `piece-postgres@0.2.6` are already published, so `find-changed-pieces.ts` will no longer report them as changed — while `0.1.6` / `0.2.7` are absent, leaving those versions free for the follow-up PR.
- No edition-specific paths touched: version-only change to two piece manifests.

Fixes # (issue)

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)
