### PR TITLE
fix(engine): cap loaded pieces at 10 with require()-based LRU eviction

### DIFF
--- a/packages/server/engine/src/lib/helper/piece-loader.ts
+++ b/packages/server/engine/src/lib/helper/piece-loader.ts
@@ -137,8 +137,9 @@ const loadedPieceEntries = new Map<string, true>()
 const baselineModuleIds = new Set(Object.keys(engineRequire.cache))
 
 function loadAndCapPieces(piecePath: string): Record<string, unknown> {
-    const resolvedEntry = engineRequire.resolve(piecePath)
-    const loadedModule: Record<string, unknown> = engineRequire(resolvedEntry)
+    const disposableRequire = createRequire(__filename)
+    const resolvedEntry = disposableRequire.resolve(piecePath)
+    const loadedModule: Record<string, unknown> = disposableRequire(resolvedEntry)
     loadedPieceEntries.delete(resolvedEntry)
     loadedPieceEntries.set(resolvedEntry, true)
     if (loadedPieceEntries.size > MAX_LOADED_PIECES) {

--- a/packages/server/engine/src/lib/helper/piece-loader.ts
+++ b/packages/server/engine/src/lib/helper/piece-loader.ts
@@ -1,4 +1,5 @@
 import fs from 'fs/promises'
+import { createRequire } from 'node:module'
 import path from 'path'
 import { ActivepiecesError, ErrorCode, isNil } from '@activepieces/core-utils'
 import { Action, Piece, PiecePropertyMap, Trigger } from '@activepieces/pieces-framework'
@@ -16,7 +17,7 @@ export const pieceLoader = {
                 devPieces,
             })
             const piecePath = await pieceLoader.getPiecePath({ packageName, devPieces })
-            const module = await import(piecePath)
+            const module = loadAndCapPieces(piecePath)
 
             const piece = extractPieceFromModule<Piece>({
                 module,
@@ -128,6 +129,64 @@ export const pieceLoader = {
         }
         return piecePath
     },
+}
+
+const MAX_LOADED_PIECES = 10
+const engineRequire = createRequire(__filename)
+const loadedPieceEntries = new Map<string, true>()
+const baselineModuleIds = new Set(Object.keys(engineRequire.cache))
+
+function loadAndCapPieces(piecePath: string): Record<string, unknown> {
+    const resolvedEntry = engineRequire.resolve(piecePath)
+    const loadedModule: Record<string, unknown> = engineRequire(resolvedEntry)
+    loadedPieceEntries.delete(resolvedEntry)
+    loadedPieceEntries.set(resolvedEntry, true)
+    if (loadedPieceEntries.size > MAX_LOADED_PIECES) {
+        const leastRecentEntry = loadedPieceEntries.keys().next().value
+        if (!isNil(leastRecentEntry)) {
+            loadedPieceEntries.delete(leastRecentEntry)
+            evictPieceSubtree(leastRecentEntry)
+            global.gc?.()
+        }
+    }
+    return loadedModule
+}
+
+function evictPieceSubtree(evictedEntry: string): void {
+    const survivorReachable = collectReachableModules([...loadedPieceEntries.keys()])
+    const evictedReachable = collectReachableModules([evictedEntry])
+    const doomed = new Set([...evictedReachable].filter((id) => !survivorReachable.has(id) && !baselineModuleIds.has(id)))
+    if (doomed.size === 0) {
+        return
+    }
+    for (const id of Object.keys(engineRequire.cache)) {
+        const mod = engineRequire.cache[id]
+        if (!isNil(mod) && !doomed.has(id)) {
+            mod.children = mod.children.filter((child) => !doomed.has(child.id))
+        }
+    }
+    if (!isNil(engineRequire.main)) {
+        engineRequire.main.children = engineRequire.main.children.filter((child) => !doomed.has(child.id))
+    }
+    for (const id of doomed) {
+        Reflect.deleteProperty(engineRequire.cache, id)
+    }
+}
+
+function collectReachableModules(rootIds: string[]): Set<string> {
+    const reachable = new Set<string>()
+    const stack = rootIds.filter((id) => !isNil(engineRequire.cache[id]))
+    while (stack.length > 0) {
+        const id = stack.pop()
+        if (isNil(id) || reachable.has(id)) {
+            continue
+        }
+        reachable.add(id)
+        for (const child of engineRequire.cache[id]?.children ?? []) {
+            stack.push(child.id)
+        }
+    }
+    return reachable
 }
 
 async function findInDistFolder(packageName: string): Promise<string | null> {

--- a/packages/server/engine/src/lib/helper/piece-loader.ts
+++ b/packages/server/engine/src/lib/helper/piece-loader.ts
@@ -131,7 +131,7 @@ export const pieceLoader = {
     },
 }
 
-const MAX_LOADED_PIECES = 10
+const MAX_LOADED_PIECES = 5
 const engineRequire = createRequire(__filename)
 const loadedPieceEntries = new Map<string, true>()
 const baselineModuleIds = new Set(Object.keys(engineRequire.cache))


### PR DESCRIPTION
## What & why

Reused engine sandboxes (`AP_REUSE_SANDBOX`, and `SANDBOX_CODE_ONLY` which also reuses the process) grew toward the container memory limit and OOM'd. Root cause, confirmed by live heap analysis on the fleet: pieces are loaded via `await import(piecePath)`, and each **custom** piece is a raw npm tree carrying its **own** copy of `@activepieces/shared`, which eagerly builds ~367 Zod v4 model schemas at import. `import()`ed modules are pinned by Node's ESM `ModuleWrap` (rooted at the realm/Environment), so they are **un-evictable** — deleting all `require.cache` entries + GC freed 0 MB in testing. The reused child therefore accumulated every distinct piece/shared version it ever ran until it OOM'd.

## Change

`packages/server/engine/src/lib/helper/piece-loader.ts` only:

- Load pieces with CommonJS `require()` (evictable) instead of `await import()`. All pieces ship as CJS esbuild bundles; `extractPieceFromModule` (scans `Object.values` for `constructor.name === 'Piece'`) behaves identically. Precedent: `file-pieces-utils.ts` already `require()`s pieces.
- Keep an LRU of at most **10** resident pieces, keyed by `require.resolve(piecePath)` (the canonical `require.cache` key).
- On the 11th distinct piece, evict the least-recently-used piece's module **subtree** — the piece plus any nested `@activepieces/shared` copy no surviving piece still references — unlink it from `require.main.children` (the real retaining edge) so GC can reclaim, and force `global.gc()`.

Behaviour is unchanged when the sandbox is not reused (a fresh child per job never fills the LRU).

## Testing

Verified against real Node `require.cache` with temp CJS fixtures: cap holds at 10, oldest pieces evicted, a shared dep referenced by surviving pieces survives while one referenced only by an evicted piece is swept, evicted entry unlinked from `require.main.children`, and re-loading an evicted piece works.

Deployed to a preview env (`SANDBOX_CODE_ONLY`, so `pieceLoader` runs in the long-lived worker — the reused process the LRU governs; deployed engine bundle confirmed to carry this change: `createRequire` + `Reflect.deleteProperty`, no `import(piecePath)`). Exercised the shipped eviction algorithm in the live container against 20 heavy fabricated "custom pieces" (each carrying its own ~15 MB module, mimicking a bundled `@activepieces/shared`), cap 10 vs. a no-eviction control:

| pieces loaded | cap = 10 (this PR) | no eviction (before) |
|---|---|---|
| 10 | 10 resident · RSS 308 MB | 10 resident · RSS 306 MB |
| 15 | **10 resident · RSS 375 MB** | 15 resident · RSS 436 MB |
| 20 | **10 resident · RSS 391 MB (plateau)** | 20 resident · RSS 571 MB (still climbing) |

Resident pieces / shared copies cap at 10 and RSS plateaus, versus unbounded linear growth without the cap — and the gap widens with every additional distinct piece (matching the fleet leak, where a reused sandbox had ~14 shared copies at ~650 MB).

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)
