### PR TITLE
fix(chat): route chatbot requests to the hosted Chat UI trigger

### DIFF
--- a/packages/server/api/src/assets/prompts/chat-system-prompt.md
+++ b/packages/server/api/src/assets/prompts/chat-system-prompt.md
@@ -239,7 +239,8 @@ Hard limits. Everything not listed here is your judgment to exercise.
 - **Never ask the user to describe, list, paste, or enumerate data you could read.** Get access (connection), find the resource yourself, then OPEN it (`ap_explore_data`) and read the columns and a sample yourself.
 - **Look in the obvious place before asking where their data lives.** When the user references their own data ("my blogs", "our leads", "the orders"), check the surfaces you can already see FIRST — their Tables (`ap_list_tables`), existing flows, and connections — before asking "where do you keep that?". Asking when a Table or connection in front of you could hold it is the failure; quietly checking, then asking only if nothing matches, is the job.
 - Don't ask which app, which field, which option-value, or anything `ap_research_pieces` / `ap_get_piece_props` / `ap_resolve_property_options` / `ap_explore_data` can answer.
-- **Generic capability → built-in piece, no question.** "a form" → **Human Input**; "a webhook / receive events" → **Webhook**; "every day/hour / on a schedule" → **Schedule**; "save / track / log data here" → **Tables**; "remember / count / dedup / only-once" → **Store**; "ask AI / classify / extract / summarize" → **AI**; "wait/pause" → **Delay**; "human sign-off / approval" → **Approval**. All built-in, no connection. Only ask "which tool?" if the user explicitly named an external product (e.g. "my Typeform").
+- **Generic capability → built-in piece, no question.** "a form" → **Human Input** (Web Form trigger); **"a chatbot / an assistant people can talk to / a chat" → Human Input (Chat UI trigger)** — we host the chat page, so never reach for a Webhook, an external chat product, or "you'd need a frontend" for this; "a webhook / receive events" → **Webhook** (only for a machine POSTing to us, never for a human typing); "every day/hour / on a schedule" → **Schedule**; "save / track / log data here" → **Tables**; "remember / count / dedup / only-once" → **Store**; "ask AI / classify / extract / summarize" → **AI**; "wait/pause" → **Delay**; "human sign-off / approval" → **Approval**. All built-in, no connection. Only ask "which tool?" if the user explicitly named an external product (e.g. "my Typeform").
+- **This list is the common cases, NOT the whole catalog.** When what the user described isn't on it, that means *look it up* — `ap_search_triggers` with the event in their own words ("when someone sends a message", "when a file lands in a folder"), then `ap_research_pieces`. Never downgrade an unlisted need to the nearest thing on the list, and never conclude the platform can't do it before you searched.
 - Take the user's message at face value — it is complete as written. Never tell them their message "got cut off" or ask them to repeat themselves.
 
 **The lenses — INFER these, don't ask them.** For any request, settle each on a sensible, context-grounded default; you're only ever blocked on the rare one you truly cannot infer:
@@ -358,6 +359,10 @@ This applies ONLY to deliverables the user asked you to produce. Normal conversa
 - Tables: {{FRONTEND_URL}}/projects/{projectId}/tables/{tableId}
 - Connections: {{FRONTEND_URL}}/projects/{projectId}/connections
 - Runs: {{FRONTEND_URL}}/projects/{projectId}/runs
+- Hosted chat page (Human Input → Chat UI trigger): {{FRONTEND_URL}}/chats/{flowId}
+- Hosted form page (Human Input → Web Form trigger): {{FRONTEND_URL}}/forms/{flowId}
+
+The chat and form pages are the *product* when you build with a Human Input trigger — the user cannot use what they cannot open. Always hand over the link in your closing brief, and say it's live once the automation is published (a draft page only answers while they're testing).
 
 Use the Connections link only when the user explicitly asks to manage/see their connections in general — NEVER as the way to fix a broken/expired connection. A broken connection is always reconnected inline via `ap_show_connection_required`/`ap_show_mcp_reconnect` (see the broken-connection rule in `<guardrails>`); do not hand out this link in that case.
 </links>

--- a/packages/server/api/src/assets/prompts/guides/build_flow.md
+++ b/packages/server/api/src/assets/prompts/guides/build_flow.md
@@ -54,7 +54,8 @@ Activepieces ships pieces that need no external app or connection; registry sear
 
 | User says | Piece | What it is |
 |---|---|---|
-| "a form" | `@activepieces/piece-forms` (**Human Input**) | hosted web form trigger w/ shareable link |
+| "a form" | `@activepieces/piece-forms` (**Human Input**) → `form_submission` | hosted web form w/ shareable link |
+| "a chatbot", "an assistant to talk to", "a chat" | `@activepieces/piece-forms` (**Human Input**) → `chat_submission` | **hosted chat page** w/ shareable link — see the chatbot recipe below |
 | "every day/hour", "cron" | `@activepieces/piece-schedule` | schedule triggers |
 | "webhook", "receive events" | `@activepieces/piece-webhook` | inbound webhook trigger |
 | "save/track data here" | `@activepieces/piece-tables` | built-in database — `ap_load_guide('tables')` |
@@ -63,6 +64,17 @@ Activepieces ships pieces that need no external app or connection; registry sear
 | "human sign-off" | `@activepieces/piece-approval` | pause for approve/reject |
 | "wait/pause" | `@activepieces/piece-delay` | delay step |
 | "split big work" | `@activepieces/piece-subflows` | call another flow |
+
+### The chatbot recipe (Human Input → Chat UI)
+"Build me a chatbot / an assistant my customers can talk to" is a **three-step flow**, not a webhook and not something they need a website for — we host the chat page:
+1. **Trigger** `@activepieces/piece-forms` → `chat_submission`. Set `botName` (required — name it for their use case, e.g. "Support Assistant"). Its output is `{{trigger['output'].message}}`, `{{trigger['output'].sessionId}}`, `files`.
+2. **The brain** — `@activepieces/piece-ai` (Ask AI, or Run Agent when it needs their tools/data). Feed it `{{trigger['output'].message}}`; put who-the-bot-is and what it may answer in the prompt, grounded in what you know about their business. Set `conversationKey` = `{{trigger['output'].sessionId}}` — that is Ask AI's built-in memory, so the bot remembers earlier turns of the same chat; never hand-roll a transcript in Store/Tables for this. Set `maxOutputTokens` generously (2000, the piece's own default) — a small cap cuts answers off mid-sentence while the run still reports success.
+3. **Reply** `@activepieces/piece-forms` → `return_response` (**Respond on UI**), markdown = the Ask AI step's raw output (`{{step_1['output']}}` in this shape) — Ask AI returns the answer text **itself**, not an object, so `.response`/`.text`/`.answer` silently resolve to nothing and the customer gets a blank bubble. (The one exception: with Web Search on and sources included, the output becomes `{text, sources}` — map `.text` then.) **This step is not optional** — a Chat UI (or a Web Form with Wait for Response) that never calls Respond on UI leaves the person staring at a spinner forever. Always the last step on every path.
+
+A chat flow whose run "succeeded" can still be broken: an empty or truncated reply is a passing run. Verify the reply step's **actual output text** — non-empty, ends properly — before you call it done, not just the run status.
+
+`conversationKey` above already covers remembering the current chat session. Reach for Store/Tables (`ap_load_guide('state')`) only for memory that must survive ACROSS sessions — returning customers, order history.
+Hand over `{{FRONTEND_URL}}/chats/{flowId}` when you're done (forms: `/forms/{flowId}`) — publish first, or the link only answers in draft/test mode.
 
 ## CODE is the last resort — use inline expressions & conditions first
 Dropping a **CODE step** into a flow to filter, reshape, calculate, or format data is almost always the wrong first move — it's slower to build, opaque to a non-coder, and harder to debug. Walk this ladder and stop at the first rung that fits; only the last rung is code:
@@ -172,7 +184,7 @@ Then close with the **brief**: enumerate the specific business assumptions you m
 
 ## Converting a one-time task into a recurring automation
 1. Ensure the one-time task's project is selected via `ap_select_project`.
-2. Pick the starting event: new/incoming items → app trigger if available; periodic → Schedule; ambiguous → default to once and ask "Would you like this to run once, or repeat automatically?". Exception: if the user got here by sending the exact phrase `Run this automatically every day`, the cadence is already decided — use a daily Schedule trigger and do NOT ask the frequency.
+2. Pick the starting event: new/incoming items → app trigger if available; **a person typing to it → Human Input (Chat UI for a conversation, Web Form for fields)**; periodic → Schedule; ambiguous → default to once and ask "Would you like this to run once, or repeat automatically?". Exception: if the user got here by sending the exact phrase `Run this automatically every day`, the cadence is already decided — use a daily Schedule trigger and do NOT ask the frequency.
 3. Reuse the same app, action, connection, and inputs from the one-time task.
 4. **The one-time task acted on data once; the recurring version must not act on the same data again.** If it reads persistent data (a sheet/table/inbox/record set), add an anti-reprocessing mechanism now — see "Recurring flows must not reprocess". The task that was safe as a one-shot becomes a re-send/re-pay bug the moment it repeats.
 5. Build per this guide.


### PR DESCRIPTION
## Description

Asking the assistant for **"a chatbot my customers can talk to"** produces a **Webhook** flow and an offer to write JavaScript for your own website — it never proposes the hosted **Chat UI** page we already ship (reported from a customer call: the user concluded we have no chat or form UI at all).

Root cause is instructions, not product: the prompt's built-in mapping ("a form" → Human Input, "webhook" → Webhook, …) has no chat entry, so chatbot requests fall through to webhook, and the `<links>` section has no chat/form page URLs, so even a correctly-built flow is never handed over as an openable page.

Prompt-only change, two files (+20/−3):

- **Built-ins mapping**: "a chatbot / an assistant people can talk to" → Human Input **Chat UI** trigger; Webhook clarified as machine-to-machine, never for a human typing.
- **Mapping is not the catalog**: when a request matches no entry, search (`ap_search_triggers`) instead of downgrading to the nearest listed thing.
- **Links**: hosted chat (`/chats/{flowId}`) and form (`/forms/{flowId}`) page URLs, with an instruction to hand the link over at close.
- **`build_flow` guide**: a 3-step chatbot recipe (Chat UI → Ask AI → Respond on UI) pinning three silent failure traps hit while validating:
  - reply mapped to `{{...output.response}}` renders an empty bubble (Ask AI returns the text itself) — and the run still "succeeds";
  - a low `maxOutputTokens` truncates replies mid-sentence — run still "succeeds";
  - `conversationKey = sessionId` is the built-in per-session memory (instead of hand-rolling transcripts in Store/Tables).

## How was this tested?

Live before/after on a local EE box, default smart tier (Sonnet 4.6), same message ("build me a chatbot my customers can talk to — I sell handmade candles online"), fresh conversations:

- **Before**: prose interrogation ("where should this chatbot live?"), then built and published a webhook JSON API and offered to write website chat-widget code.
- **After** (consistent across 5 runs): plans **Chat UI trigger** immediately, builds Chat UI → Ask AI → Respond on UI, tests, publishes, and hands over the hosted chat link. Verified end-to-end as a customer against the published endpoint: full-length replies, session memory works ("does that one you just mentioned come in a large size?" answered in context).
- System-prompt guard test headroom: ~22.2k tokens vs the 25k ceiling.

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)
