### PR TITLE
fix(redis): automatically recover after a Redis failover instead of stalling until restart

### DIFF
--- a/packages/server/api/src/app/database/redis/default-redis.ts
+++ b/packages/server/api/src/app/database/redis/default-redis.ts
@@ -1,13 +1,13 @@
 import fs from 'fs'
 import { assertNotNullOrUndefined, isNil } from '@activepieces/core-utils'
 import Redis, { RedisOptions } from 'ioredis'
+import { baseRedisOptions } from './redis-options'
 import { RedisConnectionSettings } from './types'
 
 
 export async function createDefaultRedisConnection(settings: RedisConnectionSettings): Promise<Redis> {
     const config: Partial<RedisOptions> = {
-        maxRetriesPerRequest: null,
-        keepAlive: 5000,
+        ...baseRedisOptions,
     }
 
     const url = settings.REDIS_URL

--- a/packages/server/api/src/app/database/redis/redis-options.ts
+++ b/packages/server/api/src/app/database/redis/redis-options.ts
@@ -1,0 +1,10 @@
+import { RedisOptions } from 'ioredis'
+
+const TCP_KEEP_ALIVE_MS = 5_000
+const SOCKET_TIMEOUT_MS = 30_000
+
+export const baseRedisOptions: Partial<RedisOptions> = {
+    maxRetriesPerRequest: null,
+    keepAlive: TCP_KEEP_ALIVE_MS,
+    socketTimeout: SOCKET_TIMEOUT_MS,
+}

--- a/packages/server/api/src/app/database/redis/sentinel-redis.ts
+++ b/packages/server/api/src/app/database/redis/sentinel-redis.ts
@@ -1,6 +1,7 @@
 import fs from 'fs'
 import { assertNotNullOrUndefined, isNil } from '@activepieces/core-utils'
 import Redis, { RedisOptions } from 'ioredis'
+import { baseRedisOptions } from './redis-options'
 import { RedisConnectionSettings } from './types'
 
 export async function createSentinelRedisConnection(settings: RedisConnectionSettings): Promise<Redis> {
@@ -24,7 +25,7 @@ export async function createSentinelRedisConnection(settings: RedisConnectionSet
     const tlsCa = readCAFile(sslCaFile)
     
     const redisOptions: RedisOptions = {
-        maxRetriesPerRequest: null,
+        ...baseRedisOptions,
         sentinels,
         name: sentinelName,
         username,

--- a/packages/server/api/test/unit/app/database/redis/redis-connection-options.test.ts
+++ b/packages/server/api/test/unit/app/database/redis/redis-connection-options.test.ts
@@ -1,0 +1,66 @@
+import Redis from 'ioredis'
+import { afterEach, describe, expect, it } from 'vitest'
+import { createDefaultRedisConnection } from '../../../../../src/app/database/redis/default-redis'
+import { createSentinelRedisConnection } from '../../../../../src/app/database/redis/sentinel-redis'
+import { RedisConnectionSettings } from '../../../../../src/app/database/redis/types'
+
+const SOCKET_TIMEOUT_IN_MS = 30_000
+const LONGEST_BLOCKING_COMMAND_IN_MS = 15_000
+
+const openedClients: Redis[] = []
+
+function track(client: Redis): Redis {
+    client.on('error', () => undefined)
+    openedClients.push(client)
+    return client
+}
+
+const sentinelSettings: RedisConnectionSettings = {
+    REDIS_TYPE: 'SENTINEL',
+    REDIS_SENTINEL_HOSTS: 'sentinel-one:26379,sentinel-two:26379',
+    REDIS_SENTINEL_NAME: 'mymaster',
+    REDIS_SENTINEL_ROLE: 'master',
+}
+
+const standaloneSettings: RedisConnectionSettings = {
+    REDIS_TYPE: 'DEFAULT',
+    REDIS_HOST: '127.0.0.1',
+    REDIS_PORT: '1',
+}
+
+afterEach(() => {
+    while (openedClients.length > 0) {
+        openedClients.pop()?.disconnect()
+    }
+})
+
+describe('redis connection failure detection', () => {
+    it('arms socketTimeout and keepAlive on sentinel connections', async () => {
+        const client = track(await createSentinelRedisConnection(sentinelSettings))
+
+        expect(client.options.socketTimeout).toBe(SOCKET_TIMEOUT_IN_MS)
+        expect(client.options.keepAlive).toBe(5_000)
+        expect(client.options.maxRetriesPerRequest).toBeNull()
+    })
+
+    it('arms socketTimeout and keepAlive on standalone connections', async () => {
+        const client = track(await createDefaultRedisConnection(standaloneSettings))
+
+        expect(client.options.socketTimeout).toBe(SOCKET_TIMEOUT_IN_MS)
+        expect(client.options.keepAlive).toBe(5_000)
+        expect(client.options.maxRetriesPerRequest).toBeNull()
+    })
+
+    it('keeps socketTimeout on the duplicated connection BullMQ blocks on', async () => {
+        const client = track(await createSentinelRedisConnection(sentinelSettings))
+        const blockingClient = track(client.duplicate())
+
+        expect(blockingClient.options.socketTimeout).toBe(SOCKET_TIMEOUT_IN_MS)
+    })
+
+    it('leaves headroom above the longest blocking command so healthy polls are never severed', async () => {
+        const client = track(await createSentinelRedisConnection(sentinelSettings))
+
+        expect(client.options.socketTimeout).toBeGreaterThan(LONGEST_BLOCKING_COMMAND_IN_MS)
+    })
+})


### PR DESCRIPTION
Fixes activepieces/activepieces#14619<br>Closes activepieces/activepieces#14619

## Description

After a Redis Sentinel failover the app stopped consuming jobs and never recovered: no error, no crash, no reconnect, flows simply stopped running until the pod was restarted.

Our connections had no failure detection, so a master that stops answering **without closing its TCP socket** was never noticed. `maxRetriesPerRequest: null` waits forever, a wedged master still ACKs at the TCP layer (so keepalive alone cannot see it), and the Sentinel master address is only re-resolved on reconnect — which never happened. Both the queue's blocking poll and ordinary commands parked indefinitely.

Both real connection factories now share `baseRedisOptions` with `socketTimeout: 30000` and `keepAlive: 5000`: a silent master is detected, the socket torn down, and the new master resolved on reconnect.

Product decision embedded: fixed 30s socket timeout (2x our longest blocking command) rather than a tunable; alternative considered: an `AP_REDIS_SOCKET_TIMEOUT_MS` env var, skipped to keep self-hosting zero-setup.

Ceiling: a command that legitimately needs >30s for a reply now fails instead of waiting forever. Our longest is the 15s queue poll (`drainDelay: 15`, `job-broker.ts:44`), and `socketTimeout` is armed only while a reply is outstanding and re-armed only while the command queue is non-empty, so idle and subscriber connections are unaffected.

## How was this tested?

Real Sentinel cluster in Docker (master + replica + 3 sentinels), client options identical to `sentinel-redis.ts`, master frozen mid-poll so the replica is promoted:

<!-- linear:table-colwidths:400,400 -->
| Config | Result |
| -- | -- |
| shipped ioredis 5.4.1, graceful `SENTINEL FAILOVER` | recovers already |
| shipped ioredis 5.4.1, frozen master | hangs indefinitely — reproduces the report |
| ioredis 5.11.1 + `blockingTimeout` (the upstream fix for [redis/ioredis#1888](<https://github.com/redis/ioredis/issues/1888>)) | still hangs: blocking commands get bounded, the next ordinary command parks forever |
| this PR | recovers in \~30s, and healthy 15.0s polls continue afterwards |

* Regression test red-first: 4 assertions fail on base (`socketTimeout` undefined), pass with the fix. Covers both factories plus the duplicated connection BullMQ blocks on.
* `vitest run test/unit` (api): 67 files passed. 8 files / 20 tests fail identically on pristine `upstream/main` (worker-group, agent chat-billing, cross-project-confinement, knowledge-base file-delete, mcp tool-search-flag, job-broker, active-invariant, machine-service) — pre-existing, unrelated.
* `npm run lint-dev`: 0 errors.
* Editions: connection layer is shared CE/EE/Cloud, no edition-gated code touched.
* Visual: none - backend-only Redis connection options, no rendered surface.
* Other affected paths: checked - `memory-redis.ts` left unchanged (in-process dev/test server, no failover path); no other `new Redis(` call sites exist.
* Repro: real Sentinel cluster in Docker, master frozen mid-poll — baseline hangs forever, this PR recovers in \~30s — full steps in the Reproduction block.

### Breaking change?  (required — CI fails if this is left unedited)

- [X] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

- [X] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)

<details><summary>Plan & reasoning</summary>

## Plan

* Reported as ioredis#1888 (blocking `BZPOPMIN` hang). Measured it instead of trusting it: a graceful failover already recovers on 5.4.1, and 5.11.1 + `blockingTimeout` still hangs — so the version bump is neither necessary nor sufficient, and no bump is included.
* The defect is one level down: nothing ever fails a command or closes the socket, so the Sentinel connector is never asked for the new master.
* `socketTimeout` is the smallest option that covers every command, not just blocking ones. Shared via `baseRedisOptions` so the standalone path gets it too and `maxRetriesPerRequest` stops being triplicated.
* `keepAlive: 5000` added to the Sentinel path for parity with standalone — it does not fix this case (a frozen master still ACKs) but covers a vanished peer on an idle socket, where `socketTimeout` is not armed.

## Non-happy scenarios considered

* Healthy 15s blocking poll severed by the timeout → no: 30s is 2x, and post-recovery logs show 15.0s polls continuing.
* Idle subscriber connections torn down → no: the timer is only armed while a reply is outstanding (`Redis.js` re-arms only when `commandQueue.length !== 0`).
* Redis genuinely slow (>30s for one reply) → commands now fail rather than hang. Stated as the ceiling above; a Redis not answering for 30s is already an outage.
* Handshake against a frozen master after reconnect → also covered, since handshake commands go through the same path and now time out and retry.

## Alternatives rejected

* Bump ioredis to 5.11.x + `blockingTimeout` → measured as still hanging.
* `commandTimeout` → bounds every command including legitimate long blocks, risking false failures.
* New env var for the timeout → violates zero-setup self-hosting for no demonstrated need.
* Restart-on-stall watchdog in the app → treats the symptom, and BullMQ already has such a watchdog that this failure walks straight past.

</details>

<details><summary>Reproduction</summary>

## Environment

* 5 containers on one docker network, all `redis:7-alpine`: 1 master, 1 replica (`--replicaof redis-master 6379`), 3 sentinels (`quorum 2`, `down-after-milliseconds 5000`, `failover-timeout 10000`).
* Client: `node:20-alpine` running `bullmq@5.61.0` + `ioredis@5.4.1` (the shipped pair), connection options copied verbatim from `sentinel-redis.ts`, polling `getNextJob` in a loop with `drainDelay: 15` exactly like `job-broker.ts`.

## Harness

Published gist: [https://gist.github.com/majewskibartosz/ad74fded9bf4c6d07cb84d3afc0e582f](<https://gist.github.com/majewskibartosz/ad74fded9bf4c6d07cb84d3afc0e582f>)

* `run.sh` — self-contained: writes sentinel configs, installs pinned deps via a node container, rebuilds the cluster, starts the client, pauses the master at t=8s, prints a RECOVERED/STUCK verdict.
* `repro-sentinel.js` — the client; env toggles `SOCKET_TIMEOUT` / `KEEP_ALIVE` / `BLOCKING_TIMEOUT` select the variant under test.
* `repro.js` — secondary variant: TCP proxy that freezes and later heals a standalone connection (zombie socket without failover).

Run: `git clone https://gist.github.com/ad74fded9bf4c6d07cb84d3afc0e582f.git git-1711-repro && cd git-1711-repro && ./run.sh baseline` (hangs) then `./run.sh with-fix SOCKET_TIMEOUT=30000` (recovers). Only needs docker.

## Trigger

`docker pause redis-master` mid-poll. A paused master keeps ACKing at the TCP layer without ever replying or closing the socket, so the client gets no `close` event — the production analogue is a wedged/partitioned master. This choice is the crux: a graceful `SENTINEL FAILOVER` does NOT reproduce (old master answers until demotion, client sees a clean disconnect and recovers even on current main).

## Results

Matrix in "How was this tested?" above. What each variant proves:

* baseline frozen master hangs → reproduces the report on shipped versions.
* graceful failover recovers on 5.4.1 → the failure needs a silent master, not just any failover.
* ioredis 5.11.1 + `blockingTimeout` still hangs → upstream ioredis#1888 fix insufficient; version bump rejected on evidence.
* 5.4.1 + `socketTimeout: 30000` recovers, healthy 15.0s polls continue after → the PR's change is sufficient and doesn't sever legitimate blocking polls.
* `repro.js` freeze-then-heal recovers on 5.4.1 → plain network blips were never the problem; no fix needed for that path.

</details>