### PR TITLE
fix(reddit): request permanent OAuth2 duration to receive refresh token

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -117,7 +117,7 @@
     },
     "packages/core/execution": {
       "name": "@activepieces/core-execution",
-      "version": "0.11.0",
+      "version": "0.12.0",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -5071,7 +5071,7 @@
     },
     "packages/pieces/community/linear": {
       "name": "@activepieces/piece-linear",
-      "version": "0.4.5",
+      "version": "0.5.0",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -7503,7 +7503,7 @@
     },
     "packages/pieces/community/reddit": {
       "name": "@activepieces/piece-reddit",
-      "version": "0.1.7",
+      "version": "0.2.0",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",

--- a/packages/pieces/community/reddit/package.json
+++ b/packages/pieces/community/reddit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-reddit",
-  "version": "0.1.7",
+  "version": "0.2.0",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {

--- a/packages/pieces/community/reddit/src/lib/auth.ts
+++ b/packages/pieces/community/reddit/src/lib/auth.ts
@@ -25,6 +25,7 @@ export const redditAuth = PieceAuth.OAuth2({
   authorizationMethod: OAuth2AuthorizationMethod.HEADER,
   extra: {
     grantType: OAuth2GrantType.AUTHORIZATION_CODE,
-    responseType: 'code'
+    responseType: 'code',
+    duration: 'permanent'
   }
 });


### PR DESCRIPTION
## Description

Reddit's OAuth2 authorize endpoint only issues a `refresh_token` when the request includes `duration=permanent` (per Reddit's OAuth2 docs). The `piece-reddit` auth definition never sent this parameter, so connections only ever got a short-lived access token.

Once that access token expired (~1 hour), the framework's `isExpired` check treats an AUTHORIZATION_CODE connection with no `refresh_token` as never-expired, so the stale token kept being reused and every Reddit action returned 401 — with no automatic recovery; only deleting and recreating the connection worked.

Fix: add `duration: 'permanent'` to the `extra` object in `packages/pieces/community/reddit/src/lib/auth.ts`. Piece `extra` fields are spread into the query params of the generated authorize URL (`oauth2-util.ts`), so this makes Reddit return a `refresh_token` and the existing refresh flow keeps the connection alive indefinitely.

## How was this tested?

- Verified the `extra` → query-param flow by reading `packages/server/api/src/app/app-connection/app-connection-service/oauth2/oauth2-util.ts` (`buildAuthorizationUrl`), confirming `pieceAuth.extra` is spread into the authorize URL's query string.
- `npx turbo run lint --filter=@activepieces/piece-reddit` passes with no new errors (only pre-existing unrelated warnings).
- Not manually re-verified against a live Reddit app/connection in this session (would require a fresh Reddit OAuth2 app + connection walkthrough); this is a single-line config change with a clear mechanism, per the issue reporter's own verification that adding `duration: 'permanent'` produces a `refresh_token`.

Fixes #14680

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact