### PR TITLE
refactor(skills): optimize piece skills and document getConnectionIdentifier auth hook

### DIFF
--- a/.agents/skills/piece-builder/SKILL.md
+++ b/.agents/skills/piece-builder/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: piece-builder
-description: Builds Activepieces pieces (integrations) with actions and triggers. Use when the user asks to create a new piece, add actions to a piece, add triggers to a piece, or build an integration for a third-party app. Also use when the user mentions Activepieces pieces, connectors, or integration development.
+description: Build and edit Activepieces pieces (integrations) — creating new pieces, adding actions or triggers, or fixing bugs in existing ones. Use when the user asks to work on an Activepieces piece, connector, or integration.
 ---
 
 # Activepieces Piece Builder
@@ -15,7 +15,7 @@ description: Builds Activepieces pieces (integrations) with actions and triggers
 
 **Golden rule for existing-piece modes:** the piece you're editing is the source of truth, not these templates. If the piece already has a helper, a particular auth access pattern, or a way of shaping output, follow *that*. Reach into the reference files only for a pattern the piece doesn't already demonstrate.
 
-**The one carve-out — framework calls that drop data.** Matching the piece is right for style, wrong for a call that silently loses information. If the piece you're touching calls `pollingHelper` with a hand-picked subset (`{ store, auth, propsValue }`) instead of the whole `context`, fix it to pass `context` while you're in there, in every trigger in that piece — see the rule in `trigger-patterns.md`. Two reasons to do it here rather than wait for a repo-wide codemod: you are already bumping the version and rebuilding this piece, so the fix ships for free and gets tested alongside your actual change; and the pieces people edit are the pieces people use, so fixing on touch reaches the ones that matter first without one unreviewable ~300-piece PR that forces a version bump on pieces nobody is running.
+**The one carve-out — framework calls that drop data.** Matching the piece is right for style, wrong for a call that silently loses information. If the piece calls `pollingHelper` with a hand-picked subset (`{ store, auth, propsValue }`) instead of the whole `context`, fix every trigger in that piece to pass `context` while you're in there — see `trigger-patterns.md`. The version bump and rebuild are already happening; fix-on-touch reaches the pieces people actually use without a ~300-piece codemod PR that touches dead ones too.
 
 ## Workflow (new piece)
 
@@ -31,7 +31,7 @@ description: Builds Activepieces pieces (integrations) with actions and triggers
 - **Location:** `packages/pieces/community/` by default; `packages/pieces/custom/` only if the user says "custom piece". See Piece Types below.
 - Choose the correct auth type — see Quick Auth Reference below
 - Select the most useful actions (CRUD, search, list) and triggers (webhook if supported, polling otherwise)
-- **Ask the user** if OAuth2 config is unclear, there are >10 possible actions, or API behavior is ambiguous
+- **Ask the user** before starting when: OAuth2 authUrl/tokenUrl/scopes are missing from the docs; auth method is unclear or undocumented; more than 10 possible actions exist (which to prioritize); API uses webhook signature verification; test credentials or sandbox access are needed.
 
 ### Step 3: SCAFFOLD
 
@@ -51,86 +51,13 @@ tsconfig.json
 tsconfig.lib.json
 ```
 
-**`package.json`**
-
-```json
-{
-    "name": "@activepieces/piece-<name>",
-    "version": "0.0.1",
-    "main": "./dist/src/index.js",
-    "types": "./dist/src/index.d.ts",
-    "scripts": {
-        "build": "tsc -p tsconfig.lib.json && cp package.json dist/",
-        "lint": "eslint 'src/**/*.ts'"
-    },
-    "dependencies": {
-        "@activepieces/pieces-common": "workspace:*",
-        "@activepieces/pieces-framework": "workspace:*",
-        "@activepieces/shared": "workspace:*",
-        "tslib": "2.6.2"
-    }
-}
-```
-
-Add third-party SDKs to `dependencies` with a pinned version (e.g. `"stripe": "18.2.1"`).
-
-**`.eslintrc.json`**
-
-```json
-{
-    "extends": ["../../../../.eslintrc.json"],
-    "ignorePatterns": ["!**/*"],
-    "overrides": [
-        { "files": ["*.ts", "*.tsx", "*.js", "*.jsx"], "rules": {} },
-        { "files": ["*.ts", "*.tsx"], "rules": {} },
-        { "files": ["*.js", "*.jsx"], "rules": {} }
-    ]
-}
-```
-
-**`tsconfig.json`**
-
-```json
-{
-    "extends": "../../../../tsconfig.base.json",
-    "compilerOptions": {
-        "module": "commonjs",
-        "forceConsistentCasingInFileNames": true,
-        "strict": true,
-        "noImplicitOverride": true,
-        "noPropertyAccessFromIndexSignature": true,
-        "noImplicitReturns": true,
-        "noFallthroughCasesInSwitch": true
-    },
-    "files": [],
-    "include": [],
-    "references": [{ "path": "./tsconfig.lib.json" }]
-}
-```
-
-**`tsconfig.lib.json`**
-
-```json
-{
-    "extends": "./tsconfig.json",
-    "compilerOptions": {
-        "rootDir": ".",
-        "baseUrl": ".",
-        "paths": {},
-        "outDir": "./dist",
-        "declaration": true,
-        "types": ["node"]
-    },
-    "include": ["src/**/*.ts"],
-    "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"]
-}
-```
+Copy the four config files (`package.json`, `.eslintrc.json`, `tsconfig.json`, `tsconfig.lib.json`) from [`new-piece-scaffold.md`](./new-piece-scaffold.md).
 
 ### Step 4: IMPLEMENT
 
 The condensed rules in this file (Quick Auth Reference, Quick Piece Definition Template, UX Quality, Output Quality) cover the common case. Open a reference file when you need a concrete copy-ready example for the specific pattern you're building.
 
-**When you need a pattern, read the relevant reference file — do not grep other pieces in the codebase.** The reference files contain copy-ready examples for every common case. Searching `packages/pieces/community/` surfaces inconsistent older code and wastes context.
+**Reach for the reference file, not the codebase.** The reference files carry vetted patterns for every common case; older pieces in `packages/pieces/community/` are inconsistent and eat context.
 
 | When you reach for it | Open this file |
 |---|---|
@@ -165,7 +92,7 @@ npx turbo run lint --filter=@activepieces/piece-<name>
 
 Both must pass. Lint failures (unused imports, `any` types, unused vars) block CI even when the build is green.
 
-Common TS errors: missing import in `src/index.ts`, missing `tsconfig.base.json` entry, reading `context.auth` as a plain string for SecretText (use `context.auth.secret_text`), missing `sampleData` on a trigger.
+Common TS errors: missing import in `src/index.ts`, missing `tsconfig.base.json` entry, missing `sampleData` on a trigger. Auth-shape errors are covered in the Quick Auth Reference below.
 
 **Test locally:** Add `AP_DEV_PIECES=<name>` to `packages/server/api/.env`, start with `npm start`, open `localhost:4200`.
 
@@ -298,24 +225,9 @@ The catalog is fully curated; a new action or trigger without these is a regress
 
 ---
 
-## Critical Reminders
+## Gotchas that survive the workflow
 
-1. **Register in `tsconfig.base.json`** — alphabetically in `compilerOptions.paths`. Build fails silently without this.
-2. **Action/trigger `name` fields are permanent** — never change them after publishing; flows store them.
-3. **Auth lives in `src/lib/auth.ts`** — define there, import in actions/triggers via `import { myAppAuth } from '../auth'`. Do NOT re-export from `index.ts`.
-4. **Always provide `sampleData`** on triggers — even `{}`.
-5. **Build AND lint must both pass** — lint failures (unused imports, `any`, unused vars) block CI even when build is green.
-6. **Bump version on every existing-piece change** — see Versioning above. Skipping means flows never get your fix.
-7. **AI metadata on every new action & trigger** — explicit `audience` + `aiMetadata { description, idempotent }` on actions, `aiMetadata { description }` on triggers. See `ai-metadata.md`.
+Two things the step-by-step won't catch:
 
----
-
-## When to Ask the User
-
-Pause and ask if:
-
-- OAuth2 authUrl/tokenUrl/scopes are missing from the API docs
-- Auth method is unclear or undocumented
-- More than 10 possible actions exist — ask which to prioritize
-- API uses webhook signature verification
-- You need test credentials or sandbox access
+1. **Action/trigger `name` fields are permanent** — never change them after publishing; flows store them by name.
+2. **Auth stays imported, never re-exported** — actions/triggers do `import { myAppAuth } from '../auth'`; the auth object itself never appears in `index.ts` exports.

--- a/.agents/skills/piece-builder/SKILL.md
+++ b/.agents/skills/piece-builder/SKILL.md
@@ -62,6 +62,7 @@ The condensed rules in this file (Quick Auth Reference, Quick Piece Definition T
 | When you reach for it | Open this file |
 |---|---|
 | Wiring auth beyond the Quick Auth Reference table | `auth-patterns.md` |
+| A connection needs a human-readable label in the UI (account email, workspace name) | `auth-patterns.md` (Connection Identifier) |
 | Your first action in this piece (full file shape) | `action-patterns.md` |
 | A trigger — polling, webhook, handshake, or renewal | `trigger-patterns.md` |
 | A prop type you haven't used (dropdowns, dynamic, arrays, files) | `props-patterns.md` |

--- a/.agents/skills/piece-builder/action-patterns.md
+++ b/.agents/skills/piece-builder/action-patterns.md
@@ -7,7 +7,7 @@ Each action goes in its own file under `src/lib/actions/`:
 ```typescript
 import { createAction, Property } from '@activepieces/pieces-framework';
 import { httpClient, HttpMethod, AuthenticationType } from '@activepieces/pieces-common';
-import { myAppAuth } from '../../';
+import { myAppAuth } from '../auth';
 
 export const createRecordAction = createAction({
   auth: myAppAuth,

--- a/.agents/skills/piece-builder/ai-metadata.md
+++ b/.agents/skills/piece-builder/ai-metadata.md
@@ -62,7 +62,7 @@ It is written **for an agent choosing between hundreds of tools**, not for the b
 2. **When to pick it** over neighboring actions — name the materially different sibling or mode if one exists ("for bulk inserts prefer X", "use Y to search by email instead").
 3. **The key constraint** — required pairings, limits, side effects — and the retry behavior in prose ("safe to retry", "each call creates a new record").
 
-Do **not** describe the return shape (output contracts are a separate feature), do not embed worked examples, and do not pad — shorter wins for agent context.
+Keep it to the choose-me guidance — return shapes belong in output contracts (a separate feature), examples belong elsewhere, and padding costs agent context. Shorter wins.
 
 ### Deriving `idempotent`
 

--- a/.agents/skills/piece-builder/auth-patterns.md
+++ b/.agents/skills/piece-builder/auth-patterns.md
@@ -244,8 +244,8 @@ auth: PieceAuth.None(),
 ```
 
 When auth is `None`:
-- Do NOT add `auth:` to `createAction()` / `createTrigger()`
-- Do NOT reference `context.auth` in the `run` function
-- Dropdowns do NOT receive an `auth` parameter
+- Omit `auth:` from `createAction()` / `createTrigger()`
+- `context.auth` is unavailable in `run`
+- Dropdowns receive no `auth` parameter
 
 **Real example:** `packages/pieces/core/qrcode/src/index.ts`

--- a/.agents/skills/piece-builder/auth-patterns.md
+++ b/.agents/skills/piece-builder/auth-patterns.md
@@ -234,6 +234,37 @@ async run(context) {
 
 ---
 
+## Connection Identifier
+
+`getConnectionIdentifier` is an optional callback available on every auth type (`SecretText`, `BasicAuth`, `OAuth2`, `CustomAuth`). It resolves a human-readable label for a connection — e.g. the account email, or Slack's "display-name (workspace)" — shown in the connections UI so users can tell accounts apart.
+
+```typescript
+export const myAppAuth = PieceAuth.OAuth2({
+  required: true,
+  authUrl: 'https://app.example.com/oauth/authorize',
+  tokenUrl: 'https://app.example.com/oauth/token',
+  scope: ['read', 'write'],
+  getConnectionIdentifier: async ({ auth }) => {
+    const response = await httpClient.sendRequest<{ email: string }>({
+      method: HttpMethod.GET,
+      url: 'https://api.example.com/v1/me',
+      headers: { Authorization: `Bearer ${auth.access_token}` },
+    });
+    return response.body.email;
+  },
+});
+```
+
+**Rules:**
+- Wrap risky calls in `try/catch` and resolve to `undefined` when nothing can be determined — this must stay best-effort, since a thrown error blocks the connection save.
+- For `OAuth2`, Activepieces already derives an identifier from the token response's OIDC claims when present. Add this hook only when the provider needs handling the generic path can't cover (e.g. Slack has no per-user OIDC claim — it needs a workspace name plus a follow-up `users.info` call).
+- Add it only when the provider exposes an account/workspace label worth surfacing (a bare API key with no "who am I" endpoint has nothing to resolve).
+- `auth` in the callback matches the same shape as `validate` (flat string for SecretText, flat props object for CustomAuth) — not the full connection object.
+
+**Real example:** `packages/pieces/community/slack/src/lib/auth.ts`
+
+---
+
 ## No Auth
 
 For public APIs or utility pieces that don't need credentials.

--- a/.agents/skills/piece-builder/auth-patterns.md
+++ b/.agents/skills/piece-builder/auth-patterns.md
@@ -236,7 +236,7 @@ async run(context) {
 
 ## Connection Identifier
 
-`getConnectionIdentifier` is an optional callback available on every auth type (`SecretText`, `BasicAuth`, `OAuth2`, `CustomAuth`). It resolves a human-readable label for a connection — e.g. the account email, or Slack's "display-name (workspace)" — shown in the connections UI so users can tell accounts apart.
+`getConnectionIdentifier` is an optional callback available on every auth type (`SecretText`, `BasicAuth`, `OAuth2`, `CustomAuth`). It resolves a human-readable label for a connection (e.g. the account email, or Slack's "display-name (workspace)"), shown in the connections UI so users can tell accounts apart.
 
 ```typescript
 export const myAppAuth = PieceAuth.OAuth2({
@@ -256,10 +256,10 @@ export const myAppAuth = PieceAuth.OAuth2({
 ```
 
 **Rules:**
-- Wrap risky calls in `try/catch` and resolve to `undefined` when nothing can be determined — this must stay best-effort, since a thrown error blocks the connection save.
-- For `OAuth2`, Activepieces already derives an identifier from the token response's OIDC claims when present. Add this hook only when the provider needs handling the generic path can't cover (e.g. Slack has no per-user OIDC claim — it needs a workspace name plus a follow-up `users.info` call).
+- Wrap risky calls in `try/catch` and resolve to `undefined` when nothing can be determined. This must stay best-effort: a thrown error blocks the connection save.
+- For `OAuth2`, Activepieces already derives an identifier from the token response's OIDC claims when present. Add this hook only when the provider needs handling the generic path can't cover (e.g. Slack has no per-user OIDC claim, so it needs a workspace name plus a follow-up `users.info` call).
 - Add it only when the provider exposes an account/workspace label worth surfacing (a bare API key with no "who am I" endpoint has nothing to resolve).
-- `auth` in the callback matches the same shape as `validate` (flat string for SecretText, flat props object for CustomAuth) — not the full connection object.
+- `auth` in the callback matches the same shape as `validate` (flat string for SecretText, flat props object for CustomAuth), not the full connection object.
 
 **Real example:** `packages/pieces/community/slack/src/lib/auth.ts`
 

--- a/.agents/skills/piece-builder/common-patterns.md
+++ b/.agents/skills/piece-builder/common-patterns.md
@@ -79,7 +79,7 @@ import {
   HttpResponse,
 } from '@activepieces/pieces-common';
 import { Property } from '@activepieces/pieces-framework';
-import { myAppAuth } from '../..';
+import { myAppAuth } from '../auth';
 
 const BASE_URL = 'https://api.example.com/v1';
 
@@ -141,7 +141,7 @@ Then use in actions:
 
 ```typescript
 import { myAppCommon, myAppApiCall } from '../common';
-import { myAppAuth } from '../../';
+import { myAppAuth } from '../auth';
 
 export const listTasksAction = createAction({
   auth: myAppAuth,

--- a/.agents/skills/piece-builder/new-piece-scaffold.md
+++ b/.agents/skills/piece-builder/new-piece-scaffold.md
@@ -1,0 +1,78 @@
+# New-Piece Scaffold Files
+
+Copy-ready templates for the four config files a new piece needs. Only "New piece" mode reaches here — add-action and bug-fix modes skip Step 3 entirely.
+
+## `package.json`
+
+```json
+{
+    "name": "@activepieces/piece-<name>",
+    "version": "0.0.1",
+    "main": "./dist/src/index.js",
+    "types": "./dist/src/index.d.ts",
+    "scripts": {
+        "build": "tsc -p tsconfig.lib.json && cp package.json dist/",
+        "lint": "eslint 'src/**/*.ts'"
+    },
+    "dependencies": {
+        "@activepieces/pieces-common": "workspace:*",
+        "@activepieces/pieces-framework": "workspace:*",
+        "@activepieces/shared": "workspace:*",
+        "tslib": "2.6.2"
+    }
+}
+```
+
+Add third-party SDKs to `dependencies` with a pinned version (e.g. `"stripe": "18.2.1"`).
+
+## `.eslintrc.json`
+
+```json
+{
+    "extends": ["../../../../.eslintrc.json"],
+    "ignorePatterns": ["!**/*"],
+    "overrides": [
+        { "files": ["*.ts", "*.tsx", "*.js", "*.jsx"], "rules": {} },
+        { "files": ["*.ts", "*.tsx"], "rules": {} },
+        { "files": ["*.js", "*.jsx"], "rules": {} }
+    ]
+}
+```
+
+## `tsconfig.json`
+
+```json
+{
+    "extends": "../../../../tsconfig.base.json",
+    "compilerOptions": {
+        "module": "commonjs",
+        "forceConsistentCasingInFileNames": true,
+        "strict": true,
+        "noImplicitOverride": true,
+        "noPropertyAccessFromIndexSignature": true,
+        "noImplicitReturns": true,
+        "noFallthroughCasesInSwitch": true
+    },
+    "files": [],
+    "include": [],
+    "references": [{ "path": "./tsconfig.lib.json" }]
+}
+```
+
+## `tsconfig.lib.json`
+
+```json
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "rootDir": ".",
+        "baseUrl": ".",
+        "paths": {},
+        "outDir": "./dist",
+        "declaration": true,
+        "types": ["node"]
+    },
+    "include": ["src/**/*.ts"],
+    "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"]
+}
+```

--- a/.agents/skills/piece-builder/props-patterns.md
+++ b/.agents/skills/piece-builder/props-patterns.md
@@ -129,7 +129,7 @@ Property.StaticMultiSelectDropdown({
 
 ## Dynamic Dropdown (fetches from API)
 
-> **Always pass `auth`.** Every `Property.Dropdown`, `Property.MultiSelectDropdown`, and `Property.DynamicProperties` whose `options`/`props` callback reads `auth` MUST set `auth: <pieceAuth>` (e.g. `auth: myAppAuth`). Without it, `auth` is `undefined` in the callback and the dropdown can never load. Import the auth object from the piece's `auth.ts` (or `../..`). See `packages/pieces/community/github/src/lib/common/index.ts` for the real pattern.
+> **Always pass `auth`.** Every `Property.Dropdown`, `Property.MultiSelectDropdown`, and `Property.DynamicProperties` whose `options`/`props` callback reads `auth` MUST set `auth: <pieceAuth>` (e.g. `auth: myAppAuth`). Without it, `auth` is `undefined` in the callback and the dropdown can never load. Import the auth object from `../auth` (relative to `src/lib/*`) — never from a re-export on `src/index.ts`. See `packages/pieces/community/github/src/lib/common/index.ts` for the real pattern.
 
 > **No cast needed — `auth` is already typed.** Setting `auth: myAppAuth` does double duty: it makes `auth` available in the callback *and* tells TypeScript the connection type. The framework uses that `auth` field purely to infer the type, so inside the callback `auth.secret_text` (SecretText), `auth.access_token` (OAuth2), and `auth.props.<field>` (CustomAuth) are all correctly typed — read them directly. Never write `auth as { secret_text: string }` or any cast; it's redundant and the repo bans casts. (Real no-cast examples: `airtable`, `baremetrics`, `todoist` common files.)
 

--- a/.agents/skills/piece-builder/trigger-patterns.md
+++ b/.agents/skills/piece-builder/trigger-patterns.md
@@ -8,7 +8,7 @@ Prefer webhooks when the API supports them -- they are instant and use fewer res
 
 ## Polling Trigger
 
-Use when the API does NOT support webhooks. Activepieces polls every ~5 minutes.
+Use when the API has no webhook support. Activepieces polls every ~5 minutes.
 
 Two deduplication strategies:
 - **TIMEBASED** -- Each item has a timestamp; only items newer than last poll are returned
@@ -16,14 +16,14 @@ Two deduplication strategies:
 
 **Always pass the whole `context`** to `pollingHelper.onEnable` / `onDisable` / `poll` / `test` -- never a subset like `{ store, auth, propsValue }`. Every field on the helper's param type is optional, so a partial object type-checks and whatever you left out is dropped in silence. The set also grows: `onEnable` now reads `context.isRepublish` to keep the existing `lastPoll`/`lastItem` when a running flow is republished, so a subset call still resets the checkpoint and drops every event since the last poll.
 
-**Editing an existing polling trigger? Fix its call while you're there.** Most pieces in the repo still pass the subset. If you touch one -- new trigger, bug fix, anything -- switch every `pollingHelper` call in that piece to pass `context`. You are already bumping the version and rebuilding, so the fix costs nothing extra and gets verified with your change; a one-shot codemod across every piece instead means a huge unreviewable diff and a forced version bump on pieces nobody runs. Mention the fix in your PR description so it doesn't read as an unrelated change.
+**Editing an existing polling trigger? Fix every `pollingHelper` call in the piece while you're there.** Most pieces in the repo still pass the subset — the SKILL.md carve-out explains why fix-on-touch beats a repo-wide codemod. Mention the fix in your PR description so it doesn't read as an unrelated change.
 
 ### TIMEBASED Polling (most common)
 
 ```typescript
 import { createTrigger, TriggerStrategy, AppConnectionValueForAuthProperty } from '@activepieces/pieces-framework';
 import { DedupeStrategy, Polling, pollingHelper, httpClient, HttpMethod, AuthenticationType } from '@activepieces/pieces-common';
-import { myAppAuth } from '../../';
+import { myAppAuth } from '../auth';
 
 const polling: Polling<AppConnectionValueForAuthProperty<typeof myAppAuth>, Record<string, never>> = {
   strategy: DedupeStrategy.TIMEBASED,
@@ -135,7 +135,7 @@ Use when the API supports webhook registration. The flow:
 ```typescript
 import { createTrigger, TriggerStrategy } from '@activepieces/pieces-framework';
 import { httpClient, HttpMethod, AuthenticationType } from '@activepieces/pieces-common';
-import { myAppAuth } from '../../';
+import { myAppAuth } from '../auth';
 
 export const newRecordWebhookTrigger = createTrigger({
   auth: myAppAuth,

--- a/.agents/skills/piece-output-schema/SKILL.md
+++ b/.agents/skills/piece-output-schema/SKILL.md
@@ -1,32 +1,31 @@
 ---
 name: piece-output-schema
-description: Generate and wire `outputSchema` for an Activepieces piece's actions and triggers. Use when the user asks to add output schemas to a piece, curate a step's output for the data selector / output viewer, or improve how a piece's step output appears in the builder. Captures each step's REAL output against a live connection, curates the useful fields, and writes typed, labelled schemas.
+description: Generate `outputSchema` for an Activepieces piece's actions and triggers, so a step's output renders as a curated, labelled tree in the flow builder and data selector. Use when the user asks to add or improve outputSchema for a piece.
 ---
 
 # Piece Output Schema Generator
 
 An `outputSchema` turns a step's raw JSON output into a **friendly, typed, labelled tree** in the flow builder's data selector and output viewer — and a **path map** that LLM/MCP consumers use to find the fields that matter. This skill takes a piece from "raw JSON dump" to curated schemas across all its actions and triggers.
 
-Reference: the merged 15-piece PR is [activepieces#13757](https://github.com/activepieces/activepieces/pull/13757). Look at any of those pieces' `src/lib/output-schemas.ts` for a finished example (ClickUp is the richest; `google-docs` and `google-calendar` are readable smaller ones).
+Read a shipped example before starting: `packages/pieces/community/clickup/src/lib/output-schemas.ts` is the richest; `google-docs` and `google-calendar` are readable smaller ones.
 
 ## The mental model (read this first)
 
 An `outputSchema` is **a curated tree**: at every level you describe, only the fields you list appear — their siblings are dropped. That is exactly how you keep the output clean.
 
 - **Omitting a field hides it.** At the top level, only the fields in `schema.fields` render; undescribed root siblings are gone. Inside a described object (`children`) or array item (`listItems`), only the children you list render — the resolved value's other keys are dropped.
-- **One exception — an *undescribed* container is fully drilled, not hidden.** If you *name* a field but do **not** describe its inner shape (no `children`/`listItems`), the renderer drills the whole value generically (matrices → Row/Cell, arrays → list, objects → every key) instead of dead-ending. So you either describe a container's useful inner fields **or** leave the field off entirely — you cannot name a container and show only *some* of its contents without listing them.
-- What the schema therefore does: (1) **curate** — list the fields worth surfacing, drop the rest; (2) **label** them for humans; (3) attach **formats** (`datetime`, `url`, `email`, …) so values render nicely; (4) record **paths** so the data selector and AI/MCP consumers can find the important fields.
-- Practically: **describe the fields a user actually needs**, describe the important nested/deep ones, apply formats and labels, and leave the API's internal noise (config, headers, tokens, opaque bookkeeping ids) off the list.
+- **Undescribed container drills, not hides.** If you *name* a field but do not describe its inner shape (no `children`/`listItems`), the renderer drills the whole value generically (matrices → Row/Cell, arrays → list, objects → every key). Describe a container's useful inner fields, or leave the field off entirely — there is no way to name a container and show only *some* of its contents without listing them.
+- **What you're doing at each field:** curate (drop config/headers/tokens/opaque bookkeeping), label for humans, attach a **format** (`datetime`, `url`, `email`, `boolean`, `image`, `filesize`, `html`, `number`, `date`, `currency`, `duration`) where one fits, and record the **path** so data selector and AI/MCP consumers can find it.
 
 Because the schema describes **what the action's `run()` returns** (not the raw third-party API response), you must know the return shape before you can map paths. See [capture-recipes.md](./capture-recipes.md).
 
 ## Prerequisites
 
 1. A **running local dev instance** (`npm start` / `npm run dev`). Dev pieces load from each piece's built `dist/` — see [capture-recipes.md](./capture-recipes.md#dev-piece-reload) if a piece doesn't appear.
-2. A **real, active connection** for the target piece (the user provides credentials — OAuth sign-in, API key, etc.). Prefer running steps through the piece (Test Step) so the engine handles token refresh; raw API calls with a stale OAuth token will 401.
-3. If the piece isn't already loaded as a dev piece, add its folder name to `AP_DEV_PIECES`.
+2. A **real, active connection** for the target piece — OAuth sign-in, API key, or whatever the piece's auth type requires. The user provides credentials.
+3. A piece not yet loaded as a dev piece gets its folder name appended to `AP_DEV_PIECES`.
 
-**Ask the user** for: which piece(s), and the connection/credentials to use, before starting.
+**Ask the user** for the piece(s) and the connection to use before starting.
 
 ## Workflow
 
@@ -45,9 +44,9 @@ List the piece's actions and triggers (`packages/pieces/community/<piece>/src/li
 Open the action/trigger's `run()` (and `test()` for triggers). Note whether it returns `response.body`, `response.data`, the **full HTTP/Gaxios wrapper** (`{status, headers, body, config}`), or a hand-built/transformed object. **Never surface `config` or `headers`** — `config.headers.Authorization` leaks the bearer token. The schema's top-level `value` paths are relative to this returned object.
 
 ### Step 3 — Capture the REAL output
-Run each step against the live connection and capture the exact output JSON. Full recipes in [capture-recipes.md](./capture-recipes.md). In short:
-- **Preferred:** builder **Test Step** (UI, or drive it with the browser MCP), or the `POST /v1/sample-data/test-step` API once a flow with the step exists. This runs the piece's own code — faithful output, and the engine refreshes OAuth tokens for you.
-- **Empty READ → WRITE first:** if a list/search/get returns empty because there's no data, run the corresponding **create/write** action first to seed data (chain the new id into the read's input), then re-run the read. This is a core part of the job — do not author a list schema from an empty `[]`.
+Run each step against the live connection and capture the exact output JSON. Full recipes in [capture-recipes.md](./capture-recipes.md).
+- **Preferred:** builder **Test Step** (UI, or drive it with the browser MCP), or the `POST /v1/sample-data/test-step` API once a flow with the step exists. Running the piece's own code delivers faithful output and lets the engine refresh OAuth tokens for you.
+- **Empty READ → WRITE first:** if a list/search/get returns an empty payload because the account has no data, seed data by running the corresponding **create/write** action first, then chain the new id into the read's input and re-run. Never author a list schema from an empty `[]`.
 
 ### Step 4 — Curate and author the schema
 Write the schema in `packages/pieces/community/<piece>/src/lib/output-schemas.ts` (create the file if absent). Full field reference, formats, labels, and wiring in [schema-reference.md](./schema-reference.md). The essentials:
@@ -61,11 +60,11 @@ Write the schema in `packages/pieces/community/<piece>/src/lib/output-schemas.ts
 - **Reuse shared field-sets** — factor a repeated object shape (e.g. `taskFields`, a Drive `fileFields`) into a `const` and reference it from every action/trigger that returns it.
 
 ### Step 5 — Validate every path
-For each field, confirm its path (`value ?? key`) resolves against the captured JSON **at the correct scope** (top-level against the root; children against the parent object; listItems against one array item). A path that doesn't resolve is a dead field. Re-capture if the shape is ambiguous. When many schemas are involved, verify them adversarially (one checker per schema against its real payload).
+Resolve every field's `value ?? key` against the captured JSON **at the correct scope** — top-level against the root, `children` against the parent object, `listItems` against one array item. A path that doesn't resolve is a dead field; re-capture if the shape is ambiguous. For a piece with many schemas, verify each one adversarially — one sub-agent per schema, given only the schema and its captured payload, asked to find any path that fails to resolve.
 
 ### Step 6 — Wire, version, build, lint
 - Add `outputSchema: <name>` to each action/trigger object (or populate the trigger registration map — see [schema-reference.md](./schema-reference.md#wiring)).
-- **Bump the piece's patch version** in its `package.json` (every touched piece).
+- **Bump the piece's patch version** in its `package.json` (every touched piece) — this is what forces cloud/self-hosted registries to re-ingest the fresh metadata.
 - Rebuild the piece and reload the dev instance ([capture-recipes.md](./capture-recipes.md#dev-piece-reload)); confirm the friendly tree renders in the builder.
 - Run `npm run lint-dev` (or `npx turbo run lint --filter=@activepieces/piece-<name>`). Typecheck must be clean.
 
@@ -78,7 +77,7 @@ For each field, confirm its path (`value ?? key`) resolves against the captured 
 - [ ] Each touched piece's patch version bumped; build + `lint-dev` green; friendly tree verified in the builder.
 
 ## Note: how the schema reaches the builder
-`outputSchema` is delivered via **served piece metadata** (dev pieces from `dist/`, published pieces from the registry). A past cloud bug stripped `outputSchema` during registry ingestion (`POST /v1/admin/pieces`) — **fixed in #13983**, which added `outputSchema` to the ingestion schema — so it's only a concern on server builds older than that fix. If a schema doesn't show up, first confirm the piece version was bumped and the served metadata actually carries `outputSchema` (rebuild + reload for dev pieces) before suspecting anything platform-side.
+`outputSchema` ships as part of the served piece metadata (dev pieces from `dist/`, published pieces from the registry). If a schema doesn't appear in the builder, confirm the piece's patch version was bumped and the piece was rebuilt + reloaded — that's the served metadata refreshing. Legacy servers older than #13983 stripped `outputSchema` during registry ingestion; irrelevant for current builds.
 
 ## Related
 - `piece-builder` skill — building pieces and the `output-quality.md` reference (shaping `run()` return values for table-readiness) complements this skill, which describes an *existing* return.

--- a/.agents/skills/piece-output-schema/capture-recipes.md
+++ b/.agents/skills/piece-output-schema/capture-recipes.md
@@ -15,7 +15,7 @@ OAuth caveat: some Google pieces construct a client that doesn't auto-refresh, s
 
 Ask the user for credentials, then create the connection:
 
-- **OAuth2 pieces** (Gmail, the Google pieces, most social/CRM apps): connect through the **builder UI sign-in** (Connections → New → authorize) — the browser MCP can drive it. Do **not** create these over the API: you won't have a valid access token. And do **not** capture against a cloud backend (`--mode=cloud`) — the OAuth redirect returns to `cloud.activepieces.com`, not your localhost; use a fully-local instance.
+- **OAuth2 pieces** (Gmail, the Google pieces, most social/CRM apps): connect through the **builder UI sign-in** (Connections → New → authorize) — the browser MCP can drive it. The API path yields no valid access token, so it must go through the UI. Run against a fully-local instance (never `--mode=cloud`) — OAuth redirects return to `cloud.activepieces.com`, not localhost.
 - **API-key / token / basic-auth pieces:** create via the UI or `POST /v1/app-connections` (body includes `externalId`, `pieceName`, `type`, `value`).
 
 Note the connection's **external id** — step input references it as `{{connections['<externalId>']}}`.
@@ -46,9 +46,9 @@ GET  /v1/sample-data?flowId=&flowVersionId=&stepName=&projectId=&type=OUTPUT
 
 Dev sign-in for a fresh local instance is typically `dev@ap.com` / `12345678`. The backend is proxied at `http://localhost:4200/api` in dev (not the API port directly).
 
-**Prerequisite:** a flow must already exist with the step configured (connection + props). The endpoint needs a `flowVersionId` + `stepName`; it does not create the step for you. Build the flow once in the UI (§2), then the API is handy for re-running after you tweak inputs or seed data. Constructing the flow purely over the API means driving the flow-update operations (`UPDATE_TRIGGER` / add-action) — heavier; only worth it when scripting many steps.
+**Prerequisite:** a flow with the step already configured (connection + props) — the endpoint needs a `flowVersionId` + `stepName` and does not create the step. Build the flow once in the UI (§2); the API is then handy for re-runs after input tweaks or seeded data. Constructing the flow purely over the API means driving the flow-update operations (`UPDATE_TRIGGER` / add-action) — heavier, only worth it when scripting many steps.
 
-Write throwaway driver scripts under `/tmp` (e.g. `/tmp/<piece>_capture.mjs`) — do not commit them.
+Driver scripts live under `/tmp` (e.g. `/tmp/<piece>_capture.mjs`) — throwaways, kept out of the repo.
 
 > Editing a **server** source file while a capture run is in flight hot-restarts the API and can wedge the worker (jobs stuck QUEUED). Only edit web/piece files mid-run, or restart the instance to recover.
 

--- a/.agents/skills/piece-output-schema/schema-reference.md
+++ b/.agents/skills/piece-output-schema/schema-reference.md
@@ -32,7 +32,7 @@ Every field has a required `key` and an optional `value` (the path). **When `val
 
 - **Plain field:** set `key` to the real JSON property name and **omit `value`** — the dominant shipped style (e.g. google-calendar's `eventOutputSchema` fields are all `{ key, label }`, no `value`).
 - **Set `value`** only when the path must differ from the `key` you want to show: to **unwrap** (`value: 'body'`, `value: 'data.documentId'`) or to give a field a cleaner `key`/label than its raw property name.
-- The AI/MCP path map (`flattenOutputSchemaFields` in `packages/server/api/src/app/mcp/tools/mcp-utils.ts`) resolves `value ?? key` exactly like the builder, so a `key != value` field exports its real `value` path to agents too. `key` is purely the field's identity/label; the path always comes from `value ?? key`.
+- The AI/MCP path map (`flattenOutputSchemaFields` in `packages/server/api/src/app/mcp/tools/mcp-utils.ts`) resolves `value ?? key` exactly like the builder — `key` is the field's identity/label; the path is always `value ?? key`.
 
 ## The relative-path rule (most important)
 
@@ -91,15 +91,14 @@ export const findRowsActionOutputSchema: OutputSchema = {
 
 ## Maps with opaque / variable keys → `dynamicKey`
 
-When an object's keys are *data* (calendar ids, column letters, user ids) rather than a fixed schema, mark the field `dynamicKey: true`. In the builder, each entry is **drilled generically** from the sample and labelled by `labelKey`; the entry's own `children`/`listItems` are **not rendered** in the data selector or output viewer. (They *are* still walked by the AI/MCP path map, so include them only when that path map matters — otherwise `labelKey` plus the field's `label`/`format` is all that has an effect.) The inserted expression path always uses the opaque key; `labelKey` only changes the displayed label.
+When an object's keys are *data* (calendar ids, column letters, user ids) rather than a fixed schema, mark the field `dynamicKey: true`. Each entry is drilled generically in the builder and labelled by `labelKey`; the inserted expression path uses the opaque key regardless.
+
+Under `dynamicKey`, nested `children` / `listItems` are **not** rendered in the data selector — the AI/MCP path map still walks them, so include them only when that path map matters. Otherwise `labelKey` + `label` + `format` is all that has an effect.
 
 ```ts
 // freeBusy: { calendars: { "<calendarId>": { busy: [{ start, end }] } } }
 {
   key: 'calendars', label: 'Calendars', dynamicKey: true,
-  // children below do NOT render in the builder (each calendar entry drills
-  // generically); they only enrich the AI/MCP path map. Drop them if you don't
-  // need that. labelKey on `busy` labels each period by its start time.
   children: [
     {
       key: 'busy', label: 'Busy Periods', labelKey: 'start',
@@ -156,8 +155,6 @@ export const findDocumentActionOutputSchema: OutputSchema = {
 export const newDocumentTriggerOutputSchema: OutputSchema = { fields: driveFileFields };
 ```
 
-(Some shipped files set `value` explicitly on every field, e.g. `value: 'id'`; that's equivalent — `value` defaults to `key` — just more verbose. Match the file you're editing.)
-
 ## Wiring
 
 ### Actions — inline `outputSchema:` on the `createAction` object
@@ -198,5 +195,4 @@ outputSchema: clickupTriggerOutputSchemas[name],
 - File location: `packages/pieces/community/<piece>/src/lib/output-schemas.ts`.
 - Import path from a step file: match the file's depth. Actions/triggers one level under `lib/` (`lib/actions/x.ts`) import `../output-schemas`; deeper folders (`lib/actions/tasks/x.ts`) use `../../output-schemas`. Watch **multi-line import blocks** — insert the new import after the `} from '...';` that closes the block, never inside it.
 - Write clean TypeScript object literals (unquoted keys, single quotes), consistent with `google-docs`'s file. Some shipped files are generator-emitted JSON style (quoted keys) — when editing one of those, match its existing style rather than mixing.
-- Order within `output-schemas.ts`: imports, then the **non-exported shared field-set `const`s**, then the **exported schema `const`s** that reference them. The exports must come *after* the field-sets they consume (JS declaration order — a schema const referencing a field-set declared below it throws at module load), which is exactly how the shipped files are laid out (e.g. `google-docs`'s `driveFileFields` precedes the exported schemas). Type shared field-sets as `OutputSchema['fields']`.
-- **Version bump:** bump the **patch** version in each touched piece's `package.json`. This is also what forces cloud/self-hosted registries to re-ingest fresh metadata.
+- Order within `output-schemas.ts`: imports → non-exported shared field-set `const`s → exported schema `const`s that reference them. JS declaration order matters — a schema referencing a field-set declared below it throws at module load. Type shared field-sets as `OutputSchema['fields']`. See `google-docs` for the canonical layout.

--- a/docs/build-pieces/misc/migrate-pieces-to-bundles.mdx
+++ b/docs/build-pieces/misc/migrate-pieces-to-bundles.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Migrate Pieces to Self-Contained Bundles'
-icon: 'package'
+icon: 'boxes-stacked'
 ---
 
 <Note>

--- a/docs/build-pieces/piece-reference/authentication.mdx
+++ b/docs/build-pieces/piece-reference/authentication.mdx
@@ -202,7 +202,7 @@ Please note `OAuth2GrantType.CLIENT_CREDENTIALS` is also supported for service-b
 
 ### Connection Identifier
 
-Every auth type (`SecretText`, `BasicAuth`, `OAuth2`, `CustomAuth`) accepts an optional `getConnectionIdentifier` callback. It resolves a human-readable label for a connection — e.g. the account email, or Slack's "display-name (workspace)" — shown in the UI so users can tell which account a connection belongs to.
+Every auth type (`SecretText`, `BasicAuth`, `OAuth2`, `CustomAuth`) accepts an optional `getConnectionIdentifier` callback. It resolves a human-readable label for a connection (e.g. the account email, or Slack's "display-name (workspace)"), shown in the UI so users can tell which account a connection belongs to.
 
 **Example:**
 
@@ -225,5 +225,5 @@ PieceAuth.OAuth2({
 ```
 
 <Note>
-This is best-effort: it must never throw, and returning `undefined` is fine when no identifier can be resolved. For OAuth2 connections, Activepieces already derives an identifier from the token response's OIDC claims when present — only add `getConnectionIdentifier` when the provider needs custom handling (e.g. Slack's workspace + user lookup).
+This is best-effort: it must never throw, and returning `undefined` is fine when no identifier can be resolved. For OAuth2 connections, Activepieces already derives an identifier from the token response's OIDC claims when present. Only add `getConnectionIdentifier` when the provider needs custom handling (e.g. Slack's workspace + user lookup).
 </Note>

--- a/docs/build-pieces/piece-reference/authentication.mdx
+++ b/docs/build-pieces/piece-reference/authentication.mdx
@@ -199,3 +199,31 @@ PieceAuth.OAuth2({
 <Tip>
 Please note `OAuth2GrantType.CLIENT_CREDENTIALS` is also supported for service-based authentication.
 </Tip>
+
+### Connection Identifier
+
+Every auth type (`SecretText`, `BasicAuth`, `OAuth2`, `CustomAuth`) accepts an optional `getConnectionIdentifier` callback. It resolves a human-readable label for a connection — e.g. the account email, or Slack's "display-name (workspace)" — shown in the UI so users can tell which account a connection belongs to.
+
+**Example:**
+
+```typescript
+PieceAuth.OAuth2({
+    displayName: 'OAuth2 Authentication',
+    authUrl: 'https://example.com/auth',
+    tokenUrl: 'https://example.com/token',
+    required: true,
+    scope: ['read', 'write'],
+    getConnectionIdentifier: async ({ auth }) => {
+        const response = await httpClient.sendRequest<{ email: string }>({
+            method: HttpMethod.GET,
+            url: 'https://api.example.com/v1/me',
+            headers: { Authorization: `Bearer ${auth.access_token}` },
+        });
+        return response.body.email;
+    },
+})
+```
+
+<Note>
+This is best-effort: it must never throw, and returning `undefined` is fine when no identifier can be resolved. For OAuth2 connections, Activepieces already derives an identifier from the token response's OIDC claims when present — only add `getConnectionIdentifier` when the provider needs custom handling (e.g. Slack's workspace + user lookup).
+</Note>


### PR DESCRIPTION
## Description

Writing-for-agents optimization pass on the two agent skills under `.agents/skills/`
that guide piece authoring, plus documentation for a previously-undocumented auth hook.

**Levers applied (piece-builder / piece-output-schema skills):**
- Description pointers tightened (one-branch triggers, no synonym expansions)
- Duplication cut with inline workflow sections (killed the 7-item Critical Reminders in piece-builder, of which 5 were pure restatements)
- Negations flipped to positive+guardrail where possible
- Cross-file inconsistency fixed: auth-import path in reference files (`../..` / `../../` → `../auth`) now matches the skill's own "never re-export auth from `index.ts`" rule
- New-piece config templates (tsconfig, eslint, package.json) moved to `new-piece-scaffold.md` so they load only for the New-piece branch

**Size changes on always-loaded main files:**
- `piece-builder/SKILL.md`: 321 → 233 lines
- `piece-output-schema/SKILL.md`: 106 → 84 lines

**`getConnectionIdentifier` documentation added:**
- The `getConnectionIdentifier` auth callback (shipped via #14402/#14403) resolves a human-readable connection label (account email, Slack workspace) but wasn't mentioned anywhere in the piece docs or the piece-builder skill.
- Added a "Connection Identifier" section to `docs/build-pieces/piece-reference/authentication.mdx` (usage, example, best-effort semantics, when to skip it given the built-in OAuth2 OIDC fallback).
- Added the same pattern to `.agents/skills/piece-builder/auth-patterns.md`, plus a routing-table row in `SKILL.md` so Claude discovers it when a piece needs to label a connection in the UI.

No shipped-code changes in either part of this PR.

## How was this tested?

Reviewed each file end-to-end; verified auth-import consistency with grep; confirmed `getConnectionIdentifier` behavior by reading `packages/pieces/framework/src/lib/property/authentication/common.ts`, `packages/server/engine/src/lib/helper/piece-helper.ts`, and `packages/server/api/src/app/app-connection/app-connection-service/app-connection-service.ts`, and cross-checked against the real usage in `packages/pieces/community/slack/src/lib/auth.ts`. No code paths touched — all changes are agent-consumed markdown / docs.

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)