### PR TITLE
fix(reddit): request permanent OAuth token so refresh_token is issued

### DIFF
--- a/packages/pieces/community/reddit/src/lib/auth.ts
+++ b/packages/pieces/community/reddit/src/lib/auth.ts
@@ -25,6 +25,7 @@ export const redditAuth = PieceAuth.OAuth2({
   authorizationMethod: OAuth2AuthorizationMethod.HEADER,
   extra: {
     grantType: OAuth2GrantType.AUTHORIZATION_CODE,
-    responseType: 'code'
+    responseType: 'code',
+    duration: 'permanent'
   }
 });


### PR DESCRIPTION
## What

Add `duration: 'permanent'` to the Reddit piece's OAuth2 auth definition so Reddit issues a **refresh_token** during authorization.

## Why

Reddit's OAuth2 only returns a `refresh_token` when the authorize request includes `duration=permanent`. Without it, Reddit issues only a short-lived access token (~1 hour). Once it expires, the connection can never refresh itself and every action fails with **401 Unauthorized** until the user manually deletes and recreates the connection.

This affects all self-hosted instances using the Reddit piece — see #14680 for the full root-cause analysis (including a second, framework-level issue in `isExpired` where connections without a refresh_token are never considered expired).

## Verification

Verified on a self-hosted instance (v12.x):
- Before: new Reddit connections stored **no** `refresh_token`; broke with 401 after ~1 hour / ~2 days in practice.
- After: new connections store a `refresh_token` (confirmed in the DB), and Reddit actions keep working past the access token lifetime.

## Changes

`packages/pieces/community/reddit/src/lib/auth.ts`:

```ts
extra: {
  grantType: OAuth2GrantType.AUTHORIZATION_CODE,
  responseType: 'code',
  duration: 'permanent'
}
```

Fixes #14680 (partially — the piece-level fix; the `isExpired` framework issue is tracked in the same issue).