### PR TITLE
feat(agent): run an agent from a flow step

### DIFF
--- a/packages/core/execution/src/lib/workers/job-data.ts
+++ b/packages/core/execution/src/lib/workers/job-data.ts
@@ -273,6 +273,7 @@ export const ExecuteAgentRunJobData = z.object({
     platformId: z.string(),
     userId: z.string(),
     userMessage: z.string(),
+    source: z.enum(AgentRunSource).optional(),
     modelName: z.string().nullable(),
     files: z.array(z.object({
         name: z.string(),


### PR DESCRIPTION
## Description

This is the branch the rest of the flow-step path lands on. It is open early so the work is visible, and it will grow until an agent step can actually run. Reviewing it now is not useful; reviewing it once the chain is closed is.

Everything before it is merged and unreachable on its own, which is the whole reason for collecting the remainder here:

- #14592 plans a piece action's inputs into dependency waves
- #14594 fills each wave with the model and resolves dynamic fields
- #14600 joins those to property resolution and execution

## What is here so far

`source` on `ExecuteAgentRunJobData`, so the worker can tell a flow-step run from a chat one before it wires any chat-only plumbing.

It is optional on purpose. `job-data.ts` warns that changing this payload means bumping `LATEST_JOB_DATA_SCHEMA_VERSION` and adding a migration; an optional field means jobs already queued when this deploys still parse, and they are chat runs, which is exactly how they are then treated.

## What is still to come

| | |
| --- | --- |
| `POST /v1/agents/runs` | Creates a `FLOW_STEP` conversation and enqueues the run |
| Worker flow-step branch | Same turn loop, without the chat-only tools and gates |
| Waitpoint | The step suspends instead of holding a worker slot |
| `FLOW_STEP` retention | Transcripts expire with the flow run that produced them |

The agent piece rewrite is deliberately not in this list. Published flows pin their piece version, so that half carries the real risk and gets its own review.

## Two things to settle before the endpoint

**Who is allowed to call it.** Every agent route today is `publicPlatform([PrincipalType.USER])`. This one is called from inside the engine sandbox, so it authenticates as `PrincipalType.ENGINE`. An engine-callable route that creates conversations and enqueues work is a new trust edge, and the wrong `securityAccess` shape will not show up in tests.

**Pinned piece versions.** `lookupPieceComponent` takes no version, so `executeAdhocAction` validates against the latest piece while executing whatever version it is handed. #14600 works around this by staying on the latest everywhere. Published flows pin their pieces, so a version has to be threaded through before an agent step can run correctly against a pinned one.

Fixes # (issue)

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

An optional field on an internal job payload. Jobs queued before the deploy still parse, and both ends of the queue ship in the same image.

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)

Nothing reachable changes yet. The endpoint's trust boundary is called out above and will be reviewed with the code that introduces it.
