### PR TITLE
fix(builder): backspace no longer deletes an entire formula and its arguments

### DIFF
--- a/packages/web/src/app/builder/piece-properties/text-input-with-mentions/extensions/formula-backspace.ts
+++ b/packages/web/src/app/builder/piece-properties/text-input-with-mentions/extensions/formula-backspace.ts
@@ -26,6 +26,7 @@ export function getFormulaBackspaceTransaction({
   const endPos = findFunctionEndPos({
     doc: state.doc,
     openId: nodeBefore.attrs.id,
+    after: from,
   });
 
   if (endPos < from) return state.tr.delete(startPos, from);
@@ -40,13 +41,17 @@ export function getFormulaBackspaceTransaction({
 function findFunctionEndPos({
   doc,
   openId,
+  after,
 }: {
   doc: ProseMirrorNode;
   openId: unknown;
+  after: number;
 }): number {
   let endPos = -1;
   doc.descendants((node, pos) => {
     if (
+      endPos < 0 &&
+      pos >= after &&
       node.type.name === FUNCTION_END_NODE_TYPE &&
       node.attrs.openId === openId
     ) {

--- a/packages/web/src/app/builder/piece-properties/text-input-with-mentions/extensions/formula-backspace.ts
+++ b/packages/web/src/app/builder/piece-properties/text-input-with-mentions/extensions/formula-backspace.ts
@@ -23,11 +23,7 @@ export function getFormulaBackspaceTransaction({
   }
 
   const startPos = from - nodeBefore.nodeSize;
-  const endPos = findFunctionEndPos({
-    doc: state.doc,
-    openId: nodeBefore.attrs.id,
-    after: from,
-  });
+  const endPos = findFunctionEndPos({ doc: state.doc, from });
 
   if (endPos < from) return state.tr.delete(startPos, from);
 
@@ -40,23 +36,22 @@ export function getFormulaBackspaceTransaction({
 
 function findFunctionEndPos({
   doc,
-  openId,
-  after,
+  from,
 }: {
   doc: ProseMirrorNode;
-  openId: unknown;
-  after: number;
+  from: number;
 }): number {
   let endPos = -1;
-  doc.descendants((node, pos) => {
-    if (
-      endPos < 0 &&
-      pos >= after &&
-      node.type.name === FUNCTION_END_NODE_TYPE &&
-      node.attrs.openId === openId
-    ) {
-      endPos = pos;
+  let openDepth = 0;
+  doc.nodesBetween(from, doc.resolve(from).end(), (node, pos) => {
+    if (endPos >= 0) return false;
+    if (node.type.name === FUNCTION_START_NODE_TYPE) {
+      openDepth++;
+    } else if (node.type.name === FUNCTION_END_NODE_TYPE) {
+      if (openDepth === 0) endPos = pos;
+      else openDepth--;
     }
+    return endPos < 0;
   });
   return endPos;
 }

--- a/packages/web/src/app/builder/piece-properties/text-input-with-mentions/extensions/formula-backspace.ts
+++ b/packages/web/src/app/builder/piece-properties/text-input-with-mentions/extensions/formula-backspace.ts
@@ -1,0 +1,80 @@
+import { Node as ProseMirrorNode } from '@tiptap/pm/model';
+import { EditorState, Transaction } from '@tiptap/pm/state';
+
+import {
+  FUNCTION_END_NODE_TYPE,
+  FUNCTION_SEP_NODE_TYPE,
+  FUNCTION_START_NODE_TYPE,
+} from './bracket-nodes';
+
+const ZWS_CHAR = '\u200B';
+
+export function getFormulaBackspaceTransaction({
+  state,
+}: {
+  state: EditorState;
+}): Transaction | null {
+  const { from, to } = state.selection;
+  if (from !== to) return null;
+
+  const nodeBefore = state.doc.resolve(from).nodeBefore;
+  if (!nodeBefore || nodeBefore.type.name !== FUNCTION_START_NODE_TYPE) {
+    return null;
+  }
+
+  const startPos = from - nodeBefore.nodeSize;
+  const endPos = findFunctionEndPos({
+    doc: state.doc,
+    openId: nodeBefore.attrs.id,
+  });
+
+  if (endPos < from) return state.tr.delete(startPos, from);
+
+  if (isFormulaBodyEmpty({ doc: state.doc, from, to: endPos })) {
+    return state.tr.delete(startPos, endPos + 1);
+  }
+
+  return state.tr.delete(endPos, endPos + 1).delete(startPos, from);
+}
+
+function findFunctionEndPos({
+  doc,
+  openId,
+}: {
+  doc: ProseMirrorNode;
+  openId: unknown;
+}): number {
+  let endPos = -1;
+  doc.descendants((node, pos) => {
+    if (
+      node.type.name === FUNCTION_END_NODE_TYPE &&
+      node.attrs.openId === openId
+    ) {
+      endPos = pos;
+    }
+  });
+  return endPos;
+}
+
+function isFormulaBodyEmpty({
+  doc,
+  from,
+  to,
+}: {
+  doc: ProseMirrorNode;
+  from: number;
+  to: number;
+}): boolean {
+  const bodyNodes: ProseMirrorNode[] = [];
+  doc.nodesBetween(from, to, (node) => {
+    if (!node.isInline) return true;
+    bodyNodes.push(node);
+    return false;
+  });
+
+  return bodyNodes.every(
+    (node) =>
+      node.type.name === FUNCTION_SEP_NODE_TYPE ||
+      (node.isText && (node.text ?? '').split(ZWS_CHAR).join('') === ''),
+  );
+}

--- a/packages/web/src/app/builder/piece-properties/text-input-with-mentions/tiptap-editor.tsx
+++ b/packages/web/src/app/builder/piece-properties/text-input-with-mentions/tiptap-editor.tsx
@@ -47,6 +47,7 @@ import {
   FUNCTION_END_NODE_TYPE,
   FUNCTION_SEP_NODE_TYPE,
 } from './extensions/bracket-nodes';
+import { getFormulaBackspaceTransaction } from './extensions/formula-backspace';
 import {
   FunctionSlashExtension,
   SlashCommandState,
@@ -214,30 +215,12 @@ export const TiptapEditor = ({
     editorProps: {
       handleKeyDown: (view, event) => {
         if (event.key === 'Backspace') {
-          const { state } = view;
-          const { from, to } = state.selection;
-          if (from === to) {
-            const $from = state.doc.resolve(from);
-            const nodeBefore = $from.nodeBefore;
-            if (
-              nodeBefore &&
-              nodeBefore.type.name === FUNCTION_START_NODE_TYPE
-            ) {
-              const fnId = nodeBefore.attrs.id as string;
-              const fnStartPos = from - nodeBefore.nodeSize;
-              let fnEndPos = -1;
-              state.doc.descendants((node, pos) => {
-                if (
-                  node.type.name === FUNCTION_END_NODE_TYPE &&
-                  node.attrs.openId === fnId
-                ) {
-                  fnEndPos = pos;
-                }
-              });
-              const deleteTo = fnEndPos >= 0 ? fnEndPos + 1 : from;
-              view.dispatch(state.tr.delete(fnStartPos, deleteTo));
-              return true;
-            }
+          const formulaTr = getFormulaBackspaceTransaction({
+            state: view.state,
+          });
+          if (formulaTr) {
+            view.dispatch(formulaTr);
+            return true;
           }
         }
 

--- a/packages/web/test/app/builder/piece-properties/text-input-with-mentions/extensions/formula-backspace.test.ts
+++ b/packages/web/test/app/builder/piece-properties/text-input-with-mentions/extensions/formula-backspace.test.ts
@@ -79,17 +79,17 @@ function posAfterFirstFunctionStart(currentEditor: Editor): number {
   return pos;
 }
 
-function listBadgeTypes(currentEditor: Editor): string[] {
-  const types: string[] = [];
+function listBadges(currentEditor: Editor): string[] {
+  const badges: string[] = [];
   currentEditor.state.doc.descendants((node) => {
-    if (
-      node.type.name === FUNCTION_START_NODE_TYPE ||
-      node.type.name === FUNCTION_END_NODE_TYPE
-    ) {
-      types.push(node.type.name);
+    if (node.type.name === FUNCTION_START_NODE_TYPE) {
+      badges.push(`${FUNCTION_START_NODE_TYPE}:${String(node.attrs.id)}`);
+    }
+    if (node.type.name === FUNCTION_END_NODE_TYPE) {
+      badges.push(`${FUNCTION_END_NODE_TYPE}:${String(node.attrs.openId)}`);
     }
   });
-  return types;
+  return badges;
 }
 
 function countNodes(currentEditor: Editor, typeName: string): number {
@@ -128,7 +128,7 @@ function backspaceJustInsideBracket(content: JSONContent[]) {
     startBadges: countNodes(editor, FUNCTION_START_NODE_TYPE),
     endBadges: countNodes(editor, FUNCTION_END_NODE_TYPE),
     mentions: countNodes(editor, 'mention'),
-    badgeOrder: listBadgeTypes(editor),
+    badges: listBadges(editor),
     visibleText: editor.state.doc.textContent.split(ZWS_CHAR).join(''),
   };
 }
@@ -239,11 +239,47 @@ describe('formula backspace just inside the opening bracket (GIT-1704)', () => {
       functionEnd(FN_ID),
     ]);
 
-    expect(result.badgeOrder).toEqual([
-      FUNCTION_START_NODE_TYPE,
-      FUNCTION_END_NODE_TYPE,
+    expect(result.badges).toEqual([
+      `${FUNCTION_START_NODE_TYPE}:${FN_ID}`,
+      `${FUNCTION_END_NODE_TYPE}:${FN_ID}`,
     ]);
     expect(result.visibleText).toBe('first second');
+  });
+
+  it('leaves the inner pair matched when unwrapping around a nested formula', () => {
+    const result = backspaceJustInsideBracket([
+      functionStart(FN_ID, 'uppercase'),
+      text(ZWS_CHAR),
+      functionStart(NESTED_FN_ID, 'trim'),
+      text(`${ZWS_CHAR}inner`),
+      functionEnd(NESTED_FN_ID),
+      text(' tail'),
+      functionEnd(FN_ID),
+    ]);
+
+    expect(result.badges).toEqual([
+      `${FUNCTION_START_NODE_TYPE}:${NESTED_FN_ID}`,
+      `${FUNCTION_END_NODE_TYPE}:${NESTED_FN_ID}`,
+    ]);
+    expect(result.visibleText).toBe('inner tail');
+  });
+
+  it('unwraps the outer pair when a formula is pasted inside itself', () => {
+    const result = backspaceJustInsideBracket([
+      functionStart(FN_ID, 'uppercase'),
+      text(ZWS_CHAR),
+      functionStart(FN_ID, 'uppercase'),
+      text(`${ZWS_CHAR}inner`),
+      functionEnd(FN_ID),
+      text(' tail'),
+      functionEnd(FN_ID),
+    ]);
+
+    expect(result.badges).toEqual([
+      `${FUNCTION_START_NODE_TYPE}:${FN_ID}`,
+      `${FUNCTION_END_NODE_TYPE}:${FN_ID}`,
+    ]);
+    expect(result.visibleText).toBe('inner tail');
   });
 
   it('deletes only the badge of an unclosed formula', () => {

--- a/packages/web/test/app/builder/piece-properties/text-input-with-mentions/extensions/formula-backspace.test.ts
+++ b/packages/web/test/app/builder/piece-properties/text-input-with-mentions/extensions/formula-backspace.test.ts
@@ -79,6 +79,19 @@ function posAfterFirstFunctionStart(currentEditor: Editor): number {
   return pos;
 }
 
+function listBadgeTypes(currentEditor: Editor): string[] {
+  const types: string[] = [];
+  currentEditor.state.doc.descendants((node) => {
+    if (
+      node.type.name === FUNCTION_START_NODE_TYPE ||
+      node.type.name === FUNCTION_END_NODE_TYPE
+    ) {
+      types.push(node.type.name);
+    }
+  });
+  return types;
+}
+
 function countNodes(currentEditor: Editor, typeName: string): number {
   let count = 0;
   currentEditor.state.doc.descendants((node) => {
@@ -115,6 +128,7 @@ function backspaceJustInsideBracket(content: JSONContent[]) {
     startBadges: countNodes(editor, FUNCTION_START_NODE_TYPE),
     endBadges: countNodes(editor, FUNCTION_END_NODE_TYPE),
     mentions: countNodes(editor, 'mention'),
+    badgeOrder: listBadgeTypes(editor),
     visibleText: editor.state.doc.textContent.split(ZWS_CHAR).join(''),
   };
 }
@@ -212,6 +226,24 @@ describe('formula backspace just inside the opening bracket (GIT-1704)', () => {
     expect(result.handled).toBe(true);
     expect(result.startBadges).toBe(0);
     expect(result.visibleText).toBe('before  after');
+  });
+
+  it('unwraps only its own pair when a formula id is duplicated by a paste', () => {
+    const result = backspaceJustInsideBracket([
+      functionStart(FN_ID, 'uppercase'),
+      text(`${ZWS_CHAR}first`),
+      functionEnd(FN_ID),
+      text(' '),
+      functionStart(FN_ID, 'uppercase'),
+      text(`${ZWS_CHAR}second`),
+      functionEnd(FN_ID),
+    ]);
+
+    expect(result.badgeOrder).toEqual([
+      FUNCTION_START_NODE_TYPE,
+      FUNCTION_END_NODE_TYPE,
+    ]);
+    expect(result.visibleText).toBe('first second');
   });
 
   it('deletes only the badge of an unclosed formula', () => {

--- a/packages/web/test/app/builder/piece-properties/text-input-with-mentions/extensions/formula-backspace.test.ts
+++ b/packages/web/test/app/builder/piece-properties/text-input-with-mentions/extensions/formula-backspace.test.ts
@@ -16,10 +16,12 @@ import {
   FUNCTION_START_NODE_TYPE,
 } from '@/app/builder/piece-properties/text-input-with-mentions/extensions/bracket-nodes';
 import { getFormulaBackspaceTransaction } from '@/app/builder/piece-properties/text-input-with-mentions/extensions/formula-backspace';
+import { textMentionUtils } from '@/app/builder/piece-properties/text-input-with-mentions/text-input-utils';
 
 const ZWS_CHAR = '\u200B';
 const FN_ID = 'fn-1';
 const NESTED_FN_ID = 'fn-2';
+const ORPHAN_FN_ID = 'fn-orphan';
 
 let editor: Editor | null = null;
 
@@ -101,7 +103,7 @@ function countNodes(currentEditor: Editor, typeName: string): number {
 }
 
 function backspaceJustInsideBracket(content: JSONContent[]) {
-  editor = new Editor({
+  const currentEditor = new Editor({
     extensions: [
       Document,
       Paragraph,
@@ -113,23 +115,28 @@ function backspaceJustInsideBracket(content: JSONContent[]) {
     ],
     content: { type: 'doc', content: [{ type: 'paragraph', content }] },
   });
+  editor = currentEditor;
 
-  const cursor = posAfterFirstFunctionStart(editor);
-  editor.commands.setTextSelection(cursor);
-  expect(editor.state.selection.from).toBe(cursor);
+  const cursor = posAfterFirstFunctionStart(currentEditor);
+  currentEditor.commands.setTextSelection(cursor);
+  expect(currentEditor.state.selection.from).toBe(cursor);
 
-  const transaction = getFormulaBackspaceTransaction({ state: editor.state });
+  const transaction = getFormulaBackspaceTransaction({
+    state: currentEditor.state,
+  });
   if (transaction) {
-    editor.view.dispatch(transaction);
+    currentEditor.view.dispatch(transaction);
   }
 
   return {
     handled: transaction !== null,
-    startBadges: countNodes(editor, FUNCTION_START_NODE_TYPE),
-    endBadges: countNodes(editor, FUNCTION_END_NODE_TYPE),
-    mentions: countNodes(editor, 'mention'),
-    badges: listBadges(editor),
-    visibleText: editor.state.doc.textContent.split(ZWS_CHAR).join(''),
+    startBadges: countNodes(currentEditor, FUNCTION_START_NODE_TYPE),
+    endBadges: countNodes(currentEditor, FUNCTION_END_NODE_TYPE),
+    mentions: countNodes(currentEditor, 'mention'),
+    badges: listBadges(currentEditor),
+    visibleText: currentEditor.state.doc.textContent.split(ZWS_CHAR).join(''),
+    serialize: () =>
+      textMentionUtils.convertTiptapJsonToText(currentEditor.getJSON()),
   };
 }
 
@@ -280,6 +287,19 @@ describe('formula backspace just inside the opening bracket (GIT-1704)', () => {
       `${FUNCTION_END_NODE_TYPE}:${FN_ID}`,
     ]);
     expect(result.visibleText).toBe('inner tail');
+  });
+
+  it('pairs with the closer the serializer pairs with when an orphan closer is nested', () => {
+    const result = backspaceJustInsideBracket([
+      functionStart(FN_ID, 'uppercase'),
+      text(`${ZWS_CHAR}arg`),
+      functionEnd(ORPHAN_FN_ID),
+      functionEnd(FN_ID),
+    ]);
+
+    expect(result.startBadges).toBe(0);
+    expect(result.endBadges).toBe(1);
+    expect(result.serialize()).toBe('arg)');
   });
 
   it('deletes only the badge of an unclosed formula', () => {

--- a/packages/web/test/app/builder/piece-properties/text-input-with-mentions/extensions/formula-backspace.test.ts
+++ b/packages/web/test/app/builder/piece-properties/text-input-with-mentions/extensions/formula-backspace.test.ts
@@ -1,4 +1,5 @@
 // @vitest-environment jsdom
+import { formulaEvaluator } from '@activepieces/core-formula';
 import { Editor } from '@tiptap/core';
 import { Document } from '@tiptap/extension-document';
 import { Mention } from '@tiptap/extension-mention';
@@ -121,6 +122,7 @@ function backspaceJustInsideBracket(content: JSONContent[]) {
   currentEditor.commands.setTextSelection(cursor);
   expect(currentEditor.state.selection.from).toBe(cursor);
 
+  const jsonBeforeKeypress = currentEditor.getJSON();
   const transaction = getFormulaBackspaceTransaction({
     state: currentEditor.state,
   });
@@ -137,6 +139,8 @@ function backspaceJustInsideBracket(content: JSONContent[]) {
     visibleText: currentEditor.state.doc.textContent.split(ZWS_CHAR).join(''),
     serialize: () =>
       textMentionUtils.convertTiptapJsonToText(currentEditor.getJSON()),
+    serializeBeforeKeypress: () =>
+      textMentionUtils.convertTiptapJsonToText(jsonBeforeKeypress),
   };
 }
 
@@ -300,6 +304,26 @@ describe('formula backspace just inside the opening bracket (GIT-1704)', () => {
     expect(result.startBadges).toBe(0);
     expect(result.endBadges).toBe(1);
     expect(result.serialize()).toBe('arg)');
+  });
+
+  it('does not introduce the wrapper loss an orphan closer already causes', () => {
+    const result = backspaceJustInsideBracket([
+      functionStart(FN_ID, 'uppercase'),
+      text(`${ZWS_CHAR}arg`),
+      functionEnd(ORPHAN_FN_ID),
+      functionEnd(FN_ID),
+      text(' '),
+      functionStart(NESTED_FN_ID, 'trim'),
+      text(`${ZWS_CHAR}later`),
+      functionEnd(NESTED_FN_ID),
+    ]);
+
+    expect(result.serializeBeforeKeypress()).toContain('trim(later)');
+    expect(result.serializeBeforeKeypress()).not.toContain(
+      `${formulaEvaluator.PREFIX}trim(`,
+    );
+    expect(result.serialize()).toContain('trim(later)');
+    expect(result.serialize()).not.toContain(`${formulaEvaluator.PREFIX}trim(`);
   });
 
   it('deletes only the badge of an unclosed formula', () => {

--- a/packages/web/test/app/builder/piece-properties/text-input-with-mentions/extensions/formula-backspace.test.ts
+++ b/packages/web/test/app/builder/piece-properties/text-input-with-mentions/extensions/formula-backspace.test.ts
@@ -1,0 +1,227 @@
+// @vitest-environment jsdom
+import { Editor } from '@tiptap/core';
+import { Document } from '@tiptap/extension-document';
+import { Mention } from '@tiptap/extension-mention';
+import { Paragraph } from '@tiptap/extension-paragraph';
+import { Text } from '@tiptap/extension-text';
+import { JSONContent } from '@tiptap/react';
+import { afterEach, beforeAll, describe, expect, it } from 'vitest';
+
+import {
+  FunctionArgSeparatorNode,
+  FunctionEndNode,
+  FunctionStartNode,
+  FUNCTION_END_NODE_TYPE,
+  FUNCTION_SEP_NODE_TYPE,
+  FUNCTION_START_NODE_TYPE,
+} from '@/app/builder/piece-properties/text-input-with-mentions/extensions/bracket-nodes';
+import { getFormulaBackspaceTransaction } from '@/app/builder/piece-properties/text-input-with-mentions/extensions/formula-backspace';
+
+const ZWS_CHAR = '\u200B';
+const FN_ID = 'fn-1';
+const NESTED_FN_ID = 'fn-2';
+
+let editor: Editor | null = null;
+
+beforeAll(() => {
+  const emptyRect = {
+    top: 0,
+    bottom: 0,
+    left: 0,
+    right: 0,
+    width: 0,
+    height: 0,
+    x: 0,
+    y: 0,
+  };
+  Object.defineProperty(Range.prototype, 'getClientRects', {
+    value: () => [],
+    configurable: true,
+  });
+  Object.defineProperty(Range.prototype, 'getBoundingClientRect', {
+    value: () => emptyRect,
+    configurable: true,
+  });
+  Object.defineProperty(Element.prototype, 'scrollIntoView', {
+    value: () => undefined,
+    configurable: true,
+  });
+});
+
+afterEach(() => {
+  editor?.destroy();
+  editor = null;
+});
+
+function functionStart(id: string, functionName: string): JSONContent {
+  return { type: FUNCTION_START_NODE_TYPE, attrs: { id, functionName } };
+}
+
+function functionEnd(openId: string): JSONContent {
+  return { type: FUNCTION_END_NODE_TYPE, attrs: { openId } };
+}
+
+function functionSep(openId: string): JSONContent {
+  return { type: FUNCTION_SEP_NODE_TYPE, attrs: { openId } };
+}
+
+function text(value: string): JSONContent {
+  return { type: 'text', text: value };
+}
+
+function posAfterFirstFunctionStart(currentEditor: Editor): number {
+  let pos = -1;
+  currentEditor.state.doc.descendants((node, nodePos) => {
+    if (pos < 0 && node.type.name === FUNCTION_START_NODE_TYPE) {
+      pos = nodePos + node.nodeSize;
+    }
+  });
+  return pos;
+}
+
+function countNodes(currentEditor: Editor, typeName: string): number {
+  let count = 0;
+  currentEditor.state.doc.descendants((node) => {
+    if (node.type.name === typeName) count++;
+  });
+  return count;
+}
+
+function backspaceJustInsideBracket(content: JSONContent[]) {
+  editor = new Editor({
+    extensions: [
+      Document,
+      Paragraph,
+      Text,
+      Mention.configure({ suggestion: { char: '' } }),
+      FunctionStartNode,
+      FunctionArgSeparatorNode,
+      FunctionEndNode,
+    ],
+    content: { type: 'doc', content: [{ type: 'paragraph', content }] },
+  });
+
+  const cursor = posAfterFirstFunctionStart(editor);
+  editor.commands.setTextSelection(cursor);
+  expect(editor.state.selection.from).toBe(cursor);
+
+  const transaction = getFormulaBackspaceTransaction({ state: editor.state });
+  if (transaction) {
+    editor.view.dispatch(transaction);
+  }
+
+  return {
+    handled: transaction !== null,
+    startBadges: countNodes(editor, FUNCTION_START_NODE_TYPE),
+    endBadges: countNodes(editor, FUNCTION_END_NODE_TYPE),
+    mentions: countNodes(editor, 'mention'),
+    visibleText: editor.state.doc.textContent.split(ZWS_CHAR).join(''),
+  };
+}
+
+describe('formula backspace just inside the opening bracket (GIT-1704)', () => {
+  it('deletes the whole pair when the formula is empty', () => {
+    const result = backspaceJustInsideBracket([
+      functionStart(FN_ID, 'uppercase'),
+      text(ZWS_CHAR),
+      functionEnd(FN_ID),
+    ]);
+
+    expect(result.handled).toBe(true);
+    expect(result.startBadges).toBe(0);
+    expect(result.endBadges).toBe(0);
+    expect(result.visibleText).toBe('');
+  });
+
+  it('deletes the whole pair when only the separator skeleton is left', () => {
+    const result = backspaceJustInsideBracket([
+      functionStart(FN_ID, 'concat'),
+      text(ZWS_CHAR),
+      functionSep(FN_ID),
+      text(ZWS_CHAR),
+      functionEnd(FN_ID),
+    ]);
+
+    expect(result.handled).toBe(true);
+    expect(result.startBadges).toBe(0);
+    expect(result.endBadges).toBe(0);
+    expect(result.visibleText).toBe('');
+  });
+
+  it('keeps a typed argument instead of discarding it with the formula', () => {
+    const result = backspaceJustInsideBracket([
+      functionStart(FN_ID, 'uppercase'),
+      text(`${ZWS_CHAR}something`),
+      functionEnd(FN_ID),
+    ]);
+
+    expect(result.visibleText).toBe('something');
+    expect(result.startBadges).toBe(0);
+    expect(result.endBadges).toBe(0);
+  });
+
+  it('keeps a step mention argument', () => {
+    const result = backspaceJustInsideBracket([
+      functionStart(FN_ID, 'uppercase'),
+      text(ZWS_CHAR),
+      { type: 'mention', attrs: { id: 'step_1', label: 'step_1' } },
+      functionEnd(FN_ID),
+    ]);
+
+    expect(result.mentions).toBe(1);
+    expect(result.startBadges).toBe(0);
+    expect(result.endBadges).toBe(0);
+  });
+
+  it('keeps a nested formula argument whole', () => {
+    const result = backspaceJustInsideBracket([
+      functionStart(FN_ID, 'uppercase'),
+      text(ZWS_CHAR),
+      functionStart(NESTED_FN_ID, 'trim'),
+      text(`${ZWS_CHAR}value`),
+      functionEnd(NESTED_FN_ID),
+      functionEnd(FN_ID),
+    ]);
+
+    expect(result.startBadges).toBe(1);
+    expect(result.endBadges).toBe(1);
+    expect(result.visibleText).toBe('value');
+  });
+
+  it('keeps text typed after the formula', () => {
+    const result = backspaceJustInsideBracket([
+      functionStart(FN_ID, 'uppercase'),
+      text(`${ZWS_CHAR}arg`),
+      functionEnd(FN_ID),
+      text(' tail'),
+    ]);
+
+    expect(result.visibleText).toBe('arg tail');
+    expect(result.endBadges).toBe(0);
+  });
+
+  it('keeps surrounding text when deleting an empty pair', () => {
+    const result = backspaceJustInsideBracket([
+      text('before '),
+      functionStart(FN_ID, 'uppercase'),
+      text(ZWS_CHAR),
+      functionEnd(FN_ID),
+      text(' after'),
+    ]);
+
+    expect(result.handled).toBe(true);
+    expect(result.startBadges).toBe(0);
+    expect(result.visibleText).toBe('before  after');
+  });
+
+  it('deletes only the badge of an unclosed formula', () => {
+    const result = backspaceJustInsideBracket([
+      functionStart(FN_ID, 'uppercase'),
+      text(`${ZWS_CHAR}something`),
+    ]);
+
+    expect(result.handled).toBe(true);
+    expect(result.startBadges).toBe(0);
+    expect(result.visibleText).toBe('something');
+  });
+});


### PR DESCRIPTION
Fixes [GIT-1704](https://linear.app/activepieces/issue/GIT-1704)
Closes #14574

## Problem

- In any builder text field, clicking back into a formula puts the caret just inside the opening bracket (right after the `uppercase(` badge, before the invisible U+200B anchor). Arrow keys deliberately skip that position, so it is only reachable by clicking, which is exactly what the customer did.
- From there the Backspace branch in `tiptap-editor.tsx` scanned for the matching `function_end` node and deleted the whole span in one dispatch, with no check for what sat between the brackets. One keystroke wiped `uppercase(hello world)` down to an empty field.
- Deleting the pair is right when the formula is empty. It is wrong once arguments exist, because typed text, step mentions and nested formulas are discarded silently and Undo is the only recovery.

## Fix

- New `extensions/formula-backspace.ts` owns the whole decision: `getFormulaBackspaceTransaction({ state })` returns a `Transaction` or `null`. The editor's Backspace branch is now four lines.
- Body is empty (nothing but U+200B anchors and `;` separators) → delete the pair, unchanged from today.
- Body has content → delete only the two badges and keep the body, so `uppercase(hello world)` becomes `hello world`.
- Unmatched opening badge → delete just that badge, unchanged from today.
- The closing badge is matched by **counting nesting depth** forward from the caret to the end of the caret's own paragraph, the same technique the `;` branch already uses, rather than by `openId`. `main` matched on `openId` and kept the last match anywhere in the document, which cross-paired badges whenever two pairs shared an id (copy/paste does not regenerate ids) and left an orphan `)` before an orphan `upper(`. Depth counting also scopes the search per paragraph, matching how `convertTiptapJsonToText` resets `fnDepth` per paragraph.
- **Why not simply `return false` and let ProseMirror handle it**: native contenteditable deletion removes only the opening badge and leaves an orphan `)`. `convertTiptapJsonToText` decrements `fnDepth` on every `function_end`, so an orphan drives it to `-1`; the next `function_start` in that same field then fails its `fnDepth === 0` top-level check and is serialised **without** the `ap-formula-v1::` prefix, silently saving a real formula as a literal string. Removing both badges avoids trading data loss for that corruption, and is deterministic rather than browser-dependent.

## Verification

- Red-first proven: with only the emptiness branch stripped from `formula-backspace.ts`, the 4 argument-preserving tests fail (`keeps a typed argument…`, `keeps a step mention argument`, `keeps a nested formula argument whole`, `keeps text typed after the formula`) while all 4 pair-deletion tests keep passing (`4 failed | 4 passed`). Restored → `8 passed`.
- New suite `packages/web/test/app/builder/piece-properties/text-input-with-mentions/extensions/formula-backspace.test.ts` drives a real Tiptap editor in jsdom: 13 tests covering empty body, separator-only skeleton, typed text, step mention, nested formula, trailing text, surrounding text, unmatched badge, sequential duplicated ids, nested pair matching, formula pasted inside itself, orphan closer nested before the real one, and a proof that Backspace does not introduce the wrapper loss an orphan closer already causes.
- Second red-first, for the bracket-pairing commits: with the depth counting removed from `findFunctionEndPos`, `leaves the inner pair matched when unwrapping around a nested formula` fails because the survivors are `['function_start:fn-2', 'function_end:fn-1']` — a **mismatched** pair — instead of `['function_start:fn-2', 'function_end:fn-2']`. The assertion compares badge `id`/`openId`, not counts or order, because the broken and correct documents have identical badge counts, identical order and identical text; only the pairing differs. All 12 other tests keep passing.
- Full web suite: **42 files, 423 tests, 0 failures** (`cd packages/web && npx vitest run`).
- `npx eslint` on the 3 changed files: **0 problems**. `npx turbo run lint --filter=web --force -- --fix`: **0 errors, 70 warnings**, all pre-existing `react-hooks/exhaustive-deps` on untouched files. `tsc -p packages/web/tsconfig.app.json --noEmit`: clean.
- Visual: real stack (EE, Postgres, Redis) from this branch, Code step → Inputs value field, formula inserted via `/upper`, caret placed with a real mouse click just right of the badge (verified to land on `#text` offset 0), Backspace sent as a real CDP key event. Drove 4 states: broken-with-argument (field emptied), fixed-with-argument (`hello world` kept), fixed-empty-formula (pair removed), broken-empty-formula (pair removed, unchanged). DOM asserted `[data-function-start]` / `[data-function-end]` counts and field text on every state, not eyeballed.
- Other affected paths: swept the rest of `handleKeyDown`. `;` and `)` replace the current selection, which is normal typing behaviour and destroys nothing extra; the ArrowLeft/ArrowRight branches only move the selection. Backspace was the only destructive branch. Consciously left alone: Backspace directly after a **closing** badge still removes that badge and leaves the opener unclosed (pre-existing, already flagged by `applyUnclosedErrors`); unwrapping a multi-argument formula leaves its `;` separators behind as literal text, which round-trips harmlessly; and `bracket-nodes.tsx` declares `id`/`openId` with only a `default` and renders them to `data-function-start` / `data-function-end`, so **paste does not round-trip badge ids at all**. That last one is the root cause behind every duplicated-id state discussed below and wants its own PR, but the depth-based pairing here is immune to it.

<details><summary>Plan &amp; reasoning</summary>

**Approach.** The destructive dispatch was one line inside a 25-line inline block in the React component, unreachable from a test (importing `tiptap-editor.tsx` into vitest times out on its dependency graph). Extracting the whole decision into a pure `state → Transaction | null` function made it testable against a real editor and shrank the component. Returning a `Transaction` rather than a range list avoids leaking an ordering contract to the caller: unwrapping needs two deletes applied back-to-front, and a range array would let a future caller apply them in the wrong order.

**Non-happy scenarios considered.** Multi-argument skeleton `concat(;)` with only anchors left — treated as empty, whole pair deleted. Nested formula as the argument — the inner pair survives intact, which the plain `return false` path would have wrecked. Step mention as the argument — preserved. A non-collapsed selection — bails out immediately so normal delete-selection runs. No closing badge at all in the caret's paragraph — the `endPos < from` branch treats it as unmatched and removes just the opening badge, instead of dispatching a reversed range that would have thrown a `RangeError`. Two pairs sharing an `openId`, both sequentially and nested (a formula pasted inside itself), since paste does not regenerate ids.

**Orphan closer nested before the real one** (`upper( arg )orphan )fn-1`, reachable by pasting a bare closing badge). Depth counting consumes the orphan and leaves the id-matched closer orphaned instead. Kept deliberately: `convertTiptapJsonToText` is itself id-blind and depth-based, pairing `upper(` with the first `function_end` it meets and emitting the second as a bare `)` at `fnDepth` -1, so either choice of closer serializes to the identical value. `pairs with the closer the serializer pairs with when an orphan closer is nested` runs the real serializer over the post-Backspace document and asserts `arg)`. Matching on `openId` instead would make Backspace disagree with the serializer, and would reintroduce cross-pairing on the far more common duplicated-id state. `does not introduce the wrapper loss an orphan closer already causes` serializes the same paragraph before and after the keystroke and shows a trailing `trim(...)` is already missing its `ap-formula-v1::{` prefix pre-keystroke: the operation deletes one opener and one closer, so with two closers present exactly one survives under any pairing rule and `fnDepth` reaches -1 either way.

**Alternatives rejected.** (1) `return false` on a non-empty body, as originally scoped: rejected after tracing the serializer, see the fnDepth note above. (2) Swallowing the keystroke and just moving the caret: silently dropping a keypress is worse than either deletion. (3) Guarding at the call site inside `tiptap-editor.tsx` and keeping the logic inline: no way to test it, and the component keeps growing. (4) Adding the predicate to `bracket-nodes.tsx` to reuse its ZWS constant: that file defines node schemas, and two other open PRs are already active in this folder, so a separate module keeps the blast radius minimal. (5) Pairing brackets by `openId`: correct only while ids are unique, and paste guarantees they are not.

</details>

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)
