### PR TITLE
fix(sign-now): Fix invite API inconsistencies

### DIFF
--- a/packages/pieces/community/sign-now/package.json
+++ b/packages/pieces/community/sign-now/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-sign-now",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/packages/pieces/community/sign-now/src/lib/actions/create-document-from-template-and-send-role-based-invite.ts
+++ b/packages/pieces/community/sign-now/src/lib/actions/create-document-from-template-and-send-role-based-invite.ts
@@ -97,7 +97,7 @@ export const createDocumentFromTemplateAndSendRoleBasedInviteAction = createActi
     }),
     expiration_days: Property.Number({
       displayName: 'Expiration Days',
-      description: 'Number of days before the invite expires (3–180). Defaults to 30.',
+      description: 'Number of days before the invite expires (1-180). Defaults to 30.',
       required: false,
     }),
     language: Property.StaticDropdown({

--- a/packages/pieces/community/sign-now/src/lib/actions/create-document-from-template-and-send-role-based-invite.ts
+++ b/packages/pieces/community/sign-now/src/lib/actions/create-document-from-template-and-send-role-based-invite.ts
@@ -179,7 +179,7 @@ export const createDocumentFromTemplateAndSendRoleBasedInviteAction = createActi
     if (subject) inviteBody['subject'] = subject;
     if (message) inviteBody['message'] = message;
     if (cc && (cc as string[]).length > 0) {
-      inviteBody['cc'] = (cc as string[]).map((email) => ({ email }));
+      inviteBody['cc'] = cc;
     }
     if (cc_subject) inviteBody['cc_subject'] = cc_subject;
     if (cc_message) inviteBody['cc_message'] = cc_message;

--- a/packages/pieces/community/sign-now/src/lib/actions/create-document-from-template-and-send-role-based-invite.ts
+++ b/packages/pieces/community/sign-now/src/lib/actions/create-document-from-template-and-send-role-based-invite.ts
@@ -183,7 +183,7 @@ export const createDocumentFromTemplateAndSendRoleBasedInviteAction = createActi
     }
     if (cc_subject) inviteBody['cc_subject'] = cc_subject;
     if (cc_message) inviteBody['cc_message'] = cc_message;
-    if (expiration_days) inviteBody['expiration_days'] = expiration_days;
+    if (expiration_days) inviteBody['general_expiration_days'] = expiration_days;
     if (language) inviteBody['language'] = language;
 
     try {

--- a/packages/pieces/community/sign-now/src/lib/actions/send-invite.ts
+++ b/packages/pieces/community/sign-now/src/lib/actions/send-invite.ts
@@ -150,7 +150,7 @@ export const sendInviteAction = createAction({
     if (subject) inviteBody['subject'] = subject;
     if (message) inviteBody['message'] = message;
     if (cc && (cc as string[]).length > 0) {
-      inviteBody['cc'] = (cc as string[]).map((email) => ({ email }));
+      inviteBody['cc'] = cc;
     }
     if (cc_subject) inviteBody['cc_subject'] = cc_subject;
     if (cc_message) inviteBody['cc_message'] = cc_message;


### PR DESCRIPTION
## Description

There are some inconsistencies when calling the SignNow `POST /document/{document_id}/invite` endpoint.

Documentation: https://docs.signnow.com/docs/signnow/document-field-invite/operations/create-a-document-invite

1. `cc` field is in the wrong structure

<img width="576" height="110" alt="Screenshot 2026-08-07 at 7 06 12 PM" src="https://github.com/user-attachments/assets/c3df2ff0-e31d-40fc-b36f-3002c0ca7d70" />

This expects an array of strings instead of an array of objects keyed by `email`. The action currently returns a 400 status error with message `Cc must contain valid emails.`


2. `expiration_days` is not a valid top level key

`expiration_days` only exists inside the `to` array of objects, the correct top level key is `general_expiration_days`.

<img width="980" height="238" alt="Screenshot 2026-08-07 at 7 06 01 PM" src="https://github.com/user-attachments/assets/346081d7-f684-4101-9863-d84a2dbce0f7" />

This also has a different documented validation range - update the prop description

## How was this tested?

<!-- How did you verify the change: manual steps, automated tests, and which edition paths (CE / EE / Cloud) you checked. -->



Fixes # (issue)

### Breaking change?  (required — CI fails if this is left unedited)

<!-- Tick exactly one box. If either "yes", apply the "⛓️‍💥 breaking-change" label AND add an entry to docs/install/reference/breaking-changes.mdx (what changed + the action self-hosters must take). -->

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

<!-- Tick exactly one box. "Security-sensitive" = touches authentication, secrets, permissions/roles, cryptography, SSRF / outbound HTTP, or file handling. -->

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)
