### PR TITLE
fix(cli): stop optional peer deps blocking a piece publish

### DIFF
--- a/packages/cli/src/lib/utils/bundle-piece-utils.ts
+++ b/packages/cli/src/lib/utils/bundle-piece-utils.ts
@@ -303,6 +303,20 @@ const HAZARD_WARNING_IDS = new Set<string>([
     'commonjs-variable-in-esm',
 ])
 
+// Optional peer dependencies. Their consumer requires them inside a guard and carries on
+// without them: pg catches MODULE_NOT_FOUND and leaves `pg.native` null, and the mongodb
+// driver swaps in an error module that only surfaces if you switch the matching feature on.
+// None is ever installed, so there is no version to put in the manifest — and inventing one
+// would send the runtime installer after a package that needs a compiler on the host. They
+// stay external and undeclared, which is exactly the state their consumer expects.
+//
+// Distinct from NATIVE_EXTERNALS, which a piece genuinely needs: oracledb and sharp must be
+// declared, or the piece really would crash on a missing module.
+const OPTIONAL_EXTERNALS = new Set<string>([
+    'pg-native',
+    'mongodb-client-encryption', 'kerberos', 'snappy', '@mongodb-js/zstd', 'aws4',
+])
+
 // Known-native packages: they ship a `.node` binary (or load one via a runtime-computed path)
 // and cannot be inlined. Always kept external, even under inline-by-default.
 const NATIVE_EXTERNALS = new Set<string>([
@@ -318,7 +332,7 @@ const NATIVE_EXTERNALS = new Set<string>([
     '@actual-app/api', 'pg-format', 'clarifai-nodejs-grpc',
 ])
 
-export const bundlePieceUtils = { bundlePiece, BUNDLE_FILENAME, readInlineConfig, unsafePackages }
+export const bundlePieceUtils = { bundlePiece, BUNDLE_FILENAME, readInlineConfig, unsafePackages, OPTIONAL_EXTERNALS }
 
 export type BundlePieceParams = {
     piecePath: string

--- a/packages/cli/src/lib/utils/bundle-piece-utils.ts
+++ b/packages/cli/src/lib/utils/bundle-piece-utils.ts
@@ -303,15 +303,6 @@ const HAZARD_WARNING_IDS = new Set<string>([
     'commonjs-variable-in-esm',
 ])
 
-// Optional peer dependencies. Their consumer requires them inside a guard and carries on
-// without them: pg catches MODULE_NOT_FOUND and leaves `pg.native` null, and the mongodb
-// driver swaps in an error module that only surfaces if you switch the matching feature on.
-// None is ever installed, so there is no version to put in the manifest — and inventing one
-// would send the runtime installer after a package that needs a compiler on the host. They
-// stay external and undeclared, which is exactly the state their consumer expects.
-//
-// Distinct from NATIVE_EXTERNALS, which a piece genuinely needs: oracledb and sharp must be
-// declared, or the piece really would crash on a missing module.
 const OPTIONAL_EXTERNALS = new Set<string>([
     'pg-native',
     'mongodb-client-encryption', 'kerberos', 'snappy', '@mongodb-js/zstd', 'aws4',

--- a/packages/cli/src/lib/utils/prepare-piece-utils.test.ts
+++ b/packages/cli/src/lib/utils/prepare-piece-utils.test.ts
@@ -1,8 +1,8 @@
-import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs'
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, readFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, describe, expect, it } from 'vitest'
-import { findInstalledVersion } from './prepare-piece-utils'
+import { findInstalledVersion, rewriteManifestForBundle } from './prepare-piece-utils'
 
 describe('findInstalledVersion', () => {
     let root: string | undefined
@@ -50,5 +50,80 @@ describe('findInstalledVersion', () => {
         mkdirSync(nodeModulesDir, { recursive: true })
 
         expect(findInstalledVersion({ nodeModulesDir, dep: 'missing-dep' })).toBeUndefined()
+    })
+})
+
+describe('rewriteManifestForBundle', () => {
+    let root: string | undefined
+
+    afterEach(() => {
+        if (root) {
+            rmSync(root, { recursive: true, force: true })
+            root = undefined
+        }
+    })
+
+    function setup(dependencies: Record<string, string>): { distPath: string, repoRoot: string } {
+        root = mkdtempSync(join(tmpdir(), 'ap-manifest-'))
+        const repoRoot = join(root, 'repo')
+        const distPath = join(repoRoot, 'packages', 'pieces', 'community', 'demo', 'dist')
+        mkdirSync(distPath, { recursive: true })
+        writeFileSync(join(repoRoot, 'package.json'), JSON.stringify({ name: 'root', workspaces: [] }))
+        writeFileSync(join(distPath, 'package.json'), JSON.stringify({
+            name: '@activepieces/piece-demo',
+            version: '1.0.0',
+            dependencies,
+        }))
+        return { distPath, repoRoot }
+    }
+
+    function manifestOf(distPath: string): Record<string, unknown> {
+        return JSON.parse(readFileSync(join(distPath, 'package.json'), 'utf-8'))
+    }
+
+    it('declares an external dependency it can resolve from the piece manifest', () => {
+        const { distPath, repoRoot } = setup({ pg: '8.11.3' })
+
+        rewriteManifestForBundle({ distPath, external: ['pg'], repoRoot })
+
+        expect(manifestOf(distPath).dependencies).toEqual({ pg: '8.11.3' })
+    })
+
+    it('leaves an optional peer dependency out instead of failing on it', () => {
+        // pg statically requires pg-native, so esbuild externalizes it, but it is never
+        // installed and pg runs fine without it. Declaring it would make the runtime
+        // installer build a native addon the piece never calls.
+        const { distPath, repoRoot } = setup({ pg: '8.11.3' })
+
+        rewriteManifestForBundle({ distPath, external: ['pg', 'pg-native'], repoRoot })
+
+        expect(manifestOf(distPath).dependencies).toEqual({ pg: '8.11.3' })
+    })
+
+    it('omits an optional peer dependency even when one is installed locally', () => {
+        const { distPath, repoRoot } = setup({ mongodb: '6.15.0', kerberos: '2.0.1' })
+
+        rewriteManifestForBundle({ distPath, external: ['mongodb', 'kerberos'], repoRoot })
+
+        expect(manifestOf(distPath).dependencies).toEqual({ mongodb: '6.15.0' })
+    })
+
+    it('omits every optional dep the mongodb driver loads behind a guard', () => {
+        const { distPath, repoRoot } = setup({ mongodb: '6.15.0' })
+
+        rewriteManifestForBundle({
+            distPath,
+            external: ['mongodb', 'aws4', 'kerberos', 'snappy', '@mongodb-js/zstd', 'mongodb-client-encryption'],
+            repoRoot,
+        })
+
+        expect(manifestOf(distPath).dependencies).toEqual({ mongodb: '6.15.0' })
+    })
+
+    it('still fails loudly on an external dependency that is simply missing', () => {
+        const { distPath, repoRoot } = setup({})
+
+        expect(() => rewriteManifestForBundle({ distPath, external: ['not-a-real-package-xyz'], repoRoot }))
+            .toThrow(/has no resolvable version/)
     })
 })

--- a/packages/cli/src/lib/utils/prepare-piece-utils.test.ts
+++ b/packages/cli/src/lib/utils/prepare-piece-utils.test.ts
@@ -90,9 +90,6 @@ describe('rewriteManifestForBundle', () => {
     })
 
     it('leaves an optional peer dependency out instead of failing on it', () => {
-        // pg statically requires pg-native, so esbuild externalizes it, but it is never
-        // installed and pg runs fine without it. Declaring it would make the runtime
-        // installer build a native addon the piece never calls.
         const { distPath, repoRoot } = setup({ pg: '8.11.3' })
 
         rewriteManifestForBundle({ distPath, external: ['pg', 'pg-native'], repoRoot })

--- a/packages/cli/src/lib/utils/prepare-piece-utils.ts
+++ b/packages/cli/src/lib/utils/prepare-piece-utils.ts
@@ -62,9 +62,6 @@ function rewriteManifestForBundle({ distPath, external, repoRoot }: { distPath: 
 
     const externalDeps: Record<string, string> = {}
     for (const dep of external) {
-        // Left out of the manifest on purpose, whether or not it happens to be installed
-        // here: its consumer guards the require, and declaring it would make every install
-        // of this piece build a native addon it never calls.
         if (bundlePieceUtils.OPTIONAL_EXTERNALS.has(dep)) {
             continue
         }

--- a/packages/cli/src/lib/utils/prepare-piece-utils.ts
+++ b/packages/cli/src/lib/utils/prepare-piece-utils.ts
@@ -62,6 +62,12 @@ function rewriteManifestForBundle({ distPath, external, repoRoot }: { distPath: 
 
     const externalDeps: Record<string, string> = {}
     for (const dep of external) {
+        // Left out of the manifest on purpose, whether or not it happens to be installed
+        // here: its consumer guards the require, and declaring it would make every install
+        // of this piece build a native addon it never calls.
+        if (bundlePieceUtils.OPTIONAL_EXTERNALS.has(dep)) {
+            continue
+        }
         const version = resolvedDeps[dep] ?? resolveInstalledVersion({ dep, repoRoot })
         if (version === undefined) {
             throw new Error(`[preparePiece] external dependency "${dep}" has no resolvable version (not a direct dependency and not found under node_modules); publishing it would crash at runtime with a missing module`)
@@ -174,7 +180,7 @@ function pruneDistToPublishedFiles({ distPath }: { distPath: string }): void {
     removeUnpublished(distPath)
 }
 
-export { preparePieceDistForPublish, resolveInstalledVersion, findInstalledVersion }
+export { preparePieceDistForPublish, resolveInstalledVersion, findInstalledVersion, rewriteManifestForBundle }
 
 type PieceDistPaths = {
     piecePath: string


### PR DESCRIPTION
## Description

Release Pieces has been failing on `main` since #14726. The postgres piece bumped to `0.3.0`, entered the changed-pieces set, and `preparePiece` refused it:

```
Error: [preparePiece] external dependency "pg-native" has no resolvable version
(not a direct dependency and not found under node_modules); publishing it would
crash at runtime with a missing module
```

`mysql@0.2.7` published before the job died, so the release is half-applied — postgres, mongodb and bluesky are still unpublished.

### Why the check was wrong here

`pg-native` is an **optional peer dependency** of `pg` (`peerDependenciesMeta.pg-native.optional = true`). It is never installed, and `pg` requires it inside a guard that swallows the failure:

```js
// pg/lib/index.js
get() {
  var native = null
  try { native = new PG(require('./native')) }
  catch (err) { if (err.code !== 'MODULE_NOT_FOUND') throw err }
  ...
}
```

So a missing `pg-native` is the state `pg` is designed for, not the runtime crash the error message asserts. `rewriteManifestForBundle` simply had no notion of an optional dependency — every externalized dep had to resolve to a version or the build failed.

### The fix

Known optional deps are left out of the published manifest rather than failing the build. They are skipped whether or not they happen to resolve locally, which is deliberate: declaring `kerberos@2.0.1` because a machine had it installed would make every install of the mongodb piece compile a native addon it never calls.

Anything else that cannot be resolved still fails loudly — that is what the check is for, and a test pins it.

### Fixing `pg-native` alone would not have unbroken the release

The mongodb piece was queued behind postgres and externalizes five more of the same kind. Each is loaded through a guard in the driver's `lib/deps.js` that substitutes an error module surfacing only if you switch the matching feature on:

| dep | consumer | guard |
|---|---|---|
| `pg-native` | `pg` | `try/catch` on `MODULE_NOT_FOUND`, leaves `pg.native = null` |
| `kerberos` | `mongodb` | `loadKerberos()` → error module |
| `snappy` | `mongodb` | `getSnappy()` → error module |
| `@mongodb-js/zstd` | `mongodb` | `loadZstd()` → error module |
| `aws4` | `mongodb` | `loadAws4()` → `kModuleError`, thrown only by MONGODB-AWS auth |
| `mongodb-client-encryption` | `mongodb` | `loadMongodbClientEncryption()` → error module |

## How was this tested?

Ran the release job's real prepare step (`preparePieceDistForPublish`) locally against all four pieces the release publishes, on this branch, off `main` at 7530489:

| piece | externalized | manifest declares | before |
| --- | --- | --- | --- |
| postgres 0.3.0 | `pg-format`, `pg-native` | `pg-format` only | ❌ threw on `pg-native` |
| mongodb 0.1.6 | `kerberos`, `@mongodb-js/zstd`, `snappy`, `aws4`, `mongodb-client-encryption` | none | ❌ threw on `aws4` |
| bluesky 0.1.7 | — | none | ✅ |
| mysql 0.2.7 | — | none | ✅ (already on npm, will be skipped) |

Automated: 27 tests in `packages/cli` pass, including four new cases on `rewriteManifestForBundle` — a resolvable external is still declared, an optional one is omitted, an optional one is omitted even when installed locally, and an unrelated unresolvable dep still throws. CE only; no edition-specific paths touched.

Each optional dep's guard was confirmed by reading the installed package source, not inferred from its metadata.

### Follow-ups found while investigating, not fixed here

- `aws4` is pure JavaScript yet sits in `NATIVE_EXTERNALS`. Removing it from that list would also fix mongodb by inlining it; left alone because the entry looks deliberate and this change is the narrower one.
- The oracle-database piece prepares with `dependencies: {}` — `oracledb` never reaches its manifest because esbuild never resolves an import for it. Pre-existing on `main` and unrelated to this change, but it looks like that piece ships without declaring its driver.

Fixes # (issue)

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)
