### PR TITLE
fix(auth): make first-platform creation single-use and self-healing

### DIFF
--- a/packages/server/api/src/app/database/seeds/dev-seeds.ts
+++ b/packages/server/api/src/app/database/seeds/dev-seeds.ts
@@ -51,6 +51,7 @@ const seedDevUser = async (): Promise<void> => {
         name: 'dev\'s Platform',
         invalidatePreviousTokens: true,
         isFirstPlatform: true,
+        callerTokenVersion: undefined,
     })
 
     log.info({ email: DEV_EMAIL, password: DEV_PASSWORD }, '[devSeeds#seedDevUser] Dev user and platform created')

--- a/packages/server/api/src/app/database/seeds/dev-seeds.ts
+++ b/packages/server/api/src/app/database/seeds/dev-seeds.ts
@@ -50,6 +50,7 @@ const seedDevUser = async (): Promise<void> => {
         identityId: response.id,
         name: 'dev\'s Platform',
         invalidatePreviousTokens: true,
+        isFirstPlatform: true,
     })
 
     log.info({ email: DEV_EMAIL, password: DEV_PASSWORD }, '[devSeeds#seedDevUser] Dev user and platform created')

--- a/packages/server/api/src/app/platform/platform.controller.ts
+++ b/packages/server/api/src/app/platform/platform.controller.ts
@@ -40,6 +40,7 @@ export const platformController: FastifyPluginAsyncZod = async (app) => {
             name: req.body.name,
             invalidatePreviousTokens: isOnboarding,
             isFirstPlatform: isOnboarding,
+            callerTokenVersion: req.principal.type === PrincipalType.ONBOARDING ? req.principal.tokenVersion : undefined,
         })
         return response
     })

--- a/packages/server/api/src/app/platform/platform.controller.ts
+++ b/packages/server/api/src/app/platform/platform.controller.ts
@@ -35,12 +35,13 @@ export const platformController: FastifyPluginAsyncZod = async (app) => {
         const identityId = isOnboarding
             ? req.principal.id
             : (await userService(req.log).getOneOrFail({ id: req.principal.id })).identityId
-        return platformService(req.log).createPlatformWithProject({
+        const { response } = await platformService(req.log).createPlatformWithProject({
             identityId,
             name: req.body.name,
             invalidatePreviousTokens: isOnboarding,
             isFirstPlatform: isOnboarding,
         })
+        return response
     })
 
     app.post('/:id', UpdatePlatformRequest, async (req, _res) => {

--- a/packages/server/api/src/app/platform/platform.controller.ts
+++ b/packages/server/api/src/app/platform/platform.controller.ts
@@ -39,6 +39,7 @@ export const platformController: FastifyPluginAsyncZod = async (app) => {
             identityId,
             name: req.body.name,
             invalidatePreviousTokens: isOnboarding,
+            isFirstPlatform: isOnboarding,
         })
     })
 

--- a/packages/server/api/src/app/platform/platform.service.ts
+++ b/packages/server/api/src/app/platform/platform.service.ts
@@ -76,7 +76,7 @@ export const platformService = (log: FastifyBaseLogger) => ({
         log.info({ platform: { id: savedPlatform.id }, ownerId }, 'Platform created')
         return stripFederatedAuth(savedPlatform)
     },
-    async createPlatformWithProject({ identityId, name, invalidatePreviousTokens, isFirstPlatform, callerTokenVersion }: CreatePlatformWithProjectParams): Promise<CreatePlatformWithProjectResult> {
+    async createPlatformWithProject({ identityId, name, invalidatePreviousTokens, isFirstPlatform, callerTokenVersion, beforeProvision }: CreatePlatformWithProjectParams): Promise<CreatePlatformWithProjectResult> {
         return distributedLock(log).runExclusive({
             key: `create-platform-${identityId}`,
             timeoutInSeconds: 30,
@@ -99,6 +99,7 @@ export const platformService = (log: FastifyBaseLogger) => ({
                 const unlinkedUser = existingUsers.find((user) => isNil(user.platformId))
                 const orphanedPlatform = isNil(unlinkedUser) ? null : await platformRepo().findOneBy({ ownerId: unlinkedUser.id })
                 if (!isNil(unlinkedUser) && !isNil(orphanedPlatform)) {
+                    await beforeProvision?.()
                     await userService(log).addOwnerToPlatform({ id: unlinkedUser.id, platformId: orphanedPlatform.id })
                     const response = await finishExistingPlatform({
                         user: await userService(log).getOneOrFail({ id: unlinkedUser.id }),
@@ -110,6 +111,7 @@ export const platformService = (log: FastifyBaseLogger) => ({
                     })
                     return { response, provisioned: true }
                 }
+                await beforeProvision?.()
                 const newUser = unlinkedUser
                     ?? await userService(log).create({
                         identityId,
@@ -399,6 +401,10 @@ type CreatePlatformWithProjectParams = {
     invalidatePreviousTokens: boolean
     isFirstPlatform: boolean
     callerTokenVersion: string | undefined
+    // Runs inside the provisioning lock and only when this call is the one
+    // provisioning, so whatever it writes is serialised with account creation
+    // and cannot be lost by an interruption after the account exists.
+    beforeProvision?: () => Promise<void>
 }
 
 type FinishExistingPlatformParams = {

--- a/packages/server/api/src/app/platform/platform.service.ts
+++ b/packages/server/api/src/app/platform/platform.service.ts
@@ -1,10 +1,11 @@
 import { ActivepiecesError, apId, ErrorCode, isNil, PlatformId, spreadIfDefined, spreadIfNotUndefined, tryCatch, UserId } from '@activepieces/core-utils'
-import { ApEdition, AuthenticationResponse, OPEN_SOURCE_PLAN, Platform, PlatformPlanLimits, PlatformRole, PlatformUsage, PlatformWithoutFederatedAuth, PlatformWithoutSensitiveData, ProjectType, SsoDomainVerification, SsoDomainVerificationStatus, UpdatePlatformRequestBody, UserStatus } from '@activepieces/shared'
+import { ApEdition, AuthenticationResponse, OPEN_SOURCE_PLAN, Platform, PlatformPlanLimits, PlatformRole, PlatformUsage, PlatformWithoutFederatedAuth, PlatformWithoutSensitiveData, ProjectType, SsoDomainVerification, SsoDomainVerificationStatus, UpdatePlatformRequestBody, User, UserStatus } from '@activepieces/shared'
 import { FastifyBaseLogger } from 'fastify'
 import { nanoid } from 'nanoid'
 import { authenticationUtils } from '../authentication/authentication-utils'
 import { userIdentityRepository, userIdentityService } from '../authentication/user-identity/user-identity-service'
 import { repoFactory } from '../core/db/repo-factory'
+import { distributedLock } from '../database/redis-connections'
 import { invalidateSamlClientCache } from '../ee/authentication/saml-authn/saml-client'
 import { platformPlanService } from '../ee/platform/platform-plan/platform-plan.service'
 import { defaultTheme } from '../flags/theme'
@@ -75,33 +76,58 @@ export const platformService = (log: FastifyBaseLogger) => ({
         log.info({ platform: { id: savedPlatform.id }, ownerId }, 'Platform created')
         return stripFederatedAuth(savedPlatform)
     },
-    async createPlatformWithProject({ identityId, name, invalidatePreviousTokens }: CreatePlatformWithProjectParams): Promise<AuthenticationResponse> {
-        const newUser = await userService(log).create({
-            identityId,
-            platformRole: PlatformRole.ADMIN,
-            platformId: null,
-        })
-        const platform = await this.create({ ownerId: newUser.id, name })
-        const defaultProject = await projectService(log).create({
-            displayName: `${name}'s Project`,
-            ownerId: newUser.id,
-            platformId: platform.id,
-            type: ProjectType.PERSONAL,
-        })
-        if (invalidatePreviousTokens) {
-            await userIdentityRepository().update(identityId, {
-                tokenVersion: nanoid(),
-            })
-        }
-        await authenticationUtils(log).sendTelemetry({
-            identity: await userIdentityService(log).getOneOrFail({ id: identityId }),
-            user: newUser,
-            projectId: defaultProject.id,
-        })
-        return authenticationUtils(log).getProjectAndToken({
-            userId: newUser.id,
-            platformId: platform.id,
-            projectId: defaultProject.id,
+    async createPlatformWithProject({ identityId, name, invalidatePreviousTokens, isFirstPlatform }: CreatePlatformWithProjectParams): Promise<AuthenticationResponse> {
+        return distributedLock(log).runExclusive({
+            key: `create-platform-${identityId}`,
+            timeoutInSeconds: 30,
+            fn: async () => {
+                const existingUsers = isFirstPlatform ? await userService(log).getByIdentityId({ identityId }) : []
+                const linkedUser = existingUsers.find((user) => !isNil(user.platformId))
+                if (!isNil(linkedUser) && !isNil(linkedUser.platformId)) {
+                    return finishExistingPlatform({ user: linkedUser, platformId: linkedUser.platformId, name, invalidatePreviousTokens: false, identityId, log })
+                }
+                const unlinkedUser = existingUsers.find((user) => isNil(user.platformId))
+                const orphanedPlatform = isNil(unlinkedUser) ? null : await platformRepo().findOneBy({ ownerId: unlinkedUser.id })
+                if (!isNil(unlinkedUser) && !isNil(orphanedPlatform)) {
+                    await userService(log).addOwnerToPlatform({ id: unlinkedUser.id, platformId: orphanedPlatform.id })
+                    return finishExistingPlatform({
+                        user: await userService(log).getOneOrFail({ id: unlinkedUser.id }),
+                        platformId: orphanedPlatform.id,
+                        name,
+                        invalidatePreviousTokens,
+                        identityId,
+                        log,
+                    })
+                }
+                const newUser = unlinkedUser
+                    ?? await userService(log).create({
+                        identityId,
+                        platformRole: PlatformRole.ADMIN,
+                        platformId: null,
+                    })
+                const platform = await this.create({ ownerId: newUser.id, name })
+                const defaultProject = await projectService(log).create({
+                    displayName: personalProjectName(name),
+                    ownerId: newUser.id,
+                    platformId: platform.id,
+                    type: ProjectType.PERSONAL,
+                })
+                if (invalidatePreviousTokens) {
+                    await userIdentityRepository().update(identityId, {
+                        tokenVersion: nanoid(),
+                    })
+                }
+                await authenticationUtils(log).sendTelemetry({
+                    identity: await userIdentityService(log).getOneOrFail({ id: identityId }),
+                    user: newUser,
+                    projectId: defaultProject.id,
+                })
+                return authenticationUtils(log).getProjectAndToken({
+                    userId: newUser.id,
+                    platformId: platform.id,
+                    projectId: defaultProject.id,
+                })
+            },
         })
     },
     async getAll(): Promise<PlatformWithoutFederatedAuth[]> {
@@ -251,6 +277,36 @@ export const platformService = (log: FastifyBaseLogger) => ({
     },
 })
 
+function personalProjectName(platformName: string): string {
+    return /['’]s$/.test(platformName) ? `${platformName} Project` : `${platformName}'s Project`
+}
+
+async function finishExistingPlatform({ user, platformId, name, invalidatePreviousTokens, identityId, log }: FinishExistingPlatformParams): Promise<AuthenticationResponse> {
+    const hasProjects = await projectService(log).userHasProjects({
+        platformId,
+        userId: user.id,
+        isPrivileged: userService(log).isUserPrivileged(user),
+    })
+    const project = hasProjects
+        ? null
+        : await projectService(log).create({
+            displayName: personalProjectName(name),
+            ownerId: user.id,
+            platformId,
+            type: ProjectType.PERSONAL,
+        })
+    if (invalidatePreviousTokens) {
+        await userIdentityRepository().update(identityId, {
+            tokenVersion: nanoid(),
+        })
+    }
+    return authenticationUtils(log).getProjectAndToken({
+        userId: user.id,
+        platformId,
+        projectId: project?.id ?? null,
+    })
+}
+
 async function getUsage(log: FastifyBaseLogger, platform: PlatformWithoutFederatedAuth): Promise<PlatformUsage | undefined> {
     const edition = system.getEdition()
     if (edition === ApEdition.COMMUNITY) {
@@ -315,6 +371,16 @@ type CreatePlatformWithProjectParams = {
     identityId: string
     name: string
     invalidatePreviousTokens: boolean
+    isFirstPlatform: boolean
+}
+
+type FinishExistingPlatformParams = {
+    user: User
+    platformId: PlatformId
+    name: string
+    invalidatePreviousTokens: boolean
+    identityId: string
+    log: FastifyBaseLogger
 }
 
 type ListPlatformsForIdentityParams = {

--- a/packages/server/api/src/app/platform/platform.service.ts
+++ b/packages/server/api/src/app/platform/platform.service.ts
@@ -111,11 +111,7 @@ export const platformService = (log: FastifyBaseLogger) => ({
                 if (invalidatePreviousTokens) {
                     await rotateTokenVersion(identityId)
                 }
-                await authenticationUtils(log).sendTelemetry({
-                    identity: await userIdentityService(log).getOneOrFail({ id: identityId }),
-                    user: owner,
-                    projectId: personalProject.id,
-                })
+                await reportSignup({ identityId, user: owner, projectId: personalProject.id, log })
                 const response = await authenticationUtils(log).getProjectAndToken({
                     userId: owner.id,
                     platformId: platform.id,
@@ -292,15 +288,27 @@ async function resumeProvisionedPlatform({ owner, identityId, name, invalidatePr
 
 async function linkOwnerToPlatform({ ownerId, platformId, identityId, name, invalidatePreviousTokens, log }: LinkOwnerToPlatformParams): Promise<CreatePlatformWithProjectResult> {
     await userService(log).addOwnerToPlatform({ id: ownerId, platformId })
+    const owner = await userService(log).getOneOrFail({ id: ownerId })
     const response = await finishExistingPlatform({
-        user: await userService(log).getOneOrFail({ id: ownerId }),
+        user: owner,
         platformId,
         name,
         invalidatePreviousTokens,
         identityId,
         log,
     })
+    if (!isNil(response.projectId)) {
+        await reportSignup({ identityId, user: owner, projectId: response.projectId, log })
+    }
     return { response, provisioned: true }
+}
+
+async function reportSignup({ identityId, user, projectId, log }: ReportSignupParams): Promise<void> {
+    await authenticationUtils(log).sendTelemetry({
+        identity: await userIdentityService(log).getOneOrFail({ id: identityId }),
+        user,
+        projectId,
+    })
 }
 
 function isSameTokenVersion(current: string | undefined, caller: string | undefined): boolean {
@@ -441,6 +449,12 @@ type FinishExistingPlatformParams = {
     name: string
     invalidatePreviousTokens: boolean
     identityId: string
+    log: FastifyBaseLogger
+}
+type ReportSignupParams = {
+    identityId: string
+    user: User
+    projectId: string
     log: FastifyBaseLogger
 }
 

--- a/packages/server/api/src/app/platform/platform.service.ts
+++ b/packages/server/api/src/app/platform/platform.service.ts
@@ -76,7 +76,7 @@ export const platformService = (log: FastifyBaseLogger) => ({
         log.info({ platform: { id: savedPlatform.id }, ownerId }, 'Platform created')
         return stripFederatedAuth(savedPlatform)
     },
-    async createPlatformWithProject({ identityId, name, invalidatePreviousTokens, isFirstPlatform }: CreatePlatformWithProjectParams): Promise<CreatePlatformWithProjectResult> {
+    async createPlatformWithProject({ identityId, name, invalidatePreviousTokens, isFirstPlatform, callerTokenVersion }: CreatePlatformWithProjectParams): Promise<CreatePlatformWithProjectResult> {
         return distributedLock(log).runExclusive({
             key: `create-platform-${identityId}`,
             timeoutInSeconds: 30,
@@ -84,7 +84,16 @@ export const platformService = (log: FastifyBaseLogger) => ({
                 const existingUsers = isFirstPlatform ? await userService(log).getByIdentityId({ identityId }) : []
                 const linkedUser = existingUsers.find((user) => !isNil(user.platformId))
                 if (!isNil(linkedUser) && !isNil(linkedUser.platformId)) {
-                    const response = await finishExistingPlatform({ user: linkedUser, platformId: linkedUser.platformId, name, invalidatePreviousTokens: false, identityId, log })
+                    // Rotate here only when the caller's own token is still the
+                    // current one. That means provisioning finished without ever
+                    // rotating — an interrupted attempt — so retiring the
+                    // credential now stands nothing up. If a rotation has already
+                    // happened, this is a duplicate of a call that issued a
+                    // session, and rotating again would kill it.
+                    const identity = await userIdentityService(log).getOneOrFail({ id: identityId })
+                    const rotationStillOwed = invalidatePreviousTokens
+                        && isSameTokenVersion(identity.tokenVersion, callerTokenVersion)
+                    const response = await finishExistingPlatform({ user: linkedUser, platformId: linkedUser.platformId, name, invalidatePreviousTokens: rotationStillOwed, identityId, log })
                     return { response, provisioned: false }
                 }
                 const unlinkedUser = existingUsers.find((user) => isNil(user.platformId))
@@ -280,6 +289,15 @@ export const platformService = (log: FastifyBaseLogger) => ({
     },
 })
 
+// A never-rotated identity carries no version at all, so two absent values are
+// the same version, not two unknowns.
+function isSameTokenVersion(current: string | undefined, caller: string | undefined): boolean {
+    if (isNil(current) && isNil(caller)) {
+        return true
+    }
+    return current === caller
+}
+
 function personalProjectName(platformName: string): string {
     return /['’]s$/.test(platformName) ? `${platformName} Project` : `${platformName}'s Project`
 }
@@ -380,6 +398,7 @@ type CreatePlatformWithProjectParams = {
     name: string
     invalidatePreviousTokens: boolean
     isFirstPlatform: boolean
+    callerTokenVersion: string | undefined
 }
 
 type FinishExistingPlatformParams = {

--- a/packages/server/api/src/app/platform/platform.service.ts
+++ b/packages/server/api/src/app/platform/platform.service.ts
@@ -76,7 +76,7 @@ export const platformService = (log: FastifyBaseLogger) => ({
         log.info({ platform: { id: savedPlatform.id }, ownerId }, 'Platform created')
         return stripFederatedAuth(savedPlatform)
     },
-    async createPlatformWithProject({ identityId, name, invalidatePreviousTokens, isFirstPlatform }: CreatePlatformWithProjectParams): Promise<AuthenticationResponse> {
+    async createPlatformWithProject({ identityId, name, invalidatePreviousTokens, isFirstPlatform }: CreatePlatformWithProjectParams): Promise<CreatePlatformWithProjectResult> {
         return distributedLock(log).runExclusive({
             key: `create-platform-${identityId}`,
             timeoutInSeconds: 30,
@@ -84,13 +84,14 @@ export const platformService = (log: FastifyBaseLogger) => ({
                 const existingUsers = isFirstPlatform ? await userService(log).getByIdentityId({ identityId }) : []
                 const linkedUser = existingUsers.find((user) => !isNil(user.platformId))
                 if (!isNil(linkedUser) && !isNil(linkedUser.platformId)) {
-                    return finishExistingPlatform({ user: linkedUser, platformId: linkedUser.platformId, name, invalidatePreviousTokens: false, identityId, log })
+                    const response = await finishExistingPlatform({ user: linkedUser, platformId: linkedUser.platformId, name, invalidatePreviousTokens: false, identityId, log })
+                    return { response, provisioned: false }
                 }
                 const unlinkedUser = existingUsers.find((user) => isNil(user.platformId))
                 const orphanedPlatform = isNil(unlinkedUser) ? null : await platformRepo().findOneBy({ ownerId: unlinkedUser.id })
                 if (!isNil(unlinkedUser) && !isNil(orphanedPlatform)) {
                     await userService(log).addOwnerToPlatform({ id: unlinkedUser.id, platformId: orphanedPlatform.id })
-                    return finishExistingPlatform({
+                    const response = await finishExistingPlatform({
                         user: await userService(log).getOneOrFail({ id: unlinkedUser.id }),
                         platformId: orphanedPlatform.id,
                         name,
@@ -98,6 +99,7 @@ export const platformService = (log: FastifyBaseLogger) => ({
                         identityId,
                         log,
                     })
+                    return { response, provisioned: true }
                 }
                 const newUser = unlinkedUser
                     ?? await userService(log).create({
@@ -122,11 +124,12 @@ export const platformService = (log: FastifyBaseLogger) => ({
                     user: newUser,
                     projectId: defaultProject.id,
                 })
-                return authenticationUtils(log).getProjectAndToken({
+                const response = await authenticationUtils(log).getProjectAndToken({
                     userId: newUser.id,
                     platformId: platform.id,
                     projectId: defaultProject.id,
                 })
+                return { response, provisioned: true }
             },
         })
     },
@@ -365,6 +368,11 @@ type UpdateParams = UpdatePlatformRequestBody & {
     favIconUrl?: string
     ssoDomain?: string | null
     ssoDomainVerification?: SsoDomainVerification | null
+}
+
+type CreatePlatformWithProjectResult = {
+    response: AuthenticationResponse
+    provisioned: boolean
 }
 
 type CreatePlatformWithProjectParams = {

--- a/packages/server/api/src/app/platform/platform.service.ts
+++ b/packages/server/api/src/app/platform/platform.service.ts
@@ -323,6 +323,10 @@ async function rotateTokenVersion(identityId: string): Promise<void> {
 }
 
 function personalProjectName(platformName: string): string {
+    const noun = ' Platform'
+    if (platformName.endsWith(noun)) {
+        return `${platformName.slice(0, -noun.length)} Project`
+    }
     return /['’]s$/.test(platformName) ? `${platformName} Project` : `${platformName}'s Project`
 }
 

--- a/packages/server/api/src/app/platform/platform.service.ts
+++ b/packages/server/api/src/app/platform/platform.service.ts
@@ -82,63 +82,44 @@ export const platformService = (log: FastifyBaseLogger) => ({
             timeoutInSeconds: 30,
             fn: async () => {
                 const existingUsers = isFirstPlatform ? await userService(log).getByIdentityId({ identityId }) : []
-                const linkedUser = existingUsers.find((user) => !isNil(user.platformId))
-                if (!isNil(linkedUser) && !isNil(linkedUser.platformId)) {
-                    // Rotate here only when the caller's own token is still the
-                    // current one. That means provisioning finished without ever
-                    // rotating — an interrupted attempt — so retiring the
-                    // credential now stands nothing up. If a rotation has already
-                    // happened, this is a duplicate of a call that issued a
-                    // session, and rotating again would kill it.
-                    const identity = await userIdentityService(log).getOneOrFail({ id: identityId })
-                    const rotationStillOwed = invalidatePreviousTokens
-                        && isSameTokenVersion(identity.tokenVersion, callerTokenVersion)
-                    const response = await finishExistingPlatform({ user: linkedUser, platformId: linkedUser.platformId, name, invalidatePreviousTokens: rotationStillOwed, identityId, log })
-                    return { response, provisioned: false }
+                const provisionedOwner = findProvisionedOwner(existingUsers)
+                const platformAlreadyProvisioned = !isNil(provisionedOwner)
+                if (platformAlreadyProvisioned) {
+                    return resumeProvisionedPlatform({ owner: provisionedOwner, identityId, name, invalidatePreviousTokens, callerTokenVersion, log })
                 }
-                const unlinkedUser = existingUsers.find((user) => isNil(user.platformId))
-                const orphanedPlatform = isNil(unlinkedUser) ? null : await platformRepo().findOneBy({ ownerId: unlinkedUser.id })
-                if (!isNil(unlinkedUser) && !isNil(orphanedPlatform)) {
+                const ownerWithoutPlatform = existingUsers.find((user) => isNil(user.platformId))
+                const unlinkedPlatform = isNil(ownerWithoutPlatform) ? null : await platformRepo().findOneBy({ ownerId: ownerWithoutPlatform.id })
+                const provisioningStoppedBeforeLinkingTheOwner = !isNil(ownerWithoutPlatform) && !isNil(unlinkedPlatform)
+                if (provisioningStoppedBeforeLinkingTheOwner) {
                     await beforeProvision?.()
-                    await userService(log).addOwnerToPlatform({ id: unlinkedUser.id, platformId: orphanedPlatform.id })
-                    const response = await finishExistingPlatform({
-                        user: await userService(log).getOneOrFail({ id: unlinkedUser.id }),
-                        platformId: orphanedPlatform.id,
-                        name,
-                        invalidatePreviousTokens,
-                        identityId,
-                        log,
-                    })
-                    return { response, provisioned: true }
+                    return linkOwnerToPlatform({ ownerId: ownerWithoutPlatform.id, platformId: unlinkedPlatform.id, identityId, name, invalidatePreviousTokens, log })
                 }
                 await beforeProvision?.()
-                const newUser = unlinkedUser
+                const owner = ownerWithoutPlatform
                     ?? await userService(log).create({
                         identityId,
                         platformRole: PlatformRole.ADMIN,
                         platformId: null,
                     })
-                const platform = await this.create({ ownerId: newUser.id, name })
-                const defaultProject = await projectService(log).create({
+                const platform = await this.create({ ownerId: owner.id, name })
+                const personalProject = await projectService(log).create({
                     displayName: personalProjectName(name),
-                    ownerId: newUser.id,
+                    ownerId: owner.id,
                     platformId: platform.id,
                     type: ProjectType.PERSONAL,
                 })
                 if (invalidatePreviousTokens) {
-                    await userIdentityRepository().update(identityId, {
-                        tokenVersion: nanoid(),
-                    })
+                    await rotateTokenVersion(identityId)
                 }
                 await authenticationUtils(log).sendTelemetry({
                     identity: await userIdentityService(log).getOneOrFail({ id: identityId }),
-                    user: newUser,
-                    projectId: defaultProject.id,
+                    user: owner,
+                    projectId: personalProject.id,
                 })
                 const response = await authenticationUtils(log).getProjectAndToken({
-                    userId: newUser.id,
+                    userId: owner.id,
                     platformId: platform.id,
-                    projectId: defaultProject.id,
+                    projectId: personalProject.id,
                 })
                 return { response, provisioned: true }
             },
@@ -291,13 +272,46 @@ export const platformService = (log: FastifyBaseLogger) => ({
     },
 })
 
-// A never-rotated identity carries no version at all, so two absent values are
-// the same version, not two unknowns.
+function findProvisionedOwner(users: User[]): PlatformOwner | undefined {
+    return users.find((user): user is PlatformOwner => !isNil(user.platformId))
+}
+
+async function resumeProvisionedPlatform({ owner, identityId, name, invalidatePreviousTokens, callerTokenVersion, log }: ResumeProvisionedPlatformParams): Promise<CreatePlatformWithProjectResult> {
+    const identity = await userIdentityService(log).getOneOrFail({ id: identityId })
+    const earlierAttemptNeverRotated = isSameTokenVersion(identity.tokenVersion, callerTokenVersion)
+    const response = await finishExistingPlatform({
+        user: owner,
+        platformId: owner.platformId,
+        name,
+        invalidatePreviousTokens: invalidatePreviousTokens && earlierAttemptNeverRotated,
+        identityId,
+        log,
+    })
+    return { response, provisioned: false }
+}
+
+async function linkOwnerToPlatform({ ownerId, platformId, identityId, name, invalidatePreviousTokens, log }: LinkOwnerToPlatformParams): Promise<CreatePlatformWithProjectResult> {
+    await userService(log).addOwnerToPlatform({ id: ownerId, platformId })
+    const response = await finishExistingPlatform({
+        user: await userService(log).getOneOrFail({ id: ownerId }),
+        platformId,
+        name,
+        invalidatePreviousTokens,
+        identityId,
+        log,
+    })
+    return { response, provisioned: true }
+}
+
 function isSameTokenVersion(current: string | undefined, caller: string | undefined): boolean {
-    if (isNil(current) && isNil(caller)) {
-        return true
-    }
-    return current === caller
+    const neitherHasBeenRotated = isNil(current) && isNil(caller)
+    return neitherHasBeenRotated || current === caller
+}
+
+async function rotateTokenVersion(identityId: string): Promise<void> {
+    await userIdentityRepository().update(identityId, {
+        tokenVersion: nanoid(),
+    })
 }
 
 function personalProjectName(platformName: string): string {
@@ -319,9 +333,7 @@ async function finishExistingPlatform({ user, platformId, name, invalidatePrevio
             type: ProjectType.PERSONAL,
         })
     if (invalidatePreviousTokens) {
-        await userIdentityRepository().update(identityId, {
-            tokenVersion: nanoid(),
-        })
+        await rotateTokenVersion(identityId)
     }
     return authenticationUtils(log).getProjectAndToken({
         userId: user.id,
@@ -401,12 +413,28 @@ type CreatePlatformWithProjectParams = {
     invalidatePreviousTokens: boolean
     isFirstPlatform: boolean
     callerTokenVersion: string | undefined
-    // Runs inside the provisioning lock and only when this call is the one
-    // provisioning, so whatever it writes is serialised with account creation
-    // and cannot be lost by an interruption after the account exists.
     beforeProvision?: () => Promise<void>
 }
 
+type PlatformOwner = User & {
+    platformId: PlatformId
+}
+type ResumeProvisionedPlatformParams = {
+    owner: PlatformOwner
+    identityId: string
+    name: string
+    invalidatePreviousTokens: boolean
+    callerTokenVersion: string | undefined
+    log: FastifyBaseLogger
+}
+type LinkOwnerToPlatformParams = {
+    ownerId: UserId
+    platformId: PlatformId
+    identityId: string
+    name: string
+    invalidatePreviousTokens: boolean
+    log: FastifyBaseLogger
+}
 type FinishExistingPlatformParams = {
     user: User
     platformId: PlatformId

--- a/packages/server/api/test/helpers/mocks/index.ts
+++ b/packages/server/api/test/helpers/mocks/index.ts
@@ -367,6 +367,7 @@ export const createMockOtp = (otp?: Partial<OtpModel>): OtpModel => {
         value:
             otp?.value ?? faker.number.int({ min: 100000, max: 999999 }).toString(),
         state: otp?.state ?? faker.helpers.enumValue(OtpState),
+        attempts: otp?.attempts ?? 0,
     }
 }
 

--- a/packages/server/api/test/integration/ce/platform/first-platform-provisioning.test.ts
+++ b/packages/server/api/test/integration/ce/platform/first-platform-provisioning.test.ts
@@ -32,12 +32,13 @@ async function createViaRoute({ token, name }: { token: string, name: string }) 
     })
 }
 
-async function createFirstPlatform(identityId: string) {
+async function createFirstPlatform(identityId: string, callerTokenVersion?: string) {
     const { response } = await platformService(app!.log).createPlatformWithProject({
         identityId,
         name: 'Ahmad',
         invalidatePreviousTokens: true,
         isFirstPlatform: true,
+        callerTokenVersion,
     })
     return response
 }
@@ -48,7 +49,13 @@ function provisionFirstPlatform(identityId: string) {
         name: 'Ahmad',
         invalidatePreviousTokens: true,
         isFirstPlatform: true,
+        callerTokenVersion: undefined,
     })
+}
+
+async function tokenVersionOf(identityId: string): Promise<string> {
+    const identity = await databaseConnection().getRepository('user_identity').findOneBy({ id: identityId })
+    return identity!.tokenVersion
 }
 
 async function strandUser(identityId: string): Promise<string> {
@@ -136,6 +143,31 @@ describe('First platform provisioning', () => {
         expect(retry.platformId).toBe(first.platformId)
         expect(await databaseConnection().getRepository('project').count()).toBe(1)
         expect(await databaseConnection().getRepository('platform').count()).toBe(1)
+    })
+
+    it('finishes the rotation an interrupted attempt never got to', async () => {
+        const identityId = await seedVerifiedIdentity()
+        const strandedUserId = await strandUser(identityId)
+        await databaseConnection().getRepository('platform').save(
+            createMockPlatform({ ownerId: strandedUserId }),
+        )
+        await databaseConnection().getRepository('user')
+            .update(strandedUserId, { platformId: (await databaseConnection().getRepository('platform').findOneBy({ ownerId: strandedUserId }))!.id })
+        const beforeRetry = await tokenVersionOf(identityId)
+
+        await createFirstPlatform(identityId, beforeRetry)
+
+        expect(await tokenVersionOf(identityId)).not.toBe(beforeRetry)
+    })
+
+    it('leaves the token version alone for a duplicate that carries a spent version', async () => {
+        const identityId = await seedVerifiedIdentity()
+        await createFirstPlatform(identityId, await tokenVersionOf(identityId))
+        const afterFirst = await tokenVersionOf(identityId)
+
+        await createFirstPlatform(identityId, 'a-version-from-before-the-rotation')
+
+        expect(await tokenVersionOf(identityId)).toBe(afterFirst)
     })
 
     it('rotates once when two first-platform creations race, so neither session is stranded', async () => {

--- a/packages/server/api/test/integration/ce/platform/first-platform-provisioning.test.ts
+++ b/packages/server/api/test/integration/ce/platform/first-platform-provisioning.test.ts
@@ -1,0 +1,148 @@
+import { apId } from '@activepieces/core-utils'
+import { PlatformRole, UserStatus } from '@activepieces/shared'
+import { FastifyInstance } from 'fastify'
+import { StatusCodes } from 'http-status-codes'
+import { authenticationUtils } from '../../../../src/app/authentication/authentication-utils'
+import { databaseConnection } from '../../../../src/app/database/database-connection'
+import { platformService } from '../../../../src/app/platform/platform.service'
+import { createMockPlatform, createMockUserIdentity } from '../../../helpers/mocks'
+import { setupTestEnvironment, teardownTestEnvironment } from '../../../helpers/test-setup'
+
+let app: FastifyInstance | null = null
+
+const EMAIL = 'first.platform@example.com'
+
+async function seedVerifiedIdentity(): Promise<string> {
+    const identity = createMockUserIdentity({ email: EMAIL, verified: true })
+    await databaseConnection().getRepository('user_identity').save(identity)
+    return identity.id
+}
+
+async function onboardingToken(identityId: string): Promise<string> {
+    const response = await authenticationUtils(app!.log).getOnboardingResponse({ identityId })
+    return response.token
+}
+
+async function createViaRoute({ token, name }: { token: string, name: string }) {
+    return app?.inject({
+        method: 'POST',
+        url: '/api/v1/platforms',
+        headers: { authorization: `Bearer ${token}` },
+        body: { name },
+    })
+}
+
+function createFirstPlatform(identityId: string) {
+    return platformService(app!.log).createPlatformWithProject({
+        identityId,
+        name: 'Ahmad',
+        invalidatePreviousTokens: true,
+        isFirstPlatform: true,
+    })
+}
+
+async function strandUser(identityId: string): Promise<string> {
+    const userId = apId()
+    await databaseConnection().getRepository('user').save({
+        id: userId,
+        identityId,
+        platformId: null,
+        platformRole: PlatformRole.ADMIN,
+        status: UserStatus.ACTIVE,
+    })
+    return userId
+}
+
+beforeAll(async () => {
+    app = await setupTestEnvironment()
+})
+
+afterAll(async () => {
+    await teardownTestEnvironment()
+})
+
+beforeEach(async () => {
+    await databaseConnection().getRepository('project').createQueryBuilder().delete().execute()
+    await databaseConnection().getRepository('platform').createQueryBuilder().delete().execute()
+    await databaseConnection().getRepository('user').createQueryBuilder().delete().execute()
+    await databaseConnection().getRepository('user_identity').createQueryBuilder().delete().execute()
+})
+
+describe('First platform provisioning', () => {
+    it('gives one identity a single platform however many times it asks', async () => {
+        const identityId = await seedVerifiedIdentity()
+
+        const first = await createFirstPlatform(identityId)
+        const second = await createFirstPlatform(identityId)
+
+        expect(second.platformId).toBe(first.platformId)
+        expect(await databaseConnection().getRepository('platform').count()).toBe(1)
+        expect(await databaseConnection().getRepository('project').count()).toBe(1)
+        expect(await databaseConnection().getRepository('user').count()).toBe(1)
+    })
+
+    it('reuses a user left unlinked by an interrupted attempt instead of creating a second one', async () => {
+        const identityId = await seedVerifiedIdentity()
+        await strandUser(identityId)
+
+        await createFirstPlatform(identityId)
+
+        expect(await databaseConnection().getRepository('user').count()).toBe(1)
+    })
+
+    it('adopts a platform whose owner link never landed instead of building a second one', async () => {
+        const identityId = await seedVerifiedIdentity()
+        const strandedUserId = await strandUser(identityId)
+        await databaseConnection().getRepository('platform').save(
+            createMockPlatform({ ownerId: strandedUserId }),
+        )
+
+        const response = await createFirstPlatform(identityId)
+
+        expect(await databaseConnection().getRepository('platform').count()).toBe(1)
+        expect(await databaseConnection().getRepository('user').count()).toBe(1)
+        const relinked = await databaseConnection().getRepository('user').findOneBy({ id: strandedUserId })
+        expect(relinked?.platformId).toBe(response.platformId)
+    })
+
+    it('repairs a platform left without a project instead of wedging the identity', async () => {
+        const identityId = await seedVerifiedIdentity()
+        const first = await createFirstPlatform(identityId)
+        await databaseConnection().getRepository('project').createQueryBuilder().delete().execute()
+
+        const retry = await createFirstPlatform(identityId)
+
+        expect(retry.platformId).toBe(first.platformId)
+        expect(await databaseConnection().getRepository('project').count()).toBe(1)
+        expect(await databaseConnection().getRepository('platform').count()).toBe(1)
+    })
+
+    it('rotates once when two first-platform creations race, so neither session is stranded', async () => {
+        const identityId = await seedVerifiedIdentity()
+
+        const [first, second] = await Promise.all([
+            createFirstPlatform(identityId),
+            createFirstPlatform(identityId),
+        ])
+
+        const after = await databaseConnection().getRepository('user_identity').findOneBy({ id: identityId })
+        const versionOf = (token: string) =>
+            JSON.parse(Buffer.from(token.split('.')[1], 'base64').toString()).tokenVersion
+        expect(versionOf(first.token)).toBe(after?.tokenVersion)
+        expect(versionOf(second.token)).toBe(after?.tokenVersion)
+    })
+
+    it('serves the onboarding route without provisioning a second platform', async () => {
+        const identityId = await seedVerifiedIdentity()
+        const token = await onboardingToken(identityId)
+
+        const created = await createViaRoute({ token, name: 'Ahmad' })
+
+        expect(created?.statusCode).toBe(StatusCodes.OK)
+        expect(await databaseConnection().getRepository('platform').count()).toBe(1)
+        const identity = await databaseConnection().getRepository('user_identity').findOneBy({ id: identityId })
+        expect(identity?.tokenVersion).not.toBe(
+            JSON.parse(Buffer.from(token.split('.')[1], 'base64').toString()).tokenVersion,
+        )
+    })
+})

--- a/packages/server/api/test/integration/ce/platform/first-platform-provisioning.test.ts
+++ b/packages/server/api/test/integration/ce/platform/first-platform-provisioning.test.ts
@@ -32,7 +32,17 @@ async function createViaRoute({ token, name }: { token: string, name: string }) 
     })
 }
 
-function createFirstPlatform(identityId: string) {
+async function createFirstPlatform(identityId: string) {
+    const { response } = await platformService(app!.log).createPlatformWithProject({
+        identityId,
+        name: 'Ahmad',
+        invalidatePreviousTokens: true,
+        isFirstPlatform: true,
+    })
+    return response
+}
+
+function provisionFirstPlatform(identityId: string) {
     return platformService(app!.log).createPlatformWithProject({
         identityId,
         name: 'Ahmad',
@@ -79,6 +89,17 @@ describe('First platform provisioning', () => {
         expect(await databaseConnection().getRepository('platform').count()).toBe(1)
         expect(await databaseConnection().getRepository('project').count()).toBe(1)
         expect(await databaseConnection().getRepository('user').count()).toBe(1)
+    })
+
+    it('tells exactly one of two racing callers that it provisioned the platform', async () => {
+        const identityId = await seedVerifiedIdentity()
+
+        const results = await Promise.all([
+            provisionFirstPlatform(identityId),
+            provisionFirstPlatform(identityId),
+        ])
+
+        expect(results.filter((result) => result.provisioned)).toHaveLength(1)
     })
 
     it('reuses a user left unlinked by an interrupted attempt instead of creating a second one', async () => {

--- a/packages/server/api/test/integration/ce/platform/first-platform-provisioning.test.ts
+++ b/packages/server/api/test/integration/ce/platform/first-platform-provisioning.test.ts
@@ -1,12 +1,22 @@
 import { apId } from '@activepieces/core-utils'
-import { PlatformRole, UserStatus } from '@activepieces/shared'
-import { FastifyInstance } from 'fastify'
+import { PlatformRole, TelemetryEventName, UserStatus } from '@activepieces/shared'
+import { FastifyBaseLogger, FastifyInstance } from 'fastify'
 import { StatusCodes } from 'http-status-codes'
 import { authenticationUtils } from '../../../../src/app/authentication/authentication-utils'
 import { databaseConnection } from '../../../../src/app/database/database-connection'
 import { platformService } from '../../../../src/app/platform/platform.service'
 import { createMockPlatform, createMockUserIdentity } from '../../../helpers/mocks'
 import { setupTestEnvironment, teardownTestEnvironment } from '../../../helpers/test-setup'
+
+const trackProject = vi.fn()
+
+vi.mock('../../../../src/app/helper/telemetry.utils', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('../../../../src/app/helper/telemetry.utils')>()
+    return {
+        ...actual,
+        telemetry: (log: FastifyBaseLogger) => ({ ...actual.telemetry(log), trackProject }),
+    }
+})
 
 let app: FastifyInstance | null = null
 
@@ -79,6 +89,7 @@ afterAll(async () => {
 })
 
 beforeEach(async () => {
+    trackProject.mockClear()
     await databaseConnection().getRepository('project').createQueryBuilder().delete().execute()
     await databaseConnection().getRepository('platform').createQueryBuilder().delete().execute()
     await databaseConnection().getRepository('user').createQueryBuilder().delete().execute()
@@ -131,6 +142,20 @@ describe('First platform provisioning', () => {
         expect(await databaseConnection().getRepository('user').count()).toBe(1)
         const relinked = await databaseConnection().getRepository('user').findOneBy({ id: strandedUserId })
         expect(relinked?.platformId).toBe(response.platformId)
+    })
+
+    it('reports the signup it finished for a platform whose owner link never landed', async () => {
+        const identityId = await seedVerifiedIdentity()
+        const strandedUserId = await strandUser(identityId)
+        await databaseConnection().getRepository('platform').save(
+            createMockPlatform({ ownerId: strandedUserId }),
+        )
+
+        const response = await createFirstPlatform(identityId)
+
+        const signedUp = trackProject.mock.calls.filter(([, event]) => event.name === TelemetryEventName.SIGNED_UP)
+        expect(signedUp).toHaveLength(1)
+        expect(signedUp[0][0]).toBe(response.projectId)
     })
 
     it('repairs a platform left without a project instead of wedging the identity', async () => {


### PR DESCRIPTION
## Description

**3 of 9 in the passwordless sign-in stack.** <details><summary><b>The stack</b> — review bottom-up; each PR targets the one below it</summary>

| | PR | Area |
|---|---|---|
| 1 | #14685 — OTP primitive moves to core, gains an attempt budget | server/api |
| 2 | #14692 — derive first, last and platform names | server/api |
| 3 | #14702 — first-platform creation single-use and self-healing | server/api |
| 4 | #14703 — sign in with an emailed code | server/api |
| 5 | #14708 — finish sign-up by asking for a name | server/api |
| 6 | #14709 — building blocks for the auth screen | web |
| 7 | #14689 — one screen for sign in and sign up | web |
| 8 | #14690 — ask new members their name in the card | web |
| 9 | #14707 — refuse throwaway addresses and bot sign-ups | server/api + web |

Split out of #14653, which exceeded the review-size budget. Superseded along the way:
#14686, #14694 and #14687 (reordered so the provisioning guard lands before the feature
that relies on it), #14688 and #14704 (rebased onto new bases, which GitHub will not
retarget inside a stack).

</details>

Creating an identity's first platform was replayable and is not atomic, so one identity could end up with duplicate tenant resources or stuck part-way. Found by review of PR 2, fixed here.

**The guard goes in `createPlatformWithProject`, where every caller passes through.** A lock in the sign-up route alone was not enough: `POST /v1/platforms` accepts the same `ONBOARDING` principal, so a client calling both still provisioned twice.

**Deduplication is opt-in per call site via `isFirstPlatform`, not unconditional** — on cloud an existing signed-in user is *allowed* to create additional platforms (`platform.controller` only refuses that on ce/ee). An unconditional "identity already has a platform, return it" guard would have silently broken multi-platform creation while fixing the replay.

Provisioning writes the user, the platform link and the project separately, and each gap left state a retry read wrongly:

| interrupted after | stale read | before | now |
|---|---|---|---|
| user insert | user has null `platformId` | second user created | unlinked user reused |
| platform save | user still unlinked, platform already names it owner | **500 forever** (unique owner constraint) | platform adopted |
| owner link | platform has no project | **403 forever** (`getProjectAndToken` throws) | project created |

Two of those wedged the identity permanently — every retry hit the same error.

**What this is not:** the three writes are still not atomic. One transaction across `userService`, `platformService` and `projectService`, each owning its own `repoFactory` repository, means threading an `EntityManager` through all three and touching every existing caller of platform creation — wider than this stack should carry. What is here makes retries *converge* from any interruption point. The non-atomic sequence itself predates this work.

## How was this tested?

Five integration cases, **each verified to fail without its fix** (`expected 2 to be 1`, `expected 500 to be 200`, `expected 403 to be 200`, and both routes returning the same `platformId`).

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

- [ ] no — reviewed, no security impact
- [x] yes — security-sensitive (call out the risk and mitigation in the description above)

