### PR TITLE
fix(auth): make first-platform creation single-use and self-healing

### DIFF
--- a/packages/server/api/src/app/authentication/passwordless-auth.service.ts
+++ b/packages/server/api/src/app/authentication/passwordless-auth.service.ts
@@ -122,6 +122,7 @@ export const passwordlessAuthService = (log: FastifyBaseLogger) => ({
             identityId,
             name: signupNames.platformNameFromPerson({ firstName, email: identity.email }),
             invalidatePreviousTokens: false,
+            isFirstPlatform: true,
         })
     },
 })

--- a/packages/server/api/src/app/database/seeds/dev-seeds.ts
+++ b/packages/server/api/src/app/database/seeds/dev-seeds.ts
@@ -50,6 +50,7 @@ const seedDevUser = async (): Promise<void> => {
         identityId: response.id,
         name: 'dev\'s Platform',
         invalidatePreviousTokens: true,
+        isFirstPlatform: true,
     })
 
     log.info({ email: DEV_EMAIL, password: DEV_PASSWORD }, '[devSeeds#seedDevUser] Dev user and platform created')

--- a/packages/server/api/src/app/platform/platform.controller.ts
+++ b/packages/server/api/src/app/platform/platform.controller.ts
@@ -39,6 +39,7 @@ export const platformController: FastifyPluginAsyncZod = async (app) => {
             identityId,
             name: req.body.name,
             invalidatePreviousTokens: isOnboarding,
+            isFirstPlatform: isOnboarding,
         })
     })
 

--- a/packages/server/api/src/app/platform/platform.service.ts
+++ b/packages/server/api/src/app/platform/platform.service.ts
@@ -282,11 +282,6 @@ function personalProjectName(platformName: string): string {
 }
 
 async function finishExistingPlatform({ user, platformId, name, invalidatePreviousTokens, identityId, log }: FinishExistingPlatformParams): Promise<AuthenticationResponse> {
-    if (invalidatePreviousTokens) {
-        await userIdentityRepository().update(identityId, {
-            tokenVersion: nanoid(),
-        })
-    }
     const hasProjects = await projectService(log).userHasProjects({
         platformId,
         userId: user.id,
@@ -300,6 +295,11 @@ async function finishExistingPlatform({ user, platformId, name, invalidatePrevio
             platformId,
             type: ProjectType.PERSONAL,
         })
+    if (invalidatePreviousTokens) {
+        await userIdentityRepository().update(identityId, {
+            tokenVersion: nanoid(),
+        })
+    }
     return authenticationUtils(log).getProjectAndToken({
         userId: user.id,
         platformId,

--- a/packages/server/api/src/app/platform/platform.service.ts
+++ b/packages/server/api/src/app/platform/platform.service.ts
@@ -84,7 +84,7 @@ export const platformService = (log: FastifyBaseLogger) => ({
                 const existingUsers = isFirstPlatform ? await userService(log).getByIdentityId({ identityId }) : []
                 const linkedUser = existingUsers.find((user) => !isNil(user.platformId))
                 if (!isNil(linkedUser) && !isNil(linkedUser.platformId)) {
-                    return finishExistingPlatform({ user: linkedUser, platformId: linkedUser.platformId, name, invalidatePreviousTokens, identityId, log })
+                    return finishExistingPlatform({ user: linkedUser, platformId: linkedUser.platformId, name, invalidatePreviousTokens: false, identityId, log })
                 }
                 const unlinkedUser = existingUsers.find((user) => isNil(user.platformId))
                 const orphanedPlatform = isNil(unlinkedUser) ? null : await platformRepo().findOneBy({ ownerId: unlinkedUser.id })

--- a/packages/server/api/src/app/platform/platform.service.ts
+++ b/packages/server/api/src/app/platform/platform.service.ts
@@ -1,10 +1,11 @@
 import { ActivepiecesError, apId, ErrorCode, isNil, PlatformId, spreadIfDefined, spreadIfNotUndefined, tryCatch, UserId } from '@activepieces/core-utils'
-import { ApEdition, AuthenticationResponse, OPEN_SOURCE_PLAN, Platform, PlatformPlanLimits, PlatformRole, PlatformUsage, PlatformWithoutFederatedAuth, PlatformWithoutSensitiveData, ProjectType, SsoDomainVerification, SsoDomainVerificationStatus, UpdatePlatformRequestBody, UserStatus } from '@activepieces/shared'
+import { ApEdition, AuthenticationResponse, OPEN_SOURCE_PLAN, Platform, PlatformPlanLimits, PlatformRole, PlatformUsage, PlatformWithoutFederatedAuth, PlatformWithoutSensitiveData, ProjectType, SsoDomainVerification, SsoDomainVerificationStatus, UpdatePlatformRequestBody, User, UserStatus } from '@activepieces/shared'
 import { FastifyBaseLogger } from 'fastify'
 import { nanoid } from 'nanoid'
 import { authenticationUtils } from '../authentication/authentication-utils'
 import { userIdentityRepository, userIdentityService } from '../authentication/user-identity/user-identity-service'
 import { repoFactory } from '../core/db/repo-factory'
+import { distributedLock } from '../database/redis-connections'
 import { invalidateSamlClientCache } from '../ee/authentication/saml-authn/saml-client'
 import { platformPlanService } from '../ee/platform/platform-plan/platform-plan.service'
 import { defaultTheme } from '../flags/theme'
@@ -75,33 +76,56 @@ export const platformService = (log: FastifyBaseLogger) => ({
         log.info({ platform: { id: savedPlatform.id }, ownerId }, 'Platform created')
         return stripFederatedAuth(savedPlatform)
     },
-    async createPlatformWithProject({ identityId, name, invalidatePreviousTokens }: CreatePlatformWithProjectParams): Promise<AuthenticationResponse> {
-        const newUser = await userService(log).create({
-            identityId,
-            platformRole: PlatformRole.ADMIN,
-            platformId: null,
-        })
-        const platform = await this.create({ ownerId: newUser.id, name })
-        const defaultProject = await projectService(log).create({
-            displayName: /['’]s$/.test(name) ? `${name} Project` : `${name}'s Project`,
-            ownerId: newUser.id,
-            platformId: platform.id,
-            type: ProjectType.PERSONAL,
-        })
-        if (invalidatePreviousTokens) {
-            await userIdentityRepository().update(identityId, {
-                tokenVersion: nanoid(),
-            })
-        }
-        await authenticationUtils(log).sendTelemetry({
-            identity: await userIdentityService(log).getOneOrFail({ id: identityId }),
-            user: newUser,
-            projectId: defaultProject.id,
-        })
-        return authenticationUtils(log).getProjectAndToken({
-            userId: newUser.id,
-            platformId: platform.id,
-            projectId: defaultProject.id,
+    async createPlatformWithProject({ identityId, name, invalidatePreviousTokens, isFirstPlatform }: CreatePlatformWithProjectParams): Promise<AuthenticationResponse> {
+        return distributedLock(log).runExclusive({
+            key: `create-platform-${identityId}`,
+            timeoutInSeconds: 30,
+            fn: async () => {
+                const existingUsers = isFirstPlatform ? await userService(log).getByIdentityId({ identityId }) : []
+                const linkedUser = existingUsers.find((user) => !isNil(user.platformId))
+                if (!isNil(linkedUser) && !isNil(linkedUser.platformId)) {
+                    return finishExistingPlatform({ user: linkedUser, platformId: linkedUser.platformId, name, log })
+                }
+                const unlinkedUser = existingUsers.find((user) => isNil(user.platformId))
+                const orphanedPlatform = isNil(unlinkedUser) ? null : await platformRepo().findOneBy({ ownerId: unlinkedUser.id })
+                if (!isNil(unlinkedUser) && !isNil(orphanedPlatform)) {
+                    await userService(log).addOwnerToPlatform({ id: unlinkedUser.id, platformId: orphanedPlatform.id })
+                    return finishExistingPlatform({
+                        user: await userService(log).getOneOrFail({ id: unlinkedUser.id }),
+                        platformId: orphanedPlatform.id,
+                        name,
+                        log,
+                    })
+                }
+                const newUser = unlinkedUser
+                    ?? await userService(log).create({
+                        identityId,
+                        platformRole: PlatformRole.ADMIN,
+                        platformId: null,
+                    })
+                const platform = await this.create({ ownerId: newUser.id, name })
+                const defaultProject = await projectService(log).create({
+                    displayName: personalProjectName(name),
+                    ownerId: newUser.id,
+                    platformId: platform.id,
+                    type: ProjectType.PERSONAL,
+                })
+                if (invalidatePreviousTokens) {
+                    await userIdentityRepository().update(identityId, {
+                        tokenVersion: nanoid(),
+                    })
+                }
+                await authenticationUtils(log).sendTelemetry({
+                    identity: await userIdentityService(log).getOneOrFail({ id: identityId }),
+                    user: newUser,
+                    projectId: defaultProject.id,
+                })
+                return authenticationUtils(log).getProjectAndToken({
+                    userId: newUser.id,
+                    platformId: platform.id,
+                    projectId: defaultProject.id,
+                })
+            },
         })
     },
     async getAll(): Promise<PlatformWithoutFederatedAuth[]> {
@@ -251,6 +275,31 @@ export const platformService = (log: FastifyBaseLogger) => ({
     },
 })
 
+function personalProjectName(platformName: string): string {
+    return /['’]s$/.test(platformName) ? `${platformName} Project` : `${platformName}'s Project`
+}
+
+async function finishExistingPlatform({ user, platformId, name, log }: FinishExistingPlatformParams): Promise<AuthenticationResponse> {
+    const hasProjects = await projectService(log).userHasProjects({
+        platformId,
+        userId: user.id,
+        isPrivileged: userService(log).isUserPrivileged(user),
+    })
+    const project = hasProjects
+        ? null
+        : await projectService(log).create({
+            displayName: personalProjectName(name),
+            ownerId: user.id,
+            platformId,
+            type: ProjectType.PERSONAL,
+        })
+    return authenticationUtils(log).getProjectAndToken({
+        userId: user.id,
+        platformId,
+        projectId: project?.id ?? null,
+    })
+}
+
 async function getUsage(log: FastifyBaseLogger, platform: PlatformWithoutFederatedAuth): Promise<PlatformUsage | undefined> {
     const edition = system.getEdition()
     if (edition === ApEdition.COMMUNITY) {
@@ -315,6 +364,14 @@ type CreatePlatformWithProjectParams = {
     identityId: string
     name: string
     invalidatePreviousTokens: boolean
+    isFirstPlatform: boolean
+}
+
+type FinishExistingPlatformParams = {
+    user: User
+    platformId: PlatformId
+    name: string
+    log: FastifyBaseLogger
 }
 
 type ListPlatformsForIdentityParams = {

--- a/packages/server/api/src/app/platform/platform.service.ts
+++ b/packages/server/api/src/app/platform/platform.service.ts
@@ -84,7 +84,7 @@ export const platformService = (log: FastifyBaseLogger) => ({
                 const existingUsers = isFirstPlatform ? await userService(log).getByIdentityId({ identityId }) : []
                 const linkedUser = existingUsers.find((user) => !isNil(user.platformId))
                 if (!isNil(linkedUser) && !isNil(linkedUser.platformId)) {
-                    return finishExistingPlatform({ user: linkedUser, platformId: linkedUser.platformId, name, log })
+                    return finishExistingPlatform({ user: linkedUser, platformId: linkedUser.platformId, name, invalidatePreviousTokens, identityId, log })
                 }
                 const unlinkedUser = existingUsers.find((user) => isNil(user.platformId))
                 const orphanedPlatform = isNil(unlinkedUser) ? null : await platformRepo().findOneBy({ ownerId: unlinkedUser.id })
@@ -94,6 +94,8 @@ export const platformService = (log: FastifyBaseLogger) => ({
                         user: await userService(log).getOneOrFail({ id: unlinkedUser.id }),
                         platformId: orphanedPlatform.id,
                         name,
+                        invalidatePreviousTokens,
+                        identityId,
                         log,
                     })
                 }
@@ -279,7 +281,12 @@ function personalProjectName(platformName: string): string {
     return /['’]s$/.test(platformName) ? `${platformName} Project` : `${platformName}'s Project`
 }
 
-async function finishExistingPlatform({ user, platformId, name, log }: FinishExistingPlatformParams): Promise<AuthenticationResponse> {
+async function finishExistingPlatform({ user, platformId, name, invalidatePreviousTokens, identityId, log }: FinishExistingPlatformParams): Promise<AuthenticationResponse> {
+    if (invalidatePreviousTokens) {
+        await userIdentityRepository().update(identityId, {
+            tokenVersion: nanoid(),
+        })
+    }
     const hasProjects = await projectService(log).userHasProjects({
         platformId,
         userId: user.id,
@@ -371,6 +378,8 @@ type FinishExistingPlatformParams = {
     user: User
     platformId: PlatformId
     name: string
+    invalidatePreviousTokens: boolean
+    identityId: string
     log: FastifyBaseLogger
 }
 

--- a/packages/server/api/test/helpers/mocks/index.ts
+++ b/packages/server/api/test/helpers/mocks/index.ts
@@ -366,6 +366,7 @@ export const createMockOtp = (otp?: Partial<OtpModel>): OtpModel => {
         value:
             otp?.value ?? faker.number.int({ min: 100000, max: 999999 }).toString(),
         state: otp?.state ?? faker.helpers.enumValue(OtpState),
+        attempts: otp?.attempts ?? 0,
     }
 }
 

--- a/packages/server/api/test/integration/ce/authentication/passwordless-authn.test.ts
+++ b/packages/server/api/test/integration/ce/authentication/passwordless-authn.test.ts
@@ -4,6 +4,7 @@ import { FastifyInstance } from 'fastify'
 import { StatusCodes } from 'http-status-codes'
 import { otpService } from '../../../../src/app/authentication/otp/otp-service'
 import { databaseConnection } from '../../../../src/app/database/database-connection'
+import { platformService } from '../../../../src/app/platform/platform.service'
 import { createMockPlatform } from '../../../helpers/mocks'
 import { setupTestEnvironment, teardownTestEnvironment } from '../../../helpers/test-setup'
 
@@ -314,6 +315,27 @@ describe('Passwordless Authentication API', () => {
             expect(response?.statusCode).toBe(StatusCodes.OK)
             const after = await databaseConnection().getRepository('user_identity').findOneBy({ email: EMAIL })
             expect(after?.tokenVersion).not.toBe(before?.tokenVersion)
+        })
+
+        it('rotates once when two first-platform creations race, so neither session is stranded', async () => {
+            await requestCode(EMAIL)
+            const otp = await storedOtp(EMAIL)
+            await verifyCode({ email: EMAIL, code: otp!.value })
+            const identity = await databaseConnection().getRepository('user_identity').findOneBy({ email: EMAIL })
+            const create = () => platformService(app!.log).createPlatformWithProject({
+                identityId: identity!.id,
+                name: 'Ahmad',
+                invalidatePreviousTokens: true,
+                isFirstPlatform: true,
+            })
+
+            const [first, second] = await Promise.all([create(), create()])
+
+            const after = await databaseConnection().getRepository('user_identity').findOneBy({ email: EMAIL })
+            const versionOf = (token: string) =>
+                JSON.parse(Buffer.from(token.split('.')[1], 'base64').toString()).tokenVersion
+            expect(versionOf(first.token)).toBe(after?.tokenVersion)
+            expect(versionOf(second.token)).toBe(after?.tokenVersion)
         })
 
         it('repairs a platform left without a project instead of wedging the identity', async () => {

--- a/packages/server/api/test/integration/ce/authentication/passwordless-authn.test.ts
+++ b/packages/server/api/test/integration/ce/authentication/passwordless-authn.test.ts
@@ -1,8 +1,10 @@
-import { OtpState, OtpType } from '@activepieces/shared'
+import { apId } from '@activepieces/core-utils'
+import { OtpState, OtpType, PlatformRole, UserStatus } from '@activepieces/shared'
 import { FastifyInstance } from 'fastify'
 import { StatusCodes } from 'http-status-codes'
 import { otpService } from '../../../../src/app/authentication/otp/otp-service'
 import { databaseConnection } from '../../../../src/app/database/database-connection'
+import { createMockPlatform } from '../../../helpers/mocks'
 import { setupTestEnvironment, teardownTestEnvironment } from '../../../helpers/test-setup'
 
 let app: FastifyInstance | null = null
@@ -176,6 +178,134 @@ describe('Passwordless Authentication API', () => {
             const verdicts = await Promise.all([confirm(), confirm()])
 
             expect(verdicts.filter((verdict) => verdict)).toHaveLength(1)
+        })
+
+        it('creates one platform for one identity, even when the name step is submitted twice', async () => {
+            await requestCode(EMAIL)
+            const otp = await storedOtp(EMAIL)
+            const onboarding = await verifyCode({ email: EMAIL, code: otp!.value })
+            const onboardingToken = onboarding?.json()?.token
+            const completeSignUp = () => app?.inject({
+                method: 'POST',
+                url: '/api/v1/authentication/complete-sign-up',
+                headers: { authorization: `Bearer ${onboardingToken}` },
+                body: { fullName: 'Ahmad Bin Tash' },
+            })
+
+            const first = await completeSignUp()
+            const second = await completeSignUp()
+
+            expect(first?.statusCode).toBe(StatusCodes.OK)
+            expect(second?.statusCode).toBe(StatusCodes.OK)
+            expect(second?.json()?.platformId).toBe(first?.json()?.platformId)
+            expect(await databaseConnection().getRepository('platform').count()).toBe(1)
+            expect(await databaseConnection().getRepository('project').count()).toBe(1)
+            expect(await databaseConnection().getRepository('user').count()).toBe(1)
+        })
+
+        it('creates one platform even when the other onboarding route races the name step', async () => {
+            await requestCode(EMAIL)
+            const otp = await storedOtp(EMAIL)
+            const onboarding = await verifyCode({ email: EMAIL, code: otp!.value })
+            const onboardingToken = onboarding?.json()?.token
+
+            const viaNameStep = await app?.inject({
+                method: 'POST',
+                url: '/api/v1/authentication/complete-sign-up',
+                headers: { authorization: `Bearer ${onboardingToken}` },
+                body: { fullName: 'Ahmad Bin Tash' },
+            })
+            const viaPlatformRoute = await app?.inject({
+                method: 'POST',
+                url: '/api/v1/platforms',
+                headers: { authorization: `Bearer ${onboardingToken}` },
+                body: { name: 'Ahmad' },
+            })
+
+            expect(viaNameStep?.statusCode).toBe(StatusCodes.OK)
+            expect(viaPlatformRoute?.statusCode).toBe(StatusCodes.OK)
+            expect(viaPlatformRoute?.json()?.platformId).toBe(viaNameStep?.json()?.platformId)
+            expect(await databaseConnection().getRepository('platform').count()).toBe(1)
+            expect(await databaseConnection().getRepository('user').count()).toBe(1)
+        })
+
+        it('reuses a user left unlinked by an interrupted attempt instead of creating a second one', async () => {
+            await requestCode(EMAIL)
+            const otp = await storedOtp(EMAIL)
+            const onboarding = await verifyCode({ email: EMAIL, code: otp!.value })
+            const onboardingToken = onboarding?.json()?.token
+            const identity = await databaseConnection().getRepository('user_identity').findOneBy({ email: EMAIL })
+            await databaseConnection().getRepository('user').save({
+                id: apId(),
+                identityId: identity!.id,
+                platformId: null,
+                platformRole: PlatformRole.ADMIN,
+                status: UserStatus.ACTIVE,
+            })
+
+            const response = await app?.inject({
+                method: 'POST',
+                url: '/api/v1/authentication/complete-sign-up',
+                headers: { authorization: `Bearer ${onboardingToken}` },
+                body: { fullName: 'Ahmad Bin Tash' },
+            })
+
+            expect(response?.statusCode).toBe(StatusCodes.OK)
+            expect(await databaseConnection().getRepository('user').count()).toBe(1)
+        })
+
+        it('adopts a platform whose owner link never landed instead of building a second one', async () => {
+            await requestCode(EMAIL)
+            const otp = await storedOtp(EMAIL)
+            const onboarding = await verifyCode({ email: EMAIL, code: otp!.value })
+            const onboardingToken = onboarding?.json()?.token
+            const identity = await databaseConnection().getRepository('user_identity').findOneBy({ email: EMAIL })
+            const strandedUserId = apId()
+            await databaseConnection().getRepository('user').save({
+                id: strandedUserId,
+                identityId: identity!.id,
+                platformId: null,
+                platformRole: PlatformRole.ADMIN,
+                status: UserStatus.ACTIVE,
+            })
+            await databaseConnection().getRepository('platform').save(
+                createMockPlatform({ ownerId: strandedUserId }),
+            )
+
+            const response = await app?.inject({
+                method: 'POST',
+                url: '/api/v1/authentication/complete-sign-up',
+                headers: { authorization: `Bearer ${onboardingToken}` },
+                body: { fullName: 'Ahmad Bin Tash' },
+            })
+
+            expect(response?.statusCode).toBe(StatusCodes.OK)
+            expect(await databaseConnection().getRepository('platform').count()).toBe(1)
+            expect(await databaseConnection().getRepository('user').count()).toBe(1)
+            const relinked = await databaseConnection().getRepository('user').findOneBy({ id: strandedUserId })
+            expect(relinked?.platformId).toBe(response?.json()?.platformId)
+        })
+
+        it('repairs a platform left without a project instead of wedging the identity', async () => {
+            await requestCode(EMAIL)
+            const otp = await storedOtp(EMAIL)
+            const onboarding = await verifyCode({ email: EMAIL, code: otp!.value })
+            const onboardingToken = onboarding?.json()?.token
+            const completeSignUp = () => app?.inject({
+                method: 'POST',
+                url: '/api/v1/authentication/complete-sign-up',
+                headers: { authorization: `Bearer ${onboardingToken}` },
+                body: { fullName: 'Ahmad Bin Tash' },
+            })
+            const first = await completeSignUp()
+            await databaseConnection().getRepository('project').createQueryBuilder().delete().execute()
+
+            const retry = await completeSignUp()
+
+            expect(retry?.statusCode).toBe(StatusCodes.OK)
+            expect(retry?.json()?.platformId).toBe(first?.json()?.platformId)
+            expect(await databaseConnection().getRepository('project').count()).toBe(1)
+            expect(await databaseConnection().getRepository('platform').count()).toBe(1)
         })
 
         it('sets the USER_CREATED flag only once a code is verified', async () => {

--- a/packages/server/api/test/integration/ce/authentication/passwordless-authn.test.ts
+++ b/packages/server/api/test/integration/ce/authentication/passwordless-authn.test.ts
@@ -286,6 +286,36 @@ describe('Passwordless Authentication API', () => {
             expect(relinked?.platformId).toBe(response?.json()?.platformId)
         })
 
+        it('still rotates the token version when the platform route recovers', async () => {
+            await requestCode(EMAIL)
+            const otp = await storedOtp(EMAIL)
+            const onboarding = await verifyCode({ email: EMAIL, code: otp!.value })
+            const onboardingToken = onboarding?.json()?.token
+            const before = await databaseConnection().getRepository('user_identity').findOneBy({ email: EMAIL })
+            const strandedUserId = apId()
+            await databaseConnection().getRepository('user').save({
+                id: strandedUserId,
+                identityId: before!.id,
+                platformId: null,
+                platformRole: PlatformRole.ADMIN,
+                status: UserStatus.ACTIVE,
+            })
+            await databaseConnection().getRepository('platform').save(
+                createMockPlatform({ ownerId: strandedUserId }),
+            )
+
+            const response = await app?.inject({
+                method: 'POST',
+                url: '/api/v1/platforms',
+                headers: { authorization: `Bearer ${onboardingToken}` },
+                body: { name: 'Ahmad' },
+            })
+
+            expect(response?.statusCode).toBe(StatusCodes.OK)
+            const after = await databaseConnection().getRepository('user_identity').findOneBy({ email: EMAIL })
+            expect(after?.tokenVersion).not.toBe(before?.tokenVersion)
+        })
+
         it('repairs a platform left without a project instead of wedging the identity', async () => {
             await requestCode(EMAIL)
             const otp = await storedOtp(EMAIL)


### PR DESCRIPTION
## Description

**4 of 7 in the passwordless sign-in stack.** <details><summary><b>The stack</b> — review bottom-up; each PR targets the one below it</summary>

| | PR | Area |
|---|---|---|
| 1 | #14685 — OTP primitive moves to core, gains an attempt budget | server/api |
| 2 | #14692 — derive first, last and platform names | server/api |
| 3 | #14694 — sign in with an emailed code | server/api |
| 4 | #14687 — first-platform creation single-use and self-healing | server/api |
| 5 | #14688 — building blocks for the auth screen | web |
| 6 | #14689 — one screen for sign in and sign up | web |
| 7 | #14690 — ask new members their name in the card | web |

Split out of #14653, which exceeded the review-size budget. #14686 was an earlier
incarnation of PR 3, closed because GitHub will not retarget a PR inside a stack.

</details>

Creating an identity's first platform was replayable and is not atomic, so one identity could end up with duplicate tenant resources or stuck part-way. Found by review of PR 2, fixed here.

**The guard goes in `createPlatformWithProject`, where every caller passes through.** A lock in the sign-up route alone was not enough: `POST /v1/platforms` accepts the same `ONBOARDING` principal, so a client calling both still provisioned twice.

**Deduplication is opt-in per call site via `isFirstPlatform`, not unconditional** — on cloud an existing signed-in user is *allowed* to create additional platforms (`platform.controller` only refuses that on ce/ee). An unconditional "identity already has a platform, return it" guard would have silently broken multi-platform creation while fixing the replay.

Provisioning writes the user, the platform link and the project separately, and each gap left state a retry read wrongly:

| interrupted after | stale read | before | now |
|---|---|---|---|
| user insert | user has null `platformId` | second user created | unlinked user reused |
| platform save | user still unlinked, platform already names it owner | **500 forever** (unique owner constraint) | platform adopted |
| owner link | platform has no project | **403 forever** (`getProjectAndToken` throws) | project created |

Two of those wedged the identity permanently — every retry hit the same error.

**What this is not:** the three writes are still not atomic. One transaction across `userService`, `platformService` and `projectService`, each owning its own `repoFactory` repository, means threading an `EntityManager` through all three and touching every existing caller of platform creation — wider than this stack should carry. What is here makes retries *converge* from any interruption point. The non-atomic sequence itself predates this work.

## How was this tested?

Five integration cases, **each verified to fail without its fix** (`expected 2 to be 1`, `expected 500 to be 200`, `expected 403 to be 200`, and both routes returning the same `platformId`).

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

- [ ] no — reviewed, no security impact
- [x] yes — security-sensitive (call out the risk and mitigation in the description above)

