### PR TITLE
fix(web): name the agent events the audit surfaces require

### DIFF
--- a/packages/web/src/app/routes/platform/infra/event-destinations/lib/use-event-labels.ts
+++ b/packages/web/src/app/routes/platform/infra/event-destinations/lib/use-event-labels.ts
@@ -3,6 +3,17 @@ import { t } from 'i18next';
 
 export const useEventLabels = (): EventLabelsMap => {
   return {
+    [ApplicationEventName.AGENT_CREATED]: { label: t('Agent created') },
+    [ApplicationEventName.AGENT_UPDATED]: { label: t('Agent updated') },
+    [ApplicationEventName.AGENT_DELETED]: { label: t('Agent deleted') },
+    [ApplicationEventName.AGENT_PUBLISHED]: {
+      label: t('Agent published'),
+      description: t('Fires when an agent starts running in flows.'),
+    },
+    [ApplicationEventName.AGENT_UNPUBLISHED]: {
+      label: t('Agent taken offline'),
+      description: t('Fires when an agent stops running in flows.'),
+    },
     [ApplicationEventName.FLOW_RUN_STARTED]: { label: t('Flow run started') },
     [ApplicationEventName.FLOW_RUN_FINISHED]: {
       label: t('Flow run finished'),

--- a/packages/web/src/app/routes/platform/infra/event-destinations/lib/use-event-labels.ts
+++ b/packages/web/src/app/routes/platform/infra/event-destinations/lib/use-event-labels.ts
@@ -8,11 +8,11 @@ export const useEventLabels = (): EventLabelsMap => {
     [ApplicationEventName.AGENT_DELETED]: { label: t('Agent deleted') },
     [ApplicationEventName.AGENT_PUBLISHED]: {
       label: t('Agent published'),
-      description: t('Fires when an agent starts running in flows.'),
+      description: t('Fires when someone publishes an agent. Flow steps read the published copy, not the draft.'),
     },
     [ApplicationEventName.AGENT_UNPUBLISHED]: {
       label: t('Agent taken offline'),
-      description: t('Fires when an agent stops running in flows.'),
+      description: t('Fires when someone takes an agent offline.'),
     },
     [ApplicationEventName.FLOW_RUN_STARTED]: { label: t('Flow run started') },
     [ApplicationEventName.FLOW_RUN_FINISHED]: {

--- a/packages/web/src/app/routes/platform/infra/event-destinations/lib/use-event-labels.ts
+++ b/packages/web/src/app/routes/platform/infra/event-destinations/lib/use-event-labels.ts
@@ -8,7 +8,9 @@ export const useEventLabels = (): EventLabelsMap => {
     [ApplicationEventName.AGENT_DELETED]: { label: t('Agent deleted') },
     [ApplicationEventName.AGENT_PUBLISHED]: {
       label: t('Agent published'),
-      description: t('Fires when someone publishes an agent. Flow steps read the published copy, not the draft.'),
+      description: t(
+        'Fires when someone publishes an agent. Flow steps read the published copy, not the draft.',
+      ),
     },
     [ApplicationEventName.AGENT_UNPUBLISHED]: {
       label: t('Agent taken offline'),

--- a/packages/web/src/app/routes/platform/security/audit-logs/index.tsx
+++ b/packages/web/src/app/routes/platform/security/audit-logs/index.tsx
@@ -490,6 +490,22 @@ function extractEventDetails(event: ApplicationEvent): EventDetailRow[] {
       const { variable } = event.data;
       return [{ label: t('Variable'), value: variable.name }];
     }
+    case ApplicationEventName.AGENT_CREATED:
+    case ApplicationEventName.AGENT_UPDATED:
+    case ApplicationEventName.AGENT_DELETED:
+    case ApplicationEventName.AGENT_PUBLISHED:
+    case ApplicationEventName.AGENT_UNPUBLISHED: {
+      const { agent } = event.data;
+      return [
+        { label: t('Agent'), value: agent.displayName },
+        ...(agent.publishedDigest
+          ? [{ label: t('Published version'), value: agent.publishedDigest }]
+          : []),
+        ...(agent.publishedToolNames?.length
+          ? [{ label: t('Tools'), value: agent.publishedToolNames.join(', ') }]
+          : []),
+      ];
+    }
     case ApplicationEventName.FOLDER_CREATED:
     case ApplicationEventName.FOLDER_UPDATED:
     case ApplicationEventName.FOLDER_DELETED:


### PR DESCRIPTION
## Description

`packages/web` does not typecheck on `main` right now. This fixes it.

Adding the agent audit events (`agent.created` / `updated` / `deleted` / `published` / `unpublished` across #14842, #14846 and #14848) left two exhaustive maps in the web app without entries:

- `use-event-labels.ts` builds an `EventLabelsMap` keyed by every `ApplicationEventName`
- `audit-logs/index.tsx` `extractEventDetails` switches on `event.action` with no `default`

Neither has a fallback, and that is deliberate — they exist to fail the build when an event is added without a label. They did exactly that. I missed it because those PRs verified the server and the shared package but never ran the web typecheck, and web is not in the api test path.

While adding the labels, the audit log now also surfaces the **published digest and tool names** the publish event carries. That was added so "what exactly went live?" is answerable from the audit trail, and until now nothing rendered it.

## How was this tested?

`npx tsc -p packages/web/tsconfig.app.json --noEmit` — clean. It fails on `main` with both errors, and passes here.

`packages/web` lint: 0 errors. Web unit tests: 475 passing; one pre-existing failure (`chunk-reducer.test.ts`, `window is not defined`) that also fails on a clean `main` and is unrelated.

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)
