### PR TITLE
fix(server): treat OAuth2 connections without refresh_token as expired once stale

### DIFF
--- a/packages/server/api/src/app/app-connection/app-connection-service/oauth2/oauth2-util.ts
+++ b/packages/server/api/src/app/app-connection/app-connection-service/oauth2/oauth2-util.ts
@@ -30,13 +30,11 @@ export const oauth2Util = (log: FastifyBaseLogger) => ({
     },
     isExpired: (connection: BaseOAuth2ConnectionValue): boolean => {
         const secondsSinceEpoch = Math.round(Date.now() / 1000)
-        const grantType = connection.grant_type ?? OAuth2GrantType.AUTHORIZATION_CODE
-        if (
-            grantType === OAuth2GrantType.AUTHORIZATION_CODE &&
-            !connection.refresh_token
-        ) {
-            return false
-        }
+        // AUTHORIZATION_CODE connections without a refresh_token cannot be refreshed
+        // once the access token expires. Fall through to the normal expiry check so
+        // they are flagged for re-authentication instead of being treated as
+        // never-expired and reused forever (which caused persistent 401s, e.g. Reddit
+        // when the piece did not request a refresh token).
         const parsedExpiresIn = Number(connection.expires_in)
         const expiresIn = Number.isFinite(parsedExpiresIn) && parsedExpiresIn > 0 ? parsedExpiresIn : 60 * 60
         const parsedClaimedAt = Number(connection.claimed_at)

--- a/packages/server/api/test/unit/app/app-connection/oauth2-util.test.ts
+++ b/packages/server/api/test/unit/app/app-connection/oauth2-util.test.ts
@@ -5,10 +5,10 @@ import { oauth2Util } from '../../../../src/app/app-connection/app-connection-se
 const util = oauth2Util({} as never)
 const nowSeconds = Math.round(Date.now() / 1000)
 
-function connectionWith({ claimedAt, expiresIn }: { claimedAt: number | string, expiresIn?: number | string }): never {
+function connectionWith({ claimedAt, expiresIn, refreshToken = 'refresh' }: { claimedAt: number | string, expiresIn?: number | string, refreshToken?: string | null }): never {
     return {
         access_token: 'token',
-        refresh_token: 'refresh',
+        refresh_token: refreshToken,
         claimed_at: claimedAt,
         expires_in: expiresIn,
         grant_type: OAuth2GrantType.AUTHORIZATION_CODE,
@@ -67,6 +67,18 @@ describe('oauth2Util.isExpired', () => {
 
     it('infinite claimed_at is treated as epoch → expired', () => {
         expect(util.isExpired(connectionWith({ claimedAt: '1e999', expiresIn: 3600 }))).toBe(true)
+    })
+
+    it('no refresh_token: expired access token → expired (re-auth required)', () => {
+        expect(util.isExpired(connectionWith({ claimedAt: nowSeconds - 2 * 60 * 60, expiresIn: 3600, refreshToken: null }))).toBe(true)
+    })
+
+    it('no refresh_token: valid access token → not expired', () => {
+        expect(util.isExpired(connectionWith({ claimedAt: nowSeconds, expiresIn: 3600, refreshToken: null }))).toBe(false)
+    })
+
+    it('no refresh_token: missing expires_in falls back to 1h → expired after 2h', () => {
+        expect(util.isExpired(connectionWith({ claimedAt: nowSeconds - 2 * 60 * 60, refreshToken: null }))).toBe(true)
     })
 })
 


### PR DESCRIPTION
## What

`isExpired` in `oauth2-util.ts` previously returned `false` unconditionally for `AUTHORIZATION_CODE` connections without a `refresh_token`. Such connections were therefore never considered expired, and a stale (expired) access token kept being reused forever — resulting in persistent 401 errors with no automatic recovery.

This was reported in #14680 (Reddit piece): Reddit only issues a refresh token when `duration=permanent` is requested; without it, connections only ever had a short-lived access token, and this `isExpired` behavior meant the dead token was used indefinitely.

## Fix

Remove the special-case `return false` and let connections without a `refresh_token` fall through to the normal expiry check (`expires_in` / `claimed_at`). Once the access token is stale, the connection is flagged for re-authentication instead of being reused forever. A connection whose access token is still valid keeps working as before.

## Tests

Added 3 unit tests to `oauth2-util.test.ts` covering connections without a refresh token:
- expired access token → expired (re-auth required)
- valid access token → not expired
- missing `expires_in` → falls back to the default 1h lifetime

Note: tests were not run locally in this session (no local dev environment); CI runs the unit tests (`test-unit`).

## Breaking change?

- [x] no

## Security impact?

- [x] no