### PR TITLE
fix(pieces): make serp-api agent action descriptions intent-first

### DIFF
--- a/packages/pieces/community/serp-api/package.json
+++ b/packages/pieces/community/serp-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-serp-api",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {

--- a/packages/pieces/community/serp-api/src/lib/actions/search-apple-app-store.ts
+++ b/packages/pieces/community/serp-api/src/lib/actions/search-apple-app-store.ts
@@ -12,7 +12,7 @@ export const searchAppleAppStore = createAction({
   audience: 'ai',
   aiMetadata: {
     description:
-      'Searches the Apple App Store via SerpApi for iOS apps matching a term, returning results in `organic_results` (app name, developer, rating, price, link). Use to discover iOS apps or look up an app by name. For Android apps use Search Google Play instead. Read-only and idempotent; requires the search term and a SerpApi API key.',
+      'Search the Apple App Store for iOS apps matching a name or keyword. Use to discover iOS apps, look up a specific app, or check an app\'s developer, rating, and price. For Android apps use Search Google Play instead.',
     idempotent: true,
   },
   outputSchema: searchAppleAppStoreOutputSchema,

--- a/packages/pieces/community/serp-api/src/lib/actions/search-bing.ts
+++ b/packages/pieces/community/serp-api/src/lib/actions/search-bing.ts
@@ -12,7 +12,7 @@ export const searchBing = createAction({
   audience: 'ai',
   aiMetadata: {
     description:
-      'Runs a Bing web search via SerpApi and returns organic web results (in `organic_results`) for a query. Use as an alternative web engine to cross-check or supplement Google web results. Paginate with Count (results per page) and First (offset of the first result). Read-only and idempotent; requires the query and a SerpApi API key.',
+      'Search the web with Bing and get ranked organic results for a query. Use as an alternative web search engine to cross-check or supplement Google web results. Paginate with Count (results per page) and First (offset of the first result).',
     idempotent: true,
   },
   outputSchema: searchBingOutputSchema,

--- a/packages/pieces/community/serp-api/src/lib/actions/search-duckduckgo.ts
+++ b/packages/pieces/community/serp-api/src/lib/actions/search-duckduckgo.ts
@@ -12,7 +12,7 @@ export const searchDuckduckgo = createAction({
   audience: 'ai',
   aiMetadata: {
     description:
-      'Runs a DuckDuckGo web search via SerpApi and returns organic web results (in `organic_results`) for a query. Use as a privacy-oriented alternative web engine to cross-check or supplement Google and Bing web results. Scope results to a region with the Region code. Read-only and idempotent; requires the query and a SerpApi API key.',
+      'Search the web with DuckDuckGo and get ranked organic results for a query. Use as a privacy-oriented alternative web search engine to cross-check or supplement Google and Bing web results. Scope results to a region with the Region code.',
     idempotent: true,
   },
   outputSchema: searchDuckduckgoOutputSchema,

--- a/packages/pieces/community/serp-api/src/lib/actions/search-google-images.ts
+++ b/packages/pieces/community/serp-api/src/lib/actions/search-google-images.ts
@@ -12,7 +12,7 @@ export const searchGoogleImages = createAction({
   audience: 'ai',
   aiMetadata: {
     description:
-      'Searches Google Images via SerpApi for a query, returning results in `images_results` (thumbnail URL, full-resolution image URL, title, and source page). Use to discover images, find a full-resolution URL, or locate the page an image came from. Page through results with the page index. Read-only and idempotent; requires the query and a SerpApi API key.',
+      'Search Google Images for pictures and photos matching a query. Use to discover images on a topic, find a full-resolution image URL, or locate the page an image came from. Page through results with the page index.',
     idempotent: true,
   },
   outputSchema: searchGoogleImagesOutputSchema,

--- a/packages/pieces/community/serp-api/src/lib/actions/search-google-jobs.ts
+++ b/packages/pieces/community/serp-api/src/lib/actions/search-google-jobs.ts
@@ -12,7 +12,7 @@ export const searchGoogleJobs = createAction({
   audience: 'ai',
   aiMetadata: {
     description:
-      'Searches Google Jobs via SerpApi for job listings matching a query, returning results in `jobs_results` (title, company, location, posted date, schedule, apply links). Use to find open positions for a role. Narrow with a free-text Location, and set Listing Type to "1" for work-from-home roles. Paginate with the next page token from a prior response. Read-only and idempotent; requires the query and a SerpApi API key.',
+      'Search Google Jobs for job listings, job openings, and vacancies matching a role, title, or keyword. Use to find open positions or job postings, optionally narrowed with a free-text Location; set Listing Type to "1" for remote / work-from-home roles. Paginate with the next page token from a prior response.',
     idempotent: true,
   },
   outputSchema: searchGoogleJobsOutputSchema,

--- a/packages/pieces/community/serp-api/src/lib/actions/search-google-lens.ts
+++ b/packages/pieces/community/serp-api/src/lib/actions/search-google-lens.ts
@@ -12,7 +12,7 @@ export const searchGoogleLens = createAction({
   audience: 'ai',
   aiMetadata: {
     description:
-      'Runs a Google Lens reverse-image search via SerpApi for a publicly accessible image URL, returning visual matches and related content (in `visual_matches` and related keys). Use to identify what is in an image, find where an image appears online, or find visually similar items. Optionally refine with a text query. Read-only and idempotent; requires the image URL and a SerpApi API key.',
+      'Run a Google Lens reverse image search on a publicly accessible image URL to find visual matches for a picture. Use to identify what is in an image, find where an image appears online, or find visually similar items. Optionally refine with a text query.',
     idempotent: true,
   },
   outputSchema: searchGoogleLensOutputSchema,

--- a/packages/pieces/community/serp-api/src/lib/actions/search-google-local-services.ts
+++ b/packages/pieces/community/serp-api/src/lib/actions/search-google-local-services.ts
@@ -12,7 +12,7 @@ export const searchGoogleLocalServices = createAction({
   audience: 'ai',
   aiMetadata: {
     description:
-      'Searches Google Local Services Ads via SerpApi for vetted service providers (e.g. plumbers, electricians) matching a query, returning results in `local_ads`. Requires a Data CID identifying the geographic region; this is an opaque id with no resolver in this piece, so it must be supplied by the caller. Read-only and idempotent; requires the query, the Data CID, and a SerpApi API key.',
+      'Search Google Local Services Ads for vetted local service providers (plumbers, electricians, cleaners, and similar trades) matching a query. Requires a Data CID identifying the geographic region; this is an opaque id with no resolver in this piece, so it must be supplied by the caller.',
     idempotent: true,
   },
   outputSchema: searchGoogleLocalServicesOutputSchema,

--- a/packages/pieces/community/serp-api/src/lib/actions/search-google-maps.ts
+++ b/packages/pieces/community/serp-api/src/lib/actions/search-google-maps.ts
@@ -12,7 +12,7 @@ export const searchGoogleMaps = createAction({
   audience: 'ai',
   aiMetadata: {
     description:
-      'Searches Google Maps via SerpApi for local businesses and places matching a query, returning results in `local_results` (name, rating, reviews, address, phone, type, GPS coordinates, hours). Use to find businesses, restaurants, or services in an area. Pass `ll` to anchor the search to a map center; `ll` is effectively required once you paginate with `start`. Read-only and idempotent; requires the query and a SerpApi API key.',
+      'Search Google Maps for local businesses and places matching a query: names, ratings, reviews, addresses, phone numbers, opening hours, and GPS coordinates. Use to find businesses, restaurants, or services in an area. Pass `ll` to anchor the search to a map center; `ll` is effectively required once you paginate with `start`.',
     idempotent: true,
   },
   outputSchema: searchGoogleMapsOutputSchema,

--- a/packages/pieces/community/serp-api/src/lib/actions/search-google-news-ai.ts
+++ b/packages/pieces/community/serp-api/src/lib/actions/search-google-news-ai.ts
@@ -12,7 +12,7 @@ export const searchGoogleNewsAi = createAction({
   audience: 'ai',
   aiMetadata: {
     description:
-      'Searches Google News via SerpApi for recent articles matching a query and returns them in `news_results`. Use to monitor brand or topic mentions in the press, surface breaking coverage, or gather current headlines. For general web results pick Search Google instead. Read-only and idempotent; requires the query and a SerpApi API key.',
+      'Search Google News for recent news articles matching a query. Use to get the latest news headlines about a company, brand, person, or topic, monitor press and media mentions, or track breaking news coverage. For general web results pick Search Google instead.',
     idempotent: true,
   },
   outputSchema: searchGoogleNewsAiOutputSchema,

--- a/packages/pieces/community/serp-api/src/lib/actions/search-google-play.ts
+++ b/packages/pieces/community/serp-api/src/lib/actions/search-google-play.ts
@@ -12,7 +12,7 @@ export const searchGooglePlay = createAction({
   audience: 'ai',
   aiMetadata: {
     description:
-      'Searches the Google Play store via SerpApi for a query within a chosen store section, returning results in `organic_results` (title, developer, rating, link). Use to discover Android apps, games, movies, or books. Set Store to "apps" (default), "games", "movies", or "books". For iOS apps use Search Apple App Store instead. Read-only and idempotent; requires the query and a SerpApi API key.',
+      'Search the Google Play store for Android apps, games, movies, or books matching a query. Use to discover Android apps or other Play content; set Store to "apps" (default), "games", "movies", or "books". For iOS apps use Search Apple App Store instead.',
     idempotent: true,
   },
   outputSchema: searchGooglePlayOutputSchema,

--- a/packages/pieces/community/serp-api/src/lib/actions/search-google-scholar.ts
+++ b/packages/pieces/community/serp-api/src/lib/actions/search-google-scholar.ts
@@ -12,7 +12,7 @@ export const searchGoogleScholar = createAction({
   audience: 'ai',
   aiMetadata: {
     description:
-      'Searches Google Scholar via SerpApi for academic papers and citations matching a query, returning results in `organic_results` (title, authors, publication, year, cited-by count, PDF/resource links). Use to research literature, find citations, or gather academic sources. Use `as_ylo`/`as_yhi` to restrict by publication year. Read-only and idempotent; requires the query and a SerpApi API key.',
+      'Search Google Scholar for academic papers, scholarly articles, and citations matching a query. Use to research literature, find citations, or gather academic sources. Restrict by publication year with `as_ylo`/`as_yhi`.',
     idempotent: true,
   },
   outputSchema: searchGoogleScholarOutputSchema,

--- a/packages/pieces/community/serp-api/src/lib/actions/search-google-shopping.ts
+++ b/packages/pieces/community/serp-api/src/lib/actions/search-google-shopping.ts
@@ -12,7 +12,7 @@ export const searchGoogleShopping = createAction({
   audience: 'ai',
   aiMetadata: {
     description:
-      'Searches Google Shopping via SerpApi for products matching a query, returning results in `shopping_results` (title, price, merchant/source, rating, product_id, link). Use to compare product prices across merchants or research products. Paginate with Start (preferred on this engine). Read-only and idempotent; requires the query and a SerpApi API key.',
+      'Search Google Shopping for products matching a query, to compare prices, merchants, and ratings across stores. Use for product research or price comparison before buying. Paginate with Start (preferred on this engine).',
     idempotent: true,
   },
   outputSchema: searchGoogleShoppingOutputSchema,

--- a/packages/pieces/community/serp-api/src/lib/actions/search-google-trends-ai.ts
+++ b/packages/pieces/community/serp-api/src/lib/actions/search-google-trends-ai.ts
@@ -12,7 +12,7 @@ export const searchGoogleTrendsAi = createAction({
   audience: 'ai',
   aiMetadata: {
     description:
-      'Queries Google Trends via SerpApi for search interest in a keyword. Use to gauge a topic\'s popularity trajectory, compare geographic interest, or find related/rising queries. Choose the data type: "TIMESERIES" (interest over time), "GEO_MAP" (interest by region), "RELATED_TOPICS", or "RELATED_QUERIES" — the response key matches the chosen data type (e.g. `interest_over_time`). Read-only and idempotent; requires the query and a SerpApi API key.',
+      'Look up Google Trends data for how search interest in a keyword or topic changes over time and by region. Use to gauge a topic\'s popularity trajectory, compare geographic interest, or find related and rising queries. Choose the data type: "TIMESERIES" (interest over time), "GEO_MAP" (interest by region), "RELATED_TOPICS", or "RELATED_QUERIES".',
     idempotent: true,
   },
   outputSchema: searchGoogleTrendsAiOutputSchema,

--- a/packages/pieces/community/serp-api/src/lib/actions/search-google-web-ai.ts
+++ b/packages/pieces/community/serp-api/src/lib/actions/search-google-web-ai.ts
@@ -12,7 +12,7 @@ export const searchGoogleWebAi = createAction({
   audience: 'ai',
   aiMetadata: {
     description:
-      'Runs a Google web search via SerpApi and returns organic web results (in `organic_results`) for a query. Use this for general web lookups, current information, rankings, or topic research. For news pick Search Google News, for videos Search YouTube, for products Search Google Shopping. Read-only and idempotent; requires the query and a SerpApi API key.',
+      'Search the web with Google and get ranked organic results for a query. Use for general web lookups, current information, rankings, or topic research. For news pick Search Google News, for videos Search YouTube, for products Search Google Shopping.',
     idempotent: true,
   },
   outputSchema: searchGoogleWebAiOutputSchema,

--- a/packages/pieces/community/serp-api/src/lib/actions/search-walmart.ts
+++ b/packages/pieces/community/serp-api/src/lib/actions/search-walmart.ts
@@ -12,7 +12,7 @@ export const searchWalmart = createAction({
   audience: 'ai',
   aiMetadata: {
     description:
-      'Searches Walmart via SerpApi for products matching a query, returning results in `organic_results` (title, price, rating, seller, product link). Use to look up Walmart product pricing and availability. Filter by price range and minimum rating, sort, and paginate by page. Read-only and idempotent; requires the query and a SerpApi API key.',
+      'Search Walmart for products matching a query, to check prices, ratings, and availability. Use to look up Walmart product listings for price checks or stock research. Filter by price range and minimum rating, sort, and paginate by page.',
     idempotent: true,
   },
   outputSchema: searchWalmartOutputSchema,

--- a/packages/pieces/community/serp-api/src/lib/actions/search-yelp.ts
+++ b/packages/pieces/community/serp-api/src/lib/actions/search-yelp.ts
@@ -12,7 +12,7 @@ export const searchYelp = createAction({
   audience: 'ai',
   aiMetadata: {
     description:
-      'Searches Yelp via SerpApi for businesses matching a description in a location, returning results in `organic_results` (name, rating, review count, category, price level, link). Use to find rated local businesses or read review summaries. Both what to search (Find Description) and where (Find Location) are required. Read-only and idempotent; requires those two fields and a SerpApi API key.',
+      'Search Yelp for local businesses matching a description in a location: restaurants, shops, and services with ratings, review counts, categories, and price levels. Use to find well-rated businesses nearby or in a named city. Both what to search (Find Description) and where (Find Location) are required.',
     idempotent: true,
   },
   outputSchema: searchYelpOutputSchema,

--- a/packages/pieces/community/serp-api/src/lib/actions/search-youtube-ai.ts
+++ b/packages/pieces/community/serp-api/src/lib/actions/search-youtube-ai.ts
@@ -12,7 +12,7 @@ export const searchYoutubeAi = createAction({
   audience: 'ai',
   aiMetadata: {
     description:
-      'Searches YouTube via SerpApi for videos matching a query and returns them in `video_results`. Use to find video content on a topic, discover channels, or research what is being published. For news pick Search Google News, for general web Search Google. Read-only and idempotent; requires the search query and a SerpApi API key.',
+      'Search YouTube for videos about a topic or query. Use to find videos, discover channels, look up video content, or research what is being published about a subject. For news articles pick Search Google News.',
     idempotent: true,
   },
   outputSchema: searchYoutubeAiOutputSchema,


### PR DESCRIPTION
## Description

Agent discovery misses serp-api on intent-phrased queries. On cloud, `ap_search_actions` returns `[]` (semantic mode, no-match gate τ = 0.53) for queries like "search google news for recent articles about a topic", "search youtube for videos about a topic", or "find job listings for a software engineer role in Berlin" — even though the catalog serves 17 `audience: 'ai'` serp-api actions built for exactly these intents.

The stored rows are healthy (querying with a description's full text scores 0.92), but every description repeats "via SerpApi … Read-only and idempotent; requires the query and a SerpApi API key", so the embedded document's similarity mass sits in vendor/boilerplate framing rather than in the search intent. Adding "via serpapi" to a failing query lifts it from below 0.53 to 0.72 — and users and agents don't type that.

This rewrites `aiMetadata.description` on the 17 `audience: 'ai'` actions to lead with intent:

- intent first ("Search Google News for recent news articles…", "Search the web with Google…")
- dropped "via SerpApi" and the "Read-only and idempotent; requires … a SerpApi API key" tail from every action — idempotency already lives in `aiMetadata.idempotent`, and auth is surfaced as `requiresConnection`
- dropped response-key mentions (`news_results` etc.) — output shape is `outputSchema`'s job
- kept per-action routing ("For Android apps use Search Google Play instead") and real constraints (pagination params, the required Data CID, the `ll` anchor)

Metadata-only: no `run()` logic, props, `name`s, display names, audiences, or output schemas change; the 4 `audience: 'human'` actions are untouched. Version `0.1.7` → `0.1.8`; `minimumSupportedRelease` stays `0.86.4`, below the deployed release, so the new version is served immediately.

Measured effect, reproducing the production embedding path offline (`text-embedding-3-small`, 1024-d, L2-normalized, same retrieval-doc format as `buildRetrievalDoc`; the rig reproduces live cloud cosines — the "via serpapi" control scores 0.724 offline vs 0.718 live, and a gmail control matches its live 0.665 exactly). Bold = clears τ 0.53; held-out queries were not used while writing the new texts:

| Query | Action | Before | After |
|---|---|---|---|
| search google news for recent articles about a topic | google news | 0.529 | **0.583** |
| get the latest news headlines about a company | google news | 0.413 | 0.493 |
| find recent news articles | google news | 0.477 | 0.524 |
| what is in the news today about OpenAI *(held-out)* | google news | 0.342 | 0.349 |
| search youtube for videos about a topic | youtube | 0.475 | **0.572** |
| find videos explaining kubernetes *(held-out)* | youtube | 0.323 | 0.351 |
| find job listings for a software engineer role in Berlin | google jobs | 0.376 | 0.424 |
| look for data analyst vacancies *(held-out)* | google jobs | 0.294 | 0.334 |
| run a google search and get the organic results | google search | 0.519 | 0.513 |
| search the web for information about a topic | google search | 0.366 | 0.460 |
| google something and give me the top results *(held-out)* | google search | 0.357 | 0.426 |
| compare product prices across online stores | google shopping | 0.407 | 0.467 |
| find the cheapest price for a laptop online *(held-out)* | google shopping | 0.208 | 0.293 |

Scope note: this is the content-side share of the fix — consistent gains on every probe, and two intent classes newly clear the gate. Several natural paraphrases still land below τ no matter how the description is written (see the held-out rows); that residual is retrieval-side (τ calibration / hybrid matching for this query domain) and can't be fixed from piece metadata, so it's deliberately left out of this PR.

## How was this tested?

- `npx turbo run build --filter=@activepieces/piece-serp-api` and `npx turbo run lint --filter=@activepieces/piece-serp-api` — both green (CI does not lint pieces on a piece-only PR).
- Embedding A/B above against the production model and retrieval-doc format, after validating the offline rig against live cloud `ap_search_actions` cosines.
- Live cloud probes captured before the change: every non-bold "Before" query above returns `[]` today in `mode: "semantic"`, both scoped to serp-api and unscoped.

### Breaking change?  (required — CI fails if this is left unedited)

<!-- Tick exactly one box. If either "yes", apply the "⛓️‍💥 breaking-change" label AND add an entry to docs/install/reference/breaking-changes.mdx (what changed + the action self-hosters must take). -->

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

<!-- Tick exactly one box. "Security-sensitive" = touches authentication, secrets, permissions/roles, cryptography, SSRF / outbound HTTP, or file handling. -->

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)
