### PR TITLE
fix(docker): the image build no longer fails when the bun download hits a transient error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,9 +34,9 @@ RUN apt-get update && \
 # Download, extract, and clean up bun in a single layer so the zip never ships
 RUN export ARCH=$(uname -m) && \
     if [ "$ARCH" = "x86_64" ]; then \
-      curl -fSL https://github.com/oven-sh/bun/releases/download/bun-v1.3.1/bun-linux-x64-baseline.zip -o bun.zip; \
+      curl -fSL --retry 5 --retry-delay 2 https://github.com/oven-sh/bun/releases/download/bun-v1.3.1/bun-linux-x64-baseline.zip -o bun.zip; \
     elif [ "$ARCH" = "aarch64" ]; then \
-      curl -fSL https://github.com/oven-sh/bun/releases/download/bun-v1.3.1/bun-linux-aarch64.zip -o bun.zip; \
+      curl -fSL --retry 5 --retry-delay 2 https://github.com/oven-sh/bun/releases/download/bun-v1.3.1/bun-linux-aarch64.zip -o bun.zip; \
     fi && \
     unzip bun.zip && \
     mv bun-*/bun /usr/local/bin/bun && \

--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -13,9 +13,9 @@ RUN apt-get update && \
 
 RUN export ARCH=$(uname -m) && \
     if [ "$ARCH" = "x86_64" ]; then \
-      curl -fSL https://github.com/oven-sh/bun/releases/download/bun-v1.3.1/bun-linux-x64-baseline.zip -o bun.zip; \
+      curl -fSL --retry 5 --retry-delay 2 https://github.com/oven-sh/bun/releases/download/bun-v1.3.1/bun-linux-x64-baseline.zip -o bun.zip; \
     elif [ "$ARCH" = "aarch64" ]; then \
-      curl -fSL https://github.com/oven-sh/bun/releases/download/bun-v1.3.1/bun-linux-aarch64.zip -o bun.zip; \
+      curl -fSL --retry 5 --retry-delay 2 https://github.com/oven-sh/bun/releases/download/bun-v1.3.1/bun-linux-aarch64.zip -o bun.zip; \
     fi && \
     unzip bun.zip && mv bun-*/bun /usr/local/bin/bun && chmod +x /usr/local/bin/bun && rm -rf bun.zip bun-*
 


### PR DESCRIPTION
## Description

The image build downloads bun from GitHub releases with no retry, so a single transient response from GitHub fails the whole build. It just took down the `0.88.0` release cut:

```
#7 0.198 curl: (22) The requested URL returned error: 503
ERROR: failed to build: failed to solve: process "/bin/sh -c export ARCH=$(uname -m) && ..." did not complete successfully: exit code: 22
Dockerfile:35
```

Adds `--retry 5 --retry-delay 2` to the four bun download invocations (`Dockerfile` and `Dockerfile.worker`, x64 and aarch64 branches). curl's `--retry` only retries transient failures — connection errors, timeouts, 408, 429 and 5xx — so a genuine 404 on a bad version pin still fails immediately and loudly.

This is the same class of flake as #14765, which hardened the `apt-get` layer. The bun layer was the remaining unguarded network fetch in the build.

## How was this tested?

The Docker daemon was unavailable locally, so the premise was verified directly against a local server that returns `503` twice and then `200`, reproducing the CI failure exactly:

```
--- without --retry (current main) ---
curl: (22) The requested URL returned error: 503
exit=22

--- with --retry 5 --retry-delay 2 (this PR) ---
curl: (22) The requested URL returned error: 503
Warning: Problem : HTTP error. Will retry in 2 seconds. 5 retries left.
exit=0 body=ok
```

Same exit code and same message as the failing job, and the flag recovers. No other change to the layer, so the resulting image is byte-identical on a successful first attempt.

Fixes # (no GitHub issue)

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)
