### PR TITLE
feat(agent): refuse chat-only tools on non-chat runs

### DIFF
--- a/packages/core/execution/src/lib/workers/job-data.ts
+++ b/packages/core/execution/src/lib/workers/job-data.ts
@@ -251,6 +251,11 @@ export const UserInteractionJobDataWithoutWatchingInformation = z.union([
 ])
 export type UserInteractionJobDataWithoutWatchingInformation = z.infer<typeof UserInteractionJobDataWithoutWatchingInformation>
 
+export enum AgentRunSource {
+    CHAT = 'CHAT',
+    FLOW_STEP = 'FLOW_STEP',
+}
+
 export const AgentPromptOverride = z.object({
     system: z.string().optional(),
     projectSelected: z.string().optional(),

--- a/packages/core/execution/src/lib/workers/worker-contract.ts
+++ b/packages/core/execution/src/lib/workers/worker-contract.ts
@@ -4,7 +4,7 @@ import { FlowRun, RunEnvironment } from '../flow-run/flow-run'
 import { FlowVersion } from '../flows/flow-version'
 import { TriggerRunStatus } from '../flows/triggers/trigger-run'
 import { AgentEvent } from './agent-events'
-import { AgentPromptOverride } from './job-data'
+import { AgentPromptOverride, AgentRunSource } from './job-data'
 import { ConsumeJobRequest, ConsumeJobResponse, WorkerMachineHealthcheckRequest } from './index'
 
 export type SubmitPayloadsRequest = {
@@ -141,6 +141,7 @@ export type AgentConfigResponse = {
     aiTools: AgentAiToolsConfig
     emailEnabled: boolean
     userEmail: string
+    source: AgentRunSource
 }
 
 export type SaveAgentMessagesRequest = {
@@ -189,6 +190,7 @@ export type ExecuteAgentToolRequest = {
     toolInput: Record<string, unknown>
     platformId: string
     userId: string
+    source: AgentRunSource
     conversationId?: string
 }
 

--- a/packages/core/shared/package.json
+++ b/packages/core/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/shared",
-  "version": "0.124.0",
+  "version": "0.125.0",
   "type": "commonjs",
   "sideEffects": false,
   "main": "./dist/src/index.js",

--- a/packages/core/shared/src/lib/ee/agent/index.ts
+++ b/packages/core/shared/src/lib/ee/agent/index.ts
@@ -1,4 +1,4 @@
-import { AgentPromptOverride } from '@activepieces/core-execution'
+import { AgentPromptOverride, AgentRunSource } from '@activepieces/core-execution'
 import { BaseModelSchema, Nullable } from '@activepieces/core-utils'
 import { z } from 'zod'
 import { formErrors } from '../../form-errors'
@@ -194,10 +194,7 @@ export enum AgentConversationStatus {
     ERROR = 'ERROR',
 }
 
-export enum AgentRunSource {
-    CHAT = 'CHAT',
-    FLOW_STEP = 'FLOW_STEP',
-}
+export { AgentRunSource }
 
 export const AgentConversation = z.object({
     ...BaseModelSchema,

--- a/packages/server/api/src/app/ee/agent/agent-rpc-handlers.ts
+++ b/packages/server/api/src/app/ee/agent/agent-rpc-handlers.ts
@@ -1,6 +1,6 @@
 import { ActivepiecesError, ErrorCode, isNil, sanitizeObjectForPostgresql, tryCatch, unique } from '@activepieces/core-utils'
 import { agentAiUtils } from '@activepieces/server-utils'
-import { AgentConfigResponse, AgentConversationStatus, agentToolClassification, ExecuteAgentToolRequest, ExecuteAgentToolResponse, FileCompression, FileType, FlowActionType, flowStructureUtil, GetAgentConfigRequest, GetEnabledAiToolsResponse, HeartbeatAgentConversationRequest, PersistedAgentMessage, PersistedAgentPartType, PersistedAgentRole, SaveAgentFileRequest, SaveAgentFileResponse, SaveAgentMessagesRequest, SendAgentEmailRequest, SendAgentEmailResponse, UpdateAgentProgressRequest, UpdateProjectContextRequest } from '@activepieces/shared'
+import { AgentConfigResponse, AgentConversationStatus, AgentRunSource, agentToolClassification, ExecuteAgentToolRequest, ExecuteAgentToolResponse, FileCompression, FileType, FlowActionType, flowStructureUtil, GetAgentConfigRequest, GetEnabledAiToolsResponse, HeartbeatAgentConversationRequest, PersistedAgentMessage, PersistedAgentPartType, PersistedAgentRole, SaveAgentFileRequest, SaveAgentFileResponse, SaveAgentMessagesRequest, SendAgentEmailRequest, SendAgentEmailResponse, UpdateAgentProgressRequest, UpdateProjectContextRequest } from '@activepieces/shared'
 import { ModelMessage } from 'ai'
 import { FastifyBaseLogger } from 'fastify'
 import { aiToolConfigService } from '../../ai/ai-tool-config-service'
@@ -23,6 +23,7 @@ import { agentPrompt } from './prompt/agent-prompt'
 import { executeCrossProjectTool } from './tools/agent-tools'
 
 const MAX_APPROVAL_BLOCK_MS = 50_000
+const CHAT_ONLY_TOOL_PREFIX = '__'
 
 const MAX_EMAIL_RECIPIENTS = 10
 const MAX_EMAIL_SUBJECT_LENGTH = 300
@@ -329,6 +330,7 @@ export const agentRpcHandlers = (log: FastifyBaseLogger) => ({
             aiTools,
             emailEnabled,
             userEmail: userMeta.email,
+            source: conversation.source,
         }
     },
 
@@ -443,6 +445,13 @@ export const agentRpcHandlers = (log: FastifyBaseLogger) => ({
     },
 
     async executeAgentTool(input: ExecuteAgentToolRequest): Promise<ExecuteAgentToolResponse> {
+        if (input.toolName.startsWith(CHAT_ONLY_TOOL_PREFIX) && input.source !== AgentRunSource.CHAT) {
+            log.warn({ tool: { name: input.toolName }, source: input.source }, '[agentRpc#executeAgentTool] Rejected a chat-only tool for a non-chat run')
+            throw new ActivepiecesError({
+                code: ErrorCode.AUTHORIZATION,
+                params: { message: `Tool "${input.toolName}" is only available to chat runs` },
+            })
+        }
         if (input.toolName === '__cancel_check') {
             const conversationId = input.toolInput.conversationId
             if (typeof conversationId !== 'string') {

--- a/packages/server/worker/src/lib/execute/jobs/ee/agent/execute-agent-run.ts
+++ b/packages/server/worker/src/lib/execute/jobs/ee/agent/execute-agent-run.ts
@@ -1,6 +1,6 @@
 import { AIProviderName, ErrorCode, isNil, isObject, spreadIfDefined, tryCatch, tryCatchSync } from '@activepieces/core-utils'
 import { agentAiUtils } from '@activepieces/server-utils'
-import { AgentEvent, AgentEventType, AgentPhase, EngineResponseStatus, ExecuteAgentRunJobData, PersistedAgentMessage, PersistedAgentRole, WorkerJobType } from '@activepieces/shared'
+import { AgentEvent, AgentEventType, AgentPhase, AgentRunSource, EngineResponseStatus, ExecuteAgentRunJobData, PersistedAgentMessage, PersistedAgentRole, WorkerJobType } from '@activepieces/shared'
 import { createUIMessageStream, generateText, ModelMessage, streamText, ToolSet, toUIMessageStream } from 'ai'
 import { FireAndForgetJobResult, JobContext, JobHandler, JobResultKind } from '../../../types'
 import { agentMcpClient } from './agent-mcp-client'
@@ -46,6 +46,7 @@ export const executeAgentRunJob: JobHandler<ExecuteAgentRunJobData, FireAndForge
         })
 
         const provider = config.provider as AIProviderName
+        const source = config.source
         const aiTools = config.aiTools
         // Tavily takes precedence; native LLM web search is only the no-Tavily fallback.
         const tavilySearchActive = !dryRun && !isNil(aiTools.webSearch)
@@ -90,7 +91,7 @@ export const executeAgentRunJob: JobHandler<ExecuteAgentRunJobData, FireAndForge
 
         const checkCancelled = async () => {
             const { data: response } = await tryCatch(() => ctx.apiClient.executeAgentTool({
-                toolName: '__cancel_check', toolInput: { conversationId, runId }, platformId, userId,
+                toolName: '__cancel_check', toolInput: { conversationId, runId }, platformId, userId, source,
             }))
             if (response?.result === true) {
                 abortController.abort()
@@ -137,6 +138,7 @@ export const executeAgentRunJob: JobHandler<ExecuteAgentRunJobData, FireAndForge
                 guides: config.guides, dryRun: dryRun ?? false, discoveryOnly: discoveryOnly ?? false,
                 emailEnabled: config.emailEnabled,
                 abortSignal: abortController.signal,
+                source,
             })
 
             const thinkingStartTime = Date.now()
@@ -331,7 +333,7 @@ export const executeAgentRunJob: JobHandler<ExecuteAgentRunJobData, FireAndForge
     },
 }
 
-function buildToolSet({ ctx, eventEmitter, log, phaseState, taintState, mcpToolSet, webTools, projects, projectId, conversationId, runId, platformId, userId, userEmail, guides, dryRun, discoveryOnly, emailEnabled, abortSignal }: {
+function buildToolSet({ ctx, eventEmitter, log, phaseState, taintState, mcpToolSet, webTools, projects, projectId, conversationId, runId, platformId, userId, userEmail, guides, dryRun, discoveryOnly, emailEnabled, abortSignal, source }: {
     ctx: JobContext
     eventEmitter: ReturnType<typeof agentWorkerTools.createEventEmitter>
     log: JobContext['log']
@@ -351,6 +353,7 @@ function buildToolSet({ ctx, eventEmitter, log, phaseState, taintState, mcpToolS
     discoveryOnly: boolean
     emailEnabled: boolean
     abortSignal: AbortSignal
+    source: AgentRunSource
 }) {
     const brokenConnectors = new Set<string>()
 
@@ -363,7 +366,7 @@ function buildToolSet({ ctx, eventEmitter, log, phaseState, taintState, mcpToolS
         if (discoveryOnly && DISCOVERY_ONLY_NEUTRALIZED_TOOLS.has(toolName)) {
             return { content: [{ type: 'text', text: `🧪 Discovery-only run — ${toolName} was not executed. The agent reached a runnable call.` }] }
         }
-        const response = await ctx.apiClient.executeAgentTool({ toolName, toolInput, platformId, userId, conversationId })
+        const response = await ctx.apiClient.executeAgentTool({ toolName, toolInput, platformId, userId, source, conversationId })
         return response.result
     }
 
@@ -386,7 +389,7 @@ function buildToolSet({ ctx, eventEmitter, log, phaseState, taintState, mcpToolS
             const blockMs = Math.min(remainingMs, APPROVAL_BLOCK_MS)
             const { data: response, error } = await tryCatch(() => Promise.race([
                 ctx.apiClient.executeAgentTool({
-                    toolName: '__approval_wait', toolInput: { gateId, timeoutMs: blockMs }, platformId, userId,
+                    toolName: '__approval_wait', toolInput: { gateId, timeoutMs: blockMs }, platformId, userId, source,
                 }),
                 waitForAbort(abortSignal).then(() => ({ result: 'aborted' as const })),
             ]))
@@ -431,7 +434,7 @@ function buildToolSet({ ctx, eventEmitter, log, phaseState, taintState, mcpToolS
         await tryCatch(() => ctx.apiClient.executeAgentTool({
             toolName: '__store_pending_gate',
             toolInput: { conversationId, runId, gateId, toolName: gateTool, displayName, toolInput: gateInput },
-            platformId, userId, conversationId,
+            platformId, userId, source, conversationId,
         }))
     }
 
@@ -443,7 +446,7 @@ function buildToolSet({ ctx, eventEmitter, log, phaseState, taintState, mcpToolS
             await tryCatch(() => ctx.apiClient.executeAgentTool({
                 toolName: '__store_selected_connection',
                 toolInput: { pieceName, connectionExternalId, label, projectId: connProjectId },
-                platformId, userId, conversationId,
+                platformId, userId, source, conversationId,
             }))
         },
         onConnectorReconnected: (connectorUuid) => brokenConnectors.delete(connectorUuid),
@@ -472,7 +475,7 @@ function buildToolSet({ ctx, eventEmitter, log, phaseState, taintState, mcpToolS
             },
         }),
         checkFlowWrites: async (flowId) => {
-            const response = await ctx.apiClient.executeAgentTool({ toolName: '__flow_write_check', toolInput: { flowId }, platformId, userId, conversationId })
+            const response = await ctx.apiClient.executeAgentTool({ toolName: '__flow_write_check', toolInput: { flowId }, platformId, userId, source, conversationId })
             return response.result
         },
         waitForApproval,


### PR DESCRIPTION
## Description

Step 2d of the chat/agent unification, on top of #14576.

The `__`-prefixed RPC pseudo-tools aren't really tools for the model. They drive chat's UI. `__approval_wait` blocks until someone clicks approve, `__store_pending_gate` and `__store_selected_connection` feed the approval and connection-picker surfaces, and `__cancel_check` polls the stop button.

A flow-step run has nobody there to click anything. If one of these were reachable, the run would either sit there until the approval times out, or in the case of `__store_selected_connection` and `__flow_write_check`, carry on without the confirmation the tool exists to collect in the first place.

So if the conversation's `source` isn't `CHAT`, the call gets rejected.

## Why this lands before anything can reach it

There's no `FLOW_STEP` producer yet, so nothing hits this path today. I'd rather the check already be there when the server-side runner shows up than have it be one more thing to remember. Guards are cheap to write now and annoying to retrofit once something depends on the gap.

It sits on the server, inside `executeAgentTool`, rather than in the worker's tool assembly. That way a worker that forgets to filter its tool set, or one running an older build partway through a deploy, still can't get past it.

## AgentRunSource moved to core-execution

The worker contract lives in `packages/core/execution`, and that package isn't allowed to import `@activepieces/shared`. There's a lint rule for it. Since `shared` already depends on `core-execution`, the enum belongs in the lower package.

It's re-exported from `shared`, so every existing `import { AgentRunSource } from '@activepieces/shared'` keeps working. Nothing downstream changes.

## How was this tested?

- `npx turbo run build` over api, web, worker, shared and core-execution. 19 tasks, all clean.
- `npm run lint-dev`, 0 errors.
- Chat runs go down exactly the same path they did before, so the existing agent suites still cover them.

One thing worth passing on: my first push broke CI. I'd checked locally with `turbo run typecheck`, which silently does nothing for `worker`, because that package has no `typecheck` script. Only `build` type-checks it. If you're changing worker types, run `turbo run build --filter=worker`.

Fixes # (issue)

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

No endpoint, schema or env change. `AgentRunSource` keeps its old import path through the re-export. The new `source` field on the worker/app RPC contract isn't public API, and both sides ship in the same image.

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)

This only takes reachability away, it doesn't add any. Chat runs are unaffected.
