### PR TITLE
fix(auth): stop challenging the same person twice

### DIFF
--- a/packages/web/src/features/authentication/components/auth-landing/auth-drawer-body.tsx
+++ b/packages/web/src/features/authentication/components/auth-landing/auth-drawer-body.tsx
@@ -119,7 +119,9 @@ export function AuthDrawerBody({ initialMode }: AuthDrawerBodyProps) {
     setCaptchaReset((count) => count + 1);
   }, []);
   const captchaRequired = !isNil(useTurnstileSiteKey()) && !captchaUnavailable;
-  const challengeApplies = step === 'method' || step === 'code';
+  const passwordlessAvailable = usePasswordlessAvailable();
+  const challengeApplies =
+    passwordlessAvailable && (step === 'method' || step === 'code');
 
   return (
     <AutoHeight>
@@ -209,9 +211,6 @@ function AuthStep({
   const { data: emailAuthEnabledFlag } = flagsHooks.useFlag<boolean>(
     ApFlagId.EMAIL_AUTH_ENABLED,
   );
-  const { data: smtpConfigured } = flagsHooks.useFlag<boolean>(
-    ApFlagId.SMTP_CONFIGURED,
-  );
   const { data: userCreated } = flagsHooks.useFlag<boolean>(
     ApFlagId.USER_CREATED,
   );
@@ -221,7 +220,7 @@ function AuthStep({
   const firstUser = userCreated !== true;
   const effectiveMode: AuthMode = firstUser ? 'signup' : mode;
   const emailAuthEnabled = emailAuthEnabledFlag ?? true;
-  const passwordlessAvailable = emailAuthEnabled && !!smtpConfigured;
+  const passwordlessAvailable = usePasswordlessAvailable();
   const showThirdParty = useShowThirdPartyProviders();
   const thirdParty = useThirdPartyAvailability();
 
@@ -962,6 +961,16 @@ function ModeSwitch({
       </button>
     </div>
   );
+}
+
+function usePasswordlessAvailable(): boolean {
+  const { data: emailAuthEnabled } = flagsHooks.useFlag<boolean>(
+    ApFlagId.EMAIL_AUTH_ENABLED,
+  );
+  const { data: smtpConfigured } = flagsHooks.useFlag<boolean>(
+    ApFlagId.SMTP_CONFIGURED,
+  );
+  return (emailAuthEnabled ?? true) && !!smtpConfigured;
 }
 
 // Country variants are endless (yahoo.co.uk, hotmail.fr, …), so match the


### PR DESCRIPTION
## Description

On a deployment without SMTP, the sign-up card renders the Cloudflare Turnstile challenge **twice** — two stacked "Verify you are human" boxes on *Create your account*, one above the Sign up button and one below "Already have an account?". On the sign-in card it renders **one that does nothing at all**.

`AuthDrawerBody` mounts a widget whenever `step` is `method` or `code`, and `step` starts at `method`. But when SMTP is absent, `AuthStep` takes the `!passwordlessAvailable` branch and renders `SignUpForm`/`SignInForm` instead of the email step — and `SignUpForm` mounts its own widget. So both render.

The drawer's widget is not merely a duplicate, it is **dead** on that branch: its `captchaToken` is only ever passed to `EmailStep` and `CodeStep`, neither of which renders there. `SignUpForm` submits its own token. So the second challenge is solved, round-tripped to Cloudflare, and thrown away.

On the sign-in card it is worse — `SignInForm` sends no token at all (`/authn/sign-in` has no `assertSolved`), so a self-hoster gets a captcha on their sign-in screen that is pure decoration.

The fix gates the drawer's widget on the same condition that decides whether the steps which consume its token are rendered at all. Both components now derive that from one `usePasswordlessAvailable` hook, so the challenge and the card cannot disagree about which steps exist.

**Who this affects:** self-hosted, no SMTP configured, *and* Turnstile keys set. Activepieces Cloud is unaffected — it has SMTP, so the `!passwordlessAvailable` branch never runs and it has always rendered exactly one widget.

**Interaction with #14855:** that PR makes the challenge invisible (`appearance: 'interaction-only'`). It does not fix this bug — both widgets still mount and still solve a challenge — it only stops them being *seen*. If #14855 lands first, this bug becomes two invisible wasted challenges instead of two visible ones, and nothing will ever draw attention to it again. Worth landing this one regardless of the order.

## How was this tested?

Ran a local CE instance against Cloudflare's test sitekeys (`1x00000000000000000000AA` / secret `1x0000000000000000000000000000000AA`) and counted mounted widgets via `input[name="cf-turnstile-response"]` in the real app, toggling `AP_SMTP_*` to move between the two paths.

**No SMTP (the broken path):**

| screen | before | after |
|---|---|---|
| Create your account | **2** widgets, both visible, both solved | **1**, token filled |
| Welcome back (sign-in) | **1**, dead — no token is ever submitted | **0** |

**SMTP configured (the Cloud path) — regression check:**

| screen | before | after |
|---|---|---|
| email step (`method`) | 1 | **1** — unchanged |
| password / sign-in | 0 | 0 |
| password / sign-up | 1 (`SignUpForm`'s own) | 1 |

The middle row is the one that matters: the email step must keep its challenge, since `/authn/otp/request` rejects a request without a solved token. It does.

Also: eslint and `tsc --noEmit` clean on the changed file.

**Not done:** no unit test added — the behaviour is a render-gate on two suspense-loaded flags, and the component has no existing test scaffolding. Say the word and I'll add a jsdom test asserting one widget per path.

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

No env vars, no API surface, no configuration change. Affected deployments strictly lose a redundant challenge.

### Security impact?  (required — CI fails if this is left unedited)

- [ ] no — reviewed, no security impact
- [x] yes — security-sensitive (call out the risk and mitigation in the description above)

This removes a Turnstile widget from the auth page, so it deserves a deliberate look. **The risk to check:** that the widget being removed is never the one whose token is actually submitted. It is not — the drawer's `captchaToken` flows only to `EmailStep`/`CodeStep`, and the new gate is exactly the condition under which those two render. Every path that submits a token still has a widget backing it, which the regression table above confirms on both the SMTP and no-SMTP configurations. Server-side verification is untouched.
