### PR TITLE
docs: fix project-replace CLI package and binary names (SRE-213)

### DIFF
--- a/brain/knowledge/execution-runtime/benchmark-cli.md
+++ b/brain/knowledge/execution-runtime/benchmark-cli.md
@@ -4,7 +4,7 @@ icon: ⏱️
 
 # Benchmark CLI
 
-`activepieces benchmark` load-tests a deployment's sync-webhook path and attributes *where* latency goes, so a self-hosted setup can be compared apples-to-apples against Activepieces' published reference numbers. Available in CE, EE, Cloud.
+`npx @activepieces/cli benchmark` load-tests a deployment's sync-webhook path and attributes *where* latency goes, so a self-hosted setup can be compared apples-to-apples against Activepieces' published reference numbers. Available in CE, EE, Cloud.
 
 ### How it works
 - Builds a `webhook → data-mapper → return-response` flow. Instead of a raw `--concurrency`, it **auto-discovers the deployment shape** (`GET /v1/worker-machines`) and drives load = the effective **execution slot** count, so a healthy deploy queues ~zero by construction. Any queue-wait it reports is a real finding (usually driven concurrency > slots).
@@ -22,6 +22,7 @@ icon: ⏱️
 - **App Instance Registry** (`app-machine-cache.ts`): apps have no inbound healthcheck, so each self-registers into a Redis hash `appMachines` on its `systemSnapshot` tick; `list()` drops rows untouched >120s. Kept separate from `workerMachines` so an app is never counted as an execution slot. Write gated off on Cloud.
 
 ### Gotchas
+- **CLI identity — no `ap`, no `activepieces` package.** Applies to every CLI command, not just benchmark. Published as `@activepieces/cli` on npm (`activepieces` returns 404); bin is `pieces-cli`. All user docs should invoke it as `npx @activepieces/cli <command>`. `docs/admin-guide/guides/project-replace-cli.mdx` was shipped with `npm install -g activepieces` + `ap project replace`, both fictional; this brain page had the same slip in its opening line.
 - Auth is **platform API key only** (`AP_API_KEY`/`--api-key` + `--project-id`) — email/password login was removed; SERVICE principal gets the full diagnostic bundle.
 - The infra round-trip block is **self-hosted only** — `/v1/health/diagnostics` returns `FEATURE_DISABLED` on `AP_EDITION=cloud` (a Cloud admin is a tenant, not the infra operator); the CLI degrades gracefully.
 

--- a/docs/admin-guide/guides/project-replace-cli.mdx
+++ b/docs/admin-guide/guides/project-replace-cli.mdx
@@ -4,10 +4,10 @@ description: 'Mirror a project across Activepieces deployments from CI/CD withou
 icon: 'arrow-right-arrow-left'
 ---
 
-The `ap project replace` CLI mirrors a project's flows, table schemas, and folders from one Activepieces deployment to another using direct API calls. Use it from CI/CD to promote work between independent staging and production instances when Git-based [Project Releases](/admin-guide/guides/project-releases) aren't a fit.
+The `@activepieces/cli` `project replace` command mirrors a project's flows, table schemas, and folders from one Activepieces deployment to another using direct API calls. Use it from CI/CD to promote work between independent staging and production instances when Git-based [Project Releases](/admin-guide/guides/project-releases) aren't a fit.
 
 <Tip>
-**Use case:** A nightly GitHub Action runs `ap project replace --source-url=staging --dest-url=prod`. Staging is treated as the source of truth; production becomes a byte-for-byte mirror. The job fails before any write if the destination is missing required pieces or referenced connections.
+**Use case:** A nightly GitHub Action runs `npx @activepieces/cli project replace --source-url=staging --dest-url=prod`. Staging is treated as the source of truth; production becomes a byte-for-byte mirror. The job fails before any write if the destination is missing required pieces or referenced connections.
 </Tip>
 
 ## Prerequisites
@@ -29,11 +29,11 @@ The `ap project replace` CLI mirrors a project's flows, table schemas, and folde
 
 ## Installation
 
-```bash
-npm install -g activepieces
-```
+Run via `npx` (no install needed), pinning to the version that matches your destination instance to keep request shapes aligned:
 
-The `activepieces` CLI is shipped with each Activepieces release; pin the version that matches your destination instance to keep request shapes aligned.
+```bash
+npx @activepieces/cli@latest project replace ...
+```
 
 ## Command
 
@@ -42,7 +42,7 @@ The `activepieces` CLI is shipped with each Activepieces release; pin the versio
 export AP_SOURCE_API_KEY="$STAGING_API_KEY"
 export AP_DEST_API_KEY="$PROD_API_KEY"
 
-ap project replace \
+npx @activepieces/cli project replace \
   --source-url    https://staging.activepieces.com \
   --source-project "$STAGING_PROJECT_ID" \
   --dest-url      https://prod.activepieces.com \
@@ -198,9 +198,8 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
-      - run: npm install -g activepieces
       - run: |
-          ap project replace \
+          npx @activepieces/cli project replace \
             --source-url   "${{ vars.STAGING_URL }}" \
             --source-project "${{ vars.STAGING_PROJECT_ID }}" \
             --dest-url     "${{ vars.PROD_URL }}" \

--- a/docs/admin-guide/guides/project-replace-cli.mdx
+++ b/docs/admin-guide/guides/project-replace-cli.mdx
@@ -27,14 +27,6 @@ The `@activepieces/cli` `project replace` command mirrors a project's flows, tab
 | Connections | **Metadata auto-mirrored** (externalId, pieceName, displayName); secret values never cross the wire. New connections land on the destination as placeholders with `status: MISSING`. Operator authorizes each one in the destination UI before flows can run. |
 | MCP servers, agents, project metadata, custom domains, app credentials | **Out of scope.** Not touched. |
 
-## Installation
-
-Run via `npx` (no install needed), pinning to the version that matches your destination instance to keep request shapes aligned:
-
-```bash
-npx @activepieces/cli@latest project replace ...
-```
-
 ## Command
 
 ```bash


### PR DESCRIPTION
## Description

The `docs/admin-guide/guides/project-replace-cli.mdx` page instructed users to `npm install -g activepieces` and run `ap project replace ...`. Both are fictional:

- `npm view activepieces` returns **404** — no such package.
- The published package is [`@activepieces/cli`](https://www.npmjs.com/package/@activepieces/cli), with bin `pieces-cli`.

The other CLI docs already use `npx @activepieces/cli <command>` (`benchmark.mdx`, `separate-workers.mdx`); this PR aligns the project-replace page to that idiom.

While in there, fixes the same `activepieces benchmark` slip in the `Benchmark CLI` brain page opening line, and records the CLI-identity naming gotcha under its `Gotchas` section so the next doc writer meets it in place instead of shipping the same wrong name.

Fixes [SRE-213](https://linear.app/activepieces/issue/SRE-213/project-replace-cli-docs-documented-npm-package-and-binary-dont-exist).

## How was this tested?

Live-verified against the npm registry and the published CLI:

- \`npm view @activepieces/cli\` → \`@activepieces/cli@1.3.2\`, \`bin: pieces-cli\`.
- \`npm view activepieces\` → HTTP 404 (package does not exist).
- \`npx @activepieces/cli@latest project replace --help\` → prints \`Usage: pieces-cli project replace [options]\` with the exact flag set the doc lists.

Docs-only change, no code paths touched, so no per-edition testing needed.

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)