### PR TITLE
fix: legacy embed connection claim always resolved latest piece version

### DIFF
--- a/packages/core/shared/package.json
+++ b/packages/core/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/shared",
-  "version": "0.128.0",
+  "version": "0.128.1",
   "type": "commonjs",
   "sideEffects": false,
   "main": "./dist/src/index.js",

--- a/packages/core/shared/src/lib/ee/product-embed/connection-keys/connection-requests.ts
+++ b/packages/core/shared/src/lib/ee/product-embed/connection-keys/connection-requests.ts
@@ -23,6 +23,7 @@ export const UpsertApiKeyConnectionFromToken = z.object({
     appCredentialId: z.string(),
     apiKey: z.string(),
     token: z.string(),
+    pieceVersion: z.string().optional(),
 })
 
 export type UpsertApiKeyConnectionFromToken = z.infer<typeof UpsertApiKeyConnectionFromToken>
@@ -33,6 +34,7 @@ export const UpsertOAuth2ConnectionFromToken = z.object({
     token: z.string(),
     code: z.string(),
     redirectUrl: z.string(),
+    pieceVersion: z.string().optional(),
 })
 
 export type UpsertOAuth2ConnectionFromToken = z.infer<typeof UpsertOAuth2ConnectionFromToken>

--- a/packages/server/api/src/app/ee/connection-keys/connection-key.service.ts
+++ b/packages/server/api/src/app/ee/connection-keys/connection-key.service.ts
@@ -73,6 +73,7 @@ export const connectionKeyService = (log: FastifyBaseLogger) => ({
                     externalId: `${appCredential.appName}_${connectionName}`,
                     displayName: `${appCredential.appName}_${connectionName}`,
                     pieceName: finalAppName,
+                    pieceVersion: apiRequest.pieceVersion,
                     type: AppConnectionType.SECRET_TEXT,
                     value: {
                         type: AppConnectionType.SECRET_TEXT,
@@ -90,6 +91,7 @@ export const connectionKeyService = (log: FastifyBaseLogger) => ({
                     externalId: `${appCredential.appName}_${connectionName}`,
                     displayName: `${appCredential.appName}_${connectionName}`,
                     pieceName: finalAppName,
+                    pieceVersion: apiRequest.pieceVersion,
                     type: AppConnectionType.OAUTH2,
                     value: {
                         type: AppConnectionType.OAUTH2,


### PR DESCRIPTION
## Description

`connection-key.service.ts` — the JWT-token embed/app-credential claim endpoint (`POST /v1/connection-keys/app-connections`) — never passed `pieceVersion` to `appConnectionService.upsert()`. It silently defaulted to the latest published piece version regardless of what version the caller's own authorize step actually used.

When a piece version bump changes the auth-prop shape (e.g. adding a new required placeholder like `{tenant}`), the authorize step and the claim step could resolve two different versions for the same OAuth2 handshake — the claim would build the token URL/scope from the newer template while the actual consent ran against the older one, sending an unresolved `{placeholder}` straight to the provider.

Every other connection-creation surface (dashboard, flow builder, embed iframe, agent tools, chat) goes through the shared `CreateOrEditConnectionDialogContent` component, which captures `piece.version` once and reuses it for both the authorize and claim calls — those are not affected. This is the one call site that skipped that shared component and never threaded a version through at all.

Adds an optional `pieceVersion` field to `UpsertApiKeyConnectionFromToken` / `UpsertOAuth2ConnectionFromToken` and forwards it through in both branches of `connectionKeyService.createConnection`, so a caller that supplies it stops silently falling back to latest. Fully backward compatible — omitting the field preserves today's behavior.

## How was this tested?

Verified manually against a local `AP_EDITION=cloud` server: created an app-credential + signing key, signed a JWT, and posted to `/v1/connection-keys/app-connections` with an explicit `pieceVersion` — the created connection stored that exact version instead of resolving latest. Also confirmed omitting `pieceVersion` still falls back to latest (unchanged legacy behavior). Ran `npm run lint-dev` and a full `tsc` build across `@activepieces/shared` and `api` with no new errors.

Not reproducible on Community or Enterprise (self-hosted) edition — `connectionKeyModule`/`appCredentialModule` are only registered under `ApEdition.CLOUD` in `app.ts`.

Fixes #14596

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

- [ ] no — reviewed, no security impact
- [x] yes — security-sensitive (touches the OAuth2 connection claim path: lets a caller specify which piece version its connection should resolve against, instead of the server silently guessing latest. The field is optional and the value is still validated as a real semver via existing `validatePieceVersion`, so no new attack surface — this closes a version-confusion gap rather than opening one.)