### PR TITLE
fix(builder): piece selector no longer clips under header on short viewports

### DIFF
--- a/packages/web/src/app/builder/pieces-selector/index.tsx
+++ b/packages/web/src/app/builder/pieces-selector/index.tsx
@@ -24,7 +24,6 @@ import {
   PieceSelectorTabsProvider,
   PieceSelectorTabType,
   PieceSelectorOperation,
-  pieceSelectorUtils,
   pieceSelectorCustomization,
   PieceSearchProvider,
   usePieceSearchContext,
@@ -126,9 +125,6 @@ const PieceSelectorContent = ({
   const [debouncedQuery] = useDebounce(searchQuery, 300);
   const isOpen = openedPieceSelectorStepNameOrAddButtonId === id;
   const isMobile = useIsMobile();
-  const { listHeightRef, popoverTriggerRef } =
-    pieceSelectorUtils.useAdjustPieceListHeightToAvailableSpace();
-  const listHeight = Math.min(listHeightRef.current, 300);
   const searchInputRef = useRef<HTMLInputElement>(null);
   useEffect(() => {
     if (isOpen) {
@@ -172,7 +168,6 @@ const PieceSelectorContent = ({
       }}
     >
       <PopoverTrigger
-        ref={popoverTriggerRef}
         asChild={true}
         onClick={() => {
           if (openSelectorOnClick) {
@@ -204,14 +199,15 @@ const PieceSelectorContent = ({
               e.preventDefault();
             }
           }}
-          className="w-[340px] md:w-[600px] p-0 shadow-lg"
+          collisionPadding={PIECE_SELECTOR_COLLISION_PADDING}
+          className="w-[340px] md:w-[600px] p-0 shadow-lg flex flex-col overflow-hidden max-h-(--radix-popover-content-available-height)"
           onClick={(e) => {
             e.stopPropagation();
             e.preventDefault();
           }}
         >
           <>
-            <div>
+            <div className="shrink-0">
               <PiecesSearchInput
                 searchInputRef={searchInputRef}
                 onSearchChange={(e) => {
@@ -224,12 +220,7 @@ const PieceSelectorContent = ({
               {!isMobile && <PieceSelectorTabs tabs={tabsList} />}
               <Separator orientation="horizontal" className="mt-1" />
             </div>
-            <div
-              className=" flex flex-row max-h-[300px]"
-              style={{
-                height: listHeight + 'px',
-              }}
-            >
+            <div className="flex flex-row h-[300px] min-h-[100px]">
               <ExploreTabContent operation={operation} />
               <AITabContent operation={operation} />
               <ApprovalsTabContent operation={operation} />
@@ -248,6 +239,15 @@ const PieceSelectorContent = ({
       </PieceSelectorTabsProvider>
     </Popover>
   );
+};
+
+const BUILDER_HEADER_HEIGHT = 60;
+const BUILDER_BANNER_BOTTOM_OFFSET = 58;
+const PIECE_SELECTOR_COLLISION_PADDING = {
+  top: BUILDER_HEADER_HEIGHT + BUILDER_BANNER_BOTTOM_OFFSET,
+  bottom: 8,
+  left: 8,
+  right: 8,
 };
 
 export { PieceSelectorWrapper as PieceSelector };

--- a/packages/web/src/features/pieces/utils/piece-selector-utils.ts
+++ b/packages/web/src/features/pieces/utils/piece-selector-utils.ts
@@ -28,7 +28,6 @@ import {
   FlowOperationType,
   AUTHENTICATION_PROPERTY_NAME,
 } from '@activepieces/shared';
-import { useRef } from 'react';
 
 import {
   PieceSelectorItem,
@@ -290,56 +289,10 @@ const getDefaultStepValues = ({
   }
 };
 
-// Adjusts piece list height to prevent overflow on short screens
-const useAdjustPieceListHeightToAvailableSpace = () => {
-  const listHeightRef = useRef<number>(MAX_PIECE_SELECTOR_LIST_HEIGHT);
-  const popoverTriggerRef = useRef<HTMLButtonElement | null>(null);
-
-  if (!popoverTriggerRef.current) {
-    return {
-      listHeightRef,
-      popoverTriggerRef,
-      searchInputDivHeight: SEARCH_INPUT_DIV_HEIGHT,
-    };
-  }
-
-  const popOverTriggerRect = popoverTriggerRef.current.getBoundingClientRect();
-  const viewportHeight =
-    window.innerHeight || document.documentElement.clientHeight;
-  const shouldRenderBelowPopoverTrigger =
-    popOverTriggerRect.top < viewportHeight - popOverTriggerRect.bottom;
-
-  if (shouldRenderBelowPopoverTrigger) {
-    const availableSpaceBelow =
-      viewportHeight - popOverTriggerRect.bottom - SEARCH_INPUT_DIV_HEIGHT;
-    listHeightRef.current = Math.max(
-      MIN_PIECE_SELECTOR_LIST_HEIGHT,
-      availableSpaceBelow,
-    );
-  } else {
-    const availableSpaceAbove =
-      popOverTriggerRect.top - SEARCH_INPUT_DIV_HEIGHT;
-    listHeightRef.current = Math.max(
-      MIN_PIECE_SELECTOR_LIST_HEIGHT,
-      availableSpaceAbove,
-    );
-  }
-
-  return {
-    listHeightRef,
-    popoverTriggerRef,
-  };
-};
-const MAX_PIECE_SELECTOR_LIST_HEIGHT = 300 as const;
-const MIN_PIECE_SELECTOR_LIST_HEIGHT = 100 as const;
-const SEARCH_INPUT_DIV_HEIGHT = 113 as const;
 const PIECE_ITEM_HEIGHT = 48 as const;
 const ACTION_OR_TRIGGER_ITEM_HEIGHT = 54 as const;
 const CATEGORY_ITEM_HEIGHT = 28 as const;
 export const PIECE_SELECTOR_ELEMENTS_HEIGHTS = {
-  MAX_PIECE_SELECTOR_LIST_HEIGHT,
-  MIN_PIECE_SELECTOR_LIST_HEIGHT,
-  SEARCH_INPUT_DIV_HEIGHT,
   PIECE_ITEM_HEIGHT,
   ACTION_OR_TRIGGER_ITEM_HEIGHT,
   CATEGORY_ITEM_HEIGHT,
@@ -371,7 +324,6 @@ const getStepNameFromOperationType = (
 };
 export const pieceSelectorUtils = {
   getDefaultStepValues,
-  useAdjustPieceListHeightToAvailableSpace,
   isPieceStepInputValid,
   isMcpToolTrigger,
   isChatTrigger,


### PR DESCRIPTION
Fixes [GIT-1709](https://linear.app/activepieces/issue/GIT-1709)
Closes #14603

## Problem
1. On short viewports (~<480px browser height), opening the piece selector near the bottom of the canvas flipped the popover above the trigger and its top edge slid **under the 60px builder header and the "You have unpublished changes" banner** — the Search input landed behind chrome the user could not click through.
2. The hand-rolled `useAdjustPieceListHeightToAvailableSpace` hook read `window.innerHeight` off a non-reactive `useRef` at render time. It ignored the header/banner entirely and never updated on resize.

## Fix
- `piece-selector/index.tsx` — pass `collisionPadding={{ top: 118, bottom/left/right: 8 }}` to `PopoverContent`; bind panel `max-h` to `--radix-popover-content-available-height`; make the panel a `flex-col` where the search+tabs header is `shrink-0` and the list is `h-[300px] min-h-[100px]` so the list, not the search bar, is what compresses on short screens.
- `piece-selector-utils.ts` — delete the hand-rolled hook and its unused constants (0 external consumers confirmed via grep).

## Verification
- lint: clean (0 errors, pre-existing warnings unchanged)
- unit tests: 422/422 pass (regression fix: shortcuts.test.tsx surfaced a module-load ordering issue during dev, resolved by localizing the padding constants; test now green)
- runtime drive: full dev stack (npm run dev), created flow, opened the trigger picker at 380px viewport (banner + trigger + picker all forced into ~380px), toggled with fix applied vs stashed. Before/after captured — see Visual verification comment below.
- inverse drive: also verified at 900px viewport (picker opens below cleanly, standard behavior preserved)
- Visual: driven states = flip-above short viewport, opens-below short viewport, opens-below tall viewport
- Other affected paths: checked - none (no other consumers of the deleted hook)

<details>
<summary>Plan & reasoning</summary>

## Plan
- delegate popover positioning to Radix's built-in collision system (`collisionPadding` + `--radix-popover-content-available-height` CSS var) instead of hand-rolled `window.innerHeight` math
- keep list target height of 300px but bind the panel container to available height so it shrinks on cramped screens
- delete `useAdjustPieceListHeightToAvailableSpace` entirely (48 lines, zero consumers outside its own module)
- padding constants live locally in `piece-selector/index.tsx` (not in `flow-canvas/utils/consts.ts`) to avoid a module-load cycle uncovered by the shortcuts test suite

## Non-happy scenarios considered
- Trigger high in viewport → picker opens below, no collision — verified
- Trigger low in viewport, flip → picker opens above, top pinned to (header+banner) offset — verified
- Very short viewport (< 213px) → list bottoms out at min-h-[100px], excess is clipped by outer `overflow-hidden` (graceful degradation, better than covering the search bar)
- Window resize while open → Radix `size` middleware re-runs via autoUpdate, `--radix-popover-content-available-height` updates, panel shrinks/grows live (verified in standalone Radix repro)

## Alternatives rejected
- Threading `BUILDER_HEADER_HEIGHT` through from `flow-canvas/utils/consts.ts` — created a module-load cycle (flow-canvas edges → pieces-selector → consts), breaking shortcuts.test.tsx. Localizing the constants keeps the dependency graph a tree.
- Making padding dynamic based on whether the "unpublished changes" banner is actually shown — trade-off (58px of unused space when no banner) accepted as ponytail-simpler. Add when someone complains the panel sits lower than needed on a tall viewport (they won't — collision doesn't fire there).
</details>


### Breaking change?

- [x] no — reviewed, not breaking

### Security impact?

- [x] no — reviewed, no security impact