### PR TITLE
fix(auth): keep the challenge light and off the card's edge

### DIFF
--- a/packages/web/src/features/authentication/components/auth-landing/turnstile-widget.tsx
+++ b/packages/web/src/features/authentication/components/auth-landing/turnstile-widget.tsx
@@ -4,6 +4,7 @@ import { t } from 'i18next';
 import { useEffect, useRef, useState } from 'react';
 
 import { flagsHooks } from '@/hooks/flags-hooks';
+import { cn } from '@/lib/utils';
 
 const SCRIPT_ID = 'cf-turnstile';
 const SCRIPT_SRC =
@@ -51,6 +52,19 @@ export function TurnstileWidget({
   const container = useRef<HTMLDivElement>(null);
   const widget = useRef<string | undefined>(undefined);
   const [failed, setFailed] = useState(false);
+  const [shown, setShown] = useState(false);
+
+  useEffect(() => {
+    const element = container.current;
+    if (!element) {
+      return;
+    }
+    const observer = new ResizeObserver(() =>
+      setShown(element.offsetHeight > 0),
+    );
+    observer.observe(element);
+    return () => observer.disconnect();
+  }, []);
 
   useEffect(() => {
     if (!siteKey || !container.current) {
@@ -72,6 +86,7 @@ export function TurnstileWidget({
         widgetId = window.turnstile.render(container.current, {
           sitekey: siteKey,
           appearance: 'interaction-only',
+          theme: 'light',
           callback: (token: string) => {
             setFailed(false);
             onToken(token);
@@ -118,7 +133,9 @@ export function TurnstileWidget({
   // sign-in cannot proceed and the person needs to know why.
   return (
     <>
-      <div ref={container} className="flex justify-center" />
+      <div className={cn(shown && 'pb-7')}>
+        <div ref={container} className="flex justify-center" />
+      </div>
       {failed && (
         <p className="mt-3 text-center text-xs text-destructive">
           {t(


### PR DESCRIPTION
## Description

Two appearance problems with the Turnstile challenge, both only visible on the rare occasions Cloudflare decides to show it.

**It rendered dark on a light card.** Turnstile defaults to `theme: 'auto'`, which follows `prefers-color-scheme`. The app does not — `ThemeProvider` resolves `'system'` to `'light'` — so anyone on a dark desktop got a dark challenge box sitting on a white sign-in card. Pinned to `theme: 'light'`.

**It sat flush against the card's bottom border.** The widget renders as a sibling *after* `DrawerShell`, which is what carries the card's `pb-7`, so there was nothing between the box and the card edge.

The spacing has to follow what the box is actually doing rather than be reserved up front. Cloudflare shows the challenge only to whoever it wants to interrogate, and for everyone else the container collapses to zero height — so a fixed gap would push every card's footer down for the overwhelming majority who never see a challenge at all. A `ResizeObserver` on the container drives a `shown` flag, and the gap (`pb-7`, matching the shell's own bottom padding) applies only while the box occupies space.

The gap is **padding on a wrapper**, not a margin on the container. That detail matters: a margin collapses out through `AutoHeight`'s measured `div`, whose `offsetHeight` excludes it, so the card never grew — measured 0.9px of gap with `mb-7` versus 28.9px with the wrapper.

## How was this tested?

Local CE→cloud instance against Cloudflare's test sitekeys, measuring the DOM in the real app rather than eyeballing it.

**Invisible challenge** (`1x00000000000000000000AA`, the normal case for a human):

| | before | after |
|---|---|---|
| container height | 0px | 0px |
| wrapper classes | — | *(none)* |
| wrapper padding-bottom | — | 0px |
| token still issued | yes | yes |

No dead space reintroduced — this is what #14855 was careful about.

**Visible challenge** (`3x00000000000000000000FF`, forces interaction):

| | before | after |
|---|---|---|
| container height | 71.5px | 71.5px |
| wrapper padding-bottom | 0px | 28px |
| gap from box to card bottom | **0.9px** | **28.9px** |

**Theme**, with the OS colour scheme emulated to **dark** via CDP: the widget renders light and matches the card. Before this change it followed the OS and went dark.

Also: eslint and `tsc --noEmit` clean on the changed file.

**Not done:** no unit test. The behaviour is a `ResizeObserver` reacting to a third-party iframe's height inside a shadow root, which jsdom cannot produce — a test would only assert that a mocked observer flips a boolean. Happy to add that if a reviewer wants it.

### One judgement call worth a reviewer's eye

`theme: 'light'` is pinned, not bound to the app's theme. The app resolves `'system'` → `'light'`, so light matches the card for everyone on the default. A user who has *explicitly* chosen dark mode will get a light challenge box on a dark card. Binding it to `useTheme()` instead is a few lines — say the word and I'll switch it.

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

Presentation only. No env vars, no API surface, no change to when a challenge runs or how it is verified.

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)

`theme` and layout are purely cosmetic Turnstile render options. The challenge still runs for every visitor, the token flow is untouched, and `turnstile.assertSolved` on the server is unchanged. Unlike #14855 and #14856 this one does not alter which widgets mount or when they execute.
