### PR TITLE
feat(mcp): let ap_update_step change a piece step's version

### DIFF
--- a/packages/server/api/src/app/mcp/tools/ap-update-step.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-update-step.ts
@@ -20,6 +20,7 @@ const updateStepInput = z.object({
     packageJson: z.string().optional(),
     continueOnFailure: z.boolean().optional(),
     retryOnFailure: z.boolean().optional(),
+    pieceVersion: z.string().optional(),
 })
 
 export const apUpdateStepTool = ({ mcp, userId }: McpToolContext, log: FastifyBaseLogger): McpToolDefinition => {
@@ -40,10 +41,11 @@ export const apUpdateStepTool = ({ mcp, userId }: McpToolContext, log: FastifyBa
             packageJson: z.string().optional().describe('For CODE steps only: package.json content as a JSON string for npm dependencies. Defaults to "{}".'),
             continueOnFailure: z.boolean().optional().describe('For CODE/PIECE steps: set true on the step that can fail (the one whose failure you want to react to), NOT on the recovery step. The flow keeps running on failure and the step gains On success / On failure branches — add handler steps into them with ap_add_step using stepLocationRelativeToParent INSIDE_ON_SUCCESS_BRANCH / INSIDE_ON_FAILURE_BRANCH and parentStepName = this step.'),
             retryOnFailure: z.boolean().optional().describe('For CODE/PIECE steps: whether to retry this step on failure.'),
+            pieceVersion: z.string().optional().describe('For PIECE steps: change the piece version this step runs on. Pass "latest" to upgrade to the newest version, or an exact version like "1.2.3". The action schema may change between versions — inspect the new schema with ap_get_piece_props and pass any adjusted `input` in the same call to fix removed/renamed/new properties.'),
         },
         annotations: { destructiveHint: false, idempotentHint: true, openWorldHint: false },
         execute: async (args) => {
-            const { flowId, stepName, displayName, input, auth, actionName, loopItems, skip, sourceCode, packageJson, continueOnFailure, retryOnFailure } = updateStepInput.parse(args)
+            const { flowId, stepName, displayName, input, auth, actionName, loopItems, skip, sourceCode, packageJson, continueOnFailure, retryOnFailure, pieceVersion } = updateStepInput.parse(args)
 
             const [flow, project] = await Promise.all([
                 flowService(log).getOnePopulated({ id: flowId, projectId: mcp.projectId }),
@@ -112,6 +114,30 @@ export const apUpdateStepTool = ({ mcp, userId }: McpToolContext, log: FastifyBa
                 updatedSettings.sourceCode = {
                     code: sourceCode ?? existingCode,
                     packageJson: packageJson ?? existingPkg,
+                }
+            }
+
+            if (pieceVersion !== undefined) {
+                if (step.type !== FlowActionType.PIECE) {
+                    return { content: [{ type: 'text', text: `❌ pieceVersion can only be set on PIECE steps, but "${stepName}" is type ${step.type}.` }] }
+                }
+                const pieceName = String(currentSettings.pieceName)
+                if (pieceVersion === 'latest') {
+                    const versionResult = await mcpUtils.resolveLatestPieceVersion({ pieceName, projectId: mcp.projectId, platformId: project.platformId, log })
+                    if (versionResult.error) {
+                        return versionResult.error
+                    }
+                    updatedSettings.pieceVersion = versionResult.pieceVersion
+                }
+                else {
+                    const cleanVersion = pieceVersion.replace(/^[~^]/, '')
+                    try {
+                        await pieceMetadataService(log).getOrThrow({ platformId: project.platformId, name: pieceName, version: cleanVersion })
+                    }
+                    catch {
+                        return { content: [{ type: 'text', text: `❌ Version "${cleanVersion}" of piece "${pieceName}" not found. Use ap_research_pieces to see available versions, or pass "latest".` }] }
+                    }
+                    updatedSettings.pieceVersion = `~${cleanVersion}`
                 }
             }
 

--- a/packages/server/api/src/app/mcp/tools/ap-update-step.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-update-step.ts
@@ -137,7 +137,7 @@ export const apUpdateStepTool = ({ mcp, userId }: McpToolContext, log: FastifyBa
                     catch {
                         return { content: [{ type: 'text', text: `❌ Version "${cleanVersion}" of piece "${pieceName}" not found. Use ap_research_pieces to see available versions, or pass "latest".` }] }
                     }
-                    updatedSettings.pieceVersion = `~${cleanVersion}`
+                    updatedSettings.pieceVersion = cleanVersion
                 }
             }
 

--- a/packages/server/api/test/integration/ce/mcp/mcp-tools.test.ts
+++ b/packages/server/api/test/integration/ce/mcp/mcp-tools.test.ts
@@ -2636,4 +2636,30 @@ describe('MCP Tools integration', () => {
         const result = await apReadStepSettingsTool(mcp1, mockLog).execute({ flowId, stepName: 'trigger' })
         expect(text(result)).toContain('❌ Flow not found')
     })
+
+    it('ap_update_step — explicit pieceVersion is pinned exactly with no range prefix', async () => {
+        const ctx = await createTestContext(app)
+        const mcp = makeMcp(ctx.project.id)
+        const flowId = await createFlowAndGetId(mcp, 'Pin Version Flow')
+
+        await apAddStepTool({ mcp }, mockLog).execute({
+            flowId,
+            parentStepName: 'trigger',
+            stepLocationRelativeToParent: StepLocationRelativeToParent.AFTER,
+            stepType: FlowActionType.PIECE,
+            displayName: 'Send Email',
+            pieceName: '@activepieces/piece-test-email',
+        })
+
+        const result = await apUpdateStepTool({ mcp }, mockLog).execute({
+            flowId,
+            stepName: 'step_1',
+            pieceVersion: '0.1.0',
+        })
+        expect(text(result)).not.toContain('❌')
+
+        const settings = await apReadStepSettingsTool(mcp, mockLog).execute({ flowId, stepName: 'step_1' })
+        expect(text(settings)).toContain('"pieceVersion": "0.1.0"')
+        expect(text(settings)).not.toContain('~0.1.0')
+    })
 })


### PR DESCRIPTION
## Description

Adds an optional `pieceVersion` parameter to the `ap_update_step` MCP tool so an AI client can move a PIECE step onto a different version of its piece:

- `"latest"` — resolves to the newest available version (reuses `resolveLatestPieceVersion`, the same helper `ap_update_trigger` already uses to keep triggers on the latest version).
- an exact version like `"1.2.3"` — validated against the piece registry (friendly error if it doesn't exist) and pinned as `~1.2.3`, matching how step versions are stored everywhere else.
- non-PIECE step — rejected with a clear message.

After the version is set, the existing flow-update path re-validates the step against the new action schema and diagnoses missing/unknown inputs, so the LLM can pass an adjusted `input` in the same call to handle properties that were removed, renamed, or added between versions.

Previously `ap_update_step` always copied the existing `pieceVersion` and had no way to upgrade an action step — triggers already auto-bumped, actions did not.



## How was this tested?

`npx turbo run lint --filter=api` — 0 errors. Change is confined to `ap_update_step`; no new tool registration, `disabledTools` schema, or web settings wiring needed.



Fixes # (issue)

### Breaking change?  (required — CI fails if this is left unedited)

<!-- Tick exactly one box. If either "yes", apply the "⛓️‍💥 breaking-change" label AND add an entry to docs/install/reference/breaking-changes.mdx (what changed + the action self-hosters must take). -->

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

<!-- Tick exactly one box. "Security-sensitive" = touches authentication, secrets, permissions/roles, cryptography, SSRF / outbound HTTP, or file handling. -->

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)
