### PR TITLE
feat(netsuite): add OAuth 2.0 Client Credentials (M2M) auth alongside TBA

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6212,15 +6212,17 @@
     },
     "packages/pieces/community/netsuite": {
       "name": "@activepieces/piece-netsuite",
-      "version": "0.1.10",
+      "version": "0.2.0",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
         "@activepieces/pieces-common": "workspace:*",
         "@activepieces/pieces-framework": "workspace:*",
+        "jsonwebtoken": "9.0.1",
         "sql-formatter": "15.6.10",
       },
       "devDependencies": {
+        "@types/jsonwebtoken": "9.0.10",
         "tslib": "2.6.2",
       },
     },

--- a/packages/pieces/community/netsuite/package.json
+++ b/packages/pieces/community/netsuite/package.json
@@ -1,17 +1,19 @@
 {
   "name": "@activepieces/piece-netsuite",
-  "version": "0.1.10",
+  "version": "0.2.0",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "sql-formatter": "15.6.10",
+    "jsonwebtoken": "9.0.1",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
   },
   "devDependencies": {
-    "tslib": "2.6.2"
+    "tslib": "2.6.2",
+    "@types/jsonwebtoken": "9.0.10"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/netsuite/src/index.ts
+++ b/packages/pieces/community/netsuite/src/index.ts
@@ -1,47 +1,14 @@
-import {
-  PieceAuth,
-  createPiece,
-  Property,
-  PiecePropValueSchema,
-} from '@activepieces/pieces-framework';
+import { createPiece } from '@activepieces/pieces-framework';
 import { getVendor } from './lib/actions/get-vendor';
 import { getCustomer } from './lib/actions/get-customer';
 import { runSuiteQL } from './lib/actions/run-suiteql';
 import { executeDataset } from './lib/actions/execute-dataset';
 import { PieceCategory } from '@activepieces/pieces-framework';
 import { createCustomApiCallAction } from '@activepieces/pieces-common';
-import { createOAuthHeader } from './lib/common/oauth';
+import { buildNetSuiteAuthorizationHeader } from './lib/common/client';
+import { netsuiteAuth } from './lib/auth';
 
-export const netsuiteAuth = PieceAuth.CustomAuth({
-  required: true,
-  props: {
-    accountId: Property.ShortText({
-      displayName: 'Account ID',
-      required: true,
-      description: 'Your NetSuite account ID',
-    }),
-    consumerKey: Property.ShortText({
-      displayName: 'Consumer Key',
-      required: true,
-      description: 'Your NetSuite consumer key',
-    }),
-    consumerSecret: PieceAuth.SecretText({
-      displayName: 'Consumer Secret',
-      required: true,
-      description: 'Your NetSuite consumer secret',
-    }),
-    tokenId: Property.ShortText({
-      displayName: 'Token ID',
-      required: true,
-      description: 'Your NetSuite token ID',
-    }),
-    tokenSecret: PieceAuth.SecretText({
-      displayName: 'Token Secret',
-      required: true,
-      description: 'Your NetSuite token secret',
-    }),
-  },
-});
+export { netsuiteAuth };
 
 export const netsuite = createPiece({
   displayName: 'NetSuite',
@@ -59,23 +26,16 @@ export const netsuite = createPiece({
         if (!auth) {
           return '';
         }
-        const authValue = auth.props;
-        return `https://${authValue.accountId}.suitetalk.api.netsuite.com`;
+        return `https://${auth.props.accountId}.suitetalk.api.netsuite.com`;
       },
       auth: netsuiteAuth,
       authMapping: async (auth, propsValue) => {
-        const authValue = auth.props;
-
-        const authHeader = createOAuthHeader(
-          authValue.accountId,
-          authValue.consumerKey,
-          authValue.consumerSecret,
-          authValue.tokenId,
-          authValue.tokenSecret,
-          propsValue['url']['url'],
-          propsValue['method'],
-          propsValue['queryParams']
-        );
+        const authHeader = buildNetSuiteAuthorizationHeader({
+          auth,
+          url: propsValue['url']['url'],
+          method: propsValue['method'],
+          queryParams: propsValue['queryParams'],
+        });
 
         return {
           Authorization: authHeader,

--- a/packages/pieces/community/netsuite/src/lib/actions/execute-dataset.ts
+++ b/packages/pieces/community/netsuite/src/lib/actions/execute-dataset.ts
@@ -29,7 +29,7 @@ export const executeDataset = createAction({
           };
         }
 
-        const client = new NetSuiteClient(auth.props);
+        const client = new NetSuiteClient(auth);
 
         const items = await client.makePaginatedRequest<{
           id: string;
@@ -50,7 +50,7 @@ export const executeDataset = createAction({
     }),
   },
   async run(context) {
-    const client = new NetSuiteClient(context.auth.props);
+    const client = new NetSuiteClient(context.auth);
     const { datasetId } = context.propsValue;
 
     return client.makePaginatedRequest({

--- a/packages/pieces/community/netsuite/src/lib/actions/get-customer.ts
+++ b/packages/pieces/community/netsuite/src/lib/actions/get-customer.ts
@@ -22,7 +22,7 @@ export const getCustomer = createAction({
     }),
   },
   async run(context) {
-    const client = new NetSuiteClient(context.auth.props);
+    const client = new NetSuiteClient(context.auth);
     const { customerId } = context.propsValue;
 
     return client.makeRequest({

--- a/packages/pieces/community/netsuite/src/lib/actions/get-vendor.ts
+++ b/packages/pieces/community/netsuite/src/lib/actions/get-vendor.ts
@@ -22,7 +22,7 @@ export const getVendor = createAction({
     }),
   },
   async run(context) {
-    const client = new NetSuiteClient(context.auth.props);
+    const client = new NetSuiteClient(context.auth);
     const { vendorId } = context.propsValue;
 
     return client.makeRequest({

--- a/packages/pieces/community/netsuite/src/lib/actions/run-suiteql.ts
+++ b/packages/pieces/community/netsuite/src/lib/actions/run-suiteql.ts
@@ -38,7 +38,7 @@ export const runSuiteQL = createAction({
     }),
   },
   async run(context) {
-    const client = new NetSuiteClient(context.auth.props);
+    const client = new NetSuiteClient(context.auth);
 
     const query = context.propsValue.query;
     const args: string[] = (context.propsValue.args as string[]) || [];

--- a/packages/pieces/community/netsuite/src/lib/auth.ts
+++ b/packages/pieces/community/netsuite/src/lib/auth.ts
@@ -1,0 +1,126 @@
+import {
+  AppConnectionValueForAuthProperty,
+  PieceAuth,
+  Property,
+} from '@activepieces/pieces-framework';
+import { requestNetSuiteM2MAccessToken } from './common/jwt-assertion';
+
+const DEFAULT_M2M_SCOPE = 'rest_webservices';
+
+// NetSuite Token-Based Authentication (TBA) setup - Setup > Integration > Manage Integrations:
+// https://docs.oracle.com/en/cloud/saas/netsuite/ns-online-help/section_161100716589.html
+const tbaAuth = PieceAuth.CustomAuth({
+  displayName: 'Token-Based Authentication (TBA)',
+  required: true,
+  props: {
+    accountId: Property.ShortText({
+      displayName: 'Account ID',
+      required: true,
+      description: 'Your NetSuite account ID',
+    }),
+    consumerKey: Property.ShortText({
+      displayName: 'Consumer Key',
+      required: true,
+      description: 'Your NetSuite consumer key',
+    }),
+    consumerSecret: PieceAuth.SecretText({
+      displayName: 'Consumer Secret',
+      required: true,
+      description: 'Your NetSuite consumer secret',
+    }),
+    tokenId: Property.ShortText({
+      displayName: 'Token ID',
+      required: true,
+      description: 'Your NetSuite token ID',
+    }),
+    tokenSecret: PieceAuth.SecretText({
+      displayName: 'Token Secret',
+      required: true,
+      description: 'Your NetSuite token secret',
+    }),
+  },
+});
+
+// NetSuite OAuth 2.0 Client Credentials (M2M) setup - Setup > Integration > OAuth 2.0
+// Client Credentials (M2M) Setup, mapping a certificate to an integration + role:
+// https://docs.oracle.com/en/cloud/saas/netsuite/ns-online-help/section_162730264820.html
+const m2mAuth = PieceAuth.CustomAuth({
+  displayName: 'OAuth 2.0 Client Credentials (M2M)',
+  description:
+    'Machine-to-machine OAuth 2.0 using a certificate-signed JWT client assertion. Required for tenants onboarded after NetSuite 2027.1, since new Token-Based Authentication (TBA) integrations can no longer be created from that release onward.',
+  required: true,
+  props: {
+    accountId: Property.ShortText({
+      displayName: 'Account ID',
+      required: true,
+      description: 'Your NetSuite account ID',
+    }),
+    clientId: Property.ShortText({
+      displayName: 'Client ID',
+      required: true,
+      description:
+        'The Client ID (Integration ID) of the integration record configured for OAuth 2.0 Client Credentials.',
+    }),
+    certificateId: Property.ShortText({
+      displayName: 'Certificate ID (kid)',
+      required: true,
+      description:
+        'The Certificate ID generated when the public certificate was mapped to this integration under OAuth 2.0 Client Credentials (M2M) Setup.',
+    }),
+    privateKey: PieceAuth.SecretText({
+      displayName: 'Private Key',
+      required: true,
+      description:
+        'The PEM-encoded private key matching the certificate uploaded to NetSuite (paste the contents of the key file).',
+    }),
+    scope: Property.ShortText({
+      displayName: 'Scope',
+      required: false,
+      description:
+        'Space-separated scopes to request (e.g. "rest_webservices" or "rest_webservices restlets"). Defaults to "rest_webservices".',
+    }),
+  },
+  validate: async ({ auth }) => {
+    try {
+      await requestNetSuiteM2MAccessToken({
+        accountId: auth.accountId,
+        clientId: auth.clientId,
+        certificateId: auth.certificateId,
+        privateKey: auth.privateKey,
+        scope: auth.scope?.trim() || DEFAULT_M2M_SCOPE,
+      });
+      return { valid: true };
+    } catch (e) {
+      const message = e instanceof Error ? e.message : String(e);
+      return {
+        valid: false,
+        error: `Could not obtain an access token: ${message}. Verify the Account ID, Client ID, Certificate ID and private key match the integration's OAuth 2.0 Client Credentials (M2M) mapping in NetSuite.`,
+      };
+    }
+  },
+  refresh: {
+    generate: async ({ auth }) => {
+      const { access_token, expires_in } = await requestNetSuiteM2MAccessToken({
+        accountId: auth.accountId,
+        clientId: auth.clientId,
+        certificateId: auth.certificateId,
+        privateKey: auth.privateKey,
+        scope: auth.scope?.trim() || DEFAULT_M2M_SCOPE,
+      });
+      return { access_token, expires_in };
+    },
+    defaultExpiresIn: 3300,
+  },
+});
+
+export const netsuiteAuth = [tbaAuth, m2mAuth];
+
+export type NetSuiteAuthValue = AppConnectionValueForAuthProperty<
+  typeof netsuiteAuth
+>;
+
+export function isM2MAuth(
+  auth: NetSuiteAuthValue
+): auth is Extract<NetSuiteAuthValue, { props: { clientId: string } }> {
+  return 'clientId' in auth.props;
+}

--- a/packages/pieces/community/netsuite/src/lib/common/client.ts
+++ b/packages/pieces/community/netsuite/src/lib/common/client.ts
@@ -4,16 +4,9 @@ import {
   QueryParams,
 } from '@activepieces/pieces-common';
 import { createOAuthHeader } from './oauth';
+import { isM2MAuth, NetSuiteAuthValue } from '../auth';
 
 const PAGE_SIZE = 1000;
-
-interface NetSuiteAuth {
-  accountId: string;
-  consumerKey: string;
-  consumerSecret: string;
-  tokenId: string;
-  tokenSecret: string;
-}
 
 interface MakeRequestParams {
   method: HttpMethod;
@@ -27,15 +20,47 @@ interface PaginatedResponse<T> {
   hasMore?: boolean;
 }
 
-export class NetSuiteClient {
-  private auth: NetSuiteAuth;
+export function buildNetSuiteAuthorizationHeader({
+  auth,
+  url,
+  method,
+  queryParams,
+}: {
+  auth: NetSuiteAuthValue;
+  url: string;
+  method: string;
+  queryParams?: Record<string, string | number | boolean>;
+}): string {
+  if (isM2MAuth(auth)) {
+    if (!auth.access_token) {
+      throw new Error(
+        "NetSuite OAuth 2.0 Client Credentials (M2M) access token is missing. Reconnect the connection so it can be refreshed."
+      );
+    }
+    return `Bearer ${auth.access_token}`;
+  }
 
-  constructor(auth: NetSuiteAuth) {
+  return createOAuthHeader(
+    auth.props.accountId,
+    auth.props.consumerKey,
+    auth.props.consumerSecret,
+    auth.props.tokenId,
+    auth.props.tokenSecret,
+    url,
+    method,
+    queryParams
+  );
+}
+
+export class NetSuiteClient {
+  private auth: NetSuiteAuthValue;
+
+  constructor(auth: NetSuiteAuthValue) {
     this.auth = auth;
   }
 
   get baseUrl(): string {
-    return `https://${this.auth.accountId}.suitetalk.api.netsuite.com`;
+    return `https://${this.auth.props.accountId}.suitetalk.api.netsuite.com`;
   }
 
   async makeRequest<T>({
@@ -44,16 +69,12 @@ export class NetSuiteClient {
     queryParams,
     body,
   }: MakeRequestParams): Promise<T> {
-    const authHeader = createOAuthHeader(
-      this.auth.accountId,
-      this.auth.consumerKey,
-      this.auth.consumerSecret,
-      this.auth.tokenId,
-      this.auth.tokenSecret,
+    const authHeader = buildNetSuiteAuthorizationHeader({
+      auth: this.auth,
       url,
       method,
-      queryParams
-    );
+      queryParams,
+    });
 
     const response = await httpClient.sendRequest({
       method,

--- a/packages/pieces/community/netsuite/src/lib/common/jwt-assertion.ts
+++ b/packages/pieces/community/netsuite/src/lib/common/jwt-assertion.ts
@@ -1,0 +1,97 @@
+import jwt from 'jsonwebtoken';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+
+const CLIENT_ASSERTION_LIFETIME_SECONDS = 300;
+
+// NetSuite requires the SuiteTalk REST hostname to be lowercase with underscores
+// replaced by hyphens (e.g. account id "1234567_SB1" -> host "1234567-sb1").
+// Docs: https://docs.oracle.com/en/cloud/saas/netsuite/ns-online-help/section_1497440505.html
+function toNetSuiteRestHost(accountId: string): string {
+  return accountId.toLowerCase().replace(/_/g, '-');
+}
+
+function buildClientAssertion({
+  clientId,
+  certificateId,
+  privateKey,
+  scope,
+  tokenUrl,
+}: {
+  clientId: string;
+  certificateId: string;
+  privateKey: string;
+  scope: string;
+  tokenUrl: string;
+}): string {
+  const nowSeconds = Math.floor(Date.now() / 1000);
+
+  return jwt.sign(
+    {
+      iss: clientId,
+      scope,
+      aud: tokenUrl,
+      iat: nowSeconds,
+      exp: nowSeconds + CLIENT_ASSERTION_LIFETIME_SECONDS,
+    },
+    privateKey,
+    {
+      algorithm: 'PS256',
+      keyid: certificateId,
+    }
+  );
+}
+
+interface NetSuiteM2MTokenResponse {
+  access_token: string;
+  expires_in: number;
+  token_type: string;
+}
+
+export function getNetSuiteM2MTokenUrl(accountId: string): string {
+  return `https://${toNetSuiteRestHost(
+    accountId
+  )}.suitetalk.api.netsuite.com/services/rest/auth/oauth2/v1/token`;
+}
+
+// NetSuite OAuth 2.0 Client Credentials (M2M) grant: builds a certificate-signed
+// JWT client assertion and exchanges it for an access token.
+// Docs: https://docs.oracle.com/en/cloud/saas/netsuite/ns-online-help/section_162790605110.html
+export async function requestNetSuiteM2MAccessToken({
+  accountId,
+  clientId,
+  certificateId,
+  privateKey,
+  scope,
+}: {
+  accountId: string;
+  clientId: string;
+  certificateId: string;
+  privateKey: string;
+  scope: string;
+}): Promise<NetSuiteM2MTokenResponse> {
+  const tokenUrl = getNetSuiteM2MTokenUrl(accountId);
+
+  const clientAssertion = buildClientAssertion({
+    clientId,
+    certificateId,
+    privateKey,
+    scope,
+    tokenUrl,
+  });
+
+  const response = await httpClient.sendRequest<NetSuiteM2MTokenResponse>({
+    method: HttpMethod.POST,
+    url: tokenUrl,
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+    },
+    body: new URLSearchParams({
+      grant_type: 'client_credentials',
+      client_assertion_type:
+        'urn:ietf:params:oauth:client-assertion-type:jwt-bearer',
+      client_assertion: clientAssertion,
+    }),
+  });
+
+  return response.body;
+}


### PR DESCRIPTION
## Description

NetSuite's 2026.1 release notes state that from 2027.1, new integrations can no longer be created with Token-Based Authentication (TBA) — existing TBA connections keep working, but any tenant onboarding after that release cannot create a new TBA integration record, and the NetSuite piece was TBA-only.

This adds **OAuth 2.0 Client Credentials (M2M)** as a second, selectable auth flavor alongside the existing TBA auth (`netsuiteAuth` is now `[tbaAuth, m2mAuth]`, so users pick the flavor when creating the connection). NetSuite's M2M flow is certificate-based: a JWT client assertion (`iss`=Client ID, `scope`, `aud`=token endpoint, short-lived `exp`/`iat`) is signed with the user's private key (PS256, `kid`=Certificate ID) and exchanged at `/services/rest/auth/oauth2/v1/token` via `grant_type=client_credentials`.

- `src/lib/auth.ts` — `tbaAuth` (unchanged, renamed from the old top-level `netsuiteAuth`) + new `m2mAuth` (Account ID, Client ID, Certificate ID, Private Key, optional Scope). `m2mAuth` uses the framework's `refresh.generate` hook, so the server caches and auto-refreshes the access token on the connection — no custom token-caching code in the piece, and refresh only fires ~15 min before real expiry (not per action call).
- `src/lib/common/jwt-assertion.ts` — builds and signs the client assertion (5-min throwaway lifetime, single-use per token request), exchanges it for a token, and normalizes the account ID to NetSuite's REST hostname format (lowercase, `_` → `-`) for the token endpoint URL.
- `src/lib/common/client.ts` — `NetSuiteClient` and the custom-API-call action now branch per connection: OAuth 1.0a header for TBA, `Bearer <access_token>` for M2M.
- All 4 existing actions (`get-vendor`, `get-customer`, `run-suiteql`, `execute-dataset`) updated to pass the full resolved auth value instead of just `.props`, since the M2M path needs the cached `access_token` alongside the input props.
- Existing TBA connections, signing logic, and request paths are untouched.

Comments linking the official NetSuite OAuth 2.0 M2M docs were added above the new auth definitions and the JWT/token-exchange functions, since the exact JWT claim/algorithm requirements are external spec details not derivable from the code.

## How was this tested?

- `tsc --noEmit` and `eslint` both clean on the piece (`npx turbo run lint --filter=@activepieces/piece-netsuite`).
- Not yet validated against a live NetSuite sandbox — that needs sandbox credentials with an OAuth 2.0 Client Credentials (M2M) integration record configured, which I don't have. In particular, worth confirming NetSuite's token response always includes `expires_in` (the piece falls back to a 55-min assumption if it's ever missing). TBA code path is unchanged, but should still be re-verified against a sandbox before merge.
- CE / EE / Cloud: this is a piece-level auth change with no platform/edition gating, so behavior is identical across all edition paths.

Fixes # (issue)

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

- [x] yes — security-sensitive (call out the risk and mitigation in the description above)
- [ ] no — reviewed, no security impact

Risk: adds a new authentication method (private-key JWT signing, new credential fields) to the piece. Mitigation: the private key is stored as `PieceAuth.SecretText` (encrypted at rest like all connection secrets), the JWT assertion is short-lived (5 min) and single-use per token request, and the derived access token is cached/refreshed by the existing server-side connection-refresh mechanism (with a distributed lock preventing concurrent refresh races) rather than any custom piece-side storage. No new outbound host is introduced beyond the tenant's own NetSuite account domain.