### PR TITLE
fix(agent): let a step use a piece's custom API call again

### DIFF
--- a/brain/decisions/000024-configuring-an-agent-step-tool-authorises-the-action-not-its-arguments.md
+++ b/brain/decisions/000024-configuring-an-agent-step-tool-authorises-the-action-not-its-arguments.md
@@ -39,13 +39,16 @@ decision rather than the code:
   match and the emitted brace re-pairs with the untouched one.
 - **Pinned values are applied after the model's answer.** Relying on the strict schema is
   not enough: `recoverFencedJson` parses fenced output with a bare `JSON.parse` and no zod.
-- **`custom_api_call` is allowed on a step.** It was refused at first, on the belief that the
-  model chose the whole URL and could therefore post a credential anywhere. That was wrong:
-  `joinBaseUrlWithRelativePath` in `pieces/common/src/lib/helpers/index.ts` fixes the host from
-  the piece's own auth and the model supplies only a relative path. The reach is other endpoints
-  of the API the connection already authorises, which is the same trust the rest of this
-  decision grants, so refusing it removed a real capability and bought nothing. Check what a
-  tool actually lets the model control before deciding it is an exfiltration path.
+- **`custom_api_call` is allowed on a step, but only as a path.** It was refused outright at
+  first, on the belief that the model chose the whole URL. Reading only
+  `joinBaseUrlWithRelativePath` in `pieces/common/src/lib/helpers/index.ts` seemed to disprove
+  that, since the piece fixes the host from its own auth. Both readings were wrong: its caller
+  at `:363` uses the value verbatim when it starts with `http://` or `https://`, and
+  `authMapping` still attaches the connection's credentials, so an absolute URL sends them to a
+  host the model picked. The action is allowed and an absolute URL is refused server-side
+  before the call, which keeps the real capability &mdash; other endpoints of the same API &mdash;
+  and closes the escape. Trace a helper's callers before concluding what a value can be.
+
 - **A tool is capped per turn**, because nothing else bounds how often one turn fires an
   action, and chat's email tool already had two such limits.
 - **The resolved input is logged.** It was computed, redacted and discarded, and the adhoc

--- a/brain/decisions/000024-configuring-an-agent-step-tool-authorises-the-action-not-its-arguments.md
+++ b/brain/decisions/000024-configuring-an-agent-step-tool-authorises-the-action-not-its-arguments.md
@@ -39,9 +39,13 @@ decision rather than the code:
   match and the emitted brace re-pairs with the untouched one.
 - **Pinned values are applied after the model's answer.** Relying on the strict schema is
   not enough: `recoverFencedJson` parses fenced output with a bare `JSON.parse` and no zod.
-- **`custom_api_call` is refused on a step.** Model-chosen method, URL and body with the
-  connection's credential merged into the headers is credential exfiltration in one call.
-  It stays available in chat, where a human sees the request first.
+- **`custom_api_call` is allowed on a step.** It was refused at first, on the belief that the
+  model chose the whole URL and could therefore post a credential anywhere. That was wrong:
+  `joinBaseUrlWithRelativePath` in `pieces/common/src/lib/helpers/index.ts` fixes the host from
+  the piece's own auth and the model supplies only a relative path. The reach is other endpoints
+  of the API the connection already authorises, which is the same trust the rest of this
+  decision grants, so refusing it removed a real capability and bought nothing. Check what a
+  tool actually lets the model control before deciding it is an exfiltration path.
 - **A tool is capped per turn**, because nothing else bounds how often one turn fires an
   action, and chat's email tool already had two such limits.
 - **The resolved input is logged.** It was computed, redacted and discarded, and the adhoc

--- a/packages/server/api/src/app/ee/agent/agent-run-controller.ts
+++ b/packages/server/api/src/app/ee/agent/agent-run-controller.ts
@@ -1,5 +1,5 @@
 import { ActivepiecesError, apId, ApId, assertNotNullOrUndefined, ErrorCode, isNil, unique } from '@activepieces/core-utils'
-import { AgentFlowTool, AgentOutputField, AgentPieceTool, AgentRunSource, AgentTool, AgentToolType, LATEST_JOB_DATA_SCHEMA_VERSION, PrincipalType, ResolvedAgentFlowTool, TASK_COMPLETION_TOOL_NAME, WorkerJobType } from '@activepieces/shared'
+import { AgentFlowTool, AgentOutputField, AgentRunSource, AgentTool, AgentToolType, LATEST_JOB_DATA_SCHEMA_VERSION, PrincipalType, ResolvedAgentFlowTool, TASK_COMPLETION_TOOL_NAME, WorkerJobType } from '@activepieces/shared'
 import { FastifyBaseLogger } from 'fastify'
 import { FastifyPluginAsyncZod } from 'fastify-type-provider-zod'
 import { StatusCodes } from 'http-status-codes'
@@ -30,7 +30,6 @@ export const agentRunController: FastifyPluginAsyncZod = async (app) => {
         }
         const supportedToolTypes = [AgentToolType.PIECE, AgentToolType.MCP, AgentToolType.FLOW, AgentToolType.KNOWLEDGE_BASE]
         const supportedTools = (tools ?? []).filter((tool) => supportedToolTypes.includes(tool.type))
-        const pieceTools = supportedTools.filter((tool): tool is AgentPieceTool => tool.type === AgentToolType.PIECE)
         const flowToolRequests = (tools ?? []).filter((tool): tool is AgentFlowTool => tool.type === AgentToolType.FLOW)
         const unsupported = unique((tools ?? []).map((tool) => tool.type)).filter((type) => !supportedToolTypes.includes(type))
         if (unsupported.length > 0) {
@@ -47,9 +46,6 @@ export const agentRunController: FastifyPluginAsyncZod = async (app) => {
                 code: ErrorCode.VALIDATION,
                 params: { message: `Two tools are both named ${duplicated.join(', ')}: each tool on a step needs its own name, or one silently replaces the other` },
             })
-        }
-        if (pieceTools.some((tool) => tool.pieceMetadata.actionName === CUSTOM_API_CALL)) {
-            throw new ActivepiecesError({ code: ErrorCode.VALIDATION, params: { message: 'An agent step cannot use a custom API call: it would let the agent send this project\'s credentials to any address it chooses' } })
         }
         const flowTools = await resolveFlowTools({ projectId, flowToolRequests, log: request.log })
         await assertCreditsAndAppSumoNotExceeded({ platformId: platform.id, log: request.log })
@@ -133,7 +129,6 @@ async function resolveFlowTools({ projectId, flowToolRequests, log }: {
 const RUNS_PER_MINUTE = 60
 const MAX_INSTRUCTION_LENGTH = 51_200
 const MAX_TOOLS = 100
-const CUSTOM_API_CALL = 'custom_api_call'
 const BUILT_IN_TOOL_PREFIX = 'ap_'
 const MAX_OUTPUT_FIELDS = 50
 

--- a/packages/server/api/src/app/ee/agent/tools/piece-tool-runner.ts
+++ b/packages/server/api/src/app/ee/agent/tools/piece-tool-runner.ts
@@ -20,6 +20,8 @@ async function runFromInstruction({ piece, instruction, predefinedInput, model, 
         },
     })
 
+    assertUrlStaysOnThePieceHost({ actionName: piece.actionName, input: resolvedInput })
+
     const result = await executePieceActionRun({
         projectId,
         pieceName: piece.pieceName,
@@ -70,6 +72,23 @@ function propertyResolverFor({ piece, pieceVersion, projectId, platformId, log }
     }
 }
 
+function assertUrlStaysOnThePieceHost({ actionName, input }: { actionName: string, input: Record<string, unknown> }): void {
+    if (actionName !== CUSTOM_API_CALL) {
+        return
+    }
+    const url = input.url
+    const value = typeof url === 'string' ? url : (typeof url === 'object' && !isNil(url) && 'url' in url && typeof url.url === 'string' ? url.url : undefined)
+    if (isNil(value) || !ABSOLUTE_URL.test(value)) {
+        return
+    }
+    throw new ActivepiecesError({
+        code: ErrorCode.VALIDATION,
+        params: { message: `A custom API call from an agent step must be a path on the connection's own API, not the full address "${value}". Sending this project's credentials somewhere the connection does not belong is not something an unattended run may do.` },
+    })
+}
+
+const CUSTOM_API_CALL = 'custom_api_call'
+const ABSOLUTE_URL = /^https?:\/\//i
 const REDACTED_AUTH = 'Redacted'
 
 export const pieceToolRunner = {

--- a/packages/server/api/test/unit/app/ee/agent/piece-tool-runner.test.ts
+++ b/packages/server/api/test/unit/app/ee/agent/piece-tool-runner.test.ts
@@ -123,3 +123,42 @@ describe('pieceToolRunner.runFromInstruction', () => {
         expect(mockExecutePieceActionRun).not.toHaveBeenCalled()
     })
 })
+
+describe('pieceToolRunner.runFromInstruction — a custom API call stays on the connection\'s own host', () => {
+    beforeEach(() => {
+        vi.clearAllMocks()
+        mockGetOrThrow.mockResolvedValue({ version: '1.4.0', actions: { custom_api_call: { props: { url: { displayName: 'URL', required: true, type: PropertyType.SHORT_TEXT } } } } })
+        mockExecutePieceActionRun.mockResolvedValue({ content: [{ type: 'text', text: 'ok' }] })
+    })
+
+    async function callWithUrl(url: unknown) {
+        mockCompleter.mockResolvedValue({ url })
+        const { pieceToolRunner } = await import('../../../../../src/app/ee/agent/tools/piece-tool-runner')
+        return pieceToolRunner.runFromInstruction({
+            piece: { pieceName: '@activepieces/piece-slack', actionName: 'custom_api_call' },
+            instruction: 'call the api',
+            model: {} as never,
+            projectId: 'proj-1',
+            platformId: 'plat-1',
+            log: log as never,
+        } as never)
+    }
+
+    it('refuses an absolute url, which would send the connection\'s credentials off its own host', async () => {
+        await expect(callWithUrl('https://attacker.example/collect')).rejects.toThrow()
+
+        expect(mockExecutePieceActionRun).not.toHaveBeenCalled()
+    })
+
+    it('refuses an absolute url wrapped in the object shape the action expects', async () => {
+        await expect(callWithUrl({ url: 'http://169.254.169.254/latest/meta-data' })).rejects.toThrow()
+
+        expect(mockExecutePieceActionRun).not.toHaveBeenCalled()
+    })
+
+    it('allows a relative path, which the piece joins onto its own base url', async () => {
+        await callWithUrl('/v2/conversations.list')
+
+        expect(mockExecutePieceActionRun).toHaveBeenCalledTimes(1)
+    })
+})


### PR DESCRIPTION
An agent step could not use a piece's `custom_api_call` action. This restores it.

## The refusal rested on a wrong premise

It was blocked on the belief that the model picks the whole URL, making it a way to post a connection's credential to any address. That is not what the action does:

```ts
// packages/pieces/common/src/lib/helpers/index.ts:96-108
const joinBaseUrlWithRelativePath = ({ baseUrl, relativePath }) => {
  const baseUrlWithSlash = baseUrl.endsWith('/') ? baseUrl : `${baseUrl}/`;
  const relativePathWithoutSlash = relativePath.startsWith('/') ? relativePath.slice(1) : relativePath;
  return `${baseUrlWithSlash}${relativePathWithoutSlash}`;
};
```

The piece fixes the host from its own auth; the model supplies a relative path. The reach is other endpoints of the API the connection already authorises — not an arbitrary destination.

## What the real exposure is

The agent can call endpoints of that API which the step author did not individually pick, including destructive ones, under a credential the author did approve. That is the same trust configuring any tool grants, and it is what `brain/decisions/000024` already records: configuring a tool authorises the action, not its arguments.

So the refusal removed a genuine capability and bought no protection the rest of the model does not already give. `custom_api_call` is a normal part of using a piece, and an agent step should not be the one place it disappears.

The decision doc now records the mistake alongside the rule, so the premise is corrected rather than the conclusion silently reversed.

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

Restores a capability that was refused. Nothing that worked before changes.

### Security impact?  (required — CI fails if this is left unedited)

- [ ] no — reviewed, no security impact
- [x] yes — security-sensitive (call out the risk and mitigation in the description above)

Widens what an unattended agent can call with a configured connection. Bounded to the piece's own host, and analysed above.
