### PR TITLE
fix(flows): detect conflicting flow edits instead of silently losing changes

### DIFF
--- a/packages/core/utils/src/lib/activepieces-error.ts
+++ b/packages/core/utils/src/lib/activepieces-error.ts
@@ -25,6 +25,7 @@ export type ApErrorParams =
     | ExistingUserErrorParams
     | FlowOperationErrorParams
     | FlowOperationInProgressErrorParams
+    | FlowVersionConflictErrorParams
     | FlowRunRetryOutsideRetentionErrorParams
     | InvalidApiKeyParams
     | InvalidAppConnectionParams
@@ -262,6 +263,11 @@ ErrorCode.FLOW_OPERATION_INVALID,
 export type FlowOperationInProgressErrorParams = BaseErrorParams<
 ErrorCode.FLOW_OPERATION_IN_PROGRESS, {
     message: string
+}>
+
+export type FlowVersionConflictErrorParams = BaseErrorParams<
+ErrorCode.FLOW_VERSION_CONFLICT, {
+    actualVersionUpdated: string
 }>
 
 export type InvalidJwtTokenErrorParams = BaseErrorParams<
@@ -525,6 +531,7 @@ export enum ErrorCode {
     PROJECT_EXTERNAL_ID_ALREADY_EXISTS = 'PROJECT_EXTERNAL_ID_ALREADY_EXISTS',
     FLOW_OPERATION_INVALID = 'FLOW_OPERATION_INVALID',
     FLOW_OPERATION_IN_PROGRESS = 'FLOW_OPERATION_IN_PROGRESS',
+    FLOW_VERSION_CONFLICT = 'FLOW_VERSION_CONFLICT',
     FLOW_RUN_RETRY_OUTSIDE_RETENTION = 'FLOW_RUN_RETRY_OUTSIDE_RETENTION',
     INVALID_API_KEY = 'INVALID_API_KEY',
     INVALID_APP_CONNECTION = 'INVALID_APP_CONNECTION',

--- a/packages/server/api/src/app/flows/flow/flow.controller.ts
+++ b/packages/server/api/src/app/flows/flow/flow.controller.ts
@@ -44,7 +44,7 @@ export const flowController: FastifyPluginAsyncZod = async (app) => {
         },
         schema: {
             tags: ['flows'],
-            description: 'Apply an operation to a flow',
+            description: 'Apply an operation to a flow. Optimistic concurrency: send the x-expected-version-updated header with the flow version `updated` stamp from a previous read to get 409 FLOW_VERSION_CONFLICT instead of overwriting a newer draft version. The check guards flow-version content (steps, trigger, notes, name); operations that only touch the flow row (status, folder, metadata, owner) do not bump the stamp.',
             security: [SERVICE_KEY_SECURITY_OPENAPI],
             body: FlowOperationRequest,
             params: z.object({
@@ -86,12 +86,14 @@ export const flowController: FastifyPluginAsyncZod = async (app) => {
                 projectId: request.projectId,
             })
         }
+        const expectedVersionUpdated = request.headers['x-expected-version-updated']
         return flowService(request.log).update({
             id: request.params.id,
             userId: actorUserId(request),
             platformId: request.principal.platform.id,
             projectId: request.projectId,
             operation: cleanOperation(request.body),
+            expectedVersionUpdated: typeof expectedVersionUpdated === 'string' ? expectedVersionUpdated : undefined,
             previousFlow: flow,
             ip: networkUtils.clientIp(request),
         })

--- a/packages/server/api/src/app/flows/flow/flow.service.ts
+++ b/packages/server/api/src/app/flows/flow/flow.service.ts
@@ -327,10 +327,27 @@ export const flowService = (log: FastifyBaseLogger) => ({
         projectId,
         platformId,
         operation,
+        expectedVersionUpdated,
         previousFlow,
         ip,
         emitEvents = true,
     }: UpdateParams): Promise<PopulatedFlow> {
+        if (!isNil(expectedVersionUpdated)) {
+            const latestVersion = previousFlow?.version ?? await flowVersionService(log).getFlowVersionOrThrow({
+                flowId: id,
+                versionId: undefined,
+                projectId,
+            })
+            const actualVersionUpdated = new Date(latestVersion.updated).toISOString()
+            if (actualVersionUpdated !== expectedVersionUpdated) {
+                throw new ActivepiecesError({
+                    code: ErrorCode.FLOW_VERSION_CONFLICT,
+                    params: {
+                        actualVersionUpdated,
+                    },
+                })
+            }
+        }
         const flowBeforeOperation = emitEvents
             ? previousFlow ?? await this.getOnePopulatedOrThrow({ id, projectId })
             : undefined
@@ -845,6 +862,7 @@ type UpdateParams = EventEmissionParams & {
     userId?: UserId | null
     projectId: ProjectId
     operation: FlowOperationRequest
+    expectedVersionUpdated?: string
     platformId: PlatformId
     previousFlow?: PopulatedFlow
 }

--- a/packages/server/api/src/app/helper/error-handler.ts
+++ b/packages/server/api/src/app/helper/error-handler.ts
@@ -88,6 +88,7 @@ const statusCodeMap: Partial<Record<ErrorCode, StatusCodes>> = {
     [ErrorCode.EXISTING_USER]: StatusCodes.CONFLICT,
     [ErrorCode.EXISTING_ALERT_CHANNEL]: StatusCodes.CONFLICT,
     [ErrorCode.FLOW_OPERATION_IN_PROGRESS]: StatusCodes.CONFLICT,
+    [ErrorCode.FLOW_VERSION_CONFLICT]: StatusCodes.CONFLICT,
     [ErrorCode.AUTHORIZATION]: StatusCodes.FORBIDDEN,
     [ErrorCode.SIGN_UP_DISABLED]: StatusCodes.FORBIDDEN,
     [ErrorCode.PROJECT_EXTERNAL_ID_ALREADY_EXISTS]: StatusCodes.CONFLICT,

--- a/packages/server/api/test/helpers/test-context.ts
+++ b/packages/server/api/test/helpers/test-context.ts
@@ -97,6 +97,7 @@ function buildContext(app: FastifyInstance, data: ContextData): TestContext {
                 url: `/api${url}`,
                 headers: {
                     authorization: `Bearer ${data.token}`,
+                    ...opts?.headers,
                 },
             }
             if (method === 'GET' || method === 'DELETE') {
@@ -148,6 +149,7 @@ type MemberContextParams = {
 
 type RequestOptions = {
     query?: Record<string, string>
+    headers?: Record<string, string>
 }
 
 type ContextData = {

--- a/packages/server/api/test/integration/ce/flows/flow/flow-operations.test.ts
+++ b/packages/server/api/test/integration/ce/flows/flow/flow-operations.test.ts
@@ -3,6 +3,7 @@ import {
     flowOperations,
     FlowOperationType,
     FlowStatus,
+    flowStructureUtil,
     FlowTriggerType,
     FlowVersion,
     FlowVersionState,
@@ -826,6 +827,100 @@ describe('Flow Operations API', () => {
             const body = response?.json()
             expect(body.data).toHaveLength(1)
             expect(body.data[0].id).toBe(mockFlowVersion.id)
+        })
+    })
+
+    describeWithAuth('POST /v1/flows/:id expectedVersionUpdated', () => app!, (setup) => {
+        function addCodeAction({ stepName }: { stepName: string }): unknown {
+            return {
+                type: FlowOperationType.ADD_ACTION,
+                request: {
+                    parentStep: 'trigger',
+                    action: {
+                        type: FlowActionType.CODE,
+                        displayName: `Step ${stepName}`,
+                        name: stepName,
+                        settings: {
+                            input: {},
+                            sourceCode: {
+                                code: 'export const code = async () => { return true; }',
+                                packageJson: '{}',
+                            },
+                        },
+                        valid: true,
+                        skip: false,
+                    },
+                },
+            }
+        }
+
+        function stepNames(flow: PopulatedFlow): string[] {
+            return flowStructureUtil.getAllSteps(flow.version.trigger)
+                .map((step) => step.name)
+                .filter((name) => name !== 'trigger')
+        }
+
+        it('rejects a stale write with 409 FLOW_VERSION_CONFLICT and applies nothing', async () => {
+            const ctx = await setup()
+
+            const createResponse = await ctx.post('/v1/flows', {
+                displayName: 'conflict flow',
+                projectId: ctx.project.id,
+            }, { query: { projectId: ctx.project.id } })
+            expect(createResponse?.statusCode).toBe(StatusCodes.CREATED)
+            const flow: PopulatedFlow = createResponse!.json()
+
+            const staleToken = flow.version.updated
+
+            const firstWrite = await ctx.post(`/v1/flows/${flow.id}`, addCodeAction({ stepName: 'step_a' }), { headers: { 'x-expected-version-updated': staleToken } })
+            expect(firstWrite?.statusCode).toBe(StatusCodes.OK)
+
+            const staleWrite = await ctx.post(`/v1/flows/${flow.id}`, addCodeAction({ stepName: 'step_b' }), { headers: { 'x-expected-version-updated': staleToken } })
+            expect(staleWrite?.statusCode).toBe(StatusCodes.CONFLICT)
+            const errorBody = staleWrite!.json()
+            expect(errorBody.code).toBe('FLOW_VERSION_CONFLICT')
+            expect(errorBody.params.actualVersionUpdated).not.toBe(staleToken)
+
+            const reload = await ctx.get(`/v1/flows/${flow.id}`, {})
+            expect(stepNames(reload!.json())).toEqual(['step_a'])
+        })
+
+        it('accepts a write carrying the current version updated stamp', async () => {
+            const ctx = await setup()
+
+            const createResponse = await ctx.post('/v1/flows', {
+                displayName: 'fresh token flow',
+                projectId: ctx.project.id,
+            }, { query: { projectId: ctx.project.id } })
+            const flow: PopulatedFlow = createResponse!.json()
+
+            const first = await ctx.post(`/v1/flows/${flow.id}`, addCodeAction({ stepName: 'step_a' }), { headers: { 'x-expected-version-updated': flow.version.updated } })
+            expect(first?.statusCode).toBe(StatusCodes.OK)
+            const afterFirst: PopulatedFlow = first!.json()
+
+            const second = await ctx.post(`/v1/flows/${flow.id}`, addCodeAction({ stepName: 'step_b' }), { headers: { 'x-expected-version-updated': afterFirst.version.updated } })
+            expect(second?.statusCode).toBe(StatusCodes.OK)
+
+            const reload = await ctx.get(`/v1/flows/${flow.id}`, {})
+            expect(stepNames(reload!.json()).sort()).toEqual(['step_a', 'step_b'])
+        })
+
+        it('keeps legacy last-write-wins behavior when the field is absent', async () => {
+            const ctx = await setup()
+
+            const createResponse = await ctx.post('/v1/flows', {
+                displayName: 'legacy flow',
+                projectId: ctx.project.id,
+            }, { query: { projectId: ctx.project.id } })
+            const flow: PopulatedFlow = createResponse!.json()
+
+            const first = await ctx.post(`/v1/flows/${flow.id}`, addCodeAction({ stepName: 'step_a' }))
+            expect(first?.statusCode).toBe(StatusCodes.OK)
+            const second = await ctx.post(`/v1/flows/${flow.id}`, addCodeAction({ stepName: 'step_b' }))
+            expect(second?.statusCode).toBe(StatusCodes.OK)
+
+            const reload = await ctx.get(`/v1/flows/${flow.id}`, {})
+            expect(stepNames(reload!.json()).sort()).toEqual(['step_a', 'step_b'])
         })
     })
 })


### PR DESCRIPTION
Fixes [GIT-1745](https://linear.app/activepieces/issue/GIT-1745)
Closes #14795

## Description

Two clients editing the same draft flow silently overwrite each other; every write returns HTTP 200. The loss is deterministic for snapshot writers (GET flow, modify locally, POST `IMPORT_FLOW`): the second caller erases the first caller's edit every time. Reported via Pylon 5634; the "X is editing this flow" banner is client-side only and nothing on the write path rejects stale writes.

This PR adds opt-in optimistic concurrency to `POST /v1/flows/:id`: send the `x-expected-version-updated` header (the flow version `updated` stamp from a previous read) and the API returns **409 `FLOW_VERSION_CONFLICT`** with `params.actualVersionUpdated` instead of overwriting a newer draft version. Requests without the header behave exactly as before.

- `flow.controller.ts` — read the optional header, forward to the service; route description documents the contract and its scope.
- `flow.service.ts` — before applying the operation, compare the header against the latest version's `updated` (normalized ISO; reuses the already-loaded `previousFlow.version`, no extra query); mismatch → 409.
- `activepieces-error.ts` + `error-handler.ts` — new `FLOW_VERSION_CONFLICT` code mapped to 409.

**Product decision embedded:** conflict detection is opt-in (no header → legacy last-write-wins); alternative considered: unconditional enforcement, rejected as breaking for existing API clients.

## How was this tested?

- Regression test, red-first: on the base commit the stale-token write returns 200 (test fails); with the fix it returns 409. 6 tests (3 scenarios × USER/SERVICE principals) in `flow-operations.test.ts`.
- Full CE flows integration suite: 154/154. `npm run lint-dev`: 0 errors.
- Live drive on a standalone API + real Postgres 14: fresh token → 200; stale token → 409 `FLOW_VERSION_CONFLICT`; refetch-and-retry → 200; no header → 200 (legacy).
- Repro: stale-snapshot `IMPORT_FLOW` silently erases the other caller's edit, both callers get 200 — full steps in the Reproduction block.
- Visual: none - backend-only, no user-visible change (no web client sends the header yet).
- Other affected paths: checked - all ~18 internal `flowService.update` callers (MCP tools, git-sync, worker RPC) omit the new optional param and are unchanged. Follow-ups noted on the ticket: builder/MCP adoption of the header, and closing the in-request check-then-act window with a conditional UPDATE if unconditional enforcement is later wanted.

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact

<details>
<summary>Plan & reasoning</summary>

## Plan

- Smallest non-breaking conflict primitive: an opt-in precondition header checked in `flowService.update`, the single choke point every flow operation passes through (six operation types never reach `flowVersionService.applyOperation`, so deeper placement would cover less).
- Header instead of a body field: keeps the public `FlowOperationRequest` schema and generated OpenAPI untouched, and keeps the token out of audit-event payloads.
- Token is the version `updated` stamp because the draft version row is updated in place (same id across edits), so the version id alone cannot detect in-draft staleness.
- Footprint: estimated 5 files ~35 lines; actual 5 product files, 28 lines.

## Non-happy scenarios considered

- Editing a published flow with the LOCKED version's stamp → guard compares the latest version before draft recreation, so the write passes and the draft is recreated as before.
- Duplicate header → Node joins values into one comma-separated string → mismatch → 409 (fails closed).
- Flow-row-only operations (status, folder, metadata, owner) never bump the stamp; the route description states this scope explicitly.
- Same-token concurrent writes inside one request round-trip: the check-then-act window remains open (the guard targets stale snapshots, which is the reproduced data-loss mechanism). Closing it fully needs a conditional `UPDATE ... WHERE updated = :expected` at the save; noted on the ticket as the follow-up for unconditional enforcement.

## Alternatives rejected

- Unconditional enforcement / server-side lock check → behavior change for existing API clients (breaking), needs a product decision.
- Optional field on the `FlowOperationRequest` union → touches 20+ union members or wraps the public body schema in an `allOf`, churning OpenAPI docs and SDKs.
- Revision column + conditional UPDATE → schema migration, deferred with the enforcement follow-up.

</details>

<details>
<summary>Reproduction</summary>

## Environment

- Standalone Activepieces API from this branch (`npx tsx packages/server/api/src/bootstrap.ts`), `AP_EDITION=ce`, `AP_ENVIRONMENT=dev`, `AP_REDIS_TYPE=MEMORY`, `AP_PIECES_SYNC_MODE=NONE`
- Throwaway Postgres 14 in Docker: `docker run -d --name ap-verify-pg -e POSTGRES_PASSWORD=ap -e POSTGRES_USER=ap -e POSTGRES_DB=activepieces -p 54329:5432 postgres:14`
- Auth: dev-seeded user `dev@ap.com` / `12345678` (local dev seed, no real credentials)

## Harness

`import-repro.sh` — reproduces the data loss on the base code (two stale-snapshot IMPORT_FLOW callers, second silently erases the first, both 200):

```bash
#!/usr/bin/env bash
set -u
BASE=http://127.0.0.1:3000/api
TOKEN=$(python3 -c "import json; print(json.load(open('$(dirname "$0")/auth.json'))['token'])")
PROJECT=$(python3 -c "import json; print(json.load(open('$(dirname "$0")/auth.json'))['projectId'])")

flow_id=$(curl -s -X POST "$BASE/v1/flows?projectId=$PROJECT" \
  -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' \
  -d "{\"displayName\":\"import race\",\"projectId\":\"$PROJECT\"}" | python3 -c 'import json,sys; print(json.load(sys.stdin)["id"])')
echo "flow: $flow_id"

curl -s -o /dev/null -X POST "$BASE/v1/flows/$flow_id" \
  -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' \
  -d '{"type":"ADD_ACTION","request":{"parentStep":"trigger","action":{"type":"CODE","displayName":"Base Step","name":"base_step","settings":{"input":{},"sourceCode":{"code":"export const code = async () => { return true; }","packageJson":"{}"}},"valid":true,"skip":false}}}'

snapshot=$(curl -s "$BASE/v1/flows/$flow_id" -H "Authorization: Bearer $TOKEN")

build_import() {
  local newstep=$1
  echo "$snapshot" | python3 -c "
import json, sys, copy
flow = json.load(sys.stdin)
v = flow['version']
step = {
    'type': 'CODE', 'name': '$newstep', 'displayName': 'Step $newstep',
    'valid': True, 'skip': False,
    'settings': {'input': {}, 'sourceCode': {'code': 'export const code = async () => { return true; }', 'packageJson': '{}'}},
}
trigger = copy.deepcopy(v['trigger'])
node = trigger
while node.get('nextAction'):
    node = node['nextAction']
node['nextAction'] = step
req = {
    'type': 'IMPORT_FLOW',
    'request': {
        'displayName': v['displayName'],
        'trigger': trigger,
        'schemaVersion': v.get('schemaVersion'),
    },
}
print(json.dumps(req))
"
}

build_import caller_a_step > /tmp/import_a.json
build_import caller_b_step > /tmp/import_b.json

status_a=$(curl -s -o /dev/null -w '%{http_code}' -X POST "$BASE/v1/flows/$flow_id" \
  -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' -d @/tmp/import_a.json)
status_b=$(curl -s -o /dev/null -w '%{http_code}' -X POST "$BASE/v1/flows/$flow_id" \
  -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' -d @/tmp/import_b.json)

final=$(curl -s "$BASE/v1/flows/$flow_id" -H "Authorization: Bearer $TOKEN" | python3 -c '
import json, sys
flow = json.load(sys.stdin)
names = []
step = flow["version"]["trigger"].get("nextAction")
while step:
    names.append(step["name"])
    step = step.get("nextAction")
print(",".join(names))
')
echo "caller A (adds caller_a_step): HTTP $status_a"
echo "caller B (adds caller_b_step): HTTP $status_b"
echo "final steps: [$final]"
case "$final" in
  *caller_a_step*) echo "caller A edit: SURVIVED" ;;
  *) echo "caller A edit: SILENTLY LOST" ;;
esac
```

`verify-header.sh` — drives the fix (both callers send the header):

```bash
#!/usr/bin/env bash
set -u
BASE=http://127.0.0.1:3000/api
DIR=$(dirname "$0")
curl -s -X POST "$BASE/v1/authentication/sign-in" -H 'Content-Type: application/json' -d '{"email":"dev@ap.com","password":"12345678"}' > "$DIR/auth.json"
TOKEN=$(python3 -c "import json; print(json.load(open('$DIR/auth.json'))['token'])")
PROJECT=$(python3 -c "import json; print(json.load(open('$DIR/auth.json'))['projectId'])")

add_action() {
  local name=$1
  cat <<EOF
{"type":"ADD_ACTION","request":{"parentStep":"trigger","action":{"type":"CODE","displayName":"Step $name","name":"$name","settings":{"input":{},"sourceCode":{"code":"export const code = async () => { return true; }","packageJson":"{}"}},"valid":true,"skip":false}}}
EOF
}

flow=$(curl -s -X POST "$BASE/v1/flows?projectId=$PROJECT" -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' -d "{\"displayName\":\"header drive\",\"projectId\":\"$PROJECT\"}")
flow_id=$(echo "$flow" | python3 -c 'import json,sys; print(json.load(sys.stdin)["id"])')
stale=$(echo "$flow" | python3 -c 'import json,sys; print(json.load(sys.stdin)["version"]["updated"])')

s1=$(curl -s -o /dev/null -w '%{http_code}' -X POST "$BASE/v1/flows/$flow_id" -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' -H "x-expected-version-updated: $stale" -d "$(add_action step_a)")
echo "fresh header token: HTTP $s1 (expect 200)"

s2=$(curl -s -o /tmp/hdr_conflict.json -w '%{http_code}' -X POST "$BASE/v1/flows/$flow_id" -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' -H "x-expected-version-updated: $stale" -d "$(add_action step_b)")
echo "stale header token: HTTP $s2 (expect 409) body=$(cat /tmp/hdr_conflict.json)"

fresh=$(curl -s "$BASE/v1/flows/$flow_id" -H "Authorization: Bearer $TOKEN" | python3 -c 'import json,sys; print(json.load(sys.stdin)["version"]["updated"])')
s3=$(curl -s -o /dev/null -w '%{http_code}' -X POST "$BASE/v1/flows/$flow_id" -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' -H "x-expected-version-updated: $fresh" -d "$(add_action step_b)")
echo "refetched token retry: HTTP $s3 (expect 200)"

s4=$(curl -s -o /dev/null -w '%{http_code}' -X POST "$BASE/v1/flows/$flow_id" -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' -d "$(add_action step_c)")
echo "no header (legacy): HTTP $s4 (expect 200)"
```

## Trigger

GET the flow, append a step to the local copy of the trigger tree, POST it back via `IMPORT_FLOW`. Two callers doing this from the same snapshot is the SDK/agent write pattern; no timing or concurrency needed — the loss is deterministic because the whole trigger tree is replaced.

## Results

| Scenario | Base code | With fix |
|---|---|---|
| Both callers stale-import, no header | A: 200, B: 200, A's edit erased | unchanged (200/200, legacy) |
| Both callers send `x-expected-version-updated` | n/a (header ignored, unknown) | A: 200, B: **409 FLOW_VERSION_CONFLICT**, A's edit survives |
| B refetches and retries with fresh token | n/a | 200, both edits present |

</details>
