### PR TITLE
feat(auth): run the bot challenge invisibly

### DIFF
--- a/packages/web/src/features/authentication/components/auth-landing/turnstile-widget.tsx
+++ b/packages/web/src/features/authentication/components/auth-landing/turnstile-widget.tsx
@@ -71,9 +71,16 @@ export function TurnstileWidget({
         }
         widgetId = window.turnstile.render(container.current, {
           sitekey: siteKey,
-          callback: (token: string) => onToken(token),
+          appearance: 'interaction-only',
+          callback: (token: string) => {
+            setFailed(false);
+            onToken(token);
+          },
           'expired-callback': () => onToken(undefined),
-          'error-callback': () => onToken(undefined),
+          'error-callback': () => {
+            setFailed(true);
+            onToken(undefined);
+          },
         });
         widget.current = widgetId;
       })
@@ -109,16 +116,18 @@ export function TurnstileWidget({
   // Say so rather than leaving a dead submit button: the server requires a
   // solved challenge whenever one is configured, so a blocked script means
   // sign-in cannot proceed and the person needs to know why.
-  if (failed) {
-    return (
-      <p className="mt-3 text-center text-xs text-destructive">
-        {t(
-          'The verification step could not load. Disable your ad blocker for this page, then reload.',
-        )}
-      </p>
-    );
-  }
-  return <div ref={container} className="mt-4 flex justify-center" />;
+  return (
+    <>
+      <div ref={container} className="flex justify-center" />
+      {failed && (
+        <p className="mt-3 text-center text-xs text-destructive">
+          {t(
+            'The verification step could not load. Disable your ad blocker for this page, then reload.',
+          )}
+        </p>
+      )}
+    </>
+  );
 }
 
 type TurnstileWidgetProps = {


### PR DESCRIPTION
## Description

The Cloudflare Turnstile box asked every person signing in to look at a checkbox that was never meant for them. This makes the challenge invisible without weakening it.

`appearance: 'interaction-only'` keeps the challenge running on every visitor and leaves server verification byte-identical — `turnstile.assertSolved` on `/authn/sign-up` and `/authn/otp/request` is untouched. Only the box is gone, and Cloudflare still surfaces it to whoever it actually wants to interrogate.

**Why not just switch the site key to the Invisible widget type in the Cloudflare dashboard?** Two reasons:

1. **Invisible has no checkbox fallback.** Managed mode decides per visitor: most are waved through silently, the suspicious ones get a checkbox to prove themselves. The Invisible type removes that — a visitor scored as risky simply gets no token, and since our submit button is gated on the token, they cannot sign up at all. VPN users, corporate NAT, and privacy browsers are exactly the population that would have been handed a checkbox.
2. **A dashboard change only reaches Cloud.** `AP_TURNSTILE_SITE_KEY` is per-deployment, so self-hosters use their own Cloudflare account and their own key. The code change makes it invisible by default for every deployment.

### One hole this opened, and closed

With the box hidden, a *failed* challenge rendered nothing at all — the submit button stayed permanently dead with no explanation on screen. `error-callback` now raises the message that already existed, a later token clears it, and the container stays mounted so Turnstile's own retry can still recover. (The old early return replaced the container with the message, unmounting the very node the widget needed.) This hole exists on the dashboard route too, so it was worth closing regardless.

Also dropped `mt-4` — the collapsed container was still pushing dead space under the card for everyone.

## How was this tested?

**Turnstile behaviour, measured in a real browser** against Cloudflare's published test sitekeys (`1x…AA` always-passes, `3x…FF` forces interactive, `2x…AB` always-fails):

| case | container height | token |
|---|---|---|
| `always` (before this PR), passing visitor | 70.5px + 16px margin | issued |
| `interaction-only`, passing visitor | **0px** | **still issued** |
| `interaction-only`, forced-interactive key | 70.5px — widget appears | withheld until solved |
| `interaction-only`, always-failing key | 0px, nothing shown | `error-callback` fires |

Row 2 is the goal; row 3 is the fallback we keep by staying on Managed; row 4 is what motivated the `error-callback` change.

**Static checks:** eslint and `tsc --noEmit` clean on the changed file.

**Not done, flagged for review:**
- Not exercised end-to-end inside the app — the test sitekeys pass instantly, so real Managed-mode latency is not represented here. The submit button is gated on the token arriving, so that gate is where real-world slowness would show. Worth a staging pass with the live sitekey.
- No unit test added. The state toggle is four lines and the component has no existing test scaffolding; the behaviour that actually matters (whether Cloudflare hides the box) is external and cannot be unit-tested. Happy to add a jsdom test for the error/recover toggle if a reviewer wants one.
- **Edition paths:** frontend-only and gated on the `TURNSTILE_SITE_KEY` flag, which is absent unless both `AP_TURNSTILE_SITE_KEY` and `AP_TURNSTILE_SECRET_KEY` are set. CE and EE without Turnstile configured render nothing and are unaffected; Cloud is the surface that changes.

### One thing to confirm before merge

If the Cloud site key is already set to the Invisible widget type in the Cloudflare dashboard, `appearance` is ignored there and this only does work for self-hosters. Worth checking which type the key is on — and if it *is* Invisible, consider moving it back to Managed so the checkbox fallback in row 3 comes back.

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

Nothing to reconfigure and no env var changes; a deployment with Turnstile set up keeps exactly the same protection. Note for whoever owns the privacy policy: Cloudflare asks you to reference the Turnstile Privacy Addendum once the challenge runs invisibly.

### Security impact?  (required — CI fails if this is left unedited)

- [ ] no — reviewed, no security impact
- [x] yes — security-sensitive (call out the risk and mitigation in the description above)

This touches the authentication bot-defence path, so it deserves a deliberate look even though the server side is unchanged. **The risk to check:** that hiding the widget does not weaken verification. It does not — `appearance` is purely a client-side visibility option, the challenge still executes for every visitor, and `turnstile.assertSolved` still rejects any request without a valid token. The mitigation for the one real trade-off (risky visitors being hard-blocked) is staying on the Managed widget type rather than switching to Invisible, which preserves the interactive fallback.
