### PR TITLE
fix(pieces): prevent duplicate-key errors from concurrent piece-catal…

### DIFF
--- a/packages/server/api/src/app/pieces/metadata/piece-metadata-service.ts
+++ b/packages/server/api/src/app/pieces/metadata/piece-metadata-service.ts
@@ -143,13 +143,13 @@ export const pieceMetadataService = (log: FastifyBaseLogger) => {
                 platformId,
             })
             const savedPiece = await pieceRepos().save({
-                id: apId(),
                 packageType,
                 pieceType,
                 archiveId,
                 platformId,
                 created: createdDate,
                 ...pieceMetadata,
+                id: apId(),
             })
             if (publishCacheRefresh) {
                 await pieceCache(log).invalidate()

--- a/packages/server/api/src/app/pieces/piece-sync-service.ts
+++ b/packages/server/api/src/app/pieces/piece-sync-service.ts
@@ -3,6 +3,7 @@ import { apVersionUtil } from '@activepieces/server-utils'
 import { PieceSyncMode, PieceType } from '@activepieces/shared'
 import { FastifyBaseLogger } from 'fastify'
 import semver from 'semver'
+import { distributedLock } from '../database/redis-connections'
 import { rejectedPromiseHandler } from '../helper/promise-handler'
 import { system } from '../helper/system/system'
 import { AppSystemProp } from '../helper/system/system-props'
@@ -18,6 +19,8 @@ import { pieceBundle } from './piece-bundle'
 
 const CLOUD_API_URL = 'https://cloud.activepieces.com/api/v1/pieces'
 const syncMode = system.get<PieceSyncMode>(AppSystemProp.PIECES_SYNC_MODE)
+const PIECE_SYNC_LOCK_KEY = 'piece-sync'
+const PIECE_SYNC_LOCK_TIMEOUT_SECONDS = 60
 
 export const pieceSyncService = (log: FastifyBaseLogger) => ({
     async setup(): Promise<void> {
@@ -43,40 +46,51 @@ export const pieceSyncService = (log: FastifyBaseLogger) => ({
             log.info('Piece sync service is disabled')
             return
         }
-        try {
-            log.info('Starting piece synchronization')
-            const startTime = performance.now()
-            const [dbPieces, cloudPieces] = await Promise.all([pieceRepos().find({
-                select: {
-                    name: true,
-                    version: true,
-                    pieceType: true,
-                },
-            }), listCloudPieces()])
-            log.info({ dbCount: dbPieces.length, cloudCount: cloudPieces.length }, 'Fetched pieces from DB and Cloud')
-            const added = await installNewPieces(cloudPieces, dbPieces, log, publishCacheRefresh)
-            const deleted = await deletePiecesIfNotOnCloud(dbPieces, cloudPieces, log)
-
-            log.info({
-                added,
-                deleted,
-                durationMs: Math.floor(performance.now() - startTime),
-            }, 'Piece synchronization completed')
-
-            // React to the catalog-change signal: enqueue an async tool-search reconcile (never inline
-            // — embedding must not block sync). The hash-gate means an unchanged catalog re-embeds
-            // nothing, so this is cheap; only fire when something changed AND the engine is enabled —
-            // without the flag guard a delta would enqueue a reconcile even when tool-search is off,
-            // which (if an OpenAI key exists but pgvector does not) crashes silently on every change.
-            if ((added > 0 || deleted > 0) && isToolSearchEnabled()) {
-                rejectedPromiseHandler(toolSearchReindexJob(log).enqueue({ type: 'all' }), log)
-            }
-        }
-        catch (error) {
-            log.error({ error }, 'Error syncing pieces')
+        const { error: lockError } = await tryCatch(() => distributedLock(log).runExclusive({
+            key: PIECE_SYNC_LOCK_KEY,
+            timeoutInSeconds: PIECE_SYNC_LOCK_TIMEOUT_SECONDS,
+            fn: () => runSync({ publishCacheRefresh, log }),
+        }))
+        if (lockError) {
+            log.info('Piece synchronization already in progress, skipping')
         }
     },
 })
+
+async function runSync({ publishCacheRefresh, log }: { publishCacheRefresh: boolean, log: FastifyBaseLogger }): Promise<void> {
+    try {
+        log.info('Starting piece synchronization')
+        const startTime = performance.now()
+        const [dbPieces, cloudPieces] = await Promise.all([pieceRepos().find({
+            select: {
+                name: true,
+                version: true,
+                pieceType: true,
+            },
+        }), listCloudPieces()])
+        log.info({ dbCount: dbPieces.length, cloudCount: cloudPieces.length }, 'Fetched pieces from DB and Cloud')
+        const added = await installNewPieces(cloudPieces, dbPieces, log, publishCacheRefresh)
+        const deleted = await deletePiecesIfNotOnCloud(dbPieces, cloudPieces, log)
+
+        log.info({
+            added,
+            deleted,
+            durationMs: Math.floor(performance.now() - startTime),
+        }, 'Piece synchronization completed')
+
+        // React to the catalog-change signal: enqueue an async tool-search reconcile (never inline
+        // — embedding must not block sync). The hash-gate means an unchanged catalog re-embeds
+        // nothing, so this is cheap; only fire when something changed AND the engine is enabled —
+        // without the flag guard a delta would enqueue a reconcile even when tool-search is off,
+        // which (if an OpenAI key exists but pgvector does not) crashes silently on every change.
+        if ((added > 0 || deleted > 0) && isToolSearchEnabled()) {
+            rejectedPromiseHandler(toolSearchReindexJob(log).enqueue({ type: 'all' }), log)
+        }
+    }
+    catch (error) {
+        log.error({ error }, 'Error syncing pieces')
+    }
+}
 
 async function deletePiecesIfNotOnCloud(dbPieces: PieceMetadataOnly[], cloudPieces: PieceRegistryResponse[], log: FastifyBaseLogger): Promise<number> {
     const cloudMap = new Map<string, true>(cloudPieces.map(cloudPiece => [`${cloudPiece.name}:${cloudPiece.version}`, true]))


### PR DESCRIPTION
## Summary

Self-hosted Postgres logs were flooding with `duplicate key value violates unique constraint "PK_..."` on `piece_metadata`, firing many times per second right after a fresh app boot.

Fixes: #14834

**Root cause:** `pieceSyncService.setup()` fires an immediate, unconditional catalog sync at boot *and* schedules an hourly cron job at a random minute (`0-4 */1 * * *`). On a fresh install the first sync takes several minutes to insert the full ~11.8k-piece catalog — long enough that if the container happens to boot near the top of an hour, the cron-scheduled run fires seconds later and executes a second, fully concurrent sync. Both runs compute "missing pieces" from the same stale snapshot and race to `INSERT` the same rows.

The collisions land on the **primary key** specifically (not just the app-level uniqueness check) because of a second bug: `pieceMetadataService.create()` built the inserted row as `{ id: apId(), ...pieceMetadata }`. Since `pieceMetadata` is the raw JSON fetched from the cloud piece registry, and that response carries the cloud's own internal `id` field, the object spread silently overwrote our freshly generated id — making the target row id deterministic per piece rather than random per attempt. That's what let two racing inserts collide on the exact same PK instead of just tripping the `(name, version, platformId)` unique index.

## Changes

- `piece-sync-service.ts`: wrap `sync()` in `distributedLock(...).runExclusive(...)` (Redis-backed, cluster-wide) so only one sync can run at a time. A contending call now fails fast, logs "already in progress, skipping", and exits cleanly instead of racing.
- `piece-metadata-service.ts`: reorder the `save()` payload so `id: apId()` is spread last, guaranteeing the self-hosted instance always assigns its own id regardless of what the upstream registry response contains.

## Test plan

- [ ] Reproduced against a fresh Postgres: booted the app near the top of an hour so the cron fires shortly after the immediate sync, confirmed only one `"Starting piece synchronization"` log line and no duplicate-key errors.
- [ ] Confirmed `distributedLock` also serializes across multiple `app` replicas (Redis-backed), not just within one process.
- [ ] `npm run lint-dev` / `eslint` + `tsc --noEmit` clean on both changed files.
- [ ] Existing piece-sync unit/integration tests still pass.

## Breaking change?

No — internal concurrency fix only; no API, schema, env var, or default behavior change for self-hosters or API consumers.
