### PR TITLE
perf(engine): cache materialized slices in sqlite and degrade to memory on store write failure

### DIFF
--- a/packages/server/engine/src/lib/handler/context/flow-execution-context.ts
+++ b/packages/server/engine/src/lib/handler/context/flow-execution-context.ts
@@ -1,4 +1,4 @@
-import { apId, assertEqual, createByteLruCache, isNil } from '@activepieces/core-utils'
+import { apId, assertEqual, isNil, tryCatchSync } from '@activepieces/core-utils'
 import { BaseStepOutput, EngineGenericError, executionJournal, FailedStep, FileType, FlowActionType, FlowRunStatus, GenericStepOutput, LogSliceRef, LoopStepOutput, LoopStepResult, RespondResponse, StepOutput, StepOutputStatus, StepOutputType } from '@activepieces/shared'
 import { engineFileApi } from '../../api/engine-file-api'
 import { loggingUtils } from '../../helper/logging-utils'
@@ -10,9 +10,9 @@ const DEFAULT_THRESHOLD_KB = 32
 const SLICE_THRESHOLD_BYTES = Number(
     process.env.AP_FLOW_RUN_LOG_SLICE_THRESHOLD_KB ?? DEFAULT_THRESHOLD_KB,
 ) * 1024
-const SLICE_CACHE_BUDGET_BYTES = 64 * 1024 * 1024
-
 const EMPTY_STEPS_SIZE_BYTES = sizeofUtils.recursiveSizeof({})
+
+const inFlightSliceDownloads = new Map<string, Promise<unknown>>()
 
 export class FlowExecutorContext {
     tags: readonly string[]
@@ -22,7 +22,6 @@ export class FlowExecutorContext {
     stepNameToTest?: boolean
     stepsCount: number
     engineApi?: EngineApiConfig
-    resolvedStepOutputCache: SliceCache
     slicingEnabled: boolean
     logSizeBytes: number
 
@@ -40,7 +39,6 @@ export class FlowExecutorContext {
         this.stepNameToTest = copyFrom?.stepNameToTest ?? false
         this.stepsCount = copyFrom?.stepsCount ?? 0
         this.engineApi = copyFrom?.engineApi
-        this.resolvedStepOutputCache = copyFrom?.resolvedStepOutputCache ?? createByteLruCache({ budgetBytes: SLICE_CACHE_BUDGET_BYTES })
         this.slicingEnabled = copyFrom?.slicingEnabled ?? true
         this.logSizeBytes = copyFrom?.logSizeBytes ?? EMPTY_STEPS_SIZE_BYTES
     }
@@ -136,16 +134,26 @@ export class FlowExecutorContext {
         if (runStateStore.isInitialized() && finalized.type !== FlowActionType.LOOP_ON_ITEMS) {
             const previousSizeBytes = runStateStore.getStepSize({ name: stepName, stepPath })
             const nextSizeBytes = sizeofUtils.recursiveSizeof(finalized)
-            runStateStore.put({ name: stepName, stepPath, stepOutput: finalized, sizeBytes: nextSizeBytes })
-            const stripped = new GenericStepOutput({
-                type: finalized.type,
-                status: finalized.status,
-                input: undefined,
-                outputType: finalized.outputType,
-                duration: finalized.duration,
-                errorMessage: finalized.errorMessage,
-            })
-            const steps = executionJournal.upsertStep({ stepName, stepOutput: stripped, path: this.currentPath.path, steps: this.steps })
+            const { error: putError } = tryCatchSync(() => runStateStore.put({ name: stepName, stepPath, stepOutput: finalized, sizeBytes: nextSizeBytes }))
+            if (isNil(putError)) {
+                const stripped = new GenericStepOutput({
+                    type: finalized.type,
+                    status: finalized.status,
+                    input: undefined,
+                    outputType: finalized.outputType,
+                    duration: finalized.duration,
+                    errorMessage: finalized.errorMessage,
+                })
+                const steps = executionJournal.upsertStep({ stepName, stepOutput: stripped, path: this.currentPath.path, steps: this.steps })
+                return new FlowExecutorContext({
+                    ...this,
+                    steps,
+                    logSizeBytes: this.logSizeBytes + sizeofUtils.upsertStepDeltaFromSize({ stepName, previousSizeBytes, nextSizeBytes }),
+                })
+            }
+            console.warn(`[runStateStore] put failed for step ${stepName}, keeping it in memory`, putError)
+            runStateStore.deleteStep({ name: stepName, stepPath })
+            const steps = executionJournal.upsertStep({ stepName, stepOutput: finalized, path: this.currentPath.path, steps: this.steps })
             return new FlowExecutorContext({
                 ...this,
                 steps,
@@ -163,7 +171,7 @@ export class FlowExecutorContext {
 
     public getStepOutput(stepName: string, path?: StepExecutionPath['path']): StepOutput | undefined {
         const step = executionJournal.getStep({ stepName, path: path ?? this.currentPath.path, steps: this.steps })
-        if (isNil(step) || step.type === FlowActionType.LOOP_ON_ITEMS) {
+        if (isNil(step) || step.type === FlowActionType.LOOP_ON_ITEMS || step.output !== undefined) {
             return step
         }
         const stored = runStateStore.getStepOutput({ name: stepName, stepPath: JSON.stringify(path ?? this.currentPath.path) })
@@ -201,9 +209,12 @@ export class FlowExecutorContext {
         const stepMaps = this.stepMapsAlongPath()
         for (let level = stepMaps.length - 1; level >= 0; level--) {
             const stepPath = JSON.stringify(this.currentPath.path.slice(0, level))
-            const step = runStateStore.getStepOutput({ name: stepName, stepPath }) ?? stepMaps[level][stepName]
+            const memoryStep = stepMaps[level][stepName]
+            const step = memoryStep?.output !== undefined
+                ? memoryStep
+                : runStateStore.getStepOutput({ name: stepName, stepPath }) ?? memoryStep
             if (!isNil(step)) {
-                const output = await resolveStepOutput(step, this.engineApi, this.resolvedStepOutputCache)
+                const output = await resolveStepOutput(step, this.engineApi)
                 const error = step.status === StepOutputStatus.FAILED && step.errorMessage !== undefined
                     ? { message: step.errorMessage }
                     : undefined
@@ -251,7 +262,7 @@ async function maybeSliceOutput({ value, engineApi }: MaybeSliceOutputParams): P
     return { ref: { fileId, size, url: readUrl } }
 }
 
-async function resolveStepOutput(step: StepOutput, engineApi: EngineApiConfig | undefined, cache: SliceCache): Promise<unknown> {
+async function resolveStepOutput(step: StepOutput, engineApi: EngineApiConfig | undefined): Promise<unknown> {
     if (step.outputType !== StepOutputType.SLICE) {
         return step.output
     }
@@ -259,14 +270,23 @@ async function resolveStepOutput(step: StepOutput, engineApi: EngineApiConfig | 
         throw new EngineGenericError('MissingEngineApiConfigError', 'Cannot materialize log slice ref without engine api config')
     }
     const ref = step.output as LogSliceRef
-    const existing = cache.get(ref.fileId)
-    if (!isNil(existing)) {
-        return existing
+    const cached = runStateStore.getSliceJson({ fileId: ref.fileId })
+    if (!isNil(cached)) {
+        return JSON.parse(cached)
     }
-    const promise = engineFileApi.download({ apiUrl: engineApi.internalApiUrl, engineToken: engineApi.engineToken, fileId: ref.fileId })
-        .then((bytes) => JSON.parse(new TextDecoder('utf-8').decode(bytes)))
-    cache.set({ key: ref.fileId, value: promise, sizeBytes: ref.size })
-    return promise
+    const inFlight = inFlightSliceDownloads.get(ref.fileId)
+    if (!isNil(inFlight)) {
+        return inFlight
+    }
+    const download = engineFileApi.download({ apiUrl: engineApi.internalApiUrl, engineToken: engineApi.engineToken, fileId: ref.fileId })
+        .then((bytes) => {
+            const json = new TextDecoder('utf-8').decode(bytes)
+            runStateStore.putSlice({ fileId: ref.fileId, json })
+            return JSON.parse(json)
+        })
+        .finally(() => inFlightSliceDownloads.delete(ref.fileId))
+    inFlightSliceDownloads.set(ref.fileId, download)
+    return download
 }
 
 function withTruncatedInput<T extends BaseStepOutput>(stepOutput: T): T {
@@ -306,11 +326,6 @@ export type FlowExecutorContextInit = {
 export type StepView = {
     output: unknown
     error: { message: string } | undefined
-}
-
-type SliceCache = {
-    get(key: string): Promise<unknown> | undefined
-    set(params: { key: string, value: Promise<unknown>, sizeBytes: number }): void
 }
 
 type MaybeSliceOutputParams = {

--- a/packages/server/engine/src/lib/helper/run-state-store.ts
+++ b/packages/server/engine/src/lib/helper/run-state-store.ts
@@ -2,13 +2,16 @@ import * as fs from 'node:fs'
 import * as os from 'node:os'
 import * as path from 'node:path'
 import { DatabaseSync, StatementSync } from 'node:sqlite'
-import { isNil } from '@activepieces/core-utils'
+import { isNil, tryCatchSync } from '@activepieces/core-utils'
 import { ExecutionMode, RUN_STATE_STORE_DIR_PREFIX, StepOutput } from '@activepieces/shared'
 
 type PreparedStatements = {
     put: StatementSync
     getStepOutput: StatementSync
     getStepSize: StatementSync
+    deleteStep: StatementSync
+    putSlice: StatementSync
+    getSlice: StatementSync
 }
 
 let db: DatabaseSync | null = null
@@ -31,12 +34,19 @@ export const runStateStore = {
                     output     BLOB    NOT NULL,
                     size_bytes INTEGER NOT NULL,
                     PRIMARY KEY (name, path)
+                );
+                CREATE TABLE slices (
+                    file_id TEXT PRIMARY KEY,
+                    output  BLOB NOT NULL
                 )
             `)
             statements = {
                 put: db.prepare('INSERT OR REPLACE INTO steps (name, path, output, size_bytes) VALUES (?, ?, jsonb(?), ?)'),
                 getStepOutput: db.prepare('SELECT json(output) AS output FROM steps WHERE name = ? AND path = ?'),
                 getStepSize: db.prepare('SELECT size_bytes FROM steps WHERE name = ? AND path = ?'),
+                deleteStep: db.prepare('DELETE FROM steps WHERE name = ? AND path = ?'),
+                putSlice: db.prepare('INSERT OR REPLACE INTO slices (file_id, output) VALUES (?, jsonb(?))'),
+                getSlice: db.prepare('SELECT json(output) AS output FROM slices WHERE file_id = ?'),
             }
             dbPath = filePath
         }
@@ -60,25 +70,52 @@ export const runStateStore = {
         statements.put.run(name, stepPath, JSON.stringify(stepOutput), sizeBytes)
     },
 
+    deleteStep({ name, stepPath }: { name: string, stepPath: string }): void {
+        const prepared = statements
+        if (isNil(prepared)) {
+            return
+        }
+        tryCatchSync(() => prepared.deleteStep.run(name, stepPath))
+    },
+
     getStepOutput({ name, stepPath }: { name: string, stepPath: string }): StepOutput | undefined {
         const json = runStateStore.getStepOutputJson({ name, stepPath })
         return isNil(json) ? undefined : JSON.parse(json)
     },
 
     getStepOutputJson({ name, stepPath }: { name: string, stepPath: string }): string | undefined {
-        if (isNil(statements)) {
+        const prepared = statements
+        if (isNil(prepared)) {
             return undefined
         }
-        const row = statements.getStepOutput.get(name, stepPath) as { output: string } | undefined
+        const { data: row } = tryCatchSync(() => prepared.getStepOutput.get(name, stepPath) as { output: string } | undefined)
         return row?.output
     },
 
     getStepSize({ name, stepPath }: { name: string, stepPath: string }): number | undefined {
-        if (isNil(statements)) {
+        const prepared = statements
+        if (isNil(prepared)) {
             return undefined
         }
-        const row = statements.getStepSize.get(name, stepPath) as { size_bytes: number } | undefined
+        const { data: row } = tryCatchSync(() => prepared.getStepSize.get(name, stepPath) as { size_bytes: number } | undefined)
         return row?.size_bytes
+    },
+
+    putSlice({ fileId, json }: { fileId: string, json: string }): void {
+        const prepared = statements
+        if (isNil(prepared)) {
+            return
+        }
+        tryCatchSync(() => prepared.putSlice.run(fileId, json))
+    },
+
+    getSliceJson({ fileId }: { fileId: string }): string | undefined {
+        const prepared = statements
+        if (isNil(prepared)) {
+            return undefined
+        }
+        const { data: row } = tryCatchSync(() => prepared.getSlice.get(fileId) as { output: string } | undefined)
+        return row?.output
     },
 
     isInitialized(): boolean {

--- a/packages/server/engine/src/lib/helper/state-json-streamer.ts
+++ b/packages/server/engine/src/lib/helper/state-json-streamer.ts
@@ -24,6 +24,9 @@ function* stepEntries(steps: Readonly<Record<string, StepOutput>>, pathPrefix: A
         if (step.type === FlowActionType.LOOP_ON_ITEMS && !isNil(step.output)) {
             yield [name, streamLoopStep({ step, output: step.output, name, pathPrefix })]
         }
+        else if (step.output !== undefined) {
+            yield [name, JSON.stringify(step)]
+        }
         else {
             yield [name, runStateStore.getStepOutputJson({ name, stepPath: JSON.stringify(pathPrefix) }) ?? JSON.stringify(step)]
         }

--- a/packages/server/engine/test/handler/context/flow-execution-context-store.test.ts
+++ b/packages/server/engine/test/handler/context/flow-execution-context-store.test.ts
@@ -1,7 +1,7 @@
 import * as fs from 'node:fs'
 import * as os from 'node:os'
 import * as path from 'node:path'
-import { FlowActionType, GenericStepOutput, LoopStepOutput, StepOutputStatus } from '@activepieces/shared'
+import { FlowActionType, GenericStepOutput, LoopStepOutput, StepOutputStatus, StepOutputType } from '@activepieces/shared'
 import { FlowExecutorContext } from '../../../src/lib/handler/context/flow-execution-context'
 import { runStateStore } from '../../../src/lib/helper/run-state-store'
 
@@ -13,6 +13,18 @@ function makePieceStep(output: unknown): GenericStepOutput<FlowActionType.PIECE,
         output,
     })
 }
+
+function makeSliceStep(fileId: string): GenericStepOutput<FlowActionType.PIECE, unknown> {
+    return new GenericStepOutput({
+        type: FlowActionType.PIECE,
+        status: StepOutputStatus.SUCCEEDED,
+        input: {},
+        output: { fileId, size: 123, url: `http://api/v1/files/${fileId}` },
+        outputType: StepOutputType.SLICE,
+    })
+}
+
+const ENGINE_API = { engineToken: 'token', internalApiUrl: 'http://api/' }
 
 describe('FlowExecutorContext with runStateStore', () => {
     beforeAll(() => {
@@ -96,5 +108,91 @@ describe('FlowExecutorContext with runStateStore', () => {
         expect(ctx.getStepOutput('step_1')?.output).toEqual({ scope: 'loop' })
         expect(ctx.getStepOutput('step_1', [])?.output).toEqual({ scope: 'root' })
         expect(await ctx.getStepView('step_1')).toEqual({ output: { scope: 'loop' }, error: undefined })
+    })
+
+    describe('slice materialization', () => {
+        afterEach(() => {
+            vi.unstubAllGlobals()
+            vi.restoreAllMocks()
+        })
+
+        test('getStepView downloads a slice once and serves later reads from the store', async () => {
+            const payload = { big: 'x'.repeat(100) }
+            const fetchSpy = vi.fn().mockImplementation(async () => new Response(JSON.stringify(payload)))
+            vi.stubGlobal('fetch', fetchSpy)
+
+            let ctx = FlowExecutorContext.empty({ engineApi: ENGINE_API })
+            ctx = await ctx.upsertStep('step_1', makeSliceStep('slice-1'))
+
+            expect(await ctx.getStepView('step_1')).toEqual({ output: payload, error: undefined })
+            expect(await ctx.getStepView('step_1')).toEqual({ output: payload, error: undefined })
+            expect(fetchSpy).toHaveBeenCalledTimes(1)
+            expect(runStateStore.getSliceJson({ fileId: 'slice-1' })).toEqual(JSON.stringify(payload))
+        })
+
+        test('concurrent reads of the same slice share one in-flight download', async () => {
+            const payload = { value: 42 }
+            const fetchSpy = vi.fn().mockImplementation(async () => new Response(JSON.stringify(payload)))
+            vi.stubGlobal('fetch', fetchSpy)
+
+            let ctx = FlowExecutorContext.empty({ engineApi: ENGINE_API })
+            ctx = await ctx.upsertStep('step_1', makeSliceStep('slice-2'))
+
+            const [first, second] = await Promise.all([ctx.getStepView('step_1'), ctx.getStepView('step_1')])
+            expect(first).toEqual({ output: payload, error: undefined })
+            expect(second).toEqual({ output: payload, error: undefined })
+            expect(fetchSpy).toHaveBeenCalledTimes(1)
+        })
+
+        test('a failed download is retried instead of cached', async () => {
+            const payload = { value: 'recovered' }
+            const fetchSpy = vi.fn()
+                .mockImplementationOnce(async () => new Response('gone', { status: 404 }))
+                .mockImplementation(async () => new Response(JSON.stringify(payload)))
+            vi.stubGlobal('fetch', fetchSpy)
+
+            let ctx = FlowExecutorContext.empty({ engineApi: ENGINE_API })
+            ctx = await ctx.upsertStep('step_1', makeSliceStep('slice-3'))
+
+            await expect(ctx.getStepView('step_1')).rejects.toThrow()
+            expect(await ctx.getStepView('step_1')).toEqual({ output: payload, error: undefined })
+        })
+    })
+
+    describe('store put failure', () => {
+        afterEach(() => {
+            vi.restoreAllMocks()
+        })
+
+        test('upsertStep keeps the full step in memory and deletes the stale store row', async () => {
+            vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+            let ctx = await FlowExecutorContext.empty().upsertStep('step_1', makePieceStep({ version: 1 }))
+            expect(ctx.steps.step_1.output).toBeUndefined()
+
+            vi.spyOn(runStateStore, 'put').mockImplementationOnce(() => {
+                throw new Error('disk full')
+            })
+            ctx = await ctx.upsertStep('step_1', makePieceStep({ version: 2 }))
+
+            expect(ctx.steps.step_1.output).toEqual({ version: 2 })
+            expect(runStateStore.getStepOutput({ name: 'step_1', stepPath: '[]' })).toBeUndefined()
+            expect(ctx.getStepOutput('step_1')?.output).toEqual({ version: 2 })
+            expect(await ctx.getStepView('step_1')).toEqual({ output: { version: 2 }, error: undefined })
+        })
+
+        test('the in-memory step wins over a stale store row when the delete also fails', async () => {
+            vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+            let ctx = await FlowExecutorContext.empty().upsertStep('step_1', makePieceStep({ version: 1 }))
+
+            vi.spyOn(runStateStore, 'put').mockImplementationOnce(() => {
+                throw new Error('disk full')
+            })
+            vi.spyOn(runStateStore, 'deleteStep').mockImplementationOnce(() => undefined)
+            ctx = await ctx.upsertStep('step_1', makePieceStep({ version: 2 }))
+
+            expect(runStateStore.getStepOutput({ name: 'step_1', stepPath: '[]' })?.output).toEqual({ version: 1 })
+            expect(ctx.getStepOutput('step_1')?.output).toEqual({ version: 2 })
+            expect(await ctx.getStepView('step_1')).toEqual({ output: { version: 2 }, error: undefined })
+        })
     })
 })

--- a/packages/server/engine/test/helper/flow-run-progress-reporter-store.test.ts
+++ b/packages/server/engine/test/helper/flow-run-progress-reporter-store.test.ts
@@ -143,4 +143,19 @@ describe('flowRunProgressReporter backup with runStateStore', () => {
         const parsed = await runBackupAndParseUploadedLog(ctx)
         expect(parsed).toEqual(expectedLog)
     })
+
+    test('backup serializes the in-memory copy when a step fell back to memory over a stale store row', async () => {
+        vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+        let ctx = FlowExecutorContext.empty()
+        ctx = await ctx.upsertStep('trigger_1', makePieceStep({ input: { key: 'in' }, output: { version: 1 } }))
+        vi.spyOn(runStateStore, 'put').mockImplementationOnce(() => {
+            throw new Error('disk full')
+        })
+        vi.spyOn(runStateStore, 'deleteStep').mockImplementationOnce(() => undefined)
+        ctx = await ctx.upsertStep('trigger_1', makePieceStep({ input: { key: 'in' }, output: { version: 2 } }))
+        vi.restoreAllMocks()
+
+        const parsed = await runBackupAndParseUploadedLog(ctx) as { executionState: { steps: Record<string, { output: unknown }> } }
+        expect(parsed.executionState.steps.trigger_1.output).toEqual({ version: 2 })
+    })
 })

--- a/packages/server/engine/test/helper/run-state-store.test.ts
+++ b/packages/server/engine/test/helper/run-state-store.test.ts
@@ -159,6 +159,43 @@ describe('runStateStore', () => {
         })
     })
 
+    describe('deleteStep', () => {
+        test('removes an existing row', () => {
+            putStep({ name: 'step_1', output: { a: 1 } })
+            runStateStore.deleteStep({ name: 'step_1', stepPath: ROOT_PATH })
+            expect(runStateStore.getStepOutput({ name: 'step_1', stepPath: ROOT_PATH })).toBeUndefined()
+            expect(runStateStore.getStepSize({ name: 'step_1', stepPath: ROOT_PATH })).toBeUndefined()
+        })
+
+        test('is a no-op when not initialized', () => {
+            runStateStore.dispose()
+            expect(() => runStateStore.deleteStep({ name: 'step_1', stepPath: ROOT_PATH })).not.toThrow()
+        })
+    })
+
+    describe('slices', () => {
+        test('round-trips slice json', () => {
+            runStateStore.putSlice({ fileId: 'file-1', json: '{"big":"payload"}' })
+            expect(runStateStore.getSliceJson({ fileId: 'file-1' })).toEqual('{"big":"payload"}')
+        })
+
+        test('replaces an existing slice for the same file id', () => {
+            runStateStore.putSlice({ fileId: 'file-1', json: '{"version":1}' })
+            runStateStore.putSlice({ fileId: 'file-1', json: '{"version":2}' })
+            expect(runStateStore.getSliceJson({ fileId: 'file-1' })).toEqual('{"version":2}')
+        })
+
+        test('returns undefined for a missing file id', () => {
+            expect(runStateStore.getSliceJson({ fileId: 'missing' })).toBeUndefined()
+        })
+
+        test('put and get are safe no-ops when not initialized', () => {
+            runStateStore.dispose()
+            expect(() => runStateStore.putSlice({ fileId: 'file-1', json: '{}' })).not.toThrow()
+            expect(runStateStore.getSliceJson({ fileId: 'file-1' })).toBeUndefined()
+        })
+    })
+
     describe('dispose', () => {
         test('deletes the sqlite file and marks the store uninitialized', () => {
             const sqlitePath = sqliteFilePath()


### PR DESCRIPTION
## Description

Stacked on #14518 (base: `perf/engine-sqlite-state-store`). First of a 2-PR stack; part 2 is the log-upload buffering PR.

**Slice cache → sqlite.** Materialized slice downloads were cached in a 64 MB in-heap byte-LRU (`resolvedStepOutputCache`, from #14477). They now live in a `slices` table in the per-run sqlite store, keeping the engine heap flat. Concurrent reads of the same slice share one in-flight download (a module-level map whose entries self-delete on settle), which also fixes a latent bug where a **rejected** download promise stayed poisoned in the LRU — failed downloads now retry. When the store is uninitialized (init failure, test-step ops) slices are downloaded uncached; `createMemoizedStepViewGetter` already dedups within one input resolution.

**Guarded store writes, degrade to memory.** `runStateStore.put` failures no longer kill the run: the step stays **fully in memory** (not stripped), the stale row from a prior successful put is deleted, and all three read sites (`getStepOutput`, `getStepView`, the log streamer's `stepEntries`) prefer the in-memory copy when it carries a defined `output` — stripped copies never do — so a stale row can't leak into resolution or the uploaded log even if the delete itself fails. Store reads are guarded to return `undefined` instead of throwing on a broken db. Size accounting on the fallback path uses the store's previous size so `logSizeBytes` doesn't drift.

Accepted trade-offs: the slices table is unbounded on disk (per-run file, deleted at dispose; `/box` tmpdir in sandbox mode), and a large slice referenced across N loop iterations costs one sqlite read + JSON.parse per iteration — CPU traded for heap, intentionally.

## How was this tested?

- 12 new engine unit tests: slice round-trip/replace/uninitialized, download-once-then-store, concurrent dedup, failed-download-retries, put-failure keeps memory + deletes stale row, memory-wins-over-stale-row (reads + streamed log), `deleteStep`.
- Full engine suite matches baseline; slice delay/resume e2e (`execute-flow-e2e.test.ts`) passes against a rebuilt engine.

Fixes # (issue)

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)