### PR TITLE
chore(release): sync version to 0.87.0 after off-cycle release

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   app:
-    image: ghcr.io/activepieces/activepieces:0.86.3
+    image: ghcr.io/activepieces/activepieces:0.87.0
     container_name: activepieces-app
     restart: unless-stopped
     ports:
@@ -16,7 +16,7 @@ services:
     networks:
       - activepieces
   worker:
-    image: ghcr.io/activepieces/activepieces:0.86.3
+    image: ghcr.io/activepieces/activepieces:0.87.0
     restart: unless-stopped
     depends_on:
       - app

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activepieces",
-  "version": "0.86.3",
+  "version": "0.87.0",
   "packageManager": "bun@1.3.3",
   "trustedDependencies": [
     "sqlite3",
@@ -85,8 +85,8 @@
     "eslint-plugin-react": "7.32.2",
     "eslint-plugin-react-hooks": "4.6.0",
     "eslint-plugin-tailwindcss": "3.17.4",
-    "eslint-plugin-unused-imports": "4.4.1",
     "eslint-plugin-testing-library": "6.2.2",
+    "eslint-plugin-unused-imports": "4.4.1",
     "eslint-plugin-vitest": "0.5.4",
     "http-status-codes": "2.2.0",
     "husky": "8.0.3",


### PR DESCRIPTION
The self-hosted release `0.87.0` was published from a branch whose version bump is not on `main`. This PR syncs `package.json` and the `docker-compose.yml` image pin so the next weekly release does not read a stale version. Merge before the next release-candidate cut (Thursday 5 PM UTC). See GIT-1595.