### PR TITLE
chore(release): v0.88.0

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   app:
-    image: ghcr.io/activepieces/activepieces:0.87.0
+    image: ghcr.io/activepieces/activepieces:0.88.0
     container_name: activepieces-app
     restart: unless-stopped
     ports:
@@ -16,7 +16,7 @@ services:
     networks:
       - activepieces
   worker:
-    image: ghcr.io/activepieces/activepieces:0.87.0
+    image: ghcr.io/activepieces/activepieces:0.88.0
     restart: unless-stopped
     depends_on:
       - app

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activepieces",
-  "version": "0.87.0",
+  "version": "0.88.0",
   "packageManager": "bun@1.3.3",
   "trustedDependencies": [
     "sqlite3",


### PR DESCRIPTION
## Description

Bumps the platform version to `0.88.0` for the weekly release, and pins the `docker-compose.yml` app and worker images to the same tag.

`0.87.0` shipped on 2026-08-06 and is still the latest release. Only the two files that carry the version are touched, matching the previous cuts (#14646, #14542).

| Check | Result |
|---|---|
| Version references in the repo | 3 — `package.json` and the two `docker-compose.yml` image pins, all now `0.88.0` |
| Pieces blocked at `0.87.0` (`minimumSupportedRelease` above it) | **0** — highest declared minimum is `0.87.0` |
| Pieces pushed out of range by `0.88.0` | **0** — no piece declares a `maximumSupportedRelease` |

### One thing for the release owner to confirm

The two migrations queued for this release are tagged `release = '0.87.1'`, not `0.88.0`:

`RenameChatTablesToAgent`, `AddRenamedChatTableCompatViews`

Both are `breaking = false`, so releasing `0.88.0` does not break them:

- `rollback-migrations.ts` selects with `semver.gt(m.release, targetVersion)`, so rolling back below `0.87.1` still picks them up — rollback stays correct.
- `check-release-migrations.ts` matches the release string exactly, so it will report "No migrations tagged for release 0.88.0" even though these two ship in it. Cosmetic only, and since neither is breaking, no rollback note was due either way.

So the effect is bookkeeping, not behaviour. Flagging it because `0.87.1` is the one signal in the repo pointing at a patch release rather than `0.88.0` — happy to retag both to `0.88.0`, or to cut `0.87.1` instead, if that is the plan.

Separately, three already-shipped migrations (`CreatePieceSetTable`, `AddProjectPieceSetIdIndex`, `DropPlatformPieceFilters`) carry `release = '0.103.0'`. They pre-date `0.87.0` and are not part of this cut, but the tag is wrong and will keep them out of any future release report. Worth a follow-up.

## How was this tested?

- `node --print "require('./package.json').version"` → `0.88.0`; JSON parses.
- Grepped every version reference in the repo (`package.json`, `docker-compose.yml`, workflows, docs) — no `0.87.0` left behind outside the historical `breaking-changes.mdx` heading and piece support bounds.
- Scanned every piece `index.ts` for `minimumSupportedRelease` / `maximumSupportedRelease`: nothing is blocked at `0.88.0`, and nothing caps below it.
- Verified the migrations added since the `0.87.0` tag and confirmed both are `breaking = false`, so no `breaking-changes.mdx` entry or rollback note is due.

Fixes # (no GitHub issue)

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)
