### PR TITLE
feat(agent): hand the agent's answer back to the flow step

### DIFF
--- a/packages/core/execution/src/lib/workers/job-data.ts
+++ b/packages/core/execution/src/lib/workers/job-data.ts
@@ -274,7 +274,8 @@ export const ExecuteAgentRunJobData = z.object({
     userId: z.string(),
     userMessage: z.string(),
     source: z.enum(AgentRunSource).optional(),
-    resumeUrl: z.string().optional(),
+    flowRunId: z.string().optional(),
+    waitpointId: z.string().optional(),
     modelName: z.string().nullable(),
     files: z.array(z.object({
         name: z.string(),

--- a/packages/core/execution/src/lib/workers/worker-contract.ts
+++ b/packages/core/execution/src/lib/workers/worker-contract.ts
@@ -90,6 +90,7 @@ export type WorkerToApiContract = {
     heartbeatAgentConversation(input: HeartbeatAgentConversationRequest): Promise<void>
     updateProjectContext(input: UpdateProjectContextRequest): Promise<void>
     executeAgentTool(input: ExecuteAgentToolRequest): Promise<ExecuteAgentToolResponse>
+    resumeFlowStep(input: ResumeFlowStepRequest): Promise<void>
     sendAgentEmail(input: SendAgentEmailRequest): Promise<SendAgentEmailResponse>
 }
 
@@ -194,6 +195,13 @@ export type ExecuteAgentToolRequest = {
     userId: string
     source: AgentRunSource
     conversationId?: string
+}
+
+export type ResumeFlowStepRequest = {
+    conversationId: string
+    flowRunId: string
+    waitpointId: string
+    output: unknown
 }
 
 export type ExecuteAgentToolResponse = {

--- a/packages/server/api/src/app/ee/agent/agent-rpc-handlers.ts
+++ b/packages/server/api/src/app/ee/agent/agent-rpc-handlers.ts
@@ -29,6 +29,7 @@ import { executeCrossProjectTool } from './tools/agent-tools'
 const MAX_APPROVAL_BLOCK_MS = 50_000
 const CHAT_ONLY_TOOL_PREFIX = '__'
 const OWNER_SCOPED_TOOLS = ['ap_remember']
+const UNATTENDED_FORBIDDEN_TOOLS = ['ap_run_code']
 
 const MAX_EMAIL_RECIPIENTS = 10
 const MAX_EMAIL_SUBJECT_LENGTH = 300
@@ -473,16 +474,21 @@ export const agentRpcHandlers = (log: FastifyBaseLogger) => ({
             throw new ActivepiecesError({ code: ErrorCode.AUTHORIZATION, params: { message: 'Only a flow-step run can resume a flow' } })
         }
         const flowRun = await flowRunService(log).getOneOrThrow({ id: input.flowRunId, projectId: conversation.projectId })
-        await resumeService(log).resumeFromWaitpoint({
+        const { stale } = await resumeService(log).resumeFromWaitpoint({
             flowRunId: flowRun.id,
             waitpointId: input.waitpointId,
             resumePayload: { body: sanitizeObjectForPostgresql(input.output), headers: {}, queryParams: {} },
         })
-        log.info({ conversation: { id: input.conversationId }, flowRun: { id: flowRun.id } }, '[agentRpc#resumeFlowStep] Handed the result back to the flow')
+        const resumeFields = { conversation: { id: input.conversationId }, flowRun: { id: flowRun.id }, waitpoint: { id: input.waitpointId } }
+        if (stale) {
+            log.warn(resumeFields, '[agentRpc#resumeFlowStep] Nothing to resume, so the flow keeps waiting unless another attempt already released it')
+            return
+        }
+        log.info(resumeFields, '[agentRpc#resumeFlowStep] Handed the result back to the flow')
     },
 
     async executeAgentTool(input: ExecuteAgentToolRequest): Promise<ExecuteAgentToolResponse> {
-        const chatOnlyTool = input.toolName.startsWith(CHAT_ONLY_TOOL_PREFIX) || OWNER_SCOPED_TOOLS.includes(input.toolName)
+        const chatOnlyTool = input.toolName.startsWith(CHAT_ONLY_TOOL_PREFIX) || OWNER_SCOPED_TOOLS.includes(input.toolName) || UNATTENDED_FORBIDDEN_TOOLS.includes(input.toolName)
         if (chatOnlyTool && input.source !== AgentRunSource.CHAT) {
             log.error({ tool: { name: input.toolName }, source: input.source }, '[agentRpc#executeAgentTool] Rejected a chat-only tool for a non-chat run — the worker should not have called it')
             throw new ActivepiecesError({
@@ -600,6 +606,10 @@ export const agentRpcHandlers = (log: FastifyBaseLogger) => ({
 
         const conversation = await agentHelpers.getConversationOrThrow({ id: conversationId, platformId, userId })
 
+        if (conversation.source !== AgentRunSource.CHAT) {
+            throw new ActivepiecesError({ code: ErrorCode.AUTHORIZATION, params: { message: 'Only a chat run can send email' } })
+        }
+
         // Fence the send to the active streaming owner. A run parked on an email approval must not
         // resume and send once it's been superseded (activeRunId changed) OR cancelled/finished
         // (status left STREAMING). Cancellation flips status to IDLE without touching activeRunId,
@@ -713,7 +723,7 @@ async function loadOrStartConversation({ conversationId, platformId, userId, sou
     }
     const existing = await agentHelpers.conversationRepo().findOneBy({ id: conversationId })
     if (!isNil(existing)) {
-        if (existing.platformId !== platformId || existing.userId !== userId) {
+        if (existing.platformId !== platformId || existing.userId !== userId || existing.source !== AgentRunSource.FLOW_STEP) {
             throw new ActivepiecesError({ code: ErrorCode.AUTHORIZATION, params: { message: 'That conversation belongs to someone else' } })
         }
         return existing
@@ -731,12 +741,12 @@ async function loadOrStartConversation({ conversationId, platformId, userId, sou
     })
 }
 
-async function confinedProjectFor({ conversationId }: { conversationId?: string }): Promise<string | null> {
-    if (isNil(conversationId)) {
-        return null
+async function confinedProjectFor({ conversationId }: { conversationId?: string }): Promise<string> {
+    const conversation = isNil(conversationId) ? null : await agentHelpers.conversationRepo().findOneBy({ id: conversationId })
+    if (isNil(conversation?.projectId)) {
+        throw new ActivepiecesError({ code: ErrorCode.AUTHORIZATION, params: { message: 'A flow-step run must be confined to a project' } })
     }
-    const conversation = await agentHelpers.conversationRepo().findOneBy({ id: conversationId })
-    return conversation?.projectId ?? null
+    return conversation.projectId
 }
 
 function byteLengthOf(value: unknown): number {

--- a/packages/server/api/src/app/ee/agent/agent-rpc-handlers.ts
+++ b/packages/server/api/src/app/ee/agent/agent-rpc-handlers.ts
@@ -469,14 +469,14 @@ export const agentRpcHandlers = (log: FastifyBaseLogger) => ({
 
     async resumeFlowStep(input: ResumeFlowStepRequest): Promise<void> {
         const conversation = await agentHelpers.conversationRepo().findOneBy({ id: input.conversationId })
-        if (conversation?.source !== AgentRunSource.FLOW_STEP) {
+        if (conversation?.source !== AgentRunSource.FLOW_STEP || isNil(conversation.projectId)) {
             throw new ActivepiecesError({ code: ErrorCode.AUTHORIZATION, params: { message: 'Only a flow-step run can resume a flow' } })
         }
-        const flowRun = await flowRunService(log).getOneOrThrow({ id: input.flowRunId, projectId: conversation.projectId ?? '' })
+        const flowRun = await flowRunService(log).getOneOrThrow({ id: input.flowRunId, projectId: conversation.projectId })
         await resumeService(log).resumeFromWaitpoint({
             flowRunId: flowRun.id,
             waitpointId: input.waitpointId,
-            resumePayload: { body: input.output, headers: {}, queryParams: {} },
+            resumePayload: { body: sanitizeObjectForPostgresql(input.output), headers: {}, queryParams: {} },
         })
         log.info({ conversation: { id: input.conversationId }, flowRun: { id: flowRun.id } }, '[agentRpc#resumeFlowStep] Handed the result back to the flow')
     },

--- a/packages/server/api/src/app/ee/agent/agent-rpc-handlers.ts
+++ b/packages/server/api/src/app/ee/agent/agent-rpc-handlers.ts
@@ -1,6 +1,6 @@
 import { ActivepiecesError, ErrorCode, isNil, sanitizeObjectForPostgresql, tryCatch, unique } from '@activepieces/core-utils'
 import { agentAiUtils } from '@activepieces/server-utils'
-import { AgentConfigResponse, AgentConversation, AgentConversationStatus, AgentRunSource, agentToolClassification, ExecuteAgentToolRequest, ExecuteAgentToolResponse, FileCompression, FileType, FlowActionType, flowStructureUtil, GetAgentConfigRequest, GetEnabledAiToolsResponse, HeartbeatAgentConversationRequest, PersistedAgentMessage, PersistedAgentPartType, PersistedAgentRole, SaveAgentFileRequest, SaveAgentFileResponse, SaveAgentMessagesRequest, SendAgentEmailRequest, SendAgentEmailResponse, UpdateAgentProgressRequest, UpdateProjectContextRequest } from '@activepieces/shared'
+import { AgentConfigResponse, AgentConversation, AgentConversationStatus, AgentRunSource, agentToolClassification, ExecuteAgentToolRequest, ExecuteAgentToolResponse, FileCompression, FileType, FlowActionType, flowStructureUtil, GetAgentConfigRequest, GetEnabledAiToolsResponse, HeartbeatAgentConversationRequest, PersistedAgentMessage, PersistedAgentPartType, PersistedAgentRole, ResumeFlowStepRequest, SaveAgentFileRequest, SaveAgentFileResponse, SaveAgentMessagesRequest, SendAgentEmailRequest, SendAgentEmailResponse, UpdateAgentProgressRequest, UpdateProjectContextRequest } from '@activepieces/shared'
 import { ModelMessage } from 'ai'
 import { FastifyBaseLogger } from 'fastify'
 import { aiToolConfigService } from '../../ai/ai-tool-config-service'
@@ -8,6 +8,8 @@ import { appConnectionService } from '../../app-connection/app-connection-servic
 import { fileService } from '../../file/file.service'
 import { filesService } from '../../file/files-service'
 import { flowService } from '../../flows/flow/flow.service'
+import { flowRunService } from '../../flows/flow-run/flow-run-service'
+import { resumeService } from '../../flows/flow-run/waitpoint/resume-service'
 import { rejectedPromiseHandler } from '../../helper/promise-handler'
 import { system } from '../../helper/system/system'
 import { AppSystemProp } from '../../helper/system/system-props'
@@ -463,6 +465,20 @@ export const agentRpcHandlers = (log: FastifyBaseLogger) => ({
         }
         await updateConversationForRun({ conversationId: input.conversationId, runId: input.runId, updates: { projectId: input.projectId } })
         log.info({ conversation: { id: input.conversationId }, project: input.projectId ? { id: input.projectId } : undefined }, '[agentRpc#updateProjectContext] Project context updated')
+    },
+
+    async resumeFlowStep(input: ResumeFlowStepRequest): Promise<void> {
+        const conversation = await agentHelpers.conversationRepo().findOneBy({ id: input.conversationId })
+        if (conversation?.source !== AgentRunSource.FLOW_STEP) {
+            throw new ActivepiecesError({ code: ErrorCode.AUTHORIZATION, params: { message: 'Only a flow-step run can resume a flow' } })
+        }
+        const flowRun = await flowRunService(log).getOneOrThrow({ id: input.flowRunId, projectId: conversation.projectId ?? '' })
+        await resumeService(log).resumeFromWaitpoint({
+            flowRunId: flowRun.id,
+            waitpointId: input.waitpointId,
+            resumePayload: { body: input.output, headers: {}, queryParams: {} },
+        })
+        log.info({ conversation: { id: input.conversationId }, flowRun: { id: flowRun.id } }, '[agentRpc#resumeFlowStep] Handed the result back to the flow')
     },
 
     async executeAgentTool(input: ExecuteAgentToolRequest): Promise<ExecuteAgentToolResponse> {

--- a/packages/server/api/src/app/ee/agent/agent-run-controller.ts
+++ b/packages/server/api/src/app/ee/agent/agent-run-controller.ts
@@ -13,7 +13,7 @@ const RUN_PRINCIPALS = [PrincipalType.ENGINE] as const
 
 export const agentRunController: FastifyPluginAsyncZod = async (app) => {
     app.post('/runs', StartAgentRunRoute, async (request, reply) => {
-        const { instruction, modelName, resumeUrl } = request.body
+        const { instruction, modelName, flowRunId, waitpointId } = request.body
         if (request.principal.type !== PrincipalType.ENGINE) {
             throw new ActivepiecesError({
                 code: ErrorCode.AUTHORIZATION,
@@ -46,7 +46,8 @@ export const agentRunController: FastifyPluginAsyncZod = async (app) => {
                 userMessage: instruction,
                 modelName: modelName ?? null,
                 source: AgentRunSource.FLOW_STEP,
-                resumeUrl,
+                flowRunId,
+                waitpointId,
             },
         })
 
@@ -56,10 +57,12 @@ export const agentRunController: FastifyPluginAsyncZod = async (app) => {
 }
 
 const RUNS_PER_MINUTE = 60
+const MAX_INSTRUCTION_LENGTH = 51_200
 
 const StartAgentRunRequest = z.object({
-    instruction: z.string().min(1),
-    resumeUrl: z.string().url(),
+    instruction: z.string().min(1).max(MAX_INSTRUCTION_LENGTH),
+    flowRunId: z.string(),
+    waitpointId: z.string(),
     modelName: z.string().optional(),
 })
 

--- a/packages/server/api/src/app/ee/agent/agent-run-controller.ts
+++ b/packages/server/api/src/app/ee/agent/agent-run-controller.ts
@@ -1,4 +1,4 @@
-import { ActivepiecesError, apId, ErrorCode } from '@activepieces/core-utils'
+import { ActivepiecesError, apId, ApId, ErrorCode } from '@activepieces/core-utils'
 import { AgentRunSource, LATEST_JOB_DATA_SCHEMA_VERSION, PrincipalType, WorkerJobType } from '@activepieces/shared'
 import { FastifyPluginAsyncZod } from 'fastify-type-provider-zod'
 import { StatusCodes } from 'http-status-codes'
@@ -61,8 +61,8 @@ const MAX_INSTRUCTION_LENGTH = 51_200
 
 const StartAgentRunRequest = z.object({
     instruction: z.string().min(1).max(MAX_INSTRUCTION_LENGTH),
-    flowRunId: z.string(),
-    waitpointId: z.string(),
+    flowRunId: ApId,
+    waitpointId: ApId,
     modelName: z.string().optional(),
 })
 

--- a/packages/server/api/src/app/workers/rpc/worker-rpc-service.ts
+++ b/packages/server/api/src/app/workers/rpc/worker-rpc-service.ts
@@ -329,6 +329,10 @@ export function createHandlers(log: FastifyBaseLogger, assignment: WorkerGroupAs
             return agentRpcHandlers(agentRpcLog(log, { conversationId, runId, platformId: input.platformId, userId: input.userId })).executeAgentTool(input)
         },
 
+        async resumeFlowStep(input) {
+            return agentRpcHandlers(agentRpcLog(log, { conversationId: input.conversationId })).resumeFlowStep(input)
+        },
+
         async sendAgentEmail(input) {
             return agentRpcHandlers(agentRpcLog(log, { conversationId: input.conversationId, platformId: input.platformId, userId: input.userId })).sendAgentEmail(input)
         },

--- a/packages/server/api/test/integration/cloud/agent/agent-run-endpoint.test.ts
+++ b/packages/server/api/test/integration/cloud/agent/agent-run-endpoint.test.ts
@@ -1,3 +1,4 @@
+import { apId } from '@activepieces/core-utils'
 import { FastifyInstance } from 'fastify'
 import { StatusCodes } from 'http-status-codes'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
@@ -31,7 +32,7 @@ describe('POST /v1/agents/runs', () => {
             method: 'POST',
             url: RUNS_URL,
             headers: { authorization: `Bearer ${engineToken}` },
-            body: { instruction: 'send a summary email', flowRunId: 'run-1', waitpointId: 'wp-1' },
+            body: { instruction: 'send a summary email', flowRunId: apId(), waitpointId: apId() },
         })
 
         expect(response.statusCode).toBe(StatusCodes.OK)
@@ -54,7 +55,7 @@ describe('POST /v1/agents/runs', () => {
             method: 'POST',
             url: RUNS_URL,
             headers: { authorization: `Bearer ${engineToken}` },
-            body: { instruction: 'do a thing', flowRunId: 'run-1', waitpointId: 'wp-1', projectId: other.project.id },
+            body: { instruction: 'do a thing', flowRunId: apId(), waitpointId: apId(), projectId: other.project.id },
         })
 
         expect(response.statusCode).toBe(StatusCodes.OK)
@@ -73,7 +74,7 @@ describe('POST /v1/agents/runs', () => {
             method: 'POST',
             url: RUNS_URL,
             headers: { authorization: `Bearer ${engineToken}` },
-            body: { instruction: 'do a thing', flowRunId: 'run-1', waitpointId: 'wp-1' },
+            body: { instruction: 'do a thing', flowRunId: apId(), waitpointId: apId() },
         })
 
         const list = await ctx.post('/v1/agents/conversations', { title: 'a real chat' })
@@ -88,7 +89,7 @@ describe('POST /v1/agents/runs', () => {
 
         const response = await ctx.post('/v1/agents/runs', {
             instruction: 'do a thing',
-            flowRunId: 'run-1', waitpointId: 'wp-1',
+            flowRunId: apId(), waitpointId: apId(),
         })
 
         expect([StatusCodes.UNAUTHORIZED, StatusCodes.FORBIDDEN]).toContain(response.statusCode)
@@ -106,7 +107,25 @@ describe('POST /v1/agents/runs', () => {
             method: 'POST',
             url: RUNS_URL,
             headers: { authorization: `Bearer ${engineToken}` },
-            body: { instruction: '', flowRunId: 'run-1', waitpointId: 'wp-1' },
+            body: { instruction: '', flowRunId: apId(), waitpointId: apId() },
+        })
+
+        expect(response.statusCode).toBe(StatusCodes.BAD_REQUEST)
+    })
+
+    it('rejects a waitpoint that is not an id, so nothing unbounded reaches the queue', async () => {
+        const ctx = await createTestContext(app)
+        const engineToken = await accessTokenManager(app.log).generateEngineToken({
+            jobId: 'job-4',
+            projectId: ctx.project.id,
+            platformId: ctx.platform.id,
+        })
+
+        const response = await app.inject({
+            method: 'POST',
+            url: RUNS_URL,
+            headers: { authorization: `Bearer ${engineToken}` },
+            body: { instruction: 'do a thing', flowRunId: apId(), waitpointId: 'x'.repeat(5_000) },
         })
 
         expect(response.statusCode).toBe(StatusCodes.BAD_REQUEST)

--- a/packages/server/api/test/integration/cloud/agent/agent-run-endpoint.test.ts
+++ b/packages/server/api/test/integration/cloud/agent/agent-run-endpoint.test.ts
@@ -31,7 +31,7 @@ describe('POST /v1/agents/runs', () => {
             method: 'POST',
             url: RUNS_URL,
             headers: { authorization: `Bearer ${engineToken}` },
-            body: { instruction: 'send a summary email', resumeUrl: 'https://example.com/resume/abc' },
+            body: { instruction: 'send a summary email', flowRunId: 'run-1', waitpointId: 'wp-1' },
         })
 
         expect(response.statusCode).toBe(StatusCodes.OK)
@@ -54,7 +54,7 @@ describe('POST /v1/agents/runs', () => {
             method: 'POST',
             url: RUNS_URL,
             headers: { authorization: `Bearer ${engineToken}` },
-            body: { instruction: 'do a thing', resumeUrl: 'https://example.com/resume/abc', projectId: other.project.id },
+            body: { instruction: 'do a thing', flowRunId: 'run-1', waitpointId: 'wp-1', projectId: other.project.id },
         })
 
         expect(response.statusCode).toBe(StatusCodes.OK)
@@ -73,7 +73,7 @@ describe('POST /v1/agents/runs', () => {
             method: 'POST',
             url: RUNS_URL,
             headers: { authorization: `Bearer ${engineToken}` },
-            body: { instruction: 'do a thing', resumeUrl: 'https://example.com/resume/abc' },
+            body: { instruction: 'do a thing', flowRunId: 'run-1', waitpointId: 'wp-1' },
         })
 
         const list = await ctx.post('/v1/agents/conversations', { title: 'a real chat' })
@@ -88,7 +88,7 @@ describe('POST /v1/agents/runs', () => {
 
         const response = await ctx.post('/v1/agents/runs', {
             instruction: 'do a thing',
-            resumeUrl: 'https://example.com/resume/abc',
+            flowRunId: 'run-1', waitpointId: 'wp-1',
         })
 
         expect([StatusCodes.UNAUTHORIZED, StatusCodes.FORBIDDEN]).toContain(response.statusCode)
@@ -106,7 +106,7 @@ describe('POST /v1/agents/runs', () => {
             method: 'POST',
             url: RUNS_URL,
             headers: { authorization: `Bearer ${engineToken}` },
-            body: { instruction: '', resumeUrl: 'https://example.com/resume/abc' },
+            body: { instruction: '', flowRunId: 'run-1', waitpointId: 'wp-1' },
         })
 
         expect(response.statusCode).toBe(StatusCodes.BAD_REQUEST)

--- a/packages/server/api/test/unit/app/ee/agent/agent-rpc-handlers.test.ts
+++ b/packages/server/api/test/unit/app/ee/agent/agent-rpc-handlers.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const { mockGetFlowRun, mockResumeFromWaitpoint } = vi.hoisted(() => ({
     mockGetFlowRun: vi.fn(),
-    mockResumeFromWaitpoint: vi.fn().mockResolvedValue(undefined),
+    mockResumeFromWaitpoint: vi.fn().mockResolvedValue({ stale: false }),
 }))
 
 vi.mock('../../../../../src/app/flows/flow-run/flow-run-service', () => ({
@@ -328,7 +328,18 @@ describe('agentRpcHandlers.resumeFlowStep — only a flow-step run may release a
         await resume({ id: 'conv-1', source: 'FLOW_STEP', projectId: 'proj-1' })
 
         expect(mockGetFlowRun).toHaveBeenCalledWith({ id: 'run-1', projectId: 'proj-1' })
-        expect(mockResumeFromWaitpoint).toHaveBeenCalledTimes(1)
+        expect(mockResumeFromWaitpoint).toHaveBeenCalledWith({
+            flowRunId: 'run-1',
+            waitpointId: 'wp-1',
+            resumePayload: { body: { success: true }, headers: {}, queryParams: {} },
+        })
+    })
+
+    it('sends an empty queryParams, so this path can never approve anything', async () => {
+        await resume({ id: 'conv-1', source: 'FLOW_STEP', projectId: 'proj-1' })
+
+        const { resumePayload } = mockResumeFromWaitpoint.mock.calls[0][0]
+        expect(resumePayload.queryParams).toEqual({})
     })
 
     it('refuses when the conversation is a chat', async () => {

--- a/packages/server/api/test/unit/app/ee/agent/agent-rpc-handlers.test.ts
+++ b/packages/server/api/test/unit/app/ee/agent/agent-rpc-handlers.test.ts
@@ -298,3 +298,23 @@ describe('agentRpcHandlers.executeAgentTool — the owner\'s own memory is not a
         } as never)).rejects.toThrow()
     })
 })
+
+describe('agentRpcHandlers.resumeFlowStep — only a flow-step run may release a flow', () => {
+    it('refuses when the conversation is a chat', async () => {
+        mockFindOneBy.mockResolvedValue({ id: 'conv-1', source: 'CHAT', projectId: 'proj-1' })
+        const { agentRpcHandlers } = await import('../../../../../src/app/ee/agent/agent-rpc-handlers')
+
+        await expect(agentRpcHandlers(noopLogger as never).resumeFlowStep({
+            conversationId: 'conv-1', flowRunId: 'run-1', waitpointId: 'wp-1', output: { success: true },
+        })).rejects.toThrow()
+    })
+
+    it('refuses when the conversation does not exist', async () => {
+        mockFindOneBy.mockResolvedValue(null)
+        const { agentRpcHandlers } = await import('../../../../../src/app/ee/agent/agent-rpc-handlers')
+
+        await expect(agentRpcHandlers(noopLogger as never).resumeFlowStep({
+            conversationId: 'nope', flowRunId: 'run-1', waitpointId: 'wp-1', output: { success: true },
+        })).rejects.toThrow()
+    })
+})

--- a/packages/server/api/test/unit/app/ee/agent/agent-rpc-handlers.test.ts
+++ b/packages/server/api/test/unit/app/ee/agent/agent-rpc-handlers.test.ts
@@ -1,5 +1,18 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+const { mockGetFlowRun, mockResumeFromWaitpoint } = vi.hoisted(() => ({
+    mockGetFlowRun: vi.fn(),
+    mockResumeFromWaitpoint: vi.fn().mockResolvedValue(undefined),
+}))
+
+vi.mock('../../../../../src/app/flows/flow-run/flow-run-service', () => ({
+    flowRunService: () => ({ getOneOrThrow: mockGetFlowRun }),
+}))
+
+vi.mock('../../../../../src/app/flows/flow-run/waitpoint/resume-service', () => ({
+    resumeService: () => ({ resumeFromWaitpoint: mockResumeFromWaitpoint }),
+}))
+
 const { mockSet, mockWhere, mockAndWhere, mockExecute, mockFindOneBy, mockSave, mockTrack, mockSendConversationUpdate } = vi.hoisted(() => ({
     mockSave: vi.fn(),
     mockSet: vi.fn(),
@@ -300,21 +313,40 @@ describe('agentRpcHandlers.executeAgentTool — the owner\'s own memory is not a
 })
 
 describe('agentRpcHandlers.resumeFlowStep — only a flow-step run may release a flow', () => {
-    it('refuses when the conversation is a chat', async () => {
-        mockFindOneBy.mockResolvedValue({ id: 'conv-1', source: 'CHAT', projectId: 'proj-1' })
+    async function resume(conversation: unknown) {
+        mockResumeFromWaitpoint.mockClear()
+        mockGetFlowRun.mockClear()
+        mockGetFlowRun.mockResolvedValue({ id: 'run-1' })
+        mockFindOneBy.mockResolvedValue(conversation)
         const { agentRpcHandlers } = await import('../../../../../src/app/ee/agent/agent-rpc-handlers')
-
-        await expect(agentRpcHandlers(noopLogger as never).resumeFlowStep({
+        return agentRpcHandlers(noopLogger as never).resumeFlowStep({
             conversationId: 'conv-1', flowRunId: 'run-1', waitpointId: 'wp-1', output: { success: true },
-        })).rejects.toThrow()
+        })
+    }
+
+    it('releases the waitpoint for a flow-step run, scoped to that run\'s own project', async () => {
+        await resume({ id: 'conv-1', source: 'FLOW_STEP', projectId: 'proj-1' })
+
+        expect(mockGetFlowRun).toHaveBeenCalledWith({ id: 'run-1', projectId: 'proj-1' })
+        expect(mockResumeFromWaitpoint).toHaveBeenCalledTimes(1)
+    })
+
+    it('refuses when the conversation is a chat', async () => {
+        await expect(resume({ id: 'conv-1', source: 'CHAT', projectId: 'proj-1' })).rejects.toThrow()
+
+        expect(mockResumeFromWaitpoint).not.toHaveBeenCalled()
     })
 
     it('refuses when the conversation does not exist', async () => {
-        mockFindOneBy.mockResolvedValue(null)
-        const { agentRpcHandlers } = await import('../../../../../src/app/ee/agent/agent-rpc-handlers')
+        await expect(resume(null)).rejects.toThrow()
 
-        await expect(agentRpcHandlers(noopLogger as never).resumeFlowStep({
-            conversationId: 'nope', flowRunId: 'run-1', waitpointId: 'wp-1', output: { success: true },
-        })).rejects.toThrow()
+        expect(mockResumeFromWaitpoint).not.toHaveBeenCalled()
+    })
+
+    it('refuses a flow-step run with no project, so the run lookup is never left unscoped', async () => {
+        await expect(resume({ id: 'conv-1', source: 'FLOW_STEP', projectId: null })).rejects.toThrow()
+
+        expect(mockGetFlowRun).not.toHaveBeenCalled()
+        expect(mockResumeFromWaitpoint).not.toHaveBeenCalled()
     })
 })

--- a/packages/server/worker/src/lib/execute/jobs/ee/agent/execute-agent-run.ts
+++ b/packages/server/worker/src/lib/execute/jobs/ee/agent/execute-agent-run.ts
@@ -34,6 +34,7 @@ const MAX_TURN_WALL_CLOCK_MS = 2 * 60 * 60 * 1_000
 const DISCOVERY_ONLY_NEUTRALIZED_TOOLS = new Set(['ap_execute_action', 'ap_run_code'])
 
 const UNATTENDED_FORBIDDEN_TOOLS = ['ap_run_code']
+const MAX_ANSWER_LENGTH = 51_200
 
 export const executeAgentRunJob: JobHandler<ExecuteAgentRunJobData, FireAndForgetJobResult> = {
     jobType: WorkerJobType.EXECUTE_AGENT_RUN,
@@ -103,9 +104,11 @@ export const executeAgentRunJob: JobHandler<ExecuteAgentRunJobData, FireAndForge
             }
         }
 
-        const cancelCheckInterval = setInterval(() => {
-            checkCancelled().catch(() => {})
-        }, 3_000)
+        const cancelCheckInterval = source === AgentRunSource.CHAT
+            ? setInterval(() => {
+                checkCancelled().catch(() => {})
+            }, 3_000)
+            : undefined
 
         // Continuous liveness signal for the entire turn — covers long tool/LLM steps and
         // approval waits alike, not just gaps between AI-SDK steps. Refreshes connected
@@ -120,7 +123,7 @@ export const executeAgentRunJob: JobHandler<ExecuteAgentRunJobData, FireAndForge
             void tryCatch(() => ctx.apiClient.heartbeatAgentConversation({ conversationId, runId }))
         }
         const heartbeatInterval = setInterval(sendHeartbeat, HEARTBEAT_INTERVAL_MS)
-        let answer: unknown
+        let answer: StepOutcome | undefined
 
         try {
             const phaseState: { phase: AgentPhase } = { phase: 'discovery' }
@@ -226,7 +229,7 @@ export const executeAgentRunJob: JobHandler<ExecuteAgentRunJobData, FireAndForge
                         log.error({ error: retryError, conversation: { id: conversationId } }, 'Cancel save retry also failed')
                     }
                 }
-                await releaseFlowStep({ ctx, conversationId, flowRunId, waitpointId, output: { success: false, error: 'The agent run was stopped before it finished' }, log })
+                await releaseFlowStep({ ctx, conversationId, flowRunId, waitpointId, output: { success: false, error: 'The agent run was stopped before it finished' }, source, log })
                 await sendEventWithRetry({
                     event: { type: AgentEventType.FINISHED, data: { conversationId } },
                 })
@@ -265,8 +268,7 @@ export const executeAgentRunJob: JobHandler<ExecuteAgentRunJobData, FireAndForge
             }
             await retryOnceThenThrow({ operation: () => ctx.apiClient.saveAgentMessages(savePayload), description: 'Saving the transcript', log })
 
-            answer = { success: true, output: agentTextFrom(turn.uiParts) }
-            await releaseFlowStep({ ctx, conversationId, flowRunId, waitpointId, output: answer, log })
+            answer = stepOutcomeFrom({ uiParts, truncatedAfterRetries, budgetExceeded })
 
             if (autoTitle) {
                 await sendEventWithRetry({
@@ -298,7 +300,7 @@ export const executeAgentRunJob: JobHandler<ExecuteAgentRunJobData, FireAndForge
             const clientMessage = !isCreditError && isTransientFailureText(errorMessage)
                 ? 'The AI provider is temporarily unavailable. Please try again in a moment.'
                 : errorMessage
-            const { error: releaseError } = await tryCatch(() => releaseFlowStep({ ctx, conversationId, flowRunId, waitpointId, output: answer ?? { success: false, error: clientMessage }, log }))
+            const { error: releaseError } = await tryCatch(() => releaseFlowStep({ ctx, conversationId, flowRunId, waitpointId, output: answer ?? { success: false, error: clientMessage }, source, log }))
             // Empty arrays here mean "mark this turn ERROR" — they do NOT wipe history. The
             // saveAgentMessages handler's no-shrink guard preserves whatever was persisted
             // incrementally (updateAgentProgress) and only flips status, so an errored turn keeps
@@ -334,8 +336,23 @@ export const executeAgentRunJob: JobHandler<ExecuteAgentRunJobData, FireAndForge
             }
         }
 
+        await releaseFlowStep({ ctx, conversationId, flowRunId, waitpointId, output: answer, source, log })
         return { kind: JobResultKind.FIRE_AND_FORGET, status: EngineResponseStatus.OK }
     },
+}
+
+export function stepOutcomeFrom({ uiParts, truncatedAfterRetries, budgetExceeded }: {
+    uiParts: PersistedAgentPart[]
+    truncatedAfterRetries: boolean
+    budgetExceeded: boolean
+}): StepOutcome {
+    if (truncatedAfterRetries) {
+        return { success: false, error: 'The response reached the output limit before the agent finished' }
+    }
+    if (budgetExceeded) {
+        return { success: false, error: 'The run reached its usage limit and was stopped' }
+    }
+    return { success: true, output: agentTextFrom(uiParts).slice(0, MAX_ANSWER_LENGTH) }
 }
 
 function agentTextFrom(parts: PersistedAgentPart[]): string {
@@ -346,21 +363,25 @@ function agentTextFrom(parts: PersistedAgentPart[]): string {
         .trim()
 }
 
-async function releaseFlowStep({ ctx, conversationId, flowRunId, waitpointId, output, log }: {
+async function releaseFlowStep({ ctx, conversationId, flowRunId, waitpointId, output, source, log }: {
     ctx: JobContext
     conversationId: string
     flowRunId?: string
     waitpointId?: string
     output: unknown
+    source: AgentRunSource
     log: JobContext['log']
 }): Promise<void> {
     if (isNil(flowRunId) || isNil(waitpointId)) {
+        if (source === AgentRunSource.FLOW_STEP) {
+            log.error({ flowRun: isNil(flowRunId) ? undefined : { id: flowRunId }, waitpoint: isNil(waitpointId) ? undefined : { id: waitpointId } }, '[executeAgentRun] Flow-step run has nothing to release; the flow will stay paused')
+        }
         return
     }
     await retryOnceThenThrow({
         operation: () => ctx.apiClient.resumeFlowStep({ conversationId, flowRunId, waitpointId, output }),
         description: 'Handing the result back to the flow',
-        log: log.child({ flowRun: { id: flowRunId } }),
+        log: log.child({ flowRun: { id: flowRunId }, waitpoint: { id: waitpointId } }),
     })
 }
 
@@ -721,3 +742,7 @@ async function retryWithBackoff({ fn, maxAttempts = RETRY_MAX_ATTEMPTS, log }: {
     }
 }
 
+
+export type StepOutcome =
+    | { success: true, output: string }
+    | { success: false, error: string }

--- a/packages/server/worker/src/lib/execute/jobs/ee/agent/execute-agent-run.ts
+++ b/packages/server/worker/src/lib/execute/jobs/ee/agent/execute-agent-run.ts
@@ -120,7 +120,7 @@ export const executeAgentRunJob: JobHandler<ExecuteAgentRunJobData, FireAndForge
             void tryCatch(() => ctx.apiClient.heartbeatAgentConversation({ conversationId, runId }))
         }
         const heartbeatInterval = setInterval(sendHeartbeat, HEARTBEAT_INTERVAL_MS)
-        let answerDeliveryAttempted = false
+        let answer: unknown
 
         try {
             const phaseState: { phase: AgentPhase } = { phase: 'discovery' }
@@ -264,8 +264,8 @@ export const executeAgentRunJob: JobHandler<ExecuteAgentRunJobData, FireAndForge
             }
             await retryOnceThenThrow({ operation: () => ctx.apiClient.saveAgentMessages(savePayload), description: 'Saving the transcript', log })
 
-            answerDeliveryAttempted = true
-            await releaseFlowStep({ ctx, conversationId, flowRunId, waitpointId, output: { success: true, output: agentTextFrom(turn.uiParts) }, log })
+            answer = { success: true, output: agentTextFrom(turn.uiParts) }
+            await releaseFlowStep({ ctx, conversationId, flowRunId, waitpointId, output: answer, log })
 
             if (autoTitle) {
                 await sendEventWithRetry({
@@ -297,9 +297,7 @@ export const executeAgentRunJob: JobHandler<ExecuteAgentRunJobData, FireAndForge
             const clientMessage = !isCreditError && isTransientFailureText(errorMessage)
                 ? 'The AI provider is temporarily unavailable. Please try again in a moment.'
                 : errorMessage
-            if (!answerDeliveryAttempted) {
-                await tryCatch(() => releaseFlowStep({ ctx, conversationId, flowRunId, waitpointId, output: { success: false, error: clientMessage }, log }))
-            }
+            await tryCatch(() => releaseFlowStep({ ctx, conversationId, flowRunId, waitpointId, output: answer ?? { success: false, error: clientMessage }, log }))
             // Empty arrays here mean "mark this turn ERROR" — they do NOT wipe history. The
             // saveAgentMessages handler's no-shrink guard preserves whatever was persisted
             // incrementally (updateAgentProgress) and only flips status, so an errored turn keeps

--- a/packages/server/worker/src/lib/execute/jobs/ee/agent/execute-agent-run.ts
+++ b/packages/server/worker/src/lib/execute/jobs/ee/agent/execute-agent-run.ts
@@ -120,6 +120,7 @@ export const executeAgentRunJob: JobHandler<ExecuteAgentRunJobData, FireAndForge
             void tryCatch(() => ctx.apiClient.heartbeatAgentConversation({ conversationId, runId }))
         }
         const heartbeatInterval = setInterval(sendHeartbeat, HEARTBEAT_INTERVAL_MS)
+        let answerDeliveryAttempted = false
 
         try {
             const phaseState: { phase: AgentPhase } = { phase: 'discovery' }
@@ -263,6 +264,7 @@ export const executeAgentRunJob: JobHandler<ExecuteAgentRunJobData, FireAndForge
             }
             await retryOnceThenThrow({ operation: () => ctx.apiClient.saveAgentMessages(savePayload), description: 'Saving the transcript', log })
 
+            answerDeliveryAttempted = true
             await releaseFlowStep({ ctx, conversationId, flowRunId, waitpointId, output: { success: true, output: agentTextFrom(turn.uiParts) }, log })
 
             if (autoTitle) {
@@ -295,7 +297,9 @@ export const executeAgentRunJob: JobHandler<ExecuteAgentRunJobData, FireAndForge
             const clientMessage = !isCreditError && isTransientFailureText(errorMessage)
                 ? 'The AI provider is temporarily unavailable. Please try again in a moment.'
                 : errorMessage
-            await tryCatch(() => releaseFlowStep({ ctx, conversationId, flowRunId, waitpointId, output: { success: false, error: clientMessage }, log }))
+            if (!answerDeliveryAttempted) {
+                await tryCatch(() => releaseFlowStep({ ctx, conversationId, flowRunId, waitpointId, output: { success: false, error: clientMessage }, log }))
+            }
             // Empty arrays here mean "mark this turn ERROR" — they do NOT wipe history. The
             // saveAgentMessages handler's no-shrink guard preserves whatever was persisted
             // incrementally (updateAgentProgress) and only flips status, so an errored turn keeps

--- a/packages/server/worker/src/lib/execute/jobs/ee/agent/execute-agent-run.ts
+++ b/packages/server/worker/src/lib/execute/jobs/ee/agent/execute-agent-run.ts
@@ -297,7 +297,7 @@ export const executeAgentRunJob: JobHandler<ExecuteAgentRunJobData, FireAndForge
             })
         }
         catch (err) {
-            await releaseFlowStep({ ctx, conversationId, flowRunId, waitpointId, output: { success: false, error: err instanceof Error ? err.message : 'The agent run failed' }, log })
+            await tryCatch(() => releaseFlowStep({ ctx, conversationId, flowRunId, waitpointId, output: { success: false, error: err instanceof Error ? err.message : 'The agent run failed' }, log }))
             log.error({ error: err, conversation: { id: conversationId } }, '[executeAgentRun] Agent job failed')
             const errorMessage = err instanceof Error ? err.message : 'An unexpected error occurred'
             const isCreditError = isCreditExhaustedError(errorMessage)
@@ -360,10 +360,19 @@ async function releaseFlowStep({ ctx, conversationId, flowRunId, waitpointId, ou
     if (isNil(flowRunId) || isNil(waitpointId)) {
         return
     }
-    const { error } = await tryCatch(() => ctx.apiClient.resumeFlowStep({ conversationId, flowRunId, waitpointId, output }))
-    if (error) {
-        log.error({ error, flowRun: { id: flowRunId } }, '[executeAgentRun] Could not hand the result back; the step waits for its own timeout')
+    const resume = () => ctx.apiClient.resumeFlowStep({ conversationId, flowRunId, waitpointId, output })
+    const { error } = await tryCatch(resume)
+    if (isNil(error)) {
+        return
     }
+    log.warn({ error, flowRun: { id: flowRunId } }, '[executeAgentRun] First resume attempt failed, retrying')
+    await new Promise((resolve) => setTimeout(resolve, 1_000))
+    const { error: retryError } = await tryCatch(resume)
+    if (isNil(retryError)) {
+        return
+    }
+    log.error({ error: retryError, flowRun: { id: flowRunId } }, '[executeAgentRun] Could not release the step; failing the job so it is not recorded as done')
+    throw retryError
 }
 
 function buildToolSet({ ctx, eventEmitter, log, phaseState, taintState, mcpToolSet, webTools, projects, projectId, conversationId, runId, platformId, userId, userEmail, guides, dryRun, discoveryOnly, emailEnabled, abortSignal, source }: {

--- a/packages/server/worker/src/lib/execute/jobs/ee/agent/execute-agent-run.ts
+++ b/packages/server/worker/src/lib/execute/jobs/ee/agent/execute-agent-run.ts
@@ -226,6 +226,7 @@ export const executeAgentRunJob: JobHandler<ExecuteAgentRunJobData, FireAndForge
                         log.error({ error: retryError, conversation: { id: conversationId } }, 'Cancel save retry also failed')
                     }
                 }
+                await releaseFlowStep({ ctx, conversationId, flowRunId, waitpointId, output: { success: false, error: 'The agent run was stopped before it finished' }, log })
                 await sendEventWithRetry({
                     event: { type: AgentEventType.FINISHED, data: { conversationId } },
                 })

--- a/packages/server/worker/src/lib/execute/jobs/ee/agent/execute-agent-run.ts
+++ b/packages/server/worker/src/lib/execute/jobs/ee/agent/execute-agent-run.ts
@@ -298,7 +298,7 @@ export const executeAgentRunJob: JobHandler<ExecuteAgentRunJobData, FireAndForge
             const clientMessage = !isCreditError && isTransientFailureText(errorMessage)
                 ? 'The AI provider is temporarily unavailable. Please try again in a moment.'
                 : errorMessage
-            await tryCatch(() => releaseFlowStep({ ctx, conversationId, flowRunId, waitpointId, output: answer ?? { success: false, error: clientMessage }, log }))
+            const { error: releaseError } = await tryCatch(() => releaseFlowStep({ ctx, conversationId, flowRunId, waitpointId, output: answer ?? { success: false, error: clientMessage }, log }))
             // Empty arrays here mean "mark this turn ERROR" — they do NOT wipe history. The
             // saveAgentMessages handler's no-shrink guard preserves whatever was persisted
             // incrementally (updateAgentProgress) and only flips status, so an errored turn keeps
@@ -316,7 +316,10 @@ export const executeAgentRunJob: JobHandler<ExecuteAgentRunJobData, FireAndForge
             // already been delivered to the user. Complete the job (OK); re-throwing would mark it
             // INTERNAL_ERROR and fail+retry it (pointlessly — the user is still out of credits) and page.
             if (isCreditError) {
-                return { kind: JobResultKind.FIRE_AND_FORGET, status: EngineResponseStatus.OK }
+                if (isNil(releaseError)) {
+                    return { kind: JobResultKind.FIRE_AND_FORGET, status: EngineResponseStatus.OK }
+                }
+                throw releaseError
             }
             throw err
         }

--- a/packages/server/worker/src/lib/execute/jobs/ee/agent/execute-agent-run.ts
+++ b/packages/server/worker/src/lib/execute/jobs/ee/agent/execute-agent-run.ts
@@ -35,6 +35,7 @@ const DISCOVERY_ONLY_NEUTRALIZED_TOOLS = new Set(['ap_execute_action', 'ap_run_c
 
 const UNATTENDED_FORBIDDEN_TOOLS = ['ap_run_code']
 const MAX_ANSWER_LENGTH = 51_200
+const DELIVERY_MAX_ATTEMPTS = 5
 
 export const executeAgentRunJob: JobHandler<ExecuteAgentRunJobData, FireAndForgetJobResult> = {
     jobType: WorkerJobType.EXECUTE_AGENT_RUN,
@@ -266,7 +267,7 @@ export const executeAgentRunJob: JobHandler<ExecuteAgentRunJobData, FireAndForge
                 ...spreadIfDefined('title', autoTitle),
                 ...spreadIfDefined('modelName', isNil(data.modelName) ? config.tier.id : undefined),
             }
-            await retryOnceThenThrow({ operation: () => ctx.apiClient.saveAgentMessages(savePayload), description: 'Saving the transcript', log })
+            await retryWithBackoff({ fn: () => ctx.apiClient.saveAgentMessages(savePayload), description: 'Saving the transcript', throwOnExhausted: true, log })
 
             answer = stepOutcomeFrom({ uiParts, truncatedAfterRetries, budgetExceeded })
 
@@ -378,31 +379,15 @@ async function releaseFlowStep({ ctx, conversationId, flowRunId, waitpointId, ou
         }
         return
     }
-    await retryOnceThenThrow({
-        operation: () => ctx.apiClient.resumeFlowStep({ conversationId, flowRunId, waitpointId, output }),
+    await retryWithBackoff({
+        fn: () => ctx.apiClient.resumeFlowStep({ conversationId, flowRunId, waitpointId, output }),
+        maxAttempts: DELIVERY_MAX_ATTEMPTS,
         description: 'Handing the result back to the flow',
+        throwOnExhausted: true,
         log: log.child({ flowRun: { id: flowRunId }, waitpoint: { id: waitpointId } }),
     })
 }
 
-async function retryOnceThenThrow({ operation, description, log }: {
-    operation: () => Promise<unknown>
-    description: string
-    log: JobContext['log']
-}): Promise<void> {
-    const { error } = await tryCatch(operation)
-    if (isNil(error)) {
-        return
-    }
-    log.warn({ error }, `[executeAgentRun] ${description} failed, retrying`)
-    await new Promise((resolve) => setTimeout(resolve, 1_000))
-    const { error: retryError } = await tryCatch(operation)
-    if (isNil(retryError)) {
-        return
-    }
-    log.error({ error: retryError }, `[executeAgentRun] ${description} failed again, failing the job`)
-    throw retryError
-}
 
 function buildToolSet({ ctx, eventEmitter, log, phaseState, taintState, mcpToolSet, webTools, projects, projectId, conversationId, runId, platformId, userId, userEmail, guides, dryRun, discoveryOnly, emailEnabled, abortSignal, source }: {
     ctx: JobContext
@@ -726,16 +711,21 @@ function waitForAbort(signal: AbortSignal): Promise<void> {
     })
 }
 
-async function retryWithBackoff({ fn, maxAttempts = RETRY_MAX_ATTEMPTS, log }: {
-    fn: () => Promise<void>
+async function retryWithBackoff({ fn, maxAttempts = RETRY_MAX_ATTEMPTS, description = 'Operation', throwOnExhausted = false, log }: {
+    fn: () => Promise<unknown>
     maxAttempts?: number
+    description?: string
+    throwOnExhausted?: boolean
     log?: { warn: (obj: Record<string, unknown>, msg: string) => void }
 }): Promise<void> {
     for (let attempt = 1; attempt <= maxAttempts; attempt++) {
         const { error } = await tryCatch(fn)
         if (!error) return
         if (attempt === maxAttempts) {
-            log?.warn({ error, attempt }, 'All retry attempts exhausted')
+            log?.warn({ error, attempt }, `[executeAgentRun] ${description} failed after every attempt`)
+            if (throwOnExhausted) {
+                throw error
+            }
             return
         }
         await delayWithJitter(RETRY_BASE_DELAY_MS * Math.pow(2, attempt - 1))

--- a/packages/server/worker/src/lib/execute/jobs/ee/agent/execute-agent-run.ts
+++ b/packages/server/worker/src/lib/execute/jobs/ee/agent/execute-agent-run.ts
@@ -261,16 +261,7 @@ export const executeAgentRunJob: JobHandler<ExecuteAgentRunJobData, FireAndForge
                 ...spreadIfDefined('title', autoTitle),
                 ...spreadIfDefined('modelName', isNil(data.modelName) ? config.tier.id : undefined),
             }
-            const { error: saveError } = await tryCatch(() => ctx.apiClient.saveAgentMessages(savePayload))
-            if (saveError) {
-                log.warn({ error: saveError, conversation: { id: conversationId } }, 'First saveAgentMessages attempt failed, retrying')
-                await new Promise((resolve) => setTimeout(resolve, 1_000))
-                const { error: retryError } = await tryCatch(() => ctx.apiClient.saveAgentMessages(savePayload))
-                if (retryError) {
-                    log.error({ error: retryError, conversation: { id: conversationId } }, 'saveAgentMessages retry also failed')
-                    throw retryError
-                }
-            }
+            await retryOnceThenThrow({ operation: () => ctx.apiClient.saveAgentMessages(savePayload), description: 'Saving the transcript', log })
 
             await releaseFlowStep({ ctx, conversationId, flowRunId, waitpointId, output: { success: true, output: agentTextFrom(turn.uiParts) }, log })
 
@@ -297,7 +288,6 @@ export const executeAgentRunJob: JobHandler<ExecuteAgentRunJobData, FireAndForge
             })
         }
         catch (err) {
-            await tryCatch(() => releaseFlowStep({ ctx, conversationId, flowRunId, waitpointId, output: { success: false, error: err instanceof Error ? err.message : 'The agent run failed' }, log }))
             log.error({ error: err, conversation: { id: conversationId } }, '[executeAgentRun] Agent job failed')
             const errorMessage = err instanceof Error ? err.message : 'An unexpected error occurred'
             const isCreditError = isCreditExhaustedError(errorMessage)
@@ -305,6 +295,7 @@ export const executeAgentRunJob: JobHandler<ExecuteAgentRunJobData, FireAndForge
             const clientMessage = !isCreditError && isTransientFailureText(errorMessage)
                 ? 'The AI provider is temporarily unavailable. Please try again in a moment.'
                 : errorMessage
+            await tryCatch(() => releaseFlowStep({ ctx, conversationId, flowRunId, waitpointId, output: { success: false, error: clientMessage }, log }))
             // Empty arrays here mean "mark this turn ERROR" — they do NOT wipe history. The
             // saveAgentMessages handler's no-shrink guard preserves whatever was persisted
             // incrementally (updateAgentProgress) and only flips status, so an errored turn keeps
@@ -360,18 +351,29 @@ async function releaseFlowStep({ ctx, conversationId, flowRunId, waitpointId, ou
     if (isNil(flowRunId) || isNil(waitpointId)) {
         return
     }
-    const resume = () => ctx.apiClient.resumeFlowStep({ conversationId, flowRunId, waitpointId, output })
-    const { error } = await tryCatch(resume)
+    await retryOnceThenThrow({
+        operation: () => ctx.apiClient.resumeFlowStep({ conversationId, flowRunId, waitpointId, output }),
+        description: 'Handing the result back to the flow',
+        log: log.child({ flowRun: { id: flowRunId } }),
+    })
+}
+
+async function retryOnceThenThrow({ operation, description, log }: {
+    operation: () => Promise<unknown>
+    description: string
+    log: JobContext['log']
+}): Promise<void> {
+    const { error } = await tryCatch(operation)
     if (isNil(error)) {
         return
     }
-    log.warn({ error, flowRun: { id: flowRunId } }, '[executeAgentRun] First resume attempt failed, retrying')
+    log.warn({ error }, `[executeAgentRun] ${description} failed, retrying`)
     await new Promise((resolve) => setTimeout(resolve, 1_000))
-    const { error: retryError } = await tryCatch(resume)
+    const { error: retryError } = await tryCatch(operation)
     if (isNil(retryError)) {
         return
     }
-    log.error({ error: retryError, flowRun: { id: flowRunId } }, '[executeAgentRun] Could not release the step; failing the job so it is not recorded as done')
+    log.error({ error: retryError }, `[executeAgentRun] ${description} failed again, failing the job`)
     throw retryError
 }
 

--- a/packages/server/worker/src/lib/execute/jobs/ee/agent/execute-agent-run.ts
+++ b/packages/server/worker/src/lib/execute/jobs/ee/agent/execute-agent-run.ts
@@ -1,6 +1,6 @@
 import { AIProviderName, ErrorCode, isNil, isObject, omit, spreadIfDefined, tryCatch, tryCatchSync } from '@activepieces/core-utils'
 import { agentAiUtils } from '@activepieces/server-utils'
-import { AgentEvent, AgentEventType, AgentPhase, AgentRunSource, EngineResponseStatus, ExecuteAgentRunJobData, PersistedAgentMessage, PersistedAgentRole, WorkerJobType } from '@activepieces/shared'
+import { AgentEvent, AgentEventType, AgentPhase, AgentRunSource, EngineResponseStatus, ExecuteAgentRunJobData, PersistedAgentMessage, PersistedAgentPart, PersistedAgentPartType, PersistedAgentRole, WorkerJobType } from '@activepieces/shared'
 import { createUIMessageStream, generateText, ModelMessage, streamText, ToolSet, toUIMessageStream } from 'ai'
 import { FireAndForgetJobResult, JobContext, JobHandler, JobResultKind } from '../../../types'
 import { agentMcpClient } from './agent-mcp-client'
@@ -38,7 +38,7 @@ const UNATTENDED_FORBIDDEN_TOOLS = ['ap_run_code']
 export const executeAgentRunJob: JobHandler<ExecuteAgentRunJobData, FireAndForgetJobResult> = {
     jobType: WorkerJobType.EXECUTE_AGENT_RUN,
     async execute(ctx: JobContext, data: ExecuteAgentRunJobData): Promise<FireAndForgetJobResult> {
-        const { conversationId, runId, projectId, platformId, userId, userMessage, modelName, files, promptOverride, dryRun, discoveryOnly, source: jobSource } = data
+        const { conversationId, runId, projectId, platformId, userId, userMessage, modelName, files, promptOverride, dryRun, discoveryOnly, source: jobSource, flowRunId, waitpointId } = data
         const log = ctx.log.child({ conversation: { id: conversationId }, ...spreadIfDefined('run', isNil(runId) ? undefined : { id: runId }) })
 
         const config = await ctx.apiClient.getAgentConfig({
@@ -272,6 +272,8 @@ export const executeAgentRunJob: JobHandler<ExecuteAgentRunJobData, FireAndForge
                 }
             }
 
+            await releaseFlowStep({ ctx, conversationId, flowRunId, waitpointId, output: { success: true, output: agentTextFrom(turn.uiParts) }, log })
+
             if (autoTitle) {
                 await sendEventWithRetry({
                     event: { type: AgentEventType.TITLE_UPDATE, data: { title: autoTitle } },
@@ -295,6 +297,7 @@ export const executeAgentRunJob: JobHandler<ExecuteAgentRunJobData, FireAndForge
             })
         }
         catch (err) {
+            await releaseFlowStep({ ctx, conversationId, flowRunId, waitpointId, output: { success: false, error: err instanceof Error ? err.message : 'The agent run failed' }, log })
             log.error({ error: err, conversation: { id: conversationId } }, '[executeAgentRun] Agent job failed')
             const errorMessage = err instanceof Error ? err.message : 'An unexpected error occurred'
             const isCreditError = isCreditExhaustedError(errorMessage)
@@ -336,6 +339,31 @@ export const executeAgentRunJob: JobHandler<ExecuteAgentRunJobData, FireAndForge
 
         return { kind: JobResultKind.FIRE_AND_FORGET, status: EngineResponseStatus.OK }
     },
+}
+
+function agentTextFrom(parts: PersistedAgentPart[]): string {
+    return parts
+        .filter((part) => part.type === PersistedAgentPartType.TEXT)
+        .map((part) => part.text)
+        .join('\n')
+        .trim()
+}
+
+async function releaseFlowStep({ ctx, conversationId, flowRunId, waitpointId, output, log }: {
+    ctx: JobContext
+    conversationId: string
+    flowRunId?: string
+    waitpointId?: string
+    output: unknown
+    log: JobContext['log']
+}): Promise<void> {
+    if (isNil(flowRunId) || isNil(waitpointId)) {
+        return
+    }
+    const { error } = await tryCatch(() => ctx.apiClient.resumeFlowStep({ conversationId, flowRunId, waitpointId, output }))
+    if (error) {
+        log.error({ error, flowRun: { id: flowRunId } }, '[executeAgentRun] Could not hand the result back; the step waits for its own timeout')
+    }
 }
 
 function buildToolSet({ ctx, eventEmitter, log, phaseState, taintState, mcpToolSet, webTools, projects, projectId, conversationId, runId, platformId, userId, userEmail, guides, dryRun, discoveryOnly, emailEnabled, abortSignal, source }: {

--- a/packages/server/worker/test/lib/execute/jobs/ee/agent/execute-agent-run.test.ts
+++ b/packages/server/worker/test/lib/execute/jobs/ee/agent/execute-agent-run.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest'
+import { stepOutcomeFrom } from '../../../../../../src/lib/execute/jobs/ee/agent/execute-agent-run'
 import { decideLoopAction, shouldRetryStream } from '../../../../../../src/lib/execute/jobs/ee/agent/run-agent-turn'
 
 describe('decideLoopAction', () => {
@@ -41,5 +42,32 @@ describe('shouldRetryStream', () => {
 
     it('never retries once visible output was already streamed (avoids duplicate content)', () => {
         expect(shouldRetryStream({ producedVisibleOutput: true, streamRetries: 0 })).toBe(false)
+    })
+})
+
+describe('stepOutcomeFrom', () => {
+    const text = (value: string) => ({ type: 'text' as const, text: value })
+
+    it('hands back the agent text when the turn finished properly', () => {
+        expect(stepOutcomeFrom({ uiParts: [text('done')], truncatedAfterRetries: false, budgetExceeded: false }))
+            .toEqual({ success: true, output: 'done' })
+    })
+
+    it('reports a truncated turn as a failure rather than passing off a half answer', () => {
+        const outcome = stepOutcomeFrom({ uiParts: [text('half an ans')], truncatedAfterRetries: true, budgetExceeded: false })
+
+        expect(outcome.success).toBe(false)
+    })
+
+    it('reports a turn stopped on budget as a failure', () => {
+        const outcome = stepOutcomeFrom({ uiParts: [text('partial')], truncatedAfterRetries: false, budgetExceeded: true })
+
+        expect(outcome.success).toBe(false)
+    })
+
+    it('caps the answer so an unbounded one cannot be written into the resume payload', () => {
+        const outcome = stepOutcomeFrom({ uiParts: [text('x'.repeat(80_000))], truncatedAfterRetries: false, budgetExceeded: false })
+
+        expect(outcome.success && outcome.output.length).toBe(51_200)
     })
 })


### PR DESCRIPTION
## Description

The run had no way to finish. The job carried a `resumeUrl` that nothing read, so a flow step would have created a waitpoint and waited on something that never came.

This closes the loop. When a flow-step turn ends, the worker asks the API to release the waitpoint and hands back the agent's answer.

## The callback is gone, not filtered

The obvious shape was a POST to the `resumeUrl` the piece supplies. That would have meant a caller-supplied URL, dereferenced server-side, needing `safeHttp` plus a check that the host is our own, and getting either wrong fails open.

`resumeService.resumeFromWaitpoint({ flowRunId, waitpointId, resumePayload })` already exists, and the worker already has an authenticated RPC channel to the API. So the job now carries the waitpoint's identity instead of a URL, and the resume happens in-process. There is no URL to dereference, so there is no SSRF question to answer and no allowlist to keep correct.

The handler checks the conversation is a `FLOW_STEP` run and loads the flow run **scoped to that conversation's project**, so a job payload naming another tenant's flow run finds nothing.

## Failure releases the step too

If the run throws, the step is released with the error rather than left waiting. `EXECUTE_AGENT_RUN` is enqueued with `attempts: 1`, so a failed run is never retried, and a `WEBHOOK` waitpoint has no deadline of its own to fall back on. A step that fails is honest, a step that hangs is not.

The same applies to a run stopped by the turn wall clock. That branch completes the job as `OK`, so without releasing the step it would report success while the flow waited forever. Every exit that completes the job now releases first.

## When the answer cannot be delivered

Delivery retries once. The error path retries the same answer rather than replacing it, so a run that succeeded is never recorded as a failure with its answer discarded. The failure payload is only sent when there is no answer to send.

Delivering the answer happens after the try/catch, so a delivery blip on a run that worked does not flip the conversation to ERROR, push an error to the client, and fail the job for something that succeeded.

No exit completes the job as `OK` unless the step was released. That covers the normal path, the wall-clock abort, and credit exhaustion, which previously returned `OK` with the delivery error discarded.

A truncated or budget-stopped turn is reported as a failure rather than handed to the flow as a complete answer, and the answer is capped before it is written into the resume payload.

If every attempt fails the job fails, leaving the flow paused. That is the same state a killed worker leaves, and neither can be closed by retrying harder here, because in both cases the worker has nothing left to say. Closing it needs a deadline on the step itself, and a `WEBHOOK` waitpoint has none today: `resumeDateTime` only schedules a resume for `PauseType.DELAY`.

That deadline belongs to the piece, which is what creates the waitpoint, so it is a requirement on that PR rather than this one. Nothing calls this endpoint yet, so no flow can reach that state in the meantime.

## Unattended limits are enforced where they act

Review turned up capabilities that a flow-step run was kept away from only because the worker declined to build the tool. The server would still have run them. Email and `ap_run_code` are now refused by the handler that acts, and the email check reads `conversation.source` from the row rather than a field the caller supplies.

`confinedProjectFor` returned `null` for a conversation with no project, and the tool layer reads `null` as no confinement, meaning every project the owner can see. It now refuses, matching `resumeFlowStep`, which already fails closed on the same invariant. Conversation adoption also checks the row is a flow-step run before a flow-step job may inherit it.

None of these were reachable, since the endpoint always supplies a project and nothing calls it yet. They are fixed because they all failed open on a tenant boundary.

## Debugging a flow that is still waiting

The handler used to log that it had handed the result back even when the waitpoint was already gone, so the one line that sounded like the answer was the one you could not trust. It now warns instead, with the waitpoint id. The worker logs an error when a flow-step run reaches the end with nothing to release, which is the case that previously produced no output at all.

## Also here

The instruction is capped at 51200 characters, matching chat. `flowRunId` and `waitpointId` are validated as `ApId`, the same as every other resume surface, and the answer is sanitized before it reaches the waitpoint's jsonb payload so a null byte in model output cannot fail the insert. Cancel polling is chat-only now, so a flow-step run no longer issues a rejected chat-only RPC every three seconds for its whole life.

## How was this tested?

- 91 API unit tests. Five cover `resumeFlowStep`: it releases the waitpoint scoped to the run's own project with an empty `queryParams`, and it refuses a chat conversation, a missing conversation, and a flow-step run with no project. All three refusal tests were confirmed to fail with the guard removed, so they are not passing by accident.
- 83 worker unit tests, including the outcome shape for a normal, truncated, budget-stopped, and oversized answer.
- 38 integration tests against a real database under `AP_EDITION=cloud`, 6 of them on this endpoint.
- `turbo run build` across api and worker, `npm run lint-dev` 0 errors, `check-migrations` no drift.
- Two adversarial reviews of the resume path. Both landed on the same conclusion: resuming by `(flowRunId, waitpointId)` is already an unauthenticated public capability at `resume-controller.ts`, where the waitpoint id is the bearer token by design, so this RPC is strictly weaker than a plain HTTP request. The waitpoint is bound to its run in SQL, and `queryParams` is hardcoded empty while the approval piece reads only `queryParams['action']`, so this path cannot approve anything.

## Status

Draft. The piece is the last link: it needs to create the waitpoint, call `POST /v1/agents/runs` with the waitpoint's ids, and suspend. That is the risky half, since published flows pin their piece version, so it gets its own review.

Fixes # (issue)

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

The request body of `/v1/agents/runs` changes shape, but the endpoint shipped days ago with no caller in or out of the repo, so nothing can be depending on it.

### Security impact?  (required — CI fails if this is left unedited)

- [ ] no — reviewed, no security impact
- [x] yes — security-sensitive (call out the risk and mitigation in the description above)

It adds a way for a worker to release a paused flow run. The mitigations are above: the RPC is worker-authenticated with no HTTP surface, the conversation must be a flow-step run, and the flow run is loaded scoped to that conversation's project. Flagged so it is read with that in mind. It also removes a planned SSRF surface rather than adding one.

