### PR TITLE
fix(auth): bound login-code guesses per identity and keep the code out of the logs

### DIFF
--- a/docs/install/reference/breaking-changes.mdx
+++ b/docs/install/reference/breaking-changes.mdx
@@ -55,6 +55,18 @@ This affects the Tables piece's Find Records action and any direct API call that
 
 Nothing on upgrade. Re-check any flow or API integration that filters a Date column with `gt`, `gte`, `lt` or `lte` — it now returns the rows the filter actually describes, which may be more or fewer than before.
 
+#### Emailed sign-in codes allow ten wrong guesses per account per hour
+
+The six-digit login code already allowed five wrong guesses, but that budget lived on the code itself, and the fifth wrong guess threw the code away — so asking for a new code handed out five fresh guesses immediately, with no ceiling on how often that could repeat. A six-digit code is only a million possibilities, so unlimited retries reduce it to a matter of hours.
+
+Wrong guesses are now counted per account over a rolling hour, independently of how many codes get sent. Entering the right code clears the counter, so someone who fumbles a few digits and then succeeds is unaffected.
+
+Two consequences worth knowing. Someone who spends ten wrong guesses on an account within an hour cannot sign in **with an emailed code** until the hour is up; password and Google sign-in are unaffected. And because the counter is keyed on the account rather than the caller, anyone who knows an address can spend that budget on the owner's behalf — a temporary nuisance for the owner, and the trade the cap is worth making.
+
+#### What you need to do
+
+Nothing. The limit applies out of the box and needs no configuration. If your support team sees a report of "the code keeps saying it's wrong", have them check whether the account has burned its hourly budget, and point the user at password or Google sign-in in the meantime.
+
 
 ## 0.87.0
 

--- a/packages/server/api/src/app/authentication/otp/otp-service.ts
+++ b/packages/server/api/src/app/authentication/otp/otp-service.ts
@@ -121,10 +121,6 @@ async function guessesSpentOnIdentity({ identityId, type }: IdentityBudgetParams
     return isNil(budget) ? 0 : budget.count
 }
 
-// Read-modify-write is safe without an atomic INCR because confirm() already holds the
-// per-identity-and-type lock, and that lock is the only writer of this key. The window is
-// fixed rather than sliding: the remaining TTL is carried forward so a wrong guess cannot
-// keep pushing a legitimate owner's lockout further away.
 async function countGuessOnIdentity({ identityId, type, spent }: CountGuessOnIdentityParams): Promise<void> {
     const key = identityBudgetKey({ identityId, type })
     const existing = await distributedStore.get<IdentityGuessBudget>(key)

--- a/packages/server/api/src/app/authentication/otp/otp-service.ts
+++ b/packages/server/api/src/app/authentication/otp/otp-service.ts
@@ -3,7 +3,7 @@ import { OtpModel, OtpState, OtpType } from '@activepieces/shared'
 import dayjs from 'dayjs'
 import { FastifyBaseLogger } from 'fastify'
 import { repoFactory } from '../../core/db/repo-factory'
-import { distributedLock } from '../../database/redis-connections'
+import { distributedLock, distributedStore } from '../../database/redis-connections'
 import { emailService } from '../../ee/helper/email/email-service'
 import { userIdentityService } from '../user-identity/user-identity-service'
 import { otpGenerator } from './lib/otp-generator'
@@ -15,6 +15,8 @@ const OTP_EXPIRATION_MS: Record<OtpType, number> = {
     [OtpType.EMAIL_LOGIN]: 10 * 60 * 1000,
 }
 const MAX_ATTEMPTS = 5
+const MAX_ATTEMPTS_PER_IDENTITY = 10
+const IDENTITY_BUDGET_WINDOW_SECONDS = 60 * 60
 
 const repo = repoFactory(OtpEntity)
 
@@ -65,6 +67,11 @@ export const otpService = (log: FastifyBaseLogger) => ({
             key: `otp-confirm-${identityId}-${type}`,
             timeoutInSeconds: 15,
             fn: async () => {
+                const spentOnIdentity = await guessesSpentOnIdentity({ identityId, type })
+                if (spentOnIdentity >= MAX_ATTEMPTS_PER_IDENTITY) {
+                    log.warn({ identityId, type }, '[otpService#confirm] identity guess budget exhausted, refusing')
+                    return false
+                }
                 const otp = await repo().findOneBy({ identityId, type })
                 if (isNil(otp)) {
                     return false
@@ -78,9 +85,11 @@ export const otpService = (log: FastifyBaseLogger) => ({
                 const otpMatches = otp.value === value
                 if (otpIsNotExpired && otpMatches && otpIsPending) {
                     await repo().delete({ id: otp.id })
+                    await clearIdentityBudget({ identityId, type })
                     return true
                 }
                 await countAttempt(otp.id)
+                await countGuessOnIdentity({ identityId, type, spent: spentOnIdentity })
                 if (otp.attempts + 1 >= MAX_ATTEMPTS) {
                     await discard({ otp, identityId, type, log })
                 }
@@ -103,10 +112,50 @@ function otpIsExpired(otp: OtpModel): boolean {
     return dayjs().diff(otp.updated, 'milliseconds') >= OTP_EXPIRATION_MS[otp.type]
 }
 
+function identityBudgetKey({ identityId, type }: IdentityBudgetParams): string {
+    return `otp-guess-budget:${identityId}:${type}`
+}
+
+async function guessesSpentOnIdentity({ identityId, type }: IdentityBudgetParams): Promise<number> {
+    const budget = await distributedStore.get<IdentityGuessBudget>(identityBudgetKey({ identityId, type }))
+    return isNil(budget) ? 0 : budget.count
+}
+
+// Read-modify-write is safe without an atomic INCR because confirm() already holds the
+// per-identity-and-type lock, and that lock is the only writer of this key. The window is
+// fixed rather than sliding: the remaining TTL is carried forward so a wrong guess cannot
+// keep pushing a legitimate owner's lockout further away.
+async function countGuessOnIdentity({ identityId, type, spent }: CountGuessOnIdentityParams): Promise<void> {
+    const key = identityBudgetKey({ identityId, type })
+    const existing = await distributedStore.get<IdentityGuessBudget>(key)
+    const windowStartedAt = isNil(existing) ? Date.now() : existing.windowStartedAt
+    const elapsedSeconds = Math.floor((Date.now() - windowStartedAt) / 1000)
+    const remainingSeconds = Math.max(IDENTITY_BUDGET_WINDOW_SECONDS - elapsedSeconds, 1)
+    await distributedStore.put(key, { count: spent + 1, windowStartedAt }, remainingSeconds)
+}
+
+async function clearIdentityBudget({ identityId, type }: IdentityBudgetParams): Promise<void> {
+    await distributedStore.delete(identityBudgetKey({ identityId, type }))
+}
+
 type CreateParams = {
     platformId: PlatformId | null
     email: string
     type: OtpType
+}
+
+type IdentityBudgetParams = {
+    identityId: string
+    type: OtpType
+}
+
+type CountGuessOnIdentityParams = IdentityBudgetParams & {
+    spent: number
+}
+
+type IdentityGuessBudget = {
+    count: number
+    windowStartedAt: number
 }
 
 type DiscardParams = {

--- a/packages/server/api/src/app/ee/helper/email/email-sender/smtp-email-sender.ts
+++ b/packages/server/api/src/app/ee/helper/email/email-sender/smtp-email-sender.ts
@@ -40,7 +40,7 @@ export const smtpEmailSender = (log: FastifyBaseLogger): SMTPEmailSender => {
                 const senderEmail = system.get(AppSystemProp.SMTP_SENDER_EMAIL)
     
                 if (!smtpEmailSender(log).isSmtpConfigured()) {
-                    log.error({ emailSubject }, '[smtpEmailSender#send] SMTP is not configured')
+                    log.error({ template: { name: templateData.name } }, '[smtpEmailSender#send] SMTP is not configured')
                     return
                 }
     
@@ -53,7 +53,7 @@ export const smtpEmailSender = (log: FastifyBaseLogger): SMTPEmailSender => {
                 log.info({
                     emails,
                     platform: { id: platformId },
-                    templateData,
+                    template: { name: templateData.name },
                 }, '[smtpEmailSender#send] sending email')
                 await smtpClient.sendMail({
                     from: `${senderName} <${senderEmail}>`,

--- a/packages/server/api/src/app/ee/helper/email/email-service.ts
+++ b/packages/server/api/src/app/ee/helper/email/email-service.ts
@@ -176,7 +176,6 @@ export const emailService = (log: FastifyBaseLogger) => ({
 
         log.info({
             email: userIdentity.email,
-            otp,
             identityId: userIdentity.id,
             type,
         }, 'Sending OTP email')

--- a/packages/server/api/test/integration/ce/authentication/otp-service.test.ts
+++ b/packages/server/api/test/integration/ce/authentication/otp-service.test.ts
@@ -9,6 +9,7 @@ let app: FastifyInstance | null = null
 
 const EMAIL = 'otp.budget@example.com'
 const MAX_ATTEMPTS = 5
+const MAX_ATTEMPTS_PER_IDENTITY = 10
 
 async function seedIdentityWithCode(): Promise<string> {
     const identity = createMockUserIdentity({ email: EMAIL, verified: true })
@@ -53,6 +54,19 @@ async function sendCode(): Promise<void> {
         email: EMAIL,
         type: OtpType.EMAIL_LOGIN,
     })
+}
+
+async function burnOneCodeWithWrongGuesses(): Promise<void> {
+    await sendCode()
+    const otp = await currentOtp()
+    for (let guess = 0; guess < MAX_ATTEMPTS; guess++) {
+        await confirmCode(wrongVersionOf(otp!.value))
+    }
+}
+
+async function freshCorrectCode(): Promise<string> {
+    await sendCode()
+    return (await currentOtp())!.value
 }
 
 async function backdateCode(minutesAgo: number): Promise<Date> {
@@ -143,6 +157,28 @@ describe('otpService#confirm', () => {
         await backdateCode(11)
 
         expect(await confirmCode(value)).toBe(false)
+    })
+
+    it('refuses a correct code once the identity has spent its budget across several codes', async () => {
+        await seedIdentityWithCode()
+        const rounds = MAX_ATTEMPTS_PER_IDENTITY / MAX_ATTEMPTS
+        for (let round = 0; round < rounds; round++) {
+            await burnOneCodeWithWrongGuesses()
+        }
+
+        const accepted = await confirmCode(await freshCorrectCode())
+
+        expect(accepted).toBe(false)
+    })
+
+    it('clears the identity budget when the right code lands, so an owner who fumbles is not locked out', async () => {
+        await seedIdentityWithCode()
+        await burnOneCodeWithWrongGuesses()
+
+        expect(await confirmCode(await freshCorrectCode())).toBe(true)
+
+        await burnOneCodeWithWrongGuesses()
+        expect(await confirmCode(await freshCorrectCode())).toBe(true)
     })
 
     it('does not extend the life of a code by guessing at it', async () => {


### PR DESCRIPTION
## Description

Two problems with the emailed six-digit sign-in code, both reachable on any instance that has no captcha configured — which is the default for self-hosted.

### The attempt budget was scoped to the credential, not the account

`confirm()` caps guesses at 5 per OTP row, and the fifth wrong guess calls `discard()`, which **deletes** that row. `createAndSend` then finds nothing to reuse and mints a fresh code at `attempts = 0` immediately — no waiting for the ten-minute expiry.

So the loop is: request, guess five times, the code deletes itself, request again. Each round is an independent 5-in-a-million draw, which means the real ceiling was how fast an attacker could send packets rather than any policy. Roughly 139,000 rounds gets to even odds — about two hours at a few hundred requests a second — and a landed guess returns a real session token with no password and no second factor.

The fix caps guesses **per identity per rolling hour** inside `confirm()`, independent of how many codes get minted, so the bound holds even where the per-IP limit does not (see #14875 for why it currently does not). That takes a targeted account from ~2 hours to ~7.9 years. A correct code clears the counter, so an owner who fumbles a few digits and then gets it right is not left locked out.

Notes on the implementation:

- The read-modify-write needs no atomic `INCR` because `confirm()` already holds the `otp-confirm-{identityId}-{type}` lock, and that lock is the only writer of the key.
- The window is fixed rather than sliding — the remaining TTL is carried forward — so repeated wrong guesses cannot keep pushing a legitimate owner's lockout further out.
- Redis is already a hard dependency, so this adds no new setup for self-hosters.

### The code was written to the logs

`sendOtp` logged the plaintext OTP on every send, on every edition. Anywhere logs are shipped or retained, that is a live credential in cleartext — a considerably shorter path to an account than guessing at one. Removed from the log line; identity and type remain, which is enough to trace a delivery. Grepped the server for other log sites that carry the value: this was the only one.

## How was this tested?

Automated, and each test was checked against the unfixed code to confirm it actually catches the bug:

- `refuses a correct code once the identity has spent its budget across several codes` — spends the budget across code rotations, then feeds the **correct** code and asserts it is refused. Verified this **fails against current `main`**, where that code is accepted (1 failed / 10 passed).
- `clears the identity budget when the right code lands, so an owner who fumbles is not locked out` — guards the change from over-blocking real users.
- `otp-service.test.ts` — 11/11 passing with the fix.
- Full CE integration suite — 77 files / 912 tests passing.
- `turbo run typecheck lint --filter=api` clean.

Edition paths: the OTP service and the email log line are shared code registered unconditionally in `app.ts`, so all three editions take the same path. Exercised on **CE** via the integration suite. Not yet run against EE or Cloud on a preview instance — worth doing before this leaves draft, together with a sanity check that a 10-per-hour ceiling suits Cloud's real support load.

Fixes # (issue)

### Breaking change?  (required — CI fails if this is left unedited)

- [ ] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [x] yes — functional (default/limit/behaviour change, new self-hosted setup step)

A new limit on user-visible behaviour: ten wrong guesses per account per hour, after which emailed-code sign-in is refused until the window passes. Entry added to `docs/install/reference/breaking-changes.mdx` covering the limit, the fact that password and Google sign-in are unaffected, and the deliberate trade that the counter is keyed on the account — so anyone who knows an address can spend the owner's budget for them. No configuration required.

### Security impact?  (required — CI fails if this is left unedited)

- [ ] no — reviewed, no security impact
- [x] yes — security-sensitive (call out the risk and mitigation in the description above)

Touches authentication. The risk and the mitigation are both described above: an unbounded brute-force ending in a valid session, and a plaintext credential in the logs. Neither is introduced here — both ship in the current release.
