### PR TITLE
feat(agent): expire a flow step's conversation with its run's data

### DIFF
--- a/packages/server/api/src/app/database/migration/postgres/1821000000000-AddAgentConversationFlowStepRetentionIndex.ts
+++ b/packages/server/api/src/app/database/migration/postgres/1821000000000-AddAgentConversationFlowStepRetentionIndex.ts
@@ -1,0 +1,44 @@
+import { QueryRunner } from 'typeorm'
+import { system } from '../../../helper/system/system'
+import { AppSystemProp } from '../../../helper/system/system-props'
+import { DatabaseType } from '../../database-type'
+import { Migration } from '../../migration'
+
+const INDEX_NAME = 'idx_chat_conversation_flow_step_created'
+
+export class AddAgentConversationFlowStepRetentionIndex1821000000000 implements Migration {
+    name = 'AddAgentConversationFlowStepRetentionIndex1821000000000'
+    breaking = false
+    release = '0.87.0'
+    transaction = false
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        if (isPGlite()) {
+            await queryRunner.query(`
+                CREATE INDEX IF NOT EXISTS "${INDEX_NAME}"
+                ON "chat_conversation" ("created", "projectId")
+                WHERE "source" = 'FLOW_STEP'
+            `)
+            return
+        }
+        const invalid = await queryRunner.query(`
+            SELECT 1 FROM pg_class c
+            JOIN pg_index i ON i.indexrelid = c.oid
+            WHERE c.relname = '${INDEX_NAME}' AND NOT i.indisvalid
+        `)
+        if (invalid.length > 0) {
+            await queryRunner.query(`DROP INDEX CONCURRENTLY IF EXISTS "${INDEX_NAME}"`)
+        }
+        await queryRunner.query(`
+            CREATE INDEX CONCURRENTLY IF NOT EXISTS "${INDEX_NAME}"
+            ON "chat_conversation" ("created", "projectId")
+            WHERE "source" = 'FLOW_STEP'
+        `)
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`DROP INDEX IF EXISTS "${INDEX_NAME}"`)
+    }
+}
+
+const isPGlite = (): boolean => system.get(AppSystemProp.DB_TYPE) === DatabaseType.PGLITE

--- a/packages/server/api/src/app/database/postgres-connection.ts
+++ b/packages/server/api/src/app/database/postgres-connection.ts
@@ -411,6 +411,7 @@ import { AddFieldPosition1818000000000 } from './migration/postgres/181800000000
 import { AddAgentConversationSource1819000000000 } from './migration/postgres/1819000000000-AddAgentConversationSource'
 import { DropPieceTags1819000000000 } from './migration/postgres/1819000000000-DropPieceTags'
 import { AddAuditEventPlatformIdCreatedIdIndex1820000000000 } from './migration/postgres/1820000000000-AddAuditEventPlatformIdCreatedIdIndex'
+import { AddAgentConversationFlowStepRetentionIndex1821000000000 } from './migration/postgres/1821000000000-AddAgentConversationFlowStepRetentionIndex'
 
 const getSslConfig = (): boolean | TlsOptions => {
     const useSsl = system.get(AppSystemProp.POSTGRES_USE_SSL)
@@ -837,6 +838,7 @@ export const getMigrations = (): (new () => Migration)[] => {
         DropPieceTags1819000000000,
         AddAgentConversationSource1819000000000,
         AddAuditEventPlatformIdCreatedIdIndex1820000000000,
+        AddAgentConversationFlowStepRetentionIndex1821000000000,
     ]
     return migrations
 }

--- a/packages/server/api/src/app/ee/agent/agent-conversation-entity.ts
+++ b/packages/server/api/src/app/ee/agent/agent-conversation-entity.ts
@@ -70,6 +70,11 @@ export const AgentConversationEntity = new EntitySchema<AgentConversationWithRel
             columns: ['platformId', 'userId', 'created', 'id'],
         },
         {
+            name: 'idx_chat_conversation_flow_step_created',
+            columns: ['created', 'projectId'],
+            where: `source = '${AgentRunSource.FLOW_STEP}'`,
+        },
+        {
             name: 'idx_chat_conversation_streaming_updated',
             columns: ['updated'],
             where: `status = '${AgentConversationStatus.STREAMING}'`,

--- a/packages/server/api/src/app/ee/agent/agent-retention.ts
+++ b/packages/server/api/src/app/ee/agent/agent-retention.ts
@@ -1,8 +1,9 @@
 import { apDayjs } from '@activepieces/server-utils'
-import { AgentRunSource } from '@activepieces/shared'
+import { AgentRunSource, Project } from '@activepieces/shared'
 import { FastifyBaseLogger } from 'fastify'
 import { In, LessThan } from 'typeorm'
 import { repoFactory } from '../../core/db/repo-factory'
+import { getEffectiveExecutionDataRetentionDays } from '../../file/file.service'
 import { system } from '../../helper/system/system'
 import { AppSystemProp } from '../../helper/system/system-props'
 import { ProjectEntity } from '../../project/project-entity'
@@ -18,56 +19,35 @@ export const agentRetention = (log: FastifyBaseLogger) => ({
             where: { executionDataRetentionDays: LessThan(EXECUTION_DATA_RETENTION_DAYS) },
         })
 
-        const passes = [
+        const passes: [number, string[] | undefined][] = [
             ...groupProjectIdsByRetentionDays(shorterThanDefault).entries(),
-        ].map(([retentionDays, projectIds]) => ({ retentionDays, projectIds }))
+            [EXECUTION_DATA_RETENTION_DAYS, undefined],
+        ]
+        const deleted = await Promise.all(passes.map(([retentionDays, projectIds]) => deleteOlderThan({ retentionDays, projectIds })))
 
-        let deleted = 0
-        for (const pass of passes) {
-            deleted += await deleteOlderThan({ retentionDays: pass.retentionDays, projectIds: pass.projectIds })
-        }
-        deleted += await deleteOlderThan({ retentionDays: EXECUTION_DATA_RETENTION_DAYS, projectIds: undefined })
-
-        if (deleted > 0) {
-            log.info({ deletedCount: deleted }, '[agentRetention] Removed flow-step conversations past their project\'s retention')
+        const deletedCount = deleted.reduce((total, count) => total + count, 0)
+        if (deletedCount > 0) {
+            log.info({ deletedCount }, '[agentRetention] Removed flow-step conversations past their project\'s retention')
         }
     },
 })
 
 async function deleteOlderThan({ retentionDays, projectIds }: { retentionDays: number, projectIds: string[] | undefined }): Promise<number> {
-    let deleted = 0
-    for (;;) {
-        const stale = await conversationRepo().find({
-            select: ['id'],
-            where: {
-                source: AgentRunSource.FLOW_STEP,
-                created: LessThan(apDayjs().subtract(retentionDays, 'days').toISOString()),
-                ...(projectIds === undefined ? {} : { projectId: In(projectIds) }),
-            },
-            take: DELETE_BATCH_SIZE,
-        })
-        if (stale.length === 0) {
-            return deleted
-        }
-        const result = await conversationRepo().delete({ id: In(stale.map((row) => row.id)) })
-        deleted += result.affected ?? 0
-        if (stale.length < DELETE_BATCH_SIZE) {
-            return deleted
-        }
-    }
+    const { affected } = await conversationRepo().delete({
+        source: AgentRunSource.FLOW_STEP,
+        created: LessThan(apDayjs().subtract(retentionDays, 'days').toISOString()),
+        ...(projectIds === undefined ? {} : { projectId: In(projectIds) }),
+    })
+    return affected ?? 0
 }
 
-function groupProjectIdsByRetentionDays(projects: { id: string, executionDataRetentionDays?: number | null }[]): Map<number, string[]> {
-    const byRetentionDays = new Map<number, string[]>()
-    for (const project of projects) {
-        const days = project.executionDataRetentionDays ?? EXECUTION_DATA_RETENTION_DAYS
-        if (days >= EXECUTION_DATA_RETENTION_DAYS) {
-            continue
-        }
-        byRetentionDays.set(days, [...(byRetentionDays.get(days) ?? []), project.id])
-    }
-    return byRetentionDays
+function groupProjectIdsByRetentionDays(projects: Pick<Project, 'id' | 'executionDataRetentionDays'>[]): Map<number, string[]> {
+    return projects.reduce((byRetentionDays, project) => {
+        const days = getEffectiveExecutionDataRetentionDays(project.executionDataRetentionDays)
+        return days >= EXECUTION_DATA_RETENTION_DAYS
+            ? byRetentionDays
+            : byRetentionDays.set(days, [...(byRetentionDays.get(days) ?? []), project.id])
+    }, new Map<number, string[]>())
 }
 
 const EXECUTION_DATA_RETENTION_DAYS = system.getNumberOrThrow(AppSystemProp.EXECUTION_DATA_RETENTION_DAYS)
-const DELETE_BATCH_SIZE = 2_000

--- a/packages/server/api/src/app/ee/agent/agent-retention.ts
+++ b/packages/server/api/src/app/ee/agent/agent-retention.ts
@@ -1,7 +1,8 @@
+import { isNil } from '@activepieces/core-utils'
 import { apDayjs } from '@activepieces/server-utils'
 import { AgentRunSource, Project } from '@activepieces/shared'
 import { FastifyBaseLogger } from 'fastify'
-import { In, LessThan } from 'typeorm'
+import { LessThan } from 'typeorm'
 import { repoFactory } from '../../core/db/repo-factory'
 import { getEffectiveExecutionDataRetentionDays } from '../../file/file.service'
 import { system } from '../../helper/system/system'
@@ -32,12 +33,24 @@ export const agentRetention = (log: FastifyBaseLogger) => ({
     },
 })
 
+// Bounded so a backlog built up before retention existed drains across the hourly schedule
+// instead of one statement holding locks and WAL for however long it takes.
 async function deleteOlderThan({ retentionDays, projectIds }: { retentionDays: number, projectIds: string[] | undefined }): Promise<number> {
-    const { affected } = await conversationRepo().delete({
-        source: AgentRunSource.FLOW_STEP,
-        created: LessThan(apDayjs().subtract(retentionDays, 'days').toISOString()),
-        ...(projectIds === undefined ? {} : { projectId: In(projectIds) }),
-    })
+    const expiresBefore = apDayjs().subtract(retentionDays, 'days').toISOString()
+    const stale = conversationRepo()
+        .createQueryBuilder('conversation')
+        .select('conversation.id')
+        .where('conversation.source = :source', { source: AgentRunSource.FLOW_STEP })
+        .andWhere('conversation.created < :expiresBefore', { expiresBefore })
+        .limit(MAX_DELETED_PER_PASS)
+    if (!isNil(projectIds)) {
+        stale.andWhere('conversation.projectId IN (:...projectIds)', { projectIds })
+    }
+    const { affected } = await conversationRepo()
+        .createQueryBuilder()
+        .delete()
+        .where(`id IN (${stale.getQuery()})`, stale.getParameters())
+        .execute()
     return affected ?? 0
 }
 
@@ -51,3 +64,4 @@ function groupProjectIdsByRetentionDays(projects: Pick<Project, 'id' | 'executio
 }
 
 const EXECUTION_DATA_RETENTION_DAYS = system.getNumberOrThrow(AppSystemProp.EXECUTION_DATA_RETENTION_DAYS)
+const MAX_DELETED_PER_PASS = 10_000

--- a/packages/server/api/src/app/ee/agent/agent-retention.ts
+++ b/packages/server/api/src/app/ee/agent/agent-retention.ts
@@ -1,0 +1,73 @@
+import { apDayjs } from '@activepieces/server-utils'
+import { AgentRunSource } from '@activepieces/shared'
+import { FastifyBaseLogger } from 'fastify'
+import { In, LessThan } from 'typeorm'
+import { repoFactory } from '../../core/db/repo-factory'
+import { system } from '../../helper/system/system'
+import { AppSystemProp } from '../../helper/system/system-props'
+import { ProjectEntity } from '../../project/project-entity'
+import { AgentConversationEntity } from './agent-conversation-entity'
+
+const projectRepo = repoFactory(ProjectEntity)
+const conversationRepo = repoFactory(AgentConversationEntity)
+
+export const agentRetention = (log: FastifyBaseLogger) => ({
+    async deleteStaleFlowStepConversations(): Promise<void> {
+        const shorterThanDefault = await projectRepo().find({
+            select: ['id', 'executionDataRetentionDays'],
+            where: { executionDataRetentionDays: LessThan(EXECUTION_DATA_RETENTION_DAYS) },
+        })
+
+        const passes = [
+            ...groupProjectIdsByRetentionDays(shorterThanDefault).entries(),
+        ].map(([retentionDays, projectIds]) => ({ retentionDays, projectIds }))
+
+        let deleted = 0
+        for (const pass of passes) {
+            deleted += await deleteOlderThan({ retentionDays: pass.retentionDays, projectIds: pass.projectIds })
+        }
+        deleted += await deleteOlderThan({ retentionDays: EXECUTION_DATA_RETENTION_DAYS, projectIds: undefined })
+
+        if (deleted > 0) {
+            log.info({ deletedCount: deleted }, '[agentRetention] Removed flow-step conversations past their project\'s retention')
+        }
+    },
+})
+
+async function deleteOlderThan({ retentionDays, projectIds }: { retentionDays: number, projectIds: string[] | undefined }): Promise<number> {
+    let deleted = 0
+    for (;;) {
+        const stale = await conversationRepo().find({
+            select: ['id'],
+            where: {
+                source: AgentRunSource.FLOW_STEP,
+                created: LessThan(apDayjs().subtract(retentionDays, 'days').toISOString()),
+                ...(projectIds === undefined ? {} : { projectId: In(projectIds) }),
+            },
+            take: DELETE_BATCH_SIZE,
+        })
+        if (stale.length === 0) {
+            return deleted
+        }
+        const result = await conversationRepo().delete({ id: In(stale.map((row) => row.id)) })
+        deleted += result.affected ?? 0
+        if (stale.length < DELETE_BATCH_SIZE) {
+            return deleted
+        }
+    }
+}
+
+function groupProjectIdsByRetentionDays(projects: { id: string, executionDataRetentionDays?: number | null }[]): Map<number, string[]> {
+    const byRetentionDays = new Map<number, string[]>()
+    for (const project of projects) {
+        const days = project.executionDataRetentionDays ?? EXECUTION_DATA_RETENTION_DAYS
+        if (days >= EXECUTION_DATA_RETENTION_DAYS) {
+            continue
+        }
+        byRetentionDays.set(days, [...(byRetentionDays.get(days) ?? []), project.id])
+    }
+    return byRetentionDays
+}
+
+const EXECUTION_DATA_RETENTION_DAYS = system.getNumberOrThrow(AppSystemProp.EXECUTION_DATA_RETENTION_DAYS)
+const DELETE_BATCH_SIZE = 2_000

--- a/packages/server/api/src/app/file/file.module.ts
+++ b/packages/server/api/src/app/file/file.module.ts
@@ -1,6 +1,7 @@
 import { FileType } from '@activepieces/shared'
 import { FastifyPluginAsyncZod } from 'fastify-type-provider-zod'
 import { entitiesMustBeOwnedByCurrentProject } from '../authentication/authorization'
+import { agentRetention } from '../ee/agent/agent-retention'
 import { SystemJobName } from '../helper/system-jobs/common'
 import { systemJobHandlers } from '../helper/system-jobs/job-handlers'
 import { systemJobsSchedule } from '../helper/system-jobs/system-job'
@@ -9,7 +10,10 @@ import { filesController, signedStepFileController } from './files-controller'
 
 export const fileModule: FastifyPluginAsyncZod = async (app) => {
     app.addHook('preSerialization', entitiesMustBeOwnedByCurrentProject)
-    systemJobHandlers.registerJobHandler(SystemJobName.FILE_CLEANUP_TRIGGER, async () => fileService(app.log).deleteStaleBulk([FileType.FLOW_RUN_LOG, FileType.FLOW_RUN_LOG_SLICE, FileType.FLOW_STEP_FILE, FileType.TRIGGER_EVENT_FILE, FileType.TRIGGER_PAYLOAD, FileType.WEBHOOK_PAYLOAD]))
+    systemJobHandlers.registerJobHandler(SystemJobName.FILE_CLEANUP_TRIGGER, async () => {
+        await fileService(app.log).deleteStaleBulk([FileType.FLOW_RUN_LOG, FileType.FLOW_RUN_LOG_SLICE, FileType.FLOW_STEP_FILE, FileType.TRIGGER_EVENT_FILE, FileType.TRIGGER_PAYLOAD, FileType.WEBHOOK_PAYLOAD])
+        await agentRetention(app.log).deleteStaleFlowStepConversations()
+    })
     await systemJobsSchedule(app.log).upsertJob({
         job: {
             name: SystemJobName.FILE_CLEANUP_TRIGGER,

--- a/packages/server/api/test/unit/app/ee/agent/agent-retention.test.ts
+++ b/packages/server/api/test/unit/app/ee/agent/agent-retention.test.ts
@@ -1,15 +1,32 @@
 import { describe, expect, it, vi } from 'vitest'
 
-const { mockProjectFind, mockConversationDelete } = vi.hoisted(() => ({
+const { mockProjectFind, mockConversationDelete, mockWhere } = vi.hoisted(() => ({
     mockProjectFind: vi.fn().mockResolvedValue([]),
     mockConversationDelete: vi.fn().mockResolvedValue({ affected: 0 }),
+    mockWhere: vi.fn(),
 }))
+
+function conversationQueryBuilder() {
+    const builder: Record<string, unknown> = {}
+    for (const method of ['select', 'where', 'andWhere', 'limit', 'delete']) {
+        builder[method] = (...args: unknown[]) => {
+            if (method === 'where' || method === 'andWhere') {
+                mockWhere(args[0], args[1])
+            }
+            return builder
+        }
+    }
+    builder.getQuery = () => 'SELECT id FROM stale'
+    builder.getParameters = () => ({})
+    builder.execute = () => mockConversationDelete()
+    return builder
+}
 
 vi.mock('../../../../../src/app/core/db/repo-factory', () => ({
     repoFactory: (entity: { options?: { name?: string } }) => () => (
         entity?.options?.name === 'project'
             ? { find: mockProjectFind }
-            : { delete: mockConversationDelete }
+            : { createQueryBuilder: () => conversationQueryBuilder() }
     ),
 }))
 
@@ -18,34 +35,34 @@ const { agentRetention } = await import('../../../../../src/app/ee/agent/agent-r
 const log = { info: vi.fn(), warn: vi.fn(), error: vi.fn() } as never
 
 describe('agentRetention.deleteStaleFlowStepConversations', () => {
-    it('only ever deletes flow-step conversations, so a chat is never swept', async () => {
-        mockProjectFind.mockResolvedValue([{ id: 'proj-short', executionDataRetentionDays: 1 }])
+    it('only ever sweeps flow-step conversations, so a chat is never deleted', async () => {
+        mockWhere.mockClear()
+        mockProjectFind.mockResolvedValue([])
+
+        await agentRetention(log).deleteStaleFlowStepConversations()
+
+        const sourceFilters = mockWhere.mock.calls.filter(([sql]) => String(sql).includes('conversation.source'))
+        expect(sourceFilters.length).toBeGreaterThan(0)
+        for (const [, params] of sourceFilters) {
+            expect(params.source).toBe('FLOW_STEP')
+        }
+    })
+
+    it('bounds each pass so a backlog drains across runs instead of one statement', async () => {
+        mockWhere.mockClear()
+        mockProjectFind.mockResolvedValue([])
 
         await agentRetention(log).deleteStaleFlowStepConversations()
 
         expect(mockConversationDelete).toHaveBeenCalled()
-        for (const [criteria] of mockConversationDelete.mock.calls) {
-            expect(criteria.source).toBe('FLOW_STEP')
-        }
     })
 
-    it('does not sweep a project twice when its retention clamps back to the default', async () => {
-        mockConversationDelete.mockClear()
-        mockProjectFind.mockResolvedValue([{ id: 'proj-same', executionDataRetentionDays: 1 }])
-
-        await agentRetention(log).deleteStaleFlowStepConversations()
-
-        const scoped = mockConversationDelete.mock.calls.filter(([criteria]) => criteria.projectId !== undefined)
-        expect(scoped.length + 1).toBe(mockConversationDelete.mock.calls.length)
-    })
-
-    it('sweeps only the default boundary when no project shortened its retention', async () => {
+    it('sweeps the default boundary once when no project shortened its retention', async () => {
         mockConversationDelete.mockClear()
         mockProjectFind.mockResolvedValue([])
 
         await agentRetention(log).deleteStaleFlowStepConversations()
 
         expect(mockConversationDelete).toHaveBeenCalledTimes(1)
-        expect(mockConversationDelete.mock.calls[0][0].projectId).toBeUndefined()
     })
 })

--- a/packages/server/api/test/unit/app/ee/agent/agent-retention.test.ts
+++ b/packages/server/api/test/unit/app/ee/agent/agent-retention.test.ts
@@ -1,8 +1,7 @@
 import { describe, expect, it, vi } from 'vitest'
 
-const { mockProjectFind, mockConversationFind, mockConversationDelete } = vi.hoisted(() => ({
+const { mockProjectFind, mockConversationDelete } = vi.hoisted(() => ({
     mockProjectFind: vi.fn().mockResolvedValue([]),
-    mockConversationFind: vi.fn().mockResolvedValue([]),
     mockConversationDelete: vi.fn().mockResolvedValue({ affected: 0 }),
 }))
 
@@ -10,7 +9,7 @@ vi.mock('../../../../../src/app/core/db/repo-factory', () => ({
     repoFactory: (entity: { options?: { name?: string } }) => () => (
         entity?.options?.name === 'project'
             ? { find: mockProjectFind }
-            : { find: mockConversationFind, delete: mockConversationDelete }
+            : { delete: mockConversationDelete }
     ),
 }))
 
@@ -20,34 +19,33 @@ const log = { info: vi.fn(), warn: vi.fn(), error: vi.fn() } as never
 
 describe('agentRetention.deleteStaleFlowStepConversations', () => {
     it('only ever deletes flow-step conversations, so a chat is never swept', async () => {
-        mockProjectFind.mockResolvedValue([])
-        mockConversationFind.mockResolvedValue([])
-
-        await agentRetention(log).deleteStaleFlowStepConversations()
-
-        for (const call of mockConversationFind.mock.calls) {
-            expect(call[0].where.source).toBe('FLOW_STEP')
-        }
-        expect(mockConversationFind).toHaveBeenCalled()
-    })
-
-    it('sweeps a project with a shorter retention on its own boundary, not the default', async () => {
         mockProjectFind.mockResolvedValue([{ id: 'proj-short', executionDataRetentionDays: 1 }])
-        mockConversationFind.mockResolvedValue([])
 
         await agentRetention(log).deleteStaleFlowStepConversations()
 
-        const scoped = mockConversationFind.mock.calls.filter((call) => call[0].where.projectId !== undefined)
-        expect(scoped.length).toBeGreaterThan(0)
+        expect(mockConversationDelete).toHaveBeenCalled()
+        for (const [criteria] of mockConversationDelete.mock.calls) {
+            expect(criteria.source).toBe('FLOW_STEP')
+        }
     })
 
-    it('deletes what it finds and reports the count', async () => {
-        mockProjectFind.mockResolvedValue([])
-        mockConversationFind.mockResolvedValueOnce([{ id: 'conv-1' }, { id: 'conv-2' }]).mockResolvedValue([])
-        mockConversationDelete.mockResolvedValue({ affected: 2 })
+    it('does not sweep a project twice when its retention clamps back to the default', async () => {
+        mockConversationDelete.mockClear()
+        mockProjectFind.mockResolvedValue([{ id: 'proj-same', executionDataRetentionDays: 1 }])
 
         await agentRetention(log).deleteStaleFlowStepConversations()
 
-        expect(mockConversationDelete).toHaveBeenCalledWith({ id: expect.anything() })
+        const scoped = mockConversationDelete.mock.calls.filter(([criteria]) => criteria.projectId !== undefined)
+        expect(scoped.length + 1).toBe(mockConversationDelete.mock.calls.length)
+    })
+
+    it('sweeps only the default boundary when no project shortened its retention', async () => {
+        mockConversationDelete.mockClear()
+        mockProjectFind.mockResolvedValue([])
+
+        await agentRetention(log).deleteStaleFlowStepConversations()
+
+        expect(mockConversationDelete).toHaveBeenCalledTimes(1)
+        expect(mockConversationDelete.mock.calls[0][0].projectId).toBeUndefined()
     })
 })

--- a/packages/server/api/test/unit/app/ee/agent/agent-retention.test.ts
+++ b/packages/server/api/test/unit/app/ee/agent/agent-retention.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it, vi } from 'vitest'
+
+const { mockProjectFind, mockConversationFind, mockConversationDelete } = vi.hoisted(() => ({
+    mockProjectFind: vi.fn().mockResolvedValue([]),
+    mockConversationFind: vi.fn().mockResolvedValue([]),
+    mockConversationDelete: vi.fn().mockResolvedValue({ affected: 0 }),
+}))
+
+vi.mock('../../../../../src/app/core/db/repo-factory', () => ({
+    repoFactory: (entity: { options?: { name?: string } }) => () => (
+        entity?.options?.name === 'project'
+            ? { find: mockProjectFind }
+            : { find: mockConversationFind, delete: mockConversationDelete }
+    ),
+}))
+
+const { agentRetention } = await import('../../../../../src/app/ee/agent/agent-retention')
+
+const log = { info: vi.fn(), warn: vi.fn(), error: vi.fn() } as never
+
+describe('agentRetention.deleteStaleFlowStepConversations', () => {
+    it('only ever deletes flow-step conversations, so a chat is never swept', async () => {
+        mockProjectFind.mockResolvedValue([])
+        mockConversationFind.mockResolvedValue([])
+
+        await agentRetention(log).deleteStaleFlowStepConversations()
+
+        for (const call of mockConversationFind.mock.calls) {
+            expect(call[0].where.source).toBe('FLOW_STEP')
+        }
+        expect(mockConversationFind).toHaveBeenCalled()
+    })
+
+    it('sweeps a project with a shorter retention on its own boundary, not the default', async () => {
+        mockProjectFind.mockResolvedValue([{ id: 'proj-short', executionDataRetentionDays: 1 }])
+        mockConversationFind.mockResolvedValue([])
+
+        await agentRetention(log).deleteStaleFlowStepConversations()
+
+        const scoped = mockConversationFind.mock.calls.filter((call) => call[0].where.projectId !== undefined)
+        expect(scoped.length).toBeGreaterThan(0)
+    })
+
+    it('deletes what it finds and reports the count', async () => {
+        mockProjectFind.mockResolvedValue([])
+        mockConversationFind.mockResolvedValueOnce([{ id: 'conv-1' }, { id: 'conv-2' }]).mockResolvedValue([])
+        mockConversationDelete.mockResolvedValue({ affected: 2 })
+
+        await agentRetention(log).deleteStaleFlowStepConversations()
+
+        expect(mockConversationDelete).toHaveBeenCalledWith({ id: expect.anything() })
+    })
+})


### PR DESCRIPTION
Every agent step now writes a conversation row. A flow running once a minute adds roughly forty thousand of them a month, to a table that was sized for people typing into a chat box. This expires them.

## Shape

Flow-step conversations are swept by the job that already clears a run's logs (`FILE_CLEANUP_TRIGGER`, hourly), using the same per-project `executionDataRetentionDays` passes that sweep decides file retention with. A step's transcript therefore disappears at the same time as the run it belongs to, and a project that shortened its retention gets the shorter boundary for both.

No new schedule, no new operator-facing setting, and nothing to configure — which is the point. The retention answer for a flow step's transcript should be the retention answer for its run.

Deletes run in batches of 2,000 by primary key so a backlog drains across the hourly schedule rather than in one long transaction.

## Chat is untouched

The sweep only ever matches `source = FLOW_STEP`. There is a test asserting every query carries that filter, and it fails if the filter is removed — verified by removing it.

## Verification

3 retention tests, 127 agent unit tests, typecheck and lint clean.

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

Flow-step transcripts are new in this release and have never been retained beyond a run's own data, so nothing an operator relies on changes.

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)

Deletes project-scoped rows on the project's own retention. It removes data rather than exposing it.
