### PR TITLE
fix(google-sheets): demote six legacy actions to audience 'human'

### DIFF
--- a/packages/pieces/community/google-sheets/package.json
+++ b/packages/pieces/community/google-sheets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-google-sheets",
-  "version": "0.16.7",
+  "version": "0.16.8",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "dependencies": {

--- a/packages/pieces/community/google-sheets/src/lib/actions/clear-rows.ts
+++ b/packages/pieces/community/google-sheets/src/lib/actions/clear-rows.ts
@@ -11,7 +11,7 @@ export const clearRowsAction = createAction({
 	displayName: 'Clear Row(s)',
 	description:
 		'Clears the contents of one or more rows without removing the rows themselves. Useful when you want to keep formatting and references stable.',
-	audience: 'both',
+	audience: 'human',
 	aiMetadata: {
 		description:
 			'Blanks the cell contents of one row or a contiguous row range in a worksheet without removing the rows, so row numbers and downstream references stay stable — prefer Delete Row or Delete Multiple Rows when the rows themselves should disappear, and Clear Sheet when the whole sheet should be emptied. Requires a selected spreadsheet and worksheet plus a 1-based starting row; leaving the ending row empty clears only that single row. Idempotent — re-running over the same range leaves it equally empty, but the erased values cannot be recovered.',

--- a/packages/pieces/community/google-sheets/src/lib/actions/delete-multiple-rows.ts
+++ b/packages/pieces/community/google-sheets/src/lib/actions/delete-multiple-rows.ts
@@ -10,7 +10,7 @@ export const deleteMultipleRowsAction = createAction({
 	displayName: 'Delete Multiple Rows',
 	description:
 		'Deletes a contiguous range of rows, or a list of specific row numbers. Row numbers are 1-based.',
-	audience: 'both',
+	audience: 'human',
 	aiMetadata: {
 		description:
 			'Permanently deletes rows from a worksheet in one batch, in either of two modes: a contiguous range given by starting and ending row, or a comma-separated list of specific 1-based row numbers. Use instead of Delete Row when several rows must go at once, and Clear Row(s) instead when the rows should stay in place with only their contents erased. Not idempotent — surviving rows renumber after each deletion, so repeating the same call removes different rows; re-resolve the targets before any retry.',

--- a/packages/pieces/community/google-sheets/src/lib/actions/find-or-create-row.ts
+++ b/packages/pieces/community/google-sheets/src/lib/actions/find-or-create-row.ts
@@ -22,7 +22,7 @@ export const findOrCreateRowAction = createAction({
 	name: 'find-or-create-row',
 	displayName: 'Find or Create Row',
 	description: 'Look up a row by column value; if no match is found, create a new row with the provided values.',
-	audience: 'both',
+	audience: 'human',
 	aiMetadata: {
 		description:
 			'Looks up the first row in a worksheet whose value in a chosen column matches a search value and returns it, or appends a new row from the supplied values when nothing matches, flagging which happened. Use instead of Add Row when the entry may already exist and duplicates must be avoided, and Find Rows when creation is not wanted. Matching is a case-insensitive substring test unless Exact Match is on; idempotent in practice — a second call finds the row the first one created, provided that row carries the search value in the searched column.',

--- a/packages/pieces/community/google-sheets/src/lib/actions/find-or-create-worksheet.ts
+++ b/packages/pieces/community/google-sheets/src/lib/actions/find-or-create-worksheet.ts
@@ -9,7 +9,7 @@ export const findOrCreateWorksheetAction = createAction({
 	name: 'find-or-create-worksheet',
 	displayName: 'Find or Create Worksheet',
 	description: 'Look up a worksheet by title in a spreadsheet; if not found, create it with optional headers.',
-	audience: 'both',
+	audience: 'human',
 	aiMetadata: {
 		description:
 			'Looks up a worksheet (tab) by exact, case-sensitive title inside a spreadsheet and returns it, or creates that tab — optionally seeding a header row — when no tab with the title exists, flagging which happened. Use instead of Create Worksheet when the tab may already exist, since Create Worksheet adds a duplicate tab regardless. Idempotent — a second call with the same title returns the existing tab rather than creating another, and the headers are written only on creation.',

--- a/packages/pieces/community/google-sheets/src/lib/actions/insert-row-at-top.ts
+++ b/packages/pieces/community/google-sheets/src/lib/actions/insert-row-at-top.ts
@@ -19,7 +19,7 @@ export const insertRowAtTopAction = createAction({
 	name: 'insert-row-at-top',
 	displayName: 'Add Row at Top',
 	description: 'Inserts a new row at the top of a worksheet, just below the header row.',
-	audience: 'both',
+	audience: 'human',
 	aiMetadata: {
 		description:
 			'Inserts a blank row near the top of a worksheet and writes the supplied values into it, shifting every existing row below it down by one; the insertion point defaults to just under row 1 but can be moved with Insert After Row. Use when newest-first ordering matters — prefer Add Row to append at the bottom, which is cheaper and does not renumber existing rows. Not idempotent: each call inserts another row and shifts the rest down again.',

--- a/packages/pieces/community/google-sheets/src/lib/actions/read-data-range.ts
+++ b/packages/pieces/community/google-sheets/src/lib/actions/read-data-range.ts
@@ -16,7 +16,7 @@ export const readDataRangeAction = createAction({
 	displayName: 'Read Data Range',
 	description:
 		'Read cells from a range using A1 notation (e.g. A1:D10). Returns rows and the resolved range.',
-	audience: 'both',
+	audience: 'human',
 	aiMetadata: {
 		description:
 			'Reads raw cell values from a worksheet using an A1-notation range, where leaving the range empty reads the entire worksheet, with switchable orientation (one array per row or per column) and rendering (formatted text, unformatted values, or the underlying formulas). Use when an agent needs a specific block of cells or the formulas behind them; prefer Get All Rows or Find Rows when header-keyed row objects are wanted instead of positional arrays. Read-only and idempotent.',


### PR DESCRIPTION
## Description

Six legacy Google Sheets actions serve `audience: 'both'`, so they are offered to agents alongside a near-identical `audience: 'ai'` atomic that already covers the same operation. This demotes those six to `'human'`, which is what the other 20 legacy actions in the piece already do.

| Legacy action (`'both'`) | Display name | Atomic twin (`'ai'`) | Display name |
|---|---|---|---|
| `delete-multiple-rows` | Delete Multiple Rows | `sheets_delete_multiple_rows` | Delete Multiple Rows |
| `find-or-create-row` | Find or Create Row | `sheets_find_or_create_row` | Find or Create Row |
| `find-or-create-worksheet` | Find or Create Worksheet | `sheets_find_or_create_worksheet` | Find or Create Worksheet |
| `insert-row-at-top` | Add Row at Top | `sheets_add_row_at_top` | Add Row at Top |
| `read-data-range` | Read Data Range | `sheets_get_values` | Read Cell Range |
| `clear-rows` | Clear Row(s) | `sheets_clear_values` | Clear Cell Range |

Four of the six pairs share an identical display name, so an agent listing the piece sees the same capability twice with nothing to choose between them. The atomics are the intended agent surface: they take explicit IDs rather than builder-resolved dropdowns.

### How the inconsistency arose

The demotion was authored in #13941, together with the same change to the other 20 legacy actions. These six had also been given `audience: 'both'` three weeks earlier by the `aiMetadata` backfill in #14428. The two edits landed on different lines of the same object literal (`'human'` above `displayName`, `'both'` below `description`), so merging main into the #13941 branch united them into a duplicate object key rather than a textual conflict. The build fix in 3b8d5e5bc9 resolved the duplicate by keeping `'both'` — correct for the build, and the newer of the two lines on main, but it dropped the demotion for these six. They are now the only legacy actions in the piece not marked `'human'`.

### Scope

google-sheets only. A scan of every `createAction` block under `packages/pieces/community` on current main found no other piece where an `'ai'` action and a `'both'` action share an operation: #13941 is the only PR that performed these demotions, and google-sheets is the only one of #14428's 32 pieces that contains `'ai'` atomics at all. The other three pieces in #13941 (google-forms, notion, telegram-bot) are unaffected.

## How was this tested?

- `npx tsc --noEmit` over `packages/pieces/community/google-sheets/src/**/*.ts` with the root `tsconfig.base.json` path mappings: clean (the piece's own `tsconfig.lib.json` sets `"paths": {}` and cannot resolve the framework, so it is not a usable gate here).
- `npx eslint` on the six changed files: clean, no errors or warnings.
- Confirmed against `filterActionsByAudience` (`packages/server/api/src/app/pieces/metadata/utils/index.ts`) that the AI filter keeps `action.audience !== 'human'` and the human filter keeps `action.audience !== 'ai'`. So the six leave the agent surface and stay fully available in the builder.

Metadata-only change: no action logic, props, `aiMetadata`, or `outputSchema` was touched, and no action was removed. Existing flows that already use these actions keep working, since the human surface still serves them. Piece version bumped 0.16.7 to 0.16.8.

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)
