### PR TITLE
fix(worker): register engine response listeners before enqueueing jobs

### DIFF
--- a/packages/server/api/src/app/flows/flow-run/waitpoint/resume-service.ts
+++ b/packages/server/api/src/app/flows/flow-run/waitpoint/resume-service.ts
@@ -1,10 +1,10 @@
-import { apId, FlowRunId, isNil } from '@activepieces/core-utils'
+import { apId, FlowRunId, isNil, tryCatch } from '@activepieces/core-utils'
 import { EngineHttpResponse, ExecutionType, FlowRun, FlowRunStatus, isFlowRunStateTerminal, ResumeReason, RunEnvironment, StreamStepProgress } from '@activepieces/shared'
 import { FastifyBaseLogger } from 'fastify'
 import { StatusCodes } from 'http-status-codes'
 import { distributedLock } from '../../../database/redis-connections'
 import { projectService } from '../../../project/project-service'
-import { engineResponseWatcher } from '../../../workers/engine-response-watcher'
+import { engineResponseWatcher, registerListener } from '../../../workers/engine-response-watcher'
 import { addToQueue, findFlowRunOrThrow, flowRunService, WEBHOOK_TIMEOUT_MS } from '../flow-run-service'
 import { flowRunSideEffects } from '../flow-run-side-effects'
 import { waitpointService } from './waitpoint-service'
@@ -86,15 +86,31 @@ export const resumeService = (log: FastifyBaseLogger) => ({
         }
 
         const syncServerId = engineResponseWatcher(log).getServerId()
-        const { stale } = await this.resumeFromWaitpoint({
+        const pending = registerListener<EngineHttpResponse>({
+            requestId: correlationId,
+            timeoutMs: WEBHOOK_TIMEOUT_MS,
+            defaultResponse: {
+                status: StatusCodes.NO_CONTENT,
+                body: {},
+                headers: {},
+            },
+            log,
+        })
+        const { data, error } = await tryCatch(() => this.resumeFromWaitpoint({
             flowRunId: runId,
             waitpointId,
             resumePayload: payload,
             workerHandlerId: syncServerId,
             httpRequestId: correlationId,
-        })
+        }))
 
-        if (stale) {
+        if (error) {
+            pending.cancel()
+            throw error
+        }
+
+        if (data.stale) {
+            pending.cancel()
             return {
                 status: StatusCodes.GONE,
                 body: { message: 'This link has expired. The action may have already been processed.' },
@@ -102,11 +118,7 @@ export const resumeService = (log: FastifyBaseLogger) => ({
             }
         }
 
-        return engineResponseWatcher(log).oneTimeListener<EngineHttpResponse>(correlationId, true, WEBHOOK_TIMEOUT_MS, {
-            status: StatusCodes.NO_CONTENT,
-            body: {},
-            headers: {},
-        })
+        return pending.response
     },
 
     async legacySyncResume({ runId, payload, correlationId }: LegacySyncResumeParams): Promise<EngineHttpResponse> {
@@ -119,11 +131,15 @@ export const resumeService = (log: FastifyBaseLogger) => ({
             }
         }
         const syncServerId = engineResponseWatcher(log).getServerId()
-        await enqueueResume({ flowRun, resumePayload: payload, workerHandlerId: syncServerId, httpRequestId: correlationId }, log)
-        return engineResponseWatcher(log).oneTimeListener<EngineHttpResponse>(correlationId, true, WEBHOOK_TIMEOUT_MS, {
-            status: StatusCodes.NO_CONTENT,
-            body: {},
-            headers: {},
+        return engineResponseWatcher(log).waitForResponse<EngineHttpResponse>({
+            requestId: correlationId,
+            timeoutMs: WEBHOOK_TIMEOUT_MS,
+            defaultResponse: {
+                status: StatusCodes.NO_CONTENT,
+                body: {},
+                headers: {},
+            },
+            enqueue: () => enqueueResume({ flowRun, resumePayload: payload, workerHandlerId: syncServerId, httpRequestId: correlationId }, log),
         })
     },
 })

--- a/packages/server/api/src/app/webhooks/webhook.service.ts
+++ b/packages/server/api/src/app/webhooks/webhook.service.ts
@@ -297,31 +297,34 @@ async function handleSync(params: SyncWebhookParams): Promise<EngineHttpResponse
         }
     }
 
-    const createdRun = await flowRunService(logger).start({
-        platformId,
-        environment: runEnvironment,
-        flowId: flow.id,
-        flowVersionId: flowVersionIdToRun,
-        payload,
-        workerHandlerId,
-        projectId,
-        executeTrigger: true,
-        httpRequestId: webhookRequestId,
-        executionType: ExecutionType.BEGIN,
-        streamStepProgress: StreamStepProgress.NONE,
-        parentRunId,
-        failParentOnFailure,
+    return engineResponseWatcher(logger).waitForResponse<EngineHttpResponse>({
+        requestId: webhookRequestId,
+        timeoutMs: timeoutMs ?? WEBHOOK_TIMEOUT_MS,
+        defaultResponse: {
+            status: StatusCodes.REQUEST_TIMEOUT,
+            body: {},
+            headers: {},
+        },
+        enqueue: async () => {
+            const createdRun = await flowRunService(logger).start({
+                platformId,
+                environment: runEnvironment,
+                flowId: flow.id,
+                flowVersionId: flowVersionIdToRun,
+                payload,
+                workerHandlerId,
+                projectId,
+                executeTrigger: true,
+                httpRequestId: webhookRequestId,
+                executionType: ExecutionType.BEGIN,
+                streamStepProgress: StreamStepProgress.NONE,
+                parentRunId,
+                failParentOnFailure,
+            })
+            wideEvent.set({ flowRun: { id: createdRun.id } })
+            params.onRunCreated?.(createdRun)
+        },
     })
-
-    wideEvent.set({ flowRun: { id: createdRun.id } })
-    params.onRunCreated?.(createdRun)
-
-    const listenerResult = await engineResponseWatcher(logger).oneTimeListener<EngineHttpResponse>(webhookRequestId, true, timeoutMs ?? WEBHOOK_TIMEOUT_MS, {
-        status: StatusCodes.REQUEST_TIMEOUT,
-        body: {},
-        headers: {},
-    })
-    return listenerResult
 }
 
 async function savePayload(params: Omit<AsyncWebhookParams, 'saveSampleData' | 'webhookHeader' | 'execute'>): Promise<void> {

--- a/packages/server/api/src/app/workers/engine-response-watcher.ts
+++ b/packages/server/api/src/app/workers/engine-response-watcher.ts
@@ -1,8 +1,6 @@
-import { apId } from '@activepieces/core-utils'
+import { apId, tryCatch } from '@activepieces/core-utils'
 import { FastifyBaseLogger } from 'fastify'
 import { pubsub } from '../helper/pubsub'
-
-type EngineResponseWithId<T> = { requestId: string, response: T }
 
 const listeners = new Map<string, (flowResponse: EngineResponseWithId<unknown>) => void>()
 const SERVER_ID = apId()
@@ -19,44 +17,27 @@ export const engineResponseWatcher = (log: FastifyBaseLogger) => ({
             (message: string) => {
                 const parsedMessage: EngineResponseWithId<unknown> = JSON.parse(message)
                 const listener = listeners.get(parsedMessage.requestId)
-                
+
                 if (listener) {
                     listener(parsedMessage)
                 }
-                
+
                 log.info(
-                    { requestId: parsedMessage.requestId }, 
+                    { requestId: parsedMessage.requestId },
                     '[engineWatcher#init]',
                 )
             },
         )
     },
 
-    async oneTimeListener<T>(requestId: string, timeoutRequest: boolean, timeoutMs: number | undefined, defaultResponse: T | undefined): Promise<T> {
-        log.info('[engineWatcher#listen]')
-
-        return new Promise<T>((resolve) => {
-            let timeout: NodeJS.Timeout
-
-            if (timeoutRequest) {
-                timeout = setTimeout(() => {
-                    log.info('[engineWatcher#listen] Timeout reached')
-                    listeners.delete(requestId)
-                    resolve(defaultResponse as T)
-                }, timeoutMs)
-            }
-
-            const responseHandler = (flowResponse: EngineResponseWithId<unknown>) => {
-                if (timeout) {
-                    clearTimeout(timeout)
-                }
-                listeners.delete(requestId)
-                log.info({ requestId }, '[engineWatcher#listen] Response received')
-                resolve(flowResponse.response as T)
-            }
-
-            listeners.set(requestId, responseHandler)
-        })
+    async waitForResponse<T>({ requestId, timeoutMs, defaultResponse, enqueue }: WaitForResponseParams<T>): Promise<T> {
+        const pending = registerListener({ requestId, timeoutMs, defaultResponse, log })
+        const { error } = await tryCatch(enqueue)
+        if (error) {
+            pending.cancel()
+            throw error
+        }
+        return pending.response
     },
 
     async publish(webserverId: string, requestId: string, response: unknown): Promise<void> {
@@ -70,3 +51,47 @@ export const engineResponseWatcher = (log: FastifyBaseLogger) => ({
         await pubsub.unsubscribe(`engine-run:sync:${SERVER_ID}`)
     },
 })
+
+export function registerListener<T>({ requestId, timeoutMs, defaultResponse, log }: RegisterListenerParams<T>): PendingEngineResponse<T> {
+    log.info({ requestId }, '[engineWatcher#registerListener]')
+    let cancel: () => void = () => undefined
+    const response = new Promise<T>((resolve) => {
+        const timeout = setTimeout(() => {
+            log.info({ requestId }, '[engineWatcher#registerListener] Timeout reached')
+            listeners.delete(requestId)
+            resolve(defaultResponse)
+        }, timeoutMs)
+        const settle = (value: T): void => {
+            clearTimeout(timeout)
+            listeners.delete(requestId)
+            resolve(value)
+        }
+        listeners.set(requestId, (engineResponse) => {
+            log.info({ requestId }, '[engineWatcher#registerListener] Response received')
+            settle(engineResponse.response as T)
+        })
+        cancel = () => settle(defaultResponse)
+    })
+    return { response, cancel }
+}
+
+type EngineResponseWithId<T> = { requestId: string, response: T }
+
+type ListenerParams<T> = {
+    requestId: string
+    timeoutMs: number
+    defaultResponse: T
+}
+
+type WaitForResponseParams<T> = ListenerParams<T> & {
+    enqueue: () => Promise<unknown>
+}
+
+type RegisterListenerParams<T> = ListenerParams<T> & {
+    log: FastifyBaseLogger
+}
+
+export type PendingEngineResponse<T> = {
+    response: Promise<T>
+    cancel: () => void
+}

--- a/packages/server/api/src/app/workers/user-interaction-watcher.ts
+++ b/packages/server/api/src/app/workers/user-interaction-watcher.ts
@@ -10,20 +10,24 @@ const WATCHER_GRACE_MS = 10 * 1000
 export const userInteractionWatcher = {
     submitAndWaitForResponse: async <T>(request: UserInteractionJobDataWithoutWatchingInformation, log: FastifyBaseLogger, requestId?: string): Promise<T> => {
         const id = requestId ?? apId()
-        await jobQueue(log).add({
-            id,
-            type: JobType.ONE_TIME,
-            data: {
-                ...request,
-                requestId: id,
-                webserverId: engineResponseWatcher(log).getServerId(),
-                schemaVersion: LATEST_JOB_DATA_SCHEMA_VERSION,
-            },
-        })
         const timeoutMs = request.jobType === WorkerJobType.EXECUTE_ACTION
             ? (request.expiresAt - Date.now()) + WATCHER_GRACE_MS
             : WATCHER_SAFETY_TIMEOUT_MS
-        const result = await engineResponseWatcher(log).oneTimeListener<T>(id, true, timeoutMs, undefined)
+        const result = await engineResponseWatcher(log).waitForResponse<T | undefined>({
+            requestId: id,
+            timeoutMs,
+            defaultResponse: undefined,
+            enqueue: () => jobQueue(log).add({
+                id,
+                type: JobType.ONE_TIME,
+                data: {
+                    ...request,
+                    requestId: id,
+                    webserverId: engineResponseWatcher(log).getServerId(),
+                    schemaVersion: LATEST_JOB_DATA_SCHEMA_VERSION,
+                },
+            }),
+        })
         if (isNil(result)) {
             throw new ActivepiecesError({
                 code: ErrorCode.ENGINE_OPERATION_FAILURE,

--- a/packages/server/api/test/integration/ce/workers/engine-response-watcher.test.ts
+++ b/packages/server/api/test/integration/ce/workers/engine-response-watcher.test.ts
@@ -1,0 +1,58 @@
+import { apId } from '@activepieces/core-utils'
+import { FastifyInstance } from 'fastify'
+import { engineResponseWatcher } from '../../../../src/app/workers/engine-response-watcher'
+import { setupTestEnvironment, teardownTestEnvironment } from '../../../helpers/test-setup'
+
+let app: FastifyInstance
+
+beforeAll(async () => {
+    app = await setupTestEnvironment()
+})
+
+afterAll(async () => {
+    await teardownTestEnvironment()
+})
+
+describe('engineResponseWatcher.waitForResponse', () => {
+    it('should receive a response published while the enqueue callback is still running', async () => {
+        const requestId = apId()
+        const serverId = engineResponseWatcher(app.log).getServerId()
+
+        const result = await engineResponseWatcher(app.log).waitForResponse<{ ok: boolean } | undefined>({
+            requestId,
+            timeoutMs: 5000,
+            defaultResponse: undefined,
+            enqueue: async () => {
+                await engineResponseWatcher(app.log).publish(serverId, requestId, { ok: true })
+            },
+        })
+
+        expect(result).toEqual({ ok: true })
+    })
+
+    it('should resolve with the default response when no response arrives before the timeout', async () => {
+        const requestId = apId()
+
+        const result = await engineResponseWatcher(app.log).waitForResponse<{ ok: boolean } | undefined>({
+            requestId,
+            timeoutMs: 100,
+            defaultResponse: undefined,
+            enqueue: async () => {},
+        })
+
+        expect(result).toBeUndefined()
+    })
+
+    it('should rethrow and stop waiting when the enqueue callback fails', async () => {
+        const requestId = apId()
+
+        await expect(engineResponseWatcher(app.log).waitForResponse<undefined>({
+            requestId,
+            timeoutMs: 5000,
+            defaultResponse: undefined,
+            enqueue: async () => {
+                throw new Error('enqueue failed')
+            },
+        })).rejects.toThrow('enqueue failed')
+    })
+})

--- a/packages/server/api/test/integration/ce/workers/job-broker-error-propagation.test.ts
+++ b/packages/server/api/test/integration/ce/workers/job-broker-error-propagation.test.ts
@@ -1,7 +1,7 @@
 import { apId } from '@activepieces/core-utils'
 import { EngineResponseStatus, LATEST_JOB_DATA_SCHEMA_VERSION, TriggerHookType, WorkerJobType } from '@activepieces/shared'
 import { FastifyInstance } from 'fastify'
-import { engineResponseWatcher } from '../../../../src/app/workers/engine-response-watcher'
+import { engineResponseWatcher, registerListener } from '../../../../src/app/workers/engine-response-watcher'
 import { jobBroker } from '../../../../src/app/workers/job-queue/job-broker'
 import { jobQueue, JobType } from '../../../../src/app/workers/job-queue/job-queue'
 import { mockAndSaveBasicSetup } from '../../../helpers/mocks'
@@ -48,12 +48,12 @@ describe('Job broker error propagation', () => {
         const polledJob = await jobBroker(app.log).poll()
         expect(polledJob).not.toBeNull()
 
-        const listenerPromise = engineResponseWatcher(app.log).oneTimeListener(
+        const listenerPromise = registerListener({
             requestId,
-            true,
-            5000,
-            undefined,
-        )
+            timeoutMs: 5000,
+            defaultResponse: undefined,
+            log: app.log,
+        }).response
 
         await jobBroker(app.log).completeJob({
             jobId,
@@ -99,12 +99,12 @@ describe('Job broker error propagation', () => {
         const polledJob = await jobBroker(app.log).poll()
         expect(polledJob).not.toBeNull()
 
-        const listenerPromise = engineResponseWatcher(app.log).oneTimeListener(
+        const listenerPromise = registerListener({
             requestId,
-            true,
-            5000,
-            undefined,
-        )
+            timeoutMs: 5000,
+            defaultResponse: undefined,
+            log: app.log,
+        }).response
 
         await jobBroker(app.log).completeJob({
             jobId,
@@ -149,12 +149,12 @@ describe('Job broker error propagation', () => {
         const polledJob = await jobBroker(app.log).poll()
         expect(polledJob).not.toBeNull()
 
-        const listenerPromise = engineResponseWatcher(app.log).oneTimeListener(
+        const listenerPromise = registerListener({
             requestId,
-            true,
-            5000,
-            undefined,
-        )
+            timeoutMs: 5000,
+            defaultResponse: undefined,
+            log: app.log,
+        }).response
 
         await jobBroker(app.log).completeJob({
             jobId,
@@ -200,12 +200,12 @@ describe('Job broker error propagation', () => {
         const polledJob = await jobBroker(app.log).poll()
         expect(polledJob).not.toBeNull()
 
-        const listenerPromise = engineResponseWatcher(app.log).oneTimeListener(
+        const listenerPromise = registerListener({
             requestId,
-            true,
-            5000,
-            undefined,
-        )
+            timeoutMs: 5000,
+            defaultResponse: undefined,
+            log: app.log,
+        }).response
 
         await jobBroker(app.log).completeJob({
             jobId,
@@ -252,12 +252,12 @@ describe('Job broker error propagation', () => {
         const polledJob = await jobBroker(app.log).poll()
         expect(polledJob).not.toBeNull()
 
-        const listenerPromise = engineResponseWatcher(app.log).oneTimeListener(
+        const listenerPromise = registerListener({
             requestId,
-            true,
-            5000,
-            undefined,
-        )
+            timeoutMs: 5000,
+            defaultResponse: undefined,
+            log: app.log,
+        }).response
 
         await jobBroker(app.log).completeJob({
             jobId,

--- a/packages/server/api/test/unit/app/webhooks/webhook-credit-gate.test.ts
+++ b/packages/server/api/test/unit/app/webhooks/webhook-credit-gate.test.ts
@@ -3,12 +3,12 @@ import { StatusCodes } from 'http-status-codes'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { WebhookFlowVersionToRun } from '../../../../src/app/webhooks/webhook.service'
 
-const { mockShouldBlockRunOnCredits, mockStart, mockCreateQuotaExceededRun, mockFindOneBy, mockOneTimeListener } = vi.hoisted(() => ({
+const { mockShouldBlockRunOnCredits, mockStart, mockCreateQuotaExceededRun, mockFindOneBy, mockWaitForResponse } = vi.hoisted(() => ({
     mockShouldBlockRunOnCredits: vi.fn(),
     mockStart: vi.fn(),
     mockCreateQuotaExceededRun: vi.fn(),
     mockFindOneBy: vi.fn(),
-    mockOneTimeListener: vi.fn(),
+    mockWaitForResponse: vi.fn(),
 }))
 
 vi.mock('@activepieces/server-utils', () => ({
@@ -58,7 +58,7 @@ vi.mock('../../../../src/app/flows/flow/flow-execution-cache', () => ({
 vi.mock('../../../../src/app/workers/engine-response-watcher', () => ({
     engineResponseWatcher: () => ({
         getServerId: vi.fn().mockReturnValue('worker-1'),
-        oneTimeListener: mockOneTimeListener,
+        waitForResponse: mockWaitForResponse,
     }),
 }))
 
@@ -115,7 +115,10 @@ describe('sync webhook credit gate', () => {
         mockFindOneBy.mockResolvedValue({ id: 'ver-1', flowId: 'flow-1' })
         mockCreateQuotaExceededRun.mockResolvedValue({ id: 'run-quota' })
         mockStart.mockResolvedValue({ id: 'run-1' })
-        mockOneTimeListener.mockResolvedValue({ status: StatusCodes.OK, body: { ok: true }, headers: {} })
+        mockWaitForResponse.mockImplementation(async ({ enqueue }: { enqueue: () => Promise<unknown> }) => {
+            await enqueue()
+            return { status: StatusCodes.OK, body: { ok: true }, headers: {} }
+        })
     })
 
     it('answers 402 instead of running the flow when the platform is out of credits', async () => {


### PR DESCRIPTION
## Description

Sync waits on the engine response watcher (action runs, sync webhooks, waitpoint resumes) used to enqueue the job first and register the pub/sub listener afterwards. A worker that finished fast could publish the response into that gap; Redis pub/sub has no replay, so the message was dropped and the caller stalled for the full timeout before failing with a false "Worker did not respond within the safety timeout".

This PR closes that race everywhere by making listener registration always happen before the work is enqueued:

- `engineResponseWatcher.waitForResponse({ requestId, timeoutMs, defaultResponse, enqueue })` registers the listener, then runs the `enqueue` closure, and cancels the listener (clearing the timer and map entry) if the enqueue throws.
- `registerListener` is exported for the one caller that needs to abort listening after registration: `handleSyncResumeFlow` cancels the pending listener when the resume turns out stale (410) or throws.
- `oneTimeListener` and its always-`true` `timeoutRequest` flag are deleted; `userInteractionWatcher.submitAndWaitForResponse`, the sync webhook path, and `legacySyncResume` all route through `waitForResponse`.

One deliberate semantic shift: each timeout window now starts before the enqueue/run-creation instead of after it, so `WEBHOOK_TIMEOUT_MS` now includes run-creation time (and the distributed-lock wait in `handleSyncResumeFlow`). This is what makes the race-free ordering possible and keeps the watcher deadline aligned with the client-facing one.

## How was this tested?

- New integration test `engine-response-watcher.test.ts` pins the three `waitForResponse` behaviours: a response published while the enqueue callback is still running is received, timeout resolves the default response, and an enqueue failure rethrows and stops waiting.
- Existing suites covering every converted call site pass: job-broker error propagation, webhooks (integration + credit-gate unit tests), resume-flow-run, waitpoint, human-input, piece-install (CE and EE), action-run outcome, and trigger side-effects.
- `tsc --noEmit` and `lint` clean on the api package.

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)