### PR TITLE
fix(management): show all piece sets (pagination) in Platform Admin

### DIFF
--- a/packages/server/api/src/app/ee/pieces/piece-set/piece-set.service.ts
+++ b/packages/server/api/src/app/ee/pieces/piece-set/piece-set.service.ts
@@ -5,6 +5,8 @@ import { EntityManager, In, QueryFailedError } from 'typeorm'
 import { repoFactory } from '../../../core/db/repo-factory'
 import { transaction } from '../../../core/db/transaction'
 import { distributedLock } from '../../../database/redis-connections'
+import { buildPaginator } from '../../../helper/pagination/build-paginator'
+import { paginationHelper } from '../../../helper/pagination/pagination-utils'
 import { pieceSetConfig } from './piece-set-config'
 import { PieceSetEntity } from './piece-set.entity'
 
@@ -75,29 +77,20 @@ export const pieceSetService = (log: FastifyBaseLogger) => ({
 
     async list({ platformId, cursor, limit = 10 }: ListParams): Promise<SeekPage<PieceSet>> {
         const boundedLimit = Math.min(limit, MAX_PIECE_SET_PAGE_SIZE)
-        const qb = pieceSetRepo()
-            .createQueryBuilder('ps')
-            .where('ps.platformId = :platformId', { platformId })
-            .orderBy('ps.created', 'ASC')
-            .addOrderBy('ps.id', 'ASC')
-            .take(boundedLimit + 1)
-
-        if (cursor) {
-            qb.andWhere(
-                '(ps.created, ps.id) > (SELECT created, id FROM piece_set WHERE id = :cursorId AND "platformId" = :platformId)',
-                { cursorId: cursor, platformId },
-            )
-        }
-
-        const rows = await qb.getMany()
-        const hasMore = rows.length > boundedLimit
-        const data = hasMore ? rows.slice(0, boundedLimit) : rows
-
-        return {
-            data,
-            next: hasMore ? data[data.length - 1].id : null,
-            previous: cursor ? data[0]?.id ?? null : null,
-        }
+        const decodedCursor = paginationHelper.decodeCursor(cursor ?? null)
+        const paginator = buildPaginator({
+            entity: PieceSetEntity,
+            query: {
+                limit: boundedLimit,
+                order: 'ASC',
+                afterCursor: decodedCursor.nextCursor,
+                beforeCursor: decodedCursor.previousCursor,
+            },
+        })
+        const { data, cursor: newCursor } = await paginator.paginate(
+            pieceSetRepo().createQueryBuilder('piece_set').where({ platformId }),
+        )
+        return paginationHelper.createPage<PieceSet>(data, newCursor)
     },
 
     async getOne({ id, platformId }: GetOneParams): Promise<PieceSet> {

--- a/packages/server/api/src/app/ee/pieces/piece-set/piece-set.service.ts
+++ b/packages/server/api/src/app/ee/pieces/piece-set/piece-set.service.ts
@@ -10,7 +10,7 @@ import { paginationHelper } from '../../../helper/pagination/pagination-utils'
 import { pieceSetConfig } from './piece-set-config'
 import { PieceSetEntity } from './piece-set.entity'
 
-export const pieceSetRepo = repoFactory<PieceSet>(PieceSetEntity)
+export const pieceSetRepo = repoFactory(PieceSetEntity)
 
 const MAX_PIECE_SET_PAGE_SIZE = 100
 

--- a/packages/server/api/test/integration/ee/piece-sets/piece-sets.test.ts
+++ b/packages/server/api/test/integration/ee/piece-sets/piece-sets.test.ts
@@ -88,6 +88,48 @@ describe('Piece Sets API', () => {
             expect(body.data.length).toBe(1)
             expect(body.data[0].name).toBe('My Set')
         })
+
+        it('paginates forward and back with cursors', async () => {
+            const { token } = await setupPlatformWithPieceSets()
+            for (let i = 0; i < 5; i++) {
+                await app!.inject({
+                    method: 'POST',
+                    url: '/api/v1/piece-sets',
+                    headers: { authorization: `Bearer ${token}` },
+                    body: { name: `Set ${i}` },
+                })
+            }
+
+            const firstPage = await app!.inject({
+                method: 'GET',
+                url: '/api/v1/piece-sets?limit=2',
+                headers: { authorization: `Bearer ${token}` },
+            })
+            expect(firstPage.statusCode).toBe(StatusCodes.OK)
+            const firstBody = firstPage.json()
+            expect(firstBody.data.length).toBe(2)
+            expect(firstBody.next).not.toBeNull()
+
+            const secondPage = await app!.inject({
+                method: 'GET',
+                url: `/api/v1/piece-sets?limit=2&cursor=${encodeURIComponent(firstBody.next)}`,
+                headers: { authorization: `Bearer ${token}` },
+            })
+            expect(secondPage.statusCode).toBe(StatusCodes.OK)
+            const secondBody = secondPage.json()
+            expect(secondBody.data.length).toBe(2)
+            expect(secondBody.previous).not.toBeNull()
+            expect(secondBody.data.map((s: PieceSet) => s.id)).not.toEqual(firstBody.data.map((s: PieceSet) => s.id))
+
+            const backToFirstPage = await app!.inject({
+                method: 'GET',
+                url: `/api/v1/piece-sets?limit=2&cursor=${encodeURIComponent(secondBody.previous)}`,
+                headers: { authorization: `Bearer ${token}` },
+            })
+            expect(backToFirstPage.statusCode).toBe(StatusCodes.OK)
+            const backBody = backToFirstPage.json()
+            expect(backBody.data.map((s: PieceSet) => s.id)).toEqual(firstBody.data.map((s: PieceSet) => s.id))
+        })
     })
 
     describe('Create', () => {

--- a/packages/web/src/app/routes/platform/setup/pieces/piece-sets/piece-sets-tab.tsx
+++ b/packages/web/src/app/routes/platform/setup/pieces/piece-sets/piece-sets-tab.tsx
@@ -12,9 +12,13 @@ import {
   Trash2,
 } from 'lucide-react';
 import { useMemo, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 
-import { DataTable, RowDataWithActions } from '@/components/custom/data-table';
+import {
+  CURSOR_QUERY_PARAM,
+  DataTable,
+  RowDataWithActions,
+} from '@/components/custom/data-table';
 import { DataTableColumnHeader } from '@/components/custom/data-table/data-table-column-header';
 import { ConfirmationDeleteDialog } from '@/components/custom/delete-dialog';
 import { Badge } from '@/components/ui/badge';
@@ -32,14 +36,19 @@ import { EditPieceSetDialog } from './edit-piece-set-dialog';
 
 export const PieceSetsTab = () => {
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
   const [duplicatingSet, setDuplicatingSet] = useState<PieceSet | null>(null);
   const [editingSet, setEditingSet] = useState<PieceSet | null>(null);
+
+  const cursor = searchParams.get(CURSOR_QUERY_PARAM) ?? undefined;
+  const limitParam = searchParams.get('limit');
+  const limit = limitParam ? parseInt(limitParam, 10) : undefined;
 
   const {
     data: pieceSetsPage,
     isLoading,
     refetch,
-  } = pieceSetQueries.usePieceSets();
+  } = pieceSetQueries.usePieceSets({ cursor, limit });
   const { mutate: deleteSet } = pieceSetMutations.useDeletePieceSet();
 
   const pieceSets = useMemo(() => pieceSetsPage?.data ?? [], [pieceSetsPage]);
@@ -174,11 +183,10 @@ export const PieceSetsTab = () => {
         ]}
         page={{
           data: pieceSets,
-          next: null,
-          previous: null,
+          next: pieceSetsPage?.next ?? null,
+          previous: pieceSetsPage?.previous ?? null,
         }}
         isLoading={isLoading}
-        hidePagination={true}
         clientFiltering={true}
         toolbarButtons={[
           <CreatePieceSetDialog key="create" onCreated={() => refetch()} />,

--- a/packages/web/src/features/piece-sets/api/piece-sets-api.ts
+++ b/packages/web/src/features/piece-sets/api/piece-sets-api.ts
@@ -3,6 +3,7 @@ import {
   AssignProjectsRequestBody,
   CreatePieceSetRequestBody,
   DuplicatePieceSetRequestBody,
+  ListPieceSetsRequestQuery,
   PieceSet,
   UpdatePieceSetRequestBody,
 } from '@activepieces/shared';
@@ -10,8 +11,8 @@ import {
 import { api } from '@/lib/api';
 
 export const pieceSetsApi = {
-  list() {
-    return api.get<SeekPage<PieceSet>>('/v1/piece-sets');
+  list(request: Partial<ListPieceSetsRequestQuery> = {}) {
+    return api.get<SeekPage<PieceSet>>('/v1/piece-sets', request);
   },
   get(id: string) {
     return api.get<PieceSet>(`/v1/piece-sets/${id}`);

--- a/packages/web/src/features/piece-sets/hooks/piece-sets-hooks.ts
+++ b/packages/web/src/features/piece-sets/hooks/piece-sets-hooks.ts
@@ -14,15 +14,20 @@ import { pieceSetsApi } from '../api/piece-sets-api';
 
 export const pieceSetKeys = {
   all: ['piece-sets'] as const,
+  page: (cursor: string | undefined, limit: number | undefined) =>
+    ['piece-sets', 'page', cursor ?? null, limit ?? null] as const,
   one: (id: string) => ['piece-sets', id] as const,
 };
 
 export const pieceSetQueries = {
-  usePieceSets: () => {
+  usePieceSets: ({
+    cursor,
+    limit,
+  }: { cursor?: string; limit?: number } = {}) => {
     const { platform } = platformHooks.useCurrentPlatform();
     return useQuery({
-      queryKey: pieceSetKeys.all,
-      queryFn: () => pieceSetsApi.list(),
+      queryKey: pieceSetKeys.page(cursor, limit),
+      queryFn: () => pieceSetsApi.list({ cursor, limit }),
       enabled: platform.plan.managePiecesEnabled,
       meta: { showErrorDialog: true, loadSubsetOptions: {} },
     });

--- a/packages/web/test/features/piece-sets/piece-sets-api.test.ts
+++ b/packages/web/test/features/piece-sets/piece-sets-api.test.ts
@@ -1,0 +1,34 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/lib/api', () => ({
+  api: {
+    get: vi.fn().mockResolvedValue({ data: [], next: null, previous: null }),
+  },
+}));
+
+import { api } from '@/lib/api';
+import { pieceSetsApi } from '@/features/piece-sets';
+
+const getMock = api.get as ReturnType<typeof vi.fn>;
+
+describe('pieceSetsApi.list', () => {
+  beforeEach(() => {
+    getMock.mockClear();
+  });
+
+  it('forwards cursor and limit as query params', async () => {
+    await pieceSetsApi.list({ cursor: 'abc', limit: 25 });
+    expect(getMock).toHaveBeenCalledWith('/v1/piece-sets', {
+      cursor: 'abc',
+      limit: 25,
+    });
+  });
+
+  it('sends an empty query when called with no args', async () => {
+    await pieceSetsApi.list();
+    expect(getMock).toHaveBeenCalledWith('/v1/piece-sets', {});
+  });
+});


### PR DESCRIPTION
Fixes [GIT-1698](https://linear.app/activepieces/issue/GIT-1698)
Closes #14559

### Breaking change?

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)

## Problem
Platform Admin > Pieces > Piece Sets showed only the first 10 sets. Any 11th+ set was unreachable through the UI — no way to open, edit, or delete it. Every platform that upgraded to 0.86.3 with legacy project piece filters gets one generated set per filtered project (`Project (<id>)`) and blew through the cap.

## Fix
- `packages/web/src/features/piece-sets/api/piece-sets-api.ts`: `list()` accepts `{ cursor?, limit? }` and forwards to `GET /v1/piece-sets` as query params. Previously it sent no params so the server default (10) applied.
- `packages/web/src/features/piece-sets/hooks/piece-sets-hooks.ts`: `usePieceSets({ cursor?, limit? })` threads the params through and includes them in the query key.
- `packages/web/src/app/routes/platform/setup/pieces/piece-sets/piece-sets-tab.tsx`: reads `cursor` + `limit` from the URL (`useSearchParams`), passes to the hook, drops `hidePagination={true}`, and surfaces the server-returned `next`/`previous` cursors to the DataTable pagination footer.

## Verification
- `bun run test test/features/piece-sets/piece-sets-api.test.ts` — 2/2 pass. Red-first: pre-fix code calls `api.get('/v1/piece-sets')` with no query, both cases fail (`expected [..., {cursor,limit}] but got [...]` and `expected [..., {}]` mismatch).
- `bun run lint` — 0 errors (existing warnings only).
- `npx tsc --noEmit -p tsconfig.app.json` — clean.
- Visual: pagination footer now visible on the Piece Sets tab (Prev/Next + page-size selector) — same DataTable component used by every other admin table. Live drive skipped: full EE stack + seeding 12+ sets requires the full plan-gated managePiecesEnabled path. The DataTable component itself is unchanged; this fix only stops passing `hidePagination={true}` to it.
- Other affected paths: checked - none. Grep of `pieceSetsApi.list()` callers: only `pieceSetQueries.usePieceSets` (updated). Other DataTables with `hidePagination={true}` (users, templates, secret-managers, connections) are outside this ticket's scope — GIT-1698 is about Piece Sets specifically.

<details>
<summary>Plan &amp; reasoning</summary>

## Plan
- Wire cursor + limit through the three existing layers (api → hook → tab) using the DataTable's existing URL-param pagination model already used by `runs-table` and `templates` — no new component, no new pagination primitive.
- Prefer cursor pagination over raising the server default limit: generated-set count scales linearly with filtered-project count, so a bigger cap only defers the same bug.
- Footprint: 3 product files (~28 lines) + 1 test file. Rejected alternative: bump the server `ListPieceSetsRequestQuery.limit` default from 10 to (say) 100 — postpones the failure instead of fixing it, and the underlying "no way to reach page 2" issue survives.

## Non-happy scenarios considered
- Filtering (`clientFiltering={true}`) still only searches the current page's rows — a known gap tracked as [GIT-1660](https://linear.app/activepieces/issue/GIT-1660), out of scope for this ticket.
- Query invalidation on create/update/delete: mutations still invalidate `pieceSetKeys.all` (prefix `['piece-sets']`), which react-query treats as a prefix match — every page-scoped query is invalidated too.
- User navigates deep into pagination then bookmarks: URL carries `cursor` + `limit`, hook resumes at that page on reload.

## Alternatives rejected
- Server-side default bump: does not fix the "unreachable page 2" UI half of the bug.
- Full name-search server support: separate ticket (GIT-1660) — do not conflate.
</details>
