### PR TITLE
ci(cloud): deploy canary alongside prod on cloud-hotfix

### DIFF
--- a/.github/workflows/continuous-delivery-cloud.yml
+++ b/.github/workflows/continuous-delivery-cloud.yml
@@ -125,6 +125,16 @@ jobs:
             echo "image_tag=release-candidate" >> $GITHUB_OUTPUT
           fi
 
+      - name: Deploy App to canary
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          ssh ops -t -t 'bash -ic "cd mrsk/prod && kamal deploy --version ${{ steps.image.outputs.image_tag }} --config-file=config/app-canary.yml --skip-push; exit"'
+
+      - name: Deploy Workers to canary
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          ssh ops -t -t 'bash -ic "cd mrsk/prod && kamal deploy --version ${{ steps.image.outputs.image_tag }} --config-file=config/worker-canary.yml --skip-push; exit"'
+
       - name: Deploy App to production
         run: |
           ssh ops -t -t 'bash -ic "cd mrsk/prod && kamal deploy --version ${{ steps.image.outputs.image_tag }} --config-file=config/app.yml --skip-push; exit"'

--- a/brain/engineering/cloud-deployment-paths.md
+++ b/brain/engineering/cloud-deployment-paths.md
@@ -1,0 +1,17 @@
+---
+icon: 🚀
+---
+
+# Cloud Deployment Paths
+
+How code reaches `cloud.activepieces.com`. Two workflows in `.github/workflows/`: `continuous-delivery-canary.yml` and `continuous-delivery-cloud.yml`.
+
+## The normal path
+Cloud's `workflow_call`/scheduled run calls the canary workflow as a job, then promotes the `release-candidate` tag to prod. Canary builds its own `.canary` image; prod deploys the `release-candidate` tag, not that image.
+
+## The override path
+`Continuous Delivery — Cloud` → **Run workflow** → `cloud-hotfix` builds a `.beta` image from the current branch and deploys it to canary **and** prod, in that order, from the `promote-to-production` job. It never invokes the canary workflow. A `guard` job refuses the hotfix if the scheduled promotion is under an hour away.
+
+## Gotchas
+- **`check-migrations` gates canary *and* the scheduled cloud promotion.** The canary workflow fails when any pending migration carries `breaking = true` (rollback safety — see `tools/scripts/check-manifest-migrations.ts`). Because the scheduled cloud run calls that workflow, one breaking migration blocks both. The escape hatch is `cloud-hotfix`: it deploys canary and prod without touching the canary workflow, so it bypasses the gate by construction — there is no skip flag, and there is no canary-only override.
+- **`breaking = true` on a migration and the `⛓️‍💥 breaking-change` PR label are different axes.** The migration flag is about rollback safety and is what stops deploys; the label is about self-hoster upgrade impact and is enforced by `breaking-change-check.yml` on PRs. Neither implies the other.

--- a/brain/engineering/index.md
+++ b/brain/engineering/index.md
@@ -31,5 +31,6 @@ The **Activepieces engineering brain**: how the system works, and *why* it was b
 - **API & Endpoints** — route conventions and the security contract
 - **Server Module Anatomy** — the six files of a server module (entity → migration → repo → service → controller → module), and the manual registration steps nothing auto-discovers
 - **Web Feature Anatomy** — the frontend feature folder, its barrel, route guards, and when a query gets the global error dialog
+- **Cloud Deployment Paths** — canary → prod, the `cloud-hotfix` override, and the breaking-migration gate that blocks both
 - **CI PR Review Hygiene** — draft-first Greptile review, the per-area PR size gate, and the workflow conventions reviewers keep re-litigating
 - **Architecture Spine** — the load-bearing structure of the codebase, and the gotchas that come with it: request-body `.max()` as data loss, TypeORM soft-delete across a canary window, and canary not proxying websockets


### PR DESCRIPTION
## Description

The canary workflow's `check-migrations` job fails the run whenever a pending migration is marked `breaking = true`. Because the scheduled cloud promotion calls the canary workflow, that single gate blocks **both** "Deploy to canary" and "Deploy to cloud" — there was no way to ship while a breaking migration was in flight.

The manual `cloud-hotfix` dispatch now deploys canary as well as production, from the same already-built image. It never invokes the canary workflow, so it skips the migration gate by construction — one deliberate override that covers both environments.

Scheduled / `workflow_call` runs are untouched: they still go through the canary workflow and its `check-migrations` gate, and the new steps are skipped (`if: github.event_name == 'workflow_dispatch'`).

## How was this tested?

Workflow-only change; validated the YAML parses (`bunx js-yaml`). The two new steps reuse the SSH config and image tag already set up in `promote-to-production`, and mirror the existing canary kamal commands (`config/app-canary.yml`, `config/worker-canary.yml`) verbatim. Not exercised against the real ops host.

Fixes # (issue)

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)
