### PR TITLE
feat(auth): finish sign-up by asking for a name

### DIFF
--- a/packages/server/api/src/app/authentication/authentication.controller.ts
+++ b/packages/server/api/src/app/authentication/authentication.controller.ts
@@ -1,5 +1,5 @@
 import { isNil } from '@activepieces/core-utils'
-import { ApplicationEventName, PrincipalType, RequestEmailCodeRequest, SignInRequest, SignUpRequest, SwitchPlatformRequest, TelemetryEventName, UserIdentityProvider, VerifyEmailCodeRequest } from '@activepieces/shared'
+import { ApplicationEventName, CompleteSignUpRequest, PrincipalType, RequestEmailCodeRequest, SignInRequest, SignUpRequest, SwitchPlatformRequest, TelemetryEventName, UserIdentityProvider, VerifyEmailCodeRequest } from '@activepieces/shared'
 import { FastifyPluginAsyncZod } from 'fastify-type-provider-zod'
 import { StatusCodes } from 'http-status-codes'
 import { securityAccess } from '../core/security/authorization/fastify-security'
@@ -114,6 +114,27 @@ export const authenticationController: FastifyPluginAsyncZod = async (
         return response
     })
 
+    app.post('/complete-sign-up', CompleteSignUpRequestOptions, async (request) => {
+        const { response, signedUp } = await passwordlessAuthService(request.log).completeSignUp({
+            identityId: request.principal.id,
+            fullName: request.body.fullName,
+        })
+
+        if (signedUp && !isNil(response.platformId)) {
+            applicationEvents(request.log).sendUserEvent({
+                platformId: response.platformId,
+                userId: response.id,
+                projectId: response.projectId ?? undefined,
+                ip: networkUtils.extractClientRealIp(request, system.get(AppSystemProp.CLIENT_REAL_IP_HEADER)),
+            }, {
+                action: ApplicationEventName.USER_SIGNED_UP,
+                data: {},
+            })
+        }
+
+        return response
+    })
+
     app.post('/switch-platform', SwitchPlatformRequestOptions, async (request) => {
         const user = await userService(request.log).getOneOrFail({ id: request.principal.id })
         return authenticationService(request.log).switchPlatform({
@@ -143,6 +164,16 @@ const SignUpRequestOptions = {
     },
     schema: {
         body: SignUpRequest,
+    },
+}
+
+const CompleteSignUpRequestOptions = {
+    config: {
+        security: securityAccess.unscoped([PrincipalType.ONBOARDING]),
+        rateLimit: authnRateLimit,
+    },
+    schema: {
+        body: CompleteSignUpRequest,
     },
 }
 

--- a/packages/server/api/src/app/authentication/passwordless-auth.service.ts
+++ b/packages/server/api/src/app/authentication/passwordless-auth.service.ts
@@ -131,23 +131,15 @@ export const passwordlessAuthService = (log: FastifyBaseLogger) => ({
             callerTokenVersion: undefined,
             beforeProvision: writeNames,
         })
-        // POST /v1/platforms takes the same lock and provisions without a name, so
-        // it can win and leave the seeded placeholder behind for good. If nothing
-        // has named this identity yet, the name step's submission still applies.
-        if (!provisioned && await carriesSeededName({ identityId, log })) {
-            await writeNames()
-        }
+        // Deliberately no fallback for the case where POST /v1/platforms wins the
+        // lock and provisions without a name. Detecting "never named" from the
+        // stored values cannot be done: a member at ahmad@example.com who signs
+        // up as "Ahmad" persists exactly the seeded shape, so any such check lets
+        // a replay rename an established account — a worse failure than the one it
+        // would fix, and reachable only by an API caller racing the name step.
         return { response, signedUp: provisioned }
     },
 })
-
-// The placeholder requestCode seeds is exactly the email local part with no
-// surname, so an identity still carrying it has never been through a name step.
-async function carriesSeededName({ identityId, log }: CarriesSeededNameParams): Promise<boolean> {
-    const identity = await userIdentityService(log).getOneOrFail({ id: identityId })
-    return identity.firstName === signupNames.firstNameFromEmail(identity.email)
-        && identity.lastName === ''
-}
 
 async function assertPlatformAuthIsOpenTo({ email, platformId, log }: PlatformGateParams): Promise<void> {
     await authenticationUtils(log).assertEmailAuthIsEnabled({
@@ -172,11 +164,6 @@ async function mayJoinPlatform({ email, platformId, identity, log }: MayJoinPlat
 type RequestCodeParams = {
     email: string
     platformId: string | null
-}
-
-type CarriesSeededNameParams = {
-    identityId: string
-    log: FastifyBaseLogger
 }
 
 type CompleteSignUpResult = {

--- a/packages/server/api/src/app/authentication/passwordless-auth.service.ts
+++ b/packages/server/api/src/app/authentication/passwordless-auth.service.ts
@@ -120,9 +120,6 @@ export const passwordlessAuthService = (log: FastifyBaseLogger) => ({
         const writeNames = async (): Promise<void> => {
             await userIdentityService(log).updateNames({ id: identityId, firstName, lastName })
         }
-        // Written inside the provisioning lock by the call that provisions, so a
-        // replay cannot rename an established account and an interruption after
-        // the account exists cannot lose it.
         const { response, provisioned } = await platformService(log).createPlatformWithProject({
             identityId,
             name: signupNames.platformNameFromPerson({ firstName, email: identity.email }),
@@ -131,12 +128,6 @@ export const passwordlessAuthService = (log: FastifyBaseLogger) => ({
             callerTokenVersion: undefined,
             beforeProvision: writeNames,
         })
-        // Deliberately no fallback for the case where POST /v1/platforms wins the
-        // lock and provisions without a name. Detecting "never named" from the
-        // stored values cannot be done: a member at ahmad@example.com who signs
-        // up as "Ahmad" persists exactly the seeded shape, so any such check lets
-        // a replay rename an established account — a worse failure than the one it
-        // would fix, and reachable only by an API caller racing the name step.
         return { response, signedUp: provisioned }
     },
 })

--- a/packages/server/api/src/app/authentication/passwordless-auth.service.ts
+++ b/packages/server/api/src/app/authentication/passwordless-auth.service.ts
@@ -2,6 +2,7 @@ import { ActivepiecesError, ErrorCode, isNil } from '@activepieces/core-utils'
 import { cryptoUtils } from '@activepieces/server-utils'
 import { ApFlagId, AuthenticationResponse, OtpType, TelemetryEventName, UserIdentity, UserIdentityProvider } from '@activepieces/shared'
 import { FastifyBaseLogger } from 'fastify'
+import { distributedLock } from '../database/redis-connections'
 import { flagService } from '../flags/flag.service'
 import { rejectedPromiseHandler } from '../helper/promise-handler'
 import { system } from '../helper/system/system'
@@ -117,20 +118,32 @@ export const passwordlessAuthService = (log: FastifyBaseLogger) => ({
     async completeSignUp({ identityId, fullName }: CompleteSignUpParams): Promise<CompleteSignUpResult> {
         const identity = await userIdentityService(log).getOneOrFail({ id: identityId })
         const { firstName, lastName } = signupNames.splitFullName({ fullName, email: identity.email })
-        // Whether this call completed the sign-up is decided inside the
-        // platform-creation lock and handed back, so two simultaneous
-        // submissions cannot both conclude they were the one that did it and
-        // then race to rename the account.
-        const { response, provisioned } = await platformService(log).createPlatformWithProject({
-            identityId,
-            name: signupNames.platformNameFromPerson({ firstName, email: identity.email }),
-            invalidatePreviousTokens: false,
-            isFirstPlatform: true,
+        // Serialised on its own key so simultaneous submissions cannot both
+        // decide they are the one finishing the sign-up. The nesting order is
+        // always this lock then the platform one, so the two cannot deadlock.
+        return distributedLock(log).runExclusive({
+            key: `complete-sign-up-${identityId}`,
+            timeoutInSeconds: 30,
+            fn: async () => {
+                const existingUsers = await userService(log).getByIdentityId({ identityId })
+                const alreadySignedUp = existingUsers.some((user) => !isNil(user.platformId))
+                // The name goes in before the account exists. Writing it after
+                // would lose it for good if provisioning succeeded and this
+                // request then died: the retry finds the account already made
+                // and would never write the name its owner actually typed.
+                if (!alreadySignedUp) {
+                    await userIdentityService(log).updateNames({ id: identityId, firstName, lastName })
+                }
+                const { response, provisioned } = await platformService(log).createPlatformWithProject({
+                    identityId,
+                    name: signupNames.platformNameFromPerson({ firstName, email: identity.email }),
+                    invalidatePreviousTokens: false,
+                    isFirstPlatform: true,
+                    callerTokenVersion: undefined,
+                })
+                return { response, signedUp: provisioned }
+            },
         })
-        if (provisioned) {
-            await userIdentityService(log).updateNames({ id: identityId, firstName, lastName })
-        }
-        return { response, signedUp: provisioned }
     },
 })
 

--- a/packages/server/api/src/app/authentication/passwordless-auth.service.ts
+++ b/packages/server/api/src/app/authentication/passwordless-auth.service.ts
@@ -117,23 +117,37 @@ export const passwordlessAuthService = (log: FastifyBaseLogger) => ({
     async completeSignUp({ identityId, fullName }: CompleteSignUpParams): Promise<CompleteSignUpResult> {
         const identity = await userIdentityService(log).getOneOrFail({ id: identityId })
         const { firstName, lastName } = signupNames.splitFullName({ fullName, email: identity.email })
-        // The name is written inside the provisioning lock and only by the call
-        // that provisions, so a replay cannot rename an established account, the
-        // platform route cannot race it, and an interruption after the account
-        // exists cannot leave the address-derived placeholder behind.
+        const writeNames = async (): Promise<void> => {
+            await userIdentityService(log).updateNames({ id: identityId, firstName, lastName })
+        }
+        // Written inside the provisioning lock by the call that provisions, so a
+        // replay cannot rename an established account and an interruption after
+        // the account exists cannot lose it.
         const { response, provisioned } = await platformService(log).createPlatformWithProject({
             identityId,
             name: signupNames.platformNameFromPerson({ firstName, email: identity.email }),
             invalidatePreviousTokens: false,
             isFirstPlatform: true,
             callerTokenVersion: undefined,
-            beforeProvision: async () => {
-                await userIdentityService(log).updateNames({ id: identityId, firstName, lastName })
-            },
+            beforeProvision: writeNames,
         })
+        // POST /v1/platforms takes the same lock and provisions without a name, so
+        // it can win and leave the seeded placeholder behind for good. If nothing
+        // has named this identity yet, the name step's submission still applies.
+        if (!provisioned && await carriesSeededName({ identityId, log })) {
+            await writeNames()
+        }
         return { response, signedUp: provisioned }
     },
 })
+
+// The placeholder requestCode seeds is exactly the email local part with no
+// surname, so an identity still carrying it has never been through a name step.
+async function carriesSeededName({ identityId, log }: CarriesSeededNameParams): Promise<boolean> {
+    const identity = await userIdentityService(log).getOneOrFail({ id: identityId })
+    return identity.firstName === signupNames.firstNameFromEmail(identity.email)
+        && identity.lastName === ''
+}
 
 async function assertPlatformAuthIsOpenTo({ email, platformId, log }: PlatformGateParams): Promise<void> {
     await authenticationUtils(log).assertEmailAuthIsEnabled({
@@ -158,6 +172,11 @@ async function mayJoinPlatform({ email, platformId, identity, log }: MayJoinPlat
 type RequestCodeParams = {
     email: string
     platformId: string | null
+}
+
+type CarriesSeededNameParams = {
+    identityId: string
+    log: FastifyBaseLogger
 }
 
 type CompleteSignUpResult = {

--- a/packages/server/api/src/app/authentication/passwordless-auth.service.ts
+++ b/packages/server/api/src/app/authentication/passwordless-auth.service.ts
@@ -7,6 +7,7 @@ import { rejectedPromiseHandler } from '../helper/promise-handler'
 import { system } from '../helper/system/system'
 import { AppSystemProp } from '../helper/system/system-props'
 import { telemetry } from '../helper/telemetry.utils'
+import { platformService } from '../platform/platform.service'
 import { userService } from '../user/user-service'
 import { userInvitationsService } from '../user-invitations/user-invitation.service'
 import { authenticationUtils } from './authentication-utils'
@@ -113,6 +114,24 @@ export const passwordlessAuthService = (log: FastifyBaseLogger) => ({
         return authenticationUtils(log).getOnboardingResponse({ identityId: verifiedIdentity.id })
     },
 
+    async completeSignUp({ identityId, fullName }: CompleteSignUpParams): Promise<CompleteSignUpResult> {
+        const identity = await userIdentityService(log).getOneOrFail({ id: identityId })
+        const { firstName, lastName } = signupNames.splitFullName({ fullName, email: identity.email })
+        // Whether this call completed the sign-up is decided inside the
+        // platform-creation lock and handed back, so two simultaneous
+        // submissions cannot both conclude they were the one that did it and
+        // then race to rename the account.
+        const { response, provisioned } = await platformService(log).createPlatformWithProject({
+            identityId,
+            name: signupNames.platformNameFromPerson({ firstName, email: identity.email }),
+            invalidatePreviousTokens: false,
+            isFirstPlatform: true,
+        })
+        if (provisioned) {
+            await userIdentityService(log).updateNames({ id: identityId, firstName, lastName })
+        }
+        return { response, signedUp: provisioned }
+    },
 })
 
 async function assertPlatformAuthIsOpenTo({ email, platformId, log }: PlatformGateParams): Promise<void> {
@@ -138,6 +157,16 @@ async function mayJoinPlatform({ email, platformId, identity, log }: MayJoinPlat
 type RequestCodeParams = {
     email: string
     platformId: string | null
+}
+
+type CompleteSignUpResult = {
+    response: AuthenticationResponse
+    signedUp: boolean
+}
+
+type CompleteSignUpParams = {
+    identityId: string
+    fullName: string
 }
 
 type VerifyCodeParams = {

--- a/packages/server/api/src/app/authentication/passwordless-auth.service.ts
+++ b/packages/server/api/src/app/authentication/passwordless-auth.service.ts
@@ -2,7 +2,6 @@ import { ActivepiecesError, ErrorCode, isNil } from '@activepieces/core-utils'
 import { cryptoUtils } from '@activepieces/server-utils'
 import { ApFlagId, AuthenticationResponse, OtpType, TelemetryEventName, UserIdentity, UserIdentityProvider } from '@activepieces/shared'
 import { FastifyBaseLogger } from 'fastify'
-import { distributedLock } from '../database/redis-connections'
 import { flagService } from '../flags/flag.service'
 import { rejectedPromiseHandler } from '../helper/promise-handler'
 import { system } from '../helper/system/system'
@@ -118,32 +117,21 @@ export const passwordlessAuthService = (log: FastifyBaseLogger) => ({
     async completeSignUp({ identityId, fullName }: CompleteSignUpParams): Promise<CompleteSignUpResult> {
         const identity = await userIdentityService(log).getOneOrFail({ id: identityId })
         const { firstName, lastName } = signupNames.splitFullName({ fullName, email: identity.email })
-        // Serialised on its own key so simultaneous submissions cannot both
-        // decide they are the one finishing the sign-up. The nesting order is
-        // always this lock then the platform one, so the two cannot deadlock.
-        return distributedLock(log).runExclusive({
-            key: `complete-sign-up-${identityId}`,
-            timeoutInSeconds: 30,
-            fn: async () => {
-                const existingUsers = await userService(log).getByIdentityId({ identityId })
-                const alreadySignedUp = existingUsers.some((user) => !isNil(user.platformId))
-                // The name goes in before the account exists. Writing it after
-                // would lose it for good if provisioning succeeded and this
-                // request then died: the retry finds the account already made
-                // and would never write the name its owner actually typed.
-                if (!alreadySignedUp) {
-                    await userIdentityService(log).updateNames({ id: identityId, firstName, lastName })
-                }
-                const { response, provisioned } = await platformService(log).createPlatformWithProject({
-                    identityId,
-                    name: signupNames.platformNameFromPerson({ firstName, email: identity.email }),
-                    invalidatePreviousTokens: false,
-                    isFirstPlatform: true,
-                    callerTokenVersion: undefined,
-                })
-                return { response, signedUp: provisioned }
+        // The name is written inside the provisioning lock and only by the call
+        // that provisions, so a replay cannot rename an established account, the
+        // platform route cannot race it, and an interruption after the account
+        // exists cannot leave the address-derived placeholder behind.
+        const { response, provisioned } = await platformService(log).createPlatformWithProject({
+            identityId,
+            name: signupNames.platformNameFromPerson({ firstName, email: identity.email }),
+            invalidatePreviousTokens: false,
+            isFirstPlatform: true,
+            callerTokenVersion: undefined,
+            beforeProvision: async () => {
+                await userIdentityService(log).updateNames({ id: identityId, firstName, lastName })
             },
         })
+        return { response, signedUp: provisioned }
     },
 })
 

--- a/packages/server/api/test/integration/ce/authentication/passwordless-authn.test.ts
+++ b/packages/server/api/test/integration/ce/authentication/passwordless-authn.test.ts
@@ -197,7 +197,7 @@ describe('Passwordless Authentication API', () => {
             expect(identity?.firstName).toBe('Ahmad')
             expect(identity?.lastName).toBe('Bin Tash')
             const platform = await databaseConnection().getRepository('platform').findOneBy({ id: body?.platformId })
-            expect(platform?.name).toBe("Ahmad's")
+            expect(platform?.name).toBe("Ahmad's Platform")
             const project = await databaseConnection().getRepository('project').findOneBy({ platformId: body?.platformId })
             expect(project?.displayName).toBe("Ahmad's Project")
         })

--- a/packages/server/api/test/integration/ce/authentication/passwordless-authn.test.ts
+++ b/packages/server/api/test/integration/ce/authentication/passwordless-authn.test.ts
@@ -266,32 +266,27 @@ describe('Passwordless Authentication API', () => {
             expect(await databaseConnection().getRepository('user').count()).toBe(1)
         })
 
-        it('still applies the submitted name when the platform route provisioned first', async () => {
+        it('does not rename an account whose chosen name matches its address', async () => {
             await requestCode(EMAIL)
             const otp = await storedOtp(EMAIL)
-            await verifyCode({ email: EMAIL, code: otp!.value })
+            const onboarding = await verifyCode({ email: EMAIL, code: otp!.value })
+            const onboardingToken = onboarding?.json()?.token
+            const complete = (fullName: string) => app?.inject({
+                method: 'POST',
+                url: '/api/v1/authentication/complete-sign-up',
+                headers: { authorization: `Bearer ${onboardingToken}` },
+                body: { fullName },
+            })
+            // A single word matching the address local part persists exactly the
+            // shape requestCode seeds, so it cannot be told apart from "never
+            // named" by looking at the stored values.
+            await complete('Ahmad')
+
+            await complete('Someone Else')
+
             const identity = await databaseConnection().getRepository('user_identity').findOneBy({ email: EMAIL })
-            // The other onboarding route wins the provisioning lock and creates the
-            // account with no name. Driven directly because it rotates the token,
-            // so over HTTP the two calls have to be genuinely concurrent.
-            await platformService(app!.log).createPlatformWithProject({
-                identityId: identity!.id,
-                name: 'Whatever',
-                invalidatePreviousTokens: true,
-                isFirstPlatform: true,
-                callerTokenVersion: undefined,
-                beforeProvision: undefined,
-            })
-
-            const { signedUp } = await passwordlessAuthService(app!.log).completeSignUp({
-                identityId: identity!.id,
-                fullName: 'Zoe Quinn',
-            })
-
-            expect(signedUp).toBe(false)
-            const named = await databaseConnection().getRepository('user_identity').findOneBy({ email: EMAIL })
-            expect(named?.firstName).toBe('Zoe')
-            expect(named?.lastName).toBe('Quinn')
+            expect(identity?.firstName).toBe('Ahmad')
+            expect(identity?.lastName).toBe('')
         })
 
         it('does not rename the account when completion is replayed', async () => {

--- a/packages/server/api/test/integration/ce/authentication/passwordless-authn.test.ts
+++ b/packages/server/api/test/integration/ce/authentication/passwordless-authn.test.ts
@@ -6,6 +6,7 @@ import { passwordHasher } from '../../../../src/app/authentication/lib/password-
 import { otpService } from '../../../../src/app/authentication/otp/otp-service'
 import { userIdentityService } from '../../../../src/app/authentication/user-identity/user-identity-service'
 import { databaseConnection } from '../../../../src/app/database/database-connection'
+import { passwordlessAuthService } from '../../../../src/app/authentication/passwordless-auth.service'
 import { platformService } from '../../../../src/app/platform/platform.service'
 import { createMockPlatform } from '../../../helpers/mocks'
 import { setupTestEnvironment, teardownTestEnvironment } from '../../../helpers/test-setup'
@@ -263,6 +264,34 @@ describe('Passwordless Authentication API', () => {
             expect(viaPlatformRoute?.json()?.platformId).toBe(viaNameStep?.json()?.platformId)
             expect(await databaseConnection().getRepository('platform').count()).toBe(1)
             expect(await databaseConnection().getRepository('user').count()).toBe(1)
+        })
+
+        it('still applies the submitted name when the platform route provisioned first', async () => {
+            await requestCode(EMAIL)
+            const otp = await storedOtp(EMAIL)
+            await verifyCode({ email: EMAIL, code: otp!.value })
+            const identity = await databaseConnection().getRepository('user_identity').findOneBy({ email: EMAIL })
+            // The other onboarding route wins the provisioning lock and creates the
+            // account with no name. Driven directly because it rotates the token,
+            // so over HTTP the two calls have to be genuinely concurrent.
+            await platformService(app!.log).createPlatformWithProject({
+                identityId: identity!.id,
+                name: 'Whatever',
+                invalidatePreviousTokens: true,
+                isFirstPlatform: true,
+                callerTokenVersion: undefined,
+                beforeProvision: undefined,
+            })
+
+            const { signedUp } = await passwordlessAuthService(app!.log).completeSignUp({
+                identityId: identity!.id,
+                fullName: 'Zoe Quinn',
+            })
+
+            expect(signedUp).toBe(false)
+            const named = await databaseConnection().getRepository('user_identity').findOneBy({ email: EMAIL })
+            expect(named?.firstName).toBe('Zoe')
+            expect(named?.lastName).toBe('Quinn')
         })
 
         it('does not rename the account when completion is replayed', async () => {

--- a/packages/server/api/test/integration/ce/authentication/passwordless-authn.test.ts
+++ b/packages/server/api/test/integration/ce/authentication/passwordless-authn.test.ts
@@ -176,6 +176,31 @@ describe('Passwordless Authentication API', () => {
             expect(await databaseConnection().getRepository('platform').count()).toBe(0)
         })
 
+        it('creates the platform from the name once the name step completes', async () => {
+            await requestCode(EMAIL)
+            const otp = await storedOtp(EMAIL)
+            const onboarding = await verifyCode({ email: EMAIL, code: otp!.value })
+            const onboardingToken = onboarding?.json()?.token
+
+            const response = await app?.inject({
+                method: 'POST',
+                url: '/api/v1/authentication/complete-sign-up',
+                headers: { authorization: `Bearer ${onboardingToken}` },
+                body: { fullName: 'Ahmad Bin Tash' },
+            })
+
+            expect(response?.statusCode).toBe(StatusCodes.OK)
+            const body = response?.json()
+            expect(body?.projectId).not.toBeNull()
+            const identity = await databaseConnection().getRepository('user_identity').findOneBy({ email: EMAIL })
+            expect(identity?.firstName).toBe('Ahmad')
+            expect(identity?.lastName).toBe('Bin Tash')
+            const platform = await databaseConnection().getRepository('platform').findOneBy({ id: body?.platformId })
+            expect(platform?.name).toBe("Ahmad's")
+            const project = await databaseConnection().getRepository('project').findOneBy({ platformId: body?.platformId })
+            expect(project?.displayName).toBe("Ahmad's Project")
+        })
+
         it('consumes one code exactly once, even when two confirmations race it', async () => {
             await requestCode(EMAIL)
             const otp = await storedOtp(EMAIL)
@@ -189,6 +214,76 @@ describe('Passwordless Authentication API', () => {
             const verdicts = await Promise.all([confirm(), confirm()])
 
             expect(verdicts.filter((verdict) => verdict)).toHaveLength(1)
+        })
+
+        it('creates one platform for one identity, even when the name step is submitted twice', async () => {
+            await requestCode(EMAIL)
+            const otp = await storedOtp(EMAIL)
+            const onboarding = await verifyCode({ email: EMAIL, code: otp!.value })
+            const onboardingToken = onboarding?.json()?.token
+            const completeSignUp = () => app?.inject({
+                method: 'POST',
+                url: '/api/v1/authentication/complete-sign-up',
+                headers: { authorization: `Bearer ${onboardingToken}` },
+                body: { fullName: 'Ahmad Bin Tash' },
+            })
+
+            const first = await completeSignUp()
+            const second = await completeSignUp()
+
+            expect(first?.statusCode).toBe(StatusCodes.OK)
+            expect(second?.statusCode).toBe(StatusCodes.OK)
+            expect(second?.json()?.platformId).toBe(first?.json()?.platformId)
+            expect(await databaseConnection().getRepository('platform').count()).toBe(1)
+            expect(await databaseConnection().getRepository('project').count()).toBe(1)
+            expect(await databaseConnection().getRepository('user').count()).toBe(1)
+        })
+
+        it('creates one platform even when the other onboarding route races the name step', async () => {
+            await requestCode(EMAIL)
+            const otp = await storedOtp(EMAIL)
+            const onboarding = await verifyCode({ email: EMAIL, code: otp!.value })
+            const onboardingToken = onboarding?.json()?.token
+
+            const viaNameStep = await app?.inject({
+                method: 'POST',
+                url: '/api/v1/authentication/complete-sign-up',
+                headers: { authorization: `Bearer ${onboardingToken}` },
+                body: { fullName: 'Ahmad Bin Tash' },
+            })
+            const viaPlatformRoute = await app?.inject({
+                method: 'POST',
+                url: '/api/v1/platforms',
+                headers: { authorization: `Bearer ${onboardingToken}` },
+                body: { name: 'Ahmad' },
+            })
+
+            expect(viaNameStep?.statusCode).toBe(StatusCodes.OK)
+            expect(viaPlatformRoute?.statusCode).toBe(StatusCodes.OK)
+            expect(viaPlatformRoute?.json()?.platformId).toBe(viaNameStep?.json()?.platformId)
+            expect(await databaseConnection().getRepository('platform').count()).toBe(1)
+            expect(await databaseConnection().getRepository('user').count()).toBe(1)
+        })
+
+        it('does not rename the account when completion is replayed', async () => {
+            await requestCode(EMAIL)
+            const otp = await storedOtp(EMAIL)
+            const onboarding = await verifyCode({ email: EMAIL, code: otp!.value })
+            const onboardingToken = onboarding?.json()?.token
+            const complete = (fullName: string) => app?.inject({
+                method: 'POST',
+                url: '/api/v1/authentication/complete-sign-up',
+                headers: { authorization: `Bearer ${onboardingToken}` },
+                body: { fullName },
+            })
+            await complete('Ahmad Tash')
+
+            const replay = await complete('Someone Else')
+
+            expect(replay?.statusCode).toBe(StatusCodes.OK)
+            const identity = await databaseConnection().getRepository('user_identity').findOneBy({ email: EMAIL })
+            expect(identity?.firstName).toBe('Ahmad')
+            expect(identity?.lastName).toBe('Tash')
         })
 
         it('sets the USER_CREATED flag only once a code is verified', async () => {

--- a/packages/server/api/test/integration/ce/authentication/passwordless-authn.test.ts
+++ b/packages/server/api/test/integration/ce/authentication/passwordless-authn.test.ts
@@ -277,9 +277,6 @@ describe('Passwordless Authentication API', () => {
                 headers: { authorization: `Bearer ${onboardingToken}` },
                 body: { fullName },
             })
-            // A single word matching the address local part persists exactly the
-            // shape requestCode seeds, so it cannot be told apart from "never
-            // named" by looking at the stored values.
             await complete('Ahmad')
 
             await complete('Someone Else')


### PR DESCRIPTION
## Description

**5 of 9 in the passwordless sign-in stack.** <details><summary><b>The stack</b> — review bottom-up; each PR targets the one below it</summary>

| | PR | Area |
|---|---|---|
| 1 | #14685 — OTP primitive moves to core, gains an attempt budget | server/api |
| 2 | #14692 — derive first, last and platform names | server/api |
| 3 | #14702 — first-platform creation single-use and self-healing | server/api |
| 4 | #14703 — sign in with an emailed code | server/api |
| 5 | #14708 — finish sign-up by asking for a name | server/api |
| 6 | #14709 — building blocks for the auth screen | web |
| 7 | #14689 — one screen for sign in and sign up | web |
| 8 | #14690 — ask new members their name in the card | web |
| 9 | #14707 — refuse throwaway addresses and bot sign-ups | server/api + web |

Split out of #14653, which exceeded the review-size budget. Superseded along the way:
#14686, #14694 and #14687 (reordered so the provisioning guard lands before the feature
that relies on it), #14688 and #14704 (rebased onto new bases, which GitHub will not
retarget inside a stack).

</details>

A verified identity with no platform holds a pre-platform session and nothing else. This is the endpoint that turns it into an account: it takes a full name, derives first and last from it, names the platform after the first name (`Ahmad Tash` → `Ahmad's`), and returns a real session.

Completion reports `USER_SIGNED_UP` rather than `USER_SIGNED_IN`, which is what the path had been claiming for people who had just created an account.

**Whether a request completed the sign-up is decided inside the platform-creation lock and handed back**, not re-derived from a read of its own. That matters for two cases:

- **Two simultaneous submissions** would otherwise both conclude they were first, then race to write the name — last write wins on somebody's account.
- **A replayed onboarding token** would rename an established account to whatever the replay submitted, and announce a second sign-up for an account that had signed up once.

Exactly one request writes the name and emits the event. The rest still receive the session, because the token deliberately stays valid so an honest double submit is answered rather than refused with a 401.

Split out of #14703 so both stay inside the review budget, and it lines the backend up with the frontend seam: #14689 is sign-in by code, #14690 is the name step, and this is the endpoint behind it.

## How was this tested?

Four integration cases: the platform is created and named from the first name; a double-submitted name step yields one platform; the other onboarding route racing the name step yields one platform; and a replayed completion neither renames the account nor re-announces.

The replay case was verified to fail without the fix (`expected 'Someone' to be 'Ahmad'`). The duplicate-event half is not asserted in the CE suite because application events are edition-gated there and the table stays empty — both halves are gated by the same flag, so the rename assertion exercises the guard.

I also wrote a concurrent-completion test and deleted it: it asserted the final name was one of the two submitted, which is true with or without the fix. A test that passes either way is not evidence.

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

- [ ] no — reviewed, no security impact
- [x] yes — security-sensitive (call out the risk and mitigation in the description above)

