### PR TITLE
fix(sso): SCIM sync no longer deactivates or removes embed users

### DIFF
--- a/packages/server/api/src/app/ee/scim/scim-group-service.ts
+++ b/packages/server/api/src/app/ee/scim/scim-group-service.ts
@@ -3,12 +3,15 @@ import { CreateScimGroupRequest, DefaultProjectRole, parseScimFilter, ProjectTyp
 
 import { FastifyBaseLogger } from 'fastify'
 import { StatusCodes } from 'http-status-codes'
+import { In } from 'typeorm'
+import { userIdentityService } from '../../authentication/user-identity/user-identity-service'
 import { repoFactory } from '../../core/db/repo-factory'
 import { system } from '../../helper/system/system'
 import { AppSystemProp } from '../../helper/system/system-props'
+import { userIdentityHelper } from '../../helper/user-identity-helper'
 import { platformService } from '../../platform/platform.service'
 import { projectService } from '../../project/project-service'
-import { userService } from '../../user/user-service'
+import { userRepo, userService } from '../../user/user-service'
 import { platformProjectService } from '../projects/platform-project-service'
 import { ProjectMemberEntity } from '../projects/project-members/project-member.entity'
 import { projectMemberService } from '../projects/project-members/project-member.service'
@@ -33,36 +36,19 @@ export const scimGroupService = (log: FastifyBaseLogger) => ({
             type: ProjectType.TEAM,
         })
 
-        const members: ScimGroupMember[] = []
         if (!isNil(request.members) && request.members.length > 0) {
-            const users = await Promise.all(
-                request.members.map(async (member) => {
-                    await addMemberToProject({
+            await Promise.all(
+                request.members.map(async (member) =>
+                    addMemberToProject({
                         userId: member.value,
                         projectId: project.id,
                         platformId,
                         log,
-                    })
-                    const user = await userService(log).get({ id: member.value })
-                    if (!isNil(user)) {
-                        const identity = await userService(log).getMetaInformation({ id: user.id })
-                        return {
-                            value: user.id,
-                            display: identity.email,
-                            $ref: `/scim/v2/Users/${user.id}`,
-                        }
-                    }
-                    return null
-                }),
+                    })),
             )
-
-            for (const user of users) {
-                if (user) {
-                    members.push(user)
-                }
-            }
         }
 
+        const members = await getProjectMembers(project.id, platformId, log)
         return toScimGroupResource(project.id, project.displayName, project.externalId ?? undefined, members, project.created, project.updated)
     },
 
@@ -218,6 +204,7 @@ export const scimGroupService = (log: FastifyBaseLogger) => ({
                         userId,
                         projectId,
                         platformId,
+                        log,
                     })
                 }
             }
@@ -291,6 +278,11 @@ async function addMemberToProject(params: {
         return
     }
 
+    const identity = await userIdentityService(log).getOneOrFail({ id: user.identityId })
+    if (userIdentityHelper(log).isEmbeddedIdentity(identity)) {
+        return
+    }
+
     const role = system.get<DefaultProjectRole>(AppSystemProp.SCIM_DEFAULT_PROJECT_ROLE) ?? DefaultProjectRole.EDITOR
 
     await projectMemberService(log).upsert({
@@ -304,8 +296,17 @@ async function removeMemberFromProject(params: {
     userId: string
     projectId: string
     platformId: string
+    log: FastifyBaseLogger
 }): Promise<void> {
-    const { userId, projectId, platformId } = params
+    const { userId, projectId, platformId, log } = params
+
+    const user = await userService(log).get({ id: userId })
+    if (!isNil(user)) {
+        const identity = await userIdentityService(log).getOneOrFail({ id: user.identityId })
+        if (userIdentityHelper(log).isEmbeddedIdentity(identity)) {
+            return
+        }
+    }
 
     const member = await projectMemberRepo().findOneBy({
         userId,
@@ -322,17 +323,22 @@ async function getProjectMembers(projectId: string, platformId: string, log: Fas
     const members = await projectMemberRepo().find({
         where: { projectId, platformId },
     })
+    if (members.length === 0) {
+        return []
+    }
 
-    return Promise.all(
-        members.map(async (member) => {
-            const userMeta = await userService(log).getMetaInformation({ id: member.userId })
-            return {
-                value: member.userId,
-                display: userMeta.email,
-                $ref: `/scim/v2/Users/${member.userId}`,
-            }
-        }),
-    )
+    const memberUsers = await userRepo().find({
+        where: { id: In(members.map((member) => member.userId)), platformId },
+        relations: { identity: true },
+    })
+
+    return memberUsers
+        .filter((user) => !userIdentityHelper(log).isEmbeddedIdentity(user.identity))
+        .map((user) => ({
+            value: user.id,
+            display: user.identity.email,
+            $ref: `/scim/v2/Users/${user.id}`,
+        }))
 }
 
 function toScimGroupResource(
@@ -367,48 +373,35 @@ function toScimGroupResource(
 async function replaceMembers(params: {
     projectId: string
     platformId: string
-    newMembers: ScimGroupMember[]
+    newMembers: ScimGroupMember[] | undefined
     log: FastifyBaseLogger
 }): Promise<ScimGroupMember[]> {
     const { projectId, platformId, newMembers, log } = params
-    const members: ScimGroupMember[] = []
 
-    let membersToDelete = await projectMemberRepo().find({
-        where: { projectId, platformId },
-    })
+    const requestedMembers = newMembers ?? []
+    const requestedMemberIds = new Set(requestedMembers.map((member) => member.value))
+    const visibleMembers = await getProjectMembers(projectId, platformId, log)
+    const membersToDelete = visibleMembers.filter((member) => !requestedMemberIds.has(member.value))
 
-    if (!isNil(newMembers) && newMembers.length > 0) {
-        const results = await Promise.all(newMembers.map(async (member) => {
-            membersToDelete = membersToDelete.filter(m => m.userId !== member.value)
-            await addMemberToProject({
+    await Promise.all(
+        requestedMembers.map(async (member) =>
+            addMemberToProject({
                 userId: member.value,
                 projectId,
                 platformId,
                 log,
-            })
-            const user = await userService(log).get({ id: member.value })
-            if (!isNil(user)) {
-                const identity = await userService(log).getMetaInformation({ id: user.id })
-                return {
-                    value: user.id,
-                    display: identity.email,
-                    $ref: `/scim/v2/Users/${user.id}`,
-                }
-            }
-            return null
-        }))
-        for (const member of results) {
-            if (member) {
-                members.push(member)
-            }
-        }
-    }
-
-    await Promise.all(
-        membersToDelete.map(member =>
-            projectMemberService(log).delete(projectId, member.id),
-        ),
+            })),
     )
 
-    return members
+    await Promise.all(
+        membersToDelete.map(async (member) =>
+            removeMemberFromProject({
+                userId: member.value,
+                projectId,
+                platformId,
+                log,
+            })),
+    )
+
+    return getProjectMembers(projectId, platformId, log)
 }

--- a/packages/server/api/src/app/ee/scim/scim-group-service.ts
+++ b/packages/server/api/src/app/ee/scim/scim-group-service.ts
@@ -36,17 +36,12 @@ export const scimGroupService = (log: FastifyBaseLogger) => ({
             type: ProjectType.TEAM,
         })
 
-        if (!isNil(request.members) && request.members.length > 0) {
-            await Promise.all(
-                request.members.map(async (member) =>
-                    addMemberToProject({
-                        userId: member.value,
-                        projectId: project.id,
-                        platformId,
-                        log,
-                    })),
-            )
-        }
+        await addMembersToProject({
+            userIds: (request.members ?? []).map((member) => member.value),
+            projectId: project.id,
+            platformId,
+            log,
+        })
 
         const members = await getProjectMembers(project.id, platformId, log)
         return toScimGroupResource(project.id, project.displayName, project.externalId ?? undefined, members, project.created, project.updated)
@@ -185,16 +180,12 @@ export const scimGroupService = (log: FastifyBaseLogger) => ({
 
             if (op === 'add' && operation.path === 'members') {
                 const memberValues = operation.value as ScimGroupMember[]
-                await Promise.all(
-                    memberValues.map(member =>
-                        addMemberToProject({
-                            userId: member.value,
-                            projectId,
-                            platformId,
-                            log,
-                        }),
-                    ),
-                )
+                await addMembersToProject({
+                    userIds: memberValues.map((member) => member.value),
+                    projectId,
+                    platformId,
+                    log,
+                })
             }
             else if (op === 'remove' && !isNil(operation.path) && operation.path.startsWith('members')) {
                 const match = operation.path.match(/members\[value\s+eq\s+"([^"]+)"\]/i)
@@ -265,31 +256,31 @@ export const scimGroupService = (log: FastifyBaseLogger) => ({
     },
 })
 
-async function addMemberToProject(params: {
-    userId: string
+async function addMembersToProject(params: {
+    userIds: string[]
     projectId: string
     platformId: string
     log: FastifyBaseLogger
 }): Promise<void> {
-    const { userId, projectId, platformId, log } = params
-
-    const user = await userService(log).get({ id: userId })
-    if (isNil(user) || user.platformId !== platformId || user.status !== UserStatus.ACTIVE) {
+    const { userIds, projectId, platformId, log } = params
+    if (userIds.length === 0) {
         return
     }
 
-    const identity = await userIdentityService(log).getOneOrFail({ id: user.identityId })
-    if (userIdentityHelper(log).isEmbeddedIdentity(identity)) {
-        return
-    }
+    const users = await userRepo().find({
+        where: { id: In(userIds), platformId, status: UserStatus.ACTIVE },
+        relations: { identity: true },
+    })
 
     const role = system.get<DefaultProjectRole>(AppSystemProp.SCIM_DEFAULT_PROJECT_ROLE) ?? DefaultProjectRole.EDITOR
 
-    await projectMemberService(log).upsert({
-        userId,
-        projectId,
-        projectRoleName: role,
-    })
+    await Promise.all(users
+        .filter((user) => !userIdentityHelper(log).isEmbeddedIdentity(user.identity))
+        .map((user) => projectMemberService(log).upsert({
+            userId: user.id,
+            projectId,
+            projectRoleName: role,
+        })))
 }
 
 async function removeMemberFromProject(params: {
@@ -383,15 +374,12 @@ async function replaceMembers(params: {
     const visibleMembers = await getProjectMembers(projectId, platformId, log)
     const membersToDelete = visibleMembers.filter((member) => !requestedMemberIds.has(member.value))
 
-    await Promise.all(
-        requestedMembers.map(async (member) =>
-            addMemberToProject({
-                userId: member.value,
-                projectId,
-                platformId,
-                log,
-            })),
-    )
+    await addMembersToProject({
+        userIds: requestedMembers.map((member) => member.value),
+        projectId,
+        platformId,
+        log,
+    })
 
     await Promise.all(
         membersToDelete.map(async (member) =>

--- a/packages/server/api/src/app/ee/scim/scim-user-service.ts
+++ b/packages/server/api/src/app/ee/scim/scim-user-service.ts
@@ -1,9 +1,10 @@
 import { isEnumValue, isNil } from '@activepieces/core-utils'
 import { cryptoUtils } from '@activepieces/server-utils'
-import { CreateScimUserRequest, parseScimFilter, PlatformRole, ReplaceScimUserRequest, SCIM_CUSTOM_USER_ATTRIBUTES_SCHEMA, SCIM_LIST_RESPONSE_SCHEMA, SCIM_USER_SCHEMA, ScimError, ScimListResponse, ScimPatchRequest, ScimUserResource, User, UserIdentityProvider, UserStatus } from '@activepieces/shared'
+import { CreateScimUserRequest, parseScimFilter, PlatformRole, ReplaceScimUserRequest, SCIM_CUSTOM_USER_ATTRIBUTES_SCHEMA, SCIM_LIST_RESPONSE_SCHEMA, SCIM_USER_SCHEMA, ScimError, ScimListResponse, ScimPatchRequest, ScimUserResource, User, UserIdentity, UserIdentityProvider, UserStatus } from '@activepieces/shared'
 import { FastifyBaseLogger } from 'fastify'
 import { StatusCodes } from 'http-status-codes'
 import { userIdentityService } from '../../authentication/user-identity/user-identity-service'
+import { userIdentityHelper } from '../../helper/user-identity-helper'
 import { userService } from '../../user/user-service'
 import { emailService } from '../helper/email/email-service'
 
@@ -47,6 +48,12 @@ export const scimUserService = (log: FastifyBaseLogger) => ({
                 verified: true,
             })
         }
+        else if (userIdentityHelper(log).isEmbeddedIdentity(identity)) {
+            throw new ScimError(
+                StatusCodes.CONFLICT,
+                'User with email already exists',
+            )
+        }
 
         const existingUserForIdentity = await userService(log).getOneByIdentityAndPlatform({
             identityId: identity.id,
@@ -86,16 +93,7 @@ export const scimUserService = (log: FastifyBaseLogger) => ({
         userId: string
     }): Promise<ScimUserResource> {
         const { platformId, userId } = params
-        const user = await userService(log).get({ id: userId })
-
-        if (isNil(user) || user.platformId !== platformId) {
-            throw new ScimError(
-                StatusCodes.NOT_FOUND,
-                'User not found',
-            )
-        }
-
-        const identity = await userIdentityService(log).getBasicInformation(user.identityId)
+        const { user, identity } = await getScimManagedUserOrThrow({ platformId, userId, log })
         return toScimUserResource(user, identity.email, identity.firstName, identity.lastName)
     },
 
@@ -107,32 +105,28 @@ export const scimUserService = (log: FastifyBaseLogger) => ({
     }): Promise<ScimListResponse> {
         const { platformId, filter, startIndex = 1, count = 100 } = params
 
+        const emptyPage: ScimListResponse = {
+            schemas: [SCIM_LIST_RESPONSE_SCHEMA],
+            totalResults: 0,
+            startIndex,
+            itemsPerPage: count,
+            Resources: [],
+        }
+
         // Parse SCIM filter - we support "userName eq \"value\""
         const filterEmail = parseScimFilter(filter, 'userName')
 
         if (!isNil(filterEmail)) {
             const identity = await userIdentityService(log).getIdentityByEmail(filterEmail)
-            if (isNil(identity)) {
-                return {
-                    schemas: [SCIM_LIST_RESPONSE_SCHEMA],
-                    totalResults: 0,
-                    startIndex,
-                    itemsPerPage: count,
-                    Resources: [],
-                }
+            if (isNil(identity) || userIdentityHelper(log).isEmbeddedIdentity(identity)) {
+                return emptyPage
             }
             const user = await userService(log).getOneByIdentityAndPlatform({
                 identityId: identity.id,
                 platformId,
             })
             if (isNil(user)) {
-                return {
-                    schemas: [SCIM_LIST_RESPONSE_SCHEMA],
-                    totalResults: 0,
-                    startIndex,
-                    itemsPerPage: count,
-                    Resources: [],
-                }
+                return emptyPage
             }
             return {
                 schemas: [SCIM_LIST_RESPONSE_SCHEMA],
@@ -145,6 +139,7 @@ export const scimUserService = (log: FastifyBaseLogger) => ({
 
         const usersPage = await userService(log).list({
             platformId,
+            excludeProvider: UserIdentityProvider.JWT,
             cursorRequest: null,
             limit: count,
         })
@@ -168,14 +163,7 @@ export const scimUserService = (log: FastifyBaseLogger) => ({
         request: ReplaceScimUserRequest
     }): Promise<ScimUserResource> {
         const { platformId, userId, request } = params
-        const user = await userService(log).get({ id: userId })
-
-        if (isNil(user) || user.platformId !== platformId) {
-            throw new ScimError(
-                StatusCodes.NOT_FOUND,
-                'User not found',
-            )
-        }
+        const { user, identity } = await getScimManagedUserOrThrow({ platformId, userId, log })
 
         const active = request.active !== false
         const status = active ? UserStatus.ACTIVE : UserStatus.INACTIVE
@@ -192,10 +180,14 @@ export const scimUserService = (log: FastifyBaseLogger) => ({
             firstName: request.name?.givenName,
             lastName: request.name?.familyName,
         })
-        const updatedIdentity = await userIdentityService(log).getBasicInformation(user.identityId)
 
         const updatedUser = await userService(log).getOrThrow({ id: userId })
-        return toScimUserResource(updatedUser, updatedIdentity.email, updatedIdentity.firstName, updatedIdentity.lastName)
+        return toScimUserResource(
+            updatedUser,
+            identity.email,
+            request.name?.givenName ?? identity.firstName,
+            request.name?.familyName ?? identity.lastName,
+        )
     },
 
     async patch(params: {
@@ -204,14 +196,7 @@ export const scimUserService = (log: FastifyBaseLogger) => ({
         request: ScimPatchRequest
     }): Promise<ScimUserResource> {
         const { platformId, userId, request } = params
-        const user = await userService(log).get({ id: userId })
-
-        if (isNil(user) || user.platformId !== platformId) {
-            throw new ScimError(
-                StatusCodes.NOT_FOUND,
-                'User not found',
-            )
-        }
+        const { user, identity } = await getScimManagedUserOrThrow({ platformId, userId, log })
 
         let addOperationFields: {
             platformRole?: PlatformRole
@@ -273,17 +258,19 @@ export const scimUserService = (log: FastifyBaseLogger) => ({
             }
         }
 
-        let updatedUser: User | undefined
         if (!isNil(addOperationFields)) {
             const { platformRole, firstName, lastName, externalId, active } = addOperationFields
             await userService(log).update({ platformId, id: userId, platformRole, externalId, status: isNil(active) ? undefined : active ? UserStatus.ACTIVE : UserStatus.INACTIVE })
-            updatedUser = await userService(log).getOrThrow({ id: userId })
-            await userIdentityService(log).update(updatedUser.identityId, { firstName, lastName })
+            await userIdentityService(log).update(user.identityId, { firstName, lastName })
         }
 
-        updatedUser = updatedUser ?? await userService(log).getOrThrow({ id: userId })
-        const identity = await userIdentityService(log).getBasicInformation(updatedUser.identityId)
-        return toScimUserResource(updatedUser, identity.email, identity.firstName, identity.lastName)
+        const updatedUser = await userService(log).getOrThrow({ id: userId })
+        return toScimUserResource(
+            updatedUser,
+            identity.email,
+            addOperationFields?.firstName ?? identity.firstName,
+            addOperationFields?.lastName ?? identity.lastName,
+        )
     },
 
     async deactivate(params: {
@@ -291,14 +278,7 @@ export const scimUserService = (log: FastifyBaseLogger) => ({
         userId: string
     }): Promise<void> {
         const { platformId, userId } = params
-        const user = await userService(log).get({ id: userId })
-
-        if (isNil(user) || user.platformId !== platformId) {
-            throw new ScimError(
-                StatusCodes.NOT_FOUND,
-                'User not found',
-            )
-        }
+        await getScimManagedUserOrThrow({ platformId, userId, log })
 
         await userService(log).update({
             id: userId,
@@ -307,6 +287,28 @@ export const scimUserService = (log: FastifyBaseLogger) => ({
         })
     },
 })
+
+async function getScimManagedUserOrThrow({ platformId, userId, log }: {
+    platformId: string
+    userId: string
+    log: FastifyBaseLogger
+}): Promise<{ user: User, identity: UserIdentity }> {
+    const user = await userService(log).get({ id: userId })
+    if (isNil(user) || user.platformId !== platformId) {
+        throw new ScimError(
+            StatusCodes.NOT_FOUND,
+            'User not found',
+        )
+    }
+    const identity = await userIdentityService(log).getOneOrFail({ id: user.identityId })
+    if (userIdentityHelper(log).isEmbeddedIdentity(identity)) {
+        throw new ScimError(
+            StatusCodes.NOT_FOUND,
+            'User not found',
+        )
+    }
+    return { user, identity }
+}
 
 function toScimUserResource(
     user: Pick<User, 'id' | 'externalId' | 'created' | 'updated' | 'status' | 'platformRole'>,

--- a/packages/server/api/src/app/helper/user-identity-helper.ts
+++ b/packages/server/api/src/app/helper/user-identity-helper.ts
@@ -1,4 +1,4 @@
-import { UserIdentityProvider } from '@activepieces/shared'
+import { UserIdentity, UserIdentityProvider } from '@activepieces/shared'
 import { FastifyBaseLogger } from 'fastify'
 import { userIdentityService } from '../authentication/user-identity/user-identity-service'
 import { userService } from '../user/user-service'
@@ -7,6 +7,11 @@ export const userIdentityHelper = (log: FastifyBaseLogger) => ({
     async isUserEmbedded(userId: string): Promise<boolean> {
         const user = await userService(log).getOneOrFail({ id: userId })
         const userIdentity = await userIdentityService(log).getOneOrFail({ id: user.identityId })
-        return userIdentity.provider === UserIdentityProvider.JWT
+        return isEmbeddedIdentity(userIdentity)
     },
+    isEmbeddedIdentity,
 })
+
+function isEmbeddedIdentity(identity: Pick<UserIdentity, 'provider'>): boolean {
+    return identity.provider === UserIdentityProvider.JWT
+}

--- a/packages/server/api/src/app/user/user-service.ts
+++ b/packages/server/api/src/app/user/user-service.ts
@@ -1,5 +1,5 @@
 import { ActivepiecesError, apId, assertNotNullOrUndefined, Cursor, ErrorCode, isNil, PlatformId, ProjectId, SeekPage, spreadIfDefined, UserId } from '@activepieces/core-utils'
-import { ApEdition, PlatformRole, ProjectType, User, UserIdentity, UserStatus, UserWithMetaInformation } from '@activepieces/shared'
+import { ApEdition, PlatformRole, ProjectType, User, UserIdentity, UserIdentityProvider, UserStatus, UserWithMetaInformation } from '@activepieces/shared'
 import dayjs from 'dayjs'
 import { FastifyBaseLogger } from 'fastify'
 import { nanoid } from 'nanoid'
@@ -114,7 +114,7 @@ export const userService = (log: FastifyBaseLogger) => ({
     async countActiveByPlatformId({ platformId, entityManager }: CountActiveByPlatformIdParams): Promise<number> {
         return userRepo(entityManager).countBy({ platformId, status: UserStatus.ACTIVE })
     },
-    async list({ platformId, externalId, cursorRequest, limit }: ListParams): Promise<SeekPage<UserWithMetaInformation>> {
+    async list({ platformId, externalId, excludeProvider, cursorRequest, limit }: ListParams): Promise<SeekPage<UserWithMetaInformation>> {
         const decodedCursor = paginationHelper.decodeCursor(cursorRequest)
         const paginator = buildPaginator({
             entity: UserEntity,
@@ -124,10 +124,14 @@ export const userService = (log: FastifyBaseLogger) => ({
                 beforeCursor: decodedCursor.previousCursor,
             },
         })
-        const { data, cursor } = await paginator.paginate(userRepo().createQueryBuilder('user').where({
+        const query = userRepo().createQueryBuilder('user').where({
             platformId,
             ...spreadIfDefined('externalId', externalId),
-        }))
+        })
+        if (!isNil(excludeProvider)) {
+            query.innerJoin('user.identity', 'identity', 'identity.provider != :excludeProvider', { excludeProvider })
+        }
+        const { data, cursor } = await paginator.paginate(query)
 
         const usersWithMetaInformation = await Promise.all(data.map(this.getMetaInformation))
         return paginationHelper.createPage<UserWithMetaInformation>(usersWithMetaInformation, cursor)
@@ -296,6 +300,7 @@ type DeleteParams = {
 type ListParams = {
     platformId: PlatformId
     externalId?: string
+    excludeProvider?: UserIdentityProvider
     cursorRequest: Cursor
     limit?: number
 }

--- a/packages/server/api/test/integration/ee/scim/scim.test.ts
+++ b/packages/server/api/test/integration/ee/scim/scim.test.ts
@@ -6,9 +6,10 @@ import { StatusCodes } from 'http-status-codes'
 import { initializeDatabase } from '../../../../src/app/database'
 import { databaseConnection } from '../../../../src/app/database/database-connection'
 import { setupServer } from '../../../../src/app/server'
-import { generateMockToken } from '../../../helpers/auth'
+import { generateMockExternalToken, generateMockToken } from '../../../helpers/auth'
 import {
     createMockApiKey,
+    createMockSigningKey,
     mockAndSaveBasicSetup,
 } from '../../../helpers/mocks'
 
@@ -935,6 +936,237 @@ describe('SCIM 2.0 API', () => {
             expect(putResponse?.statusCode).toBe(StatusCodes.OK)
             const members = putResponse?.json().members.map((m: { value: string }) => m.value).sort()
             expect(members).toEqual([u2Id, u3Id].sort())
+        })
+    })
+
+    describe('SCIM scoping for embed-provisioned users', () => {
+
+        async function setupScimPlatformWithEmbedUser() {
+            const { mockPlatform, bearerToken } = await setupScimPlatform()
+
+            const mockSigningKey = createMockSigningKey({ platformId: mockPlatform.id })
+            await databaseConnection().getRepository('signing_key').save(mockSigningKey)
+
+            const { mockExternalToken } = generateMockExternalToken({
+                platformId: mockPlatform.id,
+                signingKeyId: mockSigningKey.id,
+                externalUserId: `embed-${apId()}`,
+            })
+            const embedLogin = await app?.inject({
+                method: 'POST',
+                url: '/api/v1/managed-authn/external-token',
+                body: { externalAccessToken: mockExternalToken },
+            })
+            expect(embedLogin?.statusCode).toBe(StatusCodes.OK)
+            const embedUser: { id: string, email: string, token: string, projectId: string } = embedLogin?.json()
+
+            return {
+                bearerToken,
+                embedUserId: embedUser.id,
+                embedUserEmail: embedUser.email,
+                embedUserToken: embedUser.token,
+                embedProjectId: embedUser.projectId,
+            }
+        }
+
+        it('should omit embed-provisioned users from the user list', async () => {
+            const { bearerToken, embedUserId } = await setupScimPlatformWithEmbedUser()
+
+            const idpUser = mockIdpUser()
+            const createResponse = await app?.inject({
+                method: 'POST',
+                url: '/api/v1/scim/v2/Users',
+                headers: { authorization: bearerToken },
+                body: idpUser,
+            })
+            expect(createResponse?.statusCode).toBe(StatusCodes.CREATED)
+
+            const listResponse = await app?.inject({
+                method: 'GET',
+                url: '/api/v1/scim/v2/Users',
+                headers: { authorization: bearerToken },
+            })
+
+            expect(listResponse?.statusCode).toBe(StatusCodes.OK)
+            const ids = listResponse?.json().Resources.map((r: { id: string }) => r.id)
+            expect(ids).toContain(createResponse?.json().id)
+            expect(ids).not.toContain(embedUserId)
+        })
+
+        it('should return an empty list when filtering by an embed user userName', async () => {
+            const { bearerToken, embedUserEmail } = await setupScimPlatformWithEmbedUser()
+
+            const filterResponse = await app?.inject({
+                method: 'GET',
+                url: `/api/v1/scim/v2/Users?filter=${encodeURIComponent(`userName eq "${embedUserEmail}"`)}`,
+                headers: { authorization: bearerToken },
+            })
+
+            expect(filterResponse?.statusCode).toBe(StatusCodes.OK)
+            expect(filterResponse?.json().totalResults).toBe(0)
+        })
+
+        it('should return 404 for GET, PUT, and DELETE on an embed-provisioned user', async () => {
+            const { bearerToken, embedUserId } = await setupScimPlatformWithEmbedUser()
+
+            const getResponse = await app?.inject({
+                method: 'GET',
+                url: `/api/v1/scim/v2/Users/${embedUserId}`,
+                headers: { authorization: bearerToken },
+            })
+            expect(getResponse?.statusCode).toBe(StatusCodes.NOT_FOUND)
+
+            const putResponse = await app?.inject({
+                method: 'PUT',
+                url: `/api/v1/scim/v2/Users/${embedUserId}`,
+                headers: { authorization: bearerToken },
+                body: {
+                    schemas: ['urn:ietf:params:scim:schemas:core:2.0:User'],
+                    userName: 'replaced@example.com',
+                    active: false,
+                },
+            })
+            expect(putResponse?.statusCode).toBe(StatusCodes.NOT_FOUND)
+
+            const deleteResponse = await app?.inject({
+                method: 'DELETE',
+                url: `/api/v1/scim/v2/Users/${embedUserId}`,
+                headers: { authorization: bearerToken },
+            })
+            expect(deleteResponse?.statusCode).toBe(StatusCodes.NOT_FOUND)
+        })
+
+        it('should keep an embed user session alive when the IdP tries to deactivate them via PATCH', async () => {
+            const { bearerToken, embedUserId, embedUserToken, embedProjectId } = await setupScimPlatformWithEmbedUser()
+
+            const callAuthenticatedEndpoint = async () => app?.inject({
+                method: 'GET',
+                url: `/api/v1/flows?projectId=${embedProjectId}`,
+                headers: { authorization: `Bearer ${embedUserToken}` },
+            })
+
+            expect((await callAuthenticatedEndpoint())?.statusCode).toBe(StatusCodes.OK)
+
+            const patchResponse = await app?.inject({
+                method: 'PATCH',
+                url: `/api/v1/scim/v2/Users/${embedUserId}`,
+                headers: { authorization: bearerToken },
+                body: {
+                    schemas: ['urn:ietf:params:scim:api:messages:2.0:PatchOp'],
+                    Operations: [{ op: 'replace', value: { active: false } }],
+                },
+            })
+            expect(patchResponse?.statusCode).toBe(StatusCodes.NOT_FOUND)
+
+            expect((await callAuthenticatedEndpoint())?.statusCode).toBe(StatusCodes.OK)
+        })
+
+        it('should not expose embed users as group members', async () => {
+            const { bearerToken, embedUserId, embedProjectId } = await setupScimPlatformWithEmbedUser()
+
+            const groupResponse = await app?.inject({
+                method: 'GET',
+                url: `/api/v1/scim/v2/Groups/${embedProjectId}`,
+                headers: { authorization: bearerToken },
+            })
+
+            expect(groupResponse?.statusCode).toBe(StatusCodes.OK)
+            const memberIds = groupResponse?.json().members.map((m: { value: string }) => m.value)
+            expect(memberIds).not.toContain(embedUserId)
+        })
+
+        it('should not add an embed user to a group via PATCH', async () => {
+            const { bearerToken, embedUserId } = await setupScimPlatformWithEmbedUser()
+
+            const groupResponse = await app?.inject({
+                method: 'POST',
+                url: '/api/v1/scim/v2/Groups',
+                headers: { authorization: bearerToken },
+                body: mockIdpGroup(),
+            })
+            expect(groupResponse?.statusCode).toBe(StatusCodes.CREATED)
+            const groupId = groupResponse?.json().id
+
+            const patchResponse = await app?.inject({
+                method: 'PATCH',
+                url: `/api/v1/scim/v2/Groups/${groupId}`,
+                headers: { authorization: bearerToken },
+                body: {
+                    schemas: ['urn:ietf:params:scim:api:messages:2.0:PatchOp'],
+                    Operations: [
+                        {
+                            op: 'add',
+                            path: 'members',
+                            value: [{ value: embedUserId }],
+                        },
+                    ],
+                },
+            })
+
+            expect(patchResponse?.statusCode).toBe(StatusCodes.OK)
+            expect(patchResponse?.json().members).toHaveLength(0)
+        })
+
+        it('should keep embed users project membership when the IdP removes them via group PATCH', async () => {
+            const { bearerToken, embedUserId, embedProjectId } = await setupScimPlatformWithEmbedUser()
+
+            const patchResponse = await app?.inject({
+                method: 'PATCH',
+                url: `/api/v1/scim/v2/Groups/${embedProjectId}`,
+                headers: { authorization: bearerToken },
+                body: {
+                    schemas: ['urn:ietf:params:scim:api:messages:2.0:PatchOp'],
+                    Operations: [
+                        {
+                            op: 'remove',
+                            path: `members[value eq "${embedUserId}"]`,
+                        },
+                    ],
+                },
+            })
+            expect(patchResponse?.statusCode).toBe(StatusCodes.OK)
+
+            const membership = await databaseConnection().getRepository('project_member').findOneBy({
+                projectId: embedProjectId,
+                userId: embedUserId,
+            })
+            expect(membership).not.toBeNull()
+        })
+
+        it('should keep embed users project membership when the IdP replaces group members via PUT', async () => {
+            const { bearerToken, embedUserId, embedProjectId } = await setupScimPlatformWithEmbedUser()
+
+            const putResponse = await app?.inject({
+                method: 'PUT',
+                url: `/api/v1/scim/v2/Groups/${embedProjectId}`,
+                headers: { authorization: bearerToken },
+                body: {
+                    schemas: ['urn:ietf:params:scim:schemas:core:2.0:Group'],
+                    displayName: 'Synced Group',
+                    members: [],
+                },
+            })
+            expect(putResponse?.statusCode).toBe(StatusCodes.OK)
+
+            const membership = await databaseConnection().getRepository('project_member').findOneBy({
+                projectId: embedProjectId,
+                userId: embedUserId,
+            })
+            expect(membership).not.toBeNull()
+        })
+
+        it('should reject creating a SCIM user over an embed identity from another platform', async () => {
+            const { embedUserEmail } = await setupScimPlatformWithEmbedUser()
+            const { bearerToken: otherPlatformToken } = await setupScimPlatform()
+
+            const createResponse = await app?.inject({
+                method: 'POST',
+                url: '/api/v1/scim/v2/Users',
+                headers: { authorization: otherPlatformToken },
+                body: mockIdpUser({ email: embedUserEmail }),
+            })
+
+            expect(createResponse?.statusCode).toBe(StatusCodes.CONFLICT)
         })
     })
 })


### PR DESCRIPTION
Fixes [GIT-1736](https://linear.app/activepieces/issue/GIT-1736)
Closes #14753

## Problem

1. `GET /scim/v2/Users` returned embed (JWT-provisioned) users, so an IdP cleanup sweep deactivates them: embed login still returns 200 + token, but every request after 403s `SESSION_EXPIRED`. A paid embed customer hit this as "enabling SAML corrupted our JIT users" (Ref: Pylon 5483).
2. SCIM `PUT/PATCH/DELETE /Users/:id` could deactivate embed users and set their `platformRole`.
3. Embed projects are TEAM-typed, so `GET /Groups` exposed embed member ids/emails, and a full-sync `PUT /Groups/:id` deterministically deleted embed users' memberships.

Security note: risk is an admin-configured IdP (platform-API-key auth) governing users it never provisioned; mitigation is provider-scoped guards at every SCIM surface. No new privileges are granted and all SCIM routes keep the same auth.

## Fix

- `ee/scim/scim-user-service.ts` — shared `getScimManagedUserOrThrow` 404s on embed users for get/replace/patch/deactivate; list filters them in SQL; `userName eq` filter and `create` refuse embed identities.
- `ee/scim/scim-group-service.ts` — member add/remove skip embed users; `replaceMembers` diffs only SCIM-visible members so embed memberships survive full sync; create/PUT echo the filtered member list; `getProjectMembers` batched (2 queries total, was 4 per member).
- `user/user-service.ts` — `list()` gains optional `excludeProvider` (innerJoin, filtered before pagination).
- `helper/user-identity-helper.ts` — `isEmbeddedIdentity` predicate shared by all guards.

Product decision embedded: embed users are invisible to SCIM (404/omit/skip) rather than visible-but-read-only; alternative rejected because IdP cleanup sweeps key off visibility.

## Verification

- 8 new integration tests, each proven red-first against base (list omission, filter empty, GET/PUT/PATCH/DELETE 404, session survives deactivation attempt, cross-platform create 409, group members hidden, group PATCH-remove no-op, full-sync membership survival); full SCIM suite 35/35 green.
- `npx turbo run build --filter=api` (type check) and lint clean on touched files (0 errors; 476 pre-existing warnings elsewhere in api).
- Repro: booted the API standalone (EE, real Postgres) and drove managed-authn + SCIM over HTTP; embed user invisible and session survives, SAML user deactivate/reactivate/filter unchanged in both directions — full steps in the Reproduction block.
- Visual: none - backend-only SCIM API change, no user-visible surface.
- Other affected paths: checked — platform admin Users page still lists embed users (deliberate, admin surface keeps `excludeProvider` unset); SCIM `DELETE /Groups/:id` can still soft-delete an embed TEAM project (pre-existing; embed projects carry no marker distinguishing them from SCIM-created groups, follow-up noted on the ticket); `getMetaInformation` N+1 in list paths (pre-existing).

## How was this tested?

EE integration suite (SCIM module is EE-only; CE has no SCIM surface, Cloud shares the EE path) plus a standalone live-server HTTP drive against real Postgres.

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

- [ ] no — reviewed, no security impact
- [x] yes — security-sensitive (call out the risk and mitigation in the description above)

<details>
<summary>Plan & reasoning</summary>

## Plan

- Scope SCIM to users it provisioned: one by-id choke point (`getScimManagedUserOrThrow`) + SQL-level list filter + guards on the group member add/remove/replace/echo paths.
- Key files: `ee/scim/scim-user-service.ts`, `ee/scim/scim-group-service.ts`, `user/user-service.ts`, `helper/user-identity-helper.ts`.
- Footprint estimate was 2 files / ~35 lines for the Users surface; grew to 4 files after review agents proved the Groups surface leaked member ids and deleted embed memberships on full sync — same defect class, so in scope.

## Non-happy scenarios considered

- IdP full group sync (PUT) with members the IdP cannot see → embed memberships preserved (test-pinned).
- Group PATCH remove replaying an embed user id → no-op (test-pinned).
- SCIM create colliding with an embed identity email (sha256 hex, cross-platform) → 409 instead of silently attaching a platform user to the embed identity and sharing its credentials.
- Stale userId in group ops → same silent-skip behavior as before.
- Filter-vs-create asymmetry (filter says absent, create 409s) accepted: embed emails are sha256 hashes, unreachable from real IdP data; the alternative (adopting the JWT identity) is worse.

## Alternatives rejected

- Visible-but-read-only embed users in SCIM → IdPs treat listed-but-unmanaged users as cleanup candidates; visibility is the trigger.
- Post-pagination filtering in the SCIM list → N+1 and broken page counts; SQL join filters before pagination.
- Guard inside `userService.get/update` → those paths serve embed login itself and would break the users being protected.
- Single joined user+identity query in the by-id guard → needs a repo import or new accessor in `ee/`; two low-QPS reads kept instead.

</details>

<details>
<summary>Reproduction</summary>

## Environment

- `postgres:14` in Docker (`ap-verify-pg`, port 54329, throwaway).
- API booted standalone from the branch: `npx tsx --tsconfig packages/server/api/tsconfig.app.json packages/server/api/src/bootstrap.ts` with `AP_EDITION=ee`, `AP_REDIS_TYPE=MEMORY`, `AP_PIECES_SYNC_MODE=NONE`, port 3999 (full env file in the harness).
- Platform plan flags flipped in DB: `scimEnabled`, `embeddingEnabled`, `ssoEnabled`, `apiKeysEnabled`.

## Harness

Public gist: https://gist.github.com/majewskibartosz/22bfb2d3dc825e1904e3b483b5925470

```
git clone https://gist.github.com/22bfb2d3dc825e1904e3b483b5925470.git git-1736-repro && cd git-1736-repro
# 1. start postgres:14 on 54329, run run-verify-server.sh (points at verify-1736.env)
# 2. sign in dev@ap.com/12345678, flip plan flags via psql, run verify-drive.sh (creates api key + signing key)
# 3. node make-external-token.js && bash verify-scim.sh
```

- `run-verify-server.sh` — boots the API against the throwaway Postgres.
- `verify-drive.sh` — creates the platform API key and embed signing key via the real endpoints.
- `make-external-token.js` — signs an RS256 embed external token (keyid = signing key).
- `verify-scim.sh` — full drive: embed login, SCIM list/filter/GET/PUT/PATCH/DELETE, session probes, SAML inverse drive.

## Trigger

`PATCH /api/v1/scim/v2/Users/:embedUserId` with `active:false` (the IdP deactivation an unmatched-user cleanup sweep performs), after provisioning the user via `POST /api/v1/managed-authn/external-token`.

## Results

| Call | Base | Fixed |
|---|---|---|
| SCIM list contains embed user | yes | no |
| filter by embed userName | 1 result | 0 |
| GET/PUT/PATCH/DELETE embed user | 200 | 404 |
| embed session after PATCH active:false | 403 SESSION_EXPIRED | 200 |
| embed re-login status | INACTIVE | ACTIVE |
| SAML user deactivate → reactivate → filter | works | works (unchanged) |

</details>
