### PR TITLE
chore(agent): drop the chat table compat views

### DIFF
--- a/docs/install/reference/breaking-changes.mdx
+++ b/docs/install/reference/breaking-changes.mdx
@@ -8,6 +8,20 @@ icon: "hammer"
 
 ### What has changed?
 
+#### The `chat_conversation` and `user_chat_memory` tables are gone
+
+They were renamed to `agent_conversation` and `user_memory` in 0.87.1, and views under the old names were kept so a release still using them kept working while an upgrade rolled out. Those views are now removed.
+
+#### What you need to do
+
+Nothing, if you upgraded through 0.87.1 and are running a supported version. Activepieces itself has not used the old names since 0.87.1.
+
+If you query the database directly — a reporting tool, a dashboard, a backup script, an external integration — point it at `agent_conversation` and `user_memory`. The rows and columns are unchanged; only the names are.
+
+## Unreleased
+
+### What has changed?
+
 #### Agent steps move from the flow engine to the server
 
 An agent step used to run its loop inside the engine, holding a worker for as long as the agent took. It now pauses the flow, runs on the server, and resumes when the agent finishes. This upgrade rewrites every existing agent step to the new version.

--- a/packages/server/api/src/app/database/migration/postgres/1824000000000-DropRenamedChatTableCompatViews.ts
+++ b/packages/server/api/src/app/database/migration/postgres/1824000000000-DropRenamedChatTableCompatViews.ts
@@ -1,0 +1,26 @@
+import { QueryRunner } from 'typeorm'
+import { Migration } from '../../migration'
+
+const COMPAT_VIEWS: [viewName: string, backedBy: string][] = [
+    ['chat_conversation', 'agent_conversation'],
+    ['user_chat_memory', 'user_memory'],
+]
+
+export class DropRenamedChatTableCompatViews1824000000000 implements Migration {
+    name = 'DropRenamedChatTableCompatViews1824000000000'
+    breaking = false
+    release = '0.88.0'
+    transaction = true
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        for (const [viewName] of COMPAT_VIEWS) {
+            await queryRunner.query(`DROP VIEW IF EXISTS "${viewName}"`)
+        }
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        for (const [viewName, backedBy] of COMPAT_VIEWS) {
+            await queryRunner.query(`CREATE OR REPLACE VIEW "${viewName}" AS SELECT * FROM "${backedBy}"`)
+        }
+    }
+}

--- a/packages/server/api/src/app/database/postgres-connection.ts
+++ b/packages/server/api/src/app/database/postgres-connection.ts
@@ -414,6 +414,7 @@ import { AddAuditEventPlatformIdCreatedIdIndex1820000000000 } from './migration/
 import { AddAgentConversationFlowStepRetentionIndex1821000000000 } from './migration/postgres/1821000000000-AddAgentConversationFlowStepRetentionIndex'
 import { RenameChatTablesToAgent1822000000000 } from './migration/postgres/1822000000000-RenameChatTablesToAgent'
 import { AddRenamedChatTableCompatViews1823000000000 } from './migration/postgres/1823000000000-AddRenamedChatTableCompatViews'
+import { DropRenamedChatTableCompatViews1824000000000 } from './migration/postgres/1824000000000-DropRenamedChatTableCompatViews'
 
 const getSslConfig = (): boolean | TlsOptions => {
     const useSsl = system.get(AppSystemProp.POSTGRES_USE_SSL)
@@ -843,6 +844,7 @@ export const getMigrations = (): (new () => Migration)[] => {
         AddAgentConversationFlowStepRetentionIndex1821000000000,
         RenameChatTablesToAgent1822000000000,
         AddRenamedChatTableCompatViews1823000000000,
+        DropRenamedChatTableCompatViews1824000000000,
     ]
     return migrations
 }


### PR DESCRIPTION
> **Do not merge until every deployment is past 0.87.1.** Draft on purpose. Merging early recreates the outage the views were added to prevent.

This is the contract half of the table rename. #14564 renamed `chat_conversation` to `agent_conversation` and `user_chat_memory` to `user_memory`; #14759 added views under the old names so a release still querying them keeps working while a deploy rolls. This removes those views.

## The precondition

The views only stop being load-bearing once no running instance queries the old names. That means every deployment — cloud and self-hosted — is on 0.87.1 or later. Until then a rolling deploy still puts a pod on the previous release in front of a database whose old names would be gone.

Nothing in the codebase reads them today: the only remaining matches for `chat_conversation` and `user_chat_memory` are historical migrations, which operate on the schema as it was at their point in the chain and are unaffected.

## Why merge it at all rather than remember later

An unremoved compatibility view is not neutral. It keeps two names resolving to the same rows, so new code can query the old name and work, and nobody notices until the view finally goes. Filing it as a draft keeps the intent visible in the queue instead of in someone's memory.

`down()` recreates both views, so a rollback restores the compatibility layer.

### Breaking change?  (required — CI fails if this is left unedited)

- [ ] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [x] yes — functional (default/limit/behaviour change, new self-hosted setup step)

Removes relation names that existed before 0.87.1. Anything still querying `chat_conversation` or `user_chat_memory` stops working, which is the point — but it is why the precondition above is a gate rather than a suggestion.

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)

Drops two views over rows that remain in place, with permissions unchanged.
