### PR TITLE
fix(pieces): surface engine errors from POST /v1/pieces/options

### DIFF
--- a/packages/server/api/src/app/pieces/metadata/piece-metadata-controller.ts
+++ b/packages/server/api/src/app/pieces/metadata/piece-metadata-controller.ts
@@ -1,6 +1,6 @@
 import { ActivepiecesError, ErrorCode, isNil, LocalesEnum } from '@activepieces/core-utils'
 import { PieceMetadataModel, PieceMetadataModelSummary } from '@activepieces/pieces-framework'
-import { ALL_PRINCIPAL_TYPES, EngineResponse, GetPieceRequestParams, GetPieceRequestQuery, GetPieceRequestWithScopeParams, ListPiecesRequestQuery, PieceAudienceFilter, PieceCategory, PieceOptionRequest, Principal, PrincipalType, RegistryPiecesRequestQuery, SampleDataFileType, WorkerJobType } from '@activepieces/shared'
+import { ALL_PRINCIPAL_TYPES, EngineResponse, EngineResponseStatus, GetPieceRequestParams, GetPieceRequestQuery, GetPieceRequestWithScopeParams, ListPiecesRequestQuery, PieceAudienceFilter, PieceCategory, PieceOptionRequest, Principal, PrincipalType, RegistryPiecesRequestQuery, SampleDataFileType, WorkerJobType } from '@activepieces/shared'
 import { FastifyPluginAsyncZod } from 'fastify-type-provider-zod'
 import { StatusCodes } from 'http-status-codes'
 import { z } from 'zod'
@@ -133,7 +133,7 @@ const basePiecesController: FastifyPluginAsyncZod = async (app) => {
                 versionId: req.body.flowVersionId,
             })
             const sampleData = await sampleDataService(req.log).getSampleDataForFlow(projectId, flow.version, SampleDataFileType.OUTPUT)
-            const { response } = await userInteractionWatcher.submitAndWaitForResponse<EngineResponse<unknown>>({
+            const engineResponse = await userInteractionWatcher.submitAndWaitForResponse<EngineResponse<unknown>>({
                 jobType: WorkerJobType.EXECUTE_PROPERTY,
                 platformId: platform.id,
                 projectId,
@@ -145,7 +145,18 @@ const basePiecesController: FastifyPluginAsyncZod = async (app) => {
                 searchValue: req.body.searchValue,
                 piece: await getPiecePackageWithoutArchive(req.log, platform.id, req.body),
             }, req.log)
-            return response
+            if (engineResponse.status !== EngineResponseStatus.OK) {
+                throw new ActivepiecesError({
+                    code: ErrorCode.ENGINE_OPERATION_FAILURE,
+                    params: {
+                        message: engineResponse.error ?? (engineResponse.status === EngineResponseStatus.TIMEOUT
+                            ? 'Engine timed out while resolving property options'
+                            : `Engine failed while resolving property options (${engineResponse.status})`),
+                        context: { status: engineResponse.status },
+                    },
+                })
+            }
+            return engineResponse.response
         },
     )
 

--- a/packages/server/api/test/integration/ce/pieces/piece-options-error.test.ts
+++ b/packages/server/api/test/integration/ce/pieces/piece-options-error.test.ts
@@ -1,0 +1,148 @@
+import { apDayjs } from '@activepieces/server-utils'
+import {
+    EngineResponseStatus,
+    FlowTriggerType,
+    FlowVersionState,
+    PackageType,
+    PieceType,
+    PrincipalType,
+} from '@activepieces/shared'
+import { FastifyInstance } from 'fastify'
+import { StatusCodes } from 'http-status-codes'
+import { vi } from 'vitest'
+import { databaseConnection } from '../../../../src/app/database/database-connection'
+import { userInteractionWatcher } from '../../../../src/app/workers/user-interaction-watcher'
+import { generateMockToken } from '../../../helpers/auth'
+import { db } from '../../../helpers/db'
+import {
+    createMockFlow,
+    createMockFlowVersion,
+    createMockPieceMetadata,
+    mockAndSaveBasicSetup,
+} from '../../../helpers/mocks'
+import { setupTestEnvironment, teardownTestEnvironment } from '../../../helpers/test-setup'
+
+let app: FastifyInstance
+
+beforeAll(async () => {
+    app = await setupTestEnvironment()
+})
+
+afterAll(async () => {
+    await teardownTestEnvironment()
+})
+
+describe('POST /v1/pieces/options — engine failure propagation', () => {
+    const setupCallable = async () => {
+        const { mockPlatform, mockProject, mockOwner } = await mockAndSaveBasicSetup()
+
+        const mockFlow = createMockFlow({ projectId: mockProject.id })
+        await db.save('flow', mockFlow)
+
+        const mockFlowVersion = createMockFlowVersion({
+            flowId: mockFlow.id,
+            state: FlowVersionState.DRAFT,
+            trigger: {
+                type: FlowTriggerType.PIECE,
+                name: 'trigger',
+                displayName: 'Catch Webhook',
+                settings: {
+                    pieceName: '@activepieces/piece-webhook',
+                    pieceVersion: '~0.1.29',
+                    triggerName: 'catch_webhook',
+                    input: { authType: 'basic' },
+                    propertySettings: {},
+                },
+                valid: true,
+                lastUpdatedDate: apDayjs().toISOString(),
+            },
+        })
+        await db.save('flow_version', mockFlowVersion)
+
+        const mockPiece = createMockPieceMetadata({
+            name: '@activepieces/piece-webhook',
+            version: '0.1.29',
+            platformId: undefined,
+            packageType: PackageType.REGISTRY,
+            pieceType: PieceType.OFFICIAL,
+        })
+        await databaseConnection().getRepository('piece_metadata').save(mockPiece)
+
+        const token = await generateMockToken({
+            id: mockOwner.id,
+            type: PrincipalType.USER,
+            platform: { id: mockPlatform.id },
+        })
+
+        return { mockProject, mockFlow, mockFlowVersion, token }
+    }
+
+    const requestBody = (ids: { projectId: string, flowId: string, flowVersionId: string }) => ({
+        projectId: ids.projectId,
+        flowId: ids.flowId,
+        flowVersionId: ids.flowVersionId,
+        pieceName: '@activepieces/piece-webhook',
+        pieceVersion: '~0.1.29',
+        actionOrTriggerName: 'catch_webhook',
+        propertyName: 'authFields',
+        input: { authType: 'basic' },
+    })
+
+    it('returns ENGINE_OPERATION_FAILURE + engine errorMessage when the property job fails', async () => {
+        const { mockProject, mockFlow, mockFlowVersion, token } = await setupCallable()
+
+        const spy = vi.spyOn(userInteractionWatcher, 'submitAndWaitForResponse').mockResolvedValue({
+            status: EngineResponseStatus.INTERNAL_ERROR,
+            response: undefined,
+            error: 'Failed to fetch piece bundle @activepieces/piece-ai@0.4.0: 404 Not Found',
+        })
+
+        const response = await app.inject({
+            method: 'POST',
+            url: '/api/v1/pieces/options',
+            headers: { authorization: `Bearer ${token}` },
+            body: requestBody({
+                projectId: mockProject.id,
+                flowId: mockFlow.id,
+                flowVersionId: mockFlowVersion.id,
+            }),
+        })
+
+        expect(response.statusCode).toBe(StatusCodes.BAD_REQUEST)
+        const body = response.json()
+        expect(body.code).toBe('ENGINE_OPERATION_FAILURE')
+        expect(body.params.message).toContain('404 Not Found')
+        expect(body.params.context.status).toBe(EngineResponseStatus.INTERNAL_ERROR)
+
+        spy.mockRestore()
+    })
+
+    it('returns a synthesized message on TIMEOUT (no engine errorMessage)', async () => {
+        const { mockProject, mockFlow, mockFlowVersion, token } = await setupCallable()
+
+        const spy = vi.spyOn(userInteractionWatcher, 'submitAndWaitForResponse').mockResolvedValue({
+            status: EngineResponseStatus.TIMEOUT,
+            response: {},
+            error: undefined,
+        })
+
+        const response = await app.inject({
+            method: 'POST',
+            url: '/api/v1/pieces/options',
+            headers: { authorization: `Bearer ${token}` },
+            body: requestBody({
+                projectId: mockProject.id,
+                flowId: mockFlow.id,
+                flowVersionId: mockFlowVersion.id,
+            }),
+        })
+
+        expect(response.statusCode).toBe(StatusCodes.BAD_REQUEST)
+        const body = response.json()
+        expect(body.code).toBe('ENGINE_OPERATION_FAILURE')
+        expect(body.params.message).toMatch(/timed out/i)
+        expect(body.params.context.status).toBe(EngineResponseStatus.TIMEOUT)
+
+        spy.mockRestore()
+    })
+})

--- a/packages/server/api/test/integration/ce/pieces/piece-options-error.test.ts
+++ b/packages/server/api/test/integration/ce/pieces/piece-options-error.test.ts
@@ -33,6 +33,10 @@ afterAll(async () => {
 })
 
 describe('POST /v1/pieces/options — engine failure propagation', () => {
+    afterEach(() => {
+        vi.restoreAllMocks()
+    })
+
     const setupCallable = async () => {
         const { mockPlatform, mockProject, mockOwner } = await mockAndSaveBasicSetup()
 
@@ -91,7 +95,7 @@ describe('POST /v1/pieces/options — engine failure propagation', () => {
     it('returns ENGINE_OPERATION_FAILURE + engine errorMessage when the property job fails', async () => {
         const { mockProject, mockFlow, mockFlowVersion, token } = await setupCallable()
 
-        const spy = vi.spyOn(userInteractionWatcher, 'submitAndWaitForResponse').mockResolvedValue({
+        vi.spyOn(userInteractionWatcher, 'submitAndWaitForResponse').mockResolvedValue({
             status: EngineResponseStatus.INTERNAL_ERROR,
             response: undefined,
             error: 'Failed to fetch piece bundle @activepieces/piece-ai@0.4.0: 404 Not Found',
@@ -113,14 +117,12 @@ describe('POST /v1/pieces/options — engine failure propagation', () => {
         expect(body.code).toBe('ENGINE_OPERATION_FAILURE')
         expect(body.params.message).toContain('404 Not Found')
         expect(body.params.context.status).toBe(EngineResponseStatus.INTERNAL_ERROR)
-
-        spy.mockRestore()
     })
 
     it('returns a synthesized message on TIMEOUT (no engine errorMessage)', async () => {
         const { mockProject, mockFlow, mockFlowVersion, token } = await setupCallable()
 
-        const spy = vi.spyOn(userInteractionWatcher, 'submitAndWaitForResponse').mockResolvedValue({
+        vi.spyOn(userInteractionWatcher, 'submitAndWaitForResponse').mockResolvedValue({
             status: EngineResponseStatus.TIMEOUT,
             response: {},
             error: undefined,
@@ -142,7 +144,5 @@ describe('POST /v1/pieces/options — engine failure propagation', () => {
         expect(body.code).toBe('ENGINE_OPERATION_FAILURE')
         expect(body.params.message).toMatch(/timed out/i)
         expect(body.params.context.status).toBe(EngineResponseStatus.TIMEOUT)
-
-        spy.mockRestore()
     })
 })


### PR DESCRIPTION
## Description

`POST /v1/pieces/options` destructured only `.response` from the engine job result and returned it directly. On `INTERNAL_ERROR` the worker publishes `response: undefined` (`worker.ts:269-274`); on `TIMEOUT` `execute-property.ts` publishes `response: {}`. Fastify sent **200 with an empty body (or `{}`)** and the engine's `errorMessage` was dropped on the floor — the builder shows a generic "unexpected error" toast and nothing in the response, network tab, or console points at the real cause.

Burned hours on a customer thread ([Pylon 5504](https://app.usepylon.com/issues?issueNumber=5504)) chasing wrong theories (AI provider, rate limits, sandbox timeouts) while the actual error was a piece-bundle 404 (fixed separately in #14608 / GIT-1694).

## Fix

Check `status` before returning:

```ts
if (engineResponse.status !== EngineResponseStatus.OK) {
    throw new ActivepiecesError({
        code: ErrorCode.ENGINE_OPERATION_FAILURE,
        params: {
            message: engineResponse.error ?? (engineResponse.status === EngineResponseStatus.TIMEOUT
                ? 'Engine timed out while resolving property options'
                : `Engine failed while resolving property options (${engineResponse.status})`),
            context: { status: engineResponse.status },
        },
    })
}
return engineResponse.response
```

The client now receives a JSON body with `code`, `params.message`, and `params.context.status` (so `TIMEOUT` and `INTERNAL_ERROR` are distinguishable at the call site) instead of a silent 200/empty. Reuses the existing `ENGINE_OPERATION_FAILURE` code that `app-connection-service.ts:715` and `user-interaction-watcher.ts:24` already throw for engine-side failures.

## Audit of other `submitAndWaitForResponse` callers

Ticket asked to check for the same discard pattern — audited each site, all already gate on `status`:

- `piece-install-service.ts:94` — throws `Error(engineResponse.error)` on non-OK
- `webhooks/webhook-handshake.ts:29` — returns `null` on non-OK (probe, silently ok)
- `trigger-event.service.ts:74` — throws `ActivepiecesError(TEST_TRIGGER_FAILED)`
- `trigger-source/flow-trigger-side-effect.ts:39,94` — `assertEngineResponseIsOk(...)`
- `app-connection-service.ts:710` — throws `ActivepiecesError(ENGINE_OPERATION_FAILURE)`
- `app-connection.handler.ts:102` — branches on TIMEOUT vs non-OK
- `mcp/tools/*.ts` — all check `result.status !== OK`

`/v1/pieces/options` was the sole offender.

## Why not 500?

`ENGINE_OPERATION_FAILURE` is not in `error-handler.ts`'s status-code map, so it defaults to 400. Semantically an engine crash is a server-side failure, but promoting the code to 500 would also flip the status returned by the validate-auth and safety-timeout throw sites — out of scope for this PR. The observable fix (JSON body with `code` + `params.message` instead of 200/empty) is what unblocks debugging regardless of 4xx vs 5xx.

## How was this tested?

New regression test: `packages/server/api/test/integration/ce/pieces/piece-options-error.test.ts` — spies `userInteractionWatcher.submitAndWaitForResponse`, asserts the endpoint returns the engine's error message and status through the `ActivepiecesError` body for both `INTERNAL_ERROR` and `TIMEOUT`.

- `npx turbo run lint --filter=api` — 0 errors

Fixes GIT-1695 (#14533).

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)