### PR TITLE
fix(connections): OAuth2 tokens now refresh on time for providers that report expiry in a non-standard format

### DIFF
--- a/packages/server/api/src/app/app-connection/app-connection-service/app-connection.handler.ts
+++ b/packages/server/api/src/app/app-connection/app-connection-service/app-connection.handler.ts
@@ -319,10 +319,10 @@ export function isCustomAuthTokenStale(value: { access_token?: string, token_ref
 // before expiry, but never earlier than half the token's lifetime — otherwise a
 // token whose TTL is shorter than the buffer would be considered stale the instant
 // it is minted, refreshing on every fetch and defeating the cache. `expiresIn` is
-// coerced with Number() because third-party responses may carry it as a string; any
+// typed as unknown because it comes from a third-party token response; any
 // non-positive or non-finite result means the token never expires, so it never
 // needs refreshing.
-export function computeTokenRefreshAt(expiresIn: number): number | undefined {
+export function computeTokenRefreshAt(expiresIn: unknown): number | undefined {
     const expiresInSeconds = Number(expiresIn)
     if (!Number.isFinite(expiresInSeconds) || expiresInSeconds <= 0) {
         return undefined

--- a/packages/server/api/src/app/app-connection/app-connection-service/app-connection.handler.ts
+++ b/packages/server/api/src/app/app-connection/app-connection-service/app-connection.handler.ts
@@ -318,14 +318,17 @@ export function isCustomAuthTokenStale(value: { access_token?: string, token_ref
 // Returns the unix timestamp at which the token should be refreshed: 15 minutes
 // before expiry, but never earlier than half the token's lifetime — otherwise a
 // token whose TTL is shorter than the buffer would be considered stale the instant
-// it is minted, refreshing on every fetch and defeating the cache. `expiresIn <= 0`
-// means the token never expires, so it never needs refreshing.
+// it is minted, refreshing on every fetch and defeating the cache. `expiresIn` is
+// coerced with Number() because third-party responses may carry it as a string; any
+// non-positive or non-finite result means the token never expires, so it never
+// needs refreshing.
 export function computeTokenRefreshAt(expiresIn: number): number | undefined {
-    if (expiresIn <= 0) {
+    const expiresInSeconds = Number(expiresIn)
+    if (!Number.isFinite(expiresInSeconds) || expiresInSeconds <= 0) {
         return undefined
     }
-    const buffer = Math.min(TOKEN_REFRESH_BUFFER_SECONDS, Math.floor(expiresIn / 2))
-    return dayjs().unix() + expiresIn - buffer
+    const buffer = Math.min(TOKEN_REFRESH_BUFFER_SECONDS, Math.floor(expiresInSeconds / 2))
+    return dayjs().unix() + expiresInSeconds - buffer
 }
 
 function pieceRefreshSupportCacheKey(connection: Pick<AppConnection, 'platformId' | 'pieceName' | 'pieceVersion'>): string {

--- a/packages/server/api/src/app/app-connection/app-connection-service/oauth2/oauth2-util.ts
+++ b/packages/server/api/src/app/app-connection/app-connection-service/oauth2/oauth2-util.ts
@@ -39,9 +39,11 @@ export const oauth2Util = (log: FastifyBaseLogger) => ({
         }
         const parsedExpiresIn = Number(connection.expires_in)
         const expiresIn = Number.isFinite(parsedExpiresIn) && parsedExpiresIn > 0 ? parsedExpiresIn : 60 * 60
+        const parsedClaimedAt = Number(connection.claimed_at)
+        const claimedAt = Number.isFinite(parsedClaimedAt) && parsedClaimedAt > 0 ? parsedClaimedAt : 0
         const refreshThreshold = 15 * 60
         return (
-            secondsSinceEpoch + refreshThreshold >= connection.claimed_at + expiresIn
+            secondsSinceEpoch + refreshThreshold >= claimedAt + expiresIn
         )
     },
     isUserError: (e: unknown): boolean => {

--- a/packages/server/api/src/app/app-connection/app-connection-service/oauth2/oauth2-util.ts
+++ b/packages/server/api/src/app/app-connection/app-connection-service/oauth2/oauth2-util.ts
@@ -11,8 +11,10 @@ import { pieceMetadataService } from '../../../pieces/metadata/piece-metadata-se
 export const oauth2Util = (log: FastifyBaseLogger) => ({
     formatOAuth2Response: (response: Omit<BaseOAuth2ConnectionValue, 'claimed_at'>): BaseOAuth2ConnectionValue => {
         const secondsSinceEpoch = Math.round(Date.now() / 1000)
+        const expiresIn = Number(response.expires_in)
         const formattedResponse: BaseOAuth2ConnectionValue = {
             ...response,
+            expires_in: Number.isFinite(expiresIn) && expiresIn > 0 ? expiresIn : undefined,
             data: response,
             claimed_at: secondsSinceEpoch,
         }
@@ -35,7 +37,8 @@ export const oauth2Util = (log: FastifyBaseLogger) => ({
         ) {
             return false
         }
-        const expiresIn = connection.expires_in ?? 60 * 60
+        const parsedExpiresIn = Number(connection.expires_in)
+        const expiresIn = Number.isFinite(parsedExpiresIn) && parsedExpiresIn > 0 ? parsedExpiresIn : 60 * 60
         const refreshThreshold = 15 * 60
         return (
             secondsSinceEpoch + refreshThreshold >= connection.claimed_at + expiresIn

--- a/packages/server/api/src/app/ee/agent/tools/agent-tools.ts
+++ b/packages/server/api/src/app/ee/agent/tools/agent-tools.ts
@@ -612,8 +612,8 @@ function resolveConnectionInfo({ status, type, value }: { status: AppConnectionS
     if (hasRefreshToken) {
         return { status, grantedScopes }
     }
-    const claimedAtS = typeof value['claimed_at'] === 'number' ? value['claimed_at'] : 0
-    const expiresInS = typeof value['expires_in'] === 'number' ? value['expires_in'] : 0
+    const claimedAtS = Number(value['claimed_at']) || 0
+    const expiresInS = Number(value['expires_in']) || 0
     if (claimedAtS > 0 && expiresInS > 0) {
         const expiryMs = (claimedAtS + expiresInS - CLOCK_SKEW_BUFFER_S) * 1000
         if (Date.now() > expiryMs) {

--- a/packages/server/api/src/app/ee/agent/tools/agent-tools.ts
+++ b/packages/server/api/src/app/ee/agent/tools/agent-tools.ts
@@ -612,8 +612,10 @@ function resolveConnectionInfo({ status, type, value }: { status: AppConnectionS
     if (hasRefreshToken) {
         return { status, grantedScopes }
     }
-    const claimedAtS = Number(value['claimed_at']) || 0
-    const expiresInS = Number(value['expires_in']) || 0
+    const parsedClaimedAt = Number(value['claimed_at'])
+    const parsedExpiresIn = Number(value['expires_in'])
+    const claimedAtS = Number.isFinite(parsedClaimedAt) && parsedClaimedAt > 0 ? parsedClaimedAt : 0
+    const expiresInS = Number.isFinite(parsedExpiresIn) && parsedExpiresIn > 0 ? parsedExpiresIn : 0
     if (claimedAtS > 0 && expiresInS > 0) {
         const expiryMs = (claimedAtS + expiresInS - CLOCK_SKEW_BUFFER_S) * 1000
         if (Date.now() > expiryMs) {

--- a/packages/server/api/test/unit/app/app-connection/custom-auth-staleness.test.ts
+++ b/packages/server/api/test/unit/app/app-connection/custom-auth-staleness.test.ts
@@ -55,12 +55,12 @@ describe('computeTokenRefreshAt', () => {
     })
 
     it('coerces a string expires_in from a third-party token response', () => {
-        expect(computeTokenRefreshAt('3300' as never)).toBe(NOW + 3300 - BUFFER_SECONDS)
+        expect(computeTokenRefreshAt('3300')).toBe(NOW + 3300 - BUFFER_SECONDS)
     })
 
     it('returns undefined (never refresh) for a non-numeric or infinite expires_in', () => {
-        expect(computeTokenRefreshAt('not-a-number' as never)).toBeUndefined()
-        expect(computeTokenRefreshAt('1e999' as never)).toBeUndefined()
+        expect(computeTokenRefreshAt('not-a-number')).toBeUndefined()
+        expect(computeTokenRefreshAt('1e999')).toBeUndefined()
     })
 
     it('clamps the buffer to half the lifetime for short-lived tokens', () => {

--- a/packages/server/api/test/unit/app/app-connection/custom-auth-staleness.test.ts
+++ b/packages/server/api/test/unit/app/app-connection/custom-auth-staleness.test.ts
@@ -1,5 +1,5 @@
 import dayjs from 'dayjs'
-import { describe, expect, it } from 'vitest'
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
 import { computeTokenRefreshAt, isCustomAuthTokenStale } from '../../../../src/app/app-connection/app-connection-service/app-connection.handler'
 
 const BUFFER_SECONDS = 15 * 60
@@ -34,6 +34,15 @@ describe('isCustomAuthTokenStale', () => {
 })
 
 describe('computeTokenRefreshAt', () => {
+    beforeAll(() => {
+        vi.useFakeTimers()
+        vi.setSystemTime(NOW * 1000)
+    })
+
+    afterAll(() => {
+        vi.useRealTimers()
+    })
+
     it('returns undefined (never refresh) when expiresIn is zero or negative', () => {
         expect(computeTokenRefreshAt(0)).toBeUndefined()
         expect(computeTokenRefreshAt(-1)).toBeUndefined()
@@ -43,6 +52,15 @@ describe('computeTokenRefreshAt', () => {
         const expiresIn = 3300
         const refreshAt = computeTokenRefreshAt(expiresIn)
         expect(refreshAt).toBe(NOW + expiresIn - BUFFER_SECONDS)
+    })
+
+    it('coerces a string expires_in from a third-party token response', () => {
+        expect(computeTokenRefreshAt('3300' as never)).toBe(NOW + 3300 - BUFFER_SECONDS)
+    })
+
+    it('returns undefined (never refresh) for a non-numeric or infinite expires_in', () => {
+        expect(computeTokenRefreshAt('not-a-number' as never)).toBeUndefined()
+        expect(computeTokenRefreshAt('1e999' as never)).toBeUndefined()
     })
 
     it('clamps the buffer to half the lifetime for short-lived tokens', () => {

--- a/packages/server/api/test/unit/app/app-connection/oauth2-util.test.ts
+++ b/packages/server/api/test/unit/app/app-connection/oauth2-util.test.ts
@@ -1,11 +1,11 @@
 import { OAuth2GrantType } from '@activepieces/shared'
-import { describe, expect, it } from 'vitest'
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
 import { oauth2Util } from '../../../../src/app/app-connection/app-connection-service/oauth2/oauth2-util'
 
 const util = oauth2Util({} as never)
 const nowSeconds = Math.round(Date.now() / 1000)
 
-function connectionWith({ claimedAt, expiresIn }: { claimedAt: number, expiresIn?: number | string }): never {
+function connectionWith({ claimedAt, expiresIn }: { claimedAt: number | string, expiresIn?: number | string }): never {
     return {
         access_token: 'token',
         refresh_token: 'refresh',
@@ -16,6 +16,15 @@ function connectionWith({ claimedAt, expiresIn }: { claimedAt: number, expiresIn
 }
 
 describe('oauth2Util.isExpired', () => {
+    beforeAll(() => {
+        vi.useFakeTimers()
+        vi.setSystemTime(nowSeconds * 1000)
+    })
+
+    afterAll(() => {
+        vi.useRealTimers()
+    })
+
     it('numeric expires_in 3600, claimed 2h ago → expired', () => {
         expect(util.isExpired(connectionWith({ claimedAt: nowSeconds - 2 * 60 * 60, expiresIn: 3600 }))).toBe(true)
     })
@@ -46,6 +55,18 @@ describe('oauth2Util.isExpired', () => {
 
     it('infinite expires_in falls back to 1h: claimed 2h ago → expired', () => {
         expect(util.isExpired(connectionWith({ claimedAt: nowSeconds - 2 * 60 * 60, expiresIn: '1e999' }))).toBe(true)
+    })
+
+    it('string claimed_at is coerced (would concatenate with expires_in otherwise) → expired', () => {
+        expect(util.isExpired(connectionWith({ claimedAt: String(nowSeconds - 2 * 60 * 60), expiresIn: 3600 }))).toBe(true)
+    })
+
+    it('non-numeric claimed_at is treated as epoch → expired', () => {
+        expect(util.isExpired(connectionWith({ claimedAt: 'not-a-number', expiresIn: 3600 }))).toBe(true)
+    })
+
+    it('infinite claimed_at is treated as epoch → expired', () => {
+        expect(util.isExpired(connectionWith({ claimedAt: '1e999', expiresIn: 3600 }))).toBe(true)
     })
 })
 

--- a/packages/server/api/test/unit/app/app-connection/oauth2-util.test.ts
+++ b/packages/server/api/test/unit/app/app-connection/oauth2-util.test.ts
@@ -1,0 +1,73 @@
+import { OAuth2GrantType } from '@activepieces/shared'
+import { describe, expect, it } from 'vitest'
+import { oauth2Util } from '../../../../src/app/app-connection/app-connection-service/oauth2/oauth2-util'
+
+const util = oauth2Util({} as never)
+const nowSeconds = Math.round(Date.now() / 1000)
+
+function connectionWith({ claimedAt, expiresIn }: { claimedAt: number, expiresIn?: number | string }): never {
+    return {
+        access_token: 'token',
+        refresh_token: 'refresh',
+        claimed_at: claimedAt,
+        expires_in: expiresIn,
+        grant_type: OAuth2GrantType.AUTHORIZATION_CODE,
+    } as never
+}
+
+describe('oauth2Util.isExpired', () => {
+    it('numeric expires_in 3600, claimed 2h ago → expired', () => {
+        expect(util.isExpired(connectionWith({ claimedAt: nowSeconds - 2 * 60 * 60, expiresIn: 3600 }))).toBe(true)
+    })
+
+    it('string expires_in "3600", claimed 2h ago → expired', () => {
+        expect(util.isExpired(connectionWith({ claimedAt: nowSeconds - 2 * 60 * 60, expiresIn: '3600' }))).toBe(true)
+    })
+
+    it('string expires_in "3600", freshly claimed → not expired', () => {
+        expect(util.isExpired(connectionWith({ claimedAt: nowSeconds, expiresIn: '3600' }))).toBe(false)
+    })
+
+    it('missing expires_in falls back to 1h: claimed 2h ago → expired', () => {
+        expect(util.isExpired(connectionWith({ claimedAt: nowSeconds - 2 * 60 * 60 }))).toBe(true)
+    })
+
+    it('non-numeric expires_in falls back to 1h: claimed 2h ago → expired', () => {
+        expect(util.isExpired(connectionWith({ claimedAt: nowSeconds - 2 * 60 * 60, expiresIn: 'not-a-number' }))).toBe(true)
+    })
+
+    it('zero expires_in falls back to 1h: freshly claimed → not expired', () => {
+        expect(util.isExpired(connectionWith({ claimedAt: nowSeconds, expiresIn: 0 }))).toBe(false)
+    })
+
+    it('negative expires_in falls back to 1h: freshly claimed → not expired', () => {
+        expect(util.isExpired(connectionWith({ claimedAt: nowSeconds, expiresIn: '-5' }))).toBe(false)
+    })
+
+    it('infinite expires_in falls back to 1h: claimed 2h ago → expired', () => {
+        expect(util.isExpired(connectionWith({ claimedAt: nowSeconds - 2 * 60 * 60, expiresIn: '1e999' }))).toBe(true)
+    })
+})
+
+describe('oauth2Util.formatOAuth2Response', () => {
+    it('normalizes a string expires_in from the token endpoint to a number', () => {
+        const formatted = util.formatOAuth2Response({ access_token: 'token', expires_in: '3600' } as never)
+        expect(formatted.expires_in).toBe(3600)
+    })
+
+    it('keeps a numeric expires_in as-is', () => {
+        const formatted = util.formatOAuth2Response({ access_token: 'token', expires_in: 3600 } as never)
+        expect(formatted.expires_in).toBe(3600)
+    })
+
+    it('drops a non-numeric expires_in so consumers fall back to the default lifetime', () => {
+        const formatted = util.formatOAuth2Response({ access_token: 'token', expires_in: 'not-a-number' } as never)
+        expect(formatted.expires_in).toBeUndefined()
+    })
+
+    it('drops zero, negative, and infinite expires_in', () => {
+        expect(util.formatOAuth2Response({ access_token: 'token', expires_in: 0 } as never).expires_in).toBeUndefined()
+        expect(util.formatOAuth2Response({ access_token: 'token', expires_in: '-5' } as never).expires_in).toBeUndefined()
+        expect(util.formatOAuth2Response({ access_token: 'token', expires_in: '1e999' } as never).expires_in).toBeUndefined()
+    })
+})


### PR DESCRIPTION
Fixes activepieces/activepieces#14643  <br>Closes activepieces/activepieces#14643

## Problem

1. OAuth2 token endpoints that return `expires_in` as a string (`"3600"`) break the expiry check: `claimed_at + expiresIn` string-concatenates into a far-future timestamp, `isExpired` never returns true, the token is never refreshed, and flows fail with 401s while the connection stays ACTIVE. Ref: [Pylon 5574](<https://app.usepylon.com/issues?issueNumber=5574>).
2. The same un-coerced arithmetic exists in the custom-auth refresh scheduler (`computeTokenRefreshAt`) and the agent connection resolver (`resolveConnectionInfo`), where a string value silently disables expiry handling.

## Fix

* `oauth2-util.ts`: `isExpired` coerces `expires_in` (finite positive, else the 1h fallback), which also heals connections already stored with string values; `formatOAuth2Response` normalizes `expires_in` at ingestion so stored values match the declared `number` type.
* `app-connection.handler.ts`: `computeTokenRefreshAt` applies the same coercion; non-finite or non-positive keeps the documented never-refresh contract.
* `agent-tools.ts`: `resolveConnectionInfo` coerces `claimed_at`/`expires_in` so string values no longer skip the expired-connection check.

Behavior note: `expires_in: 0` or negative previously meant refresh-on-every-fetch in `isExpired`; it now falls back to the 1h default and is dropped at ingestion, aligned with `computeTokenRefreshAt`'s non-expiring contract for `0`.

## Verification

* Regression tests red-first: 7 of 12 `oauth2-util.test.ts` cases fail on `main` (including the reported scenario: string `expires_in` claimed 2h ago is reported not expired) and pass with the fix.
* `test/unit/app/app-connection` + `test/unit/app/ee/agent`: 123/123 passing, stable across 3 consecutive runs. A pre-existing wall-clock flake in `custom-auth-staleness.test.ts` (observed firing during this work) is pinned with fake timers.
* `tsc` build and `npm run lint-dev` clean. Unrelated unit-suite failures on `main` (canary worker-group, BullMQ job-broker) verified identical with the fix stashed.
* UNVERIFIED: end-to-end claim/refresh against a live IdP that returns string `expires_in` (needs an external provider); the changed logic is fully pinned at the two pure functions all refresh paths route through.
* Visual: none - backend-only, no user-visible change.
* Other affected paths: checked - cloud/platform OAuth2 claim paths bypass `formatOAuth2Response` (pre-existing) and are covered by the read-side coercion in `isExpired`; engine `piece-helper.ts` passes piece-returned `expires_in` through un-coerced (pre-existing, now guarded at the server-side choke point); custom-auth rows poisoned before this fix keep their stored far-future `token_refresh_at` (no known real occurrences, in-repo refresh pieces return numbers).
* Size: product diff grew from the planned 2 lines to \~12 across 3 files. Code-review findings added ingestion normalization (`formatOAuth2Response`), `Number.isFinite` guards (legacy negative/Infinity values), and the third un-coerced site in `agent-tools.ts`.

<details><summary>Plan & reasoning</summary>

## Plan

* Root cause pinned at `oauth2-util.ts:41` (number + string concatenation); fix at the consumption choke point so rows already stored with strings heal without a migration.
* Ingestion normalization added in `formatOAuth2Response` so the stored value matches the declared type for every future reader.
* Sibling sweep found the same defect pattern in `computeTokenRefreshAt` and `resolveConnectionInfo`; one coercion each.
* Footprint: planned 2 files / < />2 lines, landed 3 files / < />12 lines product code (growth sources in the Size line).

## Non-happy scenarios considered

* `expires_in` garbage (`"not-a-number"`, `""`): 1h fallback in `isExpired`, dropped at ingestion, never-refresh in custom auth (the pre-fix runtime outcome, now explicit).
* Negative or `"1e999"`/Infinity values in legacy rows: the finite-positive guard falls back instead of refresh-storming or never refreshing.
* Refresh response omitting or garbling `expires_in`: `mergeNonNull` keeps the previous stored value, matching prior absent-key behavior.
* Concurrent refresh across pods: unchanged; both paths re-check `needRefresh` under the Redis distributed lock.

## Alternatives rejected

* Claim-time normalization only: misses connections already stored with string values.
* Per-provider validation at each OAuth2 service: three call sites, and the cloud claim path bypasses them.
* Data migration to rewrite stored string values: connection values are encrypted at rest; read-side coercion achieves the same without touching ciphertext.

</details>

### Breaking change?  (required — CI fails if this is left unedited)

- [X] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

- [X] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)