### PR TITLE
feat(agent): give a flow step its structured output back

### DIFF
--- a/packages/core/execution/src/lib/workers/job-data.ts
+++ b/packages/core/execution/src/lib/workers/job-data.ts
@@ -9,6 +9,7 @@ import { FlowVersion } from '../flows/flow-version'
 import { FlowTriggerType } from '../flows/triggers/trigger'
 import { AppConnectionType, AppConnectionValue, PiecePackage } from '@activepieces/core-piece-types'
 import { AgentPieceTool } from '../agents/tools'
+import { AgentOutputField } from '../agents'
 
 export const LATEST_JOB_DATA_SCHEMA_VERSION = 10
 
@@ -319,6 +320,7 @@ export const ExecuteAgentRunJobData = z.object({
     flowRunId: z.string().optional(),
     waitpointId: z.string().optional(),
     tools: z.array(AgentPieceTool).optional(),
+    structuredOutput: z.array(AgentOutputField).optional(),
     modelName: z.string().nullable(),
     files: z.array(z.object({
         name: z.string(),

--- a/packages/server/api/src/app/ee/agent/agent-run-controller.ts
+++ b/packages/server/api/src/app/ee/agent/agent-run-controller.ts
@@ -1,5 +1,5 @@
 import { ActivepiecesError, apId, ApId, ErrorCode, unique } from '@activepieces/core-utils'
-import { AgentRunSource, AgentTool, AgentToolType, LATEST_JOB_DATA_SCHEMA_VERSION, PrincipalType, WorkerJobType } from '@activepieces/shared'
+import { AgentOutputField, AgentRunSource, AgentTool, AgentToolType, LATEST_JOB_DATA_SCHEMA_VERSION, PrincipalType, WorkerJobType } from '@activepieces/shared'
 import { FastifyPluginAsyncZod } from 'fastify-type-provider-zod'
 import { StatusCodes } from 'http-status-codes'
 import { z } from 'zod'
@@ -13,7 +13,7 @@ const RUN_PRINCIPALS = [PrincipalType.ENGINE] as const
 
 export const agentRunController: FastifyPluginAsyncZod = async (app) => {
     app.post('/runs', StartAgentRunRoute, async (request, reply) => {
-        const { instruction, modelName, flowRunId, waitpointId, tools } = request.body
+        const { instruction, modelName, flowRunId, waitpointId, tools, structuredOutput } = request.body
         if (request.principal.type !== PrincipalType.ENGINE) {
             throw new ActivepiecesError({
                 code: ErrorCode.AUTHORIZATION,
@@ -61,6 +61,7 @@ export const agentRunController: FastifyPluginAsyncZod = async (app) => {
                 flowRunId,
                 waitpointId,
                 tools: pieceTools,
+                structuredOutput,
             },
         })
 
@@ -74,12 +75,14 @@ const MAX_INSTRUCTION_LENGTH = 51_200
 const MAX_TOOLS = 100
 const CUSTOM_API_CALL = 'custom_api_call'
 const BUILT_IN_TOOL_PREFIX = 'ap_'
+const MAX_OUTPUT_FIELDS = 50
 
 const StartAgentRunRequest = z.object({
     instruction: z.string().min(1).max(MAX_INSTRUCTION_LENGTH),
     flowRunId: ApId,
     waitpointId: ApId,
     tools: z.array(AgentTool).max(MAX_TOOLS).optional(),
+    structuredOutput: z.array(AgentOutputField).max(MAX_OUTPUT_FIELDS).optional(),
     modelName: z.string().optional(),
 })
 

--- a/packages/server/api/src/app/ee/agent/agent-run-controller.ts
+++ b/packages/server/api/src/app/ee/agent/agent-run-controller.ts
@@ -30,7 +30,8 @@ export const agentRunController: FastifyPluginAsyncZod = async (app) => {
         if (unsupported.length > 0) {
             throw new ActivepiecesError({ code: ErrorCode.VALIDATION, params: { message: `An agent step cannot use ${unsupported.join(' or ')} tools yet, only piece actions` } })
         }
-        const reserved = pieceTools.filter((tool) => tool.toolName.startsWith(BUILT_IN_TOOL_PREFIX) || tool.toolName === TASK_COMPLETION_TOOL_NAME).map((tool) => tool.toolName)
+        const usesCompletionTool = (structuredOutput?.length ?? 0) > 0
+        const reserved = pieceTools.filter((tool) => tool.toolName.startsWith(BUILT_IN_TOOL_PREFIX) || (usesCompletionTool && tool.toolName === TASK_COMPLETION_TOOL_NAME)).map((tool) => tool.toolName)
         if (reserved.length > 0) {
             throw new ActivepiecesError({ code: ErrorCode.VALIDATION, params: { message: `A tool cannot be named ${unique(reserved).join(' or ')}: names starting with "${BUILT_IN_TOOL_PREFIX}" belong to the agent's own tools` } })
         }

--- a/packages/server/api/src/app/ee/agent/agent-run-controller.ts
+++ b/packages/server/api/src/app/ee/agent/agent-run-controller.ts
@@ -1,5 +1,5 @@
 import { ActivepiecesError, apId, ApId, ErrorCode, unique } from '@activepieces/core-utils'
-import { AgentOutputField, AgentRunSource, AgentTool, AgentToolType, LATEST_JOB_DATA_SCHEMA_VERSION, PrincipalType, WorkerJobType } from '@activepieces/shared'
+import { AgentOutputField, AgentRunSource, AgentTool, AgentToolType, LATEST_JOB_DATA_SCHEMA_VERSION, PrincipalType, TASK_COMPLETION_TOOL_NAME, WorkerJobType } from '@activepieces/shared'
 import { FastifyPluginAsyncZod } from 'fastify-type-provider-zod'
 import { StatusCodes } from 'http-status-codes'
 import { z } from 'zod'
@@ -30,7 +30,7 @@ export const agentRunController: FastifyPluginAsyncZod = async (app) => {
         if (unsupported.length > 0) {
             throw new ActivepiecesError({ code: ErrorCode.VALIDATION, params: { message: `An agent step cannot use ${unsupported.join(' or ')} tools yet, only piece actions` } })
         }
-        const reserved = pieceTools.filter((tool) => tool.toolName.startsWith(BUILT_IN_TOOL_PREFIX)).map((tool) => tool.toolName)
+        const reserved = pieceTools.filter((tool) => tool.toolName.startsWith(BUILT_IN_TOOL_PREFIX) || tool.toolName === TASK_COMPLETION_TOOL_NAME).map((tool) => tool.toolName)
         if (reserved.length > 0) {
             throw new ActivepiecesError({ code: ErrorCode.VALIDATION, params: { message: `A tool cannot be named ${unique(reserved).join(' or ')}: names starting with "${BUILT_IN_TOOL_PREFIX}" belong to the agent's own tools` } })
         }

--- a/packages/server/api/test/integration/cloud/agent/agent-run-endpoint.test.ts
+++ b/packages/server/api/test/integration/cloud/agent/agent-run-endpoint.test.ts
@@ -180,6 +180,7 @@ describe('POST /v1/agents/runs', () => {
                 instruction: 'do a thing',
                 flowRunId: apId(),
                 waitpointId: apId(),
+                structuredOutput: [{ displayName: 'summary', type: 'text' }],
                 tools: [{
                     type: 'PIECE',
                     toolName: 'updateTaskStatus',
@@ -189,6 +190,33 @@ describe('POST /v1/agents/runs', () => {
         })
 
         expect(response.statusCode).toBe(StatusCodes.CONFLICT)
+    })
+
+    it('allows that name when the step has no output fields, since no completion tool is installed', async () => {
+        const ctx = await createTestContext(app)
+        const engineToken = await accessTokenManager(app.log).generateEngineToken({
+            jobId: 'job-8',
+            projectId: ctx.project.id,
+            platformId: ctx.platform.id,
+        })
+
+        const response = await app.inject({
+            method: 'POST',
+            url: RUNS_URL,
+            headers: { authorization: `Bearer ${engineToken}` },
+            body: {
+                instruction: 'do a thing',
+                flowRunId: apId(),
+                waitpointId: apId(),
+                tools: [{
+                    type: 'PIECE',
+                    toolName: 'updateTaskStatus',
+                    pieceMetadata: { pieceName: '@activepieces/piece-gmail', pieceVersion: '0.1.0', actionName: 'send_email' },
+                }],
+            },
+        })
+
+        expect(response.statusCode).toBe(StatusCodes.OK)
     })
 
     it('rejects a waitpoint that is not an id, so nothing unbounded reaches the queue', async () => {

--- a/packages/server/api/test/integration/cloud/agent/agent-run-endpoint.test.ts
+++ b/packages/server/api/test/integration/cloud/agent/agent-run-endpoint.test.ts
@@ -164,6 +164,33 @@ describe('POST /v1/agents/runs', () => {
         expect(response.statusCode).toBe(StatusCodes.OK)
     })
 
+    it('refuses a tool named after one of the agent\'s own, so it cannot be shadowed', async () => {
+        const ctx = await createTestContext(app)
+        const engineToken = await accessTokenManager(app.log).generateEngineToken({
+            jobId: 'job-7',
+            projectId: ctx.project.id,
+            platformId: ctx.platform.id,
+        })
+
+        const response = await app.inject({
+            method: 'POST',
+            url: RUNS_URL,
+            headers: { authorization: `Bearer ${engineToken}` },
+            body: {
+                instruction: 'do a thing',
+                flowRunId: apId(),
+                waitpointId: apId(),
+                tools: [{
+                    type: 'PIECE',
+                    toolName: 'updateTaskStatus',
+                    pieceMetadata: { pieceName: '@activepieces/piece-gmail', pieceVersion: '0.1.0', actionName: 'send_email' },
+                }],
+            },
+        })
+
+        expect(response.statusCode).toBe(StatusCodes.CONFLICT)
+    })
+
     it('rejects a waitpoint that is not an id, so nothing unbounded reaches the queue', async () => {
         const ctx = await createTestContext(app)
         const engineToken = await accessTokenManager(app.log).generateEngineToken({

--- a/packages/server/worker/src/lib/execute/jobs/ee/agent/agent-step-result.ts
+++ b/packages/server/worker/src/lib/execute/jobs/ee/agent/agent-step-result.ts
@@ -2,23 +2,25 @@ import { AgentPieceTool, AgentResult, AgentStepBlock, AgentTaskStatus, ContentBl
 
 const MAX_RESULT_LENGTH = 262_144
 
-export function stepResultFrom({ prompt, uiParts, timestamp, tools, failure }: {
+export function stepResultFrom({ prompt, uiParts, timestamp, tools, structuredOutput, failure }: {
     prompt: string
     uiParts: PersistedAgentPart[]
     timestamp: string
     tools: AgentPieceTool[]
+    structuredOutput?: Record<string, unknown>
     failure?: string
 }): AgentResult {
     const configured = new Map(tools.map((tool) => [tool.toolName, tool.pieceMetadata]))
     const steps = withinBudget(uiParts.flatMap((part) => toStepBlocks({ part, timestamp, configured })))
     const anyToolFailed = uiParts.some((part) => part.type === PersistedAgentPartType.TOOL_CALL && part.status === PersistedToolCallStatus.ERROR)
     if (failure === undefined) {
-        return { prompt, steps, status: anyToolFailed ? AgentTaskStatus.FAILED : AgentTaskStatus.COMPLETED }
+        return { prompt, steps, status: anyToolFailed ? AgentTaskStatus.FAILED : AgentTaskStatus.COMPLETED, ...(structuredOutput === undefined ? {} : { structuredOutput }) }
     }
     return {
         prompt,
         steps: [...steps, { type: ContentBlockType.MARKDOWN, markdown: failure }],
         status: AgentTaskStatus.FAILED,
+        ...(structuredOutput === undefined ? {} : { structuredOutput }),
     }
 }
 

--- a/packages/server/worker/src/lib/execute/jobs/ee/agent/agent-worker-tools.ts
+++ b/packages/server/worker/src/lib/execute/jobs/ee/agent/agent-worker-tools.ts
@@ -1476,6 +1476,12 @@ function createConfiguredPieceTools({ tools, runPieceTool, log }: {
     ]))
 }
 
+// Per-turn flag, set once the turn reads untrusted external content; forces the action-preview gate.
+export type TaintState = { tainted: boolean }
+
+export type GateOutcome = 'approved' | 'declined' | 'timeout' | 'aborted'
+export type GateDecision = { outcome: GateOutcome, payload?: Record<string, unknown> }
+
 function createStructuredOutputTool({ fields, capture }: {
     fields: AgentOutputField[]
     capture: (output: Record<string, unknown>) => void
@@ -1502,12 +1508,6 @@ function schemaForOutputField(field: AgentOutputField): z.ZodType {
             return z.string().describe(field.description ?? field.displayName)
     }
 }
-
-// Per-turn flag, set once the turn reads untrusted external content; forces the action-preview gate.
-export type TaintState = { tainted: boolean }
-
-export type GateOutcome = 'approved' | 'declined' | 'timeout' | 'aborted'
-export type GateDecision = { outcome: GateOutcome, payload?: Record<string, unknown> }
 
 export const agentWorkerTools = {
     createEventEmitter,

--- a/packages/server/worker/src/lib/execute/jobs/ee/agent/agent-worker-tools.ts
+++ b/packages/server/worker/src/lib/execute/jobs/ee/agent/agent-worker-tools.ts
@@ -1,6 +1,6 @@
 import { chunk, isNil, isObject, spreadIfDefined, tryCatch, tryCatchSync } from '@activepieces/core-utils'
 import { safeHttp } from '@activepieces/server-utils'
-import { ActionPreviewEvent, ActionReceiptEvent, AgentEventType, AgentPhase, AgentPieceTool, AgentPieceToolMetadata, agentToolClassification, apId, BatchItemResult, BuildPlanEvent, FileProducedEvent, ImageGeneratedEvent, SaveAgentFileResponse, SendAgentEmailResponse, SendAgentEventRequest, ToolProgressEvent } from '@activepieces/shared'
+import { ActionPreviewEvent, ActionReceiptEvent, AgentEventType, AgentOutputField, AgentOutputFieldType, AgentPhase, AgentPieceTool, AgentPieceToolMetadata, agentToolClassification, apId, BatchItemResult, BuildPlanEvent, FileProducedEvent, ImageGeneratedEvent, SaveAgentFileResponse, SendAgentEmailResponse, SendAgentEventRequest, TASK_COMPLETION_TOOL_NAME, ToolProgressEvent } from '@activepieces/shared'
 import { tool, ToolExecutionOptions, ToolSet } from 'ai'
 import { FastifyBaseLogger } from 'fastify'
 import { stripHtml } from 'string-strip-html'
@@ -1476,6 +1476,33 @@ function createConfiguredPieceTools({ tools, runPieceTool, log }: {
     ]))
 }
 
+function createStructuredOutputTool({ fields, capture }: {
+    fields: AgentOutputField[]
+    capture: (output: Record<string, unknown>) => void
+}): ToolSet {
+    return {
+        [TASK_COMPLETION_TOOL_NAME]: tool({
+            description: 'Call this as your final action, once the task is done or you cannot continue, to report the result in the shape the flow expects. Nothing you write outside this tool reaches the rest of the flow.',
+            inputSchema: z.object({ output: z.object(Object.fromEntries(fields.map((field) => [field.displayName, schemaForOutputField(field)]))) }),
+            execute: async ({ output }) => {
+                capture(output)
+                return { content: [{ type: 'text', text: 'Result recorded.' }] }
+            },
+        }),
+    }
+}
+
+function schemaForOutputField(field: AgentOutputField): z.ZodType {
+    switch (field.type) {
+        case AgentOutputFieldType.NUMBER:
+            return z.number().describe(field.description ?? field.displayName)
+        case AgentOutputFieldType.BOOLEAN:
+            return z.boolean().describe(field.description ?? field.displayName)
+        default:
+            return z.string().describe(field.description ?? field.displayName)
+    }
+}
+
 // Per-turn flag, set once the turn reads untrusted external content; forces the action-preview gate.
 export type TaintState = { tainted: boolean }
 
@@ -1497,6 +1524,7 @@ export const agentWorkerTools = {
     createPhaseTools,
     createBuildPlanTools,
     createConfiguredPieceTools,
+    createStructuredOutputTool,
     isSuccessResult,
     extractResultText,
     extractUserFacingError,

--- a/packages/server/worker/src/lib/execute/jobs/ee/agent/execute-agent-run.ts
+++ b/packages/server/worker/src/lib/execute/jobs/ee/agent/execute-agent-run.ts
@@ -1,6 +1,6 @@
 import { AIProviderName, ErrorCode, isNil, isObject, omit, spreadIfDefined, tryCatch, tryCatchSync } from '@activepieces/core-utils'
 import { agentAiUtils } from '@activepieces/server-utils'
-import { AgentEvent, AgentEventType, AgentPhase, AgentPieceTool, AgentResult, AgentRunSource, EngineResponseStatus, ExecuteAgentRunJobData, PersistedAgentMessage, PersistedAgentRole, WorkerJobType } from '@activepieces/shared'
+import { AgentEvent, AgentEventType, AgentOutputField, AgentPhase, AgentPieceTool, AgentResult, AgentRunSource, EngineResponseStatus, ExecuteAgentRunJobData, PersistedAgentMessage, PersistedAgentRole, WorkerJobType } from '@activepieces/shared'
 import { createUIMessageStream, generateText, ModelMessage, streamText, ToolSet, toUIMessageStream } from 'ai'
 import { FireAndForgetJobResult, JobContext, JobHandler, JobResultKind } from '../../../types'
 import { agentMcpClient } from './agent-mcp-client'
@@ -125,6 +125,7 @@ export const executeAgentRunJob: JobHandler<ExecuteAgentRunJobData, FireAndForge
         }
         const heartbeatInterval = setInterval(sendHeartbeat, HEARTBEAT_INTERVAL_MS)
         let answer: AgentResult | undefined
+        const structured: { output?: Record<string, unknown> } = {}
 
         try {
             const phaseState: { phase: AgentPhase } = { phase: 'discovery' }
@@ -150,6 +151,10 @@ export const executeAgentRunJob: JobHandler<ExecuteAgentRunJobData, FireAndForge
                 abortSignal: abortController.signal,
                 source,
                 configuredPieceTools: data.tools ?? [],
+                structuredOutput: data.structuredOutput ?? [],
+                captureStructured: (output) => {
+                    structured.output = output 
+                },
             })
 
             const thinkingStartTime = Date.now()
@@ -231,7 +236,7 @@ export const executeAgentRunJob: JobHandler<ExecuteAgentRunJobData, FireAndForge
                         log.error({ error: retryError, conversation: { id: conversationId } }, 'Cancel save retry also failed')
                     }
                 }
-                await releaseFlowStep({ ctx, conversationId, flowRunId, waitpointId, output: stepResultFrom({ prompt: userMessage, uiParts: [], timestamp: new Date().toISOString(), tools: data.tools ?? [], failure: 'The agent run was stopped before it finished' }), source, log })
+                await releaseFlowStep({ ctx, conversationId, flowRunId, waitpointId, output: stepResultFrom({ prompt: userMessage, uiParts: [], timestamp: new Date().toISOString(), tools: data.tools ?? [], structuredOutput: structured.output, failure: 'The agent run was stopped before it finished' }), source, log })
                 await sendEventWithRetry({
                     event: { type: AgentEventType.FINISHED, data: { conversationId } },
                 })
@@ -270,7 +275,7 @@ export const executeAgentRunJob: JobHandler<ExecuteAgentRunJobData, FireAndForge
             }
             await retryWithBackoff({ fn: () => ctx.apiClient.saveAgentMessages(savePayload), description: 'Saving the transcript', throwOnExhausted: true, log })
 
-            answer = stepResultFrom({ prompt: userMessage, uiParts, timestamp: new Date().toISOString(), tools: data.tools ?? [], failure: incompleteReason({ truncatedAfterRetries, budgetExceeded }) })
+            answer = stepResultFrom({ prompt: userMessage, uiParts, timestamp: new Date().toISOString(), tools: data.tools ?? [], structuredOutput: structured.output, failure: incompleteReason({ truncatedAfterRetries, budgetExceeded }) })
 
             if (autoTitle) {
                 await sendEventWithRetry({
@@ -302,7 +307,7 @@ export const executeAgentRunJob: JobHandler<ExecuteAgentRunJobData, FireAndForge
             const clientMessage = !isCreditError && isTransientFailureText(errorMessage)
                 ? 'The AI provider is temporarily unavailable. Please try again in a moment.'
                 : errorMessage
-            const { error: releaseError } = await tryCatch(() => releaseFlowStep({ ctx, conversationId, flowRunId, waitpointId, output: answer ?? stepResultFrom({ prompt: userMessage, uiParts: [], timestamp: new Date().toISOString(), tools: data.tools ?? [], failure: clientMessage }), source, log }))
+            const { error: releaseError } = await tryCatch(() => releaseFlowStep({ ctx, conversationId, flowRunId, waitpointId, output: answer ?? stepResultFrom({ prompt: userMessage, uiParts: [], timestamp: new Date().toISOString(), tools: data.tools ?? [], structuredOutput: structured.output, failure: clientMessage }), source, log }))
             // Empty arrays here mean "mark this turn ERROR" — they do NOT wipe history. The
             // saveAgentMessages handler's no-shrink guard preserves whatever was persisted
             // incrementally (updateAgentProgress) and only flips status, so an errored turn keeps
@@ -379,7 +384,7 @@ async function releaseFlowStep({ ctx, conversationId, flowRunId, waitpointId, ou
 }
 
 
-function buildToolSet({ ctx, eventEmitter, log, phaseState, taintState, mcpToolSet, webTools, projects, projectId, conversationId, runId, platformId, userId, userEmail, guides, dryRun, discoveryOnly, emailEnabled, abortSignal, source, configuredPieceTools }: {
+function buildToolSet({ ctx, eventEmitter, log, phaseState, taintState, mcpToolSet, webTools, projects, projectId, conversationId, runId, platformId, userId, userEmail, guides, dryRun, discoveryOnly, emailEnabled, abortSignal, source, configuredPieceTools, structuredOutput, captureStructured }: {
     ctx: JobContext
     eventEmitter: ReturnType<typeof agentWorkerTools.createEventEmitter>
     log: JobContext['log']
@@ -400,6 +405,8 @@ function buildToolSet({ ctx, eventEmitter, log, phaseState, taintState, mcpToolS
     emailEnabled: boolean
     abortSignal: AbortSignal
     configuredPieceTools: AgentPieceTool[]
+    structuredOutput: AgentOutputField[]
+    captureStructured: (output: Record<string, unknown>) => void
     source: AgentRunSource
 }) {
     const brokenConnectors = new Set<string>()
@@ -553,7 +560,10 @@ function buildToolSet({ ctx, eventEmitter, log, phaseState, taintState, mcpToolS
         log,
     })
     const unattendedTools = omit(allTools, UNATTENDED_FORBIDDEN_TOOLS)
-    return { ...configuredTools, ...unattendedTools }
+    const completionTool = structuredOutput.length === 0
+        ? {}
+        : agentWorkerTools.createStructuredOutputTool({ fields: structuredOutput, capture: captureStructured })
+    return { ...configuredTools, ...unattendedTools, ...completionTool }
 }
 
 async function streamChunksToClient({ result, ctx, userId, conversationId, runId, log, abortSignal, onStreamIdle }: {

--- a/packages/server/worker/test/lib/execute/jobs/ee/agent/execute-agent-run.test.ts
+++ b/packages/server/worker/test/lib/execute/jobs/ee/agent/execute-agent-run.test.ts
@@ -131,3 +131,26 @@ describe('stepResultFrom — a configured action keeps its identity in the run v
         expect(result.steps[0]).toMatchObject({ toolCallType: 'UNKNOWN' })
     })
 })
+
+describe('stepResultFrom — structured output reaches the flow', () => {
+    const at = '2026-08-07T00:00:00.000Z'
+
+    it('carries the structured result the agent reported', () => {
+        const result = stepResultFrom({ prompt: 'summarise', uiParts: [], timestamp: at, tools: [], structuredOutput: { sentiment: 'positive', score: 8 } })
+
+        expect(result.structuredOutput).toEqual({ sentiment: 'positive', score: 8 })
+    })
+
+    it('carries it even when the run failed, so a later step is not left guessing', () => {
+        const result = stepResultFrom({ prompt: 'summarise', uiParts: [], timestamp: at, tools: [], structuredOutput: { score: 1 }, failure: 'ran out of room' })
+
+        expect(result.structuredOutput).toEqual({ score: 1 })
+        expect(result.status).toBe('FAILED')
+    })
+
+    it('omits the key entirely when the step configured no fields', () => {
+        const result = stepResultFrom({ prompt: 'summarise', uiParts: [], timestamp: at, tools: [] })
+
+        expect(result).not.toHaveProperty('structuredOutput')
+    })
+})


### PR DESCRIPTION
## Description

A step can define output fields in the builder, and later steps read them as `{{step.structuredOutput.field}}`. The server-side run had no way to produce them.

That matters now rather than later. The piece is about to become a thin client that returns whatever the server hands back, and if the server cannot produce structured output, every one of those references in every published flow silently becomes `undefined`. No error, no failed run, just an empty value flowing into the next step. It is the kind of gap nobody catches reviewing the conversion PR, because it is an absence rather than a diff.

## How it works

The piece already solves this with a terminal tool the model calls to finish, carrying the result as a typed object. The server now does the same: the step's configured fields become that tool's input schema, so the model reports its result in the shape the flow already expects, and the two paths share `TASK_COMPLETION_TOOL_NAME` and the same field semantics.

Only a step that configured fields gets the tool. A step with none is unchanged, and the key is omitted from the result rather than set to an empty object.

## The completion tool's name is reserved only where it collides

A configured tool named `updateTaskStatus` would be replaced by the completion tool, so the author's action would vanish and the model's calls to it would record output instead. The endpoint refuses that name when the step configured output fields, which is when the completion tool is installed.

A step with no output fields keeps the name, because nothing is installed for it to collide with. The cost is that adding an output field to such a step later starts rejecting it; the message names the tool, so the fix is renaming it.

## Carried on failure too

A run that was cut short after reporting its fields hands them back anyway, with `status: FAILED`. A later step reading one field is better served by the value plus a failed status than by a blank, and the status is what tells it something went wrong.

## How was this tested?

- 90 worker unit tests, three on the projection: the result is carried, it survives a failed run, and the key is absent when the step configured nothing.
- 104 API unit tests, 40 integration tests under `AP_EDITION=cloud`.
- `turbo run build` across api and worker, `npm run lint-dev` 0 errors.

## What is left in this phase

The piece itself, which becomes create-waitpoint, call, suspend, resume, and must set a deadline on the waitpoint. Then retention for flow-step transcripts.

One decision still open, and it belongs before the piece lands: `run-agent.ts` calls `context.output.update` on every stream chunk, which is what makes the builder timeline fill in live. A suspended piece cannot do that. Either the server writes step output progressively through the waitpoint, which needs a write path that does not exist today, or the live timeline goes away and we say so deliberately.

Fixes # (issue)

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

`structuredOutput` is optional on the request and the job, nothing calls the endpoint yet, and a step that configures no fields behaves exactly as before.

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)

It adds one tool whose only effect is to record a typed object into the run's own step output. It reaches no connection, executes no action, and the field count is capped. The tool is only built for a step that configured fields.
