### PR TITLE
docs: correct the Advanced-section rules for step-settings props

### DIFF
--- a/.agents/skills/piece-builder/property-ui-selection.md
+++ b/.agents/skills/piece-builder/property-ui-selection.md
@@ -86,9 +86,9 @@ These live directly on the property. They fine-tune placement without changing t
 | `placeholder` | string | Any text input — show an example value (`you@example.com`). |
 | `width` | `'half'` | Two short related fields should sit side-by-side (First / Last name). Only takes effect **inside a `section` group**. |
 | `icon` | icon name | Give a filter-builder row or section field a leading glyph. Must be a **valid name** — see §5. |
-| `advanced` | `true` / `false` | `false` promotes a normally-optional field into the main form (e.g. a message body). `true` pushes an important-looking field into the collapsible **Advanced** section. |
+| `advanced` | `true` | Tucks a secondary field into the collapsible **Advanced** section. Nothing collapses there unless you set it — `advanced: false` is the default and does nothing. |
 
-**Advanced section rule:** non-required props collapse into *Advanced* by default. Reach for `advanced: false` when an optional field is actually central to the action.
+**Advanced section rule:** every prop renders in the main form by default, required or not. Opt a field *out* with `advanced: true`. Don't set it on a required prop — the Advanced section starts collapsed, so a mandatory field hidden there only surfaces as a validation error.
 
 ---
 
@@ -106,13 +106,14 @@ propertyGroups: [{ key, display, label?, description?, icon?, props: ['fieldA', 
 | Intent | `display` | Behaviour |
 |---|---|---|
 | Mutually-exclusive **modes** of the same concept (To / Cc / Bcc; by-URL vs by-ID) | `'tabs'` | Segmented control; one tab's fields visible at a time. |
-| **Related fields as a titled card** (a "Send to" card, a "Message" card) | `'section'` | Titled card; `width: 'half'` packs two-up. **Keeps the Advanced section** — ungrouped optional props still collapse as usual. |
+| **Related fields as a titled card** (a "Send to" card, a "Message" card) | `'section'` | Titled card; `width: 'half'` packs two-up. **Keeps the Advanced section** for props outside the cards — group members are always essential. |
 | A **search/filter** action where users add only the filters they need | `'builder'` | Progressive "Add filter" picker; each `builder` group is a category. A filter row persists only when its value is set — give each filter a `placeholder` + `icon`. |
-| A pinned control **below** a filter builder (result limit) | `'footer'` | Pins its prop (e.g. a `stepper`) under the builder list. Pair with `'builder'` groups. |
+| A pinned control **below** a filter builder (result limit) | `'footer'` | Pins its prop (e.g. a `stepper`) under the builder list. Pair with `'builder'` groups — like `'builder'`, it disables the Advanced section form-wide. |
 
 **Rules:**
 - Every prop named in a group must exist in `props`.
-- Props left out of every group follow the normal essential/Advanced rule (only `section` preserves this — `tabs` and `builder` take full control of their members).
+- Only ungrouped props honour `advanced: true` — members of `tabs` and `section` groups are always essential; the flag is ignored on them.
+- **One `builder` or `footer` group disables the Advanced section for the whole action/trigger** — every prop is forced essential and `advanced: true` stops working form-wide. Don't combine a filter builder with Advanced props.
 - Give `section` and `builder` groups a `label` and `icon` so cards/categories read clearly.
 
 ---
@@ -140,7 +141,7 @@ props: {
   chat_id: Property.ShortText({ displayName: 'Chat Id', required: true, placeholder: '@channel or 123456789' }),
   format:  Property.StaticDropdown({ displayName: 'Format', required: false, display: 'cards', options: { options: [/* Markdown / HTML / Plain */] } }),
   message: Property.RichText({ displayName: 'Message', required: true, formatProperty: 'format' }),
-  disable_notification: Property.Checkbox({ displayName: 'Disable notification', required: false }), // → Advanced
+  disable_notification: Property.Checkbox({ displayName: 'Disable notification', required: false, advanced: true }), // → Advanced (ungrouped + flagged)
 },
 ```
 
@@ -179,5 +180,6 @@ props: {
 - **Invalid `icon` name.** Anything outside the §5 list silently renders nothing; verify before shipping.
 - **`Property.Json` as an escape hatch.** If the shape is known, model it with real props or an `Array` of fields.
 - **`Property.DynamicProperties` for a static form.** It's the heaviest widget; only use it when fields truly depend on runtime data.
+- **`advanced: true` on a required prop.** Advanced starts collapsed; a mandatory field hidden there only surfaces as a validation error.
 
 Full type syntax and dynamic-dropdown/refresher mechanics: `props-patterns.md`. Rendered previews of every option: `docs/build-pieces/piece-reference/properties.mdx`.

--- a/.agents/skills/piece-builder/property-ui-selection.md
+++ b/.agents/skills/piece-builder/property-ui-selection.md
@@ -112,7 +112,7 @@ propertyGroups: [{ key, display, label?, description?, icon?, props: ['fieldA', 
 
 **Rules:**
 - Every prop named in a group must exist in `props`.
-- Only ungrouped props honour `advanced: true` — members of `tabs` and `section` groups are always essential; the flag is ignored on them.
+- Only ungrouped props honour `advanced: true` — members of `tabs` and `section` groups are always essential; the flag is ignored on them. In a sectioned layout, checkbox `reveals` targets are forced essential too: they render inline under their toggle, never in Advanced.
 - **One `builder` or `footer` group disables the Advanced section for the whole action/trigger** — every prop is forced essential and `advanced: true` stops working form-wide. Don't combine a filter builder with Advanced props.
 - Give `section` and `builder` groups a `label` and `icon` so cards/categories read clearly.
 

--- a/docs/build-pieces/piece-reference/properties.mdx
+++ b/docs/build-pieces/piece-reference/properties.mdx
@@ -611,7 +611,7 @@ createAction({
 
 ### Sectioned cards
 
-`display: 'section'` groups related props into titled cards — for example a *Send to* card and a *Message* card. Unlike tabs and the filter builder, sectioned layouts **keep the collapsible _Advanced_ section** for props outside the cards: an ungrouped prop still honours `advanced: true`, while props inside a section are always essential. Give each group a `label` and `icon`, and use `width: 'half'` on members to pack two fields per row.
+`display: 'section'` groups related props into titled cards — for example a *Send to* card and a *Message* card. Unlike tabs and the filter builder, sectioned layouts **keep the collapsible _Advanced_ section** for props outside the cards: an ungrouped prop still honours `advanced: true` — unless it is a checkbox `reveals` target, which renders inline under its toggle instead. Props inside a section are always essential. Give each group a `label` and `icon`, and use `width: 'half'` on members to pack two fields per row.
 
 <SectionCardsPreview />
 

--- a/docs/build-pieces/piece-reference/properties.mdx
+++ b/docs/build-pieces/piece-reference/properties.mdx
@@ -537,9 +537,9 @@ Every property accepts a few optional hints that fine-tune how it renders. They 
 | `placeholder` | text inputs | Grey hint text shown inside an empty field (e.g. `you@example.com`). |
 | `width: 'half'` | any prop inside a group | Renders two fields side-by-side instead of full-width. |
 | `icon` | any prop | A named icon shown beside the field in the filter builder. |
-| `advanced: false` | non-required props | Forces a normally-optional field to stay **outside** the collapsible *Advanced* section. |
+| `advanced: true` | any prop | Moves the field into the collapsible *Advanced* section. Props render in the main form by default. |
 
-Non-required properties are collapsed into an **Advanced** section by default. Set `advanced: false` to promote an important optional field (like a message body) back into the main form, or `advanced: true` to push a field into Advanced.
+Every property renders in the main form by default, required or not. Set `advanced: true` on a secondary option to tuck it into the collapsible **Advanced** section — `advanced: false` is the default and has no effect. Avoid the flag on required props: the section starts collapsed, so a mandatory field hidden there only surfaces as a validation error.
 
 **Half-width fields**
 
@@ -606,12 +606,12 @@ createAction({
 ```
 
 <Tip>
-  A filter row is shown when its value is set, so there's nothing extra to persist. Give filters short `placeholder` hints and an `icon` so each row reads clearly.
+  A filter row is shown when its value is set, so there's nothing extra to persist. Give filters short `placeholder` hints and an `icon` so each row reads clearly. Note that a `builder` or `footer` group also switches off the *Advanced* section for the whole step — every prop lives in the builder.
 </Tip>
 
 ### Sectioned cards
 
-`display: 'section'` groups related props into titled cards — for example a *Send to* card and a *Message* card. Unlike tabs and the filter builder, sectioned layouts **keep the collapsible _Advanced_ section**: any prop you don't place in a section still follows the normal essential/advanced rule, so secondary options stay tucked away. Give each group a `label` and `icon`, and use `width: 'half'` on members to pack two fields per row.
+`display: 'section'` groups related props into titled cards — for example a *Send to* card and a *Message* card. Unlike tabs and the filter builder, sectioned layouts **keep the collapsible _Advanced_ section** for props outside the cards: an ungrouped prop still honours `advanced: true`, while props inside a section are always essential. Give each group a `label` and `icon`, and use `width: 'half'` on members to pack two fields per row.
 
 <SectionCardsPreview />
 
@@ -626,8 +626,8 @@ createAction({
     chat_id: Property.ShortText({ displayName: 'Chat Id', required: true, placeholder: '@channelusername or 123456789' }),
     format: Property.StaticDropdown({ displayName: 'Format', required: false, display: 'cards', options: { options: [/* Markdown / HTML / Plain */] } }),
     message: Property.RichText({ displayName: 'Message', required: true, formatProperty: 'format' }),
-    // props left out of every group collapse into Advanced as usual
-    disable_notification: Property.Checkbox({ displayName: 'Disable notification', required: false }),
+    // ungrouped props can opt into Advanced with advanced: true
+    disable_notification: Property.Checkbox({ displayName: 'Disable notification', required: false, advanced: true }),
   },
 });
 ```


### PR DESCRIPTION
## Description

The step-settings property guides (`.agents/skills/piece-builder/property-ui-selection.md` and `docs/build-pieces/piece-reference/properties.mdx`, both introduced by #14503) describe the essential/Advanced split differently from how `packages/web/src/app/builder/step-settings/piece-settings/index.tsx` implements it. This PR aligns the docs with the shipped behaviour — no code changes.

What the code does vs. what the docs said:

1. **Nothing is Advanced by default.** `isAdvancedProp()` returns `false` unless a prop explicitly sets `advanced: true`; `required` is never consulted. Both docs claimed non-required props collapse into Advanced by default and recommended `advanced: false` — which is the default and a no-op. An author following that advice ships a form with no visual change and believes they adopted the redesign.
2. **`tabs` and `section` group members never honour `advanced: true`** (`collectForcedEssentialNames()` forces them essential). The docs claimed sectioned layouts keep the normal essential/Advanced rule; that is only true for props left *outside* the cards.
3. **One `builder` or `footer` group disables the Advanced section for the entire action/trigger** (`splitProps()` short-circuits via `hasFilterBuilderLayout()` and returns every prop as essential, so `AdvancedSection` renders `null`). Neither doc warned about this.
4. The worked examples showed `disable_notification` reaching Advanced with no flag set — updated to set `advanced: true` so the examples match the behaviour.

Also added an anti-pattern note: `advanced: true` on a required prop hides a mandatory field in a section that starts collapsed and only auto-opens on a validation error.

If any of these behaviours is unintended (especially 2 and 3), happy to re-align the docs once the code changes — cc @AhmadTash.

## How was this tested?

Docs-only change. Wording was verified line-by-line against current `main` (`d5c1a67c7fb`): `isAdvancedProp` (piece-settings/index.tsx L263–268), `hasFilterBuilderLayout` (L278–284), `collectForcedEssentialNames` (L286–305), the `splitProps` short-circuit (L307–321), and `advanced-section.tsx` (returns `null` at count 0; auto-opens only on validation errors).

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)