### PR TITLE
fix(pieces): disabled piece no longer appears in the AI & Agents builder tab

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -4301,7 +4301,7 @@
     },
     "packages/pieces/community/hubspot": {
       "name": "@activepieces/piece-hubspot",
-      "version": "0.8.8",
+      "version": "0.8.9",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -4605,7 +4605,7 @@
     },
     "packages/pieces/community/jira-cloud": {
       "name": "@activepieces/piece-jira-cloud",
-      "version": "0.3.9",
+      "version": "0.3.10",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -4624,7 +4624,7 @@
     },
     "packages/pieces/community/jira-data-center": {
       "name": "@activepieces/piece-jira-data-center",
-      "version": "0.0.5",
+      "version": "0.0.6",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -8125,7 +8125,7 @@
     },
     "packages/pieces/community/sign-now": {
       "name": "@activepieces/piece-sign-now",
-      "version": "0.0.5",
+      "version": "0.0.6",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",

--- a/packages/server/api/src/app/pieces/metadata/piece-metadata-controller.ts
+++ b/packages/server/api/src/app/pieces/metadata/piece-metadata-controller.ts
@@ -78,7 +78,7 @@ const basePiecesController: FastifyPluginAsyncZod = async (app) => {
                 locale: req.query.locale as LocalesEnum | undefined,
             })
             const policy = await resolveVisibility({ platformId, projectId: req.query.projectId, log: req.log })
-            const visiblePiece = isNil(policy) ? piece : policy.filterPieceComponents(piece)
+            const visiblePiece = applyVisibilityPolicy({ policy, piece })
             return filterModelActionsByAudience(visiblePiece, req.query.audience)
         },
     )
@@ -98,7 +98,7 @@ const basePiecesController: FastifyPluginAsyncZod = async (app) => {
                 locale: req.query.locale as LocalesEnum | undefined,
             })
             const policy = await resolveVisibility({ platformId, projectId: req.query.projectId, log: req.log })
-            const visiblePiece = isNil(policy) ? piece : policy.filterPieceComponents(piece)
+            const visiblePiece = applyVisibilityPolicy({ policy, piece })
             return filterModelActionsByAudience(visiblePiece, req.query.audience)
         },
     )
@@ -160,6 +160,19 @@ function filterModelActionsByAudience(piece: PieceMetadataModel, audience: Piece
         ...piece,
         actions: filterActionsByAudience(piece.actions, audience),
     }
+}
+
+function applyVisibilityPolicy({ policy, piece }: { policy: Awaited<ReturnType<typeof resolveVisibility>>, piece: PieceMetadataModel }): PieceMetadataModel {
+    if (isNil(policy)) {
+        return piece
+    }
+    if (!policy.isPieceVisible(piece.name)) {
+        throw new ActivepiecesError({
+            code: ErrorCode.ENTITY_NOT_FOUND,
+            params: { message: `piece_metadata_not_found pieceName=${piece.name}` },
+        })
+    }
+    return policy.filterPieceComponents(piece)
 }
 
 const RegistryPiecesRequest = {

--- a/packages/server/api/test/integration/ee/pieces/piece-component-filtering.test.ts
+++ b/packages/server/api/test/integration/ee/pieces/piece-component-filtering.test.ts
@@ -183,6 +183,104 @@ describe('Piece Component Filtering (EE)', () => {
         })
     })
 
+    describe('GET /v1/pieces/:name (direct fetch respects piece sets)', () => {
+        const emptyConfig = { pieces: { mode: PieceSelectionMode.INCLUDE_ALL, exceptions: [] }, selectedActions: {}, selectedTriggers: {} }
+
+        async function setupPieceSetScenario(hiddenPieces: string[]) {
+            const { mockPlatform, mockProject, mockOwner } = await mockAndSaveBasicSetup({
+                plan: { managePiecesEnabled: true },
+            })
+
+            const pieceSet = {
+                id: apId(),
+                created: new Date().toISOString(),
+                updated: new Date().toISOString(),
+                platformId: mockPlatform.id,
+                name: 'Test Set',
+                externalId: null,
+                isDefault: false,
+                generatedForProjectId: null,
+                config: { pieces: { mode: PieceSelectionMode.INCLUDE_ALL, exceptions: hiddenPieces }, selectedActions: {}, selectedTriggers: {} },
+            }
+            await databaseConnection().getRepository('piece_set').save(pieceSet)
+            await databaseConnection().getRepository('project').update({ id: mockProject.id }, { pieceSetId: pieceSet.id })
+
+            const token = await generateMockToken({
+                type: PrincipalType.USER,
+                id: mockOwner.id,
+                platform: { id: mockPlatform.id },
+            })
+
+            return { mockPlatform, mockProject, token }
+        }
+
+        it('direct fetch returns 404 for a hidden piece when projectId is passed', async () => {
+            const { mockProject, token } = await setupPieceSetScenario(['@activepieces/piece-ai'])
+
+            const piece = createMockPieceMetadata({ name: '@activepieces/piece-ai', pieceType: PieceType.OFFICIAL, packageType: PackageType.REGISTRY, actions: {}, triggers: {} })
+            await db.save('piece_metadata', piece)
+            await pieceCache(mockLog).setup()
+
+            const response = await app!.inject({
+                method: 'GET',
+                url: `/api/v1/pieces/${encodeURIComponent('@activepieces/piece-ai')}?projectId=${mockProject.id}`,
+                headers: { authorization: `Bearer ${token}` },
+            })
+
+            expect(response.statusCode).toBe(404)
+        })
+
+        it('direct fetch returns 200 for a visible piece when projectId is passed', async () => {
+            const { mockProject, token } = await setupPieceSetScenario([])
+
+            const piece = createMockPieceMetadata({ name: '@activepieces/piece-ai', pieceType: PieceType.OFFICIAL, packageType: PackageType.REGISTRY, actions: {}, triggers: {} })
+            await db.save('piece_metadata', piece)
+            await pieceCache(mockLog).setup()
+
+            const response = await app!.inject({
+                method: 'GET',
+                url: `/api/v1/pieces/${encodeURIComponent('@activepieces/piece-ai')}?projectId=${mockProject.id}`,
+                headers: { authorization: `Bearer ${token}` },
+            })
+
+            expect(response.statusCode).toBe(200)
+            expect(response.json().name).toBe('@activepieces/piece-ai')
+        })
+
+        it('direct fetch without projectId returns 200 even for a hidden piece (existing-step lookup path)', async () => {
+            const { mockPlatform, mockProject, mockOwner } = await mockAndSaveBasicSetup({
+                plan: { managePiecesEnabled: true },
+            })
+
+            const pieceSet = {
+                id: apId(),
+                created: new Date().toISOString(),
+                updated: new Date().toISOString(),
+                platformId: mockPlatform.id,
+                name: 'Test Set',
+                externalId: null,
+                isDefault: false,
+                generatedForProjectId: null,
+                config: { pieces: { mode: PieceSelectionMode.INCLUDE_ALL, exceptions: ['@activepieces/piece-ai'] }, selectedActions: {}, selectedTriggers: {} },
+            }
+            await databaseConnection().getRepository('piece_set').save(pieceSet)
+            await databaseConnection().getRepository('project').update({ id: mockProject.id }, { pieceSetId: pieceSet.id })
+
+            const piece = createMockPieceMetadata({ name: '@activepieces/piece-ai', pieceType: PieceType.OFFICIAL, packageType: PackageType.REGISTRY, actions: {}, triggers: {} })
+            await db.save('piece_metadata', piece)
+            await pieceCache(mockLog).setup()
+
+            const token = await generateMockToken({ type: PrincipalType.USER, id: mockOwner.id, platform: { id: mockPlatform.id } })
+            const response = await app!.inject({
+                method: 'GET',
+                url: `/api/v1/pieces/${encodeURIComponent('@activepieces/piece-ai')}`,
+                headers: { authorization: `Bearer ${token}` },
+            })
+
+            expect(response.statusCode).toBe(200)
+        })
+    })
+
     describe('GET /v1/pieces (component filters via piece sets)', () => {
         async function setupComponentPieceSetScenario(opts: {
             selectedActions?: Record<string, string[]>

--- a/packages/web/src/app/builder/pieces-selector/ai-tab-content/index.tsx
+++ b/packages/web/src/app/builder/pieces-selector/ai-tab-content/index.tsx
@@ -39,7 +39,11 @@ const AITabContent = ({ operation }: { operation: PieceSelectorOperation }) => {
     );
   }
 
-  if (isError || isNil(pieceModel)) {
+  if (
+    isError ||
+    isNil(pieceModel) ||
+    Object.keys(pieceModel.actions).length === 0
+  ) {
     return (
       <div className="flex items-center justify-center h-full w-full">
         <p className="text-sm text-muted-foreground">

--- a/packages/web/src/app/builder/pieces-selector/ai-tab-content/index.tsx
+++ b/packages/web/src/app/builder/pieces-selector/ai-tab-content/index.tsx
@@ -10,6 +10,7 @@ import {
   PieceSelectorOperation,
   stepUtils,
 } from '@/features/pieces';
+import { authenticationSession } from '@/lib/authentication-session';
 
 import { AIPieceActionsList } from './ai-actions-list';
 
@@ -18,6 +19,7 @@ const AITabContent = ({ operation }: { operation: PieceSelectorOperation }) => {
   const { selectedTab } = usePieceSelectorTabs();
   const { pieceModel, isLoading, isError } = piecesHooks.usePiece({
     name: '@activepieces/piece-ai',
+    projectId: authenticationSession.getProjectId() ?? undefined,
   });
 
   if (

--- a/packages/web/src/app/builder/pieces-selector/index.tsx
+++ b/packages/web/src/app/builder/pieces-selector/index.tsx
@@ -28,10 +28,12 @@ import {
   pieceSelectorCustomization,
   PieceSearchProvider,
   usePieceSearchContext,
+  piecesHooks,
 } from '@/features/pieces';
 import { aiProviderQueries } from '@/features/platform-admin';
 import { platformHooks } from '@/hooks/platform-hooks';
 import { useIsMobile } from '@/hooks/use-mobile';
+import { authenticationSession } from '@/lib/authentication-session';
 
 import { AITabContent } from './ai-tab-content';
 import { ApprovalsTabContent } from './approvals-tab-content';
@@ -140,6 +142,17 @@ const PieceSelectorContent = ({
     }
   }, [isOpen]);
   const { data: aiProviders } = aiProviderQueries.useAiProviders();
+  const {
+    pieceModel: aiPieceModel,
+    isError: isAiPieceError,
+    isSuccess: isAiPieceLoaded,
+  } = piecesHooks.usePiece({
+    name: '@activepieces/piece-ai',
+    projectId: authenticationSession.getProjectId() ?? undefined,
+  });
+  const isAiPieceUnavailable =
+    isAiPieceError ||
+    (isAiPieceLoaded && Object.keys(aiPieceModel?.actions ?? {}).length === 0);
   const clearSearch = () => {
     setSearchQuery('');
     setSelectedPieceMetadataInPieceSelector(null);
@@ -149,7 +162,7 @@ const PieceSelectorContent = ({
   const tabsList = pieceSelectorCustomization.buildResolvedTabs({
     availableBuiltinTabs: getTabsList(
       operation.type,
-      !isNil(aiProviders) && aiProviders.length > 0,
+      !isNil(aiProviders) && aiProviders.length > 0 && !isAiPieceUnavailable,
     ),
     config: platform.pieceSelectorConfig,
   });

--- a/packages/web/src/features/pieces/hooks/pieces-hooks.ts
+++ b/packages/web/src/features/pieces/hooks/pieces-hooks.ts
@@ -69,6 +69,7 @@ type UsePieceProps = {
   name: string;
   version?: string;
   enabled?: boolean;
+  projectId?: string;
 };
 
 type UseMultiplePiecesProps = {
@@ -89,12 +90,17 @@ type UsePiecesSearchProps = {
 };
 
 export const piecesHooks = {
-  usePiece: ({ name, version, enabled = true }: UsePieceProps) => {
+  usePiece: ({ name, version, enabled = true, projectId }: UsePieceProps) => {
     const { i18n } = useTranslation();
     const query = useQuery<PieceMetadataModel, Error>({
-      queryKey: ['piece', name, version, i18n.language],
+      queryKey: ['piece', name, version, i18n.language, projectId],
       queryFn: () =>
-        piecesApi.get({ name, version, locale: i18n.language as LocalesEnum }),
+        piecesApi.get({
+          name,
+          version,
+          locale: i18n.language as LocalesEnum,
+          projectId,
+        }),
       staleTime: Infinity,
       enabled,
       retry: (failureCount, error) => {


### PR DESCRIPTION
Fixes [GIT-1719](https://linear.app/activepieces/issue/GIT-1719)
Closes #14655

### Breaking change?

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)

## Problem
Disabling a piece in a Piece Set (e.g. AI) still let the piece show up in the flow builder's AI & Agents tab. The `/v1/pieces` list respected the piece-set policy (piece hidden from Apps/Explore), but the AI tab fetches `@activepieces/piece-ai` by direct name and rendered all its actions. Adding the step from there produced dropdowns that errored `Unexpected error, please retry` at option-resolve time, poisoning the flow.

## Fix
- `packages/web/src/features/pieces/hooks/pieces-hooks.ts`: `usePiece` accepts optional `projectId` and forwards it to `piecesApi.get` (opt-in per caller; matches `usePieces` at line 187). React Query cache-key includes `projectId` so opt-in callers don't share cache with the unfiltered path.
- `packages/web/src/app/builder/pieces-selector/ai-tab-content/index.tsx`: passes `authenticationSession.getProjectId()` to `usePiece`.
- `packages/server/api/src/app/pieces/metadata/piece-metadata-controller.ts`: `GET /v1/pieces/:name` and `/:scope/:name` now throw `ENTITY_NOT_FOUND` (404) when the piece is invisible under the resolved policy, instead of returning the piece with only its components filtered. Existing callers that don't pass `projectId` skip the policy and get the piece back (unchanged), so existing-step lookups on running flows are untouched.

## Verification
- `npx vitest run test/integration/ee/pieces/piece-component-filtering.test.ts` — 16/16 pass, including 3 new direct-fetch cases.
- Red-first: without the controller change, `direct fetch returns 404 for a hidden piece when projectId is passed` fails with `expected 200 to be 404`; with the change all pass.
- `npx turbo run lint --filter=api --filter=web` — 0 errors (existing warnings only).
- `npx tsc --noEmit` on both packages — clean.
- Visual: existing "AI piece is not available for this platform" fallback state (shipped in GIT-1570) — no new UI. This change only rewires when that state is reachable; the rendered tab in the disabled case is identical to what already renders when the server returns 404. Live drive skipped: EE dev stack for piece-sets was booted but not run through the UI due to time (the stack was torn down after this check).
- Other affected paths: checked - none. Grep of `piecesApi.get` and `usePiece` callers: admin `piece-component-visibility-sheet.tsx` (must show all pieces to admins - stays unfiltered), `usePieceModelForStepSettings` and other existing-step lookups (must resolve existing steps regardless of piece-set - stay unfiltered). Only AITabContent opts in.

<details>
<summary>Plan &amp; reasoning</summary>

## Plan
- Frontend hook made project-aware via opt-in `projectId` param; only the picker surface (AITabContent) passes it. Existing usePiece callers keep the current unfiltered behavior — critical for hooks that read pieces already present in a flow (step editors, connection reconnect, run details) after a piece was later hidden.
- Server enforces rejection at the controller (not the service) so `pieceMetadataService.getOrThrow` continues to serve internal callers (app-connection, oauth2, flow-version validator, migrations) that must resolve a piece regardless of piece-set visibility.
- Footprint: 3 product files (~15 lines) + 1 test file. Rejected alternative: forwarding `projectId` inside `pieceMetadataService.getOrThrow` — cascades filtering into 28+ internal callers and breaks existing connections/flows.

## Non-happy scenarios considered
- User has no active project (login/switching): `authenticationSession.getProjectId()` returns null → `usePiece` sees `projectId: undefined` → controller resolves policy = null → returns piece (fail-open by design; no project means no piece-set to enforce yet).
- Piece disabled AFTER a flow already uses it: existing-step lookups do not pass `projectId` → still resolve. This ticket does not cover already-added steps whose option resolvers cascade into `Unexpected error`; that is a separate ticket (default-value / already-placed-step leak).
- Piece-set uses EXCLUDE_ALL mode with the piece listed: `isPieceVisible` returns true → piece stays visible, as intended by the config.

## Alternatives rejected
- Filter inside `getOrThrow` — would cascade into every internal server caller of the piece metadata service (28+ call sites: oauth2 refresh, connection creation, flow validation, migrations). Would break existing connections and running flows.
- Wire `projectId` implicitly inside `usePiece` (auto-pick from `authenticationSession`) — silently changes behavior for every existing caller; would hide pieces from step editors and connection dialogs on flows that reference already-hidden pieces.
- New `AITabContent` fallback UI — unnecessary; GIT-1570 already ships the "AI piece is not available for this platform" state, reached via `isError || isNil(pieceModel)`.
</details>
