### PR TITLE
Feat/pie 373 output schemas youtrack pinterest math helper

### DIFF
--- a/packages/pieces/community/pinterest/package.json
+++ b/packages/pieces/community/pinterest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-pinterest",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {

--- a/packages/pieces/community/pinterest/src/lib/actions/create-board.ts
+++ b/packages/pieces/community/pinterest/src/lib/actions/create-board.ts
@@ -7,10 +7,12 @@ import { makeRequest } from '../common';
 import { pinterestAuth } from '../common/auth';
 import { HttpMethod, getAccessTokenOrThrow } from '@activepieces/pieces-common';
 import { adAccountIdDropdown } from '../common/props';
+import { createBoardActionOutputSchema } from '../output-schemas';
 
 export const createBoard = createAction({
   auth: pinterestAuth,
   name: 'createBoard',
+  outputSchema: createBoardActionOutputSchema,
   displayName: 'Create Board',
   description: 'Create a new Pinterest board for organizing Pins.',
   audience: 'both',

--- a/packages/pieces/community/pinterest/src/lib/actions/create-pin.ts
+++ b/packages/pieces/community/pinterest/src/lib/actions/create-pin.ts
@@ -12,10 +12,12 @@ import {
   boardSectionIdDropdown,
   pinIdMultiSelectDropdown,
 } from '../common/props';
+import { createPinActionOutputSchema } from '../output-schemas';
 
 export const createPin = createAction({
   auth: pinterestAuth,
   name: 'createPin',
+  outputSchema: createPinActionOutputSchema,
   displayName: 'Create Pin',
   description: 'Upload an image or video to create a new Pin on a board.',
   audience: 'both',

--- a/packages/pieces/community/pinterest/src/lib/actions/delete-pin.ts
+++ b/packages/pieces/community/pinterest/src/lib/actions/delete-pin.ts
@@ -7,10 +7,12 @@ import { makeRequest } from '../common';
 import { pinterestAuth } from '../common/auth';
 import { HttpMethod, getAccessTokenOrThrow } from '@activepieces/pieces-common';
 import { adAccountIdDropdown, pinIdDropdown } from '../common/props';
+import { deletePinActionOutputSchema } from '../output-schemas';
 
 export const deletePin = createAction({
   auth: pinterestAuth,
   name: 'deletePin',
+  outputSchema: deletePinActionOutputSchema,
   displayName: 'Delete Pin',
   description: 'Permanently delete a specific Pin.',
   audience: 'both',
@@ -31,11 +33,7 @@ export const deletePin = createAction({
       path = `/pins/${pin_id}?ad_account_id=${ad_account_id}`;
     }
 
-    const response = await makeRequest(
-      getAccessTokenOrThrow(auth),
-      HttpMethod.DELETE,
-      path
-    );
+    await makeRequest(getAccessTokenOrThrow(auth), HttpMethod.DELETE, path);
 
     return {
       success: true,

--- a/packages/pieces/community/pinterest/src/lib/actions/find-board-by-name.ts
+++ b/packages/pieces/community/pinterest/src/lib/actions/find-board-by-name.ts
@@ -7,10 +7,12 @@ import { makeRequest } from '../common';
 import { pinterestAuth } from '../common/auth';
 import { HttpMethod, getAccessTokenOrThrow } from '@activepieces/pieces-common';
 import { adAccountIdDropdown } from '../common/props';
+import { findBoardByNameActionOutputSchema } from '../output-schemas';
 
 export const findBoardByName = createAction({
   auth: pinterestAuth,
   name: 'findBoardByName',
+  outputSchema: findBoardByNameActionOutputSchema,
   displayName: 'Find Board by Name',
   description: "Search for boards by name using Pinterest's search API.",
   audience: 'both',

--- a/packages/pieces/community/pinterest/src/lib/actions/find-pin.ts
+++ b/packages/pieces/community/pinterest/src/lib/actions/find-pin.ts
@@ -7,10 +7,12 @@ import { makeRequest } from '../common';
 import { pinterestAuth } from '../common/auth';
 import { HttpMethod, getAccessTokenOrThrow } from '@activepieces/pieces-common';
 import { adAccountIdDropdown } from '../common/props';
+import { findPinActionOutputSchema } from '../output-schemas';
 
 export const findPin = createAction({
   auth: pinterestAuth,
   name: 'findPin',
+  outputSchema: findPinActionOutputSchema,
   displayName: 'Find Pin by Title/Keyword',
   description: 'Search for Pins using title, description, or keywords.',
   audience: 'both',

--- a/packages/pieces/community/pinterest/src/lib/actions/update-board.ts
+++ b/packages/pieces/community/pinterest/src/lib/actions/update-board.ts
@@ -7,10 +7,12 @@ import { makeRequest } from '../common';
 import { pinterestAuth } from '../common/auth';
 import { HttpMethod, getAccessTokenOrThrow } from '@activepieces/pieces-common';
 import { adAccountIdDropdown, boardIdDropdown } from '../common/props';
+import { updateBoardActionOutputSchema } from '../output-schemas';
 
 export const updateBoard = createAction({
   auth: pinterestAuth,
   name: 'updateBoard',
+  outputSchema: updateBoardActionOutputSchema,
   displayName: 'Update Board',
   description: "Update a board's name, description, or privacy settings.",
   audience: 'both',

--- a/packages/pieces/community/pinterest/src/lib/output-schemas.ts
+++ b/packages/pieces/community/pinterest/src/lib/output-schemas.ts
@@ -1,0 +1,162 @@
+import { OutputSchema } from '@activepieces/pieces-framework';
+
+// -----------------------------------------------------------------------------
+// Shared field sets
+// -----------------------------------------------------------------------------
+
+/**
+ * A Pinterest Board. Verified identical across `POST /boards`,
+ * `PATCH /boards/{id}`, `GET /search/boards` items and `GET /boards`
+ * (the New Board trigger).
+ */
+const boardFields: OutputSchema['fields'] = [
+  { key: 'id', label: 'Board ID' },
+  { key: 'name', label: 'Name' },
+  { key: 'description', label: 'Description' },
+  { key: 'privacy', label: 'Privacy' },
+  {
+    key: 'owner',
+    label: 'Owner',
+    children: [{ key: 'username', label: 'Username' }],
+  },
+  { key: 'pin_count', label: 'Pin Count', format: 'number' },
+  { key: 'follower_count', label: 'Follower Count', format: 'number' },
+  { key: 'collaborator_count', label: 'Collaborator Count', format: 'number' },
+  { key: 'is_ads_only', label: 'Ads Only', format: 'boolean' },
+  {
+    key: 'media',
+    label: 'Media',
+    children: [
+      { key: 'image_cover_url', label: 'Cover Image', format: 'image' },
+      // Array of plain URL strings — no inner fields to describe, so it is left
+      // undescribed and drilled generically as a list.
+      { key: 'pin_thumbnail_urls', label: 'Pin Thumbnails' },
+    ],
+  },
+  { key: 'created_at', label: 'Created At', format: 'datetime' },
+  {
+    key: 'board_pins_modified_at',
+    label: 'Pins Modified At',
+    format: 'datetime',
+  },
+];
+
+/**
+ * A Pinterest Pin. Verified identical across `POST /pins`,
+ * `GET /search/pins` items and `GET /boards/{id}/pins` (the New Pin trigger).
+ */
+const pinFields: OutputSchema['fields'] = [
+  { key: 'id', label: 'Pin ID' },
+  { key: 'title', label: 'Title' },
+  { key: 'description', label: 'Description' },
+  { key: 'alt_text', label: 'Alt Text' },
+  { key: 'link', label: 'Destination Link', format: 'url' },
+  { key: 'board_id', label: 'Board ID' },
+  { key: 'board_section_id', label: 'Board Section ID' },
+  {
+    key: 'board_owner',
+    label: 'Board Owner',
+    children: [{ key: 'username', label: 'Username' }],
+  },
+  {
+    key: 'media',
+    label: 'Media',
+    children: [
+      { key: 'media_type', label: 'Media Type' },
+      // Keyed by image size ("150x150", "600x", ...), so the entries are data
+      // rather than a fixed schema.
+      {
+        key: 'images',
+        label: 'Images',
+        description:
+          'Rendered image variants keyed by size, each with url, width and height.',
+        dynamicKey: true,
+      },
+    ],
+  },
+  { key: 'dominant_color', label: 'Dominant Color' },
+  { key: 'creative_type', label: 'Creative Type' },
+  { key: 'parent_pin_id', label: 'Parent Pin ID' },
+  { key: 'product_tags', label: 'Product Tags' },
+  { key: 'pin_metrics', label: 'Pin Metrics' },
+  { key: 'is_owner', label: 'Is Owner', format: 'boolean' },
+  { key: 'is_standard', label: 'Is Standard', format: 'boolean' },
+  { key: 'is_product', label: 'Is Product', format: 'boolean' },
+  { key: 'is_removable', label: 'Is Removable', format: 'boolean' },
+  { key: 'has_been_promoted', label: 'Has Been Promoted', format: 'boolean' },
+  { key: 'created_at', label: 'Created At', format: 'datetime' },
+];
+
+// -----------------------------------------------------------------------------
+// Boards
+// -----------------------------------------------------------------------------
+
+export const createBoardActionOutputSchema: OutputSchema = { fields: boardFields };
+export const updateBoardActionOutputSchema: OutputSchema = { fields: boardFields };
+
+export const findBoardByNameActionOutputSchema: OutputSchema = {
+  fields: [
+    {
+      key: 'items',
+      label: 'Boards',
+      labelKey: 'name',
+      listItems: boardFields,
+    },
+    {
+      key: 'bookmark',
+      label: 'Next Page Bookmark',
+      description: 'Pass back as "Bookmark" to fetch the next page.',
+    },
+  ],
+};
+
+// -----------------------------------------------------------------------------
+// Pins
+// -----------------------------------------------------------------------------
+
+export const createPinActionOutputSchema: OutputSchema = { fields: pinFields };
+
+export const findPinActionOutputSchema: OutputSchema = {
+  fields: [
+    {
+      key: 'items',
+      label: 'Pins',
+      labelKey: 'title',
+      listItems: pinFields,
+    },
+    { key: 'total_results', label: 'Total Results', format: 'number' },
+    { key: 'query_used', label: 'Query Used' },
+    { key: 'has_more', label: 'Has More', format: 'boolean' },
+    {
+      key: 'bookmark',
+      label: 'Next Page Bookmark',
+      description: 'Pass back as "Bookmark" to fetch the next page.',
+    },
+  ],
+};
+
+export const deletePinActionOutputSchema: OutputSchema = {
+  fields: [
+    { key: 'success', label: 'Success', format: 'boolean' },
+    { key: 'pin_id', label: 'Pin ID' },
+    { key: 'message', label: 'Message' },
+  ],
+};
+
+// -----------------------------------------------------------------------------
+// Triggers — one Board / Pin per event
+// -----------------------------------------------------------------------------
+
+export const newBoardTriggerOutputSchema: OutputSchema = { fields: boardFields };
+export const newPinOnBoardTriggerOutputSchema: OutputSchema = { fields: pinFields };
+
+/**
+ * One follower per event, from `GET /user_account/followers`. The endpoint
+ * returns only these two fields — no id, avatar or display name.
+ */
+export const newFollowerTriggerOutputSchema: OutputSchema = {
+  fields: [
+    { key: 'username', label: 'Username' },
+    { key: 'type', label: 'Account Type' },
+  ],
+};

--- a/packages/pieces/community/pinterest/src/lib/triggers/new-board.ts
+++ b/packages/pieces/community/pinterest/src/lib/triggers/new-board.ts
@@ -17,6 +17,7 @@ import dayjs from 'dayjs';
 import { makeRequest } from '../common';
 import { pinterestAuth } from '../common/auth';
 import { adAccountIdDropdown } from '../common/props';
+import { newBoardTriggerOutputSchema } from '../output-schemas';
 
 const polling: Polling<
   AppConnectionValueForAuthProperty<typeof pinterestAuth>,
@@ -98,6 +99,7 @@ const polling: Polling<
 export const newBoard = createTrigger({
   auth: pinterestAuth,
   name: 'newBoard',
+  outputSchema: newBoardTriggerOutputSchema,
   displayName: 'New Board',
   description: 'Fires when a new board is created in the account.',
   aiMetadata: {

--- a/packages/pieces/community/pinterest/src/lib/triggers/new-follower.ts
+++ b/packages/pieces/community/pinterest/src/lib/triggers/new-follower.ts
@@ -14,6 +14,7 @@ import {
 } from '@activepieces/pieces-common';
 import { makeRequest } from '../common';
 import { pinterestAuth } from '../common/auth';
+import { newFollowerTriggerOutputSchema } from '../output-schemas';
 
 const polling: Polling<
   AppConnectionValueForAuthProperty<typeof pinterestAuth>,
@@ -72,6 +73,7 @@ const polling: Polling<
 export const newFollower = createTrigger({
   auth: pinterestAuth,
   name: 'newFollower',
+  outputSchema: newFollowerTriggerOutputSchema,
   displayName: 'New Follower',
   description: 'Triggers when a user gains a new follower.',
   aiMetadata: {

--- a/packages/pieces/community/pinterest/src/lib/triggers/new-pin-on-board.ts
+++ b/packages/pieces/community/pinterest/src/lib/triggers/new-pin-on-board.ts
@@ -17,6 +17,7 @@ import dayjs from 'dayjs';
 import { makeRequest } from '../common';
 import { pinterestAuth } from '../common/auth';
 import { adAccountIdDropdown, boardIdDropdown } from '../common/props';
+import { newPinOnBoardTriggerOutputSchema } from '../output-schemas';
 
 const polling: Polling<
   AppConnectionValueForAuthProperty<typeof pinterestAuth>,
@@ -114,6 +115,7 @@ const polling: Polling<
 export const newPinOnBoard = createTrigger({
   auth: pinterestAuth,
   name: 'newPinOnBoard',
+  outputSchema: newPinOnBoardTriggerOutputSchema,
   displayName: 'New Pin on Board',
   description: 'Fires when a new Pin is added to a specific board.',
   aiMetadata: {
@@ -139,75 +141,37 @@ export const newPinOnBoard = createTrigger({
         'Filter by specific pin types. Leave empty to watch all types.',
     }),
   },
+  // One Pin per event: the polling items() returns `data: item` from
+  // GET /boards/{board_id}/pins, not the raw { items, bookmark } envelope.
   sampleData: {
-    items: [
-      {
-        id: '813744226420795884',
-        created_at: '2020-01-01T20:10:40-00:00',
-        link: 'https://www.pinterest.com/',
-        title: 'string',
-        description: 'string',
-        dominant_color: '#6E7874',
-        alt_text: 'string',
-        creative_type: 'REGULAR',
-        board_id: 'string',
-        board_section_id: 'string',
-        board_owner: {
-          username: 'string',
-        },
-        is_owner: 'false',
-        media: {
-          media_type: 'string',
-          images: {
-            '150x150': {
-              width: 150,
-              height: 150,
-              url: 'https://i.pinimg.com/150x150/0d/f6/f1/0df6f1f0bfe7aaca849c1bbc3607a34b.jpg',
-            },
-            '400x300': {
-              width: 400,
-              height: 300,
-              url: 'https://i.pinimg.com/400x300/0d/f6/f1/0df6f1f0bfe7aaca849c1bbc3607a34b.jpg',
-            },
-            '600x': {
-              width: 600,
-              height: 600,
-              url: 'https://i.pinimg.com/600x/0d/f6/f1/0df6f1f0bfe7aaca849c1bbc3607a34b.jpg',
-            },
-            '1200x': {
-              width: 1200,
-              height: 1200,
-              url: 'https://i.pinimg.com/1200x/0d/f6/f1/0df6f1f0bfe7aaca849c1bbc3607a34b.jpg',
-            },
-          },
-        },
-        parent_pin_id: 'string',
-        is_standard: 'false',
-        has_been_promoted: 'false',
-        product_tags: [
-          {
-            pin_id: '903972677830',
-          },
-        ],
-        note: 'string',
-        pin_metrics: {
-          '90d': {
-            pin_click: 7,
-            impression: 2,
-            clickthrough: 3,
-          },
-          lifetime_metrics: {
-            pin_click: 7,
-            impression: 2,
-            clickthrough: 3,
-            reaction: 10,
-            comment: 2,
-          },
-        },
-        is_removable: true,
+    id: '813744226420795884',
+    title: 'Summer Recipe',
+    description: 'A refreshing summer dish',
+    alt_text: 'Plated summer salad',
+    link: 'https://www.activepieces.com/',
+    board_id: '1145392186421331995',
+    board_section_id: null,
+    board_owner: { username: 'sample_username' },
+    media: {
+      media_type: 'image',
+      images: {
+        '150x150': { width: 150, height: 150, url: 'https://i.pinimg.com/150x150/0d/f6/f1/0df6f1f0bfe7aaca849c1bbc3607a34b.jpg' },
+        '400x300': { width: 400, height: 300, url: 'https://i.pinimg.com/400x300/0d/f6/f1/0df6f1f0bfe7aaca849c1bbc3607a34b.jpg' },
+        '600x': { width: 600, height: 600, url: 'https://i.pinimg.com/564x/0d/f6/f1/0df6f1f0bfe7aaca849c1bbc3607a34b.jpg' },
+        '1200x': { width: 1200, height: 1200, url: 'https://i.pinimg.com/1200x/0d/f6/f1/0df6f1f0bfe7aaca849c1bbc3607a34b.jpg' },
       },
-    ],
-    bookmark: 'string',
+    },
+    dominant_color: '#6E7874',
+    creative_type: 'REGULAR',
+    parent_pin_id: null,
+    product_tags: [],
+    pin_metrics: null,
+    is_owner: true,
+    is_standard: true,
+    is_product: false,
+    is_removable: false,
+    has_been_promoted: false,
+    created_at: '2020-01-01T20:10:40',
   },
   type: TriggerStrategy.POLLING,
   async test(context) {

--- a/packages/pieces/community/youtrack/package.json
+++ b/packages/pieces/community/youtrack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-youtrack",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/packages/pieces/community/youtrack/package.json
+++ b/packages/pieces/community/youtrack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-youtrack",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/packages/pieces/community/youtrack/src/index.ts
+++ b/packages/pieces/community/youtrack/src/index.ts
@@ -2,9 +2,11 @@
 // YouTrack Piece - Main Entry Point
 // =============================================================================
 
-import { createPiece, PieceAuth, Property } from '@activepieces/pieces-framework';
+import { createPiece } from '@activepieces/pieces-framework';
 import { createCustomApiCallAction } from '@activepieces/pieces-common';
 import { PieceCategory } from '@activepieces/pieces-framework';
+
+import { youtrackAuth } from './lib/auth';
 
 import { createIssueAction } from './lib/actions/create-issue';
 import { getIssueAction } from './lib/actions/get-issue';
@@ -27,32 +29,7 @@ import { listAttachmentsAction } from './lib/actions/list-attachments';
 import { newIssueTrigger } from './lib/triggers/new-issue';
 import { updatedIssueTrigger } from './lib/triggers/updated-issue';
 
-export const youtrackAuth = PieceAuth.CustomAuth({
-  displayName: 'YouTrack Connection',
-  description:
-    'Connect your YouTrack instance.\n\n' +
-    '**How to get your permanent token:**\n' +
-    '1. Log in to your YouTrack instance\n' +
-    '2. Click your avatar -> **Profile** -> **Authentication** tab\n' +
-    '3. Click **New permanent token**\n' +
-    '4. Name it (e.g. "Activepieces") and click **Create**\n' +
-    '5. **Copy the token immediately** - it is shown only once\n' +
-    '6. Paste it below with your Instance URL\n\n' +
-    'Your **Instance URL** is your browser address, e.g. https://example.youtrack.cloud',
-  required: true,
-  props: {
-    baseUrl: Property.ShortText({
-      displayName: 'Instance URL',
-      description: 'Your YouTrack URL (e.g. https://example.youtrack.cloud). Do NOT include /api.',
-      required: true,
-    }),
-    apiToken: PieceAuth.SecretText({
-      displayName: 'Permanent Token',
-      description: 'From Profile -> Authentication -> Permanent Tokens. Starts with "perm:".',
-      required: true,
-    }),
-  },
-});
+export { youtrackAuth };
 
 export const youtrack = createPiece({
   displayName: 'YouTrack',
@@ -83,13 +60,12 @@ export const youtrack = createPiece({
     listAttachmentsAction,
     createCustomApiCallAction({
       baseUrl: (auth) => {
-        const { baseUrl } = auth as unknown as { baseUrl: string };
+        const baseUrl = auth?.props.baseUrl ?? '';
         return baseUrl.replace(/\/+$/, '') + '/api';
       },
       auth: youtrackAuth,
       authMapping: async (auth) => {
-        const { apiToken } = auth as unknown as { apiToken: string };
-        return { Authorization: 'Bearer ' + apiToken };
+        return { Authorization: 'Bearer ' + auth.props.apiToken };
       },
     }),
   ],

--- a/packages/pieces/community/youtrack/src/lib/actions/add-comment.ts
+++ b/packages/pieces/community/youtrack/src/lib/actions/add-comment.ts
@@ -2,10 +2,12 @@ import { createAction, Property } from '@activepieces/pieces-framework';
 import { HttpMethod } from '@activepieces/pieces-common';
 import { youtrackAuth } from '../auth';
 import { dropdownError, issueDropdown, youtrackApiCall } from '../common';
+import { addCommentActionOutputSchema } from '../output-schemas';
 
 export const addCommentAction = createAction({
   auth: youtrackAuth,
   name: 'add_comment',
+  outputSchema: addCommentActionOutputSchema,
   displayName: 'Add Comment',
   description: 'Adds a comment to an issue. Supports Markdown formatting.',
   audience: 'both',

--- a/packages/pieces/community/youtrack/src/lib/actions/add-comment.ts
+++ b/packages/pieces/community/youtrack/src/lib/actions/add-comment.ts
@@ -1,7 +1,7 @@
 import { createAction, Property } from '@activepieces/pieces-framework';
 import { HttpMethod } from '@activepieces/pieces-common';
-import { youtrackAuth } from '../../';
-import { issueDropdown, youtrackApiCall } from '../common';
+import { youtrackAuth } from '../auth';
+import { dropdownError, issueDropdown, youtrackApiCall } from '../common';
 
 export const addCommentAction = createAction({
   auth: youtrackAuth,
@@ -18,21 +18,23 @@ export const addCommentAction = createAction({
       required: true,
     }),
     visibleToGroup: Property.Dropdown({
-      auth:youtrackAuth,
+      auth: youtrackAuth,
       displayName: 'Visible to Group',
       description: 'Restrict comment visibility to a group. Leave empty for everyone.',
       required: false,
       refreshers: [],
       options: async ({ auth }) => {
         if (!auth) return { disabled: true, options: [], placeholder: 'Connect your account first' };
-        const { baseUrl, apiToken } = auth as unknown as { baseUrl: string; apiToken: string };
+        const { baseUrl, apiToken } = auth.props;
         try {
           const response = await youtrackApiCall<Array<{ id: string; name: string }>>({
             baseUrl, token: apiToken, method: HttpMethod.GET,
             path: '/groups', queryParams: { fields: 'id,name' },
           });
           return { disabled: false, options: [{ label: '[Visible to everyone]', value: '' }, ...response.body.map((g) => ({ label: g.name, value: g.id }))] };
-        } catch { return { disabled: true, options: [], placeholder: 'Failed to load groups.' }; }
+        } catch (error) {
+          return dropdownError('Failed to load groups', error);
+        }
       },
     }),
   },

--- a/packages/pieces/community/youtrack/src/lib/actions/add-tag-to-issue.ts
+++ b/packages/pieces/community/youtrack/src/lib/actions/add-tag-to-issue.ts
@@ -1,6 +1,6 @@
 import { createAction } from '@activepieces/pieces-framework';
 import { HttpMethod } from '@activepieces/pieces-common';
-import { youtrackAuth } from '../../';
+import { youtrackAuth } from '../auth';
 import { issueDropdown, tagDropdown, flattenObject, youtrackApiCall } from '../common';
 
 export const addTagToIssueAction = createAction({

--- a/packages/pieces/community/youtrack/src/lib/actions/add-tag-to-issue.ts
+++ b/packages/pieces/community/youtrack/src/lib/actions/add-tag-to-issue.ts
@@ -2,10 +2,12 @@ import { createAction } from '@activepieces/pieces-framework';
 import { HttpMethod } from '@activepieces/pieces-common';
 import { youtrackAuth } from '../auth';
 import { issueDropdown, tagDropdown, flattenObject, youtrackApiCall } from '../common';
+import { addTagToIssueActionOutputSchema } from '../output-schemas';
 
 export const addTagToIssueAction = createAction({
   auth: youtrackAuth,
   name: 'add_tag_to_issue',
+  outputSchema: addTagToIssueActionOutputSchema,
   displayName: 'Add Tag to Issue',
   description: 'Adds an existing tag to an issue.',
   audience: 'both',

--- a/packages/pieces/community/youtrack/src/lib/actions/add-user-to-team.ts
+++ b/packages/pieces/community/youtrack/src/lib/actions/add-user-to-team.ts
@@ -2,10 +2,12 @@ import { createAction } from '@activepieces/pieces-framework';
 import { HttpMethod } from '@activepieces/pieces-common';
 import { youtrackAuth } from '../auth';
 import { projectDropdown, userDropdown, flattenObject, youtrackApiCall } from '../common';
+import { addUserToTeamActionOutputSchema } from '../output-schemas';
 
 export const addUserToTeamAction = createAction({
   auth: youtrackAuth,
   name: 'add_user_to_team',
+  outputSchema: addUserToTeamActionOutputSchema,
   displayName: 'Add User to Project Team',
   description: 'Adds a user as a direct member of a project team, giving them access to the project.',
   audience: 'both',

--- a/packages/pieces/community/youtrack/src/lib/actions/add-user-to-team.ts
+++ b/packages/pieces/community/youtrack/src/lib/actions/add-user-to-team.ts
@@ -1,6 +1,6 @@
 import { createAction } from '@activepieces/pieces-framework';
 import { HttpMethod } from '@activepieces/pieces-common';
-import { youtrackAuth } from '../../';
+import { youtrackAuth } from '../auth';
 import { projectDropdown, userDropdown, flattenObject, youtrackApiCall } from '../common';
 
 export const addUserToTeamAction = createAction({

--- a/packages/pieces/community/youtrack/src/lib/actions/apply-command.ts
+++ b/packages/pieces/community/youtrack/src/lib/actions/apply-command.ts
@@ -2,10 +2,12 @@ import { createAction, Property } from '@activepieces/pieces-framework';
 import { HttpMethod } from '@activepieces/pieces-common';
 import { youtrackAuth } from '../auth';
 import { issueDropdown, youtrackApiCall } from '../common';
+import { applyCommandActionOutputSchema } from '../output-schemas';
 
 export const applyCommandAction = createAction({
   auth: youtrackAuth,
   name: 'apply_command',
+  outputSchema: applyCommandActionOutputSchema,
   displayName: 'Apply Command',
   description: 'Applies a YouTrack command to an issue (e.g. change state, assign, set sprint).',
   audience: 'both',

--- a/packages/pieces/community/youtrack/src/lib/actions/apply-command.ts
+++ b/packages/pieces/community/youtrack/src/lib/actions/apply-command.ts
@@ -1,6 +1,6 @@
 import { createAction, Property } from '@activepieces/pieces-framework';
 import { HttpMethod } from '@activepieces/pieces-common';
-import { youtrackAuth } from '../../';
+import { youtrackAuth } from '../auth';
 import { issueDropdown, youtrackApiCall } from '../common';
 
 export const applyCommandAction = createAction({

--- a/packages/pieces/community/youtrack/src/lib/actions/create-issue.ts
+++ b/packages/pieces/community/youtrack/src/lib/actions/create-issue.ts
@@ -2,11 +2,13 @@
 import { createAction, Property } from '@activepieces/pieces-framework';
 import { HttpMethod } from '@activepieces/pieces-common';
 import { youtrackAuth } from '../auth';
-import { projectDropdown, ISSUE_FIELDS, flattenObject, youtrackApiCall } from '../common';
+import { projectDropdown, ISSUE_FIELDS, flattenIssue, normalizeCustomFields, youtrackApiCall } from '../common';
+import { createIssueActionOutputSchema } from '../output-schemas';
 
 export const createIssueAction = createAction({
   auth: youtrackAuth,
   name: 'create_issue',
+  outputSchema: createIssueActionOutputSchema,
   displayName: 'Create Issue',
   description: 'Creates a new issue in a YouTrack project.',
   audience: 'both',
@@ -40,7 +42,8 @@ export const createIssueAction = createAction({
       summary: context.propsValue.summary,
     };
     if (context.propsValue.description) body['description'] = context.propsValue.description;
-    if (context.propsValue.customFieldsJson) body['customFields'] = context.propsValue.customFieldsJson;
+    const customFields = normalizeCustomFields(context.propsValue.customFieldsJson);
+    if (customFields) body['customFields'] = customFields;
 
     const response = await youtrackApiCall<Record<string, unknown>>({
       baseUrl,
@@ -50,6 +53,6 @@ export const createIssueAction = createAction({
       queryParams: { fields: ISSUE_FIELDS },
       body,
     });
-    return flattenObject(response.body);
+    return flattenIssue(response.body);
   },
 });

--- a/packages/pieces/community/youtrack/src/lib/actions/create-issue.ts
+++ b/packages/pieces/community/youtrack/src/lib/actions/create-issue.ts
@@ -1,7 +1,7 @@
 // Action: Create Issue
 import { createAction, Property } from '@activepieces/pieces-framework';
 import { HttpMethod } from '@activepieces/pieces-common';
-import { youtrackAuth } from '../../';
+import { youtrackAuth } from '../auth';
 import { projectDropdown, ISSUE_FIELDS, flattenObject, youtrackApiCall } from '../common';
 
 export const createIssueAction = createAction({

--- a/packages/pieces/community/youtrack/src/lib/actions/create-tag.ts
+++ b/packages/pieces/community/youtrack/src/lib/actions/create-tag.ts
@@ -1,6 +1,6 @@
 import { createAction, Property } from '@activepieces/pieces-framework';
 import { HttpMethod } from '@activepieces/pieces-common';
-import { youtrackAuth } from '../../';
+import { youtrackAuth } from '../auth';
 import { flattenObject, youtrackApiCall } from '../common';
 
 export const createTagAction = createAction({

--- a/packages/pieces/community/youtrack/src/lib/actions/create-tag.ts
+++ b/packages/pieces/community/youtrack/src/lib/actions/create-tag.ts
@@ -2,10 +2,12 @@ import { createAction, Property } from '@activepieces/pieces-framework';
 import { HttpMethod } from '@activepieces/pieces-common';
 import { youtrackAuth } from '../auth';
 import { flattenObject, youtrackApiCall } from '../common';
+import { createTagActionOutputSchema } from '../output-schemas';
 
 export const createTagAction = createAction({
   auth: youtrackAuth,
   name: 'create_tag',
+  outputSchema: createTagActionOutputSchema,
   displayName: 'Create Tag',
   description: 'Creates a new tag in YouTrack.',
   audience: 'both',

--- a/packages/pieces/community/youtrack/src/lib/actions/delete-attachment.ts
+++ b/packages/pieces/community/youtrack/src/lib/actions/delete-attachment.ts
@@ -1,6 +1,6 @@
 import { createAction, Property } from '@activepieces/pieces-framework';
 import { HttpMethod } from '@activepieces/pieces-common';
-import { youtrackAuth } from '../../';
+import { youtrackAuth } from '../auth';
 import { issueDropdown, youtrackApiCall } from '../common';
 
 export const deleteAttachmentAction = createAction({

--- a/packages/pieces/community/youtrack/src/lib/actions/delete-attachment.ts
+++ b/packages/pieces/community/youtrack/src/lib/actions/delete-attachment.ts
@@ -2,10 +2,12 @@ import { createAction, Property } from '@activepieces/pieces-framework';
 import { HttpMethod } from '@activepieces/pieces-common';
 import { youtrackAuth } from '../auth';
 import { issueDropdown, youtrackApiCall } from '../common';
+import { deleteAttachmentActionOutputSchema } from '../output-schemas';
 
 export const deleteAttachmentAction = createAction({
   auth: youtrackAuth,
   name: 'delete_attachment',
+  outputSchema: deleteAttachmentActionOutputSchema,
   displayName: 'Delete Attachment',
   description: 'Deletes an attachment from an issue.',
   audience: 'both',

--- a/packages/pieces/community/youtrack/src/lib/actions/download-attachment.ts
+++ b/packages/pieces/community/youtrack/src/lib/actions/download-attachment.ts
@@ -1,6 +1,6 @@
 import { createAction, Property } from '@activepieces/pieces-framework';
 import { HttpMethod } from '@activepieces/pieces-common';
-import { youtrackAuth } from '../../';
+import { youtrackAuth } from '../auth';
 import { issueDropdown, youtrackApiCall } from '../common';
 
 export const downloadAttachmentAction = createAction({

--- a/packages/pieces/community/youtrack/src/lib/actions/download-attachment.ts
+++ b/packages/pieces/community/youtrack/src/lib/actions/download-attachment.ts
@@ -2,10 +2,12 @@ import { createAction, Property } from '@activepieces/pieces-framework';
 import { HttpMethod } from '@activepieces/pieces-common';
 import { youtrackAuth } from '../auth';
 import { issueDropdown, youtrackApiCall } from '../common';
+import { downloadAttachmentActionOutputSchema } from '../output-schemas';
 
 export const downloadAttachmentAction = createAction({
   auth: youtrackAuth,
   name: 'download_attachment',
+  outputSchema: downloadAttachmentActionOutputSchema,
   displayName: 'Download Attachment',
   description: 'Downloads an attachment from an issue and returns it as a Base64-encoded string. Use this with the "Upload to Drive" or "Send Email" actions in your flow.',
   audience: 'both',
@@ -22,18 +24,23 @@ export const downloadAttachmentAction = createAction({
     const { baseUrl, apiToken } = context.auth.props;
     const base = baseUrl.replace(/\/+$/, '');
 
-    const metaResponse = await youtrackApiCall<{ url?: string; name?: string; size?: number; contentType?: string }>({
+    const metaResponse = await youtrackApiCall<{ url?: string; name?: string; size?: number; mimeType?: string }>({
       baseUrl,
       token: apiToken,
       method: HttpMethod.GET,
       path: '/issues/' + context.propsValue.issue + '/attachments/' + context.propsValue.attachmentId,
-      queryParams: { fields: 'id,name,url,size,contentType' },
+      queryParams: { fields: 'id,name,url,size,mimeType' },
     });
     const meta = metaResponse.body;
 
     // fetch() is used here because the download URL may point to an external CDN and
     // the response must be consumed as an ArrayBuffer, which httpClient does not support.
-    const downloadUrl = meta.url || (base + '/api/issues/' + context.propsValue.issue + '/attachments/' + context.propsValue.attachmentId + '/file');
+    // YouTrack returns `url` as an instance-relative path (/api/files/<id>?sign=...),
+    // which fetch() cannot parse, so resolve it against the instance URL.
+    const resolvedUrl = meta.url
+      ? (/^https?:\/\//.test(meta.url) ? meta.url : base + meta.url)
+      : undefined;
+    const downloadUrl = resolvedUrl ?? (base + '/api/issues/' + context.propsValue.issue + '/attachments/' + context.propsValue.attachmentId + '/file');
     const fileResponse = await fetch(downloadUrl, {
       method: HttpMethod.GET,
       headers: { 'Authorization': 'Bearer ' + apiToken },
@@ -42,7 +49,7 @@ export const downloadAttachmentAction = createAction({
 
     const buffer = await fileResponse.arrayBuffer();
     const base64 = Buffer.from(buffer).toString('base64');
-    const contentType = meta.contentType || fileResponse.headers.get('content-type') || 'application/octet-stream';
+    const contentType = meta.mimeType || fileResponse.headers.get('content-type') || 'application/octet-stream';
 
     return {
       attachment_id: context.propsValue.attachmentId,

--- a/packages/pieces/community/youtrack/src/lib/actions/get-issue-history.ts
+++ b/packages/pieces/community/youtrack/src/lib/actions/get-issue-history.ts
@@ -1,7 +1,7 @@
 // Action: Get Issue History
 import { createAction, Property } from '@activepieces/pieces-framework';
 import { HttpMethod } from '@activepieces/pieces-common';
-import { youtrackAuth } from '../../';
+import { youtrackAuth } from '../auth';
 import { issueDropdown, youtrackApiCall } from '../common';
 
 export const getIssueHistoryAction = createAction({

--- a/packages/pieces/community/youtrack/src/lib/actions/get-issue-history.ts
+++ b/packages/pieces/community/youtrack/src/lib/actions/get-issue-history.ts
@@ -3,10 +3,12 @@ import { createAction, Property } from '@activepieces/pieces-framework';
 import { HttpMethod } from '@activepieces/pieces-common';
 import { youtrackAuth } from '../auth';
 import { issueDropdown, youtrackApiCall } from '../common';
+import { getIssueHistoryActionOutputSchema } from '../output-schemas';
 
 export const getIssueHistoryAction = createAction({
   auth: youtrackAuth,
   name: 'get_issue_history',
+  outputSchema: getIssueHistoryActionOutputSchema,
   displayName: 'Get Issue History',
   description: 'Retrieves the full change history (activity log) for a specific issue.',
   audience: 'both',

--- a/packages/pieces/community/youtrack/src/lib/actions/get-issue.ts
+++ b/packages/pieces/community/youtrack/src/lib/actions/get-issue.ts
@@ -1,6 +1,6 @@
 import { createAction } from '@activepieces/pieces-framework';
 import { HttpMethod } from '@activepieces/pieces-common';
-import { youtrackAuth } from '../../';
+import { youtrackAuth } from '../auth';
 import { issueDropdown, ISSUE_FIELDS, flattenObject, youtrackApiCall } from '../common';
 
 export const getIssueAction = createAction({

--- a/packages/pieces/community/youtrack/src/lib/actions/get-issue.ts
+++ b/packages/pieces/community/youtrack/src/lib/actions/get-issue.ts
@@ -1,11 +1,13 @@
 import { createAction } from '@activepieces/pieces-framework';
 import { HttpMethod } from '@activepieces/pieces-common';
 import { youtrackAuth } from '../auth';
-import { issueDropdown, ISSUE_FIELDS, flattenObject, youtrackApiCall } from '../common';
+import { issueDropdown, ISSUE_FIELDS, flattenIssue, youtrackApiCall } from '../common';
+import { getIssueActionOutputSchema } from '../output-schemas';
 
 export const getIssueAction = createAction({
   auth: youtrackAuth,
   name: 'get_issue',
+  outputSchema: getIssueActionOutputSchema,
   displayName: 'Get Issue',
   description: 'Retrieves full details of an issue including all custom field values.',
   audience: 'both',
@@ -20,6 +22,6 @@ export const getIssueAction = createAction({
       path: '/issues/' + context.propsValue.issue,
       queryParams: { fields: ISSUE_FIELDS },
     });
-    return flattenObject(response.body);
+    return flattenIssue(response.body);
   },
 });

--- a/packages/pieces/community/youtrack/src/lib/actions/link-issues.ts
+++ b/packages/pieces/community/youtrack/src/lib/actions/link-issues.ts
@@ -1,6 +1,6 @@
 import { createAction, Property } from '@activepieces/pieces-framework';
 import { HttpMethod } from '@activepieces/pieces-common';
-import { youtrackAuth } from '../../';
+import { youtrackAuth } from '../auth';
 import { issueDropdown, youtrackApiCall } from '../common';
 
 export const linkIssuesAction = createAction({

--- a/packages/pieces/community/youtrack/src/lib/actions/link-issues.ts
+++ b/packages/pieces/community/youtrack/src/lib/actions/link-issues.ts
@@ -2,10 +2,12 @@ import { createAction, Property } from '@activepieces/pieces-framework';
 import { HttpMethod } from '@activepieces/pieces-common';
 import { youtrackAuth } from '../auth';
 import { issueDropdown, youtrackApiCall } from '../common';
+import { linkIssuesActionOutputSchema } from '../output-schemas';
 
 export const linkIssuesAction = createAction({
   auth: youtrackAuth,
   name: 'link_issues',
+  outputSchema: linkIssuesActionOutputSchema,
   displayName: 'Link Issues',
   description: 'Creates a relationship between two issues (e.g. "relates to", "depends on", "is duplicated by").',
   audience: 'both',

--- a/packages/pieces/community/youtrack/src/lib/actions/list-attachments.ts
+++ b/packages/pieces/community/youtrack/src/lib/actions/list-attachments.ts
@@ -2,10 +2,12 @@ import { createAction, Property } from '@activepieces/pieces-framework';
 import { HttpMethod } from '@activepieces/pieces-common';
 import { youtrackAuth } from '../auth';
 import { issueDropdown, youtrackApiCall } from '../common';
+import { listAttachmentsActionOutputSchema } from '../output-schemas';
 
 export const listAttachmentsAction = createAction({
   auth: youtrackAuth,
   name: 'list_attachments',
+  outputSchema: listAttachmentsActionOutputSchema,
   displayName: 'List Attachments',
   description: 'Lists all attachments on a specific issue with metadata (name, size, type).',
   audience: 'both',
@@ -22,13 +24,13 @@ export const listAttachmentsAction = createAction({
       token: apiToken,
       method: HttpMethod.GET,
       path: '/issues/' + context.propsValue.issue + '/attachments',
-      queryParams: { fields: 'id,name,contentType,size,author(name,login),created', '$top': String(limit) },
+      queryParams: { fields: 'id,name,mimeType,size,author(name,login),created', '$top': String(limit) },
     });
     const data = response.body;
     return (data || []).map((att) => ({
       id: att['id'],
       name: att['name'],
-      content_type: att['contentType'],
+      content_type: att['mimeType'] ?? null,
       size_bytes: att['size'],
       author_name: (att['author'] as Record<string, unknown>)?.['name'] ?? null,
       author_login: (att['author'] as Record<string, unknown>)?.['login'] ?? null,

--- a/packages/pieces/community/youtrack/src/lib/actions/list-attachments.ts
+++ b/packages/pieces/community/youtrack/src/lib/actions/list-attachments.ts
@@ -1,6 +1,6 @@
 import { createAction, Property } from '@activepieces/pieces-framework';
 import { HttpMethod } from '@activepieces/pieces-common';
-import { youtrackAuth } from '../../';
+import { youtrackAuth } from '../auth';
 import { issueDropdown, youtrackApiCall } from '../common';
 
 export const listAttachmentsAction = createAction({

--- a/packages/pieces/community/youtrack/src/lib/actions/list-comments.ts
+++ b/packages/pieces/community/youtrack/src/lib/actions/list-comments.ts
@@ -1,6 +1,6 @@
 import { createAction, Property } from '@activepieces/pieces-framework';
 import { HttpMethod } from '@activepieces/pieces-common';
-import { youtrackAuth } from '../../';
+import { youtrackAuth } from '../auth';
 import { issueDropdown, youtrackApiCall } from '../common';
 
 export const listCommentsAction = createAction({

--- a/packages/pieces/community/youtrack/src/lib/actions/list-comments.ts
+++ b/packages/pieces/community/youtrack/src/lib/actions/list-comments.ts
@@ -2,10 +2,12 @@ import { createAction, Property } from '@activepieces/pieces-framework';
 import { HttpMethod } from '@activepieces/pieces-common';
 import { youtrackAuth } from '../auth';
 import { issueDropdown, youtrackApiCall } from '../common';
+import { listCommentsActionOutputSchema } from '../output-schemas';
 
 export const listCommentsAction = createAction({
   auth: youtrackAuth,
   name: 'list_comments',
+  outputSchema: listCommentsActionOutputSchema,
   displayName: 'List Comments',
   description: 'Lists all comments on an issue with author details and timestamps.',
   audience: 'both',

--- a/packages/pieces/community/youtrack/src/lib/actions/list-tags.ts
+++ b/packages/pieces/community/youtrack/src/lib/actions/list-tags.ts
@@ -1,7 +1,7 @@
 // Action: List Tags
 import { createAction, Property } from '@activepieces/pieces-framework';
 import { HttpMethod } from '@activepieces/pieces-common';
-import { youtrackAuth } from '../../';
+import { youtrackAuth } from '../auth';
 import { youtrackApiCall } from '../common';
 
 export const listTagsAction = createAction({

--- a/packages/pieces/community/youtrack/src/lib/actions/list-tags.ts
+++ b/packages/pieces/community/youtrack/src/lib/actions/list-tags.ts
@@ -3,10 +3,12 @@ import { createAction, Property } from '@activepieces/pieces-framework';
 import { HttpMethod } from '@activepieces/pieces-common';
 import { youtrackAuth } from '../auth';
 import { youtrackApiCall } from '../common';
+import { listTagsActionOutputSchema } from '../output-schemas';
 
 export const listTagsAction = createAction({
   auth: youtrackAuth,
   name: 'list_tags',
+  outputSchema: listTagsActionOutputSchema,
   displayName: 'List Tags',
   description: 'Lists all tags visible to the current user.',
   audience: 'both',

--- a/packages/pieces/community/youtrack/src/lib/actions/remove-tag-from-issue.ts
+++ b/packages/pieces/community/youtrack/src/lib/actions/remove-tag-from-issue.ts
@@ -3,10 +3,12 @@ import { createAction } from '@activepieces/pieces-framework';
 import { HttpMethod } from '@activepieces/pieces-common';
 import { youtrackAuth } from '../auth';
 import { issueDropdown, tagDropdown, youtrackApiCall } from '../common';
+import { removeTagFromIssueActionOutputSchema } from '../output-schemas';
 
 export const removeTagFromIssueAction = createAction({
   auth: youtrackAuth,
   name: 'remove_tag_from_issue',
+  outputSchema: removeTagFromIssueActionOutputSchema,
   displayName: 'Remove Tag from Issue',
   description: 'Removes a tag from an issue.',
   audience: 'both',

--- a/packages/pieces/community/youtrack/src/lib/actions/remove-tag-from-issue.ts
+++ b/packages/pieces/community/youtrack/src/lib/actions/remove-tag-from-issue.ts
@@ -1,7 +1,7 @@
 // Action: Remove Tag from Issue
 import { createAction } from '@activepieces/pieces-framework';
 import { HttpMethod } from '@activepieces/pieces-common';
-import { youtrackAuth } from '../../';
+import { youtrackAuth } from '../auth';
 import { issueDropdown, tagDropdown, youtrackApiCall } from '../common';
 
 export const removeTagFromIssueAction = createAction({

--- a/packages/pieces/community/youtrack/src/lib/actions/search-issues.ts
+++ b/packages/pieces/community/youtrack/src/lib/actions/search-issues.ts
@@ -1,7 +1,7 @@
 import { createAction, Property } from '@activepieces/pieces-framework';
 import { HttpMethod } from '@activepieces/pieces-common';
-import { youtrackAuth } from '../../';
-import { ISSUE_FIELDS, flattenObject, youtrackApiCall } from '../common';
+import { youtrackAuth } from '../auth';
+import { ISSUE_FIELDS, dropdownError, flattenObject, youtrackApiCall } from '../common';
 
 export const searchIssuesAction = createAction({
   auth: youtrackAuth,
@@ -12,14 +12,14 @@ export const searchIssuesAction = createAction({
   aiMetadata: { description: 'Search issues using YouTrack query syntax (e.g. #unresolved, assignee: me, Priority: Critical), optionally scoped to one project. Leave both the project and query empty to list all accessible issues, or supply filters to narrow results. Use to find issues matching criteria before acting on them. Read-only and idempotent.', idempotent: true },
   props: {
     project: Property.Dropdown({
-      auth:youtrackAuth,
+      auth: youtrackAuth,
       displayName: 'Project',
       description: 'Optional: filter by project. Leave empty to search across all projects.',
       required: false,
       refreshers: [],
       options: async ({ auth }) => {
         if (!auth) return { disabled: true, options: [], placeholder: 'Please connect your account first' };
-        const { baseUrl, apiToken } = auth as unknown as { baseUrl: string; apiToken: string };
+        const { baseUrl, apiToken } = auth.props;
         try {
           const response = await youtrackApiCall<Array<{ id: string; name: string; shortName: string }>>({
             baseUrl,
@@ -35,8 +35,8 @@ export const searchIssuesAction = createAction({
               ...response.body.map((p) => ({ label: p.name + ' (' + p.shortName + ')', value: p.shortName })),
             ],
           };
-        } catch {
-          return { disabled: true, options: [], placeholder: 'Failed to load projects.' };
+        } catch (error) {
+          return dropdownError('Failed to load projects', error);
         }
       },
     }),

--- a/packages/pieces/community/youtrack/src/lib/actions/search-issues.ts
+++ b/packages/pieces/community/youtrack/src/lib/actions/search-issues.ts
@@ -1,11 +1,13 @@
 import { createAction, Property } from '@activepieces/pieces-framework';
 import { HttpMethod } from '@activepieces/pieces-common';
 import { youtrackAuth } from '../auth';
-import { ISSUE_FIELDS, dropdownError, flattenObject, youtrackApiCall } from '../common';
+import { ISSUE_FIELDS, dropdownError, flattenIssue, youtrackApiCall } from '../common';
+import { searchIssuesActionOutputSchema } from '../output-schemas';
 
 export const searchIssuesAction = createAction({
   auth: youtrackAuth,
   name: 'search_issues',
+  outputSchema: searchIssuesActionOutputSchema,
   displayName: 'Search Issues',
   description: 'Searches for issues using YouTrack query syntax. Returns flat rows for spreadsheets.',
   audience: 'both',
@@ -75,6 +77,6 @@ export const searchIssuesAction = createAction({
       path: '/issues',
       queryParams,
     });
-    return (response.body || []).map((item) => flattenObject(item));
+    return (response.body || []).map((item) => flattenIssue(item));
   },
 });

--- a/packages/pieces/community/youtrack/src/lib/actions/update-issue.ts
+++ b/packages/pieces/community/youtrack/src/lib/actions/update-issue.ts
@@ -1,7 +1,7 @@
 // Action: Update Issue
 import { createAction, Property } from '@activepieces/pieces-framework';
 import { HttpMethod } from '@activepieces/pieces-common';
-import { youtrackAuth } from '../../';
+import { youtrackAuth } from '../auth';
 import { issueDropdown, ISSUE_FIELDS, flattenObject, youtrackApiCall } from '../common';
 
 export const updateIssueAction = createAction({

--- a/packages/pieces/community/youtrack/src/lib/actions/update-issue.ts
+++ b/packages/pieces/community/youtrack/src/lib/actions/update-issue.ts
@@ -2,11 +2,13 @@
 import { createAction, Property } from '@activepieces/pieces-framework';
 import { HttpMethod } from '@activepieces/pieces-common';
 import { youtrackAuth } from '../auth';
-import { issueDropdown, ISSUE_FIELDS, flattenObject, youtrackApiCall } from '../common';
+import { issueDropdown, ISSUE_FIELDS, flattenIssue, normalizeCustomFields, youtrackApiCall } from '../common';
+import { updateIssueActionOutputSchema } from '../output-schemas';
 
 export const updateIssueAction = createAction({
   auth: youtrackAuth,
   name: 'update_issue',
+  outputSchema: updateIssueActionOutputSchema,
   displayName: 'Update Issue',
   description: 'Updates an existing issue - summary, description, or custom fields.',
   audience: 'both',
@@ -26,7 +28,8 @@ export const updateIssueAction = createAction({
     const body: Record<string, unknown> = {};
     if (context.propsValue.summary !== undefined && context.propsValue.summary !== '') body['summary'] = context.propsValue.summary;
     if (context.propsValue.description !== undefined && context.propsValue.description !== '') body['description'] = context.propsValue.description;
-    if (context.propsValue.customFieldsJson) body['customFields'] = context.propsValue.customFieldsJson;
+    const customFields = normalizeCustomFields(context.propsValue.customFieldsJson);
+    if (customFields) body['customFields'] = customFields;
     const response = await youtrackApiCall<Record<string, unknown>>({
       baseUrl,
       token: apiToken,
@@ -35,6 +38,6 @@ export const updateIssueAction = createAction({
       queryParams: { fields: ISSUE_FIELDS },
       body,
     });
-    return flattenObject(response.body);
+    return flattenIssue(response.body);
   },
 });

--- a/packages/pieces/community/youtrack/src/lib/actions/upload-attachment.ts
+++ b/packages/pieces/community/youtrack/src/lib/actions/upload-attachment.ts
@@ -3,10 +3,12 @@ import { createAction, Property } from '@activepieces/pieces-framework';
 import { HttpMethod } from '@activepieces/pieces-common';
 import { youtrackAuth } from '../auth';
 import { issueDropdown, youtrackApiCall } from '../common';
+import { uploadAttachmentActionOutputSchema } from '../output-schemas';
 
 export const uploadAttachmentAction = createAction({
   auth: youtrackAuth,
   name: 'upload_attachment',
+  outputSchema: uploadAttachmentActionOutputSchema,
   displayName: 'Upload Attachment',
   description: 'Uploads one or more files as attachments to an existing issue.',
   audience: 'both',
@@ -60,7 +62,8 @@ export const uploadAttachmentAction = createAction({
         headers: { 'Content-Type': 'multipart/form-data; boundary=' + boundary },
         body,
       });
-      results.push(...(response.body || []));
+      // Only id/name — the raw entries also carry YouTrack's internal `$type`.
+      results.push(...(response.body || []).map((a) => ({ id: a.id, name: a.name })));
     }
     return results;
   },

--- a/packages/pieces/community/youtrack/src/lib/actions/upload-attachment.ts
+++ b/packages/pieces/community/youtrack/src/lib/actions/upload-attachment.ts
@@ -1,7 +1,7 @@
 // Action: Upload Attachment
 import { createAction, Property } from '@activepieces/pieces-framework';
 import { HttpMethod } from '@activepieces/pieces-common';
-import { youtrackAuth } from '../../';
+import { youtrackAuth } from '../auth';
 import { issueDropdown, youtrackApiCall } from '../common';
 
 export const uploadAttachmentAction = createAction({

--- a/packages/pieces/community/youtrack/src/lib/auth.ts
+++ b/packages/pieces/community/youtrack/src/lib/auth.ts
@@ -1,0 +1,28 @@
+import { PieceAuth, Property } from '@activepieces/pieces-framework';
+
+export const youtrackAuth = PieceAuth.CustomAuth({
+  displayName: 'YouTrack Connection',
+  description:
+    'Connect your YouTrack instance.\n\n' +
+    '**How to get your permanent token:**\n' +
+    '1. Log in to your YouTrack instance\n' +
+    '2. Click your avatar -> **Profile** -> **Authentication** tab\n' +
+    '3. Click **New permanent token**\n' +
+    '4. Name it (e.g. "Activepieces") and click **Create**\n' +
+    '5. **Copy the token immediately** - it is shown only once\n' +
+    '6. Paste it below with your Instance URL\n\n' +
+    'Your **Instance URL** is your browser address, e.g. https://example.youtrack.cloud',
+  required: true,
+  props: {
+    baseUrl: Property.ShortText({
+      displayName: 'Instance URL',
+      description: 'Your YouTrack URL (e.g. https://example.youtrack.cloud). Do NOT include /api.',
+      required: true,
+    }),
+    apiToken: PieceAuth.SecretText({
+      displayName: 'Permanent Token',
+      description: 'From Profile -> Authentication -> Permanent Tokens. Starts with "perm:".',
+      required: true,
+    }),
+  },
+});

--- a/packages/pieces/community/youtrack/src/lib/common/index.ts
+++ b/packages/pieces/community/youtrack/src/lib/common/index.ts
@@ -80,6 +80,91 @@ export function flattenObject(
   return result;
 }
 
+/**
+ * YouTrack requires `customFields` to be an array. The builder's JSON editor
+ * starts out as `{}`, which is truthy, so forwarding the raw value makes the API
+ * fail with a 500 "IssueCustomFieldMegaProxy cannot be cast to java.util.List".
+ * Empty values are omitted; a non-empty non-array is a user mistake worth
+ * reporting clearly instead of letting it surface as a Java cast error.
+ */
+export function normalizeCustomFields(value: unknown): unknown[] | undefined {
+  if (value === null || value === undefined) {
+    return undefined;
+  }
+  if (Array.isArray(value)) {
+    return value.length > 0 ? value : undefined;
+  }
+  if (typeof value === 'object' && Object.keys(value).length === 0) {
+    return undefined;
+  }
+  throw new Error(
+    'Custom Fields (JSON) must be an array of field objects, for example: ' +
+      '[{ "name": "Priority", "$type": "SingleEnumIssueCustomField", "value": { "name": "Critical" } }]',
+  );
+}
+
+/**
+ * Reduces one custom field value to a scalar. YouTrack returns a different
+ * `$type` per field kind: enum/state/version/owned values carry `name`, user
+ * values `fullName`/`login`, text values `text`, period values `presentation`
+ * (with `minutes`), and simple fields (integer, float, string, date) come back
+ * as a bare primitive. Multi-value fields arrive as an array.
+ */
+function customFieldValue(value: unknown): unknown {
+  if (value === null || value === undefined) {
+    return null;
+  }
+  if (Array.isArray(value)) {
+    if (value.length === 0) {
+      return null;
+    }
+    return value
+      .map((entry) => customFieldValue(entry))
+      .filter((entry) => entry !== null)
+      .join(', ');
+  }
+  if (typeof value === 'object') {
+    const obj = value as Record<string, unknown>;
+    for (const key of ['name', 'fullName', 'login', 'text', 'presentation']) {
+      const candidate = obj[key];
+      if (typeof candidate === 'string' && candidate !== '') {
+        return candidate;
+      }
+    }
+    if (typeof obj['minutes'] === 'number') {
+      return obj['minutes'];
+    }
+    return JSON.stringify(value);
+  }
+  return value;
+}
+
+/**
+ * Flattens an issue the same way as {@link flattenObject}, except `customFields`
+ * becomes a `{ fieldName: value }` map instead of being collapsed to a list of
+ * field *names* — the generic flattener discards every custom field value,
+ * which is where an issue's Priority, State and Assignee live.
+ */
+export function flattenIssue(
+  issue: Record<string, unknown>,
+): Record<string, unknown> {
+  const { customFields, ...rest } = issue;
+  const result = flattenObject(rest);
+
+  const values: Record<string, unknown> = {};
+  if (Array.isArray(customFields)) {
+    for (const field of customFields as Array<Record<string, unknown>>) {
+      const name = field['name'];
+      if (typeof name === 'string' && name !== '') {
+        values[name] = customFieldValue(field['value']);
+      }
+    }
+  }
+  result['customFields'] = values;
+
+  return result;
+}
+
 // -----------------------------------------------------------------------------
 // Shared Dropdowns
 // -----------------------------------------------------------------------------

--- a/packages/pieces/community/youtrack/src/lib/common/index.ts
+++ b/packages/pieces/community/youtrack/src/lib/common/index.ts
@@ -5,7 +5,7 @@ import {
   HttpResponse,
 } from '@activepieces/pieces-common';
 import { Property } from '@activepieces/pieces-framework';
-import { youtrackAuth } from '../../';
+import { youtrackAuth } from '../auth';
 
 const API_PATH = '/api';
 
@@ -84,15 +84,24 @@ export function flattenObject(
 // Shared Dropdowns
 // -----------------------------------------------------------------------------
 
+/**
+ * Surfaces the real reason a dropdown could not load instead of a generic
+ * message, otherwise a wrong URL and an expired token look identical.
+ */
+export function dropdownError(prefix: string, error: unknown) {
+  const message = error instanceof Error ? error.message : String(error);
+  return { disabled: true, options: [], placeholder: prefix + ': ' + message };
+}
+
 export const projectDropdown = Property.Dropdown({
   displayName: 'Project',
   description: 'Select the YouTrack project to work with.',
   required: true,
-  auth:youtrackAuth,
+  auth: youtrackAuth,
   refreshers: [],
   options: async ({ auth }) => {
     if (!auth) return { disabled: true, options: [], placeholder: 'Please connect your account first' };
-    const { baseUrl, apiToken } = auth as unknown as { baseUrl: string; apiToken: string };
+    const { baseUrl, apiToken } = auth.props;
     try {
       const response = await youtrackApiCall<Array<{ id: string; name: string; shortName: string }>>({
         baseUrl, token: apiToken, method: HttpMethod.GET,
@@ -108,8 +117,8 @@ export const projectDropdown = Property.Dropdown({
           value: p.id,
         })),
       };
-    } catch {
-      return { disabled: true, options: [], placeholder: 'Failed to load projects. Check your connection.' };
+    } catch (error) {
+      return dropdownError('Failed to load projects', error);
     }
   },
 });
@@ -118,38 +127,34 @@ export const issueDropdown = Property.Dropdown({
   displayName: 'Issue',
   description: 'Select the issue to work with.',
   required: true,
-  auth:youtrackAuth,
+  auth: youtrackAuth,
   refreshers: ['project'],
   options: async ({ auth, project }) => {
     if (!auth) return { disabled: true, options: [], placeholder: 'Please connect your account first' };
-    const { baseUrl, apiToken } = auth as unknown as { baseUrl: string; apiToken: string };
-    if (!project) {
-      try {
-        const response = await youtrackApiCall<Array<{ id: string; idReadable: string; summary: string }>>({
-          baseUrl, token: apiToken, method: HttpMethod.GET, path: '/issues',
-          queryParams: { fields: 'id,idReadable,summary', '$top': '50' },
-        });
-        if (!response.body || response.body.length === 0) {
-          return { disabled: false, options: [], placeholder: 'No issues found.' };
-        }
-        return {
-          disabled: false,
-          options: response.body.map((i) => ({
-            label: i.idReadable + ': ' + i.summary,
-            value: i.id,
-          })),
-        };
-      } catch {
-        return { disabled: true, options: [], placeholder: 'Failed to load issues. Check your connection.' };
-      }
-    }
+    const { baseUrl, apiToken } = auth.props;
     try {
+      const queryParams: Record<string, string> = {
+        fields: 'id,idReadable,summary',
+        '$top': project ? '100' : '50',
+      };
+      if (project) {
+        // The project dropdown yields an internal id (e.g. "0-5"), but YouTrack
+        // search syntax only matches a project by name/shortName.
+        const projectResponse = await youtrackApiCall<{ shortName: string }>({
+          baseUrl, token: apiToken, method: HttpMethod.GET,
+          path: '/admin/projects/' + project, queryParams: { fields: 'shortName' },
+        });
+        queryParams['query'] = 'project: {' + projectResponse.body.shortName + '}';
+      }
       const response = await youtrackApiCall<Array<{ id: string; idReadable: string; summary: string }>>({
-        baseUrl, token: apiToken, method: HttpMethod.GET, path: '/issues',
-        queryParams: { fields: 'id,idReadable,summary', query: 'project: {' + project + '}', '$top': '100' },
+        baseUrl, token: apiToken, method: HttpMethod.GET, path: '/issues', queryParams,
       });
       if (!response.body || response.body.length === 0) {
-        return { disabled: false, options: [], placeholder: 'No issues found in this project.' };
+        return {
+          disabled: false,
+          options: [],
+          placeholder: project ? 'No issues found in this project.' : 'No issues found.',
+        };
       }
       return {
         disabled: false,
@@ -158,8 +163,8 @@ export const issueDropdown = Property.Dropdown({
           value: i.id,
         })),
       };
-    } catch {
-      return { disabled: true, options: [], placeholder: 'Failed to load issues. Check your connection.' };
+    } catch (error) {
+      return dropdownError('Failed to load issues', error);
     }
   },
 });
@@ -169,10 +174,10 @@ export const tagDropdown = Property.Dropdown({
   description: 'Select a tag to apply to the issue.',
   required: true,
   refreshers: [],
-  auth:youtrackAuth,
+  auth: youtrackAuth,
   options: async ({ auth }) => {
     if (!auth) return { disabled: true, options: [], placeholder: 'Please connect your account first' };
-    const { baseUrl, apiToken } = auth as unknown as { baseUrl: string; apiToken: string };
+    const { baseUrl, apiToken } = auth.props;
     try {
       const response = await youtrackApiCall<Array<{ id: string; name: string }>>({
         baseUrl, token: apiToken, method: HttpMethod.GET,
@@ -182,8 +187,8 @@ export const tagDropdown = Property.Dropdown({
         return { disabled: false, options: [], placeholder: 'No tags found. Create one in YouTrack first.' };
       }
       return { disabled: false, options: response.body.map((t) => ({ label: t.name, value: t.id })) };
-    } catch {
-      return { disabled: true, options: [], placeholder: 'Failed to load tags. Check your connection.' };
+    } catch (error) {
+      return dropdownError('Failed to load tags', error);
     }
   },
 });
@@ -193,10 +198,10 @@ export const userDropdown = Property.Dropdown({
   description: 'Select a YouTrack user.',
   required: true,
   refreshers: [],
-  auth:youtrackAuth,
+  auth: youtrackAuth,
   options: async ({ auth }) => {
     if (!auth) return { disabled: true, options: [], placeholder: 'Please connect your account first' };
-    const { baseUrl, apiToken } = auth as unknown as { baseUrl: string; apiToken: string };
+    const { baseUrl, apiToken } = auth.props;
     try {
       const response = await youtrackApiCall<Array<{ id: string; name: string; login: string }>>({
         baseUrl, token: apiToken, method: HttpMethod.GET,
@@ -212,8 +217,8 @@ export const userDropdown = Property.Dropdown({
           value: u.id,
         })),
       };
-    } catch {
-      return { disabled: true, options: [], placeholder: 'Failed to load users. Check your connection.' };
+    } catch (error) {
+      return dropdownError('Failed to load users', error);
     }
   },
 });

--- a/packages/pieces/community/youtrack/src/lib/output-schemas.ts
+++ b/packages/pieces/community/youtrack/src/lib/output-schemas.ts
@@ -1,0 +1,225 @@
+import { OutputSchema } from '@activepieces/pieces-framework';
+
+// -----------------------------------------------------------------------------
+// Shared field sets
+// -----------------------------------------------------------------------------
+
+/**
+ * An issue as returned by `flattenIssue`: nested objects are flattened to
+ * underscore-joined keys, and `customFields` is a `{ fieldName: value }` map
+ * whose keys vary per project — hence `dynamicKey`.
+ */
+const issueFields: OutputSchema['fields'] = [
+  { key: 'idReadable', label: 'Issue ID' },
+  { key: 'summary', label: 'Summary' },
+  { key: 'description', label: 'Description' },
+  { key: 'id', label: 'Internal ID' },
+  { key: 'project_id', label: 'Project ID' },
+  { key: 'project_name', label: 'Project Name' },
+  { key: 'project_shortName', label: 'Project Short Name' },
+  { key: 'reporter_id', label: 'Reporter ID' },
+  { key: 'reporter_name', label: 'Reporter Name' },
+  { key: 'reporter_login', label: 'Reporter Login' },
+  {
+    key: 'customFields',
+    label: 'Custom Fields',
+    description:
+      'Custom field values keyed by field name (Priority, State, Assignee, Estimation, ...). The available keys depend on the project.',
+    dynamicKey: true,
+  },
+  { key: 'created', label: 'Created', format: 'datetime' },
+  { key: 'updated', label: 'Updated', format: 'datetime' },
+  { key: 'resolved', label: 'Resolved', format: 'datetime' },
+  { key: 'commentsCount', label: 'Comments Count', format: 'number' },
+  { key: 'votes', label: 'Votes', format: 'number' },
+];
+
+const commentFields: OutputSchema['fields'] = [
+  { key: 'id', label: 'Comment ID' },
+  { key: 'text', label: 'Text' },
+  { key: 'author_name', label: 'Author Name' },
+  { key: 'author_login', label: 'Author Login' },
+  { key: 'created', label: 'Created', format: 'datetime' },
+];
+
+const commentListFields: OutputSchema['fields'] = [
+  ...commentFields,
+  { key: 'updated', label: 'Updated', format: 'datetime' },
+];
+
+const attachmentFields: OutputSchema['fields'] = [
+  { key: 'id', label: 'Attachment ID' },
+  { key: 'name', label: 'File Name' },
+  { key: 'content_type', label: 'Content Type' },
+  { key: 'size_bytes', label: 'Size', format: 'filesize' },
+  { key: 'author_name', label: 'Author Name' },
+  { key: 'author_login', label: 'Author Login' },
+  { key: 'created', label: 'Created', format: 'datetime' },
+];
+
+const uploadedAttachmentFields: OutputSchema['fields'] = [
+  { key: 'id', label: 'Attachment ID' },
+  { key: 'name', label: 'File Name' },
+];
+
+const tagBaseFields: OutputSchema['fields'] = [
+  { key: 'id', label: 'Tag ID' },
+  { key: 'name', label: 'Name' },
+  { key: 'owner_id', label: 'Owner ID' },
+  { key: 'owner_name', label: 'Owner Name' },
+];
+
+const activityFields: OutputSchema['fields'] = [
+  { key: 'type', label: 'Activity Type' },
+  { key: 'timestamp', label: 'Timestamp', format: 'datetime' },
+  { key: 'author_name', label: 'Author Name' },
+  { key: 'author_login', label: 'Author Login' },
+  { key: 'added_values', label: 'Added Values' },
+  { key: 'removed_values', label: 'Removed Values' },
+  { key: 'comment_text', label: 'Comment Text' },
+];
+
+// -----------------------------------------------------------------------------
+// Issues
+// -----------------------------------------------------------------------------
+
+export const createIssueActionOutputSchema: OutputSchema = { fields: issueFields };
+export const getIssueActionOutputSchema: OutputSchema = { fields: issueFields };
+export const updateIssueActionOutputSchema: OutputSchema = { fields: issueFields };
+
+export const searchIssuesActionOutputSchema: OutputSchema = {
+  itemLabel: '{idReadable}: {summary}',
+  fields: [
+    { key: 'issues', label: 'Issues', value: '', listItems: issueFields },
+  ],
+};
+
+// -----------------------------------------------------------------------------
+// Comments
+// -----------------------------------------------------------------------------
+
+export const addCommentActionOutputSchema: OutputSchema = { fields: commentFields };
+
+export const listCommentsActionOutputSchema: OutputSchema = {
+  itemLabel: '{author_name}: {text}',
+  fields: [
+    { key: 'comments', label: 'Comments', value: '', listItems: commentListFields },
+  ],
+};
+
+// -----------------------------------------------------------------------------
+// Tags
+// -----------------------------------------------------------------------------
+
+export const createTagActionOutputSchema: OutputSchema = {
+  fields: [
+    ...tagBaseFields,
+    { key: 'untagOnResolve', label: 'Remove When Resolved', format: 'boolean' },
+  ],
+};
+
+export const addTagToIssueActionOutputSchema: OutputSchema = {
+  fields: [
+    { key: 'id', label: 'Tag ID' },
+    { key: 'name', label: 'Name' },
+  ],
+};
+
+export const listTagsActionOutputSchema: OutputSchema = {
+  itemLabel: '{name}',
+  fields: [
+    {
+      key: 'tags',
+      label: 'Tags',
+      value: '',
+      listItems: [
+        ...tagBaseFields,
+        { key: 'visible_for_name', label: 'Visible For' },
+        { key: 'updateable_by_name', label: 'Updateable By' },
+        { key: 'untag_on_resolve', label: 'Remove When Resolved', format: 'boolean' },
+      ],
+    },
+  ],
+};
+
+export const removeTagFromIssueActionOutputSchema: OutputSchema = {
+  fields: [{ key: 'success', label: 'Success', format: 'boolean' }],
+};
+
+// -----------------------------------------------------------------------------
+// Attachments
+// -----------------------------------------------------------------------------
+
+export const listAttachmentsActionOutputSchema: OutputSchema = {
+  itemLabel: '{name}',
+  fields: [
+    { key: 'attachments', label: 'Attachments', value: '', listItems: attachmentFields },
+  ],
+};
+
+export const uploadAttachmentActionOutputSchema: OutputSchema = {
+  itemLabel: '{name}',
+  fields: [
+    {
+      key: 'attachments',
+      label: 'Uploaded Attachments',
+      value: '',
+      listItems: uploadedAttachmentFields,
+    },
+  ],
+};
+
+export const downloadAttachmentActionOutputSchema: OutputSchema = {
+  fields: [
+    { key: 'file_name', label: 'File Name' },
+    { key: 'attachment_id', label: 'Attachment ID' },
+    { key: 'content_type', label: 'Content Type' },
+    { key: 'size_bytes', label: 'Size', format: 'filesize' },
+    { key: 'base64_content', label: 'Base64 Content' },
+  ],
+};
+
+export const deleteAttachmentActionOutputSchema: OutputSchema = {
+  fields: [{ key: 'success', label: 'Success', format: 'boolean' }],
+};
+
+// -----------------------------------------------------------------------------
+// History, commands, team
+// -----------------------------------------------------------------------------
+
+export const getIssueHistoryActionOutputSchema: OutputSchema = {
+  itemLabel: '{author_name}: {type}',
+  fields: [
+    { key: 'activities', label: 'Activities', value: '', listItems: activityFields },
+  ],
+};
+
+export const applyCommandActionOutputSchema: OutputSchema = {
+  fields: [
+    { key: 'success', label: 'Success', format: 'boolean' },
+    { key: 'command', label: 'Command' },
+  ],
+};
+
+export const linkIssuesActionOutputSchema: OutputSchema = {
+  fields: [
+    { key: 'success', label: 'Success', format: 'boolean' },
+    { key: 'link_type', label: 'Link Type' },
+    { key: 'target_issue', label: 'Target Issue' },
+  ],
+};
+
+export const addUserToTeamActionOutputSchema: OutputSchema = {
+  fields: [
+    { key: 'id', label: 'User ID' },
+    { key: 'name', label: 'Name' },
+    { key: 'login', label: 'Login' },
+  ],
+};
+
+// -----------------------------------------------------------------------------
+// Triggers — one flattened issue per event
+// -----------------------------------------------------------------------------
+
+export const newIssueTriggerOutputSchema: OutputSchema = { fields: issueFields };
+export const updatedIssueTriggerOutputSchema: OutputSchema = { fields: issueFields };

--- a/packages/pieces/community/youtrack/src/lib/triggers/new-issue.ts
+++ b/packages/pieces/community/youtrack/src/lib/triggers/new-issue.ts
@@ -2,11 +2,15 @@
 import { AppConnectionValueForAuthProperty, createTrigger, TriggerStrategy } from '@activepieces/pieces-framework';
 import { DedupeStrategy, HttpMethod, Polling, pollingHelper } from '@activepieces/pieces-common';
 import { youtrackAuth } from '../auth';
-import { ISSUE_FIELDS, flattenObject, youtrackApiCall } from '../common';
+import { ISSUE_FIELDS, flattenIssue, youtrackApiCall } from '../common';
+import { newIssueTriggerOutputSchema } from '../output-schemas';
 
 const polling: Polling<AppConnectionValueForAuthProperty<typeof youtrackAuth>, Record<string, never>> = {
   strategy: DedupeStrategy.TIMEBASED,
-  items: async ({ auth, lastFetchEpochMS }) => {
+  // No date filter in the query: YouTrack search syntax has no `{after <epoch>}`
+  // form (it 400s), and pollingHelper already drops items at or below
+  // `lastFetchEpochMS`. Newest-first ordering keeps the fetched window relevant.
+  items: async ({ auth }) => {
     const response = await youtrackApiCall<Array<Record<string, unknown>>>({
       baseUrl: auth.props.baseUrl,
       token: auth.props.apiToken,
@@ -14,13 +18,13 @@ const polling: Polling<AppConnectionValueForAuthProperty<typeof youtrackAuth>, R
       path: '/issues',
       queryParams: {
         fields: ISSUE_FIELDS,
-        query: 'created: {after ' + lastFetchEpochMS + '}',
+        query: 'sort by: created desc',
         '$top': '50',
       },
     });
     return (response.body || []).map((issue) => ({
       epochMilliSeconds: (issue['created'] as number) || 0,
-      data: flattenObject(issue),
+      data: flattenIssue(issue),
     }));
   },
 };
@@ -28,6 +32,7 @@ const polling: Polling<AppConnectionValueForAuthProperty<typeof youtrackAuth>, R
 export const newIssueTrigger = createTrigger({
   auth: youtrackAuth,
   name: 'new_issue',
+  outputSchema: newIssueTriggerOutputSchema,
   displayName: 'New Issue',
   description: 'Triggers when a new issue is created in any project you can access.',
   aiMetadata: {
@@ -35,9 +40,28 @@ export const newIssueTrigger = createTrigger({
   },
   props: {},
   sampleData: {
-    idReadable: 'SP-42', summary: 'Fix login page crash', project_name: 'Sample Project',
-    project_shortName: 'SP', reporter_name: 'Jane Doe', commentsCount: 0,
-    created: 1644916724088, updated: 1644916724088,
+    idReadable: 'SP-42',
+    summary: 'Fix login page crash',
+    description: 'Users cannot sign in after the latest deploy.',
+    id: '3-19',
+    project_id: '0-0',
+    project_name: 'Sample Project',
+    project_shortName: 'SP',
+    reporter_id: '2-1',
+    reporter_name: 'Jane Doe',
+    reporter_login: 'jane.doe',
+    customFields: {
+      Priority: 'Critical',
+      Type: 'Bug',
+      State: 'To do',
+      Assignee: null,
+      Estimation: '2h',
+    },
+    created: 1644916724088,
+    updated: 1644916724088,
+    resolved: null,
+    commentsCount: 0,
+    votes: 0,
   },
   type: TriggerStrategy.POLLING,
   async test(context) { return await pollingHelper.test(polling, context); },

--- a/packages/pieces/community/youtrack/src/lib/triggers/new-issue.ts
+++ b/packages/pieces/community/youtrack/src/lib/triggers/new-issue.ts
@@ -1,7 +1,7 @@
 // Trigger: New Issue
 import { AppConnectionValueForAuthProperty, createTrigger, TriggerStrategy } from '@activepieces/pieces-framework';
 import { DedupeStrategy, HttpMethod, Polling, pollingHelper } from '@activepieces/pieces-common';
-import { youtrackAuth } from '../../';
+import { youtrackAuth } from '../auth';
 import { ISSUE_FIELDS, flattenObject, youtrackApiCall } from '../common';
 
 const polling: Polling<AppConnectionValueForAuthProperty<typeof youtrackAuth>, Record<string, never>> = {

--- a/packages/pieces/community/youtrack/src/lib/triggers/updated-issue.ts
+++ b/packages/pieces/community/youtrack/src/lib/triggers/updated-issue.ts
@@ -2,11 +2,16 @@
 import { AppConnectionValueForAuthProperty, createTrigger, TriggerStrategy } from '@activepieces/pieces-framework';
 import { DedupeStrategy, HttpMethod, Polling, pollingHelper } from '@activepieces/pieces-common';
 import { youtrackAuth } from '../auth';
-import { ISSUE_FIELDS, flattenObject, youtrackApiCall } from '../common';
+import { ISSUE_FIELDS, flattenIssue, youtrackApiCall } from '../common';
+import { updatedIssueTriggerOutputSchema } from '../output-schemas';
 
 const polling: Polling<AppConnectionValueForAuthProperty<typeof youtrackAuth>, Record<string, never>> = {
   strategy: DedupeStrategy.TIMEBASED,
-  items: async ({ auth, lastFetchEpochMS }) => {
+  // No date filter in the query: YouTrack search syntax has no `{after <epoch>}`
+  // form (it 400s), and pollingHelper already drops items at or below
+  // `lastFetchEpochMS`. Issues whose `updated` still equals `created` have never
+  // been modified, so they belong to the New Issue trigger only.
+  items: async ({ auth }) => {
     const response = await youtrackApiCall<Array<Record<string, unknown>>>({
       baseUrl: auth.props.baseUrl,
       token: auth.props.apiToken,
@@ -14,20 +19,23 @@ const polling: Polling<AppConnectionValueForAuthProperty<typeof youtrackAuth>, R
       path: '/issues',
       queryParams: {
         fields: ISSUE_FIELDS,
-        query: 'updated: {after ' + lastFetchEpochMS + '} AND created: {before ' + lastFetchEpochMS + '}',
+        query: 'sort by: updated desc',
         '$top': '50',
       },
     });
-    return (response.body || []).map((issue) => ({
-      epochMilliSeconds: (issue['updated'] as number) || (issue['created'] as number) || 0,
-      data: flattenObject(issue),
-    }));
+    return (response.body || [])
+      .filter((issue) => issue['updated'] !== issue['created'])
+      .map((issue) => ({
+        epochMilliSeconds: (issue['updated'] as number) || 0,
+        data: flattenIssue(issue),
+      }));
   },
 };
 
 export const updatedIssueTrigger = createTrigger({
   auth: youtrackAuth,
   name: 'updated_issue',
+  outputSchema: updatedIssueTriggerOutputSchema,
   displayName: 'Updated Issue',
   description: 'Triggers when an existing issue is modified (summary, description, custom fields, etc.).',
   aiMetadata: {
@@ -35,9 +43,28 @@ export const updatedIssueTrigger = createTrigger({
   },
   props: {},
   sampleData: {
-    idReadable: 'SP-42', summary: 'Fixed login page crash', project_name: 'Sample Project',
-    project_shortName: 'SP', reporter_name: 'Jane Doe', commentsCount: 3,
-    created: 1644916724088, updated: 1648110830229,
+    idReadable: 'SP-42',
+    summary: 'Fixed login page crash',
+    description: 'Users cannot sign in after the latest deploy.',
+    id: '3-19',
+    project_id: '0-0',
+    project_name: 'Sample Project',
+    project_shortName: 'SP',
+    reporter_id: '2-1',
+    reporter_name: 'Jane Doe',
+    reporter_login: 'jane.doe',
+    customFields: {
+      Priority: 'Critical',
+      Type: 'Bug',
+      State: 'Done',
+      Assignee: 'John Smith',
+      Estimation: '2h',
+    },
+    created: 1644916724088,
+    updated: 1648110830229,
+    resolved: 1648110830229,
+    commentsCount: 3,
+    votes: 0,
   },
   type: TriggerStrategy.POLLING,
   async test(context) { return await pollingHelper.test(polling, context); },

--- a/packages/pieces/community/youtrack/src/lib/triggers/updated-issue.ts
+++ b/packages/pieces/community/youtrack/src/lib/triggers/updated-issue.ts
@@ -1,7 +1,7 @@
 // Trigger: Updated Issue
 import { AppConnectionValueForAuthProperty, createTrigger, TriggerStrategy } from '@activepieces/pieces-framework';
 import { DedupeStrategy, HttpMethod, Polling, pollingHelper } from '@activepieces/pieces-common';
-import { youtrackAuth } from '../../';
+import { youtrackAuth } from '../auth';
 import { ISSUE_FIELDS, flattenObject, youtrackApiCall } from '../common';
 
 const polling: Polling<AppConnectionValueForAuthProperty<typeof youtrackAuth>, Record<string, never>> = {

--- a/packages/pieces/core/math-helper/package.json
+++ b/packages/pieces/core/math-helper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-math-helper",
-  "version": "0.0.28",
+  "version": "0.0.29",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "bundleDeps": true,

--- a/packages/pieces/core/math-helper/src/lib/actions/addition.ts
+++ b/packages/pieces/core/math-helper/src/lib/actions/addition.ts
@@ -3,10 +3,12 @@ import {
   PieceAuth,
   Property,
 } from '@activepieces/pieces-framework';
+import { additionActionOutputSchema } from '../output-schemas';
 
 export const addition = createAction({
   audience: 'both',
   name: 'addition_math',
+  outputSchema: additionActionOutputSchema,
   auth: PieceAuth.None(),
   displayName: 'Addition',
   description: 'Add the first number and the second number',

--- a/packages/pieces/core/math-helper/src/lib/actions/division.ts
+++ b/packages/pieces/core/math-helper/src/lib/actions/division.ts
@@ -5,10 +5,12 @@ import {
 } from '@activepieces/pieces-framework';
 import { propsValidation } from '@activepieces/pieces-common';
 import * as z from 'zod/mini';
+import { divisionActionOutputSchema } from '../output-schemas';
 
 export const division = createAction({
   audience: 'both',
   name: 'division_math',
+  outputSchema: divisionActionOutputSchema,
   auth: PieceAuth.None(),
   displayName: 'Division',
   description: 'Divide first number by the second number',

--- a/packages/pieces/core/math-helper/src/lib/actions/generateRandom.ts
+++ b/packages/pieces/core/math-helper/src/lib/actions/generateRandom.ts
@@ -3,10 +3,12 @@ import {
   Property,
   createAction,
 } from '@activepieces/pieces-framework';
+import { generateRandomActionOutputSchema } from '../output-schemas';
 
 export const generateRandom = createAction({
   audience: 'both',
   name: 'generateRandom_math',
+  outputSchema: generateRandomActionOutputSchema,
   auth: PieceAuth.None(),
   displayName: 'Generate Random Number',
   description: 'Generate random number between two numbers (inclusive)',

--- a/packages/pieces/core/math-helper/src/lib/actions/modulo.ts
+++ b/packages/pieces/core/math-helper/src/lib/actions/modulo.ts
@@ -3,10 +3,12 @@ import {
   PieceAuth,
   Property,
 } from '@activepieces/pieces-framework';
+import { moduloActionOutputSchema } from '../output-schemas';
 
 export const modulo = createAction({
   audience: 'both',
   name: 'modulo_math',
+  outputSchema: moduloActionOutputSchema,
   auth: PieceAuth.None(),
   displayName: 'Modulo',
   description: 'Get the remainder of the first number divided by second number',

--- a/packages/pieces/core/math-helper/src/lib/actions/multiplication.ts
+++ b/packages/pieces/core/math-helper/src/lib/actions/multiplication.ts
@@ -3,10 +3,12 @@ import {
   Property,
   createAction,
 } from '@activepieces/pieces-framework';
+import { multiplicationActionOutputSchema } from '../output-schemas';
 
 export const multiplication = createAction({
   audience: 'both',
   name: 'multiplication_math',
+  outputSchema: multiplicationActionOutputSchema,
   auth: PieceAuth.None(),
   displayName: 'Multiplication',
   description: 'Multiply first number by the second number',

--- a/packages/pieces/core/math-helper/src/lib/actions/subtraction.ts
+++ b/packages/pieces/core/math-helper/src/lib/actions/subtraction.ts
@@ -3,10 +3,12 @@ import {
   PieceAuth,
   Property,
 } from '@activepieces/pieces-framework';
+import { subtractionActionOutputSchema } from '../output-schemas';
 
 export const subtraction = createAction({
   audience: 'both',
   name: 'subtraction_math',
+  outputSchema: subtractionActionOutputSchema,
   auth: PieceAuth.None(),
   displayName: 'Subtraction',
   description: 'Subtract the first number from the second number',

--- a/packages/pieces/core/math-helper/src/lib/output-schemas.ts
+++ b/packages/pieces/core/math-helper/src/lib/output-schemas.ts
@@ -1,0 +1,54 @@
+import { OutputSchema } from '@activepieces/pieces-framework';
+
+/**
+ * Every Math Helper action returns a bare number rather than an object, so each
+ * schema is a single whole-output field: `value: ''` resolves to the entire
+ * step output and contributes no path segment.
+ *
+ * This shape is what `describeWholeOutputSchema` (server MCP utils) recognises —
+ * exactly one field, `value: ''`, no `children`/`listItems` — so agents get a
+ * one-line description of the result instead of a bogus `result` path.
+ */
+const wholeNumberOutput = (
+  key: string,
+  label: string,
+  description: string,
+): OutputSchema => ({
+  fields: [{ key, label, value: '', format: 'number', description }],
+});
+
+export const additionActionOutputSchema = wholeNumberOutput(
+  'sum',
+  'Sum',
+  'The first number plus the second number.',
+);
+
+export const subtractionActionOutputSchema = wholeNumberOutput(
+  'difference',
+  'Difference',
+  'The second number minus the first number.',
+);
+
+export const multiplicationActionOutputSchema = wholeNumberOutput(
+  'product',
+  'Product',
+  'The first number multiplied by the second number.',
+);
+
+export const divisionActionOutputSchema = wholeNumberOutput(
+  'quotient',
+  'Quotient',
+  'The first number divided by the second number. May be fractional.',
+);
+
+export const moduloActionOutputSchema = wholeNumberOutput(
+  'remainder',
+  'Remainder',
+  'The remainder of the first number divided by the second number.',
+);
+
+export const generateRandomActionOutputSchema = wholeNumberOutput(
+  'randomNumber',
+  'Random Number',
+  'A pseudo-random integer between the two numbers, inclusive.',
+);


### PR DESCRIPTION
## Description

Fixed a few bugs in the YouTrack piece and added output schemas to YouTrack, Pinterest and Math Helper.

**YouTrack fixes**
- Both polling triggers never fired — the search query was invalid and returned `400` on every poll
- Download Attachment always failed on YouTrack's relative attachment URL
- Attachment content type was always empty — the piece asked for `contentType`, the API field is `mimeType`
- Create/Update Issue returned a `500` when Custom Fields was left at its default `{}`
- Custom field values (Priority, State, Assignee) were being discarded from the output
- Upload Attachment leaked an internal `$type` field

**Output schemas**
- YouTrack `0.0.6` — 18 actions + 2 triggers
- Pinterest `0.1.6` — 6 actions + 3 triggers
- Math Helper `0.0.29` — 6 actions

## How was this tested?

Manually on a self-hosted CE dev instance. Every action and trigger was run against a live account, and each schema was checked against the real captured output. Build and lint pass on all three pieces; Math Helper's existing tests still pass.

Fixes # (issue)

### Breaking change?  (required — CI fails if this is left unedited)

- [ ] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [x] yes — functional (default/limit/behaviour change, new self-hosted setup step)

YouTrack's `customFields` output changes from a comma-joined string of field names to an object of name → value. Flows using `{{step.customFields}}` need `{{step.customFields.Priority}}`.

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)
