### PR TITLE
fix(pieces): actions no longer fail with "Invalid input" when optional dropdown fields are left empty

### DIFF
--- a/packages/server/engine/src/lib/variables/props-processor.ts
+++ b/packages/server/engine/src/lib/variables/props-processor.ts
@@ -86,6 +86,9 @@ export const propsProcessor = {
                     }
                 }
             }
+            if (!property.required && isNil(processedInput[key])) {
+                processedInput[key] = undefined
+            }
             const processor = processors[property.type]
             if (processor) {
                 processedInput[key] = await processor(property, processedInput[key])

--- a/packages/server/engine/test/variables/props-validator.test.ts
+++ b/packages/server/engine/test/variables/props-validator.test.ts
@@ -370,6 +370,65 @@ describe('Property Validation', () => {
             )
             expect(errors).toEqual({})
         })
+
+        it('should convert null to undefined for unset optional properties', async () => {
+            const props = {
+                staticDropdown: Property.StaticDropdown({
+                    displayName: 'Static Dropdown',
+                    required: false,
+                    options: { options: [{ label: 'A', value: 'a' }] },
+                }),
+                dropdown: Property.Dropdown({
+                    displayName: 'Dropdown',
+                    required: false,
+                    refreshers: [],
+                    options: async () => ({ options: [{ label: 'A', value: 'a' }] }),
+                }),
+                text: Property.ShortText({
+                    displayName: 'Text',
+                    required: false,
+                }),
+            }
+
+            const { processedInput, errors } = await propsProcessor.applyProcessorsAndValidators(
+                { staticDropdown: null, dropdown: null, text: null },
+                props,
+                PieceAuth.None(),
+                false,
+                {},
+            )
+
+            expect(processedInput.staticDropdown).toBeUndefined()
+            expect(processedInput.dropdown).toBeUndefined()
+            expect(processedInput.text).toBeUndefined()
+            expect(errors).toEqual({})
+        })
+
+        it('should keep selected values and null required properties unchanged', async () => {
+            const props = {
+                staticDropdown: Property.StaticDropdown({
+                    displayName: 'Static Dropdown',
+                    required: false,
+                    options: { options: [{ label: 'A', value: 'a' }] },
+                }),
+                requiredDropdown: Property.StaticDropdown({
+                    displayName: 'Required Dropdown',
+                    required: true,
+                    options: { options: [{ label: 'A', value: 'a' }] },
+                }),
+            }
+
+            const { processedInput } = await propsProcessor.applyProcessorsAndValidators(
+                { staticDropdown: 'a', requiredDropdown: null },
+                props,
+                PieceAuth.None(),
+                false,
+                {},
+            )
+
+            expect(processedInput.staticDropdown).toBe('a')
+            expect(processedInput.requiredDropdown).toBeNull()
+        })
     })
 
     describe('type validation', () => {
@@ -487,7 +546,7 @@ describe('Property Validation', () => {
             })
         })
 
-        it('should pass nil through unchanged, leaving required-ness to validation', async () => {
+        it('should map nil to undefined on optional props, leaving required-ness to validation', async () => {
             const { processedInput, errors } = await propsProcessor.applyProcessorsAndValidators(
                 {
                     staticMultiSelect: null,
@@ -500,7 +559,7 @@ describe('Property Validation', () => {
                 {},
             )
 
-            expect(processedInput.staticMultiSelect).toBeNull()
+            expect(processedInput.staticMultiSelect).toBeUndefined()
             expect(processedInput.multiSelect).toBeUndefined()
             expect(errors).toEqual({
                 requiredMultiSelect: ['Expected array, received: null'],


### PR DESCRIPTION
## Description

Fixes [GIT-1742](https://linear.app/activepieces/issue/GIT-1742)
Closes #14788

### Problem

1. Google Chat "Send a Message" fails on every run with `{"errors":{"thread":"Invalid input","messageReplyOption":"Invalid input","privateMessageViewer":"Invalid input"}}` when its optional dropdowns are left empty, which is the default state of a fresh step. Reported on Pylon 5629, reproduced against the published `@activepieces/piece-googlechat@0.1.7` bundle.
2. Root cause: the builder saves unset optional single-select dropdowns as `null` (`form-utils.tsx`, `property.defaultValue ?? null`), and the engine hands `null` through to piece zod schemas where `z.optional()` (zod/mini) accepts only `undefined`. Empty optional text already gets converted to `undefined` by `textProcessor`; dropdowns have no processor, so exactly the dropdown fields fail. 30+ published pieces combine `propsValidation.validateZod` with optional dropdowns (google-sheets, openai, shopify, mongodb, ...), so any of them can hit this.

### Fix

- `packages/server/engine/src/lib/variables/props-processor.ts`: optional props whose resolved value is nil are passed to pieces as `undefined`, normalized before the per-type processors run. One guard at the choke point both actions (`piece-executor`) and triggers (`trigger-helper`) flow through. The framework already types optional props as `| undefined`, never `| null`, so this makes runtime match the declared contract.
- Engine-side on purpose: piece bundles are self-contained since #13834, so a fix in `pieces-common` or per-piece schemas only reaches newly published bundles. The engine ships with the platform release and heals every already-published piece version and every already-saved flow.

## How was this tested?

- Red-first regression test: the new test fails on base (optional dropdown `null` reaches `propsValue` as `null`) and passes with the fix. Full engine suite failure set is byte-identical to base (25 pre-existing env-dependent failures, unrelated files).
- End-to-end drive: fed the engine pipeline output into the real published `piece-googlechat@0.1.7` bundle. Builder-saved nulls now pass the piece's zod validation and reach the Google API; fully filled dropdowns pass through unchanged; required-field violations still fail with the piece's own message.
- `npm run lint-dev` clean.
- Repro: exact customer error reproduced from the published 0.1.7 bundle in plain node; `null` fails `z.optional`, `undefined` and missing keys pass. Full steps in the Reproduction block.
- Visual: none - engine-only change, no user-visible surface touched (runs that previously failed now succeed).
- Other affected paths: checked. Triggers share the same choke point (covered by the fix). FILE props keep their existing null contract (`fileProcessor` normalizes every nil to `null`; behavior unchanged, pinned by existing tests). ARRAY-with-schema props already map `null` to `[]` (pre-existing). A flow that deliberately maps a null-resolving expression into an optional prop now omits the key from JSON request bodies instead of sending `"field": null`; that matches the framework's `| undefined` contract and is intended.

<details>
<summary>Plan & reasoning</summary>

## Plan

- Normalize `null` to `undefined` for non-required props at the single choke point (`applyProcessorsAndValidators`) used by both action and trigger execution.
- Place the guard before per-type processors so processor-produced null (e.g. `fileProcessor`'s "no usable file") keeps its meaning; all processors treat null and undefined identically on input (`isNil` early return).
- Regression tests pin: optional dropdown/static-dropdown/text null becomes `undefined`; selected values and required-prop null are untouched.
- Footprint estimate: 1 file, ~3 lines of product code. Actual: 3 lines.

## Non-happy scenarios considered

- Required prop with null: guard skips it; validation errors unchanged.
- Optional FILE prop with null or failed fetch: `fileProcessor` still returns `null` (deliberate contract, pinned by `file-processor.test.ts`); no change.
- Auth sub-props (custom auth with optional fields): recursion applies the same normalization; `validateProperty` treats nil identically, and no piece in the repo branches on `=== null` for auth or props values (grepped; only `!== undefined && !== null` exclusion patterns exist).
- DYNAMIC/ARRAY branches: their outputs are always objects/arrays, never null, so the guard only ever touches raw resolved nulls.
- Step Input tab / run logs: captured from the resolver output before this code runs; display is byte-identical.
- Explicit-null PATCH semantics ("clear this field"): a null-resolving expression mapped into an optional prop previously serialized as `"field": null` in JSON bodies and now omits the key. Optional props are typed `| undefined`, so pieces could never rely on null arriving; accepted as intended behavior.

## Alternatives rejected

- Per-piece `z.nullish()` across 30+ pieces: requires republishing every affected piece; whack-a-mole.
- Fix `validateZod` in pieces-common: bundled per piece since #13834, so it only reaches newly published versions.
- Builder-side fix (stop saving null in `form-utils.tsx`): React controlled selects need a non-undefined form value, and it would not heal the null already stored in existing flow versions.

</details>

<details>
<summary>Reproduction</summary>

## Environment

- Published bundle `@activepieces/piece-googlechat@0.1.7` from npm (self-contained, zero deps, node builtins only).
- Node 20+, vitest (engine package), no server, no DB.

## Harness

Fetch the bundle:

```bash
mkdir repro && cd repro
npm pack @activepieces/piece-googlechat@0.1.7 && tar xzf *.tgz
```

Standalone zod check (proves the mechanism):

```js
const z = require('zod/mini')
const schema = z.object({ thread: z.optional(z.string()) })
z.safeParse(schema, { thread: null }).error.issues[0].message   // "Invalid input"
z.safeParse(schema, { thread: undefined }).success              // true
z.safeParse(schema, {}).success                                 // true
```

End-to-end drive (engine props pipeline into the published bundle), run as a vitest file inside `packages/server/engine` with `BUNDLE_PATH` pointing at the extracted `package/src/index.js`:

```ts
import { createRequire } from 'node:module'
import { PieceAuth, Property } from '@activepieces/pieces-framework'
import { propsProcessor } from '../../src/lib/variables/props-processor'

const nodeRequire = createRequire(__filename)
const BUNDLE_PATH = '<path-to>/repro/package/src/index.js'

const props = {
    spaceId: Property.StaticDropdown({ displayName: 'Space', required: true, options: { options: [{ label: 'S', value: 'spaces/AAAA1234' }] } }),
    text: Property.LongText({ displayName: 'Message', required: true }),
    thread: Property.StaticDropdown({ displayName: 'Thread', required: false, options: { options: [{ label: 'T', value: 'spaces/AAAA1234/threads/BBBB' }] } }),
    messageReplyOption: Property.StaticDropdown({ displayName: 'Reply', required: false, options: { options: [{ label: 'R', value: 'REPLY_MESSAGE_FALLBACK_TO_NEW_THREAD' }] } }),
    customMessageId: Property.ShortText({ displayName: 'Custom ID', required: false }),
    isPrivate: Property.Checkbox({ displayName: 'Private', required: false }),
    privateMessageViewer: Property.Dropdown({ displayName: 'Viewer', required: false, refreshers: [], options: async () => ({ options: [{ label: 'U', value: 'users/1234' }] }) }),
}

async function run(propsValue: Record<string, unknown>): Promise<string> {
    const action = nodeRequire(BUNDLE_PATH).googlechat.actions().sendAMessage
    try {
        await action.run({ auth: { access_token: 'fake-token' }, propsValue })
        return 'OK'
    }
    catch (e) {
        return (e as Error).message
    }
}

it('customer repro: builder-saved nulls pass validation and reach the Google API', async () => {
    const builderSaved = { spaceId: 'spaces/AAAA1234', text: 'hello', thread: null, messageReplyOption: null, customMessageId: '', isPrivate: false, privateMessageViewer: null }
    const { processedInput, errors } = await propsProcessor.applyProcessorsAndValidators(builderSaved, props, PieceAuth.None(), false, {})
    expect(errors).toEqual({})
    const result = await run(processedInput)
    expect(result).not.toContain('Invalid input')
    expect(result).toContain('401')
})
```

## Trigger

Call `sendAMessage.run()` with `thread: null, messageReplyOption: null, privateMessageViewer: null` (what the builder stores for a fresh step). Null is the only value a dropdown can carry that produces "Invalid input" at 0.1.7: absent keys, `undefined`, and `''` all pass, so the customer's exact three-field error proves the runtime value was null.

## Results

| propsValue for the optional dropdowns | before fix | after fix |
| --- | --- | --- |
| `null` (builder default) | `"Invalid input"` per field | passes validation, reaches Google API (401 on fake token) |
| `undefined` / keys absent | passes | passes (unchanged) |
| filled values | passes, values intact | passes, values intact (unchanged) |
| required field empty | piece's own message (`Message text is required`) | same (unchanged) |

</details>

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)
