### PR TITLE
feat(agent): hand the flow step a result it can already render

### DIFF
--- a/packages/server/api/src/app/ee/agent/agent-helpers.ts
+++ b/packages/server/api/src/app/ee/agent/agent-helpers.ts
@@ -1,5 +1,7 @@
 import { ActivepiecesError, AIProviderName, apId, ErrorCode, isNil, tryCatch, unique } from '@activepieces/core-utils'
+import { agentAiUtils } from '@activepieces/server-utils'
 import { ACTIVEPIECES_CHAT_TIERS, AgentConversationStatus, aiProviderUtils, DEFAULT_CHAT_TIER_ID, GetAgentMemoryResponse, GetProviderConfigResponse, Project, ProjectType, UserMemory } from '@activepieces/shared'
+import { LanguageModel } from 'ai'
 import { FastifyBaseLogger } from 'fastify'
 import { aiProviderService } from '../../ai/ai-provider-service'
 import { repoFactory } from '../../core/db/repo-factory'
@@ -113,6 +115,16 @@ function resolveModelIdForAnalytics({ provider, selectedModel }: { provider: AIP
 // Round one of the chat turn runs on the fastest tier so its first token streams in ~400ms
 // (the opener + first discovery) — fast enough to replace the bare "Thinking…" gap —
 // regardless of which tier the user picked for the main turn.
+async function resolveFastModel({ platformId, log }: { platformId: string, log: FastifyBaseLogger }): Promise<LanguageModel> {
+    const providerConfig = await resolveChatProvider({ platformId, log })
+    return agentAiUtils.createChatModel({
+        provider: providerConfig.provider,
+        auth: providerConfig.auth,
+        config: providerConfig.config,
+        modelId: resolveFastModelId({ provider: providerConfig.provider }),
+    })
+}
+
 function resolveFastModelId({ provider }: { provider: AIProviderName }): string {
     return resolveModelIdForProvider({ provider, selectedModel: FAST_TIER_ID })
 }
@@ -222,6 +234,7 @@ export const agentHelpers = {
     resolveModelIdForProvider,
     resolveModelIdForAnalytics,
     resolveFastModelId,
+    resolveFastModel,
     resolveChatProviderName,
     recoverAllStaleStreamingConversations,
     incrementAndCheckLimit,

--- a/packages/server/api/src/app/ee/agent/agent-memory-ai.ts
+++ b/packages/server/api/src/app/ee/agent/agent-memory-ai.ts
@@ -3,7 +3,7 @@ import path from 'node:path'
 import { isNil, parseToJsonIfPossible, tryCatch } from '@activepieces/core-utils'
 import { agentAiUtils } from '@activepieces/server-utils'
 import { GetAgentMemoryResponse } from '@activepieces/shared'
-import { generateText, LanguageModel } from 'ai'
+import { generateText } from 'ai'
 import { FastifyBaseLogger } from 'fastify'
 import { z } from 'zod'
 import { agentHelpers } from './agent-helpers'
@@ -27,15 +27,6 @@ const MemoriesSchema = z.object({
     memories: z.array(z.string().catch('')).catch([]),
 })
 
-async function resolveModel(platformId: string, log: FastifyBaseLogger): Promise<LanguageModel> {
-    const providerConfig = await agentHelpers.resolveChatProvider({ platformId, log })
-    return agentAiUtils.createChatModel({
-        provider: providerConfig.provider,
-        auth: providerConfig.auth as Record<string, unknown>,
-        config: providerConfig.config as Record<string, unknown>,
-        modelId: agentHelpers.resolveFastModelId({ provider: providerConfig.provider }),
-    })
-}
 
 function parseJsonObject<T>(raw: string, schema: z.ZodType<T>): T | null {
     const start = raw.indexOf('{')
@@ -62,7 +53,7 @@ async function runMemoryLlm<T>({ platformId, instructions, prompt, schema, log }
     log: FastifyBaseLogger
 }): Promise<T | null> {
     const { data, error } = await tryCatch(async () => {
-        const { text: raw } = await generateText({ model: await resolveModel(platformId, log), instructions, prompt, telemetry: agentAiUtils.buildTelemetry({ functionId: 'agent-memory' }) })
+        const { text: raw } = await generateText({ model: await agentHelpers.resolveFastModel({ platformId, log }), instructions, prompt, telemetry: agentAiUtils.buildTelemetry({ functionId: 'agent-memory' }) })
         return parseJsonObject(raw, schema)
     })
     if (!isNil(error)) {

--- a/packages/server/api/src/app/ee/agent/agent-rpc-handlers.ts
+++ b/packages/server/api/src/app/ee/agent/agent-rpc-handlers.ts
@@ -493,17 +493,10 @@ export const agentRpcHandlers = (log: FastifyBaseLogger) => ({
         if (conversation?.source !== AgentRunSource.FLOW_STEP || isNil(conversation.projectId)) {
             throw new ActivepiecesError({ code: ErrorCode.AUTHORIZATION, params: { message: 'Only a flow-step run can run a configured piece tool' } })
         }
-        const providerConfig = await agentHelpers.resolveChatProvider({ platformId: conversation.platformId, log })
-        const model = agentAiUtils.createChatModel({
-            provider: providerConfig.provider,
-            auth: providerConfig.auth as Record<string, unknown>,
-            config: providerConfig.config as Record<string, unknown>,
-            modelId: agentHelpers.resolveFastModelId({ provider: providerConfig.provider }),
-        })
         const { result } = await pieceToolRunner.runFromInstruction({
+            model: await agentHelpers.resolveFastModel({ platformId: conversation.platformId, log }),
             piece: { pieceName: input.piece.pieceName, actionName: input.piece.actionName },
             instruction: input.instruction,
-            model,
             projectId: conversation.projectId,
             platformId: conversation.platformId,
             log,

--- a/packages/server/api/src/app/ee/agent/agent-run-controller.ts
+++ b/packages/server/api/src/app/ee/agent/agent-run-controller.ts
@@ -25,12 +25,11 @@ export const agentRunController: FastifyPluginAsyncZod = async (app) => {
         if (!allowed) {
             throw new ActivepiecesError({ code: ErrorCode.VALIDATION, params: { message: `This project started ${count} agent runs in the last minute, above the limit of ${RUNS_PER_MINUTE}` } })
         }
-        const requestedTools = tools ?? []
-        const unsupported = unique(requestedTools.filter((tool) => tool.type !== AgentToolType.PIECE).map((tool) => tool.type))
+        const pieceTools = (tools ?? []).filter((tool) => tool.type === AgentToolType.PIECE)
+        const unsupported = unique((tools ?? []).map((tool) => tool.type)).filter((type) => type !== AgentToolType.PIECE)
         if (unsupported.length > 0) {
             throw new ActivepiecesError({ code: ErrorCode.VALIDATION, params: { message: `An agent step cannot use ${unsupported.join(' or ')} tools yet, only piece actions` } })
         }
-        const pieceTools = requestedTools.filter((tool) => tool.type === AgentToolType.PIECE)
         await assertCreditsAndAppSumoNotExceeded({ platformId: platform.id, log: request.log })
         const { ownerId } = await projectService(request.log).getOneOrThrow(projectId)
 

--- a/packages/server/api/src/app/ee/agent/tools/piece-input-filler.ts
+++ b/packages/server/api/src/app/ee/agent/tools/piece-input-filler.ts
@@ -29,7 +29,7 @@ async function fillInput({ action, instruction, predefinedInput, ports }: FillIn
             schema,
             prompt: extractionPrompt({ instruction, propertyNames, resolvedInput, choices }),
         })
-        resolvedInput = { ...resolvedInput, ...filled }
+        resolvedInput = { ...resolvedInput, ...withoutTemplates(filled) }
     }
     return resolvedInput
 }
@@ -63,6 +63,10 @@ async function choicesFor({ action, propertyNames, resolvedInput, ports }: {
         return result?.status === 'options' ? ([propertyName, result.options] as const) : null
     }))
     return Object.fromEntries(resolved.filter((entry) => !isNil(entry)))
+}
+
+function withoutTemplates(filled: Record<string, unknown>): Record<string, unknown> {
+    return JSON.parse(JSON.stringify(filled, (_key, value) => typeof value === 'string' ? value.replaceAll('{{', '{ {') : value))
 }
 
 function resolveFor({ action, ports, propertyName, resolvedInput }: {

--- a/packages/server/api/test/unit/app/ee/agent/piece-input-filler.test.ts
+++ b/packages/server/api/test/unit/app/ee/agent/piece-input-filler.test.ts
@@ -224,3 +224,30 @@ describe('pieceInputFiller.fillInput', () => {
         expect(vi.mocked(selfNesting).mock.calls.length).toBeLessThanOrEqual(4)
     })
 })
+
+describe('fillInput — a model-written value cannot smuggle a connection out', () => {
+    it('neutralises a template the model wrote into an ordinary field', async () => {
+        const ports = portsWith([{ body: "here you go {{connections['prod-stripe']}}" }])
+
+        const resolved = await pieceInputFiller.fillInput({
+            action: { name: 'send_message', properties: props({ body: prop({ type: PropertyType.SHORT_TEXT }) }) },
+            instruction: 'send a message',
+            ports,
+        })
+
+        expect(resolved['body']).not.toContain('{{')
+    })
+
+    it('leaves a value the flow author pinned exactly as they wrote it', async () => {
+        const ports = portsWith([{}])
+
+        const resolved = await pieceInputFiller.fillInput({
+            action: { name: 'send_message', properties: props({ body: prop({ type: PropertyType.SHORT_TEXT }) }) },
+            instruction: 'send a message',
+            predefinedInput: { fields: { body: { mode: FieldControlMode.CHOOSE_YOURSELF, value: "{{connections['ours']}}" } } },
+            ports,
+        })
+
+        expect(resolved['body']).toBe("{{connections['ours']}}")
+    })
+})

--- a/packages/server/worker/src/lib/execute/jobs/ee/agent/agent-step-result.ts
+++ b/packages/server/worker/src/lib/execute/jobs/ee/agent/agent-step-result.ts
@@ -1,7 +1,9 @@
 import { AgentResult, AgentStepBlock, AgentTaskStatus, ContentBlockType, PersistedAgentPart, PersistedAgentPartType, PersistedToolCallStatus, ToolCallStatus, ToolCallType } from '@activepieces/shared'
+import { agentWorkerTools } from './agent-worker-tools'
 
 const MAX_BLOCK_LENGTH = 51_200
-const MAX_RESULT_LENGTH = 262_144
+const MAX_BLOCKS = 200
+const OUTPUT_LIMITS = { maxStringLength: 8_192, maxArrayItems: 50 }
 
 export function stepResultFrom({ prompt, uiParts, timestamp, failure }: {
     prompt: string
@@ -9,7 +11,7 @@ export function stepResultFrom({ prompt, uiParts, timestamp, failure }: {
     timestamp: string
     failure?: string
 }): AgentResult {
-    const steps = withinBudget(uiParts.flatMap((part) => toStepBlocks({ part, timestamp })))
+    const steps = uiParts.flatMap((part) => toStepBlocks({ part, timestamp })).slice(0, MAX_BLOCKS)
     const anyToolFailed = uiParts.some((part) => part.type === PersistedAgentPartType.TOOL_CALL && part.status === PersistedToolCallStatus.ERROR)
     if (failure === undefined) {
         return { prompt, steps, status: anyToolFailed ? AgentTaskStatus.FAILED : AgentTaskStatus.COMPLETED }
@@ -19,20 +21,6 @@ export function stepResultFrom({ prompt, uiParts, timestamp, failure }: {
         steps: [...steps, { type: ContentBlockType.MARKDOWN, markdown: failure }],
         status: AgentTaskStatus.FAILED,
     }
-}
-
-function withinBudget(steps: AgentStepBlock[]): AgentStepBlock[] {
-    const kept: AgentStepBlock[] = []
-    let spent = 0
-    for (const step of steps) {
-        spent += JSON.stringify(step).length
-        if (spent > MAX_RESULT_LENGTH) {
-            kept.push({ type: ContentBlockType.MARKDOWN, markdown: `The remaining ${steps.length - kept.length} steps were left out because the result grew too large to hand back.` })
-            return kept
-        }
-        kept.push(step)
-    }
-    return kept
 }
 
 function toStepBlocks({ part, timestamp }: { part: PersistedAgentPart, timestamp: string }): AgentStepBlock[] {
@@ -48,7 +36,7 @@ function toStepBlocks({ part, timestamp }: { part: PersistedAgentPart, timestamp
                 toolName: part.toolName,
                 toolCallId: part.toolCallId,
                 input: part.input,
-                output: part.status === PersistedToolCallStatus.ERROR ? { failed: true, error: part.errorText ?? 'The action failed' } : part.output,
+                output: agentWorkerTools.shrinkLargeValue(failureOrOutput(part), OUTPUT_LIMITS),
                 status: ToolCallStatus.COMPLETED,
                 startTime: timestamp,
                 endTime: timestamp,
@@ -56,4 +44,10 @@ function toStepBlocks({ part, timestamp }: { part: PersistedAgentPart, timestamp
         default:
             return []
     }
+}
+
+function failureOrOutput(part: { status: PersistedToolCallStatus, errorText?: string, output?: unknown }): unknown {
+    return part.status === PersistedToolCallStatus.ERROR
+        ? { failed: true, error: part.errorText ?? 'The action failed' }
+        : part.output
 }

--- a/packages/server/worker/src/lib/execute/jobs/ee/agent/agent-step-result.ts
+++ b/packages/server/worker/src/lib/execute/jobs/ee/agent/agent-step-result.ts
@@ -1,0 +1,43 @@
+import { AgentResult, AgentStepBlock, AgentTaskStatus, ContentBlockType, PersistedAgentPart, PersistedAgentPartType, ToolCallStatus, ToolCallType } from '@activepieces/shared'
+
+const MAX_BLOCK_LENGTH = 51_200
+
+export function stepResultFrom({ prompt, uiParts, timestamp, failure }: {
+    prompt: string
+    uiParts: PersistedAgentPart[]
+    timestamp: string
+    failure?: string
+}): AgentResult {
+    const steps = uiParts.flatMap((part) => toStepBlocks({ part, timestamp }))
+    if (failure === undefined) {
+        return { prompt, steps, status: AgentTaskStatus.COMPLETED }
+    }
+    return {
+        prompt,
+        steps: [...steps, { type: ContentBlockType.MARKDOWN, markdown: failure }],
+        status: AgentTaskStatus.FAILED,
+    }
+}
+
+function toStepBlocks({ part, timestamp }: { part: PersistedAgentPart, timestamp: string }): AgentStepBlock[] {
+    switch (part.type) {
+        case PersistedAgentPartType.TEXT:
+        case PersistedAgentPartType.REASONING:
+            return part.text.trim().length === 0 ? [] : [{ type: ContentBlockType.MARKDOWN, markdown: part.text.slice(0, MAX_BLOCK_LENGTH) }]
+        case PersistedAgentPartType.TOOL_CALL:
+            return [{
+                type: ContentBlockType.TOOL_CALL,
+                toolCallType: ToolCallType.UNKNOWN,
+                displayName: part.title ?? part.toolName,
+                toolName: part.toolName,
+                toolCallId: part.toolCallId,
+                input: part.input,
+                output: part.output,
+                status: ToolCallStatus.COMPLETED,
+                startTime: timestamp,
+                endTime: timestamp,
+            }]
+        default:
+            return []
+    }
+}

--- a/packages/server/worker/src/lib/execute/jobs/ee/agent/agent-step-result.ts
+++ b/packages/server/worker/src/lib/execute/jobs/ee/agent/agent-step-result.ts
@@ -1,6 +1,7 @@
-import { AgentResult, AgentStepBlock, AgentTaskStatus, ContentBlockType, PersistedAgentPart, PersistedAgentPartType, ToolCallStatus, ToolCallType } from '@activepieces/shared'
+import { AgentResult, AgentStepBlock, AgentTaskStatus, ContentBlockType, PersistedAgentPart, PersistedAgentPartType, PersistedToolCallStatus, ToolCallStatus, ToolCallType } from '@activepieces/shared'
 
 const MAX_BLOCK_LENGTH = 51_200
+const MAX_RESULT_LENGTH = 262_144
 
 export function stepResultFrom({ prompt, uiParts, timestamp, failure }: {
     prompt: string
@@ -8,15 +9,30 @@ export function stepResultFrom({ prompt, uiParts, timestamp, failure }: {
     timestamp: string
     failure?: string
 }): AgentResult {
-    const steps = uiParts.flatMap((part) => toStepBlocks({ part, timestamp }))
+    const steps = withinBudget(uiParts.flatMap((part) => toStepBlocks({ part, timestamp })))
+    const anyToolFailed = uiParts.some((part) => part.type === PersistedAgentPartType.TOOL_CALL && part.status === PersistedToolCallStatus.ERROR)
     if (failure === undefined) {
-        return { prompt, steps, status: AgentTaskStatus.COMPLETED }
+        return { prompt, steps, status: anyToolFailed ? AgentTaskStatus.FAILED : AgentTaskStatus.COMPLETED }
     }
     return {
         prompt,
         steps: [...steps, { type: ContentBlockType.MARKDOWN, markdown: failure }],
         status: AgentTaskStatus.FAILED,
     }
+}
+
+function withinBudget(steps: AgentStepBlock[]): AgentStepBlock[] {
+    const kept: AgentStepBlock[] = []
+    let spent = 0
+    for (const step of steps) {
+        spent += JSON.stringify(step).length
+        if (spent > MAX_RESULT_LENGTH) {
+            kept.push({ type: ContentBlockType.MARKDOWN, markdown: `The remaining ${steps.length - kept.length} steps were left out because the result grew too large to hand back.` })
+            return kept
+        }
+        kept.push(step)
+    }
+    return kept
 }
 
 function toStepBlocks({ part, timestamp }: { part: PersistedAgentPart, timestamp: string }): AgentStepBlock[] {
@@ -32,7 +48,7 @@ function toStepBlocks({ part, timestamp }: { part: PersistedAgentPart, timestamp
                 toolName: part.toolName,
                 toolCallId: part.toolCallId,
                 input: part.input,
-                output: part.output,
+                output: part.status === PersistedToolCallStatus.ERROR ? { failed: true, error: part.errorText ?? 'The action failed' } : part.output,
                 status: ToolCallStatus.COMPLETED,
                 startTime: timestamp,
                 endTime: timestamp,

--- a/packages/server/worker/src/lib/execute/jobs/ee/agent/agent-worker-tools.ts
+++ b/packages/server/worker/src/lib/execute/jobs/ee/agent/agent-worker-tools.ts
@@ -183,6 +183,11 @@ function looksLikeMcpContentParts(array: unknown[]): boolean {
     return array.every((element) => isObject(element) && typeof element['type'] === 'string')
 }
 
+function humanizedPieceName(piece: string): string {
+    const stripped = piece.replace('@activepieces/piece-', '').replace(/^piece-/, '')
+    return stripped.split(/[-_]/).filter((word) => word.length > 0).map((word) => word[0].toUpperCase() + word.slice(1)).join(' ')
+}
+
 function normalizePieceName(piece: string): string {
     if (piece.startsWith('@')) return piece
     const stripped = piece.startsWith('piece-') ? piece.slice('piece-'.length) : piece
@@ -1446,15 +1451,19 @@ function createConfiguredPieceTools({ tools, runPieceTool, log }: {
     return Object.fromEntries(tools.map((configured) => [
         configured.toolName,
         tool({
-            description: `Run the "${configured.pieceMetadata.actionName}" action of ${normalizePieceName(configured.pieceMetadata.pieceName)}. Describe what you want it to do in plain language; its inputs are worked out from your instruction and the fields already pinned on this step.`,
+            description: `Run the "${configured.pieceMetadata.actionName}" action of ${humanizedPieceName(configured.pieceMetadata.pieceName)}. Say what you want it to do in plain language, including any values it needs. Its inputs are worked out from what you say here, and any field the flow author already pinned on this step keeps their value whatever you say. Returns whatever the action returns, or an explanation if it failed.`,
             inputSchema: z.object({
                 instruction: z.string().describe('What this action should do, including any values it needs, in plain language'),
             }),
             execute: async ({ instruction }) => {
                 const { data, error } = await tryCatch(() => runPieceTool({ toolName: configured.toolName, instruction, piece: configured.pieceMetadata }))
                 if (error) {
-                    log.warn({ error, tool: { name: configured.toolName } }, '[configuredPieceTool] Action failed')
-                    return { content: [{ type: 'text', text: `That action failed: ${error instanceof Error ? error.message : 'unknown error'}` }] }
+                    log.warn({ error, tool: { name: configured.toolName } }, '[configuredPieceTool] Action threw')
+                    return { content: [{ type: 'text', text: `That action failed: ${String(error)}` }] }
+                }
+                if (!isSuccessResult(data.result)) {
+                    log.warn({ tool: { name: configured.toolName } }, '[configuredPieceTool] Action reported a failure')
+                    return { content: [{ type: 'text', text: `That action failed: ${extractUserFacingError({ result: data.result })}` }] }
                 }
                 return truncateLargeResult(data.result)
             },

--- a/packages/server/worker/src/lib/execute/jobs/ee/agent/execute-agent-run.ts
+++ b/packages/server/worker/src/lib/execute/jobs/ee/agent/execute-agent-run.ts
@@ -149,7 +149,7 @@ export const executeAgentRunJob: JobHandler<ExecuteAgentRunJobData, FireAndForge
                 emailEnabled: config.emailEnabled,
                 abortSignal: abortController.signal,
                 source,
-                ...spreadIfDefined('configuredPieceTools', data.tools),
+                configuredPieceTools: data.tools ?? [],
             })
 
             const thinkingStartTime = Date.now()
@@ -270,7 +270,7 @@ export const executeAgentRunJob: JobHandler<ExecuteAgentRunJobData, FireAndForge
             }
             await retryWithBackoff({ fn: () => ctx.apiClient.saveAgentMessages(savePayload), description: 'Saving the transcript', throwOnExhausted: true, log })
 
-            answer = stepResultFrom({ prompt: userMessage, uiParts, timestamp: new Date().toISOString(), ...spreadIfDefined('failure', incompleteReason({ truncatedAfterRetries, budgetExceeded })) })
+            answer = stepResultFrom({ prompt: userMessage, uiParts, timestamp: new Date().toISOString(), failure: incompleteReason({ truncatedAfterRetries, budgetExceeded }) })
 
             if (autoTitle) {
                 await sendEventWithRetry({
@@ -399,7 +399,7 @@ function buildToolSet({ ctx, eventEmitter, log, phaseState, taintState, mcpToolS
     discoveryOnly: boolean
     emailEnabled: boolean
     abortSignal: AbortSignal
-    configuredPieceTools?: AgentPieceTool[]
+    configuredPieceTools: AgentPieceTool[]
     source: AgentRunSource
 }) {
     const brokenConnectors = new Set<string>()
@@ -548,11 +548,12 @@ function buildToolSet({ ctx, eventEmitter, log, phaseState, taintState, mcpToolS
         return allTools
     }
     const configuredTools = agentWorkerTools.createConfiguredPieceTools({
-        tools: configuredPieceTools ?? [],
+        tools: dryRun || discoveryOnly ? [] : configuredPieceTools,
         runPieceTool: ({ toolName, instruction, piece }) => ctx.apiClient.executePieceTool({ conversationId, toolName, instruction, piece }),
         log,
     })
-    return { ...omit(allTools, UNATTENDED_FORBIDDEN_TOOLS), ...configuredTools }
+    const unattendedTools = omit(allTools, UNATTENDED_FORBIDDEN_TOOLS)
+    return { ...configuredTools, ...unattendedTools }
 }
 
 async function streamChunksToClient({ result, ctx, userId, conversationId, runId, log, abortSignal, onStreamIdle }: {

--- a/packages/server/worker/src/lib/execute/jobs/ee/agent/execute-agent-run.ts
+++ b/packages/server/worker/src/lib/execute/jobs/ee/agent/execute-agent-run.ts
@@ -1,9 +1,10 @@
 import { AIProviderName, ErrorCode, isNil, isObject, omit, spreadIfDefined, tryCatch, tryCatchSync } from '@activepieces/core-utils'
 import { agentAiUtils } from '@activepieces/server-utils'
-import { AgentEvent, AgentEventType, AgentPhase, AgentPieceTool, AgentRunSource, EngineResponseStatus, ExecuteAgentRunJobData, PersistedAgentMessage, PersistedAgentPart, PersistedAgentPartType, PersistedAgentRole, WorkerJobType } from '@activepieces/shared'
+import { AgentEvent, AgentEventType, AgentPhase, AgentPieceTool, AgentResult, AgentRunSource, EngineResponseStatus, ExecuteAgentRunJobData, PersistedAgentMessage, PersistedAgentRole, WorkerJobType } from '@activepieces/shared'
 import { createUIMessageStream, generateText, ModelMessage, streamText, ToolSet, toUIMessageStream } from 'ai'
 import { FireAndForgetJobResult, JobContext, JobHandler, JobResultKind } from '../../../types'
 import { agentMcpClient } from './agent-mcp-client'
+import { stepResultFrom } from './agent-step-result'
 import { agentWorkerTools, GateDecision, TaintState } from './agent-worker-tools'
 import { delayWithJitter, isTransientFailureText, runAgentTurn } from './run-agent-turn'
 
@@ -34,7 +35,6 @@ const MAX_TURN_WALL_CLOCK_MS = 2 * 60 * 60 * 1_000
 const DISCOVERY_ONLY_NEUTRALIZED_TOOLS = new Set(['ap_execute_action', 'ap_run_code'])
 
 const UNATTENDED_FORBIDDEN_TOOLS = ['ap_run_code']
-const MAX_ANSWER_LENGTH = 51_200
 const DELIVERY_MAX_ATTEMPTS = 5
 
 export const executeAgentRunJob: JobHandler<ExecuteAgentRunJobData, FireAndForgetJobResult> = {
@@ -124,7 +124,7 @@ export const executeAgentRunJob: JobHandler<ExecuteAgentRunJobData, FireAndForge
             void tryCatch(() => ctx.apiClient.heartbeatAgentConversation({ conversationId, runId }))
         }
         const heartbeatInterval = setInterval(sendHeartbeat, HEARTBEAT_INTERVAL_MS)
-        let answer: StepOutcome | undefined
+        let answer: AgentResult | undefined
 
         try {
             const phaseState: { phase: AgentPhase } = { phase: 'discovery' }
@@ -231,7 +231,7 @@ export const executeAgentRunJob: JobHandler<ExecuteAgentRunJobData, FireAndForge
                         log.error({ error: retryError, conversation: { id: conversationId } }, 'Cancel save retry also failed')
                     }
                 }
-                await releaseFlowStep({ ctx, conversationId, flowRunId, waitpointId, output: { success: false, error: 'The agent run was stopped before it finished' }, source, log })
+                await releaseFlowStep({ ctx, conversationId, flowRunId, waitpointId, output: stepResultFrom({ prompt: userMessage, uiParts: [], timestamp: new Date().toISOString(), failure: 'The agent run was stopped before it finished' }), source, log })
                 await sendEventWithRetry({
                     event: { type: AgentEventType.FINISHED, data: { conversationId } },
                 })
@@ -270,7 +270,7 @@ export const executeAgentRunJob: JobHandler<ExecuteAgentRunJobData, FireAndForge
             }
             await retryWithBackoff({ fn: () => ctx.apiClient.saveAgentMessages(savePayload), description: 'Saving the transcript', throwOnExhausted: true, log })
 
-            answer = stepOutcomeFrom({ uiParts, truncatedAfterRetries, budgetExceeded })
+            answer = stepResultFrom({ prompt: userMessage, uiParts, timestamp: new Date().toISOString(), ...spreadIfDefined('failure', incompleteReason({ truncatedAfterRetries, budgetExceeded })) })
 
             if (autoTitle) {
                 await sendEventWithRetry({
@@ -302,7 +302,7 @@ export const executeAgentRunJob: JobHandler<ExecuteAgentRunJobData, FireAndForge
             const clientMessage = !isCreditError && isTransientFailureText(errorMessage)
                 ? 'The AI provider is temporarily unavailable. Please try again in a moment.'
                 : errorMessage
-            const { error: releaseError } = await tryCatch(() => releaseFlowStep({ ctx, conversationId, flowRunId, waitpointId, output: answer ?? { success: false, error: clientMessage }, source, log }))
+            const { error: releaseError } = await tryCatch(() => releaseFlowStep({ ctx, conversationId, flowRunId, waitpointId, output: answer ?? stepResultFrom({ prompt: userMessage, uiParts: [], timestamp: new Date().toISOString(), failure: clientMessage }), source, log }))
             // Empty arrays here mean "mark this turn ERROR" — they do NOT wipe history. The
             // saveAgentMessages handler's no-shrink guard preserves whatever was persisted
             // incrementally (updateAgentProgress) and only flips status, so an errored turn keeps
@@ -343,27 +343,16 @@ export const executeAgentRunJob: JobHandler<ExecuteAgentRunJobData, FireAndForge
     },
 }
 
-export function stepOutcomeFrom({ uiParts, truncatedAfterRetries, budgetExceeded }: {
-    uiParts: PersistedAgentPart[]
-    truncatedAfterRetries: boolean
-    budgetExceeded: boolean
-}): StepOutcome {
+function incompleteReason({ truncatedAfterRetries, budgetExceeded }: { truncatedAfterRetries: boolean, budgetExceeded: boolean }): string | undefined {
     if (truncatedAfterRetries) {
-        return { success: false, error: 'The response reached the output limit before the agent finished' }
+        return 'The response reached the output limit before the agent finished'
     }
     if (budgetExceeded) {
-        return { success: false, error: 'The run reached its usage limit and was stopped' }
+        return 'The run reached its usage limit and was stopped'
     }
-    return { success: true, output: agentTextFrom(uiParts).slice(0, MAX_ANSWER_LENGTH) }
+    return undefined
 }
 
-function agentTextFrom(parts: PersistedAgentPart[]): string {
-    return parts
-        .filter((part) => part.type === PersistedAgentPartType.TEXT)
-        .map((part) => part.text)
-        .join('\n')
-        .trim()
-}
 
 async function releaseFlowStep({ ctx, conversationId, flowRunId, waitpointId, output, source, log }: {
     ctx: JobContext
@@ -742,7 +731,3 @@ async function retryWithBackoff({ fn, maxAttempts = RETRY_MAX_ATTEMPTS, descript
     }
 }
 
-
-export type StepOutcome =
-    | { success: true, output: string }
-    | { success: false, error: string }

--- a/packages/server/worker/test/lib/execute/jobs/ee/agent/execute-agent-run.test.ts
+++ b/packages/server/worker/test/lib/execute/jobs/ee/agent/execute-agent-run.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { stepOutcomeFrom } from '../../../../../../src/lib/execute/jobs/ee/agent/execute-agent-run'
+import { stepResultFrom } from '../../../../../../src/lib/execute/jobs/ee/agent/agent-step-result'
 import { decideLoopAction, shouldRetryStream } from '../../../../../../src/lib/execute/jobs/ee/agent/run-agent-turn'
 
 describe('decideLoopAction', () => {
@@ -45,29 +45,34 @@ describe('shouldRetryStream', () => {
     })
 })
 
-describe('stepOutcomeFrom', () => {
+describe('stepResultFrom', () => {
     const text = (value: string) => ({ type: 'text' as const, text: value })
+    const at = '2026-08-05T00:00:00.000Z'
 
-    it('hands back the agent text when the turn finished properly', () => {
-        expect(stepOutcomeFrom({ uiParts: [text('done')], truncatedAfterRetries: false, budgetExceeded: false }))
-            .toEqual({ success: true, output: 'done' })
+    it('projects the transcript into the step blocks the run viewer reads', () => {
+        const result = stepResultFrom({ prompt: 'do it', uiParts: [text('done')], timestamp: at })
+
+        expect(result.status).toBe('COMPLETED')
+        expect(result.prompt).toBe('do it')
+        expect(result.steps).toEqual([{ type: 'MARKDOWN', markdown: 'done' }])
     })
 
-    it('reports a truncated turn as a failure rather than passing off a half answer', () => {
-        const outcome = stepOutcomeFrom({ uiParts: [text('half an ans')], truncatedAfterRetries: true, budgetExceeded: false })
+    it('keeps the partial answer when the turn did not finish, and says it failed', () => {
+        const result = stepResultFrom({ prompt: 'do it', uiParts: [text('half')], timestamp: at, failure: 'ran out of room' })
 
-        expect(outcome.success).toBe(false)
+        expect(result.status).toBe('FAILED')
+        expect(result.steps).toHaveLength(2)
     })
 
-    it('reports a turn stopped on budget as a failure', () => {
-        const outcome = stepOutcomeFrom({ uiParts: [text('partial')], truncatedAfterRetries: false, budgetExceeded: true })
+    it('drops empty text so a blank block never reaches the flow', () => {
+        const result = stepResultFrom({ prompt: 'do it', uiParts: [text('   ')], timestamp: at })
 
-        expect(outcome.success).toBe(false)
+        expect(result.steps).toEqual([])
     })
 
-    it('caps the answer so an unbounded one cannot be written into the resume payload', () => {
-        const outcome = stepOutcomeFrom({ uiParts: [text('x'.repeat(80_000))], truncatedAfterRetries: false, budgetExceeded: false })
+    it('caps a block so an unbounded answer cannot be written into the resume payload', () => {
+        const result = stepResultFrom({ prompt: 'do it', uiParts: [text('x'.repeat(80_000))], timestamp: at })
 
-        expect(outcome.success && outcome.output.length).toBe(51_200)
+        expect(result.steps[0]).toEqual({ type: 'MARKDOWN', markdown: 'x'.repeat(51_200) })
     })
 })

--- a/packages/server/worker/test/lib/execute/jobs/ee/agent/execute-agent-run.test.ts
+++ b/packages/server/worker/test/lib/execute/jobs/ee/agent/execute-agent-run.test.ts
@@ -76,3 +76,27 @@ describe('stepResultFrom', () => {
         expect(result.steps[0]).toEqual({ type: 'MARKDOWN', markdown: 'x'.repeat(51_200) })
     })
 })
+
+describe('stepResultFrom — a failed tool call must not read as success', () => {
+    const at = '2026-08-05T00:00:00.000Z'
+    const failedCall = {
+        type: 'tool-call' as const,
+        toolCallId: 'call-1',
+        toolName: 'send_email',
+        input: { to: 'a@b.c' },
+        status: 'error' as const,
+        errorText: 'mailbox full',
+    }
+
+    it('marks the whole result failed when any tool call errored', () => {
+        const result = stepResultFrom({ prompt: 'send it', uiParts: [failedCall], timestamp: at })
+
+        expect(result.status).toBe('FAILED')
+    })
+
+    it('carries the error text so a later step can see what went wrong', () => {
+        const result = stepResultFrom({ prompt: 'send it', uiParts: [failedCall], timestamp: at })
+
+        expect(JSON.stringify(result.steps[0])).toContain('mailbox full')
+    })
+})


### PR DESCRIPTION
## Description

Stacked on #14613. Review that one first; this diff is the top commit only.

The flow step was being handed `{ success, output }`, but a step's stored output has to stay an `AgentResult`. That shape is what the run viewer reads, what `AgentTimeline` renders, and what `ai-usage-extractor` parses. Handing back anything else would break all three the moment the piece starts using it.

The worker already holds the transcript at the point it releases the step, so it projects that into an `AgentResult` there. Every outcome is now one type instead of two.

## What the projection does with an unfinished turn

A turn that hit the output limit or its usage cap used to have its answer thrown away and replaced with an error string. Now it keeps the partial answer and carries `status: FAILED`, which is both more useful and more honest: something was produced, and it is not the whole thing.

The error and abort paths build the same shape, with the message as a final markdown block.

## Tool calls project as UNKNOWN

The persisted transcript records a tool call's name, input, output and status, but not whether it came from a piece, a sub-flow, an MCP server or a knowledge base. `ToolCallType.UNKNOWN` exists for exactly this, so that is what they become, carrying the tool's own name as the display name.

Claiming a kind we did not record would be inventing one, and the timeline would render it wrongly. If the kind turns out to matter for how the timeline looks, the fix is to record it on the transcript rather than guess here.

Timestamps are the same value for start and end, because the transcript does not persist per-call durations either.

## How was this tested?

- 83 worker unit tests, four of them on the projection: a normal turn, an unfinished turn keeping its partial answer, empty text being dropped rather than becoming a blank block, and an oversized answer being capped before it reaches the resume payload.
- 94 API unit tests, 40 integration tests under `AP_EDITION=cloud`.
- `turbo run build` across api and worker, `npm run lint-dev` 0 errors.

## What is left in this phase

The piece itself, which becomes create-waitpoint, call, suspend, resume, and must set a deadline on the waitpoint. Then retention for flow-step transcripts.

Fixes # (issue)

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

It changes the shape of a payload nothing consumes yet, and towards the shape existing consumers already expect.

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)

The projection reads a transcript the run itself produced and writes it to that run's own step output. It adds no new caller, no new authorization decision, and caps each block so an unbounded answer cannot be written into the resume payload.
