### PR TITLE
feat(framework): widen action classification to READ/SEARCH/WRITE/DESTRUCTIVE

### DIFF
--- a/packages/pieces/framework/src/lib/piece-metadata.ts
+++ b/packages/pieces/framework/src/lib/piece-metadata.ts
@@ -58,22 +58,9 @@ export const AiMetadata = z.object({
 })
 export type AiMetadata = z.infer<typeof AiMetadata>
 
-/**
- * What a step does to the connected system, in escalating order of consequence.
- *
- * - `READ`        fetches a known resource by id or returns fixed state — get, retrieve, describe
- * - `SEARCH`      queries or enumerates without mutating — search, list, find, lookup
- * - `WRITE`       adds or changes state, recoverable — create, send, update, upsert
- * - `DESTRUCTIVE` removes or disables state; a retry cannot undo it — delete, archive, revoke
- *
- * Exactly one value per action or trigger. `SEARCH` narrows `READ` and `DESTRUCTIVE` narrows
- * `WRITE`, so anything non-mutating is one of the first two and anything mutating is one of the
- * last two.
- */
 export const ActionClassification = z.enum(['READ', 'SEARCH', 'WRITE', 'DESTRUCTIVE'])
 export type ActionClassification = z.infer<typeof ActionClassification>
 
-/** Non-mutating classifications — safe to run without confirmation. */
 export const READ_ONLY_CLASSIFICATIONS: readonly ActionClassification[] = ['READ', 'SEARCH']
 
 export const isReadOnlyClassification = (classification: ActionClassification | undefined): boolean =>

--- a/packages/pieces/framework/src/lib/piece-metadata.ts
+++ b/packages/pieces/framework/src/lib/piece-metadata.ts
@@ -58,8 +58,26 @@ export const AiMetadata = z.object({
 })
 export type AiMetadata = z.infer<typeof AiMetadata>
 
-export const ActionClassification = z.enum(['READ', 'WRITE'])
+/**
+ * What a step does to the connected system, in escalating order of consequence.
+ *
+ * - `READ`        fetches a known resource by id or returns fixed state — get, retrieve, describe
+ * - `SEARCH`      queries or enumerates without mutating — search, list, find, lookup
+ * - `WRITE`       adds or changes state, recoverable — create, send, update, upsert
+ * - `DESTRUCTIVE` removes or disables state; a retry cannot undo it — delete, archive, revoke
+ *
+ * Exactly one value per action or trigger. `SEARCH` narrows `READ` and `DESTRUCTIVE` narrows
+ * `WRITE`, so anything non-mutating is one of the first two and anything mutating is one of the
+ * last two.
+ */
+export const ActionClassification = z.enum(['READ', 'SEARCH', 'WRITE', 'DESTRUCTIVE'])
 export type ActionClassification = z.infer<typeof ActionClassification>
+
+/** Non-mutating classifications — safe to run without confirmation. */
+export const READ_ONLY_CLASSIFICATIONS: readonly ActionClassification[] = ['READ', 'SEARCH']
+
+export const isReadOnlyClassification = (classification: ActionClassification | undefined): boolean =>
+  classification !== undefined && READ_ONLY_CLASSIFICATIONS.includes(classification)
 
 export const PropertyGroupDisplay = z.enum(['tabs', 'section', 'summary', 'builder', 'footer'])
 export type PropertyGroupDisplay = z.infer<typeof PropertyGroupDisplay>

--- a/packages/web/src/app/builder/pieces-selector/generic-piece-selector-item.tsx
+++ b/packages/web/src/app/builder/pieces-selector/generic-piece-selector-item.tsx
@@ -108,8 +108,6 @@ const GenericActionOrTriggerItem = ({
 GenericActionOrTriggerItem.displayName = 'GenericActionOrTriggerItem';
 export default GenericActionOrTriggerItem;
 
-// Only DESTRUCTIVE is coloured — a red pill on every mutating step would read as a
-// warning the user has to dismiss 40 times, so WRITE stays as quiet as the reads.
 const CLASSIFICATION_BADGE: Record<
   ActionClassification,
   { label: () => string; variant: 'accent' | 'destructive' }

--- a/packages/web/src/app/builder/pieces-selector/generic-piece-selector-item.tsx
+++ b/packages/web/src/app/builder/pieces-selector/generic-piece-selector-item.tsx
@@ -1,3 +1,4 @@
+import type { ActionClassification } from '@activepieces/pieces-framework';
 import { FlowActionType, FlowTriggerType } from '@activepieces/shared';
 import { t } from 'i18next';
 
@@ -15,6 +16,18 @@ type GenericActionOrTriggerItemProps = {
   hidePieceIconAndDescription: boolean;
   stepMetadataWithSuggestions: StepMetadataWithSuggestions;
   onClick: () => void;
+};
+
+// Only DESTRUCTIVE is coloured — a red pill on every mutating step would read as a
+// warning the user has to dismiss 40 times, so WRITE stays as quiet as the reads.
+const CLASSIFICATION_BADGE: Record<
+  ActionClassification,
+  { label: () => string; variant: 'accent' | 'destructive' }
+> = {
+  READ: { label: () => t('Read'), variant: 'accent' },
+  SEARCH: { label: () => t('Search'), variant: 'accent' },
+  WRITE: { label: () => t('Write'), variant: 'accent' },
+  DESTRUCTIVE: { label: () => t('Destructive'), variant: 'destructive' },
 };
 
 const getPieceSelectorItemInfo = (item: PieceSelectorItem) => {
@@ -77,12 +90,15 @@ const GenericActionOrTriggerItem = ({
             </div>
             {pieceSelectorItemInfo.classification && (
               <Badge
-                variant="accent"
+                variant={
+                  CLASSIFICATION_BADGE[pieceSelectorItemInfo.classification]
+                    .variant
+                }
                 className="shrink-0 px-1.5 py-0 text-[10px] font-normal"
               >
-                {pieceSelectorItemInfo.classification === 'READ'
-                  ? t('Read')
-                  : t('Write')}
+                {CLASSIFICATION_BADGE[
+                  pieceSelectorItemInfo.classification
+                ].label()}
               </Badge>
             )}
           </div>

--- a/packages/web/src/app/builder/pieces-selector/generic-piece-selector-item.tsx
+++ b/packages/web/src/app/builder/pieces-selector/generic-piece-selector-item.tsx
@@ -18,18 +18,6 @@ type GenericActionOrTriggerItemProps = {
   onClick: () => void;
 };
 
-// Only DESTRUCTIVE is coloured — a red pill on every mutating step would read as a
-// warning the user has to dismiss 40 times, so WRITE stays as quiet as the reads.
-const CLASSIFICATION_BADGE: Record<
-  ActionClassification,
-  { label: () => string; variant: 'accent' | 'destructive' }
-> = {
-  READ: { label: () => t('Read'), variant: 'accent' },
-  SEARCH: { label: () => t('Search'), variant: 'accent' },
-  WRITE: { label: () => t('Write'), variant: 'accent' },
-  DESTRUCTIVE: { label: () => t('Destructive'), variant: 'destructive' },
-};
-
 const getPieceSelectorItemInfo = (item: PieceSelectorItem) => {
   if (
     item.type === FlowActionType.PIECE ||
@@ -119,3 +107,15 @@ const GenericActionOrTriggerItem = ({
 
 GenericActionOrTriggerItem.displayName = 'GenericActionOrTriggerItem';
 export default GenericActionOrTriggerItem;
+
+// Only DESTRUCTIVE is coloured — a red pill on every mutating step would read as a
+// warning the user has to dismiss 40 times, so WRITE stays as quiet as the reads.
+const CLASSIFICATION_BADGE: Record<
+  ActionClassification,
+  { label: () => string; variant: 'accent' | 'destructive' }
+> = {
+  READ: { label: () => t('Read'), variant: 'accent' },
+  SEARCH: { label: () => t('Search'), variant: 'accent' },
+  WRITE: { label: () => t('Write'), variant: 'accent' },
+  DESTRUCTIVE: { label: () => t('Destructive'), variant: 'destructive' },
+};


### PR DESCRIPTION
## Description

`ActionClassification` shipped in #14501 as a two-value enum, `READ | WRITE`. This widens it to four before anything adopts it.

Two values cannot express the distinction that matters most. `delete_draft` and `update_draft` are both `WRITE`, so the badge says the same thing about an edit you can undo and a deletion you cannot. Every `list_*`/`search_*` action likewise collapses into `READ` alongside `get_by_id`, hiding the difference between fetching one known thing and enumerating whatever matches.

```ts
export const ActionClassification = z.enum(['READ', 'SEARCH', 'WRITE', 'DESTRUCTIVE'])
```

| Value | Means | Verbs |
|---|---|---|
| `READ` | fetches a known resource by id, or returns fixed state | get, retrieve, describe, download |
| `SEARCH` | queries or enumerates without mutating | search, list, find, lookup, query |
| `WRITE` | adds or changes state, recoverable | create, send, update, upsert, mark |
| `DESTRUCTIVE` | removes or disables state; a retry cannot undo it | delete, archive, revoke, cancel, stop |

Ordered by consequence rather than alphabetically. `SEARCH` narrows `READ` and `DESTRUCTIVE` narrows `WRITE`, so the non-mutating half is the first two — exported as `READ_ONLY_CLASSIFICATIONS` / `isReadOnlyClassification` so no consumer has to re-derive that split from string comparison.

The piece selector badge renders all four. Only `DESTRUCTIVE` is coloured, reusing the existing `destructive` `Badge` variant; a red pill on every mutating step would be a warning users learn to ignore, so `WRITE` stays as quiet as the reads.

### Why now

No piece carries a `classification` yet — zero across all 726 pieces — and nothing outside the badge reads the field. Widening the enum is free today and expensive once the catalog starts carrying values.

### Why four, specifically

Measured against the catalog while scoping a backfill. Deriving tags from `aiMetadata.idempotent` plus the action's leading verb was unreliable under two values, because ~850 actions are `idempotent: true` yet mutating (update-by-id, delete, upsert) and had nowhere sensible to go. With `DESTRUCTIVE` as its own bucket the rule composes cleanly and auto-derives ~90% of 5,603 actions, leaving ~535 for human review instead of the whole catalog. `DESTRUCTIVE` alone accounts for ~459 actions the product currently cannot distinguish from an ordinary edit.

Worth noting for reviewers: `agentToolClassification` (`packages/core/shared/src/lib/ee/agent/tool-classification.ts`) already reasons about read-vs-write independently, by word-matching action names, and gates the agent approval path on the answer. It is blind on ~41% of catalog action names. This PR does not touch that path, but `isReadOnlyClassification` is deliberately shaped as the seam if we later want a declared value to back it — which is what ADR `000024` asks for.

## How was this tested?

Ran end-to-end against a local build, plus static checks.

**End-to-end.** Booted the full dev stack (PGLITE + in-memory queue) with a Gmail piece tagged across all four values, then read the metadata back out of the running API:

```
GET /api/v1/pieces/@activepieces/piece-gmail?audience=all
-> 30 entries: READ 11, SEARCH 6, WRITE 10, DESTRUCTIVE 2, untagged 1 (custom_api_call)
```

That matches the source tagging exactly, so all four values survive the piece loader, the zod metadata schema, and the API response. `SEARCH` and `DESTRUCTIVE` are not stripped or coerced anywhere in the pipeline — the failure mode a type-check alone cannot rule out.

Note the default (`audience=human`) response omits both `DESTRUCTIVE` actions, since they are `audience: 'ai'`. That is the pre-existing audience filter, not a regression here, but it does mean the badge is invisible for exactly the actions where read-vs-write carries the most risk.

**Static.**

- `tsc --noEmit` clean on `@activepieces/pieces-framework`, `packages/web`, and the re-tagged Gmail piece
- `eslint` clean on both changed files
- `vitest` on `@activepieces/pieces-framework` — 15/15 pass. These cover date-range properties, auth properties and connection identifiers; **none exercise `classification`**. They confirm nothing existing broke, not that the new code works.
- Grepped every consumer of `ActionClassification` / `.classification`: the framework passes it through as an optional type, the admin controller validates against the schema, and the selector badge is the only code that branches on the value. No exhaustive switch exists anywhere, so widening is transparent to all of them.

**Visual.** All four badges confirmed rendering in the builder's piece selector against the local build: `Read`, `Search` and `Write` as neutral grey pills, and `Destructive` as a red one. The red variant was checked by temporarily classifying a `human`-audience Gmail action `DESTRUCTIVE`, since the two genuinely destructive Gmail actions are `audience: 'ai'` and therefore never reach the selector. That temporary change has been reverted.

**Remaining gap: no automated test.** There is no test for this field anywhere in the repo, before or after this PR — `packages/web` has no component-test harness at all (no testing-library, no jsdom, zero existing component tests). Adding one is a repo-wide dependency decision rather than something to slip into this PR; a `CLASSIFICATION_BADGE` test belongs with the first piece that adopts the values.

Fixes # (n/a)

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

<!-- Additive widening of an optional enum: both existing values keep their meaning, nothing is removed or renamed, and no piece sets the field yet. Flagging for a reviewer's judgement anyway, since the type is published in @activepieces/pieces-framework and a downstream consumer that narrowed on the two-value union would need updating. -->

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)

<!-- The field is inert: nothing outside the piece selector badge reads it, and no execution, permission, or agent path consults it. -->
