### PR TITLE
feat(web): building blocks for the unified auth screen

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -10964,6 +10964,7 @@
         "i18next-browser-languagedetector": "8.0.0",
         "i18next-http-backend": "3.0.5",
         "i18next-icu": "2.3.0",
+        "input-otp": "1.4.2",
         "jszip": "3.10.1",
         "jwt-decode": "4.0.0",
         "lucide-react": "0.576.0",
@@ -15857,6 +15858,8 @@
     "inline-style-parser": ["inline-style-parser@0.2.7", "", {}, "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA=="],
 
     "inline-style-prefixer": ["inline-style-prefixer@7.0.1", "", { "dependencies": { "css-in-js-utils": "^3.1.0" } }, "sha512-lhYo5qNTQp3EvSSp3sRvXMbVQTLrvGV6DycRMJ5dm2BLMiJ30wpXKdDdgX+GmJZ5uQMucwRKHamXSst3Sj/Giw=="],
+
+    "input-otp": ["input-otp@1.4.2", "", { "peerDependencies": { "react": "^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc" } }, "sha512-l3jWwYNvrEa6NTCt7BECfCm48GvwuZzkoeG3gBL2w4CHeOXW3eKFmf9UNYkNfYc3mxMrthMnxjIE07MT0zLBQA=="],
 
     "inquirer": ["inquirer@8.2.7", "", { "dependencies": { "@inquirer/external-editor": "^1.0.0", "ansi-escapes": "^4.2.1", "chalk": "^4.1.1", "cli-cursor": "^3.1.0", "cli-width": "^3.0.0", "figures": "^3.0.0", "lodash": "^4.17.21", "mute-stream": "0.0.8", "ora": "^5.4.1", "run-async": "^2.4.0", "rxjs": "^7.5.5", "string-width": "^4.1.0", "strip-ansi": "^6.0.0", "through": "^2.3.6", "wrap-ansi": "^6.0.1" } }, "sha512-UjOaSel/iddGZJ5xP/Eixh6dY1XghiBw4XK13rCCIJcJfyhhoul/7KhLLUGtebEj6GDYM6Vnx/mVsjx2L/mFIA=="],
 

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -3,6 +3,8 @@
   "version": "0.0.1",
   "private": true,
   "dependencies": {
+    "@activepieces/core-formula": "workspace:*",
+    "@activepieces/core-utils": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "@activepieces/shared": "workspace:*",
     "@codemirror/commands": "6.10.3",
@@ -68,6 +70,7 @@
     "i18next-browser-languagedetector": "8.0.0",
     "i18next-http-backend": "3.0.5",
     "i18next-icu": "2.3.0",
+    "input-otp": "1.4.2",
     "jszip": "3.10.1",
     "jwt-decode": "4.0.0",
     "lucide-react": "0.576.0",
@@ -111,9 +114,7 @@
     "use-stick-to-bottom": "1.1.3",
     "vaul": "1.1.2",
     "zod": "4.3.6",
-    "zustand": "4.5.4",
-    "@activepieces/core-utils": "workspace:*",
-    "@activepieces/core-formula": "workspace:*"
+    "zustand": "4.5.4"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "4.1.17",

--- a/packages/web/public/locales/en/translation.json
+++ b/packages/web/public/locales/en/translation.json
@@ -2295,5 +2295,6 @@
   "1 min ago": "1 min ago",
   "{count} mins ago": "{count} mins ago",
   "1 hour ago": "1 hour ago",
-  "{count} hours ago": "{count} hours ago"
+  "{count} hours ago": "{count} hours ago",
+  "Continue with Google": "Continue with Google"
 }

--- a/packages/web/src/api/authentication-api.ts
+++ b/packages/web/src/api/authentication-api.ts
@@ -2,6 +2,8 @@ import { ProjectRole } from '@activepieces/core-utils';
 import {
   CreateOtpRequestBody,
   GetCurrentProjectMemberRoleQuery,
+  CompleteSignUpRequest,
+  RequestEmailCodeRequest,
   ResetPasswordRequestBody,
   VerifyEmailRequestBody,
   AuthenticationResponse,
@@ -12,6 +14,7 @@ import {
   SwitchPlatformRequest,
   ThirdPartyAuthnProviderEnum,
   UserIdentity,
+  VerifyEmailCodeRequest,
 } from '@activepieces/shared';
 
 import { api } from '@/lib/api';
@@ -40,6 +43,21 @@ export const authenticationApi = {
   claimThirdPartyRequest(request: ClaimTokenRequest) {
     return api.post<AuthenticationResponse>(
       '/v1/authn/federated/claim',
+      request,
+    );
+  },
+  requestEmailCode(request: RequestEmailCodeRequest) {
+    return api.post<void>('/v1/authentication/otp/request', request);
+  },
+  completeSignUp(request: CompleteSignUpRequest) {
+    return api.post<AuthenticationResponse>(
+      '/v1/authentication/complete-sign-up',
+      request,
+    );
+  },
+  verifyEmailCode(request: VerifyEmailCodeRequest) {
+    return api.post<AuthenticationResponse>(
+      '/v1/authentication/otp/verify',
       request,
     );
   },

--- a/packages/web/src/components/custom/full-logo.tsx
+++ b/packages/web/src/components/custom/full-logo.tsx
@@ -1,12 +1,13 @@
 import { t } from 'i18next';
 
 import { flagsHooks } from '@/hooks/flags-hooks';
+import { cn } from '@/lib/utils';
 
-const FullLogo = () => {
+const FullLogo = ({ className }: { className?: string }) => {
   const branding = flagsHooks.useWebsiteBranding();
 
   return (
-    <div className="h-[60px]">
+    <div className={cn('h-[60px]', className)}>
       <img
         className="h-full"
         src={branding.logos.fullLogoUrl}

--- a/packages/web/src/components/ui/input-otp.tsx
+++ b/packages/web/src/components/ui/input-otp.tsx
@@ -1,0 +1,76 @@
+import { OTPInput, OTPInputContext } from 'input-otp';
+import { Minus } from 'lucide-react';
+import * as React from 'react';
+
+import { cn } from '@/lib/utils';
+
+const InputOTP = React.forwardRef<
+  React.ElementRef<typeof OTPInput>,
+  React.ComponentPropsWithoutRef<typeof OTPInput>
+>(({ className, containerClassName, ...props }, ref) => (
+  <OTPInput
+    ref={ref}
+    containerClassName={cn(
+      'flex items-center gap-2 has-[:disabled]:opacity-50',
+      containerClassName,
+    )}
+    className={cn('disabled:cursor-not-allowed', className)}
+    {...props}
+  />
+));
+InputOTP.displayName = 'InputOTP';
+
+const InputOTPGroup = React.forwardRef<
+  React.ElementRef<'div'>,
+  React.ComponentPropsWithoutRef<'div'>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn('flex items-center gap-2', className)}
+    {...props}
+  />
+));
+InputOTPGroup.displayName = 'InputOTPGroup';
+
+const InputOTPSlot = React.forwardRef<
+  React.ElementRef<'div'>,
+  React.ComponentPropsWithoutRef<'div'> & { index: number }
+>(({ index, className, ...props }, ref) => {
+  const inputOTPContext = React.useContext(OTPInputContext);
+  const slot = inputOTPContext.slots[index];
+  const char = slot?.char;
+  const hasFakeCaret = slot?.hasFakeCaret;
+  const isActive = slot?.isActive;
+
+  return (
+    <div
+      ref={ref}
+      className={cn(
+        'relative flex size-12 items-center justify-center rounded-lg border border-input bg-background text-lg font-medium shadow-sm transition-all',
+        isActive && 'z-10 border-primary ring-2 ring-primary/30',
+        className,
+      )}
+      {...props}
+    >
+      {char}
+      {hasFakeCaret && (
+        <div className="pointer-events-none absolute inset-0 flex items-center justify-center">
+          <div className="h-5 w-px animate-pulse bg-foreground" />
+        </div>
+      )}
+    </div>
+  );
+});
+InputOTPSlot.displayName = 'InputOTPSlot';
+
+const InputOTPSeparator = React.forwardRef<
+  React.ElementRef<'div'>,
+  React.ComponentPropsWithoutRef<'div'>
+>(({ ...props }, ref) => (
+  <div ref={ref} role="separator" {...props}>
+    <Minus className="size-4 text-muted-foreground" />
+  </div>
+));
+InputOTPSeparator.displayName = 'InputOTPSeparator';
+
+export { InputOTP, InputOTPGroup, InputOTPSlot, InputOTPSeparator };

--- a/packages/web/src/features/authentication/components/auth-landing/auth-backdrop.tsx
+++ b/packages/web/src/features/authentication/components/auth-landing/auth-backdrop.tsx
@@ -1,0 +1,231 @@
+import { t } from 'i18next';
+import {
+  ArrowUp,
+  BarChart3,
+  Check,
+  ChevronsUpDown,
+  House,
+  MessageCircle,
+  Mic,
+  Paperclip,
+  Plus,
+  Search,
+  Sparkles,
+  Table2,
+  Workflow,
+} from 'lucide-react';
+
+import { flagsHooks } from '@/hooks/flags-hooks';
+
+export function AuthBackdrop() {
+  const branding = flagsHooks.useWebsiteBranding();
+  const logoUrl = branding.logos.logoIconUrl;
+
+  return (
+    <div
+      aria-hidden
+      className="pointer-events-none absolute inset-0 flex select-none overflow-hidden bg-sidebar animate-in fade-in duration-700"
+    >
+      <SidebarFacsimile logoUrl={logoUrl} />
+      <div className="min-w-0 flex-1 p-1.5">
+        <div className="flex h-full flex-col overflow-hidden rounded-xl border bg-background shadow-[2px_0px_4px_-2px_rgba(0,0,0,0.05),0px_2px_4px_-2px_rgba(0,0,0,0.05)]">
+          <div className="flex items-center gap-2 border-b px-5 py-3 text-sm text-muted-foreground">
+            <MessageCircle className="size-4" />
+            <span className="font-medium text-foreground/80">
+              {t('Daily Stripe summary')}
+            </span>
+          </div>
+          <div className="min-h-0 flex-1 overflow-hidden px-8 pt-8">
+            <div className="mx-auto w-full max-w-3xl space-y-6">
+              {CONVERSATION.map((turn, index) =>
+                turn.role === 'user' ? (
+                  <UserTurn key={index} text={turn.text} />
+                ) : (
+                  <AssistantTurn key={index} turn={turn} />
+                ),
+              )}
+            </div>
+          </div>
+          <div className="px-8 pb-6 pt-4">
+            <div className="mx-auto w-full max-w-3xl">
+              <ComposerFacsimile />
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function SidebarFacsimile({ logoUrl }: { logoUrl: string }) {
+  return (
+    <div className="hidden w-60 shrink-0 flex-col gap-4 px-3 py-3 lg:flex">
+      <div className="flex items-center gap-2 rounded-md px-1.5 py-1">
+        <img src={logoUrl} alt="" className="size-5 object-contain" />
+        <span className="truncate text-sm font-medium text-foreground/80">
+          {t('Acme Inc')}
+        </span>
+        <ChevronsUpDown className="ml-auto size-3.5 text-muted-foreground" />
+      </div>
+
+      <div className="flex items-center gap-2 rounded-lg bg-primary px-2.5 py-2 text-sm font-medium text-primary-foreground shadow-sm">
+        <Plus className="size-4" strokeWidth={2.5} />
+        {t('New chat')}
+      </div>
+
+      <div className="flex flex-col gap-0.5">
+        {NAV_ITEMS.map(({ icon: Icon, label, active }) => (
+          <div
+            key={label}
+            className={
+              active
+                ? 'flex items-center gap-2.5 rounded-md bg-accent px-2.5 py-1.5 text-sm font-medium text-accent-foreground'
+                : 'flex items-center gap-2.5 rounded-md px-2.5 py-1.5 text-sm text-muted-foreground'
+            }
+          >
+            <Icon className="size-4" />
+            {t(label)}
+          </div>
+        ))}
+      </div>
+
+      <div className="flex min-h-0 flex-col gap-1">
+        <span className="px-2.5 pb-1 text-[11px] font-medium uppercase tracking-wide text-muted-foreground/70">
+          {t('Recent')}
+        </span>
+        {RECENT_CHATS.map((title, index) => (
+          <div
+            key={title}
+            className={
+              index === 0
+                ? 'truncate rounded-md bg-accent px-2.5 py-1.5 text-[13px] text-accent-foreground'
+                : 'truncate rounded-md px-2.5 py-1.5 text-[13px] text-muted-foreground'
+            }
+          >
+            {t(title)}
+          </div>
+        ))}
+      </div>
+
+      <div className="mt-auto flex items-center gap-2 rounded-md px-1.5 py-1">
+        <div className="size-6 rounded-full bg-muted" />
+        <div className="h-2.5 w-20 rounded-full bg-muted" />
+      </div>
+    </div>
+  );
+}
+
+function UserTurn({ text }: { text: string }) {
+  return (
+    <div className="flex justify-end">
+      <div className="max-w-[80%] rounded-2xl rounded-br-md bg-muted px-4 py-3 text-[15px] leading-relaxed text-foreground/80">
+        {t(text)}
+      </div>
+    </div>
+  );
+}
+
+function AssistantTurn({ turn }: { turn: AssistantTurnData }) {
+  return (
+    <div className="space-y-3">
+      {turn.activity && (
+        <span className="inline-flex items-center gap-1.5 rounded-full border bg-muted/50 px-2.5 py-1 text-xs text-foreground/70">
+          <Sparkles className="size-3" />
+          {t(turn.activity)}
+        </span>
+      )}
+      <p className="text-[15px] leading-relaxed text-foreground/75">
+        {t(turn.text)}
+      </p>
+      {turn.steps && (
+        <div className="space-y-1.5 rounded-xl border bg-muted/30 p-3">
+          {turn.steps.map((step) => (
+            <div
+              key={step}
+              className="flex items-center gap-2 text-[13px] text-foreground/70"
+            >
+              <Check className="size-3.5 text-primary" strokeWidth={3} />
+              {t(step)}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ComposerFacsimile() {
+  return (
+    <div className="rounded-2xl border border-foreground/20 bg-background px-4 pb-2.5 pt-3.5">
+      <p className="text-sm text-muted-foreground">
+        {t('Tell me what you need... (@ to mention, : for emoji)')}
+      </p>
+      <div className="mt-3 flex items-center justify-between">
+        <div className="flex items-center gap-1">
+          <div className="flex h-7 w-7 items-center justify-center rounded-full text-muted-foreground">
+            <Paperclip className="size-4" />
+          </div>
+          <div className="flex h-7 w-7 items-center justify-center rounded-full text-muted-foreground">
+            <Mic className="size-4" />
+          </div>
+        </div>
+        <div className="flex h-7 w-7 items-center justify-center rounded-full bg-primary text-primary-foreground">
+          <ArrowUp className="size-4" />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+const NAV_ITEMS = [
+  { icon: House, label: 'Home', active: false },
+  { icon: MessageCircle, label: 'Chats', active: true },
+  { icon: Workflow, label: 'Automations', active: false },
+  { icon: Table2, label: 'Tables', active: false },
+  { icon: BarChart3, label: 'Insights', active: false },
+  { icon: Search, label: 'Search', active: false },
+];
+
+const RECENT_CHATS = [
+  'Daily Stripe summary',
+  'Chase overdue invoices',
+  'Onboard new signups',
+  'Weekly report to leadership',
+  'Sync HubSpot to Sheets',
+  'Tidy up my inbox',
+];
+
+const CONVERSATION: Turn[] = [
+  {
+    role: 'user',
+    text: "Every morning, pull yesterday's Stripe payments into a Google Sheet and post a summary in Slack.",
+  },
+  {
+    role: 'assistant',
+    activity: 'Checked Stripe, Google Sheets and Slack',
+    text: 'Done. It runs at 8:00 every morning, writes one row per payment, and posts the daily total to #finance.',
+    steps: [
+      'Every day at 08:00',
+      'Stripe: list yesterday’s payments',
+      'Google Sheets: append rows',
+      'Slack: send summary to #finance',
+    ],
+  },
+  {
+    role: 'user',
+    text: 'Nice. Also ping me if a payment fails.',
+  },
+  {
+    role: 'assistant',
+    text: 'Added a branch: failed payments now send you a direct message the moment Stripe reports them.',
+  },
+];
+
+type AssistantTurnData = {
+  role: 'assistant';
+  text: string;
+  activity?: string;
+  steps?: string[];
+};
+
+type Turn = AssistantTurnData | { role: 'user'; text: string };

--- a/packages/web/src/features/authentication/components/auth-landing/auth-backdrop.tsx
+++ b/packages/web/src/features/authentication/components/auth-landing/auth-backdrop.tsx
@@ -1,4 +1,3 @@
-import { t } from 'i18next';
 import {
   ArrowUp,
   BarChart3,
@@ -32,7 +31,7 @@ export function AuthBackdrop() {
           <div className="flex items-center gap-2 border-b px-5 py-3 text-sm text-muted-foreground">
             <MessageCircle className="size-4" />
             <span className="font-medium text-foreground/80">
-              {t('Daily Stripe summary')}
+              Daily Stripe summary
             </span>
           </div>
           <div className="min-h-0 flex-1 overflow-hidden px-8 pt-8">
@@ -63,14 +62,14 @@ function SidebarFacsimile({ logoUrl }: { logoUrl: string }) {
       <div className="flex items-center gap-2 rounded-md px-1.5 py-1">
         <img src={logoUrl} alt="" className="size-5 object-contain" />
         <span className="truncate text-sm font-medium text-foreground/80">
-          {t('Acme Inc')}
+          Acme Inc
         </span>
         <ChevronsUpDown className="ml-auto size-3.5 text-muted-foreground" />
       </div>
 
       <div className="flex items-center gap-2 rounded-lg bg-primary px-2.5 py-2 text-sm font-medium text-primary-foreground shadow-sm">
         <Plus className="size-4" strokeWidth={2.5} />
-        {t('New chat')}
+        New chat
       </div>
 
       <div className="flex flex-col gap-0.5">
@@ -84,14 +83,14 @@ function SidebarFacsimile({ logoUrl }: { logoUrl: string }) {
             }
           >
             <Icon className="size-4" />
-            {t(label)}
+            {label}
           </div>
         ))}
       </div>
 
       <div className="flex min-h-0 flex-col gap-1">
         <span className="px-2.5 pb-1 text-[11px] font-medium uppercase tracking-wide text-muted-foreground/70">
-          {t('Recent')}
+          Recent
         </span>
         {RECENT_CHATS.map((title, index) => (
           <div
@@ -102,7 +101,7 @@ function SidebarFacsimile({ logoUrl }: { logoUrl: string }) {
                 : 'truncate rounded-md px-2.5 py-1.5 text-[13px] text-muted-foreground'
             }
           >
-            {t(title)}
+            {title}
           </div>
         ))}
       </div>
@@ -119,7 +118,7 @@ function UserTurn({ text }: { text: string }) {
   return (
     <div className="flex justify-end">
       <div className="max-w-[80%] rounded-2xl rounded-br-md bg-muted px-4 py-3 text-[15px] leading-relaxed text-foreground/80">
-        {t(text)}
+        {text}
       </div>
     </div>
   );
@@ -131,11 +130,11 @@ function AssistantTurn({ turn }: { turn: AssistantTurnData }) {
       {turn.activity && (
         <span className="inline-flex items-center gap-1.5 rounded-full border bg-muted/50 px-2.5 py-1 text-xs text-foreground/70">
           <Sparkles className="size-3" />
-          {t(turn.activity)}
+          {turn.activity}
         </span>
       )}
       <p className="text-[15px] leading-relaxed text-foreground/75">
-        {t(turn.text)}
+        {turn.text}
       </p>
       {turn.steps && (
         <div className="space-y-1.5 rounded-xl border bg-muted/30 p-3">
@@ -145,7 +144,7 @@ function AssistantTurn({ turn }: { turn: AssistantTurnData }) {
               className="flex items-center gap-2 text-[13px] text-foreground/70"
             >
               <Check className="size-3.5 text-primary" strokeWidth={3} />
-              {t(step)}
+              {step}
             </div>
           ))}
         </div>
@@ -158,7 +157,7 @@ function ComposerFacsimile() {
   return (
     <div className="rounded-2xl border border-foreground/20 bg-background px-4 pb-2.5 pt-3.5">
       <p className="text-sm text-muted-foreground">
-        {t('Tell me what you need... (@ to mention, : for emoji)')}
+        Tell me what you need... (@ to mention, : for emoji)
       </p>
       <div className="mt-3 flex items-center justify-between">
         <div className="flex items-center gap-1">

--- a/packages/web/src/features/authentication/components/saml-login-form.tsx
+++ b/packages/web/src/features/authentication/components/saml-login-form.tsx
@@ -25,9 +25,15 @@ type FormValues = z.infer<typeof FormValues>;
 
 type SamlLoginFormProps = {
   onBack: () => void;
+  // The auth card supplies its own back affordance, so it opts out of this
+  // one rather than showing two.
+  showBackButton?: boolean;
 };
 
-export const SamlLoginForm = ({ onBack }: SamlLoginFormProps) => {
+export const SamlLoginForm = ({
+  onBack,
+  showBackButton = true,
+}: SamlLoginFormProps) => {
   const form = useForm<FormValues>({
     resolver: zodResolver(FormValues),
     defaultValues: { email: '' },
@@ -92,10 +98,12 @@ export const SamlLoginForm = ({ onBack }: SamlLoginFormProps) => {
         >
           {t('Continue')}
         </Button>
-        <Button variant="ghost" type="button" onClick={onBack}>
-          <ArrowLeft className="mr-2 h-4 w-4" />
-          {t('Back to sign in')}
-        </Button>
+        {showBackButton && (
+          <Button variant="ghost" type="button" onClick={onBack}>
+            <ArrowLeft className="mr-2 h-4 w-4" />
+            {t('Back to sign in')}
+          </Button>
+        )}
       </form>
     </Form>
   );

--- a/packages/web/src/features/authentication/components/third-party-logins.tsx
+++ b/packages/web/src/features/authentication/components/third-party-logins.tsx
@@ -17,17 +17,41 @@ import { internalErrorToast } from '@/components/ui/sonner';
 import { oauth2Utils } from '@/features/connections/utils/oauth2-utils';
 import { flagsHooks } from '@/hooks/flags-hooks';
 
+// Mirrors the render gates below so callers can hide surrounding chrome — an
+// "or" divider — or place each provider themselves. SAML is offered on cloud
+// for enterprise SSO, and self-hosted only once a SAML config exists.
+function useThirdPartyAvailability(): ThirdPartyAvailability {
+  const { data: thirdPartyAuthProviders } =
+    flagsHooks.useFlag<ThirdPartyAuthnProvidersToShowMap>(
+      ApFlagId.THIRD_PARTY_AUTH_PROVIDERS_TO_SHOW_MAP,
+    );
+  const { data: edition } = flagsHooks.useFlag<ApEdition>(ApFlagId.EDITION);
+  const isCloud = edition === ApEdition.CLOUD;
+  return {
+    google: Boolean(thirdPartyAuthProviders?.google),
+    saml: isCloud || Boolean(thirdPartyAuthProviders?.saml),
+    samlIsCloud: isCloud,
+  };
+}
+
+function useShowThirdPartyProviders(): boolean {
+  const { google, saml } = useThirdPartyAvailability();
+  return google || saml;
+}
+
 const ThirdPartyIcon = ({ icon }: { icon: string }) => {
-  return <img src={icon} alt="icon" width={24} height={24} className="mr-2" />;
+  return <img src={icon} alt="icon" width={18} height={18} className="mr-2" />;
 };
 
 const ThirdPartyLogin = React.memo(
   ({
     isSignUp,
     onSamlClick,
+    hideSaml = false,
   }: {
     isSignUp: boolean;
     onSamlClick: () => void;
+    hideSaml?: boolean;
   }) => {
     const { data: thirdPartyAuthProviders } =
       flagsHooks.useFlag<ThirdPartyAuthnProvidersToShowMap>(
@@ -40,6 +64,9 @@ const ThirdPartyLogin = React.memo(
     const isCloud = edition === ApEdition.CLOUD;
     const thirdPartyLogin = oauth2Utils.useThirdPartyLogin();
     const { capture } = useTelemetry();
+    const availability = useThirdPartyAvailability();
+    const showProviders =
+      availability.google || (!hideSaml && availability.saml);
 
     const handleProviderClick = async (
       event: React.MouseEvent<HTMLButtonElement, MouseEvent>,
@@ -67,26 +94,28 @@ const ThirdPartyLogin = React.memo(
       thirdPartyLogin(loginUrl, providerName);
     };
 
+    if (!showProviders) {
+      return null;
+    }
+
     return (
       <div className="flex flex-col gap-4">
         {thirdPartyAuthProviders?.google && (
           <Button
             variant="outline"
-            className="w-full rounded-sm"
+            className="h-10 w-full rounded-lg text-sm font-normal"
             onClick={(e) =>
               handleProviderClick(e, ThirdPartyAuthnProviderEnum.GOOGLE)
             }
           >
             <ThirdPartyIcon icon={GoogleIcon} />
-            {isSignUp
-              ? `${t(`Sign up With`)} ${t('Google')}`
-              : `${t(`Sign in With`)} ${t('Google')}`}
+            {t('Continue with Google')}
           </Button>
         )}
-        {isCloud && (
+        {!hideSaml && isCloud && (
           <Button
             variant="outline"
-            className="w-full rounded-sm"
+            className="h-10 w-full rounded-lg text-sm font-normal"
             onClick={() => {
               capture({
                 name: TelemetryEventName.FEDERATED_LOGIN_STARTED,
@@ -101,10 +130,10 @@ const ThirdPartyLogin = React.memo(
               : `${t(`Sign in With`)} ${t('SAML')}`}
           </Button>
         )}
-        {!isCloud && thirdPartyAuthProviders?.saml && (
+        {!hideSaml && !isCloud && thirdPartyAuthProviders?.saml && (
           <Button
             variant="outline"
-            className="w-full rounded-sm"
+            className="h-10 w-full rounded-lg text-sm font-normal"
             onClick={() => {
               capture({
                 name: TelemetryEventName.FEDERATED_LOGIN_STARTED,
@@ -125,4 +154,15 @@ const ThirdPartyLogin = React.memo(
 );
 
 ThirdPartyLogin.displayName = 'ThirdPartyLogin';
-export { ThirdPartyLogin };
+
+export {
+  ThirdPartyLogin,
+  useShowThirdPartyProviders,
+  useThirdPartyAvailability,
+};
+
+type ThirdPartyAvailability = {
+  google: boolean;
+  saml: boolean;
+  samlIsCloud: boolean;
+};

--- a/packages/web/src/features/authentication/hooks/auth-hooks.ts
+++ b/packages/web/src/features/authentication/hooks/auth-hooks.ts
@@ -1,11 +1,14 @@
 import {
   AuthenticationResponse,
+  CompleteSignUpRequest,
   CreateOtpRequestBody,
+  RequestEmailCodeRequest,
   ResetPasswordRequestBody,
   SignInRequest,
   SignUpRequest,
   UserIdentity,
   VerifyEmailRequestBody,
+  VerifyEmailCodeRequest,
 } from '@activepieces/shared';
 import { useMutation } from '@tanstack/react-query';
 
@@ -35,6 +38,53 @@ export const authMutations = {
   }) => {
     return useMutation<AuthenticationResponse, HttpError, SignUpRequest>({
       mutationFn: authenticationApi.signUp,
+      onSuccess,
+      onError,
+    });
+  },
+  useRequestEmailCode: ({
+    onSuccess,
+    onError,
+  }: {
+    onSuccess: () => void;
+    onError: (error: HttpError) => void;
+  }) => {
+    return useMutation<void, HttpError, RequestEmailCodeRequest>({
+      mutationFn: authenticationApi.requestEmailCode,
+      onSuccess,
+      onError,
+    });
+  },
+  useCompleteSignUp: ({
+    onSuccess,
+    onError,
+  }: {
+    onSuccess: (data: AuthenticationResponse) => void;
+    onError: (error: HttpError) => void;
+  }) => {
+    return useMutation<
+      AuthenticationResponse,
+      HttpError,
+      CompleteSignUpRequest
+    >({
+      mutationFn: authenticationApi.completeSignUp,
+      onSuccess,
+      onError,
+    });
+  },
+  useVerifyEmailCode: ({
+    onSuccess,
+    onError,
+  }: {
+    onSuccess: (data: AuthenticationResponse) => void;
+    onError: (error: HttpError) => void;
+  }) => {
+    return useMutation<
+      AuthenticationResponse,
+      HttpError,
+      VerifyEmailCodeRequest
+    >({
+      mutationFn: authenticationApi.verifyEmailCode,
       onSuccess,
       onError,
     });

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -23,6 +23,8 @@ const disallowedRoutes = [
   '/v1/managed-authn/external-token',
   '/v1/authentication/sign-in',
   '/v1/authentication/sign-up',
+  '/v1/authentication/otp/request',
+  '/v1/authentication/otp/verify',
   '/v1/authn/local/verify-email',
   '/v1/authn/federated/login',
   '/v1/authn/federated/claim',


### PR DESCRIPTION
## Description

**6 of 9 in the passwordless sign-in stack**, and the first web PR. <details><summary><b>The stack</b> — review bottom-up; each PR targets the one below it</summary>

| | PR | Area |
|---|---|---|
| 1 | #14685 — OTP primitive moves to core, gains an attempt budget | server/api |
| 2 | #14692 — derive first, last and platform names | server/api |
| 3 | #14702 — first-platform creation single-use and self-healing | server/api |
| 4 | #14703 — sign in with an emailed code | server/api |
| 5 | #14708 — finish sign-up by asking for a name | server/api |
| 6 | #14709 — building blocks for the auth screen | web |
| 7 | #14689 — one screen for sign in and sign up | web |
| 8 | #14690 — ask new members their name in the card | web |
| 9 | #14707 — refuse throwaway addresses and bot sign-ups | server/api + web |

Split out of #14653, which exceeded the review-size budget. Superseded along the way:
#14686, #14694 and #14687 (reordered so the provisioning guard lands before the feature
that relies on it), #14688 and #14704 (rebased onto new bases, which GitHub will not
retarget inside a stack).

</details>

The pieces the new sign-in card is assembled from, landed before anything renders them so the screen itself reviews as one diff:

- **`input-otp`** — the one-time-code field.
- **`auth-backdrop.tsx`** — the product facsimile that sits behind the card (sidebar, a chat, a composer). Unused until the next PR.
- **The passwordless API client and hooks** for the endpoints added in PR 2.
- **`SamlLoginForm` gains an opt-out for its own back button**, since the card supplies one and would otherwise show two. Optional prop with a default, so existing callers are unaffected.
- **Third-party availability moves behind a hook**, so a caller can place each provider itself rather than taking the whole block. That is what lets Google sit above the email field instead of below it.
- **`reset-password-form`** switches to the narrowed `CreateOtpRequestBody.shape.type` from PR 1, replacing a deprecated `z.nativeEnum`.

## How was this tested?

`turbo build lint typecheck --filter=web` clean. Nothing user-visible changes in this PR on its own: the new components have no consumer yet, and the two modified components keep their existing behaviour for existing callers.

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

- [ ] no — reviewed, no security impact
- [x] yes — security-sensitive (call out the risk and mitigation in the description above)

