### PR TITLE
fix(graphql): "No Error on Failure" now works for unreachable endpoints and timeouts

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -117,7 +117,7 @@
     },
     "packages/core/execution": {
       "name": "@activepieces/core-execution",
-      "version": "0.10.0",
+      "version": "0.10.1",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -213,7 +213,7 @@
     },
     "packages/pieces/common": {
       "name": "@activepieces/pieces-common",
-      "version": "0.12.7",
+      "version": "0.12.8",
       "dependencies": {
         "@activepieces/core-utils": "workspace:*",
         "@activepieces/pieces-framework": "workspace:*",
@@ -10288,7 +10288,7 @@
     },
     "packages/pieces/core/graphql": {
       "name": "@activepieces/piece-graphql",
-      "version": "0.0.17",
+      "version": "0.0.18",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -10299,6 +10299,7 @@
       },
       "devDependencies": {
         "tslib": "2.6.2",
+        "vitest": "3.2.6",
       },
     },
     "packages/pieces/core/http": {

--- a/packages/pieces/core/graphql/package.json
+++ b/packages/pieces/core/graphql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-graphql",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "dependencies": {
@@ -12,11 +12,13 @@
     "@activepieces/core-utils": "workspace:*"
   },
   "devDependencies": {
-    "tslib": "2.6.2"
+    "tslib": "2.6.2",
+    "vitest": "3.2.6"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",
     "bundle": "node ../../../../dist/packages/cli/src/index.js pieces bundle",
-    "lint": "eslint 'src/**/*.ts'"
+    "lint": "eslint 'src/**/*.ts'",
+    "test": "vitest run"
   }
 }

--- a/packages/pieces/core/graphql/src/lib/actions/query.ts
+++ b/packages/pieces/core/graphql/src/lib/actions/query.ts
@@ -1,9 +1,9 @@
 import {
   httpClient,
-  HttpError,
   HttpHeaders,
   HttpRequest,
   QueryParams,
+  toFailsafeOutput,
 } from '@activepieces/pieces-common';
 import {
   createAction,
@@ -149,7 +149,7 @@ export const query = createAction({
       return await httpClient.sendRequest(request);
     } catch (error) {
       if (failsafe) {
-        return (error as HttpError).errorMessage();
+        return toFailsafeOutput({ error, requestBody: request.body });
       }
 
       throw error;

--- a/packages/pieces/core/graphql/test/query-failsafe.test.ts
+++ b/packages/pieces/core/graphql/test/query-failsafe.test.ts
@@ -1,0 +1,61 @@
+/// <reference types="vitest/globals" />
+
+import http from 'node:http';
+import { createMockActionContext } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { query } from '../src/lib/actions/query';
+
+let server: http.Server;
+let baseUrl: string;
+
+beforeAll(async () => {
+  server = http.createServer((req, res) => {
+    req.resume();
+    req.on('end', () => {
+      res.writeHead(404, { 'content-type': 'application/json' });
+      res.end('{}');
+    });
+  });
+  await new Promise<void>((resolve) => server.listen(0, resolve));
+  baseUrl = `http://127.0.0.1:${(server.address() as { port: number }).port}/`;
+});
+
+afterAll(() => server.close());
+
+const runQuery = (propsValue: Record<string, unknown>) =>
+  query.run(createMockActionContext({ propsValue }));
+
+const baseProps = {
+  method: HttpMethod.POST,
+  headers: {},
+  queryParams: {},
+  query: '{ ok }',
+};
+
+describe('failsafe surfaces the real error, never TypeError', () => {
+  const unreachable = 'http://127.0.0.1:1/';
+
+  test('failsafe reports a transport error', async () => {
+    const result = await runQuery({
+      ...baseProps,
+      url: unreachable,
+      failsafe: true,
+    });
+    expect(result).toMatchObject({
+      response: { status: 0 },
+      request: { body: '{"query":"{ ok }"}' },
+    });
+  });
+
+  test('failsafe still reports HTTP errors', async () => {
+    const result = await runQuery({ ...baseProps, url: baseUrl, failsafe: true });
+    expect(result).toMatchObject({
+      response: { status: 404 },
+      request: { body: '{"query":"{ ok }"}' },
+    });
+  });
+
+  test('failsafe off still throws', async () => {
+    await expect(runQuery({ ...baseProps, url: unreachable })).rejects.toThrow();
+  });
+});

--- a/packages/pieces/core/graphql/vitest.config.ts
+++ b/packages/pieces/core/graphql/vitest.config.ts
@@ -1,0 +1,18 @@
+import path from 'path'
+import { defineConfig } from 'vitest/config'
+
+const repoRoot = path.resolve(__dirname, '../../../..')
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+  },
+  resolve: {
+    alias: {
+      '@activepieces/shared': path.resolve(repoRoot, 'packages/core/shared/src/index.ts'),
+      '@activepieces/pieces-framework': path.resolve(repoRoot, 'packages/pieces/framework/src/index.ts'),
+      '@activepieces/pieces-common': path.resolve(repoRoot, 'packages/pieces/common/src/index.ts'),
+    },
+  },
+})


### PR DESCRIPTION
Fixes [GIT-1715](https://linear.app/activepieces/issue/GIT-1715)
Closes #14642

## Problem

1. GraphQL **Send Request** with **No Error on Failure** enabled crashes with `TypeError: … .errorMessage is not a function` when the request fails before an HTTP response exists (connection refused, DNS, TLS, timeout abort), instead of returning the error payload.
2. With **Use Proxy** enabled the crash is guaranteed for any failure: that branch throws `AxiosError`, never `HttpError`.

## Fix

- `packages/pieces/core/graphql/src/lib/actions/query.ts` — failsafe catch routes through `toFailsafeOutput` (shared helper from #14557); this was the last failsafe call site still hand-rolling the `HttpError` cast, and the output shape now matches Custom API Call / HTTP piece / http-oauth2.
- graphql piece `0.0.17 → 0.0.18`; vitest wiring copied from the sibling http piece.
- `bun.lock` — two stale entry syncs (`core-execution`, `pieces-common`) produced by `bun install` on clean main.

## How was this tested?

- Regression test proven red-first: pre-fix, the transport test fails with the exact reported TypeError at `query.ts:152`; post-fix 3/3 pass (`packages/pieces/core/graphql && npx vitest run`).
- Failsafe off still throws; HTTP-status failsafe output unchanged (both test-pinned).
- http piece suite: 27/27 pass in `get-with-body.test.ts`; the 3 failures in `test/http.test.ts` are pre-existing on main (real DNS to `api.example.com`, ENOTFOUND) and unrelated.
- `npm run lint-dev`: 0 errors.
- Visual: none - piece runtime error output only, no UI change.
- Other affected paths: checked - telegram-bot actions (7 files) call `.errorMessage().response.body` unconditionally — same TypeError class but not failsafe-gated; left out deliberately (see reasoning). amazon-bedrock's failsafe is already null-safe (divergent shape, no crash). Both noted on [GIT-1715](https://linear.app/activepieces/issue/GIT-1715).

<details>
<summary>Plan & reasoning</summary>

## Plan

- The ticket's original target (shared `createCustomApiCallAction` factory) was already fixed by #14557; a sweep of all failsafe call sites found graphql as the last one with the blind cast.
- Reuse `toFailsafeOutput` rather than a local guard — one failsafe output contract across all 4 sites.
- Footprint estimate 5 files / ~8 product lines; actual 2 product lines + version bump + test infra.

## Non-happy scenarios considered

- Connection refused / DNS / TLS → status-0 envelope (test-pinned).
- Timeout abort (`AbortError`) → same fallback branch, message preserved.
- Proxy branch (`AxiosError`) → same fallback branch; not separately tested (needs a live proxy; the helper treats it identically to any non-`HttpError`).
- Failsafe disabled → original error rethrown (test-pinned).

## Alternatives rejected

- Normalizing transport errors to `HttpError{status: 0}` inside `fetch-http-client.ts` — would fix telegram-bot for free but changes behavior of ~29 `instanceof HttpError` sites across independently-versioned piece bundles; its own PR.
- Patching telegram-bot's 7 unconditional `errorMessage()` calls here — no failsafe prop there, always-swallow semantics; needs its own product decision.
</details>

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)
