### PR TITLE
fix(pieces): keep polling checkpoint on republish for hubspot and jira

### DIFF
--- a/packages/pieces/community/hubspot/package.json
+++ b/packages/pieces/community/hubspot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-hubspot",
-  "version": "0.8.8",
+  "version": "0.8.9",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "dependencies": {

--- a/packages/pieces/community/hubspot/src/lib/triggers/deal-stage-updated.ts
+++ b/packages/pieces/community/hubspot/src/lib/triggers/deal-stage-updated.ts
@@ -130,18 +130,10 @@ export const dealStageUpdatedTrigger = createTrigger({
 	},
 	type: TriggerStrategy.POLLING,
 	async onEnable(context) {
-		await pollingHelper.onEnable(polling, {
-			auth: context.auth,
-			store: context.store,
-			propsValue: context.propsValue,
-		});
+		await pollingHelper.onEnable(polling, context);
 	},
 	async onDisable(context) {
-		await pollingHelper.onDisable(polling, {
-			auth: context.auth,
-			store: context.store,
-			propsValue: context.propsValue,
-		});
+		await pollingHelper.onDisable(polling, context);
 	},
 	async test(context) {
 		return await pollingHelper.test(polling, context);

--- a/packages/pieces/community/hubspot/src/lib/triggers/email-subscriptions-timeline.ts
+++ b/packages/pieces/community/hubspot/src/lib/triggers/email-subscriptions-timeline.ts
@@ -67,18 +67,10 @@ export const newEmailSubscriptionsTimelineTrigger = createTrigger({
 	type: TriggerStrategy.POLLING,
 	props: {},
 	async onEnable(context) {
-		await pollingHelper.onEnable(polling, {
-			auth: context.auth,
-			store: context.store,
-			propsValue: context.propsValue,
-		});
+		await pollingHelper.onEnable(polling, context);
 	},
 	async onDisable(context) {
-		await pollingHelper.onDisable(polling, {
-			auth: context.auth,
-			store: context.store,
-			propsValue: context.propsValue,
-		});
+		await pollingHelper.onDisable(polling, context);
 	},
 	async test(context) {
 		return await pollingHelper.test(polling, context);

--- a/packages/pieces/community/hubspot/src/lib/triggers/new-blog-article.ts
+++ b/packages/pieces/community/hubspot/src/lib/triggers/new-blog-article.ts
@@ -115,18 +115,10 @@ export const newBlogArticleTrigger = createTrigger({
 		}),
 	},
 	async onEnable(context) {
-		await pollingHelper.onEnable(polling, {
-			auth: context.auth,
-			store: context.store,
-			propsValue: context.propsValue,
-		});
+		await pollingHelper.onEnable(polling, context);
 	},
 	async onDisable(context) {
-		await pollingHelper.onDisable(polling, {
-			auth: context.auth,
-			store: context.store,
-			propsValue: context.propsValue,
-		});
+		await pollingHelper.onDisable(polling, context);
 	},
 	async test(context) {
 		return await pollingHelper.test(polling, context);

--- a/packages/pieces/community/hubspot/src/lib/triggers/new-company-property-change.ts
+++ b/packages/pieces/community/hubspot/src/lib/triggers/new-company-property-change.ts
@@ -144,18 +144,10 @@ export const newCompanyPropertyChangeTrigger = createTrigger({
 	},
 	type: TriggerStrategy.POLLING,
 	async onEnable(context) {
-		await pollingHelper.onEnable(polling, {
-			auth: context.auth,
-			store: context.store,
-			propsValue: context.propsValue,
-		});
+		await pollingHelper.onEnable(polling, context);
 	},
 	async onDisable(context) {
-		await pollingHelper.onDisable(polling, {
-			auth: context.auth,
-			store: context.store,
-			propsValue: context.propsValue,
-		});
+		await pollingHelper.onDisable(polling, context);
 	},
 	async test(context) {
 		return await pollingHelper.test(polling, context);

--- a/packages/pieces/community/hubspot/src/lib/triggers/new-company.ts
+++ b/packages/pieces/community/hubspot/src/lib/triggers/new-company.ts
@@ -95,18 +95,10 @@ export const newCompanyTrigger = createTrigger({
 	},
 	type: TriggerStrategy.POLLING,
 	async onEnable(context) {
-		await pollingHelper.onEnable(polling, {
-			auth: context.auth,
-			store: context.store,
-			propsValue: context.propsValue,
-		});
+		await pollingHelper.onEnable(polling, context);
 	},
 	async onDisable(context) {
-		await pollingHelper.onDisable(polling, {
-			auth: context.auth,
-			store: context.store,
-			propsValue: context.propsValue,
-		});
+		await pollingHelper.onDisable(polling, context);
 	},
 	async test(context) {
 		return await pollingHelper.test(polling, context);

--- a/packages/pieces/community/hubspot/src/lib/triggers/new-contact-in-list.ts
+++ b/packages/pieces/community/hubspot/src/lib/triggers/new-contact-in-list.ts
@@ -151,18 +151,10 @@ export const newContactInListTrigger = createTrigger({
 		}),
 	},
 	async onEnable(context) {
-		await pollingHelper.onEnable(polling, {
-			auth: context.auth,
-			store: context.store,
-			propsValue: context.propsValue,
-		});
+		await pollingHelper.onEnable(polling, context);
 	},
 	async onDisable(context) {
-		await pollingHelper.onDisable(polling, {
-			auth: context.auth,
-			store: context.store,
-			propsValue: context.propsValue,
-		});
+		await pollingHelper.onDisable(polling, context);
 	},
 	async test(context) {
 		return await pollingHelper.test(polling, context);

--- a/packages/pieces/community/hubspot/src/lib/triggers/new-contact-property-change.ts
+++ b/packages/pieces/community/hubspot/src/lib/triggers/new-contact-property-change.ts
@@ -146,18 +146,10 @@ export const newContactPropertyChangeTrigger = createTrigger({
 	},
 	type: TriggerStrategy.POLLING,
 	async onEnable(context) {
-		await pollingHelper.onEnable(polling, {
-			auth: context.auth,
-			store: context.store,
-			propsValue: context.propsValue,
-		});
+		await pollingHelper.onEnable(polling, context);
 	},
 	async onDisable(context) {
-		await pollingHelper.onDisable(polling, {
-			auth: context.auth,
-			store: context.store,
-			propsValue: context.propsValue,
-		});
+		await pollingHelper.onDisable(polling, context);
 	},
 	async test(context) {
 		return await pollingHelper.test(polling, context);

--- a/packages/pieces/community/hubspot/src/lib/triggers/new-contact.ts
+++ b/packages/pieces/community/hubspot/src/lib/triggers/new-contact.ts
@@ -97,18 +97,10 @@ export const newContactTrigger = createTrigger({
 	},
 	type: TriggerStrategy.POLLING,
 	async onEnable(context) {
-		await pollingHelper.onEnable(polling, {
-			auth: context.auth,
-			store: context.store,
-			propsValue: context.propsValue,
-		});
+		await pollingHelper.onEnable(polling, context);
 	},
 	async onDisable(context) {
-		await pollingHelper.onDisable(polling, {
-			auth: context.auth,
-			store: context.store,
-			propsValue: context.propsValue,
-		});
+		await pollingHelper.onDisable(polling, context);
 	},
 	async test(context) {
 		return await pollingHelper.test(polling, context);

--- a/packages/pieces/community/hubspot/src/lib/triggers/new-custom-object-property-change.ts
+++ b/packages/pieces/community/hubspot/src/lib/triggers/new-custom-object-property-change.ts
@@ -144,18 +144,10 @@ export const newCustomObjectPropertyChangeTrigger = createTrigger({
 	},
 	type: TriggerStrategy.POLLING,
 	async onEnable(context) {
-		await pollingHelper.onEnable(polling, {
-			auth: context.auth,
-			store: context.store,
-			propsValue: context.propsValue,
-		});
+		await pollingHelper.onEnable(polling, context);
 	},
 	async onDisable(context) {
-		await pollingHelper.onDisable(polling, {
-			auth: context.auth,
-			store: context.store,
-			propsValue: context.propsValue,
-		});
+		await pollingHelper.onDisable(polling, context);
 	},
 	async test(context) {
 		return await pollingHelper.test(polling, context);

--- a/packages/pieces/community/hubspot/src/lib/triggers/new-custom-object.ts
+++ b/packages/pieces/community/hubspot/src/lib/triggers/new-custom-object.ts
@@ -113,18 +113,10 @@ export const newCustomObjectTrigger = createTrigger({
 	},
 	type: TriggerStrategy.POLLING,
 	async onEnable(context) {
-		await pollingHelper.onEnable(polling, {
-			auth: context.auth,
-			store: context.store,
-			propsValue: context.propsValue,
-		});
+		await pollingHelper.onEnable(polling, context);
 	},
 	async onDisable(context) {
-		await pollingHelper.onDisable(polling, {
-			auth: context.auth,
-			store: context.store,
-			propsValue: context.propsValue,
-		});
+		await pollingHelper.onDisable(polling, context);
 	},
 	async test(context) {
 		return await pollingHelper.test(polling, context);

--- a/packages/pieces/community/hubspot/src/lib/triggers/new-deal-property-change.ts
+++ b/packages/pieces/community/hubspot/src/lib/triggers/new-deal-property-change.ts
@@ -145,18 +145,10 @@ export const newDealPropertyChangeTrigger = createTrigger({
 	},
 	type: TriggerStrategy.POLLING,
 	async onEnable(context) {
-		await pollingHelper.onEnable(polling, {
-			auth: context.auth,
-			store: context.store,
-			propsValue: context.propsValue,
-		});
+		await pollingHelper.onEnable(polling, context);
 	},
 	async onDisable(context) {
-		await pollingHelper.onDisable(polling, {
-			auth: context.auth,
-			store: context.store,
-			propsValue: context.propsValue,
-		});
+		await pollingHelper.onDisable(polling, context);
 	},
 	async test(context) {
 		return await pollingHelper.test(polling, context);

--- a/packages/pieces/community/hubspot/src/lib/triggers/new-deal.ts
+++ b/packages/pieces/community/hubspot/src/lib/triggers/new-deal.ts
@@ -97,18 +97,10 @@ export const newDealTrigger = createTrigger({
 	},
 	type: TriggerStrategy.POLLING,
 	async onEnable(context) {
-		await pollingHelper.onEnable(polling, {
-			auth: context.auth,
-			store: context.store,
-			propsValue: context.propsValue,
-		});
+		await pollingHelper.onEnable(polling, context);
 	},
 	async onDisable(context) {
-		await pollingHelper.onDisable(polling, {
-			auth: context.auth,
-			store: context.store,
-			propsValue: context.propsValue,
-		});
+		await pollingHelper.onDisable(polling, context);
 	},
 	async test(context) {
 		return await pollingHelper.test(polling, context);

--- a/packages/pieces/community/hubspot/src/lib/triggers/new-email-event.ts
+++ b/packages/pieces/community/hubspot/src/lib/triggers/new-email-event.ts
@@ -129,18 +129,10 @@ export const newEmailEventTrigger = createTrigger({
 		}),
 	},
 	async onEnable(context) {
-		await pollingHelper.onEnable(polling, {
-			auth: context.auth,
-			store: context.store,
-			propsValue: context.propsValue,
-		});
+		await pollingHelper.onEnable(polling, context);
 	},
 	async onDisable(context) {
-		await pollingHelper.onDisable(polling, {
-			auth: context.auth,
-			store: context.store,
-			propsValue: context.propsValue,
-		});
+		await pollingHelper.onDisable(polling, context);
 	},
 	async test(context) {
 		return await pollingHelper.test(polling, context);

--- a/packages/pieces/community/hubspot/src/lib/triggers/new-engagement.ts
+++ b/packages/pieces/community/hubspot/src/lib/triggers/new-engagement.ts
@@ -104,18 +104,10 @@ export const newEngagementTrigger = createTrigger({
 		}),
 	},
 	async onEnable(context) {
-		await pollingHelper.onEnable(polling, {
-			auth: context.auth,
-			store: context.store,
-			propsValue: context.propsValue,
-		});
+		await pollingHelper.onEnable(polling, context);
 	},
 	async onDisable(context) {
-		await pollingHelper.onDisable(polling, {
-			auth: context.auth,
-			store: context.store,
-			propsValue: context.propsValue,
-		});
+		await pollingHelper.onDisable(polling, context);
 	},
 	async test(context) {
 		return await pollingHelper.test(polling, context);

--- a/packages/pieces/community/hubspot/src/lib/triggers/new-form-submission.ts
+++ b/packages/pieces/community/hubspot/src/lib/triggers/new-form-submission.ts
@@ -141,18 +141,10 @@ export const newFormSubmissionTrigger = createTrigger({
 		}),
 	},
 	async onEnable(context) {
-		await pollingHelper.onEnable(polling, {
-			auth: context.auth,
-			store: context.store,
-			propsValue: context.propsValue,
-		});
+		await pollingHelper.onEnable(polling, context);
 	},
 	async onDisable(context) {
-		await pollingHelper.onDisable(polling, {
-			auth: context.auth,
-			store: context.store,
-			propsValue: context.propsValue,
-		});
+		await pollingHelper.onDisable(polling, context);
 	},
 	async test(context) {
 		return await pollingHelper.test(polling, context);

--- a/packages/pieces/community/hubspot/src/lib/triggers/new-line-item.ts
+++ b/packages/pieces/community/hubspot/src/lib/triggers/new-line-item.ts
@@ -101,18 +101,10 @@ export const newLineItemTrigger = createTrigger({
 	},
 	type: TriggerStrategy.POLLING,
 	async onEnable(context) {
-		await pollingHelper.onEnable(polling, {
-			auth: context.auth,
-			store: context.store,
-			propsValue: context.propsValue,
-		});
+		await pollingHelper.onEnable(polling, context);
 	},
 	async onDisable(context) {
-		await pollingHelper.onDisable(polling, {
-			auth: context.auth,
-			store: context.store,
-			propsValue: context.propsValue,
-		});
+		await pollingHelper.onDisable(polling, context);
 	},
 	async test(context) {
 		return await pollingHelper.test(polling, context);

--- a/packages/pieces/community/hubspot/src/lib/triggers/new-or-updated-company.ts
+++ b/packages/pieces/community/hubspot/src/lib/triggers/new-or-updated-company.ts
@@ -97,18 +97,10 @@ export const newOrUpdatedCompanyTrigger = createTrigger({
 	},
 	type: TriggerStrategy.POLLING,
 	async onEnable(context) {
-		await pollingHelper.onEnable(polling, {
-			auth: context.auth,
-			store: context.store,
-			propsValue: context.propsValue,
-		});
+		await pollingHelper.onEnable(polling, context);
 	},
 	async onDisable(context) {
-		await pollingHelper.onDisable(polling, {
-			auth: context.auth,
-			store: context.store,
-			propsValue: context.propsValue,
-		});
+		await pollingHelper.onDisable(polling, context);
 	},
 	async test(context) {
 		return await pollingHelper.test(polling, context);

--- a/packages/pieces/community/hubspot/src/lib/triggers/new-or-updated-contact.ts
+++ b/packages/pieces/community/hubspot/src/lib/triggers/new-or-updated-contact.ts
@@ -97,18 +97,10 @@ export const newOrUpdatedContactTrigger = createTrigger({
 	},
 	type: TriggerStrategy.POLLING,
 	async onEnable(context) {
-		await pollingHelper.onEnable(polling, {
-			auth: context.auth,
-			store: context.store,
-			propsValue: context.propsValue,
-		});
+		await pollingHelper.onEnable(polling, context);
 	},
 	async onDisable(context) {
-		await pollingHelper.onDisable(polling, {
-			auth: context.auth,
-			store: context.store,
-			propsValue: context.propsValue,
-		});
+		await pollingHelper.onDisable(polling, context);
 	},
 	async test(context) {
 		return await pollingHelper.test(polling, context);

--- a/packages/pieces/community/hubspot/src/lib/triggers/new-or-updated-line-item.ts
+++ b/packages/pieces/community/hubspot/src/lib/triggers/new-or-updated-line-item.ts
@@ -97,18 +97,10 @@ export const newOrUpdatedLineItemTrigger = createTrigger({
 	},
 	type: TriggerStrategy.POLLING,
 	async onEnable(context) {
-		await pollingHelper.onEnable(polling, {
-			auth: context.auth,
-			store: context.store,
-			propsValue: context.propsValue,
-		});
+		await pollingHelper.onEnable(polling, context);
 	},
 	async onDisable(context) {
-		await pollingHelper.onDisable(polling, {
-			auth: context.auth,
-			store: context.store,
-			propsValue: context.propsValue,
-		});
+		await pollingHelper.onDisable(polling, context);
 	},
 	async test(context) {
 		return await pollingHelper.test(polling, context);

--- a/packages/pieces/community/hubspot/src/lib/triggers/new-or-updated-product.ts
+++ b/packages/pieces/community/hubspot/src/lib/triggers/new-or-updated-product.ts
@@ -97,18 +97,10 @@ export const newOrUpdatedProductTrigger = createTrigger({
 	},
 	type: TriggerStrategy.POLLING,
 	async onEnable(context) {
-		await pollingHelper.onEnable(polling, {
-			auth: context.auth,
-			store: context.store,
-			propsValue: context.propsValue,
-		});
+		await pollingHelper.onEnable(polling, context);
 	},
 	async onDisable(context) {
-		await pollingHelper.onDisable(polling, {
-			auth: context.auth,
-			store: context.store,
-			propsValue: context.propsValue,
-		});
+		await pollingHelper.onDisable(polling, context);
 	},
 	async test(context) {
 		return await pollingHelper.test(polling, context);

--- a/packages/pieces/community/hubspot/src/lib/triggers/new-product.ts
+++ b/packages/pieces/community/hubspot/src/lib/triggers/new-product.ts
@@ -101,18 +101,10 @@ export const newProductTrigger = createTrigger({
 	},
 	type: TriggerStrategy.POLLING,
 	async onEnable(context) {
-		await pollingHelper.onEnable(polling, {
-			auth: context.auth,
-			store: context.store,
-			propsValue: context.propsValue,
-		});
+		await pollingHelper.onEnable(polling, context);
 	},
 	async onDisable(context) {
-		await pollingHelper.onDisable(polling, {
-			auth: context.auth,
-			store: context.store,
-			propsValue: context.propsValue,
-		});
+		await pollingHelper.onDisable(polling, context);
 	},
 	async test(context) {
 		return await pollingHelper.test(polling, context);

--- a/packages/pieces/community/hubspot/src/lib/triggers/new-task.ts
+++ b/packages/pieces/community/hubspot/src/lib/triggers/new-task.ts
@@ -97,18 +97,10 @@ export const newTaskTrigger = createTrigger({
 	},
 	type: TriggerStrategy.POLLING,
 	async onEnable(context) {
-		await pollingHelper.onEnable(polling, {
-			auth: context.auth,
-			store: context.store,
-			propsValue: context.propsValue,
-		});
+		await pollingHelper.onEnable(polling, context);
 	},
 	async onDisable(context) {
-		await pollingHelper.onDisable(polling, {
-			auth: context.auth,
-			store: context.store,
-			propsValue: context.propsValue,
-		});
+		await pollingHelper.onDisable(polling, context);
 	},
 	async test(context) {
 		return await pollingHelper.test(polling, context);

--- a/packages/pieces/community/hubspot/src/lib/triggers/new-ticket-property-change.ts
+++ b/packages/pieces/community/hubspot/src/lib/triggers/new-ticket-property-change.ts
@@ -145,18 +145,10 @@ export const newTicketPropertyChangeTrigger = createTrigger({
 	},
 	type: TriggerStrategy.POLLING,
 	async onEnable(context) {
-		await pollingHelper.onEnable(polling, {
-			auth: context.auth,
-			store: context.store,
-			propsValue: context.propsValue,
-		});
+		await pollingHelper.onEnable(polling, context);
 	},
 	async onDisable(context) {
-		await pollingHelper.onDisable(polling, {
-			auth: context.auth,
-			store: context.store,
-			propsValue: context.propsValue,
-		});
+		await pollingHelper.onDisable(polling, context);
 	},
 	async test(context) {
 		return await pollingHelper.test(polling, context);

--- a/packages/pieces/community/hubspot/src/lib/triggers/new-ticket.ts
+++ b/packages/pieces/community/hubspot/src/lib/triggers/new-ticket.ts
@@ -97,18 +97,10 @@ export const newTicketTrigger = createTrigger({
 	},
 	type: TriggerStrategy.POLLING,
 	async onEnable(context) {
-		await pollingHelper.onEnable(polling, {
-			auth: context.auth,
-			store: context.store,
-			propsValue: context.propsValue,
-		});
+		await pollingHelper.onEnable(polling, context);
 	},
 	async onDisable(context) {
-		await pollingHelper.onDisable(polling, {
-			auth: context.auth,
-			store: context.store,
-			propsValue: context.propsValue,
-		});
+		await pollingHelper.onDisable(polling, context);
 	},
 	async test(context) {
 		return await pollingHelper.test(polling, context);

--- a/packages/pieces/community/jira-cloud/package.json
+++ b/packages/pieces/community/jira-cloud/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-jira-cloud",
-  "version": "0.3.9",
+  "version": "0.3.10",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "dependencies": {

--- a/packages/pieces/community/jira-cloud/src/lib/triggers/new-issue-type.ts
+++ b/packages/pieces/community/jira-cloud/src/lib/triggers/new-issue-type.ts
@@ -29,6 +29,9 @@ export const newIssueType = createTrigger({
     hierarchyLevel: 0,
   },
   async onEnable(context) {
+    if (context.isRepublish && !isNil(await context.store.get('issueTypeIds'))) {
+      return;
+    }
     const { projectId } = context.propsValue;
 
     const issueTypes = await getIssueTypes({

--- a/packages/pieces/community/jira-cloud/src/lib/triggers/new-priority.ts
+++ b/packages/pieces/community/jira-cloud/src/lib/triggers/new-priority.ts
@@ -23,6 +23,9 @@ export const newPriority = createTrigger({
     id: '1',
   },
   async onEnable(context) {
+    if (context.isRepublish && !isNil(await context.store.get('priorityIds'))) {
+      return;
+    }
     const priorities = await getPriorities({ auth: context.auth });
     const ids = priorities.map((p) => p.id).filter(Boolean);
     await context.store.put('priorityIds', JSON.stringify(ids));

--- a/packages/pieces/community/jira-cloud/src/lib/triggers/new-project.ts
+++ b/packages/pieces/community/jira-cloud/src/lib/triggers/new-project.ts
@@ -24,6 +24,9 @@ export const newProject = createTrigger({
     self: 'https://instance.atlassian.net/rest/api/3/project/10000',
   },
   async onEnable(context) {
+    if (context.isRepublish && !isNil(await context.store.get('projectIds'))) {
+      return;
+    }
     const projects = await getProjects(context.auth);
     const ids = projects.map((p) => p.id);
     await context.store.put('projectIds', JSON.stringify(ids));

--- a/packages/pieces/community/jira-data-center/package.json
+++ b/packages/pieces/community/jira-data-center/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-jira-data-center",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "dependencies": {


### PR DESCRIPTION
## Description

Follow-up to #14147 (preserve polling checkpoint on flow republish). That fix relies on `pollingHelper.onEnable`/`onDisable` receiving the *whole* trigger `context` so it can see `context.isRepublish` — but the param type only requires `{ store, auth, propsValue }`, so a call site that destructures just those three still type-checks while silently dropping `isRepublish`.

- **hubspot**: all 23 polling triggers called `pollingHelper.onEnable(polling, { auth: context.auth, store: context.store, propsValue: context.propsValue })`. Switched every one to `pollingHelper.onEnable(polling, context)` / `onDisable(polling, context)`. Without this, republishing a running HubSpot polling trigger reset `lastPoll`/`lastItem` and silently dropped every event created between the last poll and the republish. Bumped `piece-hubspot` 0.8.8 → 0.8.9.
- **jira-cloud**: its 6 `pollingHelper`-based triggers already passed full `context` (predates this PR) — no change needed. Its other 3 polling triggers (`new-project`, `new-priority`, `new-issue-type`) don't use `pollingHelper` at all; each keeps its own dedup snapshot directly in the store and unconditionally overwrote it on every `onEnable`, hitting the same republish-drops-events bug through a different code path. Added an inline `isRepublish` guard to each, mirroring `pollingHelper.onEnable`'s own "skip reset if republishing and a checkpoint already exists" branch. Bumped `piece-jira-cloud` 0.3.9 → 0.3.10.
- **jira-data-center**: its 3 polling triggers already pass full `context` to `pollingHelper` — no code change. Version bumped 0.0.5 → 0.0.6 so it republishes alongside this fix.

## How was this tested?

- `npx turbo run lint build --filter=@activepieces/piece-hubspot --filter=@activepieces/piece-jira-cloud --filter=@activepieces/piece-jira-data-center` — 0 errors (only pre-existing lint warnings unrelated to this change).
- Manual read-through of `pollingHelper.onEnable`'s `isRepublish` branch (`packages/pieces/common/src/lib/polling/index.ts`) to confirm the guard added to the jira-cloud hand-rolled triggers matches its semantics (skip reseeding the snapshot when republishing and a checkpoint already exists in the store).
- Not run against a live HubSpot/Jira connection — no automated integration tests exist for these triggers' `onEnable`/`onDisable` paths; this is a pass-through/guard change with no change to `run()`/`items()` behavior.

Fixes # (issue)

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)