### PR TITLE
fix(webhooks): signed webhooks with file uploads are no longer silently rejected

### DIFF
--- a/packages/server/api/src/app/webhooks/webhook-module.ts
+++ b/packages/server/api/src/app/webhooks/webhook-module.ts
@@ -3,18 +3,23 @@ import { buffer as streamToBuffer } from 'node:stream/consumers'
 import { XMLParser } from 'fast-xml-parser'
 import { FastifyPluginAsync, FastifyRequest } from 'fastify'
 import { webhookController } from './webhook-controller'
-import { isBinaryContentType, isMultipartContentType } from './webhook-request-converter'
+import { captureRawBodyWhileStreaming, isBinaryContentType, isMultipartContentType } from './webhook-request-converter'
 
 export const webhookModule: FastifyPluginAsync = async (app) => {
-    // Capture rawBody (for signature verification) only for the small, string-parsed content
-    // types. Streamed types (multipart, binary files) are consumed straight to storage and get
-    // no rawBody — this replaces fastify-raw-body, which buffered the whole body and defeated streaming.
+    // Capture rawBody so signature-verifying triggers can check it. String-parsed types are
+    // buffered whole; binary bodies keep streaming to storage and retain only a capped copy, so a
+    // large upload is never held in memory. Multipart is tapped in webhook-request-converter
+    // instead: @fastify/multipart pipes request.raw itself, so consuming the payload here would
+    // starve busboy of the parts.
     app.addHook('preParsing', async (request, _reply, payload) => {
         // isMultipart() isn't set this early (it's flagged during content-type parsing), so
-        // detect streamed types from the header directly and leave their stream untouched.
+        // detect streamed types from the header directly.
         const contentType = request.headers['content-type']
-        if (isMultipartContentType(contentType) || isBinaryContentType(contentType)) {
+        if (isMultipartContentType(contentType)) {
             return payload
+        }
+        if (isBinaryContentType(contentType)) {
+            return captureRawBodyWhileStreaming({ request, payload })
         }
         const raw = await streamToBuffer(payload)
         request.rawBody = raw.toString('utf8')

--- a/packages/server/api/src/app/webhooks/webhook-request-converter.ts
+++ b/packages/server/api/src/app/webhooks/webhook-request-converter.ts
@@ -1,4 +1,4 @@
-import { PassThrough, Readable } from 'node:stream'
+import { PassThrough, Readable, Transform } from 'node:stream'
 import { EventPayload, FAIL_PARENT_ON_FAILURE_HEADER, FileCompression, FileType, FlowRun, PARENT_RUN_ID_HEADER } from '@activepieces/shared'
 import { MultipartFile } from '@fastify/multipart'
 import { FastifyBaseLogger, FastifyRequest } from 'fastify'
@@ -20,6 +20,8 @@ const BINARY_CONTENT_TYPE_PATTERNS = [
     /^text\/csv$/,
 ]
 
+const RAW_BODY_CAPTURE_LIMIT_BYTES = system.getNumberOrThrow(AppSystemProp.WEBHOOK_PAYLOAD_INLINE_THRESHOLD_KB) * 1024
+
 export function isBinaryContentType(contentType: string | undefined): boolean {
     if (!contentType) return false
     const baseContentType = contentType.split(';')[0].trim().toLowerCase()
@@ -30,21 +32,32 @@ export function isMultipartContentType(contentType: string | undefined): boolean
     return contentType?.trim().toLowerCase().startsWith('multipart/') ?? false
 }
 
+export function captureRawBodyWhileStreaming({ request, payload }: CaptureRawBodyParams): Readable {
+    const capture = createBoundedRawBodyCapture(request)
+    return payload.pipe(new Transform({
+        transform(chunk: Buffer, _encoding, callback): void {
+            capture.record(chunk)
+            callback(null, chunk)
+        },
+        flush(callback): void {
+            request.rawBody = capture.result()
+            callback()
+        },
+    }))
+}
+
 export async function convertRequest(
     request: FastifyRequest,
     projectId: string,
     flowId: string,
 ): Promise<EventPayload> {
-    const contentType = request.headers['content-type']
-    const isBinary = isBinaryContentType(contentType)
+    const body = await convertBody(request, projectId, flowId)
     return {
         method: request.method,
         headers: request.headers as Record<string, string>,
-        body: await convertBody(request, projectId, flowId),
+        body,
         queryParams: request.query as Record<string, string>,
-        // Streamed bodies (binary/multipart) are consumed straight to storage, so there is no
-        // raw payload to forward; rawBody is captured only for the string-parsed signed types.
-        rawBody: isBinary ? undefined : request.rawBody,
+        rawBody: request.rawBody,
     }
 }
 
@@ -64,6 +77,11 @@ async function convertBody(
         const platformId = await projectService(request.log).getPlatformId(projectId)
         const maxFileSizeInBytes = system.getNumberOrThrow(AppSystemProp.MAX_FILE_SIZE_MB) * 1024 * 1024
         const jsonResult: Record<string, unknown> = {}
+        // @fastify/multipart pipes request.raw itself, so the raw bytes are mirrored off the same
+        // stream rather than intercepted. Attached with no await before request.parts(), so no
+        // chunk can be emitted until busboy is listening too.
+        const capture = createBoundedRawBodyCapture(request)
+        request.raw.on('data', capture.record)
         for await (const part of request.parts()) {
             if (part.type === 'file') {
                 const url = await saveStepFileAndConstructUrl({
@@ -80,6 +98,7 @@ async function convertBody(
                 jsonResult[part.fieldname] = appendMultiValue(jsonResult[part.fieldname], part.value)
             }
         }
+        request.rawBody = capture.result()
         return jsonResult
     }
 
@@ -131,12 +150,47 @@ function failIfTruncated(file: MultipartFile['file'], maxBytes: number): Readabl
     }))
 }
 
+// A truncated rawBody would produce a wrong-but-plausible signature, so once the body outgrows the
+// limit the retained copy is dropped and rawBody stays unset. A declared content-length over the
+// limit skips accumulation entirely, so a large upload never allocates a copy it cannot keep.
+function createBoundedRawBodyCapture(request: FastifyRequest): BoundedRawBodyCapture {
+    const declaredLength = Number.parseInt(request.headers['content-length'] ?? '', 10)
+    const chunks: Buffer[] = []
+    let capturedBytes = 0
+    let withinLimit = Number.isNaN(declaredLength) || declaredLength <= RAW_BODY_CAPTURE_LIMIT_BYTES
+    return {
+        record: (chunk: Buffer): void => {
+            if (!withinLimit) {
+                return
+            }
+            capturedBytes += chunk.length
+            if (capturedBytes > RAW_BODY_CAPTURE_LIMIT_BYTES) {
+                withinLimit = false
+                chunks.length = 0
+                return
+            }
+            chunks.push(chunk)
+        },
+        result: () => withinLimit ? Buffer.concat(chunks).toString('utf8') : undefined,
+    }
+}
+
 // A repeated multipart field name collects into an array, matching the previous body shape.
 function appendMultiValue(existing: unknown, value: unknown): unknown {
     if (existing === undefined) {
         return value
     }
     return Array.isArray(existing) ? [...existing, value] : [existing, value]
+}
+
+type BoundedRawBodyCapture = {
+    record: (chunk: Buffer) => void
+    result: () => string | undefined
+}
+
+type CaptureRawBodyParams = {
+    request: FastifyRequest
+    payload: Readable
 }
 
 type SaveStepFileParams = {

--- a/packages/server/api/src/app/webhooks/webhook-request-converter.ts
+++ b/packages/server/api/src/app/webhooks/webhook-request-converter.ts
@@ -1,5 +1,5 @@
 import { PassThrough, Readable, Transform } from 'node:stream'
-import { EventPayload, FAIL_PARENT_ON_FAILURE_HEADER, FileCompression, FileType, FlowRun, PARENT_RUN_ID_HEADER } from '@activepieces/shared'
+import { EventPayload, FAIL_PARENT_ON_FAILURE_HEADER, FileCompression, FileType, FlowRun, PARENT_RUN_ID_HEADER, tryCatchSync } from '@activepieces/shared'
 import { MultipartFile } from '@fastify/multipart'
 import { FastifyBaseLogger, FastifyRequest } from 'fastify'
 import mime from 'mime-types'
@@ -21,6 +21,7 @@ const BINARY_CONTENT_TYPE_PATTERNS = [
 ]
 
 const RAW_BODY_CAPTURE_LIMIT_BYTES = system.getNumberOrThrow(AppSystemProp.WEBHOOK_PAYLOAD_INLINE_THRESHOLD_KB) * 1024
+const STRICT_UTF8_DECODER = new TextDecoder('utf-8', { fatal: true })
 
 export function isBinaryContentType(contentType: string | undefined): boolean {
     if (!contentType) return false
@@ -150,9 +151,11 @@ function failIfTruncated(file: MultipartFile['file'], maxBytes: number): Readabl
     }))
 }
 
-// A truncated rawBody would produce a wrong-but-plausible signature, so once the body outgrows the
-// limit the retained copy is dropped and rawBody stays unset. A declared content-length over the
-// limit skips accumulation entirely, so a large upload never allocates a copy it cannot keep.
+// rawBody crosses to the engine as a string, and a lossy utf8 decode would silently change the
+// bytes a signature was computed over — and collapse distinct payloads onto one representation,
+// since every invalid sequence becomes the same replacement char. So a body that is not valid utf8
+// yields no rawBody at all rather than a corrupted one. Same reasoning for the size limit: a
+// truncated copy would hash to a plausible-looking digest over partial content.
 function createBoundedRawBodyCapture(request: FastifyRequest): BoundedRawBodyCapture {
     const declaredLength = Number.parseInt(request.headers['content-length'] ?? '', 10)
     const chunks: Buffer[] = []
@@ -171,7 +174,13 @@ function createBoundedRawBodyCapture(request: FastifyRequest): BoundedRawBodyCap
             }
             chunks.push(chunk)
         },
-        result: () => withinLimit ? Buffer.concat(chunks).toString('utf8') : undefined,
+        result: (): string | undefined => {
+            if (!withinLimit) {
+                return undefined
+            }
+            const { data } = tryCatchSync(() => STRICT_UTF8_DECODER.decode(Buffer.concat(chunks)))
+            return data ?? undefined
+        },
     }
 }
 

--- a/packages/server/api/test/integration/ce/webhooks/webhook-signature-rawbody.test.ts
+++ b/packages/server/api/test/integration/ce/webhooks/webhook-signature-rawbody.test.ts
@@ -38,7 +38,7 @@ describe('Webhook rawBody capture for signature verification', () => {
         expect(sign(Buffer.from(queued.rawBody!, 'utf8'))).toBe(sign(body))
     })
 
-    it('captures rawBody for a binary body', async () => {
+    it('captures rawBody for a binary content type whose bytes are valid utf8', async () => {
         const { mockFlow, mockProject } = await createEnabledFlow()
         const body = Buffer.from('a raw pdf body that is also signed')
 
@@ -52,6 +52,49 @@ describe('Webhook rawBody capture for signature verification', () => {
         expect(response.statusCode).toBe(StatusCodes.OK)
         const queued = await readQueuedPayload(mockProject.id)
         expect(queued.rawBody).toBe(body.toString('utf8'))
+    })
+
+    // A lossy utf8 decode would both reject correctly signed uploads and map distinct wire payloads
+    // onto one authenticated string, so no rawBody is preferred over a corrupted one.
+    it('leaves rawBody unset for a binary body that is not valid utf8', async () => {
+        const { mockFlow, mockProject } = await createEnabledFlow()
+        const body = Buffer.from([0x25, 0x50, 0x44, 0x46, 0xC0, 0x80, 0xFF, 0xFE, 0x89, 0x50])
+
+        const response = await app.inject({
+            method: 'POST',
+            url: `/api/v1/webhooks/${mockFlow.id}`,
+            headers: { 'content-type': 'application/pdf' },
+            payload: body,
+        })
+
+        expect(response.statusCode).toBe(StatusCodes.OK)
+        const queued = await readQueuedPayload(mockProject.id)
+        expect(queued.rawBody).toBeUndefined()
+    })
+
+    it('leaves rawBody unset for a multipart body carrying a non-utf8 file part', async () => {
+        const { mockFlow, mockProject } = await createEnabledFlow()
+        const body = Buffer.concat([
+            Buffer.from(
+                `--${BOUNDARY}\r\n`
+                + 'Content-Disposition: form-data; name="upload"; filename="doc.pdf"\r\n'
+                + 'Content-Type: application/pdf\r\n\r\n',
+                'utf8',
+            ),
+            Buffer.from([0x25, 0x50, 0x44, 0x46, 0xC0, 0x80, 0xFF, 0xFE]),
+            Buffer.from(`\r\n--${BOUNDARY}--\r\n`, 'utf8'),
+        ])
+
+        const response = await app.inject({
+            method: 'POST',
+            url: `/api/v1/webhooks/${mockFlow.id}`,
+            headers: { 'content-type': `multipart/form-data; boundary=${BOUNDARY}` },
+            payload: body,
+        })
+
+        expect(response.statusCode).toBe(StatusCodes.OK)
+        const queued = await readQueuedPayload(mockProject.id)
+        expect(queued.rawBody).toBeUndefined()
     })
 
     it('still captures rawBody for JSON', async () => {

--- a/packages/server/api/test/integration/ce/webhooks/webhook-signature-rawbody.test.ts
+++ b/packages/server/api/test/integration/ce/webhooks/webhook-signature-rawbody.test.ts
@@ -1,0 +1,120 @@
+import { createHmac } from 'node:crypto'
+import { FileType, Flow, FlowStatus, Project } from '@activepieces/shared'
+import { FastifyInstance } from 'fastify'
+import { StatusCodes } from 'http-status-codes'
+import { db } from '../../../helpers/db'
+import { createMockFlow, createMockFlowVersion, mockAndSaveBasicSetup } from '../../../helpers/mocks'
+import { setupTestEnvironment, teardownTestEnvironment } from '../../../helpers/test-setup'
+
+const SECRET = 'shared-secret'
+const BOUNDARY = '----signatureBoundary'
+const CAPTURE_LIMIT_BYTES = 512 * 1024
+
+let app: FastifyInstance
+
+beforeAll(async () => {
+    app = await setupTestEnvironment()
+})
+
+afterAll(async () => {
+    await teardownTestEnvironment()
+})
+
+describe('Webhook rawBody capture for signature verification', () => {
+    it('captures rawBody for multipart so a signature over the sent bytes verifies', async () => {
+        const { mockFlow, mockProject } = await createEnabledFlow()
+        const body = multipartBody('invoice.paid')
+
+        const response = await app.inject({
+            method: 'POST',
+            url: `/api/v1/webhooks/${mockFlow.id}`,
+            headers: { 'content-type': `multipart/form-data; boundary=${BOUNDARY}` },
+            payload: body,
+        })
+
+        expect(response.statusCode).toBe(StatusCodes.OK)
+        const queued = await readQueuedPayload(mockProject.id)
+        expect(queued.rawBody).toBe(body.toString('utf8'))
+        expect(sign(Buffer.from(queued.rawBody!, 'utf8'))).toBe(sign(body))
+    })
+
+    it('captures rawBody for a binary body', async () => {
+        const { mockFlow, mockProject } = await createEnabledFlow()
+        const body = Buffer.from('a raw pdf body that is also signed')
+
+        const response = await app.inject({
+            method: 'POST',
+            url: `/api/v1/webhooks/${mockFlow.id}`,
+            headers: { 'content-type': 'application/pdf' },
+            payload: body,
+        })
+
+        expect(response.statusCode).toBe(StatusCodes.OK)
+        const queued = await readQueuedPayload(mockProject.id)
+        expect(queued.rawBody).toBe(body.toString('utf8'))
+    })
+
+    it('still captures rawBody for JSON', async () => {
+        const { mockFlow, mockProject } = await createEnabledFlow()
+        const body = JSON.stringify({ event: 'invoice.paid' })
+
+        const response = await app.inject({
+            method: 'POST',
+            url: `/api/v1/webhooks/${mockFlow.id}`,
+            headers: { 'content-type': 'application/json' },
+            payload: body,
+        })
+
+        expect(response.statusCode).toBe(StatusCodes.OK)
+        const queued = await readQueuedPayload(mockProject.id)
+        expect(queued.rawBody).toBe(body)
+    })
+
+    it('leaves rawBody unset rather than truncated when the body exceeds the capture limit', async () => {
+        const { mockFlow, mockProject } = await createEnabledFlow()
+        const oversized = multipartBody('x'.repeat(CAPTURE_LIMIT_BYTES + 1024))
+
+        const response = await app.inject({
+            method: 'POST',
+            url: `/api/v1/webhooks/${mockFlow.id}`,
+            headers: { 'content-type': `multipart/form-data; boundary=${BOUNDARY}` },
+            payload: oversized,
+        })
+
+        expect(response.statusCode).toBe(StatusCodes.OK)
+        const queued = await readQueuedPayload(mockProject.id)
+        expect(queued.rawBody).toBeUndefined()
+    })
+})
+
+function multipartBody(value: string): Buffer {
+    return Buffer.from(
+        `--${BOUNDARY}\r\n`
+        + 'Content-Disposition: form-data; name="event"\r\n\r\n'
+        + `${value}\r\n`
+        + `--${BOUNDARY}--\r\n`,
+        'utf8',
+    )
+}
+
+function sign(body: Buffer): string {
+    return createHmac('sha256', SECRET).update(body).digest('hex')
+}
+
+async function createEnabledFlow(): Promise<{ mockFlow: Flow, mockProject: Project }> {
+    const { mockProject } = await mockAndSaveBasicSetup()
+    const mockFlow = createMockFlow({ projectId: mockProject.id, status: FlowStatus.ENABLED })
+    await db.save('flow', [mockFlow])
+    const mockFlowVersion = createMockFlowVersion({ flowId: mockFlow.id })
+    await db.save('flow_version', [mockFlowVersion])
+    await db.update('flow', mockFlow.id, { publishedVersionId: mockFlowVersion.id })
+    return { mockFlow, mockProject }
+}
+
+async function readQueuedPayload(projectId: string): Promise<{ rawBody?: string }> {
+    const file = await db.findOneByOrFail<{ data: Buffer }>('file', {
+        projectId,
+        type: FileType.WEBHOOK_PAYLOAD,
+    })
+    return JSON.parse(Buffer.from(file.data).toString('utf8'))
+}


### PR DESCRIPTION
Fixes [GIT-1748](https://linear.app/activepieces/issue/GIT-1748)
Closes #14807

## Problem

1. A published flow with `catch_webhook` + Authentication = HMAC Signature rejected **every** correctly signed `multipart/form-data` request. Caller got `HTTP 200`, no run was created, nothing was logged. No configuration could make it pass.
2. Cause: the raw bytes never reached the trigger, so the HMAC was computed over an empty string. Regressed for multipart in 0.86.3 by #14251, which dropped `rawBody: true` from the webhook route. Signed binary bodies (`image/*`, `application/pdf`, …) were already broken before 0.86.3.

**Scope, stated up front:** this restores verification for utf8-safe bodies (JSON, text multipart form posts). It does **not** make signature verification work for binary or multipart-with-file uploads. `rawBody` reaches the engine as a string across a JSON job payload, and arbitrary bytes cannot survive that losslessly, so those bodies now yield no `rawBody` rather than a corrupted one. Binary was already broken this way before 0.86.3, so this is not a regression here. Fixing it needs byte-safe transport through `EventPayload` and `catch_webhook`'s `hmac.update()`, tracked as [GIT-1753](https://linear.app/activepieces/issue/GIT-1753).

Ref: Pylon 5648

## Fix

- `webhook-request-converter.ts` — `createBoundedRawBodyCapture` retains the raw bytes up to `WEBHOOK_PAYLOAD_INLINE_THRESHOLD_KB` (512 KB default, existing prop, no new env var). Over the limit the copy is dropped and `rawBody` stays **unset**, never truncated: a truncated body would produce a wrong-but-plausible signature. A declared `content-length` over the limit skips accumulation entirely.
- `webhook-request-converter.ts` — multipart mirrors bytes off `request.raw` via a `data` listener attached with no `await` before `request.parts()`. `@fastify/multipart` pipes `request.raw` itself, so intercepting the `preParsing` payload starves busboy of its parts (this broke 4 existing tests before I moved it here).
- `webhook-module.ts` — binary bodies keep streaming and are tapped through a `Transform`, so a large upload is still never buffered whole.
- `webhook-request-converter.ts` — `convertRequest` stops discarding `rawBody` for binary, and reads it after `convertBody` resolves.
- `webhook-request-converter.ts` — decode with `TextDecoder('utf-8', { fatal: true })` and leave `rawBody` unset when the bytes are not valid utf8. A lossy decode rejected correctly signed binary uploads and collapsed distinct payloads onto one authenticated string (Greptile P1, confirmed and fixed in 17a506bcc6).

Streaming behaviour from #14251 is unchanged; nothing is reverted.

## Verification

- `npx turbo run lint --filter=api`: 0 errors. Warnings 480 → 478 (fixed 4, added 0); the 2 remaining in these two files pre-date this PR (`streamThroughBinary`, `failIfTruncated`).
- Webhook suites (`test/integration/ce/webhooks` + `test/unit/app/webhooks`): 75/75 pass, including `webhook-multipart-file`, `webhook-oversized-file`, `webhook-handshake-double-consume`.
- New regression tests in `webhook-signature-rawbody.test.ts` (6), all **red-first proven**. Against the base commit, `multipart` and `binary` capture fail (`expected undefined to be '------signatureBoundary…'`). Against the first commit, the two non-utf8 tests fail with the corrupted `'%PDF�����P'` instead of `undefined`.
- First implementation attempt tapped the stream in `preParsing` and **broke 4 existing multipart tests**: `@fastify/multipart` pipes `request.raw` itself, so consuming the payload there starves busboy of its parts. That is also why 0.86.2 was unaffected — it parsed multipart through the content-type parser. Recorded here because it constrains any future change to this hook.
- Live end-to-end on a full local stack (Postgres + Redis + app + worker + engine, real published flow, real HTTP): multipart + correct signature → **1 run**; multipart + wrong signature → **0 runs**; json + correct signature → **1 run**; json + wrong signature → **0 runs**. The same harness produced 0 runs for multipart + correct signature before the fix.
- `npm run test-unit`: one unrelated pre-existing failure, `packages/web/test/features/chat/lib/chunk-reducer.test.ts` (`ReferenceError: window is not defined`, suite fails to load, 465/465 assertions pass). Not touched by this PR; pushed with `SKIP_CHECK=1`.
- `/simplify`, `/code-review` and `/security-review` were done as focused manual passes over a 3-file diff, not full skill runs. Stated plainly rather than claimed. Greptile's review on this PR is the independent pass.
- Repro: signed multipart webhook accepted with 200 and silently dropped, reproduced and then fixed on a full local stack — full steps in the Reproduction block.
- Product decision embedded: signature verification is supported only up to `WEBHOOK_PAYLOAD_INLINE_THRESHOLD_KB` (512 KB); above it `rawBody` is unset and verification cannot pass. Alternative considered: buffer the whole body so any size can be verified, rejected because it reintroduces the memory blowup #14251 fixed. The string-parsed path already buffers up to `MAX_WEBHOOK_PAYLOAD_SIZE_MB` (25 MB), so this cap is strictly more conservative than existing behaviour.
- Visual: none - backend only, no user-visible surface changed.
- Other affected paths: checked - binary content types share the same root cause and go through the same choke point, fixed for utf8-safe bodies. `app-event-routing` uses its own `rawBody: true` route config and is unaffected. Left unfixed and out of scope, both worth follow-ups: a rejected webhook still returns 200 with no run and no log ([GIT-1749](https://linear.app/activepieces/issue/GIT-1749)), which is what made this silent; and byte-safe `rawBody` transport so non-utf8 bodies can be verified at all ([GIT-1753](https://linear.app/activepieces/issue/GIT-1753)).

<details>
<summary>Plan & reasoning</summary>

## Plan
- Reuse `WEBHOOK_PAYLOAD_INLINE_THRESHOLD_KB` rather than add an env var, so self-hosters need zero setup.
- One bounded-capture helper shared by both paths instead of per-content-type handling.
- Fix binary in the same change: it is the sibling of the same root cause, and one choke point is a smaller true footprint than two special cases.
- Footprint estimated 1 file / ~25 lines; actual 2 files / ~60 lines of product code. The growth is the shared helper plus its types, after the multipart tap had to move out of `preParsing`.

## Non-happy scenarios considered
- Body over the limit → `rawBody` unset, not truncated, so a wrong signature can never be computed from a partial body.
- No `content-length` (chunked) → accumulate then discard at the limit; still bounded.
- `request.parts()` throws mid-upload (file too large) → `rawBody` never assigned, request fails as before.
- Flow not found / disabled → body never consumed, no listener attached, nothing retained.
- Concurrency → worst case 512 KB per in-flight streamed webhook, versus up to 25 MB per in-flight JSON webhook today.

## Alternatives rejected
- Re-enable `rawBody: true` on the webhook route → buffers whole bodies, reverts #14251, and still starves `request.parts()`.
- Replace `request.raw` with a tee'd stream → monkey-patches a core Fastify property that logging and abort detection rely on.
- Hand-roll busboy over the `preParsing` payload → duplicates `@fastify/multipart`'s file-size and truncation handling that `failIfTruncated` depends on.
- Fail loudly instead of restoring verification → does not fix this ticket, and belongs to [GIT-1749](https://linear.app/activepieces/issue/GIT-1749).
</details>

<details>
<summary>Reproduction</summary>

## Environment
- `docker compose -f docker-compose.dev.yml up -d` → `postgres:14.4` on `:5432`, `redis:7.0.7` on `:6379`.
- Throwaway database (`ap_fix`), so no existing dev data is touched.
- App + worker + engine from the worktree:
```
AP_ENCRYPTION_KEY=<32 hex chars> AP_DB_TYPE=POSTGRES AP_POSTGRES_HOST=localhost \
AP_POSTGRES_PORT=5432 AP_POSTGRES_DATABASE=ap_fix AP_POSTGRES_USERNAME=postgres \
AP_POSTGRES_PASSWORD=<compose password> AP_REDIS_HOST=localhost AP_REDIS_PORT=6379 \
AP_QUEUE_MODE=REDIS AP_JWT_SECRET=dev-secret-please-change-in-production \
AP_DEV_PIECES=webhook \
npx turbo run serve --filter=api --filter=@activepieces/engine --filter=worker --env-mode=loose
```
- `npx turbo run build --filter=@activepieces/piece-webhook` first, or the dev piece is not discoverable.

## Harness
Public gist: https://gist.github.com/majewskibartosz/a7afc7b45e091b7b0e1ce032b21c45ac

```
git clone https://gist.github.com/a7afc7b45e091b7b0e1ce032b21c45ac.git git-1748-repro
cd git-1748-repro && python3 verify_fix.py
```
- `verify_fix.py` — signs in, publishes a `catch_webhook` flow with HMAC Signature auth, then drives the 4-case matrix and asserts run counts.
- `repro.py` — the original pre-fix reproduction (JSON vs multipart, run counts only).

Stdlib only, no dependencies.

## Trigger
POST the webhook URL with `Content-Type: multipart/form-data` and `x-signature` set to `HMAC-SHA256(secret, exact bytes sent)`. Signing the exact transmitted bytes matters: a signature over reconstructed or re-encoded form data would fail for an unrelated reason and prove nothing.

## Results
| Request | Signature | Pre-fix | Post-fix |
|---|---|---|---|
| multipart | correct | 200, **0 runs** | 200, **1 run** |
| multipart | wrong | 200, 0 runs | 200, 0 runs |
| json | correct | 200, 1 run | 200, 1 run |
| json | wrong | 200, 0 runs | 200, 0 runs |
| multipart | auth disabled | 200, 1 run | 200, 1 run |

The last row is the control that isolates the cause: multipart delivery itself always worked, so only signature verification was failing.
</details>

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

No env var added or required, no API shape or column change, no self-hosted setup step. Behaviour moves from "silently broken" to "works as documented". Worth a reviewer's eye on one consequence: a flow that was silently dropping signed multipart webhooks will start executing them, so previously-lost deliveries now create runs and consume quota.

### Security impact?  (required — CI fails if this is left unedited)

- [ ] no — reviewed, no security impact
- [x] yes — security-sensitive (call out the risk and mitigation in the description above)

This is signature verification and file handling, so treating it as security-sensitive:

- **Signature correctness.** `rawBody` is left unset rather than truncated (over the size limit) or lossily decoded (non-utf8 bytes). Both would hash to a valid-looking digest over content the sender never sent; unset simply fails verification. The lossy-decode case also collapsed distinct wire payloads onto one authenticated string, which Greptile caught as a P1 and 17a506bcc6 fixes.
- **No verification bypass.** Wrong signatures still produce zero runs, driven explicitly in the live matrix above. The fix restores rejection accuracy, it does not weaken it.
- **Memory / DoS.** Retention is bounded at `WEBHOOK_PAYLOAD_INLINE_THRESHOLD_KB` (512 KB) per in-flight streamed request, and a declared `content-length` over the limit skips accumulation entirely. The existing string-parsed path already buffers whole bodies up to `MAX_WEBHOOK_PAYLOAD_SIZE_MB` (25 MB), so this is strictly more conservative than current behaviour.
