### PR TITLE
fix(worker): remove auto-detect of sandbox memory limit at concurrency 1

### DIFF
--- a/packages/server/worker/src/lib/runtime/sandbox-config.ts
+++ b/packages/server/worker/src/lib/runtime/sandbox-config.ts
@@ -1,27 +1,10 @@
-import { isNil, tryCatch } from '@activepieces/core-utils'
 import { type SandboxSettings } from '@activepieces/sandbox'
-import { systemUsage } from '@activepieces/server-utils'
 import { system, WorkerSystemProp } from '../config/configs'
-import { logger } from '../config/logger'
 import { workerSettings } from '../config/worker-settings'
-
-let fullContainerMemoryKb: number | null = null
 
 export const sandboxConfig = {
     getCacheBasePath(): string {
         return system.get(WorkerSystemProp.CACHE_BASE_PATH) ?? 'cache'
-    },
-    // At concurrency 1 the single sandbox is the only engine on the box, so it gets the full
-    // container memory instead of the fixed server-provided SANDBOX_MEMORY_LIMIT. Called once
-    // per (re)connect from startPollingWorkers; best-effort — on failure the server limit stays.
-    async primeFullContainerMemory(): Promise<void> {
-        const { data, error } = await tryCatch(() => systemUsage.getContainerMemoryUsage())
-        if (error) {
-            logger.warn({ error }, 'Could not read container memory, keeping configured sandbox memory limit')
-            return
-        }
-        fullContainerMemoryKb = Math.floor(data.totalRamInBytes / 1024)
-        logger.info({ fullContainerMemoryKb }, 'Concurrency is 1 — sandbox memory limit set to full container memory')
     },
     // The worker's runtime settings mapped to what the pool reads. REUSE_SANDBOX is an env-only
     // override not present in WorkerSettings, so it is merged in here. Returns a fresh object each
@@ -29,7 +12,6 @@ export const sandboxConfig = {
     getSandboxSettings(): SandboxSettings {
         return {
             ...workerSettings.getSettings(),
-            ...(isNil(fullContainerMemoryKb) ? {} : { SANDBOX_MEMORY_LIMIT: String(fullContainerMemoryKb) }),
             REUSE_SANDBOX: system.get(WorkerSystemProp.REUSE_SANDBOX),
         }
     },

--- a/packages/server/worker/src/lib/worker.ts
+++ b/packages/server/worker/src/lib/worker.ts
@@ -170,9 +170,6 @@ async function startPollingWorkers(apiClient: WorkerToApiContract): Promise<void
     if (!Number.isInteger(rawConcurrency) || rawConcurrency < 1) {
         logger.warn({ rawConcurrency }, 'Invalid AP_WORKER_CONCURRENCY value, falling back to 1')
     }
-    if (concurrency === 1) {
-        await sandboxConfig.primeFullContainerMemory()
-    }
     // Bring up a fresh runtime on every (re)connect — a prior connection's in-flight job is killed
     // along with its box (usually already done by the disconnect handler), so it fails fast and is
     // retried instead of lingering on a reused box. Reusing the box made the next generation's poll

--- a/packages/server/worker/test/lib/sandbox-config.test.ts
+++ b/packages/server/worker/test/lib/sandbox-config.test.ts
@@ -1,39 +1,15 @@
 import { describe, it, expect, vi } from 'vitest'
 
-// Inlined in the mock factory below too — vi.mock is hoisted above const initialization.
-const TWO_GB_IN_BYTES = 2 * 1024 * 1024 * 1024
-
-vi.mock('@activepieces/server-utils', async (importOriginal) => {
-    const actual = await importOriginal<typeof import('@activepieces/server-utils')>()
-    return {
-        ...actual,
-        systemUsage: {
-            ...actual.systemUsage,
-            getContainerMemoryUsage: vi.fn().mockResolvedValue({ totalRamInBytes: 2 * 1024 * 1024 * 1024, ramUsage: 10 }),
-        },
-    }
-})
-
 vi.mock('../../src/lib/config/worker-settings', () => ({
     workerSettings: {
         getSettings: vi.fn().mockReturnValue({ SANDBOX_MEMORY_LIMIT: '1048576' }),
     },
 }))
 
-vi.mock('../../src/lib/config/logger', () => ({
-    logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
-}))
-
 import { sandboxConfig } from '../../src/lib/runtime/sandbox-config'
 
-// Order matters: the module holds the primed value, so the un-primed assertion runs first.
 describe('sandboxConfig memory limit', () => {
-    it('uses the server-provided limit before priming', () => {
+    it('uses the server-provided limit', () => {
         expect(sandboxConfig.getSandboxSettings().SANDBOX_MEMORY_LIMIT).toBe('1048576')
-    })
-
-    it('uses the full container memory after priming (concurrency 1)', async () => {
-        await sandboxConfig.primeFullContainerMemory()
-        expect(sandboxConfig.getSandboxSettings().SANDBOX_MEMORY_LIMIT).toBe(String(TWO_GB_IN_BYTES / 1024))
     })
 })


### PR DESCRIPTION
## What does this PR do?

Removes the worker-side auto-detection of the sandbox memory limit. Previously, when `AP_WORKER_CONCURRENCY=1`, the worker read the container's total memory and overrode the server-provided `SANDBOX_MEMORY_LIMIT` with it. The sandbox now always uses the configured `SANDBOX_MEMORY_LIMIT`.

### Breaking change?

- [x] No

🤖 Generated with [Claude Code](https://claude.com/claude-code)