### PR TITLE
fix(billing): let legacy-free and AppSumo platforms be deleted

### DIFF
--- a/packages/web/src/app/routes/platform/setup/general/danger-zone-section.tsx
+++ b/packages/web/src/app/routes/platform/setup/general/danger-zone-section.tsx
@@ -1,9 +1,9 @@
+import { hasActiveSubscription } from '@activepieces/shared';
 import { t } from 'i18next';
 import { Trash2 } from 'lucide-react';
 import { useState } from 'react';
 
 import { Button } from '@/components/ui/button';
-import { billingUtils } from '@/features/billing';
 import { platformHooks } from '@/hooks/platform-hooks';
 
 import { DeletePlatformDialog } from './delete-platform-dialog';
@@ -11,7 +11,7 @@ import { DeletePlatformDialog } from './delete-platform-dialog';
 export const DangerZoneSection = ({ platformName }: DangerZoneSectionProps) => {
   const { platform } = platformHooks.useCurrentPlatform();
   const [isDeleteOpen, setIsDeleteOpen] = useState(false);
-  const hasSubscription = billingUtils.isPaidPlan(platform.plan.plan);
+  const hasSubscription = hasActiveSubscription(platform.plan.plan);
 
   return (
     <div className="flex flex-col gap-3">


### PR DESCRIPTION
## Description

A platform on the `free_legacy` or `appsumo` plan could not delete itself: the **Delete platform** button was permanently disabled with the message *"Cancel your subscription before deleting this platform"* — but there is no subscription to cancel on either plan.

The UI and the API disagreed on what counts as a subscription:

| | predicate | blocks |
|---|---|---|
| Web (`danger-zone-section.tsx`) | `billingUtils.isPaidPlan` | everything except `free` |
| API (`platform.controller.ts`) | `hasActiveSubscription` | everything except `free`, `appsumo`, `free_legacy` |

So the API would have accepted the delete, while the UI refused to send it. This surfaced on a customer account sitting on a legacy free plan.

Fix: gate the danger zone on `hasActiveSubscription` from `@activepieces/shared` — the exact predicate the endpoint enforces — so the button state can no longer drift from what the API allows.

`isPaidPlan` is left alone; it still means "not on the free tier" for the billing cards, which is a different question from "has a subscription to cancel".

## How was this tested?

Delete-platform is Cloud-only (`edition === ApEdition.CLOUD`), so the CE/EE paths are unaffected — the danger zone is the only surface that changed.

- `npx turbo run lint --filter=web` — 0 errors
- `npx turbo run typecheck --filter=web` — clean
- Traced the predicates by hand: `free` → blocked in both before and after; `plus`/`team`/`enterprise` → still blocked in both; `free_legacy`/`appsumo` → was blocked in the UI only, now allowed in both, matching the endpoint.

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)
