### PR TITLE
feat: add Peer Cash piece

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6800,6 +6800,18 @@
         "tslib": "2.6.2",
       },
     },
+    "packages/pieces/community/peer-cash": {
+      "name": "@activepieces/piece-peer-cash",
+      "version": "0.1.0",
+      "dependencies": {
+        "@activepieces/pieces-framework": "workspace:*",
+        "@zkp2p/cash": "0.4.9",
+        "viem": "2.55.13",
+      },
+      "devDependencies": {
+        "tslib": "2.6.2",
+      },
+    },
     "packages/pieces/community/pendo": {
       "name": "@activepieces/piece-pendo",
       "version": "0.1.4",
@@ -12037,6 +12049,8 @@
 
     "@activepieces/piece-peekshot": ["@activepieces/piece-peekshot@workspace:packages/pieces/community/peekshot"],
 
+    "@activepieces/piece-peer-cash": ["@activepieces/piece-peer-cash@workspace:packages/pieces/community/peer-cash"],
+
     "@activepieces/piece-pendo": ["@activepieces/piece-pendo@workspace:packages/pieces/community/pendo"],
 
     "@activepieces/piece-perplexity-ai": ["@activepieces/piece-perplexity-ai@workspace:packages/pieces/community/perplexity-ai"],
@@ -13501,6 +13515,8 @@
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@0.2.12", "", { "dependencies": { "@emnapi/core": "^1.4.3", "@emnapi/runtime": "^1.4.3", "@tybys/wasm-util": "^0.10.0" } }, "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ=="],
 
+    "@noble/ciphers": ["@noble/ciphers@1.3.0", "", {}, "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw=="],
+
     "@noble/curves": ["@noble/curves@1.2.0", "", { "dependencies": { "@noble/hashes": "1.3.2" } }, "sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw=="],
 
     "@noble/hashes": ["@noble/hashes@1.3.2", "", {}, "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ=="],
@@ -13542,6 +13558,30 @@
     "@pdf-lib/standard-fonts": ["@pdf-lib/standard-fonts@1.0.0", "", { "dependencies": { "pako": "^1.0.6" } }, "sha512-hU30BK9IUN/su0Mn9VdlVKsWBS6GyhVfqjwl1FjZN4TxP6cCw0jP2w7V3Hf5uX7M0AZJ16vey9yE0ny7Sa59ZA=="],
 
     "@pdf-lib/upng": ["@pdf-lib/upng@1.0.1", "", { "dependencies": { "pako": "^1.0.10" } }, "sha512-dQK2FUMQtowVP00mtIksrlZhdFXQZPC+taih1q4CvPZ5vqdxR/LKBaFg0oAfzd1GlHZXXSPdQfzQnt+ViGvEIQ=="],
+
+    "@peculiar/asn1-cms": ["@peculiar/asn1-cms@2.8.0", "", { "dependencies": { "@peculiar/asn1-schema": "^2.8.0", "@peculiar/asn1-x509": "^2.8.0", "@peculiar/asn1-x509-attr": "^2.8.0", "asn1js": "^3.0.10", "tslib": "^2.8.1" } }, "sha512-NgekZOrSJFSBFLFoLfwePguAWAx7z1+f2TEsWFUMyiqqfntZ4+S/S5hzqME3q4pCA0iOsFKdwiQ35dwY24eVqA=="],
+
+    "@peculiar/asn1-csr": ["@peculiar/asn1-csr@2.8.0", "", { "dependencies": { "@peculiar/asn1-schema": "^2.8.0", "@peculiar/asn1-x509": "^2.8.0", "asn1js": "^3.0.10", "tslib": "^2.8.1" } }, "sha512-akbF8+uvleHs8sejNPQxwmVFuInAg6FMNHOwMILXfP518YfFJwdR3jr6oNUPOaEJfuEhn/vkNOCIT6ASUd4mbg=="],
+
+    "@peculiar/asn1-ecc": ["@peculiar/asn1-ecc@2.8.0", "", { "dependencies": { "@peculiar/asn1-schema": "^2.8.0", "@peculiar/asn1-x509": "^2.8.0", "asn1js": "^3.0.10", "tslib": "^2.8.1" } }, "sha512-ohwlk+u9Rv2NOAY1c6MfHj45ATVF8R1DUN/WCgABiRtLi2ZftlZWZX7KvpAbU8v9xPcmoILfELeEABj/rn18AQ=="],
+
+    "@peculiar/asn1-pfx": ["@peculiar/asn1-pfx@2.8.0", "", { "dependencies": { "@peculiar/asn1-cms": "^2.8.0", "@peculiar/asn1-pkcs8": "^2.8.0", "@peculiar/asn1-rsa": "^2.8.0", "@peculiar/asn1-schema": "^2.8.0", "asn1js": "^3.0.10", "tslib": "^2.8.1" } }, "sha512-5yof1ytoB++RQtaFbqSUJ8pxDJtZT6vbVqZ8XoJ61ph7UjNVvfFwAilnCodqkNsAodpy13gDhoxZXw00pghnyg=="],
+
+    "@peculiar/asn1-pkcs8": ["@peculiar/asn1-pkcs8@2.8.0", "", { "dependencies": { "@peculiar/asn1-schema": "^2.8.0", "@peculiar/asn1-x509": "^2.8.0", "asn1js": "^3.0.10", "tslib": "^2.8.1" } }, "sha512-qAKXtLpBEw9LqhKpjw3ajZSXlBur+ipW+y2ivVBQAG6F6qRx94yO+1ZR4mvw+YaCfKSaOzLeYEzsPaBp4SJELA=="],
+
+    "@peculiar/asn1-pkcs9": ["@peculiar/asn1-pkcs9@2.8.0", "", { "dependencies": { "@peculiar/asn1-cms": "^2.8.0", "@peculiar/asn1-pfx": "^2.8.0", "@peculiar/asn1-pkcs8": "^2.8.0", "@peculiar/asn1-schema": "^2.8.0", "@peculiar/asn1-x509": "^2.8.0", "@peculiar/asn1-x509-attr": "^2.8.0", "asn1js": "^3.0.10", "tslib": "^2.8.1" } }, "sha512-b5nDWCnkV60+cQ141D6sVVwK9nz64R5n3zSVnklGd+ECdkW2Ol3U1a6yYFlalpSOaD557yuJB64A+q42jG7lUQ=="],
+
+    "@peculiar/asn1-rsa": ["@peculiar/asn1-rsa@2.8.0", "", { "dependencies": { "@peculiar/asn1-schema": "^2.8.0", "@peculiar/asn1-x509": "^2.8.0", "asn1js": "^3.0.10", "tslib": "^2.8.1" } }, "sha512-zHEUlCqB2mk7x2lxDwHHJy7hWZOPdGHVlsmITWKB5/PbQo61atbu9PJ/0r9dQNMwFzbKPXZ8uK8/91eUhRznSg=="],
+
+    "@peculiar/asn1-schema": ["@peculiar/asn1-schema@2.8.0", "", { "dependencies": { "@peculiar/utils": "^2.0.2", "asn1js": "^3.0.10", "tslib": "^2.8.1" } }, "sha512-7YT0U/ze0tF2QOBbE15gKZwy5tvgGyLRiRHLzhlbOpf7BT032oBSd0haZqXn5W6l26WLlu3dyxzjM+2638/z2Q=="],
+
+    "@peculiar/asn1-x509": ["@peculiar/asn1-x509@2.8.0", "", { "dependencies": { "@peculiar/asn1-schema": "^2.8.0", "@peculiar/utils": "^2.0.2", "asn1js": "^3.0.10", "tslib": "^2.8.1" } }, "sha512-N0CMuhWUzsWEVq6F1q9X6+VKUnWzSW+cSVg+aPaGGwDdbFoFWTYgin5MHwXgpWd6y9COMBxnfy/Qc+Xc7F0Zwg=="],
+
+    "@peculiar/asn1-x509-attr": ["@peculiar/asn1-x509-attr@2.8.0", "", { "dependencies": { "@peculiar/asn1-schema": "^2.8.0", "@peculiar/asn1-x509": "^2.8.0", "asn1js": "^3.0.10", "tslib": "^2.8.1" } }, "sha512-tHjkfS/qhMnmrlB2J9NhflQlQ7In3khO3CfmVrriOlpTeErY9ZIKOso1hQ5JQiyrJ7ShvqVPk7E5fQmbclkSKA=="],
+
+    "@peculiar/utils": ["@peculiar/utils@2.0.3", "", { "dependencies": { "tslib": "^2.8.1" } }, "sha512-+oL3HPFRIZ1St2K50lWCXiioIgSoxzz7R1J3uF6neO2yl1sgmpgY6XXJH4BdpoDkMWznQTeYF6oWNDZLCdQ4eQ=="],
+
+    "@peculiar/x509": ["@peculiar/x509@1.14.3", "", { "dependencies": { "@peculiar/asn1-cms": "^2.6.0", "@peculiar/asn1-csr": "^2.6.0", "@peculiar/asn1-ecc": "^2.6.0", "@peculiar/asn1-pkcs9": "^2.6.0", "@peculiar/asn1-rsa": "^2.6.0", "@peculiar/asn1-schema": "^2.6.0", "@peculiar/asn1-x509": "^2.6.0", "pvtsutils": "^1.3.6", "reflect-metadata": "^0.2.2", "tslib": "^2.8.1", "tsyringe": "^4.10.0" } }, "sha512-C2Xj8FZ0uHWeCXXqX5B4/gVFQmtSkiuOolzAgutjTfseNOHT3pUjljDZsTSxXFGgio54bCzVFqmEOUrIVk8RDA=="],
 
     "@pinecone-database/pinecone": ["@pinecone-database/pinecone@6.1.4", "", {}, "sha512-wkipvpkBYNGYDeYj4azVVyCzSrekJE3Pgo0HImkbw80SGnTo9gz5kSbDCXCfVvFnhqC2q4nGikdTUvFCDiuruA=="],
 
@@ -13717,6 +13757,8 @@
 
     "@readme/openapi-schemas": ["@readme/openapi-schemas@3.1.0", "", {}, "sha512-9FC/6ho8uFa8fV50+FPy/ngWN53jaUu4GRXlAjcxIRrzhltJnpKkBG2Tp0IDraFJeWrOpk84RJ9EMEEYzaI1Bw=="],
 
+    "@relayprotocol/relay-sdk": ["@relayprotocol/relay-sdk@7.0.1", "", { "dependencies": { "axios": "^1.6.5" }, "peerDependencies": { "viem": ">=2.26.0" } }, "sha512-GgoUTeSk3hzTcSivSIEfkUwWLqw+4/wjJD8HA9OM+b4LlK8N8FPkSvqrSHrW6gj5OY/EhcspqXVAnScuCU8AjA=="],
+
     "@remirror/core-constants": ["@remirror/core-constants@3.0.0", "", {}, "sha512-42aWfPrimMfDKDi4YegyS7x+/0tlzaqwPQCULLanv3DMIlu96KTJR0fM5isWX2UViOqlGnX6YFgqWepcX+XMNg=="],
 
     "@remix-run/router": ["@remix-run/router@1.6.2", "", {}, "sha512-LzqpSrMK/3JBAVBI9u3NWtOhWNw5AMQfrUFYB0+bDHTSw17z++WJLsPsxAuK+oSddsxk4d7F/JcdDPM1M5YAhA=="],
@@ -13784,6 +13826,8 @@
     "@scrapeless-ai/sdk": ["@scrapeless-ai/sdk@1.5.1", "", { "dependencies": { "dotenv": "^16.5.0", "form-data": "^4.0.2", "node-fetch": "2.7.0", "playwright-core": "^1.52.0", "puppeteer-core": "^24.9.0", "stack-trace": "1.0.0-pre2", "tsdown": "^0.11.13", "winston": "^3.17.0", "winston-daily-rotate-file": "^5.0.0", "winston-transport": "^4.9.0", "zod": "^3.25.42", "zod-to-json-schema": "^3.24.5" } }, "sha512-dZ92ERwMMH3zR8tIYuYnk9sBuRzddlOJTTlBFxvSHAN7bkDEa0d8YGio+YsrNwJ7S2bNuU1NCcTK95WdbaSRJw=="],
 
     "@scure/base": ["@scure/base@1.2.6", "", {}, "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg=="],
+
+    "@scure/bip32": ["@scure/bip32@1.7.0", "", { "dependencies": { "@noble/curves": "~1.9.0", "@noble/hashes": "~1.8.0", "@scure/base": "~1.2.5" } }, "sha512-E4FFX/N3f4B80AKWp5dP6ow+flD1LQZo/w8UnLGYZO674jS6YnYeepycOOksv+vLPSpgN35wgKgy+ybfTb2SMw=="],
 
     "@scure/bip39": ["@scure/bip39@1.6.0", "", { "dependencies": { "@noble/hashes": "~1.8.0", "@scure/base": "~1.2.5" } }, "sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A=="],
 
@@ -14521,11 +14565,23 @@
 
     "@zip.js/zip.js": ["@zip.js/zip.js@2.8.26", "", {}, "sha512-RQ4h9F6DOiHxpdocUDrOl6xBM+yOtz+LkUol47AVWcfebGBDpZ7w7Xvz9PS24JgXvLGiXXzSAfdCdVy1tPlaFA=="],
 
+    "@zkp2p/cash": ["@zkp2p/cash@0.4.9", "", { "dependencies": { "@relayprotocol/relay-sdk": "^7.0.1", "@zkp2p/sdk": "0.12.0", "zod": "^4.4.3" }, "peerDependencies": { "react": ">=18", "viem": ">=2.37.3 <3" }, "optionalPeers": ["react"] }, "sha512-8lAPVO3fEGPGM2hRszv9wV/IC6XuxOknjJy/ReY+GJdLDbckurjg+Zh5Uu5YDRXs7uf1oqh11uKdHFTNMWLpKQ=="],
+
+    "@zkp2p/contracts-v2": ["@zkp2p/contracts-v2@0.4.0", "", { "dependencies": { "abitype": "^1.0.0" }, "peerDependencies": { "ethers": "^5.0.0 || ^6.0.0" } }, "sha512-wE4IfjRSUVfOiAULoh6eVUj5vExSlcMY6+VsRLOhGq+1q06uy/aS2lMYjzqoDAXibMpYPTVhsuy1MEB2jKGKqw=="],
+
+    "@zkp2p/indexer-schema": ["@zkp2p/indexer-schema@0.20.0", "", {}, "sha512-EQsmFfp61hI0zzILYoh8aPzf+CGeduoiAQQ+FD27oIQBj5piKFqNQCfzhI14A7lBWtS69gXqjPuJJTo/BOaO3w=="],
+
+    "@zkp2p/sdk": ["@zkp2p/sdk@0.12.0", "", { "dependencies": { "@zkp2p/contracts-v2": "0.4.0", "@zkp2p/indexer-schema": "0.20.0", "@zkp2p/zkp2p-attestation": "2.0.0", "ethers": "^6.0.0", "ox": "^0.11.1" }, "peerDependencies": { "react": ">=16.8.0", "viem": "^2.37.3" }, "optionalPeers": ["react"] }, "sha512-7boAYdUV+R3G+1hFOp7lQLxX9NUDVXtfW3RsgBt4ijhg3BqO9RBgpMfeWfqoE7kRUVDo/xNZL39bhBbXK6NmIA=="],
+
+    "@zkp2p/zkp2p-attestation": ["@zkp2p/zkp2p-attestation@2.0.0", "", { "dependencies": { "@peculiar/x509": "^1.14.0", "ethers": "^6.13.4" }, "bin": { "zkp2p-attestation-verify": "dist/cli/verify.js" } }, "sha512-m+HWDYTEW109xSqh0NWJFoWR0ZIoxJqQRguQltfr6RSkALBJFWv5WWDQrcPN0TiqTN2KdLI7BYQTDluZfjq2MA=="],
+
     "@zone-eu/mailsplit": ["@zone-eu/mailsplit@5.4.8", "", { "dependencies": { "libbase64": "1.3.0", "libmime": "5.3.7", "libqp": "2.1.1" } }, "sha512-eEyACj4JZ7sjzRvy26QhLgKEMWwQbsw1+QZnlLX+/gihcNH07lVPOcnwf5U6UAL7gkc//J3jVd76o/WS+taUiA=="],
 
     "JSONStream": ["JSONStream@1.3.5", "", { "dependencies": { "jsonparse": "^1.2.0", "through": ">=2.2.7 <3" }, "bin": { "JSONStream": "./bin.js" } }, "sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ=="],
 
     "abbrev": ["abbrev@1.1.1", "", {}, "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="],
+
+    "abitype": ["abitype@1.2.3", "", { "peerDependencies": { "typescript": ">=5.0.4", "zod": "^3.22.0 || ^4.0.0" }, "optionalPeers": ["typescript", "zod"] }, "sha512-Ofer5QUnuUdTFsBRwARMoWKOH1ND5ehwYhJ3OJ/BQO+StkwQjHw0XyVh4vDttzHB7QOFhPHa/o413PJ82gU/Tg=="],
 
     "abort-controller": ["abort-controller@3.0.0", "", { "dependencies": { "event-target-shim": "^5.0.0" } }, "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg=="],
 
@@ -14646,6 +14702,8 @@
     "asn1.js-rfc2560": ["asn1.js-rfc2560@5.0.1", "", { "dependencies": { "asn1.js-rfc5280": "^3.0.0" }, "peerDependencies": { "asn1.js": "^5.0.0" } }, "sha512-1PrVg6kuBziDN3PGFmRk3QrjpKvP9h/Hv5yMrFZvC1kpzP6dQRzf5BpKstANqHBkaOUmTpakJWhicTATOA/SbA=="],
 
     "asn1.js-rfc5280": ["asn1.js-rfc5280@3.0.0", "", { "dependencies": { "asn1.js": "^5.0.0" } }, "sha512-Y2LZPOWeZ6qehv698ZgOGGCZXBQShObWnGthTrIFlIQjuV1gg2B8QOhWFRExq/MR1VnPpIIe7P9vX2vElxv+Pg=="],
+
+    "asn1js": ["asn1js@3.0.10", "", { "dependencies": { "pvtsutils": "^1.3.6", "pvutils": "^1.1.5", "tslib": "^2.8.1" } }, "sha512-S2s3aOytiKdFRdulw2qPE51MzjzVOisppcVv7jVFR+Kw0kxwvFrDcYA0h7Ndqbmj0HkMIXYWaoj7fli8kgx1eg=="],
 
     "assemblyai": ["assemblyai@4.7.0", "", { "dependencies": { "ws": "^8.17.1" } }, "sha512-m0GGgb9StJMYJns9bUrMtz+WlrcM8jNiYnhlSalz5tGgu9XUThxjOs6bWXxPNsD/0BjXp4VijMEvwmue3Q85mQ=="],
 
@@ -15999,6 +16057,8 @@
 
     "isomorphic-unfetch": ["isomorphic-unfetch@3.1.0", "", { "dependencies": { "node-fetch": "^2.6.1", "unfetch": "^4.2.0" } }, "sha512-geDJjpoZ8N0kWexiwkX8F9NkTsXhetLPVbZFQ+JTW239QNOwvB0gniuR1Wc6f0AMTn7/mFGyXvHTifrCp/GH8Q=="],
 
+    "isows": ["isows@1.0.7", "", { "peerDependencies": { "ws": "*" } }, "sha512-I1fSfDCZL5P0v33sVqeTDSpcstAg/N+wF5HS033mogOVIp4B+oHC7oOCsA3axAbBSGTJ8QubbNmnIRN/h8U7hg=="],
+
     "jackspeak": ["jackspeak@3.4.3", "", { "dependencies": { "@isaacs/cliui": "^8.0.2" }, "optionalDependencies": { "@pkgjs/parseargs": "^0.11.0" } }, "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw=="],
 
     "jake": ["jake@10.9.4", "", { "dependencies": { "async": "^3.2.6", "filelist": "^1.0.4", "picocolors": "^1.1.1" }, "bin": { "jake": "bin/cli.js" } }, "sha512-wpHYzhxiVQL+IV05BLE2Xn34zW1S223hvjtqk0+gsPrwd/8JNLXJgZZM/iPFsYc1xyphF+6M6EvdE5E9MBGkDA=="],
@@ -16637,6 +16697,8 @@
 
     "own-keys": ["own-keys@1.0.1", "", { "dependencies": { "get-intrinsic": "^1.2.6", "object-keys": "^1.1.1", "safe-push-apply": "^1.0.0" } }, "sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg=="],
 
+    "ox": ["ox@0.14.33", "", { "dependencies": { "@adraffy/ens-normalize": "^1.11.0", "@noble/ciphers": "^1.3.0", "@noble/curves": "1.9.1", "@noble/hashes": "^1.8.0", "@scure/bip32": "^1.7.0", "@scure/bip39": "^1.6.0", "abitype": "^1.2.3", "eventemitter3": "5.0.1" }, "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-rooA/4o7bBof4Ge2VH/eovfNPb/AEEYyrNj03wggc55g5HZD8Pjs/OeWhttgjic3dDcqn0r29bDuvQEdTiUemQ=="],
+
     "p-finally": ["p-finally@1.0.0", "", {}, "sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow=="],
 
     "p-limit": ["p-limit@2.3.0", "", { "dependencies": { "p-try": "^2.0.0" } }, "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w=="],
@@ -16900,6 +16962,10 @@
     "puppeteer-core": ["puppeteer-core@24.42.0", "", { "dependencies": { "@puppeteer/browsers": "2.13.0", "chromium-bidi": "14.0.0", "debug": "^4.4.3", "devtools-protocol": "0.0.1595872", "typed-query-selector": "^2.12.1", "webdriver-bidi-protocol": "0.4.1", "ws": "^8.19.0" } }, "sha512-T4zXokk/izH01fYPhyyev1A4piWiOKrYq7CUFpdoYQxmOnXoV6YjUabmfIjCYkNspSoAXIxRid3Tw+Vg0fthYg=="],
 
     "pure-color": ["pure-color@1.3.0", "", {}, "sha512-QFADYnsVoBMw1srW7OVKEYjG+MbIa49s54w1MA1EDY6r2r/sTcKKYqRX1f4GYvnXP7eN/Pe9HFcX+hwzmrXRHA=="],
+
+    "pvtsutils": ["pvtsutils@1.3.6", "", { "dependencies": { "tslib": "^2.8.1" } }, "sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg=="],
+
+    "pvutils": ["pvutils@1.2.0", "", {}, "sha512-BbubeCEyTuQjVMakvJQ/Sxbc93F2pwmbsxONT/ZRrwU7Ua38d8unYTwXpTVLAKJ4BDuH9IGztCjQcd/N/39Dvg=="],
 
     "qrcode": ["qrcode@1.5.4", "", { "dependencies": { "dijkstrajs": "^1.0.1", "pngjs": "^5.0.0", "yargs": "^15.3.1" }, "bin": { "qrcode": "bin/qrcode" } }, "sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg=="],
 
@@ -17541,6 +17607,8 @@
 
     "tsx": ["tsx@4.21.0", "", { "dependencies": { "esbuild": "~0.27.0", "get-tsconfig": "^4.7.5" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "bin": { "tsx": "dist/cli.mjs" } }, "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw=="],
 
+    "tsyringe": ["tsyringe@4.10.0", "", { "dependencies": { "tslib": "^1.9.3" } }, "sha512-axr3IdNuVIxnaK5XGEUFTu3YmAQ6lllgrvqfEoR16g/HGnYY/6We4oWENtAnzK6/LpJ2ur9PAb80RBt7/U4ugw=="],
+
     "tunnel": ["tunnel@0.0.6", "", {}, "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg=="],
 
     "tunnel-agent": ["tunnel-agent@0.6.0", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w=="],
@@ -17696,6 +17764,8 @@
     "vfile-message": ["vfile-message@4.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-stringify-position": "^4.0.0" } }, "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw=="],
 
     "victory-vendor": ["victory-vendor@36.9.2", "", { "dependencies": { "@types/d3-array": "^3.0.3", "@types/d3-ease": "^3.0.0", "@types/d3-interpolate": "^3.0.1", "@types/d3-scale": "^4.0.2", "@types/d3-shape": "^3.1.0", "@types/d3-time": "^3.0.0", "@types/d3-timer": "^3.0.0", "d3-array": "^3.1.6", "d3-ease": "^3.0.1", "d3-interpolate": "^3.0.1", "d3-scale": "^4.0.2", "d3-shape": "^3.1.0", "d3-time": "^3.0.0", "d3-timer": "^3.0.1" } }, "sha512-PnpQQMuxlwYdocC8fIJqVXvkeViHYzotI+NJrCuav0ZYFoq912ZHBk3mCeuj+5/VpodOjPe1z0Fk2ihgzlXqjQ=="],
+
+    "viem": ["viem@2.55.13", "", { "dependencies": { "@noble/curves": "1.9.1", "@noble/hashes": "1.8.0", "@scure/bip32": "1.7.0", "@scure/bip39": "1.6.0", "abitype": "1.2.3", "isows": "1.0.7", "ox": "0.14.33", "ws": "8.21.0" }, "peerDependencies": { "typescript": ">=5.0.4" }, "optionalPeers": ["typescript"] }, "sha512-Rt1NAsdtTdvJgqaCxsv2TuO55xv2d2dKEuRuzrg34xMGxvTSFOX0iIFvEfymPvh+fwN2tbgEU2JwN0YHOVM+Bg=="],
 
     "vinyl": ["vinyl@3.0.1", "", { "dependencies": { "clone": "^2.1.2", "remove-trailing-separator": "^1.1.0", "replace-ext": "^2.0.0", "teex": "^1.0.1" } }, "sha512-0QwqXteBNXgnLCdWdvPQBX6FXRHtIH3VhJPTd5Lwn28tJXc34YqSCWUmkOvtJHBmB3gGoPtrOKk3Ts8/kEZ9aA=="],
 
@@ -19229,6 +19299,30 @@
 
     "@pdf-lib/upng/pako": ["pako@1.0.11", "", {}, "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="],
 
+    "@peculiar/asn1-cms/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "@peculiar/asn1-csr/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "@peculiar/asn1-ecc/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "@peculiar/asn1-pfx/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "@peculiar/asn1-pkcs8/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "@peculiar/asn1-pkcs9/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "@peculiar/asn1-rsa/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "@peculiar/asn1-schema/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "@peculiar/asn1-x509/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "@peculiar/asn1-x509-attr/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "@peculiar/utils/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "@peculiar/x509/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
     "@playwright/test/playwright": ["playwright@1.54.1", "", { "dependencies": { "playwright-core": "1.54.1" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-peWpSwIBmSLi6aW2auvrUtf2DqY16YYcCMO8rTVx486jKmDTJg7UAhyrraP98GB8BoPURZP8+nxO7TSd4cPr5g=="],
 
     "@pnpm/network.ca-file/graceful-fs": ["graceful-fs@4.2.10", "", {}, "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA=="],
@@ -19402,6 +19496,10 @@
     "@scrapeless-ai/sdk/form-data": ["form-data@4.0.5", "", { "dependencies": { "asynckit": "^0.4.0", "combined-stream": "^1.0.8", "es-set-tostringtag": "^2.1.0", "hasown": "^2.0.2", "mime-types": "^2.1.12" } }, "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w=="],
 
     "@scrapeless-ai/sdk/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
+    "@scure/bip32/@noble/curves": ["@noble/curves@1.9.1", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA=="],
+
+    "@scure/bip32/@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
 
     "@scure/bip39/@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
 
@@ -19609,6 +19707,10 @@
 
     "@vitest/snapshot/pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
 
+    "@zkp2p/cash/zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
+
+    "@zkp2p/sdk/ox": ["ox@0.11.3", "", { "dependencies": { "@adraffy/ens-normalize": "^1.11.0", "@noble/ciphers": "^1.3.0", "@noble/curves": "1.9.1", "@noble/hashes": "^1.8.0", "@scure/bip32": "^1.7.0", "@scure/bip39": "^1.6.0", "abitype": "^1.2.3", "eventemitter3": "5.0.1" }, "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-1bWYGk/xZel3xro3l8WGg6eq4YEKlaqvyMtVhfMFpbJzK2F6rj4EDRtqDCWVEJMkzcmEi9uW2QxsqELokOlarw=="],
+
     "aggregate-error/clean-stack": ["clean-stack@2.2.0", "", {}, "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A=="],
 
     "ai/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@5.0.16", "", { "dependencies": { "@ai-sdk/provider": "4.0.4", "@standard-schema/spec": "^1.1.0", "@workflow/serde": "4.1.0", "eventsource-parser": "^3.0.8", "undici": "^7.28.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-LWDrmYWkZoAJwMbToUglpR6AmgvtnNtCCGeU9MKlXiSV3Yiu4u73/pVA18sQAAe3kZtCRBY9P31lAfnPekWWyg=="],
@@ -19672,6 +19774,8 @@
     "aria-hidden/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "asn1.js/bn.js": ["bn.js@4.12.3", "", {}, "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g=="],
+
+    "asn1js/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "ast-kit/pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
 
@@ -20237,6 +20341,14 @@
 
     "openai/@types/node": ["@types/node@18.19.130", "", { "dependencies": { "undici-types": "~5.26.4" } }, "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg=="],
 
+    "ox/@adraffy/ens-normalize": ["@adraffy/ens-normalize@1.11.1", "", {}, "sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ=="],
+
+    "ox/@noble/curves": ["@noble/curves@1.9.1", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA=="],
+
+    "ox/@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
+
+    "ox/eventemitter3": ["eventemitter3@5.0.1", "", {}, "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="],
+
     "p-locate/p-limit": ["p-limit@3.1.0", "", { "dependencies": { "yocto-queue": "^0.1.0" } }, "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ=="],
 
     "p-queue/eventemitter3": ["eventemitter3@4.0.7", "", {}, "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="],
@@ -20280,6 +20392,8 @@
     "proxy-chain/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "psl/punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
+
+    "pvtsutils/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "qrcode/pngjs": ["pngjs@5.0.0", "", {}, "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw=="],
 
@@ -20511,6 +20625,8 @@
 
     "tsx/esbuild": ["esbuild@0.27.7", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.7", "@esbuild/android-arm": "0.27.7", "@esbuild/android-arm64": "0.27.7", "@esbuild/android-x64": "0.27.7", "@esbuild/darwin-arm64": "0.27.7", "@esbuild/darwin-x64": "0.27.7", "@esbuild/freebsd-arm64": "0.27.7", "@esbuild/freebsd-x64": "0.27.7", "@esbuild/linux-arm": "0.27.7", "@esbuild/linux-arm64": "0.27.7", "@esbuild/linux-ia32": "0.27.7", "@esbuild/linux-loong64": "0.27.7", "@esbuild/linux-mips64el": "0.27.7", "@esbuild/linux-ppc64": "0.27.7", "@esbuild/linux-riscv64": "0.27.7", "@esbuild/linux-s390x": "0.27.7", "@esbuild/linux-x64": "0.27.7", "@esbuild/netbsd-arm64": "0.27.7", "@esbuild/netbsd-x64": "0.27.7", "@esbuild/openbsd-arm64": "0.27.7", "@esbuild/openbsd-x64": "0.27.7", "@esbuild/openharmony-arm64": "0.27.7", "@esbuild/sunos-x64": "0.27.7", "@esbuild/win32-arm64": "0.27.7", "@esbuild/win32-ia32": "0.27.7", "@esbuild/win32-x64": "0.27.7" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w=="],
 
+    "tsyringe/tslib": ["tslib@1.14.1", "", {}, "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="],
+
     "type-is/mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
 
     "typeorm/dayjs": ["dayjs@1.11.21", "", {}, "sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA=="],
@@ -20556,6 +20672,12 @@
     "vfile-message/@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
 
     "vfile-message/unist-util-stringify-position": ["unist-util-stringify-position@4.0.0", "", { "dependencies": { "@types/unist": "^3.0.0" } }, "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ=="],
+
+    "viem/@noble/curves": ["@noble/curves@1.9.1", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA=="],
+
+    "viem/@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
+
+    "viem/ws": ["ws@8.21.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g=="],
 
     "vinyl-contents/bl": ["bl@5.1.0", "", { "dependencies": { "buffer": "^6.0.3", "inherits": "^2.0.4", "readable-stream": "^3.4.0" } }, "sha512-tv1ZJHLfTDnXE6tMHv73YgSJaWR2AFuPwMntBe7XL/GBFHnT0CLnsHMogfk5+GzCDC5ZWarSCYaIGATZt9dNsQ=="],
 
@@ -21036,6 +21158,14 @@
     "@types/ssh2/@types/node/undici-types": ["undici-types@5.26.5", "", {}, "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="],
 
     "@typescript-eslint/typescript-estree/minimatch/brace-expansion": ["brace-expansion@2.1.0", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w=="],
+
+    "@zkp2p/sdk/ox/@adraffy/ens-normalize": ["@adraffy/ens-normalize@1.11.1", "", {}, "sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ=="],
+
+    "@zkp2p/sdk/ox/@noble/curves": ["@noble/curves@1.9.1", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA=="],
+
+    "@zkp2p/sdk/ox/@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
+
+    "@zkp2p/sdk/ox/eventemitter3": ["eventemitter3@5.0.1", "", {}, "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="],
 
     "ai-gateway-provider/@ai-sdk/amazon-bedrock/@smithy/eventstream-codec": ["@smithy/eventstream-codec@4.2.14", "", { "dependencies": { "@aws-crypto/crc32": "5.2.0", "@smithy/types": "^4.14.1", "@smithy/util-hex-encoding": "^4.2.2", "tslib": "^2.6.2" } }, "sha512-erZq0nOIpzfeZdCyzZjdJb4nVSKLUmSkaQUVkRGQTXs30gyUGeKnrYEg+Xe1W5gE3aReS7IgsvANwVPxSzY6Pw=="],
 

--- a/packages/pieces/community/peer-cash/.eslintrc.json
+++ b/packages/pieces/community/peer-cash/.eslintrc.json
@@ -1,0 +1,32 @@
+{
+  "extends": ["../../../../.eslintrc.base.json"],
+  "ignorePatterns": ["!**/*"],
+  "overrides": [
+    {
+      "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.ts", "*.tsx"],
+      "rules": {
+        "no-restricted-imports": [
+          "error",
+          {
+            "patterns": [
+              "lodash",
+              "lodash/*",
+              "@activepieces/core-*",
+              "@activepieces/server*",
+              "@activepieces/engine",
+              "@activepieces/shared"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "files": ["*.js", "*.jsx"],
+      "rules": {}
+    }
+  ]
+}

--- a/packages/pieces/community/peer-cash/README.md
+++ b/packages/pieces/community/peer-cash/README.md
@@ -1,0 +1,3 @@
+# Peer Cash
+
+Cash out Base USDC to supported fiat payment platforms at the live oracle rate. The piece prepares unsigned transactions for the Activepieces host to inspect, sign, and submit. It never accepts private keys or broadcasts transactions.

--- a/packages/pieces/community/peer-cash/package.json
+++ b/packages/pieces/community/peer-cash/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@activepieces/piece-peer-cash",
+  "version": "0.1.0",
+  "main": "./dist/src/index.js",
+  "types": "./dist/src/index.d.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.lib.json && cp package.json dist/",
+    "bundle": "node ../../../../dist/packages/cli/src/index.js pieces bundle",
+    "lint": "eslint 'src/**/*.ts'"
+  },
+  "dependencies": {
+    "@activepieces/pieces-framework": "workspace:*",
+    "@zkp2p/cash": "0.4.9",
+    "viem": "2.55.13"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
+  }
+}

--- a/packages/pieces/community/peer-cash/src/index.ts
+++ b/packages/pieces/community/peer-cash/src/index.ts
@@ -1,0 +1,37 @@
+import {
+  createPiece,
+  PieceAuth,
+  PieceCategory,
+} from '@activepieces/pieces-framework';
+import { estimateCashOut } from './lib/actions/estimate-cash-out';
+import { finalizeCashOut } from './lib/actions/finalize-cash-out';
+import { getCapabilities } from './lib/actions/get-capabilities';
+import { getOrder } from './lib/actions/get-order';
+import { listOrders } from './lib/actions/list-orders';
+import { prepareAccessPolicy } from './lib/actions/prepare-access-policy';
+import { prepareCashOut } from './lib/actions/prepare-cash-out';
+import { prepareTopUp } from './lib/actions/prepare-top-up';
+import { prepareWithdrawal } from './lib/actions/prepare-withdrawal';
+
+export const peerCash = createPiece({
+  displayName: 'Peer Cash',
+  description:
+    'Cash out Base USDC to fiat at the live oracle rate with unsigned transactions.',
+  auth: PieceAuth.None(),
+  minimumSupportedRelease: '0.36.1',
+  logoUrl: 'https://cdn.activepieces.com/pieces/peer-cash.png',
+  categories: [PieceCategory.PAYMENT_PROCESSING],
+  authors: ['ADWilkinson'],
+  actions: [
+    getCapabilities,
+    estimateCashOut,
+    prepareCashOut,
+    finalizeCashOut,
+    prepareAccessPolicy,
+    getOrder,
+    listOrders,
+    prepareWithdrawal,
+    prepareTopUp,
+  ],
+  triggers: [],
+});

--- a/packages/pieces/community/peer-cash/src/lib/actions/estimate-cash-out.ts
+++ b/packages/pieces/community/peer-cash/src/lib/actions/estimate-cash-out.ts
@@ -1,0 +1,53 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import {
+  assertPlatformCurrency,
+  currencyProperty,
+  getCashClient,
+  parseUsdc,
+  platformProperty,
+  resolveCurrency,
+  toSerializable,
+} from '../common';
+
+export const estimateCashOut = createAction({
+  name: 'estimate_cash_out',
+  displayName: 'Estimate Cash Out',
+  description:
+    'Estimate fiat proceeds at the current oracle rate without creating an order.',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Returns a read-only Peer Cash oracle estimate for a Base USDC amount and fiat currency, with optional recent fill timing for a payout platform. The rate is indicative and binds only when a buyer fills the order. Idempotent for the same live market state.',
+    idempotent: true,
+  },
+  props: {
+    amount: Property.ShortText({
+      displayName: 'USDC Amount',
+      description: 'Base USDC amount in human units, for example 25.50.',
+      required: true,
+    }),
+    currency: currencyProperty(),
+    platform: platformProperty(false),
+    includeEta: Property.Checkbox({
+      displayName: 'Include Recent Fill Estimate',
+      required: false,
+      defaultValue: true,
+    }),
+  },
+  async run(context) {
+    const currency = resolveCurrency(context.propsValue.currency);
+    const platform = context.propsValue.platform;
+    if (platform) {
+      assertPlatformCurrency(platform, currency);
+    }
+    const result = await getCashClient().estimate(
+      {
+        amount: parseUsdc(context.propsValue.amount, 'USDC amount'),
+        currency,
+        platform,
+      },
+      { includeEta: context.propsValue.includeEta }
+    );
+    return toSerializable(result);
+  },
+});

--- a/packages/pieces/community/peer-cash/src/lib/actions/finalize-cash-out.ts
+++ b/packages/pieces/community/peer-cash/src/lib/actions/finalize-cash-out.ts
@@ -19,11 +19,6 @@ export const finalizeCashOut = createAction({
       displayName: 'Create Deposit Transaction Hash',
       required: true,
     }),
-    rpcUrl: Property.ShortText({
-      displayName: 'Base RPC URL',
-      description: 'Optional Base RPC override.',
-      required: false,
-    }),
   },
   async run(context) {
     const transactionHash = context.propsValue.transactionHash;
@@ -32,7 +27,7 @@ export const finalizeCashOut = createAction({
     }
     const publicClient = createPublicClient({
       chain: base,
-      transport: http(context.propsValue.rpcUrl),
+      transport: http(),
     });
     const receipt = await publicClient.getTransactionReceipt({
       hash: transactionHash,

--- a/packages/pieces/community/peer-cash/src/lib/actions/finalize-cash-out.ts
+++ b/packages/pieces/community/peer-cash/src/lib/actions/finalize-cash-out.ts
@@ -1,0 +1,43 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { base } from 'viem/chains';
+import { createPublicClient, http, isHash } from 'viem';
+import { getCashClient, toSerializable } from '../common';
+
+export const finalizeCashOut = createAction({
+  name: 'finalize_cash_out',
+  displayName: 'Finalize Confirmed Cash Out',
+  description:
+    'Resolve a confirmed create-deposit transaction into a resumable cash-out order.',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Fetches a confirmed Base create-deposit receipt by transaction hash and resolves it into the Peer Cash deposit ID and resumable order state. Use after the createDeposit transaction from Prepare Cash Out confirms. Read-only and idempotent.',
+    idempotent: true,
+  },
+  props: {
+    transactionHash: Property.ShortText({
+      displayName: 'Create Deposit Transaction Hash',
+      required: true,
+    }),
+    rpcUrl: Property.ShortText({
+      displayName: 'Base RPC URL',
+      description: 'Optional Base RPC override.',
+      required: false,
+    }),
+  },
+  async run(context) {
+    const transactionHash = context.propsValue.transactionHash;
+    if (!isHash(transactionHash)) {
+      throw new Error('Enter a valid transaction hash');
+    }
+    const publicClient = createPublicClient({
+      chain: base,
+      transport: http(context.propsValue.rpcUrl),
+    });
+    const receipt = await publicClient.getTransactionReceipt({
+      hash: transactionHash,
+    });
+    const result = getCashClient().finalizePreparedCashout(receipt);
+    return toSerializable(result);
+  },
+});

--- a/packages/pieces/community/peer-cash/src/lib/actions/get-capabilities.ts
+++ b/packages/pieces/community/peer-cash/src/lib/actions/get-capabilities.ts
@@ -1,0 +1,30 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { getCashClient, toSerializable } from '../common';
+
+export const getCapabilities = createAction({
+  name: 'get_capabilities',
+  displayName: 'Get Capabilities',
+  description:
+    'List supported payout platforms, fiat currencies, amount bounds, and source assets.',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Discovers the current Peer Cash payout platforms, fiat currencies, amount bounds, pricing model, and optionally live Relay source assets. Read-only and idempotent.',
+    idempotent: true,
+  },
+  props: {
+    includeRelaySources: Property.Checkbox({
+      displayName: 'Include Relay Source Assets',
+      description:
+        'Load live EVM source chains and tokens in addition to Base USDC.',
+      required: false,
+      defaultValue: false,
+    }),
+  },
+  async run(context) {
+    const result = context.propsValue.includeRelaySources
+      ? await getCashClient().capabilities({ includeRelaySources: true })
+      : getCashClient().capabilities();
+    return toSerializable(result);
+  },
+});

--- a/packages/pieces/community/peer-cash/src/lib/actions/get-order.ts
+++ b/packages/pieces/community/peer-cash/src/lib/actions/get-order.ts
@@ -1,0 +1,24 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { getCashClient, toSerializable } from '../common';
+
+export const getOrder = createAction({
+  name: 'get_order',
+  displayName: 'Get Order',
+  description: 'Get the current lifecycle state of a Peer Cash order.',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Returns the current on-chain and indexer-derived lifecycle state, fills, balances, payout pricing, and next actions for a Peer Cash deposit ID. Read-only and idempotent.',
+    idempotent: true,
+  },
+  props: {
+    depositId: Property.ShortText({
+      displayName: 'Deposit ID',
+      required: true,
+    }),
+  },
+  async run(context) {
+    const result = await getCashClient().order(context.propsValue.depositId);
+    return toSerializable(result);
+  },
+});

--- a/packages/pieces/community/peer-cash/src/lib/actions/list-orders.ts
+++ b/packages/pieces/community/peer-cash/src/lib/actions/list-orders.ts
@@ -1,0 +1,43 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { isAddress } from 'viem';
+import { getCashClient, toSerializable } from '../common';
+
+export const listOrders = createAction({
+  name: 'list_orders',
+  displayName: 'List Orders',
+  description: 'List Peer Cash orders owned by a Base address.',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Lists Peer Cash orders for a Base wallet, optionally limited to orders still needing attention. Returns indexer-native order state without signing or mutation. Read-only and idempotent.',
+    idempotent: true,
+  },
+  props: {
+    owner: Property.ShortText({
+      displayName: 'Owner Address',
+      description: 'Base wallet address that owns the deposits.',
+      required: true,
+    }),
+    inFlightOnly: Property.Checkbox({
+      displayName: 'In-Flight Orders Only',
+      required: false,
+      defaultValue: false,
+    }),
+    limit: Property.Number({
+      displayName: 'Limit',
+      description: 'Maximum deposits to scan.',
+      required: false,
+      defaultValue: 100,
+    }),
+  },
+  async run(context) {
+    if (!isAddress(context.propsValue.owner)) {
+      throw new Error('Enter a valid Base owner address');
+    }
+    const result = await getCashClient().orders(context.propsValue.owner, {
+      inFlight: context.propsValue.inFlightOnly,
+      limit: context.propsValue.limit,
+    });
+    return toSerializable(result);
+  },
+});

--- a/packages/pieces/community/peer-cash/src/lib/actions/prepare-access-policy.ts
+++ b/packages/pieces/community/peer-cash/src/lib/actions/prepare-access-policy.ts
@@ -1,0 +1,28 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { getCashClient, toSerializable } from '../common';
+
+export const prepareAccessPolicy = createAction({
+  name: 'prepare_access_policy',
+  displayName: 'Prepare Access Policy',
+  description:
+    'Prepare the unsigned access-policy transaction required by restricted payout methods.',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Prepares an unsigned access-policy transaction for a confirmed Peer Cash deposit when Prepare Cash Out returned accessPolicyRequired. The host must inspect, sign, submit, and confirm it before the order can fill. Read-only on-chain and idempotent.',
+    idempotent: true,
+  },
+  props: {
+    depositId: Property.ShortText({
+      displayName: 'Deposit ID',
+      description:
+        'Composite Peer Cash deposit ID returned after finalization.',
+      required: true,
+    }),
+  },
+  async run(context) {
+    return toSerializable(
+      getCashClient().prepareAccessPolicy(context.propsValue.depositId)
+    );
+  },
+});

--- a/packages/pieces/community/peer-cash/src/lib/actions/prepare-cash-out.ts
+++ b/packages/pieces/community/peer-cash/src/lib/actions/prepare-cash-out.ts
@@ -1,0 +1,91 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import {
+  assertPlatformCurrency,
+  currencyProperty,
+  getCashClient,
+  parseOptionalUsdc,
+  parseUsdc,
+  platformProperty,
+  referralCodeProperty,
+  resolveCurrency,
+  toSerializable,
+} from '../common';
+
+export const prepareCashOut = createAction({
+  name: 'prepare_cash_out',
+  displayName: 'Prepare Cash Out',
+  description:
+    'Prepare unsigned Base transactions for a market-rate fiat cash-out.',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Registers payout details and prepares unsigned approve and create-deposit transactions for a Base USDC cash-out. The host must inspect, sign, and submit transactions in order. Some payout methods require prior payee verification or a follow-up access-policy transaction. Not idempotent because it can register payee details.',
+    idempotent: false,
+  },
+  props: {
+    amount: Property.ShortText({
+      displayName: 'USDC Amount',
+      description: 'Base USDC amount in human units, for example 25.50.',
+      required: true,
+    }),
+    platform: platformProperty(true),
+    currency: currencyProperty(),
+    payee: Property.ShortText({
+      displayName: 'Payee Handle',
+      description:
+        'Recipient handle or account identifier for the selected payment platform.',
+      required: true,
+    }),
+    minimumFillAmount: Property.ShortText({
+      displayName: 'Minimum Fill Amount',
+      description:
+        'Optional minimum partial fill in USDC. Set this together with the maximum.',
+      required: false,
+    }),
+    maximumFillAmount: Property.ShortText({
+      displayName: 'Maximum Fill Amount',
+      description:
+        'Optional maximum partial fill in USDC. Set this together with the minimum.',
+      required: false,
+    }),
+    referralCode: referralCodeProperty(),
+  },
+  async run(context) {
+    const currency = resolveCurrency(context.propsValue.currency);
+    const platform = context.propsValue.platform;
+    if (!platform) {
+      throw new Error('Select a payment platform');
+    }
+    assertPlatformCurrency(platform, currency);
+    const minimumFillAmount = parseOptionalUsdc(
+      context.propsValue.minimumFillAmount,
+      'Minimum fill amount'
+    );
+    const maximumFillAmount = parseOptionalUsdc(
+      context.propsValue.maximumFillAmount,
+      'Maximum fill amount'
+    );
+    if (
+      (minimumFillAmount === undefined) !==
+      (maximumFillAmount === undefined)
+    ) {
+      throw new Error('Set both minimum and maximum fill amounts, or neither');
+    }
+    const intentAmountRange =
+      minimumFillAmount !== undefined && maximumFillAmount !== undefined
+        ? { min: minimumFillAmount, max: maximumFillAmount }
+        : undefined;
+    const result = await getCashClient(context.propsValue.referralCode).prepare(
+      {
+        amount: parseUsdc(context.propsValue.amount, 'USDC amount'),
+        receive: {
+          platform,
+          currency,
+          payee: context.propsValue.payee,
+        },
+        intentAmountRange,
+      }
+    );
+    return toSerializable(result);
+  },
+});

--- a/packages/pieces/community/peer-cash/src/lib/actions/prepare-top-up.ts
+++ b/packages/pieces/community/peer-cash/src/lib/actions/prepare-top-up.ts
@@ -1,0 +1,33 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { getCashClient, parseUsdc, toSerializable } from '../common';
+
+export const prepareTopUp = createAction({
+  name: 'prepare_top_up',
+  displayName: 'Prepare Top Up',
+  description:
+    'Prepare unsigned transactions to add Base USDC to a live order.',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Checks a live Peer Cash order and prepares unsigned approve and add-funds transactions to increase its Base USDC balance while keeping the same payout details and market-rate pricing. The host must inspect, sign, and submit transactions in order. Read-only on-chain and idempotent for unchanged state.',
+    idempotent: true,
+  },
+  props: {
+    depositId: Property.ShortText({
+      displayName: 'Deposit ID',
+      required: true,
+    }),
+    amount: Property.ShortText({
+      displayName: 'USDC Amount',
+      description: 'Top-up amount in human USDC units.',
+      required: true,
+    }),
+  },
+  async run(context) {
+    const result = await getCashClient().prepareTopUp(
+      context.propsValue.depositId,
+      parseUsdc(context.propsValue.amount, 'Top-up amount')
+    );
+    return toSerializable(result);
+  },
+});

--- a/packages/pieces/community/peer-cash/src/lib/actions/prepare-withdrawal.ts
+++ b/packages/pieces/community/peer-cash/src/lib/actions/prepare-withdrawal.ts
@@ -1,0 +1,38 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { getCashClient, parseOptionalUsdc, toSerializable } from '../common';
+
+export const prepareWithdrawal = createAction({
+  name: 'prepare_withdrawal',
+  displayName: 'Prepare Withdrawal',
+  description:
+    'Prepare unsigned transactions to withdraw unlocked USDC from an order.',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Checks a Peer Cash order and prepares unsigned transactions to withdraw an optional partial USDC amount or close the order fully. It may include pruning expired buyer intents first. The host must inspect, sign, and submit transactions in order. Read-only on-chain and idempotent for unchanged state.',
+    idempotent: true,
+  },
+  props: {
+    depositId: Property.ShortText({
+      displayName: 'Deposit ID',
+      required: true,
+    }),
+    amount: Property.ShortText({
+      displayName: 'Partial USDC Amount',
+      description:
+        'Leave blank to close the order and withdraw all unlocked USDC.',
+      required: false,
+    }),
+  },
+  async run(context) {
+    const amount = parseOptionalUsdc(
+      context.propsValue.amount,
+      'Partial withdrawal amount'
+    );
+    const result = await getCashClient().prepareWithdraw(
+      context.propsValue.depositId,
+      { amount }
+    );
+    return toSerializable(result);
+  },
+});

--- a/packages/pieces/community/peer-cash/src/lib/common/index.ts
+++ b/packages/pieces/community/peer-cash/src/lib/common/index.ts
@@ -1,0 +1,121 @@
+import {
+  CashClient,
+  CashCapabilities,
+  CurrencyType,
+  createCashClient,
+} from '@zkp2p/cash';
+import { Property } from '@activepieces/pieces-framework';
+import { parseUnits } from 'viem';
+
+const client = createCashClient({
+  environment: 'production',
+  referrer: 'activepieces',
+});
+
+const capabilities = client.capabilities();
+
+export function getCashClient(referralCode?: string): CashClient {
+  if (!referralCode) {
+    return client;
+  }
+  return createCashClient({
+    environment: 'production',
+    referrer: 'activepieces',
+    referralCode,
+  });
+}
+
+export function getCashCapabilities(): CashCapabilities {
+  return capabilities;
+}
+
+export function currencyProperty() {
+  return Property.StaticDropdown({
+    displayName: 'Fiat Currency',
+    description: 'The fiat currency the recipient should receive.',
+    required: true,
+    options: {
+      disabled: false,
+      options: capabilities.currencies.map((currency) => ({
+        label: currency,
+        value: currency,
+      })),
+    },
+  });
+}
+
+export function platformProperty(required: boolean) {
+  return Property.StaticDropdown({
+    displayName: 'Payment Platform',
+    description: 'A payout platform listed by Peer Cash capabilities.',
+    required,
+    options: {
+      disabled: false,
+      options: capabilities.platforms.map((platform) => ({
+        label: platform.platform,
+        value: platform.platform,
+      })),
+    },
+  });
+}
+
+export function referralCodeProperty() {
+  return Property.ShortText({
+    displayName: 'Peer Referral Code',
+    description:
+      'Optional six-character Peer referral code for integration attribution.',
+    required: false,
+  });
+}
+
+export function resolveCurrency(value: string): CurrencyType {
+  const currency = capabilities.currencies.find(
+    (candidate) => candidate === value
+  );
+  if (!currency) {
+    throw new Error(`Unsupported fiat currency: ${value}`);
+  }
+  return currency;
+}
+
+export function assertPlatformCurrency(
+  platformName: string,
+  currency: CurrencyType
+): void {
+  const platform = capabilities.platforms.find(
+    (candidate) => candidate.platform === platformName
+  );
+  if (!platform) {
+    throw new Error(`Unsupported payment platform: ${platformName}`);
+  }
+  if (!platform.currencies.includes(currency)) {
+    throw new Error(`${platformName} does not support ${currency}`);
+  }
+}
+
+export function parseUsdc(value: string, fieldName: string): bigint {
+  const amount = parseUnits(value, capabilities.token.decimals);
+  if (amount <= 0n) {
+    throw new Error(`${fieldName} must be greater than zero`);
+  }
+  return amount;
+}
+
+export function parseOptionalUsdc(
+  value: string | undefined,
+  fieldName: string
+): bigint | undefined {
+  if (!value) {
+    return undefined;
+  }
+  return parseUsdc(value, fieldName);
+}
+
+export function toSerializable(value: unknown): unknown {
+  const serialized: unknown = JSON.parse(
+    JSON.stringify(value, (_key, item: unknown) =>
+      typeof item === 'bigint' ? item.toString() : item
+    )
+  );
+  return serialized;
+}

--- a/packages/pieces/community/peer-cash/tsconfig.json
+++ b/packages/pieces/community/peer-cash/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "es2022",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "noPropertyAccessFromIndexSignature": false
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/packages/pieces/community/peer-cash/tsconfig.lib.json
+++ b/packages/pieces/community/peer-cash/tsconfig.lib.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "baseUrl": ".",
+    "paths": {},
+    "outDir": "./dist",
+    "declaration": true,
+    "declarationMap": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -983,6 +983,9 @@
       "@activepieces/piece-peekshot": [
         "packages/pieces/community/peekshot/src/index.ts"
       ],
+      "@activepieces/piece-peer-cash": [
+        "packages/pieces/community/peer-cash/src/index.ts"
+      ],
       "@activepieces/piece-pendo": [
         "packages/pieces/community/pendo/src/index.ts"
       ],


### PR DESCRIPTION
## Description

Adds a Peer Cash piece for cashing out Base USDC to supported fiat payment platforms at the live oracle rate.

The piece exposes nine actions: capability discovery, cash-out estimates, unsigned cash-out preparation, confirmed-deposit finalization, restricted-method access-policy preparation, order lookup, order listing, unsigned withdrawal preparation, and unsigned top-up preparation.

Mutation actions preserve wallet custody. They return ordered unsigned transactions for the host to inspect, sign, and submit; the piece never accepts private keys or broadcasts transactions. Payout capabilities come from `@zkp2p/cash`, and the piece surfaces identity-attestation and access-policy requirements instead of bypassing them.

## How was this tested?

- `npx turbo run build lint --filter=@activepieces/piece-peer-cash`
- `npm run lint-dev`
- Loaded the piece and verified all nine action registrations.
- Ran the Estimate Cash Out action against production for 10 Base USDC to USD and received a serializable oracle estimate.
- Verified the production capability catalog loads 8 payout platforms and 13 fiat currencies.

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

- [ ] no — reviewed, no security impact
- [x] yes — security-sensitive (call out the risk and mitigation in the description above)
