### PR TITLE
feat(agent): publish an agent so flow steps have something to run

### DIFF
--- a/packages/core/shared/package.json
+++ b/packages/core/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/shared",
-  "version": "0.133.0",
+  "version": "0.134.0",
   "type": "commonjs",
   "sideEffects": false,
   "main": "./dist/src/index.js",

--- a/packages/core/shared/src/lib/ee/agent/agent.ts
+++ b/packages/core/shared/src/lib/ee/agent/agent.ts
@@ -75,8 +75,13 @@ const ListAgentsRequest = z.object({
     limit: z.coerce.number().int().min(1).max(MAX_AGENT_PAGE_SIZE).optional(),
 })
 
+const agentUtils = {
+    isPublishable: (config: AgentConfig): boolean => config.instructions.trim().length > 0,
+}
+
 export {
     Agent,
+    agentUtils,
     AgentConfig,
     AgentIcon,
     AgentVisibility,

--- a/packages/core/shared/src/lib/ee/agent/agent.ts
+++ b/packages/core/shared/src/lib/ee/agent/agent.ts
@@ -76,7 +76,7 @@ const ListAgentsRequest = z.object({
 })
 
 const agentUtils = {
-    isPublishable: (config: AgentConfig): boolean => config.instructions.trim().length > 0,
+    isPublishable: (config: AgentConfig): boolean => (config.instructions ?? '').trim().length > 0,
 }
 
 export {

--- a/packages/core/shared/src/lib/ee/audit-events/index.ts
+++ b/packages/core/shared/src/lib/ee/audit-events/index.ts
@@ -37,6 +37,7 @@ export enum ApplicationEventName {
     AGENT_CREATED = 'agent.created',
     AGENT_UPDATED = 'agent.updated',
     AGENT_DELETED = 'agent.deleted',
+    AGENT_PUBLISHED = 'agent.published',
     VARIABLE_UPSERTED = 'variable.upserted',
     VARIABLE_DELETED = 'variable.deleted',
     VARIABLE_VALUE_REVEALED = 'variable.value.revealed',
@@ -115,6 +116,7 @@ export const AgentAuditEvent = z.object({
         z.literal(ApplicationEventName.AGENT_CREATED),
         z.literal(ApplicationEventName.AGENT_UPDATED),
         z.literal(ApplicationEventName.AGENT_DELETED),
+        z.literal(ApplicationEventName.AGENT_PUBLISHED),
     ]),
     data: AgentEventData,
 })
@@ -562,6 +564,8 @@ export function summarizeApplicationEvent(event: ApplicationEvent) {
             return `Agent ${event.data.agent.displayName} is updated`
         case ApplicationEventName.AGENT_DELETED:
             return `Agent ${event.data.agent.displayName} is deleted`
+        case ApplicationEventName.AGENT_PUBLISHED:
+            return `Agent ${event.data.agent.displayName} is published`
         case ApplicationEventName.VARIABLE_UPSERTED:
             return `Variable ${event.data.variable.name} is created or updated`
         case ApplicationEventName.VARIABLE_DELETED:

--- a/packages/core/shared/src/lib/ee/audit-events/mock-event-builder.ts
+++ b/packages/core/shared/src/lib/ee/audit-events/mock-event-builder.ts
@@ -171,7 +171,8 @@ export const buildMockEvent = ({ event, platformId, projectId }: BuildMockEventP
         }
         case ApplicationEventName.AGENT_CREATED:
         case ApplicationEventName.AGENT_UPDATED:
-        case ApplicationEventName.AGENT_DELETED: {
+        case ApplicationEventName.AGENT_DELETED:
+        case ApplicationEventName.AGENT_PUBLISHED: {
             const mock: AgentAuditEvent = {
                 ...baseEnvelope,
                 action: event,

--- a/packages/server/api/src/app/ee/agent/agent-controller.ts
+++ b/packages/server/api/src/app/ee/agent/agent-controller.ts
@@ -58,6 +58,19 @@ export const agentController: FastifyPluginAsyncZod = async (app) => {
         return agent
     })
 
+    app.post('/:id/publish', PublishAgentRoute, async (request): Promise<Agent> => {
+        const agent = await agentService(request.log).publish({
+            id: request.params.id,
+            projectId: request.projectId,
+            userId: await resolveUserId(request),
+        })
+        applicationEvents(request.log).sendUserEvent(request, {
+            action: ApplicationEventName.AGENT_PUBLISHED,
+            data: { agent: { id: agent.id, displayName: agent.displayName } },
+        })
+        return agent
+    })
+
     app.delete('/:id', DeleteAgentRoute, async (request, reply): Promise<void> => {
         const agent = await agentService(request.log).delete({
             id: request.params.id,
@@ -145,6 +158,25 @@ const UpdateAgentRoute = {
         description: 'Update an agent',
         params: z.object({ id: ApId }),
         body: UpdateAgentRequest,
+        response: {
+            [StatusCodes.OK]: Agent,
+        },
+    },
+}
+
+const PublishAgentRoute = {
+    config: {
+        security: securityAccess.project(
+            [PrincipalType.USER, PrincipalType.SERVICE],
+            Permission.WRITE_AGENT,
+            { type: ProjectResourceType.TABLE, tableName: AgentEntity },
+        ),
+    },
+    schema: {
+        tags: ['agents'],
+        security: [SERVICE_KEY_SECURITY_OPENAPI],
+        description: 'Publish an agent, so flow steps run the current draft',
+        params: z.object({ id: ApId }),
         response: {
             [StatusCodes.OK]: Agent,
         },

--- a/packages/server/api/src/app/ee/agent/agent-service.ts
+++ b/packages/server/api/src/app/ee/agent/agent-service.ts
@@ -90,14 +90,17 @@ export const agentService = (log: FastifyBaseLogger) => ({
             .update()
             .set({ published: () => '"draft"' })
             .where('"id" = :id AND "projectId" = :projectId', { id, projectId })
-            .andWhere('"draft" ->> \'instructions\' ~ \'[^[:space:]]\'')
+            .andWhere('"draft" = CAST(:reviewedDraft AS jsonb)', { reviewedDraft: JSON.stringify(agent.draft) })
             .andWhere(visibleToUser({ userId, prefix: '' }))
             .returning('id')
             .execute()
 
         const publishedRows: unknown[] = published.raw ?? []
         if (publishedRows.length === 0) {
-            throw agentNotFound(id)
+            throw new ActivepiecesError({
+                code: ErrorCode.VALIDATION,
+                params: { message: 'The agent changed while it was being published, review it and publish again' },
+            })
         }
         return this.getOneOrThrow({ id, projectId, userId })
     },

--- a/packages/server/api/src/app/ee/agent/agent-service.ts
+++ b/packages/server/api/src/app/ee/agent/agent-service.ts
@@ -1,4 +1,4 @@
-import { ActivepiecesError, ApId, apId, Cursor, ErrorCode, isNil, Permission, PlatformId, ProjectId, SeekPage, UserId } from '@activepieces/core-utils'
+import { ActivepiecesError, ApId, apId, Cursor, ErrorCode, isNil, omit, Permission, PlatformId, ProjectId, sanitizeObjectForPostgresql, SeekPage, UserId } from '@activepieces/core-utils'
 import { Agent, agentUtils, AgentVisibility, CreateAgentRequest, UpdateAgentRequest } from '@activepieces/shared'
 import { FastifyBaseLogger } from 'fastify'
 import { Brackets, In, SelectQueryBuilder } from 'typeorm'
@@ -28,7 +28,7 @@ export const agentService = (log: FastifyBaseLogger) => ({
             color: request.color,
             visibility,
             sharedWithUserIds: await resolveShare({ visibility, sharedWithUserIds: request.sharedWithUserIds, projectId, log }),
-            draft: request.draft,
+            draft: sanitizeObjectForPostgresql(request.draft),
             published: null,
         })
     },
@@ -73,7 +73,8 @@ export const agentService = (log: FastifyBaseLogger) => ({
             projectId,
             log,
         })
-        return agentRepo().save({ ...agent, ...request, visibility, sharedWithUserIds })
+        const draft = isNil(request.draft) ? agent.draft : sanitizeObjectForPostgresql(request.draft)
+        return agentRepo().save({ ...omit(agent, ['published']), ...request, draft, visibility, sharedWithUserIds })
     },
 
     async publish({ id, projectId, userId }: GetParams): Promise<Agent> {
@@ -89,6 +90,7 @@ export const agentService = (log: FastifyBaseLogger) => ({
             .update()
             .set({ published: () => '"draft"' })
             .where('"id" = :id AND "projectId" = :projectId', { id, projectId })
+            .andWhere('"draft" ->> \'instructions\' ~ \'[^[:space:]]\'')
             .returning('id')
             .execute()
 

--- a/packages/server/api/src/app/ee/agent/agent-service.ts
+++ b/packages/server/api/src/app/ee/agent/agent-service.ts
@@ -1,5 +1,5 @@
 import { ActivepiecesError, ApId, apId, Cursor, ErrorCode, isNil, Permission, PlatformId, ProjectId, SeekPage, UserId } from '@activepieces/core-utils'
-import { Agent, AgentVisibility, CreateAgentRequest, UpdateAgentRequest } from '@activepieces/shared'
+import { Agent, agentUtils, AgentVisibility, CreateAgentRequest, UpdateAgentRequest } from '@activepieces/shared'
 import { FastifyBaseLogger } from 'fastify'
 import { Brackets, In, SelectQueryBuilder } from 'typeorm'
 import { repoFactory } from '../../core/db/repo-factory'
@@ -78,13 +78,25 @@ export const agentService = (log: FastifyBaseLogger) => ({
 
     async publish({ id, projectId, userId }: GetParams): Promise<Agent> {
         const agent = await this.getOneOrThrow({ id, projectId, userId })
-        if (agent.draft.instructions.trim().length === 0) {
+        if (!agentUtils.isPublishable(agent.draft)) {
             throw new ActivepiecesError({
                 code: ErrorCode.VALIDATION,
                 params: { message: 'An agent needs instructions before it can be published' },
             })
         }
-        return agentRepo().save({ ...agent, published: agent.draft })
+        const published = await agentRepo()
+            .createQueryBuilder()
+            .update()
+            .set({ published: () => '"draft"' })
+            .where('"id" = :id AND "projectId" = :projectId', { id, projectId })
+            .returning('id')
+            .execute()
+
+        const publishedRows: unknown[] = published.raw ?? []
+        if (publishedRows.length === 0) {
+            throw agentNotFound(id)
+        }
+        return this.getOneOrThrow({ id, projectId, userId })
     },
 
     async delete({ id, projectId, userId }: GetParams): Promise<Agent> {

--- a/packages/server/api/src/app/ee/agent/agent-service.ts
+++ b/packages/server/api/src/app/ee/agent/agent-service.ts
@@ -91,6 +91,7 @@ export const agentService = (log: FastifyBaseLogger) => ({
             .set({ published: () => '"draft"' })
             .where('"id" = :id AND "projectId" = :projectId', { id, projectId })
             .andWhere('"draft" ->> \'instructions\' ~ \'[^[:space:]]\'')
+            .andWhere(visibleToUser({ userId, prefix: '' }))
             .returning('id')
             .execute()
 
@@ -111,11 +112,15 @@ export const agentService = (log: FastifyBaseLogger) => ({
 function visibleAgents({ userId }: { userId: UserId }): SelectQueryBuilder<AgentWithRelations> {
     return agentRepo()
         .createQueryBuilder('agent')
-        .where(new Brackets((qb) => {
-            qb.where('agent.visibility = :projectVisibility', { projectVisibility: AgentVisibility.PROJECT })
-                .orWhere('agent."ownerId" = :userId', { userId })
-                .orWhere(':userId = ANY(agent."sharedWithUserIds")', { userId })
-        }))
+        .where(visibleToUser({ userId, prefix: 'agent.' }))
+}
+
+function visibleToUser({ userId, prefix }: { userId: UserId, prefix: string }): Brackets {
+    return new Brackets((qb) => {
+        qb.where(`${prefix}"visibility" = :projectVisibility`, { projectVisibility: AgentVisibility.PROJECT })
+            .orWhere(`${prefix}"ownerId" = :userId`, { userId })
+            .orWhere(`:userId = ANY(${prefix}"sharedWithUserIds")`, { userId })
+    })
 }
 
 async function resolveShare({ visibility, sharedWithUserIds, projectId, log }: ResolveShareParams): Promise<UserId[]> {

--- a/packages/server/api/src/app/ee/agent/agent-service.ts
+++ b/packages/server/api/src/app/ee/agent/agent-service.ts
@@ -76,6 +76,17 @@ export const agentService = (log: FastifyBaseLogger) => ({
         return agentRepo().save({ ...agent, ...request, visibility, sharedWithUserIds })
     },
 
+    async publish({ id, projectId, userId }: GetParams): Promise<Agent> {
+        const agent = await this.getOneOrThrow({ id, projectId, userId })
+        if (agent.draft.instructions.trim().length === 0) {
+            throw new ActivepiecesError({
+                code: ErrorCode.VALIDATION,
+                params: { message: 'An agent needs instructions before it can be published' },
+            })
+        }
+        return agentRepo().save({ ...agent, published: agent.draft })
+    },
+
     async delete({ id, projectId, userId }: GetParams): Promise<Agent> {
         const agent = await this.getOneOrThrow({ id, projectId, userId })
         await agentRepo().delete({ id, projectId })

--- a/packages/server/api/test/integration/ee/agent/agent-controller.test.ts
+++ b/packages/server/api/test/integration/ee/agent/agent-controller.test.ts
@@ -135,6 +135,49 @@ describe('agent publish', () => {
         expect(third.published.instructions).toBe('Second version.')
     })
 
+    it('keeps the published config when the agent is edited afterwards', async () => {
+        const ctx = await context()
+        const agent = await createAgent(ctx)
+        await ctx.post(`/v1/agents/${agent.id}/publish`)
+
+        await ctx.post(`/v1/agents/${agent.id}`, { displayName: 'Renamed' })
+
+        const after = (await ctx.get(`/v1/agents/${agent.id}`)).json()
+        expect(after.displayName).toBe('Renamed')
+        expect(after.published).not.toBeNull()
+    })
+
+    it('publishes a piece tool with its predefined input intact', async () => {
+        const ctx = await context()
+        const draft = {
+            instructions: 'File the ticket.',
+            provider: null,
+            modelName: null,
+            maxSteps: 3,
+            tools: [{
+                type: 'PIECE',
+                toolName: 'create_issue',
+                pieceMetadata: {
+                    pieceName: '@activepieces/piece-github',
+                    pieceVersion: '0.1.0',
+                    actionName: 'create_issue',
+                    predefinedInput: { fields: { title: { mode: 'choose-yourself', value: 'Bug' } } },
+                },
+            }],
+            structuredOutput: [],
+        }
+        const agent = await createAgent(ctx, { draft })
+
+        expect((await ctx.post(`/v1/agents/${agent.id}/publish`)).json().published).toStrictEqual(draft)
+    })
+
+    it('refuses instructions that are only a non-breaking space', async () => {
+        const ctx = await context()
+        const agent = await createAgent(ctx, { draft: { ...agentBody(ctx.project.id).draft, instructions: '\u00a0' } })
+
+        expect((await ctx.post(`/v1/agents/${agent.id}/publish`)).statusCode).toBe(StatusCodes.CONFLICT)
+    })
+
     it('refuses to publish a restricted agent the caller cannot see', async () => {
         const owner = await context()
         const member = await createMemberContext(app, owner, { projectRole: DefaultProjectRole.EDITOR })

--- a/packages/server/api/test/integration/ee/agent/agent-controller.test.ts
+++ b/packages/server/api/test/integration/ee/agent/agent-controller.test.ts
@@ -2,6 +2,7 @@ import { apId } from '@activepieces/core-utils'
 import { AgentIcon, AgentVisibility, ColorName, DefaultProjectRole } from '@activepieces/shared'
 import { FastifyInstance } from 'fastify'
 import { StatusCodes } from 'http-status-codes'
+import { db } from '../../../helpers/db'
 import { createMemberContext, createTestContext, TestContext } from '../../../helpers/test-context'
 import { setupTestEnvironment, teardownTestEnvironment } from '../../../helpers/test-setup'
 
@@ -96,12 +97,51 @@ describe('agent publish', () => {
         expect(after.published.instructions).toBe('Draft launch posts.')
     })
 
-    it('refuses to publish an agent with no instructions', async () => {
-        const ctx = await context()
-        const agent = await createAgent(ctx, { draft: { ...agentBody(ctx.project.id).draft, instructions: '   ' } })
+    it.each([['spaces', '   '], ['tabs', '\t\t'], ['newlines', '\n\n'], ['empty', '']])(
+        'refuses to publish an agent whose instructions are only %s',
+        async (_kind, instructions) => {
+            const ctx = await context()
+            const agent = await createAgent(ctx, { draft: { ...agentBody(ctx.project.id).draft, instructions } })
 
-        expect((await ctx.post(`/v1/agents/${agent.id}/publish`)).statusCode).toBe(StatusCodes.CONFLICT)
-        expect((await ctx.get(`/v1/agents/${agent.id}`)).json().published).toBeNull()
+            expect((await ctx.post(`/v1/agents/${agent.id}/publish`)).statusCode).toBe(StatusCodes.CONFLICT)
+            expect((await ctx.get(`/v1/agents/${agent.id}`)).json().published).toBeNull()
+        })
+
+    it('keeps a rich config byte-for-byte through the copy', async () => {
+        const ctx = await context()
+        const draft = {
+            instructions: 'Check the brand guide first.',
+            provider: null,
+            modelName: 'claude-sonnet-4-6',
+            maxSteps: 7,
+            tools: [],
+            structuredOutput: [{ displayName: 'summary', type: 'text' }],
+        }
+        const agent = await createAgent(ctx, { draft })
+
+        const published = (await ctx.post(`/v1/agents/${agent.id}/publish`)).json().published
+        expect(published).toStrictEqual(draft)
+    })
+
+    it('republishes the newer draft, and is a no-op when nothing changed', async () => {
+        const ctx = await context()
+        const agent = await createAgent(ctx)
+        const first = (await ctx.post(`/v1/agents/${agent.id}/publish`)).json()
+        const again = (await ctx.post(`/v1/agents/${agent.id}/publish`)).json()
+        expect(again.published).toStrictEqual(first.published)
+
+        await ctx.post(`/v1/agents/${agent.id}`, { draft: { ...agentBody(ctx.project.id).draft, instructions: 'Second version.' } })
+        const third = (await ctx.post(`/v1/agents/${agent.id}/publish`)).json()
+        expect(third.published.instructions).toBe('Second version.')
+    })
+
+    it('refuses to publish a restricted agent the caller cannot see', async () => {
+        const owner = await context()
+        const member = await createMemberContext(app, owner, { projectRole: DefaultProjectRole.EDITOR })
+        const agent = await createAgent(owner, { visibility: AgentVisibility.RESTRICTED })
+
+        expect((await member.post(`/v1/agents/${agent.id}/publish`)).statusCode).toBe(StatusCodes.NOT_FOUND)
+        expect((await owner.get(`/v1/agents/${agent.id}`)).json().published).toBeNull()
     })
 
     it('refuses a viewer, and an agent in another project', async () => {
@@ -225,10 +265,17 @@ describe('agent routes coexist with the chat routes already on /v1/agents', () =
 })
 
 describe('agent feature gate', () => {
-    it('refuses every agent route when the platform does not have agents', async () => {
-        const ctx = await createTestContext(app, { plan: { agentsEnabled: false } })
+    it('refuses every agent route once the platform loses the entitlement', async () => {
+        const ctx = await context()
+        const agent = await createAgent(ctx)
+        const plan = await db.findOneByOrFail<{ id: string }>('platform_plan', { platformId: ctx.platform.id })
+        await db.update('platform_plan', plan.id, { agentsEnabled: false })
 
         expect((await ctx.get('/v1/agents')).statusCode).toBe(StatusCodes.PAYMENT_REQUIRED)
         expect((await ctx.post('/v1/agents', agentBody(ctx.project.id))).statusCode).toBe(StatusCodes.PAYMENT_REQUIRED)
+        expect((await ctx.get(`/v1/agents/${agent.id}`)).statusCode).toBe(StatusCodes.PAYMENT_REQUIRED)
+        expect((await ctx.post(`/v1/agents/${agent.id}`, { displayName: 'x' })).statusCode).toBe(StatusCodes.PAYMENT_REQUIRED)
+        expect((await ctx.post(`/v1/agents/${agent.id}/publish`)).statusCode).toBe(StatusCodes.PAYMENT_REQUIRED)
+        expect((await ctx.delete(`/v1/agents/${agent.id}`)).statusCode).toBe(StatusCodes.PAYMENT_REQUIRED)
     })
 })

--- a/packages/server/api/test/integration/ee/agent/agent-controller.test.ts
+++ b/packages/server/api/test/integration/ee/agent/agent-controller.test.ts
@@ -73,6 +73,49 @@ describe('agent crud', () => {
     })
 })
 
+describe('agent publish', () => {
+    it('copies the draft to published, so a flow step has something to run', async () => {
+        const ctx = await context()
+        const agent = await createAgent(ctx)
+
+        const response = await ctx.post(`/v1/agents/${agent.id}/publish`)
+
+        expect(response.statusCode).toBe(StatusCodes.OK)
+        expect(response.json().published).toStrictEqual(response.json().draft)
+    })
+
+    it('leaves the published copy alone when the draft moves on', async () => {
+        const ctx = await context()
+        const agent = await createAgent(ctx)
+        await ctx.post(`/v1/agents/${agent.id}/publish`)
+
+        await ctx.post(`/v1/agents/${agent.id}`, { draft: { ...agentBody(ctx.project.id).draft, instructions: 'Rewritten.' } })
+
+        const after = (await ctx.get(`/v1/agents/${agent.id}`)).json()
+        expect(after.draft.instructions).toBe('Rewritten.')
+        expect(after.published.instructions).toBe('Draft launch posts.')
+    })
+
+    it('refuses to publish an agent with no instructions', async () => {
+        const ctx = await context()
+        const agent = await createAgent(ctx, { draft: { ...agentBody(ctx.project.id).draft, instructions: '   ' } })
+
+        expect((await ctx.post(`/v1/agents/${agent.id}/publish`)).statusCode).toBe(StatusCodes.CONFLICT)
+        expect((await ctx.get(`/v1/agents/${agent.id}`)).json().published).toBeNull()
+    })
+
+    it('refuses a viewer, and an agent in another project', async () => {
+        const owner = await context()
+        const viewer = await createMemberContext(app, owner, { projectRole: DefaultProjectRole.VIEWER })
+        const stranger = await context()
+        const agent = await createAgent(owner)
+
+        expect((await viewer.post(`/v1/agents/${agent.id}/publish`)).statusCode).toBe(StatusCodes.FORBIDDEN)
+        expect((await stranger.post(`/v1/agents/${agent.id}/publish`)).statusCode).toBe(StatusCodes.FORBIDDEN)
+        expect((await owner.get(`/v1/agents/${agent.id}`)).json().published).toBeNull()
+    })
+})
+
 describe('agent project isolation', () => {
     it.each([
         ['read', (ctx: TestContext, id: string) => ctx.get(`/v1/agents/${id}`)],


### PR DESCRIPTION
## Description

Adds `POST /v1/agents/:id/publish`. Continues #14842.

Until now `published` was returned on every agent response, was always `null`, and no endpoint could set it — a field nobody could write. Publishing copies the current draft into it.

**This is the only act that changes what a linked flow runs.** Editing an agent changes the draft, which is what you and chat iterate against; a flow step reads the published copy. So publishing is audited as its own event (`agent.published`) rather than folded into `agent.updated`, and the draft keeps moving independently afterwards — the tests pin that.

**An agent with no instructions cannot be published.** A draft is allowed to be empty while you're still writing it, which is why `instructions` has no minimum on the schema. A *published* agent that does nothing is not worth running, so the guard lives at the commitment point rather than on the field.

**Two parts of the planned scope are deliberately not here**, both for the same reason the delete guard was cut from #14842:

- *Reporting the blast radius* ("used in N flows") needs flows that can reference an agent. No AI-piece action declares an `agentId` prop yet, so `flow_version.agentIds` is never populated and the number would always be zero. It belongs in the PR that adds the reference.
- *Version history* needs its own table, and has no reader until the editor UI lands — which is still waiting on design sign-off. Committing to a schema now, unread, is the kind of guess that's expensive to reverse.

## How was this tested?

4 new integration tests, 25 in the agent suite, all green. Full runs: EE 149 passing (16 files), CE 872 passing (74 files). Lint and typecheck clean. 86 meaningful lines in `server/api`, well under budget.

The publish guard was **proven able to fail**: replacing the empty-instructions check with `if (false)` makes `refuses to publish an agent with no instructions` fail, and restoring it makes it pass.

Covered: publish copies draft to published; the published copy stays put when the draft is edited afterwards; an empty draft is refused and leaves `published` null; a viewer is refused; another project's agent is refused and stays unpublished.

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

- [ ] no — reviewed, no security impact
- [x] yes — security-sensitive (call out the risk and mitigation in the description above)

Publishing is the act that changes what runs unattended in every flow linked to an agent, which is the authorisation widening decision 000027 accepted. It is gated by `WRITE_AGENT` on the agent's own project — resolved from the agent row via `ProjectTableResource`, never from caller input — and it emits a distinct audit event so the change is attributable. Tests cover a viewer being refused and a cross-project caller being refused without the agent being published.
