### PR TITLE
fix(connections): stop oauth2 connections failing to save when the code has special characters

### DIFF
--- a/packages/web/src/features/connections/utils/oauth2-utils.ts
+++ b/packages/web/src/features/connections/utils/oauth2-utils.ts
@@ -76,7 +76,7 @@ function getCode(redirectUrl: string): Promise<string> {
         redirectUrl.startsWith(event.origin) &&
         event.data['code']
       ) {
-        resolve(decodeURIComponent(event.data.code));
+        resolve(event.data.code);
         closeOAuth2Popup();
         window.removeEventListener('message', handler);
       }

--- a/packages/web/test/features/connections/utils/oauth2-authorization-code-decode.test.ts
+++ b/packages/web/test/features/connections/utils/oauth2-authorization-code-decode.test.ts
@@ -1,0 +1,61 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, expect, it } from 'vitest';
+
+import { oauth2Utils } from '@/features/connections/utils/oauth2-utils';
+
+const REDIRECT_URL = 'http://localhost/redirect';
+
+function codeAsPostedByRedirectPage(issuedCode: string): string {
+  const redirectSearch = `?code=${encodeURIComponent(issuedCode)}`;
+  const code = new URLSearchParams(redirectSearch).get('code');
+  if (code === null) {
+    throw new Error('code param missing');
+  }
+  return code;
+}
+
+function dispatchCodeMessage(code: string): void {
+  window.dispatchEvent(
+    new MessageEvent('message', {
+      data: { code },
+      origin: 'http://localhost',
+    }),
+  );
+}
+
+async function codeReachingTokenExchange(issuedCode: string): Promise<string> {
+  const response = oauth2Utils.openOAuth2Popup({
+    authorizationUrl: 'https://provider.example/authorize',
+    redirectUrl: REDIRECT_URL,
+  });
+  dispatchCodeMessage(codeAsPostedByRedirectPage(issuedCode));
+  const { code } = await response;
+  return code;
+}
+
+describe('OAuth2 authorization code decode (GIT-1763)', () => {
+  it('preserves a code containing a percent-encoded sequence', async () => {
+    const issuedCode = 'k1%2Fk2';
+    expect(await codeReachingTokenExchange(issuedCode)).toBe(issuedCode);
+  });
+
+  it('resolves without hanging when the code contains a stray percent sign', async () => {
+    const issuedCode = 'abc%zzdef';
+
+    const outcome = await Promise.race([
+      codeReachingTokenExchange(issuedCode),
+      new Promise<'still-pending'>((resolve) =>
+        setTimeout(() => resolve('still-pending'), 100),
+      ),
+    ]);
+
+    expect(outcome).toBe(issuedCode);
+  });
+
+  it('leaves URL-safe codes unchanged', async () => {
+    const issuedCode = 'plainSafeCode-123_456.789';
+    expect(await codeReachingTokenExchange(issuedCode)).toBe(issuedCode);
+  });
+});


### PR DESCRIPTION
Fixes [GIT-1763](https://linear.app/activepieces/issue/GIT-1763)
Closes #14871

## Problem
1. OAuth2 connect fails at token exchange (shown as INVALID_CLAIM / "Connection failed with error") for any provider whose authorization code contains a percent-encoded sequence (e.g. base64 `+` `/` `=`).
2. A code containing a stray `%` throws inside the popup message listener, so the connect popup hangs forever with no error.

## Fix
- `packages/web/src/features/connections/utils/oauth2-utils.ts` (`getCode`): drop the second `decodeURIComponent` on the received code. The redirect page already decodes once via `URLSearchParams.get('code')` and posts that value verbatim; the backend re-encodes exactly once when it POSTs to the token endpoint, so the second decode corrupted codes and threw on a stray `%`.

## Security
Touches the OAuth2 connect path, so flagged security-sensitive. No injection surface: the code is never rendered, and the backend serializes it via `URLSearchParams` (percent-encoded) before the token POST. Passing it through un-decoded sends the provider's code faithfully; removing the throw-on-stray-`%` path also eliminates an unhandled-exception hang. Net effect is neutral-to-safer.

## Verification
- Regression test `oauth2-authorization-code-decode.test.ts` drives the real `getCode` via a `MessageEvent`. Red-first: 2 fail pre-fix (corruption + hang), 3 pass post-fix.
- lint: 0 errors (pre-existing warnings only, none in touched files).
- Other affected paths: checked - none (single sender `redirect.tsx:70` -> single listener `getCode` -> single consumer `oauth2-connection-settings.tsx:343`; no parallel decode path).
- Visual: none - one-line logic change in an OAuth util; no rendered-surface, style, locale, piece, or email change. The only user-visible difference (connect succeeds vs "Connection failed") is gated behind an external provider issuing encoded codes; behavioral effect is proven by the red-first test through the real message flow.

<details>
<summary>Plan & reasoning</summary>

## Plan
- Delete the second decode so the code reaches the token exchange byte-identical to what the provider issued, symmetric with the backend's single encode. Files: `oauth2-utils.ts` (1 line) + new regression test. Footprint 2 files / ~2 lines product code, matches estimate.
- Fix at the choke point (`getCode`): grep confirms a single sender, single listener, single consumer, so one deletion covers every path.

## Non-happy scenarios considered
- URL-safe codes (no `%`): removal is a literal no-op -> test case 3.
- Stray `%` codes: previously threw URIError and hung the popup -> now resolve -> test case 2.
- Provider that double-encodes its redirect (violates RFC 6749): currently propped up by the bug, would flip to broken; none known in our set, would also fail in Postman/curl/standard OAuth libraries, fails loud at connect time, one-line revert.

## Alternatives rejected
- Preserve the encoded value at `redirect.tsx` and decode in `getCode`: more code, fragile (`URLSearchParams.get` always decodes), no benefit.
</details>

### Breaking change?

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?

- [ ] no — reviewed, no security impact
- [x] yes — security-sensitive (see the Security section above)