### PR TITLE
feat(flows): any waitpoint can carry a deadline, not only a delay

### DIFF
--- a/packages/server/api/src/app/flows/flow-run/waitpoint/waitpoint-service.ts
+++ b/packages/server/api/src/app/flows/flow-run/waitpoint/waitpoint-service.ts
@@ -1,5 +1,5 @@
 import { apId, isNil } from '@activepieces/core-utils'
-import { FlowRunStatus, PauseType } from '@activepieces/shared'
+import { FlowRunStatus } from '@activepieces/shared'
 import dayjs from 'dayjs'
 import { FastifyBaseLogger } from 'fastify'
 import { repoFactory } from '../../../core/db/repo-factory'
@@ -49,7 +49,9 @@ export const waitpointService = (log: FastifyBaseLogger) => ({
         const inserted = waitpoint.id === id
         if (inserted) {
             log.info({ flowRun: { id: params.flowRunId }, waitpoint: { id } }, '[waitpointService#createForPause] Waitpoint created')
-            if (params.type === PauseType.DELAY && !isNil(params.resumeDateTime)) {
+            // Any waitpoint may carry a deadline, not only a delay. A webhook waitpoint whose caller
+            // never comes back would otherwise hold the run forever.
+            if (!isNil(params.resumeDateTime)) {
                 await systemJobsSchedule(log).upsertJob({
                     job: {
                         name: SystemJobName.RESUME_DELAY_WAITPOINT,


### PR DESCRIPTION
## Description

A waitpoint scheduled its own resume only when it was a `DELAY`. A `WEBHOOK` waitpoint had no expiry at all, so if whoever was meant to call back never did, the run stayed paused forever with nothing to reap it.

That is not hypothetical for the agent step. The step will suspend on a webhook waitpoint and wait for the server to hand back the agent's answer, and a worker that is killed mid-run has nothing left to send. Without a deadline the flow sits paused indefinitely, and the earlier PRs in this series could only make the failure loud, never bounded.

## The change

The schedule follows the deadline rather than the pause type. `CreateWaitpointRequest` already accepted `resumeDateTime` regardless of type; it was simply ignored for anything that was not a delay.

Nothing existing changes. Delay is still the only caller that sets a `resumeDateTime` today, so every flow running now takes the same path it took before. What this does is make the field mean the same thing everywhere, so the next caller does not have to special-case itself.

## What a deadline does when it fires

`RESUME_DELAY_WAITPOINT` resumes the run with no payload, exactly as it does for a delay. A step that reads its resume payload therefore sees nothing and can report a timeout, which is the behaviour the agent piece will want: the run ends, badly but definitely, instead of hanging.

## How was this tested?

- `turbo run build` across api, `npm run lint-dev` 0 errors.
- The change is one condition on a path already covered by the delay-piece flows; no existing caller reaches the new branch, so no existing test changes.

Fixes # (issue)

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

It widens when an existing optional field is honoured. No caller passes it on a non-delay waitpoint today, so no running flow behaves differently.

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)

The scheduled job carries the same `flowRunId`, `projectId` and `waitpointId` the delay path already schedules, and resumes through the same service with the same project scoping. It grants no new reach; it only lets an existing mechanism apply to one more pause type.
