### PR TITLE
fix(deps): bump nanoid, nodemailer, undici to clear Dependabot alerts

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -87,7 +87,7 @@
         "form-data": "4.0.6",
         "inquirer": "8.2.7",
         "jsonwebtoken": "9.0.1",
-        "nanoid": "3.3.8",
+        "nanoid": "3.3.17",
         "tslib": "2.6.2",
       },
       "devDependencies": {
@@ -162,7 +162,7 @@
     },
     "packages/core/shared": {
       "name": "@activepieces/shared",
-      "version": "0.128.0",
+      "version": "0.128.3",
       "dependencies": {
         "@activepieces/core-execution": "workspace:*",
         "@activepieces/core-formula": "workspace:*",
@@ -172,7 +172,7 @@
         "deepmerge-ts": "7.1.0",
         "expr-eval": "2.0.2",
         "ipaddr.js": "2.3.0",
-        "nanoid": "3.3.8",
+        "nanoid": "3.3.17",
         "semver": "7.6.0",
         "socket.io-client": "4.8.1",
         "tslib": "2.6.2",
@@ -187,11 +187,11 @@
     },
     "packages/core/utils": {
       "name": "@activepieces/core-utils",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "dependencies": {
         "deepmerge-ts": "7.1.0",
         "ipaddr.js": "2.3.0",
-        "nanoid": "3.3.8",
+        "nanoid": "3.3.17",
         "tslib": "2.6.2",
         "zod": "4.3.6",
       },
@@ -3119,7 +3119,7 @@
         "@activepieces/core-utils": "workspace:*",
         "@activepieces/pieces-common": "workspace:*",
         "@activepieces/pieces-framework": "workspace:*",
-        "nanoid": "3.3.8",
+        "nanoid": "3.3.17",
       },
       "devDependencies": {
         "tslib": "2.6.2",
@@ -3687,7 +3687,7 @@
         "google-auth-library": "10.5.0",
         "mailparser": "3.9.3",
         "mime-types": "2.1.35",
-        "nodemailer": "8.0.5",
+        "nodemailer": "9.0.1",
       },
       "devDependencies": {
         "@types/mailparser": "3.4.6",
@@ -3898,7 +3898,7 @@
         "gaxios": "6.7.1",
         "google-auth-library": "10.5.0",
         "lodash": "4.18.1",
-        "nanoid": "3.3.8",
+        "nanoid": "3.3.17",
         "zod": "4.3.6",
       },
       "devDependencies": {
@@ -4293,7 +4293,7 @@
         "@activepieces/pieces-common": "workspace:*",
         "@activepieces/pieces-framework": "workspace:*",
         "form-data": "4.0.6",
-        "undici": "7.28.0",
+        "undici": "7.29.0",
       },
       "devDependencies": {
         "tslib": "2.6.2",
@@ -6890,7 +6890,7 @@
     },
     "packages/pieces/community/pinterest": {
       "name": "@activepieces/piece-pinterest",
-      "version": "0.1.6",
+      "version": "0.1.7",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -7940,7 +7940,7 @@
         "@activepieces/pieces-common": "workspace:*",
         "@activepieces/pieces-framework": "workspace:*",
         "mime-types": "2.1.35",
-        "nodemailer": "8.0.5",
+        "nodemailer": "9.0.1",
       },
       "devDependencies": {
         "@types/mime-types": "2.1.1",
@@ -9153,7 +9153,7 @@
         "@activepieces/core-utils": "workspace:*",
         "@activepieces/pieces-common": "workspace:*",
         "@activepieces/pieces-framework": "workspace:*",
-        "nanoid": "3.3.8",
+        "nanoid": "3.3.17",
       },
       "devDependencies": {
         "tslib": "2.6.2",
@@ -9898,7 +9898,7 @@
     },
     "packages/pieces/community/youtrack": {
       "name": "@activepieces/piece-youtrack",
-      "version": "0.0.5",
+      "version": "0.1.0",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -10312,7 +10312,7 @@
         "@activepieces/pieces-framework": "workspace:*",
         "axios": "1.18.0",
         "form-data": "4.0.6",
-        "undici": "7.28.0",
+        "undici": "7.29.0",
       },
       "devDependencies": {
         "tslib": "2.6.2",
@@ -10354,7 +10354,7 @@
     },
     "packages/pieces/core/math-helper": {
       "name": "@activepieces/piece-math-helper",
-      "version": "0.0.28",
+      "version": "0.0.29",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -10377,7 +10377,7 @@
         "@activepieces/pieces-framework": "workspace:*",
         "jimp": "^0.22.12",
         "mime-types": "2.1.35",
-        "nanoid": "3.3.8",
+        "nanoid": "3.3.17",
         "pdf-lib": "1.17.1",
         "unpdf": "1.4.0",
       },
@@ -10446,7 +10446,7 @@
         "@activepieces/pieces-common": "workspace:*",
         "@activepieces/pieces-framework": "workspace:*",
         "mime-types": "2.1.35",
-        "nodemailer": "8.0.5",
+        "nodemailer": "9.0.1",
       },
       "devDependencies": {
         "@types/mime-types": "2.1.1",
@@ -10668,7 +10668,7 @@
         "mammoth": "1.11.0",
         "mime-types": "2.1.35",
         "mustache": "4.2.0",
-        "nanoid": "3.3.8",
+        "nanoid": "3.3.17",
         "node-cache": "5.1.2",
         "node-cron": "3.0.3",
         "nodemailer": "9.0.1",
@@ -10739,10 +10739,10 @@
         "https-proxy-agent": "7.0.6",
         "isolated-vm": "6.0.2",
         "jsep": "1.4.0",
-        "nanoid": "3.3.8",
+        "nanoid": "3.3.17",
         "socket.io-client": "4.8.1",
         "tslib": "2.6.2",
-        "undici": "7.28.0",
+        "undici": "7.29.0",
         "zod": "4.3.6",
       },
       "devDependencies": {
@@ -10758,7 +10758,7 @@
         "@activepieces/core-utils": "workspace:*",
         "@activepieces/server-utils": "workspace:*",
         "@activepieces/shared": "workspace:*",
-        "nanoid": "3.3.8",
+        "nanoid": "3.3.17",
         "socket.io": "4.7.5",
         "tree-kill": "1.2.2",
         "tslib": "2.6.2",
@@ -10829,7 +10829,7 @@
         "decompress": "4.2.1",
         "dotenv": "16.4.7",
         "env-var": "7.5.0",
-        "nanoid": "3.3.8",
+        "nanoid": "3.3.17",
         "proxy-chain": "2.7.1",
         "socket.io": "4.7.5",
         "socket.io-client": "4.8.1",
@@ -10934,7 +10934,7 @@
         "lucide-react": "0.576.0",
         "marked": "18.0.2",
         "motion": "12.35.0",
-        "nanoid": "3.3.8",
+        "nanoid": "3.3.17",
         "pako": "2.1.0",
         "papaparse": "5.5.3",
         "posthog-js": "1.393.5",
@@ -10997,6 +10997,7 @@
   ],
   "overrides": {
     "axios": "1.18.0",
+    "nanoid": "3.3.17",
     "rollup": "npm:@rollup/wasm-node",
   },
   "packages": {
@@ -16442,7 +16443,7 @@
 
     "nano-css": ["nano-css@5.6.2", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.4.15", "css-tree": "^1.1.2", "csstype": "^3.1.2", "fastest-stable-stringify": "^2.0.2", "inline-style-prefixer": "^7.0.1", "rtl-css-js": "^1.16.1", "stacktrace-js": "^2.0.2", "stylis": "^4.3.0" }, "peerDependencies": { "react": "*", "react-dom": "*" } }, "sha512-+6bHaC8dSDGALM1HJjOHVXpuastdu2xFoZlC77Jh4cg+33Zcgm+Gxd+1xsnpZK14eyHObSp82+ll5y3SX75liw=="],
 
-    "nanoid": ["nanoid@3.3.8", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w=="],
+    "nanoid": ["nanoid@3.3.17", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g=="],
 
     "napi-build-utils": ["napi-build-utils@2.0.0", "", {}, "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA=="],
 
@@ -16492,7 +16493,7 @@
 
     "node-xmllint": ["node-xmllint@1.0.0", "", {}, "sha512-71UV2HRUP+djvHpdyatiuv+Y1o8hI4ZI7bMfuuoACMLR1JJCErM4WXAclNeHd6BgHXkqeqnnAk3wpDkSQWmFXw=="],
 
-    "nodemailer": ["nodemailer@8.0.5", "", {}, "sha512-0PF8Yb1yZuQfQbq+5/pZJrtF6WQcjTd5/S4JOHs9PGFxuTqoB/icwuB44pOdURHJbRKX1PPoJZtY7R4VUoCC8w=="],
+    "nodemailer": ["nodemailer@9.0.1", "", {}, "sha512-Gwv8SQewT616ZM/URn0H54b8PWo/Wum7md3EW2aWy1lO27+WZCX+Xyak3J+NlmHUjDh5ME+uesJUDRbR3Ye8Bw=="],
 
     "nopt": ["nopt@5.0.0", "", { "dependencies": { "abbrev": "1" }, "bin": { "nopt": "bin/nopt.js" } }, "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ=="],
 
@@ -17546,7 +17547,7 @@
 
     "underscore.string": ["underscore.string@3.3.6", "", { "dependencies": { "sprintf-js": "^1.1.1", "util-deprecate": "^1.0.2" } }, "sha512-VoC83HWXmCrF6rgkyxS9GHv8W9Q5nhMKho+OadDJGzL2oDYbYEppBaCMH6pFlwLeqj2QS+hhkw2kpXkSdD1JxQ=="],
 
-    "undici": ["undici@7.28.0", "", {}, "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA=="],
+    "undici": ["undici@7.29.0", "", {}, "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw=="],
 
     "undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
 
@@ -18046,7 +18047,7 @@
 
     "@activepieces/piece-fountain/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
-    "@activepieces/piece-fragment/dayjs": ["dayjs@1.11.20", "", {}, "sha512-YbwwqR/uYpeoP4pu043q+LTDLFBLApUP6VxRihdfNTqu4ubqMlGDLd6ErXhEgsyvY0K6nCs7nggYumAN+9uEuQ=="],
+    "@activepieces/piece-fragment/dayjs": ["dayjs@1.11.21", "", {}, "sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA=="],
 
     "@activepieces/piece-fragment/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
@@ -19588,8 +19589,6 @@
 
     "api/fast-xml-parser": ["fast-xml-parser@5.7.2", "", { "dependencies": { "@nodable/entities": "^2.1.0", "fast-xml-builder": "^1.1.5", "path-expression-matcher": "^1.5.0", "strnum": "^2.2.3" }, "bin": { "fxparser": "src/cli/cli.js" } }, "sha512-P7oW7tLbYnhOLQk/Gv7cZgzgMPP/XN03K02/Jy6Y/NHzyIAIpxuZIM/YqAkfiXFPxA2CTm7NtCijK9EDu09u2w=="],
 
-    "api/nodemailer": ["nodemailer@9.0.1", "", {}, "sha512-Gwv8SQewT616ZM/URn0H54b8PWo/Wum7md3EW2aWy1lO27+WZCX+Xyak3J+NlmHUjDh5ME+uesJUDRbR3Ye8Bw=="],
-
     "api/socket.io": ["socket.io@4.8.1", "", { "dependencies": { "accepts": "~1.3.4", "base64id": "~2.0.0", "cors": "~2.8.5", "debug": "~4.3.2", "engine.io": "~6.6.0", "socket.io-adapter": "~2.5.2", "socket.io-parser": "~4.2.4" } }, "sha512-oZ7iUCxph8WYRHHcjBEc9unw3adt5CmSNlppj/5Q4k2RIrhl8Z5yY2Xr4j9zj0+wzVZ0bxmYoGSzKJnRl6A4yg=="],
 
     "apify-client/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
@@ -20198,8 +20197,6 @@
 
     "playwright/fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
 
-    "postcss/nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
-
     "promise-retry/retry": ["retry@0.12.0", "", {}, "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow=="],
 
     "prop-types/react-is": ["react-is@16.13.1", "", {}, "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="],
@@ -20696,11 +20693,31 @@
 
     "@activepieces/pieces-framework/ai/@ai-sdk/provider": ["@ai-sdk/provider@3.0.9", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-/ngMKqKdL9dSlY/eQ3NFDzzFyw0Hix+cbFFlyuKEKcOgpHdBt/spKUvX/i0wGrDLFPYJeVvv3N0j92LxWRL7yQ=="],
 
+    "@ai-sdk/amazon-bedrock/@ai-sdk/provider-utils/undici": ["undici@7.28.0", "", {}, "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA=="],
+
+    "@ai-sdk/anthropic/@ai-sdk/provider-utils/undici": ["undici@7.28.0", "", {}, "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA=="],
+
+    "@ai-sdk/azure/@ai-sdk/provider-utils/undici": ["undici@7.28.0", "", {}, "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA=="],
+
+    "@ai-sdk/deepseek/@ai-sdk/provider-utils/undici": ["undici@7.28.0", "", {}, "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA=="],
+
+    "@ai-sdk/gateway/@ai-sdk/provider-utils/undici": ["undici@7.28.0", "", {}, "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA=="],
+
+    "@ai-sdk/google-vertex/@ai-sdk/provider-utils/undici": ["undici@7.28.0", "", {}, "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA=="],
+
     "@ai-sdk/google-vertex/google-auth-library/gaxios": ["gaxios@7.3.0", "", { "dependencies": { "extend": "^3.0.2", "https-proxy-agent": "^7.0.1", "node-fetch": "^3.3.2" } }, "sha512-RB5vLV+vvQeoFPCX4QMK6/hjVkbIamPp1QSUD0CiZcnj12qbpiL+pLbYtgD+oZkWl0tl9z+o2Utp+MpM3QRhBA=="],
 
     "@ai-sdk/google-vertex/google-auth-library/gcp-metadata": ["gcp-metadata@8.1.2", "", { "dependencies": { "gaxios": "^7.0.0", "google-logging-utils": "^1.0.0", "json-bigint": "^1.0.0" } }, "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg=="],
 
     "@ai-sdk/google-vertex/google-auth-library/jws": ["jws@4.0.1", "", { "dependencies": { "jwa": "^2.0.1", "safe-buffer": "^5.0.1" } }, "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA=="],
+
+    "@ai-sdk/google/@ai-sdk/provider-utils/undici": ["undici@7.28.0", "", {}, "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA=="],
+
+    "@ai-sdk/openai-compatible/@ai-sdk/provider-utils/undici": ["undici@7.28.0", "", {}, "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA=="],
+
+    "@ai-sdk/openai/@ai-sdk/provider-utils/undici": ["undici@7.28.0", "", {}, "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA=="],
+
+    "@ai-sdk/replicate/@ai-sdk/provider-utils/undici": ["undici@7.28.0", "", {}, "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA=="],
 
     "@anthropic-ai/sdk/@types/node/undici-types": ["undici-types@5.26.5", "", {}, "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="],
 
@@ -20953,6 +20970,8 @@
     "ai-gateway-provider/@ai-sdk/google-vertex/google-auth-library": ["google-auth-library@10.6.1", "", { "dependencies": { "base64-js": "^1.3.0", "ecdsa-sig-formatter": "^1.0.11", "gaxios": "7.1.3", "gcp-metadata": "8.1.2", "google-logging-utils": "1.1.3", "jws": "^4.0.0" } }, "sha512-5awwuLrzNol+pFDmKJd0dKtZ0fPLAtoA5p7YO4ODsDu6ONJUVqbYwvv8y2ZBO5MBNp9TJXigB19710kYpBPdtA=="],
 
     "ai-gateway-provider/ai/@ai-sdk/gateway": ["@ai-sdk/gateway@3.0.105", "", { "dependencies": { "@ai-sdk/provider": "3.0.9", "@ai-sdk/provider-utils": "4.0.24", "@vercel/oidc": "3.2.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-XpERadvLMHkYGJO4hz1Sw7Y9J705Iex48TmdZLdZdaPiFFtVgiA9qhXugLUWGAxdlXU/2N6ipoPSOwfnULZbXw=="],
+
+    "ai/@ai-sdk/provider-utils/undici": ["undici@7.28.0", "", {}, "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA=="],
 
     "api/@ai-sdk/mcp/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@5.0.16", "", { "dependencies": { "@ai-sdk/provider": "4.0.4", "@standard-schema/spec": "^1.1.0", "@workflow/serde": "4.1.0", "eventsource-parser": "^3.0.8", "undici": "^7.28.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-LWDrmYWkZoAJwMbToUglpR6AmgvtnNtCCGeU9MKlXiSV3Yiu4u73/pVA18sQAAe3kZtCRBY9P31lAfnPekWWyg=="],
 
@@ -21960,6 +21979,10 @@
 
     "ai-gateway-provider/@ai-sdk/google-vertex/google-auth-library/jws": ["jws@4.0.1", "", { "dependencies": { "jwa": "^2.0.1", "safe-buffer": "^5.0.1" } }, "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA=="],
 
+    "api/@ai-sdk/mcp/@ai-sdk/provider-utils/undici": ["undici@7.28.0", "", {}, "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA=="],
+
+    "api/ai-gateway-provider/@ai-sdk/provider-utils/undici": ["undici@7.28.0", "", {}, "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA=="],
+
     "api/ai-gateway-provider/@openrouter/ai-sdk-provider/ai": ["ai@6.0.170", "", { "dependencies": { "@ai-sdk/gateway": "3.0.105", "@ai-sdk/provider": "3.0.9", "@ai-sdk/provider-utils": "4.0.24", "@opentelemetry/api": "1.9.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-FWTKeGGDRcYJtPWIrdZDSuvOW5LCjI2NZUJmaml8OTOaPEsXnFdFvmawCXbT+wTGxyWKJTgZ9sZtCjbJsmjM2Q=="],
 
     "api/socket.io/engine.io/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
@@ -22155,6 +22178,8 @@
     "vinyl-contents/bl/readable-stream/string_decoder": ["string_decoder@1.3.0", "", { "dependencies": { "safe-buffer": "~5.2.0" } }, "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA=="],
 
     "vite-plugin-checker/chokidar/readdirp/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
+
+    "worker/@ai-sdk/mcp/@ai-sdk/provider-utils/undici": ["undici@7.28.0", "", {}, "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA=="],
 
     "@ai-sdk/google-vertex/google-auth-library/gcp-metadata/gaxios/node-fetch": ["node-fetch@3.3.2", "", { "dependencies": { "data-uri-to-buffer": "^4.0.0", "fetch-blob": "^3.1.4", "formdata-polyfill": "^4.0.10" } }, "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA=="],
 

--- a/package.json
+++ b/package.json
@@ -136,6 +136,7 @@
   ],
   "resolutions": {
     "rollup": "npm:@rollup/wasm-node",
-    "axios": "1.18.0"
+    "axios": "1.18.0",
+    "nanoid": "3.3.17"
   }
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -25,7 +25,7 @@
     "form-data": "4.0.6",
     "inquirer": "8.2.7",
     "jsonwebtoken": "9.0.1",
-    "nanoid": "3.3.8",
+    "nanoid": "3.3.17",
     "tslib": "2.6.2"
   },
   "devDependencies": {

--- a/packages/core/shared/package.json
+++ b/packages/core/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/shared",
-  "version": "0.128.2",
+  "version": "0.128.3",
   "type": "commonjs",
   "sideEffects": false,
   "main": "./dist/src/index.js",
@@ -14,7 +14,7 @@
     "deepmerge-ts": "7.1.0",
     "expr-eval": "2.0.2",
     "ipaddr.js": "2.3.0",
-    "nanoid": "3.3.8",
+    "nanoid": "3.3.17",
     "semver": "7.6.0",
     "socket.io-client": "4.8.1",
     "tslib": "2.6.2",

--- a/packages/core/utils/package.json
+++ b/packages/core/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/core-utils",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "scripts": {
@@ -11,7 +11,7 @@
   "dependencies": {
     "deepmerge-ts": "7.1.0",
     "ipaddr.js": "2.3.0",
-    "nanoid": "3.3.8",
+    "nanoid": "3.3.17",
     "tslib": "2.6.2",
     "zod": "4.3.6"
   },

--- a/packages/pieces/community/figma/package.json
+++ b/packages/pieces/community/figma/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "nanoid": "3.3.8",
+    "nanoid": "3.3.17",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
   },

--- a/packages/pieces/community/gmail/package.json
+++ b/packages/pieces/community/gmail/package.json
@@ -12,7 +12,7 @@
     "google-auth-library": "10.5.0",
     "mailparser": "3.9.3",
     "mime-types": "2.1.35",
-    "nodemailer": "8.0.5",
+    "nodemailer": "9.0.1",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
   },

--- a/packages/pieces/community/google-sheets/package.json
+++ b/packages/pieces/community/google-sheets/package.json
@@ -13,7 +13,7 @@
     "gaxios": "6.7.1",
     "google-auth-library": "10.5.0",
     "lodash": "4.18.1",
-    "nanoid": "3.3.8",
+    "nanoid": "3.3.17",
     "zod": "4.3.6",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"

--- a/packages/pieces/community/http-oauth2/package.json
+++ b/packages/pieces/community/http-oauth2/package.json
@@ -7,7 +7,7 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "form-data": "4.0.6",
-    "undici": "7.28.0",
+    "undici": "7.29.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
   },

--- a/packages/pieces/community/sendgrid/package.json
+++ b/packages/pieces/community/sendgrid/package.json
@@ -12,7 +12,7 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "mime-types": "2.1.35",
-    "nodemailer": "8.0.5",
+    "nodemailer": "9.0.1",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
   },

--- a/packages/pieces/community/typeform/package.json
+++ b/packages/pieces/community/typeform/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
-    "nanoid": "3.3.8",
+    "nanoid": "3.3.17",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
   },

--- a/packages/pieces/core/http/package.json
+++ b/packages/pieces/core/http/package.json
@@ -8,7 +8,7 @@
     "@activepieces/pieces-framework": "workspace:*",
     "axios": "1.18.0",
     "form-data": "4.0.6",
-    "undici": "7.28.0",
+    "undici": "7.29.0",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
   },

--- a/packages/pieces/core/pdf/package.json
+++ b/packages/pieces/core/pdf/package.json
@@ -8,7 +8,7 @@
     "@activepieces/pieces-framework": "workspace:*",
     "jimp": "^0.22.12",
     "mime-types": "2.1.35",
-    "nanoid": "3.3.8",
+    "nanoid": "3.3.17",
     "pdf-lib": "1.17.1",
     "unpdf": "1.4.0",
     "@activepieces/core-piece-types": "workspace:*",

--- a/packages/pieces/core/smtp/package.json
+++ b/packages/pieces/core/smtp/package.json
@@ -12,7 +12,7 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "mime-types": "2.1.35",
-    "nodemailer": "8.0.5",
+    "nodemailer": "9.0.1",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
   },

--- a/packages/server/api/package.json
+++ b/packages/server/api/package.json
@@ -80,7 +80,7 @@
     "mammoth": "1.11.0",
     "mime-types": "2.1.35",
     "mustache": "4.2.0",
-    "nanoid": "3.3.8",
+    "nanoid": "3.3.17",
     "node-cache": "5.1.2",
     "node-cron": "3.0.3",
     "nodemailer": "9.0.1",

--- a/packages/server/engine/package.json
+++ b/packages/server/engine/package.json
@@ -21,10 +21,10 @@
     "https-proxy-agent": "7.0.6",
     "isolated-vm": "6.0.2",
     "jsep": "1.4.0",
-    "nanoid": "3.3.8",
+    "nanoid": "3.3.17",
     "socket.io-client": "4.8.1",
     "tslib": "2.6.2",
-    "undici": "7.28.0",
+    "undici": "7.29.0",
     "zod": "4.3.6",
     "@activepieces/core-utils": "workspace:*",
     "@activepieces/core-formula": "workspace:*"

--- a/packages/server/sandbox/package.json
+++ b/packages/server/sandbox/package.json
@@ -13,7 +13,7 @@
     "@activepieces/core-utils": "workspace:*",
     "@activepieces/server-utils": "workspace:*",
     "@activepieces/shared": "workspace:*",
-    "nanoid": "3.3.8",
+    "nanoid": "3.3.17",
     "socket.io": "4.7.5",
     "tree-kill": "1.2.2",
     "tslib": "2.6.2",

--- a/packages/server/worker/package.json
+++ b/packages/server/worker/package.json
@@ -29,7 +29,7 @@
     "dayjs": "1.11.9",
     "decompress": "4.2.1",
     "env-var": "7.5.0",
-    "nanoid": "3.3.8",
+    "nanoid": "3.3.17",
     "proxy-chain": "2.7.1",
     "socket.io": "4.7.5",
     "dotenv": "16.4.7",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -73,7 +73,7 @@
     "lucide-react": "0.576.0",
     "marked": "18.0.2",
     "motion": "12.35.0",
-    "nanoid": "3.3.8",
+    "nanoid": "3.3.17",
     "pako": "2.1.0",
     "papaparse": "5.5.3",
     "posthog-js": "1.393.5",


### PR DESCRIPTION
## Description

nanoid 3.3.8/3.3.11 -> 3.3.17,
nodemailer 8.0.5 -> 9.0.1 in smtp/gmail/sendgrid pieces,
undici 7.24.6/7.28.0 -> 7.29.0 in http/http-oauth2/engine.
bumps are hygiene-only, no functional risk. Added a flat "nanoid" resolution to dedupe the transitive postcss copy since bun only honours flat override keys.



### Breaking change?  (required — CI fails if this is left unedited)

<!-- Tick exactly one box. If either "yes", apply the "⛓️‍💥 breaking-change" label AND add an entry to docs/install/reference/breaking-changes.mdx (what changed + the action self-hosters must take). -->

- [X] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

<!-- Tick exactly one box. "Security-sensitive" = touches authentication, secrets, permissions/roles, cryptography, SSRF / outbound HTTP, or file handling. -->

- [X] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)
