### PR TITLE
fix(web): gate piece sets behind managePiecesEnabled

### DIFF
--- a/packages/web/src/app/routes/platform/setup/pieces/piece-sets/create-piece-set-dialog.tsx
+++ b/packages/web/src/app/routes/platform/setup/pieces/piece-sets/create-piece-set-dialog.tsx
@@ -32,6 +32,7 @@ type FormValues = z.infer<typeof formSchema>;
 
 type CreatePieceSetDialogProps = {
   onCreated: () => void;
+  isEnabled: boolean;
 };
 
 const CreatePieceSetForm = ({
@@ -99,12 +100,13 @@ const CreatePieceSetForm = ({
 
 export const CreatePieceSetDialog = ({
   onCreated,
+  isEnabled,
 }: CreatePieceSetDialogProps) => {
   const [open, setOpen] = useState(false);
   return (
     <Dialog open={open} onOpenChange={setOpen}>
       <DialogTrigger asChild>
-        <Button>
+        <Button disabled={!isEnabled}>
           <Plus className="size-4 mr-1" />
           {t('New Piece Set')}
         </Button>

--- a/packages/web/src/app/routes/platform/setup/pieces/piece-sets/piece-set-details-page.tsx
+++ b/packages/web/src/app/routes/platform/setup/pieces/piece-sets/piece-set-details-page.tsx
@@ -4,11 +4,13 @@ import { ArrowLeft, Layers, Loader2 } from 'lucide-react';
 import { useNavigate, useParams } from 'react-router-dom';
 
 import { DashboardPageHeader } from '@/app/components/dashboard-page-header';
+import LockedFeatureGuard from '@/app/components/locked-feature-guard';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Switch } from '@/components/ui/switch';
 import { pieceSetMutations, pieceSetQueries } from '@/features/piece-sets';
 import { piecesHooks } from '@/features/pieces';
+import { platformHooks } from '@/hooks/platform-hooks';
 import { cn } from '@/lib/utils';
 
 import { PieceSetPiecesTab } from './piece-set-pieces-tab';
@@ -35,6 +37,8 @@ function flipSelectionMode({
 const PieceSetDetailsPage = () => {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
+  const { platform } = platformHooks.useCurrentPlatform();
+  const isEnabled = platform.plan.managePiecesEnabled;
   const { data: pieceSet, isLoading } = pieceSetQueries.usePieceSet(id ?? '');
   const { pieces, isLoading: piecesLoading } = piecesHooks.usePieces({
     includeHidden: true,
@@ -57,6 +61,21 @@ const PieceSetDetailsPage = () => {
       },
     });
   };
+
+  if (!isEnabled) {
+    return (
+      <LockedFeatureGuard
+        featureKey="ENTERPRISE_PIECES"
+        locked={true}
+        lockTitle={t('Piece Sets')}
+        lockDescription={t(
+          'Create a piece set to control which pieces are available to specific projects',
+        )}
+      >
+        {null}
+      </LockedFeatureGuard>
+    );
+  }
 
   if (isLoading || !pieceSet) {
     return (

--- a/packages/web/src/app/routes/platform/setup/pieces/piece-sets/piece-sets-tab.tsx
+++ b/packages/web/src/app/routes/platform/setup/pieces/piece-sets/piece-sets-tab.tsx
@@ -14,6 +14,7 @@ import {
 import { useMemo, useState } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 
+import { RequestTrial } from '@/app/components/request-trial';
 import {
   CURSOR_QUERY_PARAM,
   DataTable,
@@ -21,6 +22,7 @@ import {
 } from '@/components/custom/data-table';
 import { DataTableColumnHeader } from '@/components/custom/data-table/data-table-column-header';
 import { ConfirmationDeleteDialog } from '@/components/custom/delete-dialog';
+import { LockedAlert } from '@/components/custom/locked-alert';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import {
@@ -29,6 +31,7 @@ import {
   TooltipTrigger,
 } from '@/components/ui/tooltip';
 import { pieceSetMutations, pieceSetQueries } from '@/features/piece-sets';
+import { platformHooks } from '@/hooks/platform-hooks';
 
 import { CreatePieceSetDialog } from './create-piece-set-dialog';
 import { DuplicatePieceSetDialog } from './duplicate-piece-set-dialog';
@@ -36,6 +39,8 @@ import { EditPieceSetDialog } from './edit-piece-set-dialog';
 
 export const PieceSetsTab = () => {
   const navigate = useNavigate();
+  const { platform } = platformHooks.useCurrentPlatform();
+  const isEnabled = platform.plan.managePiecesEnabled;
   const [searchParams] = useSearchParams();
   const [duplicatingSet, setDuplicatingSet] = useState<PieceSet | null>(null);
   const [editingSet, setEditingSet] = useState<PieceSet | null>(null);
@@ -120,6 +125,7 @@ export const PieceSetsTab = () => {
                 <Button
                   variant="ghost"
                   size="sm"
+                  disabled={!isEnabled}
                   onClick={() => setEditingSet(row.original)}
                 >
                   <Settings2 className="size-4" />
@@ -132,6 +138,7 @@ export const PieceSetsTab = () => {
                 <Button
                   variant="ghost"
                   size="sm"
+                  disabled={!isEnabled}
                   onClick={() => setDuplicatingSet(row.original)}
                 >
                   <Copy className="size-4" />
@@ -152,7 +159,7 @@ export const PieceSetsTab = () => {
               <Button
                 variant="ghost"
                 size="sm"
-                disabled={row.original.isDefault}
+                disabled={!isEnabled || row.original.isDefault}
               >
                 <Trash2 className="size-4 text-destructive" />
               </Button>
@@ -161,11 +168,25 @@ export const PieceSetsTab = () => {
         ),
       },
     ],
-    [deleteSet, navigate, setDuplicatingSet, setEditingSet],
+    [deleteSet, isEnabled, navigate, setDuplicatingSet, setEditingSet],
   );
 
   return (
     <>
+      {!isEnabled && (
+        <LockedAlert
+          title={t('Piece Sets')}
+          description={t(
+            'Create a piece set to control which pieces are available to specific projects',
+          )}
+          button={
+            <RequestTrial
+              featureKey="ENTERPRISE_PIECES"
+              buttonVariant="basic"
+            />
+          }
+        />
+      )}
       <DataTable
         emptyStateTextTitle={t('No piece sets found')}
         emptyStateTextDescription={t(
@@ -189,7 +210,11 @@ export const PieceSetsTab = () => {
         isLoading={isLoading}
         clientFiltering={true}
         toolbarButtons={[
-          <CreatePieceSetDialog key="create" onCreated={() => refetch()} />,
+          <CreatePieceSetDialog
+            key="create"
+            isEnabled={isEnabled}
+            onCreated={() => refetch()}
+          />,
         ]}
       />
       {duplicatingSet && (


### PR DESCRIPTION
## Description

On plans without the manage pieces feature, **Platform Admin → Pieces → Piece Sets** let the user open the **New Piece Set** dialog and submit a name. The request hit `POST /v1/piece-sets`, which is gated by `platformMustHaveFeatureEnabled((p) => p.plan.managePiecesEnabled)`, and came back 402 `FEATURE_DISABLED`. The only feedback was a generic "Failed to create piece set. Please try again." toast, which reads like a transient server bug rather than a plan restriction and gives no path to upgrade.

The Piece Sets tab now gates the same way the sibling **Pieces** tab on that settings page already does:

- Shows the `LockedAlert` banner with a `RequestTrial` upgrade CTA when the plan lacks the feature.
- Disables **New Piece Set**, so the dialog cannot open and the 402 is never triggered.
- Disables the per row edit, duplicate and delete actions. Delete keeps its existing `isDefault` guard.

The piece set details page is covered too. Its query was already gated on the same flag, so a user without the feature who reached `/platform/setup/pieces/piece-sets/:id` by direct URL was left with a loader that never resolved. It now renders `LockedFeatureGuard` with the upgrade prompt.

No new translation keys were added. The banner reuses the existing `Piece Sets` and `Create a piece set to control which pieces are available to specific projects` strings.

<img width="1280" alt="Piece Sets tab with the locked banner and a disabled New Piece Set button" src="https://raw.githubusercontent.com/Anmol202005/activepieces/pr-assets/piece-sets-locked-state.png" />

## How was this tested?

Manually, against a local Community Edition dev server whose platform has `managePiecesEnabled: false`, which reproduces the exact state in the issue.

- Piece Sets tab renders the locked banner with the upgrade CTA, and the **New Piece Set** button reports `disabled: true` in the DOM rather than only looking greyed out. The create request is never sent.
- `/platform/setup/pieces/piece-sets/:id` by direct URL shows the upgrade prompt instead of the loader that never resolved.
- The unlocked path was checked by temporarily forcing the flag on: no banner, button enabled, table renders normally. The override was reverted before committing.
- `tsc --noEmit` and `eslint` on the touched files are clean.

Edition paths: verified on Community Edition. The gating code is the same pattern the Pieces tab uses on this page, so Enterprise and Cloud follow the platform plan flag identically. The CTA that `RequestTrial` renders differs by edition, which is existing shared behaviour and unchanged here.

Note on the row level edit, duplicate and delete guards: `usePieceSets` is already gated on the same flag, so on a locked plan the table has no rows and those buttons do not render. They are disabled for correctness and defence in depth, but they cannot be exercised in that state.

Fixes #14671

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)
