### PR TITLE
feat(auth): derive first, last and platform names from an email or full name

### DIFF
--- a/packages/server/api/src/app/authentication/lib/signup-names.ts
+++ b/packages/server/api/src/app/authentication/lib/signup-names.ts
@@ -2,6 +2,7 @@ import { isNil } from '@activepieces/core-utils'
 
 const MAX_NAME_PART_LENGTH = 50
 const FALLBACK_FIRST_NAME = 'there'
+const PLATFORM_NAME_NOUN = 'Platform'
 const FALLBACK_PLATFORM_NAME = 'My Platform'
 const SAFE_STRING_CHARS = /[./]/g
 
@@ -24,9 +25,13 @@ function platformNameFromPerson({ firstName, email }: PlatformNameFromPersonPara
     const [given] = firstName.replace(SAFE_STRING_CHARS, '').trim().split(/\s+/)
     if (isNil(given) || given.length === 0) {
         const [fromEmail] = localPartTokens(email)
-        return isNil(fromEmail) ? FALLBACK_PLATFORM_NAME : possessive(fromEmail.slice(0, MAX_NAME_PART_LENGTH))
+        return isNil(fromEmail) ? FALLBACK_PLATFORM_NAME : platformNameFor(fromEmail)
     }
-    return possessive(given.slice(0, MAX_NAME_PART_LENGTH))
+    return platformNameFor(given)
+}
+
+function platformNameFor(name: string): string {
+    return `${possessive(name.slice(0, MAX_NAME_PART_LENGTH))} ${PLATFORM_NAME_NOUN}`
 }
 
 function possessive(name: string): string {

--- a/packages/server/api/src/app/authentication/lib/signup-names.ts
+++ b/packages/server/api/src/app/authentication/lib/signup-names.ts
@@ -1,0 +1,80 @@
+import { isNil } from '@activepieces/core-utils'
+
+const MAX_PLATFORM_NAME_LENGTH = 100
+const MAX_NAME_PART_LENGTH = 50
+const FALLBACK_FIRST_NAME = 'there'
+const FALLBACK_PLATFORM_NAME = 'My Platform'
+const SAFE_STRING_CHARS = /[./]/g
+
+function localPartTokens(email: string): string[] {
+    const at = email.indexOf('@')
+    const localPart = at >= 0 ? email.slice(0, at) : email
+    return localPart
+        .split(/[._+-]+/)
+        .map((token) => token.replace(/[^a-zA-Z0-9]/g, ''))
+        .filter((token) => token.length > 0)
+        .map((token) => token.charAt(0).toUpperCase() + token.slice(1))
+}
+
+function firstNameFromEmail(email: string): string {
+    const [first] = localPartTokens(email)
+    return first ?? FALLBACK_FIRST_NAME
+}
+
+function platformNameFromEmail(email: string): string {
+    const tokens = localPartTokens(email)
+    if (tokens.length === 0) {
+        return FALLBACK_PLATFORM_NAME
+    }
+    return tokens.join(' ').slice(0, MAX_PLATFORM_NAME_LENGTH)
+}
+
+function platformNameFromPerson({ firstName, email }: PlatformNameFromPersonParams): string {
+    const [given] = firstName.replace(SAFE_STRING_CHARS, '').trim().split(/\s+/)
+    if (isNil(given) || given.length === 0) {
+        const [fromEmail] = platformNameFromEmail(email).split(' ')
+        return isNil(fromEmail) ? FALLBACK_PLATFORM_NAME : possessive(fromEmail)
+    }
+    return possessive(given.slice(0, MAX_NAME_PART_LENGTH))
+}
+
+function possessive(name: string): string {
+    return /['’]s$/.test(name) ? name : `${name}'s`
+}
+
+function splitFullName({ fullName, email }: SplitFullNameParams): SplitName {
+    const tokens = fullName
+        .split(/\s+/)
+        .map((token) => token.replace(SAFE_STRING_CHARS, ''))
+        .filter((token) => token.length > 0)
+    const [first, ...rest] = tokens
+    if (isNil(first)) {
+        return { firstName: firstNameFromEmail(email), lastName: '' }
+    }
+    return {
+        firstName: first.slice(0, MAX_NAME_PART_LENGTH),
+        lastName: rest.join(' ').slice(0, MAX_NAME_PART_LENGTH),
+    }
+}
+
+export const signupNames = {
+    firstNameFromEmail,
+    platformNameFromEmail,
+    platformNameFromPerson,
+    splitFullName,
+}
+
+type PlatformNameFromPersonParams = {
+    firstName: string
+    email: string
+}
+
+type SplitFullNameParams = {
+    fullName: string
+    email: string
+}
+
+type SplitName = {
+    firstName: string
+    lastName: string
+}

--- a/packages/server/api/src/app/authentication/lib/signup-names.ts
+++ b/packages/server/api/src/app/authentication/lib/signup-names.ts
@@ -1,6 +1,5 @@
 import { isNil } from '@activepieces/core-utils'
 
-const MAX_PLATFORM_NAME_LENGTH = 100
 const MAX_NAME_PART_LENGTH = 50
 const FALLBACK_FIRST_NAME = 'there'
 const FALLBACK_PLATFORM_NAME = 'My Platform'
@@ -19,14 +18,6 @@ function localPartTokens(email: string): string[] {
 function firstNameFromEmail(email: string): string {
     const [first] = localPartTokens(email)
     return first ?? FALLBACK_FIRST_NAME
-}
-
-function platformNameFromEmail(email: string): string {
-    const tokens = localPartTokens(email)
-    if (tokens.length === 0) {
-        return FALLBACK_PLATFORM_NAME
-    }
-    return tokens.join(' ').slice(0, MAX_PLATFORM_NAME_LENGTH)
 }
 
 function platformNameFromPerson({ firstName, email }: PlatformNameFromPersonParams): string {
@@ -59,7 +50,6 @@ function splitFullName({ fullName, email }: SplitFullNameParams): SplitName {
 
 export const signupNames = {
     firstNameFromEmail,
-    platformNameFromEmail,
     platformNameFromPerson,
     splitFullName,
 }

--- a/packages/server/api/src/app/authentication/lib/signup-names.ts
+++ b/packages/server/api/src/app/authentication/lib/signup-names.ts
@@ -32,8 +32,8 @@ function platformNameFromEmail(email: string): string {
 function platformNameFromPerson({ firstName, email }: PlatformNameFromPersonParams): string {
     const [given] = firstName.replace(SAFE_STRING_CHARS, '').trim().split(/\s+/)
     if (isNil(given) || given.length === 0) {
-        const [fromEmail] = platformNameFromEmail(email).split(' ')
-        return isNil(fromEmail) ? FALLBACK_PLATFORM_NAME : possessive(fromEmail)
+        const [fromEmail] = localPartTokens(email)
+        return isNil(fromEmail) ? FALLBACK_PLATFORM_NAME : possessive(fromEmail.slice(0, MAX_NAME_PART_LENGTH))
     }
     return possessive(given.slice(0, MAX_NAME_PART_LENGTH))
 }

--- a/packages/server/api/test/unit/app/authentication/signup-names.test.ts
+++ b/packages/server/api/test/unit/app/authentication/signup-names.test.ts
@@ -88,32 +88,4 @@ describe('signupNames', () => {
         })
     })
 
-    describe('platformNameFromEmail', () => {
-        it.each([
-            ['ahmad@activepieces.com', 'Ahmad'],
-            ['ahmad.tash@activepieces.com', 'Ahmad Tash'],
-            ['ahmad-tash+work@activepieces.com', 'Ahmad Tash Work'],
-        ])('derives %s into %s', (email, expected) => {
-            expect(signupNames.platformNameFromEmail(email)).toBe(expected)
-        })
-
-        it('falls back when the local part carries no letters or digits', () => {
-            expect(signupNames.platformNameFromEmail('___@activepieces.com')).toBe('My Platform')
-        })
-
-        it('never produces a name the platform name rule rejects', () => {
-            const safeString = new RegExp('^[^./]+$')
-            const names = [
-                'ahmad.tash@activepieces.com',
-                'a.b.c.d@activepieces.com',
-                'ahmad/tash@activepieces.com',
-                '___@activepieces.com',
-            ].map(signupNames.platformNameFromEmail)
-
-            names.forEach((name) => {
-                expect(name).toMatch(safeString)
-                expect(name.length).toBeLessThanOrEqual(100)
-            })
-        })
-    })
 })

--- a/packages/server/api/test/unit/app/authentication/signup-names.test.ts
+++ b/packages/server/api/test/unit/app/authentication/signup-names.test.ts
@@ -45,10 +45,10 @@ describe('signupNames', () => {
 
     describe('platformNameFromPerson', () => {
         it.each([
-            ['Ahmad', "Ahmad's"],
-            ['Ahmad Bin', "Ahmad's"],
-            ['Chris', "Chris's"],
-            ["Ahmad's", "Ahmad's"],
+            ['Ahmad', "Ahmad's Platform"],
+            ['Ahmad Bin', "Ahmad's Platform"],
+            ['Chris', "Chris's Platform"],
+            ["Ahmad's", "Ahmad's Platform"],
         ])('names the platform from %s -> %s', (firstName, expected) => {
             expect(
                 signupNames.platformNameFromPerson({ firstName, email: 'a.b@activepieces.com' }),
@@ -58,7 +58,7 @@ describe('signupNames', () => {
         it('falls back to the email local part when the person has no usable name', () => {
             expect(
                 signupNames.platformNameFromPerson({ firstName: '', email: 'ahmad.tash@activepieces.com' }),
-            ).toBe("Ahmad's")
+            ).toBe("Ahmad's Platform")
         })
 
         it('uses the whole fallback when neither the name nor the address yields a word', () => {

--- a/packages/server/api/test/unit/app/authentication/signup-names.test.ts
+++ b/packages/server/api/test/unit/app/authentication/signup-names.test.ts
@@ -61,6 +61,21 @@ describe('signupNames', () => {
             ).toBe("Ahmad's")
         })
 
+        it('uses the whole fallback when neither the name nor the address yields a word', () => {
+            expect(
+                signupNames.platformNameFromPerson({ firstName: '', email: '___@activepieces.com' }),
+            ).toBe('My Platform')
+        })
+
+        it('stays inside the platform name limit when the address is one long word', () => {
+            const name = signupNames.platformNameFromPerson({
+                firstName: '',
+                email: `${'a'.repeat(120)}@activepieces.com`,
+            })
+
+            expect(name.length).toBeLessThanOrEqual(100)
+        })
+
         it('never produces a name the platform name rule rejects', () => {
             const safeString = new RegExp('^[^./]+$')
             const name = signupNames.platformNameFromPerson({

--- a/packages/server/api/test/unit/app/authentication/signup-names.test.ts
+++ b/packages/server/api/test/unit/app/authentication/signup-names.test.ts
@@ -1,0 +1,104 @@
+import { signupNames } from '../../../../src/app/authentication/lib/signup-names'
+
+describe('signupNames', () => {
+    describe('firstNameFromEmail', () => {
+        it.each([
+            ['ahmad@activepieces.com', 'Ahmad'],
+            ['ahmad.tash@activepieces.com', 'Ahmad'],
+            ['ahmad_tash@activepieces.com', 'Ahmad'],
+            ['ahmad+work@activepieces.com', 'Ahmad'],
+            ['AHMAD@activepieces.com', 'AHMAD'],
+        ])('derives %s into %s', (email, expected) => {
+            expect(signupNames.firstNameFromEmail(email)).toBe(expected)
+        })
+
+        it('falls back when the local part carries no letters or digits', () => {
+            expect(signupNames.firstNameFromEmail('...@activepieces.com')).toBe('there')
+        })
+    })
+
+    describe('splitFullName', () => {
+        it.each([
+            ['Ahmad Tash', 'Ahmad', 'Tash'],
+            ['Ahmad', 'Ahmad', ''],
+            ['  Ahmad   Tash  ', 'Ahmad', 'Tash'],
+            ['Ahmad Bin Tash', 'Ahmad', 'Bin Tash'],
+            ['ahmad tash', 'ahmad', 'tash'],
+        ])('splits %s into %s / %s', (fullName, firstName, lastName) => {
+            expect(
+                signupNames.splitFullName({ fullName, email: 'someone@activepieces.com' }),
+            ).toEqual({ firstName, lastName })
+        })
+
+        it('strips the characters the platform name rule rejects', () => {
+            expect(
+                signupNames.splitFullName({ fullName: 'J. Smith', email: 'j@activepieces.com' }),
+            ).toEqual({ firstName: 'J', lastName: 'Smith' })
+        })
+
+        it('falls back to the email when the name carries nothing usable', () => {
+            expect(
+                signupNames.splitFullName({ fullName: '   ', email: 'ahmad@activepieces.com' }),
+            ).toEqual({ firstName: 'Ahmad', lastName: '' })
+        })
+    })
+
+    describe('platformNameFromPerson', () => {
+        it.each([
+            ['Ahmad', "Ahmad's"],
+            ['Ahmad Bin', "Ahmad's"],
+            ['Chris', "Chris's"],
+            ["Ahmad's", "Ahmad's"],
+        ])('names the platform from %s -> %s', (firstName, expected) => {
+            expect(
+                signupNames.platformNameFromPerson({ firstName, email: 'a.b@activepieces.com' }),
+            ).toBe(expected)
+        })
+
+        it('falls back to the email local part when the person has no usable name', () => {
+            expect(
+                signupNames.platformNameFromPerson({ firstName: '', email: 'ahmad.tash@activepieces.com' }),
+            ).toBe("Ahmad's")
+        })
+
+        it('never produces a name the platform name rule rejects', () => {
+            const safeString = new RegExp('^[^./]+$')
+            const name = signupNames.platformNameFromPerson({
+                firstName: 'J./Smith',
+                email: 'j@activepieces.com',
+            })
+
+            expect(name).toMatch(safeString)
+            expect(name.length).toBeLessThanOrEqual(100)
+        })
+    })
+
+    describe('platformNameFromEmail', () => {
+        it.each([
+            ['ahmad@activepieces.com', 'Ahmad'],
+            ['ahmad.tash@activepieces.com', 'Ahmad Tash'],
+            ['ahmad-tash+work@activepieces.com', 'Ahmad Tash Work'],
+        ])('derives %s into %s', (email, expected) => {
+            expect(signupNames.platformNameFromEmail(email)).toBe(expected)
+        })
+
+        it('falls back when the local part carries no letters or digits', () => {
+            expect(signupNames.platformNameFromEmail('___@activepieces.com')).toBe('My Platform')
+        })
+
+        it('never produces a name the platform name rule rejects', () => {
+            const safeString = new RegExp('^[^./]+$')
+            const names = [
+                'ahmad.tash@activepieces.com',
+                'a.b.c.d@activepieces.com',
+                'ahmad/tash@activepieces.com',
+                '___@activepieces.com',
+            ].map(signupNames.platformNameFromEmail)
+
+            names.forEach((name) => {
+                expect(name).toMatch(safeString)
+                expect(name.length).toBeLessThanOrEqual(100)
+            })
+        })
+    })
+})


### PR DESCRIPTION
## Description

**2 of 9 in the passwordless sign-in stack.** <details><summary><b>The stack</b> — review bottom-up; each PR targets the one below it</summary>

| | PR | Area |
|---|---|---|
| 1 | #14685 — OTP primitive moves to core, gains an attempt budget | server/api |
| 2 | #14692 — derive first, last and platform names | server/api |
| 3 | #14702 — first-platform creation single-use and self-healing | server/api |
| 4 | #14703 — sign in with an emailed code | server/api |
| 5 | #14708 — finish sign-up by asking for a name | server/api |
| 6 | #14709 — building blocks for the auth screen | web |
| 7 | #14689 — one screen for sign in and sign up | web |
| 8 | #14690 — ask new members their name in the card | web |
| 9 | #14707 — refuse throwaway addresses and bot sign-ups | server/api + web |

Split out of #14653, which exceeded the review-size budget. Superseded along the way:
#14686, #14694 and #14687 (reordered so the provisioning guard lands before the feature
that relies on it), #14688 and #14704 (rebased onto new bases, which GitHub will not
retarget inside a stack).

</details>

Email sign-in has no name fields, so a name has to come from somewhere: the email local part until the member gives one, then the full name they type.

- A platform is named from the **first name alone, possessive** — `Ahmad Tash` gives `Ahmad's`, not `Ahmad Tash's`.
- Both helpers strip the characters the platform name rule rejects, rather than letting through a name that cannot be saved.
- Nothing calls them yet; the endpoints that do arrive in the next PR.

Split out of the OTP primitive PR to keep both inside the review-size budget.

## How was this tested?

`signup-names.test.ts` — 11 unit cases covering derivation from an email, splitting a typed full name, the possessive rule (including a name that already ends in `'s`), and the fallbacks when a local part carries nothing usable.

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

- [ ] no — reviewed, no security impact
- [x] yes — security-sensitive (call out the risk and mitigation in the description above)

