### PR TITLE
perf(engine): buffer small run logs for the presigned redirect and back off between upload retries

### DIFF
--- a/packages/server/engine/src/lib/helper/flow-run-progress-reporter.ts
+++ b/packages/server/engine/src/lib/helper/flow-run-progress-reporter.ts
@@ -1,5 +1,6 @@
 import { Readable } from 'node:stream'
-import { createZstdCompress } from 'node:zlib'
+import { promisify } from 'node:util'
+import { createZstdCompress, zstdCompress as zstdCompressCallback } from 'node:zlib'
 import { setTimeout } from 'timers/promises'
 import { isNil, tryCatch } from '@activepieces/core-utils'
 import { OutputContext } from '@activepieces/pieces-framework'
@@ -16,6 +17,10 @@ import { stateJsonStreamer } from './state-json-streamer'
 
 const stateLock = new Mutex()
 const LOG_UPLOAD_ATTEMPTS = 3
+const LOG_UPLOAD_RETRY_DELAY_MS = 1000
+const LOG_BUFFER_UPLOAD_THRESHOLD_BYTES = 4 * 1024 * 1024
+
+const zstdCompress = promisify(zstdCompressCallback)
 
 const SNAPSHOT_FLUSH_INTERVAL_MS = 15000
 let latestUpdateParams: UpdateStepProgressParams | null = null
@@ -213,16 +218,23 @@ const extractStepResponse = (params: ExtractStepResponse): StepRunResponse | und
 }
 
 async function uploadLogsFromStore({ engineConstants, flowExecutorContext, logsFileId }: UploadLogsFromStoreParams): Promise<void> {
+    const shouldBuffer = flowExecutorContext.logSizeBytes < LOG_BUFFER_UPLOAD_THRESHOLD_BYTES
+    const buffered = shouldBuffer
+        ? await zstdCompress(Array.from(stateJsonStreamer.stream(flowExecutorContext)).join(''))
+        : undefined
     let lastError: unknown
     for (let attempt = 0; attempt < LOG_UPLOAD_ATTEMPTS; attempt++) {
-        const compressed = Readable.from(stateJsonStreamer.stream(flowExecutorContext)).pipe(createZstdCompress())
+        if (attempt > 0) {
+            await setTimeout(attempt * LOG_UPLOAD_RETRY_DELAY_MS)
+        }
+        const data = buffered ?? Readable.from(stateJsonStreamer.stream(flowExecutorContext)).pipe(createZstdCompress())
         const { error } = await tryCatch(() => engineFileApi.upload({
             engineToken: engineConstants.engineToken,
             apiUrl: engineConstants.internalApiUrl,
             fileId: logsFileId,
             type: FileType.FLOW_RUN_LOG,
             compression: FileCompression.ZSTD,
-            data: compressed,
+            data,
         }))
         if (isNil(error)) {
             return

--- a/packages/server/engine/test/helper/flow-run-progress-reporter-store.test.ts
+++ b/packages/server/engine/test/helper/flow-run-progress-reporter-store.test.ts
@@ -57,7 +57,7 @@ async function buildContextWithLoop(): Promise<FlowExecutorContext> {
     return ctx.setCurrentPath(StepExecutionPath.empty())
 }
 
-async function runBackupAndParseUploadedLog(ctx: FlowExecutorContext): Promise<Record<string, unknown>> {
+async function runBackup(ctx: FlowExecutorContext): Promise<Buffer | Readable> {
     await flowRunProgressReporter.sendUpdate({
         engineConstants: generateMockEngineConstants({ logsFileId: 'logs-1' }),
         flowExecutorContext: ctx,
@@ -65,13 +65,27 @@ async function runBackupAndParseUploadedLog(ctx: FlowExecutorContext): Promise<R
     await flowRunProgressReporter.backup()
 
     expect(mockUpload).toHaveBeenCalledTimes(1)
-    const uploaded = mockUpload.mock.calls[0][0].data as Readable
-    const chunks: Buffer[] = []
-    for await (const chunk of uploaded) {
-        chunks.push(chunk)
+    return mockUpload.mock.calls[0][0].data
+}
+
+async function parseUploadedLog(uploaded: Buffer | Readable): Promise<Record<string, unknown>> {
+    let compressed: Buffer
+    if (uploaded instanceof Readable) {
+        const chunks: Buffer[] = []
+        for await (const chunk of uploaded) {
+            chunks.push(chunk)
+        }
+        compressed = Buffer.concat(chunks)
     }
-    const serialized = await zstdDecompress(Buffer.concat(chunks))
+    else {
+        compressed = uploaded
+    }
+    const serialized = await zstdDecompress(compressed)
     return JSON.parse(serialized.toString('utf-8'))
+}
+
+async function runBackupAndParseUploadedLog(ctx: FlowExecutorContext): Promise<Record<string, unknown>> {
+    return parseUploadedLog(await runBackup(ctx))
 }
 
 const expectedLog = {
@@ -142,6 +156,20 @@ describe('flowRunProgressReporter backup with runStateStore', () => {
 
         const parsed = await runBackupAndParseUploadedLog(ctx)
         expect(parsed).toEqual(expectedLog)
+    })
+
+    test('backup uploads a buffered log when the state is below the size threshold', async () => {
+        const ctx = await buildContextWithLoop()
+        const uploaded = await runBackup(ctx)
+        expect(uploaded).toBeInstanceOf(Buffer)
+        expect(await parseUploadedLog(uploaded)).toEqual(expectedLog)
+    })
+
+    test('backup streams the log when the state exceeds the size threshold', async () => {
+        const ctx = new FlowExecutorContext({ ...(await buildContextWithLoop()), logSizeBytes: 5 * 1024 * 1024 })
+        const uploaded = await runBackup(ctx)
+        expect(uploaded).toBeInstanceOf(Readable)
+        expect(await parseUploadedLog(uploaded)).toEqual(expectedLog)
     })
 
     test('backup serializes the in-memory copy when a step fell back to memory over a stale store row', async () => {


### PR DESCRIPTION
## Description

Stacked on #14638 (base: `perf/engine-slice-cache-sqlite`), which stacks on #14518. Second (top) of the 2-PR stack.

**Buffered upload below 4 MB.** Since the streaming-backup change, every log upload flowed through the API tier: a chunked PUT has no Content-Length, and the server's 307 presigned-S3 redirect requires one (`files-controller.ts`). `uploadLogsFromStore` now checks the already-maintained `logSizeBytes`: below 4 MB (the vast majority of runs) it materializes the streamed JSON, compresses with buffered `zstdCompress`, and uploads a Buffer — Content-Length present, so S3-signed deployments get the presigned redirect + fetch-retry back and the API tier stops proxying every 15-second flush. At/above the threshold the streaming pipeline is unchanged. The buffer is built once outside the retry loop and reused across attempts.

Notes: `File.size` on the redirect path records the compressed length — nothing reads it semantically, and today's S3/DB paths already store compressed sizes. `logSizeBytes` counts SLICE steps at their full materialized size while the log holds only the tiny ref, so slice-heavy runs overshoot the estimate and stream — the safe direction.

**Retry backoff.** The 3 upload attempts were back-to-back; against a struggling upstream that just fails three times instantly. Now 1 s / 2 s delays between attempts, none after the final failure — bounded well under the 15 s flush interval.

## How was this tested?

- Engine unit tests: small state → `engineFileApi.upload` receives a Buffer that zstd-decompresses to the exact expected log; state above the threshold → receives a Readable with identical content.
- Full engine suite matches baseline; slice delay/resume e2e passes against a rebuilt engine.

Fixes # (issue)

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)