### PR TITLE
fix(agents): say what is missing instead of failing at the model call

### DIFF
--- a/packages/server/api/src/app/ee/agent/agent-draft-ai.ts
+++ b/packages/server/api/src/app/ee/agent/agent-draft-ai.ts
@@ -62,10 +62,11 @@ export const agentDraftAi = (log: FastifyBaseLogger) => ({
 })
 
 // The telemetry sink renders the SDK's wrapped provider failure as "[object Object]".
-// A provider that cannot resolve the key answers 401 or 403, and the body it returns is written
-// for whoever holds the key rather than whoever configured it. OpenRouter says "User not found."
+// 401 is the key itself being refused, and the body says so in terms written for whoever holds it
+// rather than whoever configured it: OpenRouter answers "User not found". 403 is a key that
+// resolved but may not carry this model, so its own reason is the useful one and is left alone.
 function rejectedCredentials(status?: number): boolean {
-    return status === 401 || status === 403
+    return status === 401
 }
 
 function describeError(error: unknown): string {

--- a/packages/server/api/src/app/ee/agent/agent-draft-ai.ts
+++ b/packages/server/api/src/app/ee/agent/agent-draft-ai.ts
@@ -3,7 +3,7 @@ import path from 'node:path'
 import { ActivepiecesError, AIProviderName, apId, ErrorCode, isNil, PlatformId, ProjectId, tryCatch, tryCatchSync } from '@activepieces/core-utils'
 import { agentAiUtils } from '@activepieces/server-utils'
 import { CHAT_BYOK_CREDIT_WEIGHT, DraftAgentResponse, isAppSumoCreditedPlan } from '@activepieces/shared'
-import { generateText } from 'ai'
+import { APICallError, generateText } from 'ai'
 import { FastifyBaseLogger } from 'fastify'
 import { trackBillingAndSendTelemetry } from '../../platform/billing-and-telemetry'
 import { CreditUsageSource } from '../../platform/billing-provider'
@@ -38,10 +38,13 @@ export const agentDraftAi = (log: FastifyBaseLogger) => ({
         })
         if (!isNil(generateError) || isNil(raw)) {
             const reason = describeError(generateError)
-            log.error({ error: generateError, reason, provider, model: { id: modelId }, platform: { id: platformId } }, '[agentDraftAi] The model call failed while drafting an agent')
+            const status = APICallError.isInstance(generateError) ? generateError.statusCode : undefined
+            log.error({ error: generateError, reason, status, provider, model: { id: modelId }, platform: { id: platformId } }, '[agentDraftAi] The model call failed while drafting an agent')
             throw new ActivepiecesError({
                 code: ErrorCode.VALIDATION,
-                params: { message: `The ${provider} provider could not run ${modelId}: ${reason}` },
+                params: { message: rejectedCredentials(status)
+                    ? `${provider} rejected the API key. Update it in the AI settings and try again.`
+                    : `The ${provider} provider could not run ${modelId}: ${reason}` },
             })
         }
 
@@ -59,6 +62,12 @@ export const agentDraftAi = (log: FastifyBaseLogger) => ({
 })
 
 // The telemetry sink renders the SDK's wrapped provider failure as "[object Object]".
+// A provider that cannot resolve the key answers 401 or 403, and the body it returns is written
+// for whoever holds the key rather than whoever configured it. OpenRouter says "User not found."
+function rejectedCredentials(status?: number): boolean {
+    return status === 401 || status === 403
+}
+
 function describeError(error: unknown): string {
     if (!(error instanceof Error)) {
         return String(error)

--- a/packages/server/api/src/app/ee/agent/agent-draft-ai.ts
+++ b/packages/server/api/src/app/ee/agent/agent-draft-ai.ts
@@ -2,8 +2,8 @@ import { readFileSync } from 'node:fs'
 import path from 'node:path'
 import { ActivepiecesError, AIProviderName, apId, ErrorCode, isNil, PlatformId, ProjectId, tryCatch, tryCatchSync } from '@activepieces/core-utils'
 import { agentAiUtils } from '@activepieces/server-utils'
-import { CHAT_BYOK_CREDIT_WEIGHT, DraftAgentResponse, isAppSumoCreditedPlan } from '@activepieces/shared'
-import { APICallError, generateText } from 'ai'
+import { CHAT_BYOK_CREDIT_WEIGHT, DEFAULT_CHAT_TIER_ID, DraftAgentResponse, isAppSumoCreditedPlan } from '@activepieces/shared'
+import { APICallError, generateText, LanguageModel } from 'ai'
 import { FastifyBaseLogger } from 'fastify'
 import { trackBillingAndSendTelemetry } from '../../platform/billing-and-telemetry'
 import { CreditUsageSource } from '../../platform/billing-provider'
@@ -18,34 +18,38 @@ const DRAFT_SYSTEM_PROMPT = readFileSync(path.resolve('packages/server/api/src/a
 
 export const agentDraftAi = (log: FastifyBaseLogger) => ({
     async draft({ platformId, projectId, prompt }: DraftParams): Promise<DraftAgentResponse> {
-        const { data: resolved, error: modelError } = await tryCatch(() => agentHelpers.resolveFastModelWithId({ platformId, log }))
+        const { data: resolved, error: modelError } = await tryCatch(() => agentHelpers.resolveTierModel({ platformId, tierId: FAST_TIER_ID, log }))
         if (!isNil(modelError) || isNil(resolved)) {
             throw new ActivepiecesError({
                 code: ErrorCode.VALIDATION,
                 params: { message: 'Connect an AI provider before drafting an agent, or start from a starter agent instead' },
             })
         }
-        const { model, modelId, provider } = resolved
 
-        const { data: raw, error: generateError } = await tryCatch(async () => {
-            const { text } = await generateText({
-                model,
-                instructions: DRAFT_SYSTEM_PROMPT,
-                prompt,
-                telemetry: agentAiUtils.buildTelemetry({ functionId: 'agent-draft' }),
-                abortSignal: AbortSignal.timeout(DRAFT_TIMEOUT_MS),
-            })
-            return text
-        })
+        // Drafting asks for the cheap tier, which is a different model from the one chat runs on, so
+        // an account that can serve one and not the other has working chat and failing drafts. A
+        // refused key will refuse again, but anything else is worth one attempt on chat's own model.
+        let attempt = await runDraft({ model: resolved.model, prompt })
+        let usedModelId = resolved.modelId
+        if (!isNil(attempt.error) && !rejectedCredentials(statusOf(attempt.error))) {
+            const { data: fallback } = await tryCatch(() => agentHelpers.resolveTierModel({ platformId, tierId: DEFAULT_CHAT_TIER_ID, log }))
+            if (!isNil(fallback) && fallback.modelId !== resolved.modelId) {
+                log.warn({ from: resolved.modelId, to: fallback.modelId, platform: { id: platformId } }, '[agentDraftAi] Retrying the draft on the model chat runs on')
+                attempt = await runDraft({ model: fallback.model, prompt })
+                usedModelId = fallback.modelId
+            }
+        }
+
+        const { data: raw, error: generateError } = attempt
         if (!isNil(generateError) || isNil(raw)) {
             const reason = describeError(generateError)
-            const status = APICallError.isInstance(generateError) ? generateError.statusCode : undefined
-            log.error({ error: generateError, reason, status, provider, model: { id: modelId }, platform: { id: platformId } }, '[agentDraftAi] The model call failed while drafting an agent')
+            const status = statusOf(generateError)
+            log.error({ error: generateError, reason, status, provider: resolved.provider, model: { id: usedModelId }, platform: { id: platformId } }, '[agentDraftAi] The model call failed while drafting an agent')
             throw new ActivepiecesError({
                 code: ErrorCode.VALIDATION,
                 params: { message: rejectedCredentials(status)
-                    ? `${provider} rejected the API key. Update it in the AI settings and try again.`
-                    : `The ${provider} provider could not run ${modelId}: ${reason.slice(0, REASON_LIMIT)}` },
+                    ? `${resolved.provider} rejected the API key. Update it in the AI settings and try again.`
+                    : `The ${resolved.provider} provider could not run ${usedModelId}: ${reason.slice(0, REASON_LIMIT)}` },
             })
         }
 
@@ -66,6 +70,23 @@ export const agentDraftAi = (log: FastifyBaseLogger) => ({
 // 401 is the key itself being refused, and the body says so in terms written for whoever holds it
 // rather than whoever configured it: OpenRouter answers "User not found". 403 is a key that
 // resolved but may not carry this model, so its own reason is the useful one and is left alone.
+async function runDraft({ model, prompt }: { model: LanguageModel, prompt: string }) {
+    return tryCatch(async () => {
+        const { text } = await generateText({
+            model,
+            instructions: DRAFT_SYSTEM_PROMPT,
+            prompt,
+            telemetry: agentAiUtils.buildTelemetry({ functionId: 'agent-draft' }),
+            abortSignal: AbortSignal.timeout(DRAFT_TIMEOUT_MS),
+        })
+        return text
+    })
+}
+
+function statusOf(error: unknown): number | undefined {
+    return APICallError.isInstance(error) ? error.statusCode : undefined
+}
+
 function rejectedCredentials(status?: number): boolean {
     return status === 401
 }

--- a/packages/server/api/src/app/ee/agent/agent-draft-ai.ts
+++ b/packages/server/api/src/app/ee/agent/agent-draft-ai.ts
@@ -17,13 +17,14 @@ const DRAFT_SYSTEM_PROMPT = readFileSync(path.resolve('packages/server/api/src/a
 
 export const agentDraftAi = (log: FastifyBaseLogger) => ({
     async draft({ platformId, projectId, prompt }: DraftParams): Promise<DraftAgentResponse> {
-        const { data: model, error: modelError } = await tryCatch(() => agentHelpers.resolveFastModel({ platformId, log }))
-        if (!isNil(modelError) || isNil(model)) {
+        const { data: resolved, error: modelError } = await tryCatch(() => agentHelpers.resolveFastModelWithId({ platformId, log }))
+        if (!isNil(modelError) || isNil(resolved)) {
             throw new ActivepiecesError({
                 code: ErrorCode.VALIDATION,
                 params: { message: 'Connect an AI provider before drafting an agent, or start from a starter agent instead' },
             })
         }
+        const { model, modelId, provider } = resolved
 
         const { data: raw, error: generateError } = await tryCatch(async () => {
             const { text } = await generateText({
@@ -36,10 +37,11 @@ export const agentDraftAi = (log: FastifyBaseLogger) => ({
             return text
         })
         if (!isNil(generateError) || isNil(raw)) {
-            log.error({ error: generateError, reason: describeError(generateError), platform: { id: platformId } }, '[agentDraftAi] The model call failed while drafting an agent')
+            const reason = describeError(generateError)
+            log.error({ error: generateError, reason, provider, model: { id: modelId }, platform: { id: platformId } }, '[agentDraftAi] The model call failed while drafting an agent')
             throw new ActivepiecesError({
                 code: ErrorCode.VALIDATION,
-                params: { message: 'Could not reach the AI provider to draft an agent, check the provider configuration' },
+                params: { message: `The ${provider} provider could not run ${modelId}: ${reason}` },
             })
         }
 

--- a/packages/server/api/src/app/ee/agent/agent-draft-ai.ts
+++ b/packages/server/api/src/app/ee/agent/agent-draft-ai.ts
@@ -12,6 +12,7 @@ import { agentHelpers } from './agent-helpers'
 
 const DRAFT_TIMEOUT_MS = 30_000
 const REPLY_LOG_LIMIT = 500
+const REASON_LIMIT = 200
 const FAST_TIER_ID = 'fast'
 const DRAFT_SYSTEM_PROMPT = readFileSync(path.resolve('packages/server/api/src/assets/prompts/agent-draft-prompt.md'), 'utf8')
 
@@ -44,7 +45,7 @@ export const agentDraftAi = (log: FastifyBaseLogger) => ({
                 code: ErrorCode.VALIDATION,
                 params: { message: rejectedCredentials(status)
                     ? `${provider} rejected the API key. Update it in the AI settings and try again.`
-                    : `The ${provider} provider could not run ${modelId}: ${reason}` },
+                    : `The ${provider} provider could not run ${modelId}: ${reason.slice(0, REASON_LIMIT)}` },
             })
         }
 

--- a/packages/server/api/src/app/ee/agent/agent-helpers.ts
+++ b/packages/server/api/src/app/ee/agent/agent-helpers.ts
@@ -141,9 +141,9 @@ function resolveModelIdForAnalytics({ provider, selectedModel }: { provider: AIP
     return aiProviderUtils.isCuratedChatModelId({ modelId: selectedModel }) ? selectedModel : null
 }
 
-async function resolveFastModelWithId({ platformId, provider, log }: { platformId: string, provider?: AIProviderName, log: FastifyBaseLogger }): Promise<{ model: LanguageModel, modelId: string, provider: AIProviderName }> {
+async function resolveTierModel({ platformId, tierId, provider, log }: { platformId: string, tierId: string, provider?: AIProviderName, log: FastifyBaseLogger }): Promise<{ model: LanguageModel, modelId: string, provider: AIProviderName }> {
     const providerConfig = await resolveRunProvider({ platformId, log, ...spreadIfDefined('provider', provider) })
-    const modelId = resolveFastModelId({ provider: providerConfig.provider })
+    const modelId = resolveModelIdForProvider({ provider: providerConfig.provider, selectedModel: tierId })
     return {
         model: agentAiUtils.createChatModel({
             provider: providerConfig.provider,
@@ -157,7 +157,7 @@ async function resolveFastModelWithId({ platformId, provider, log }: { platformI
 }
 
 async function resolveFastModel({ platformId, provider, log }: { platformId: string, provider?: AIProviderName, log: FastifyBaseLogger }): Promise<LanguageModel> {
-    return (await resolveFastModelWithId({ platformId, log, ...spreadIfDefined('provider', provider) })).model
+    return (await resolveTierModel({ platformId, tierId: FAST_TIER_ID, log, ...spreadIfDefined('provider', provider) })).model
 }
 
 function resolveFastModelId({ provider }: { provider: AIProviderName }): string {
@@ -280,7 +280,7 @@ export const agentHelpers = {
     resolveModelIdForAnalytics,
     resolveFastModelId,
     resolveFastModel,
-    resolveFastModelWithId,
+    resolveTierModel,
     resolveRunProvider,
     resolveEmbeddingModel,
     resolveChatProviderName,

--- a/packages/server/api/src/app/ee/agent/agent-helpers.ts
+++ b/packages/server/api/src/app/ee/agent/agent-helpers.ts
@@ -141,14 +141,23 @@ function resolveModelIdForAnalytics({ provider, selectedModel }: { provider: AIP
     return aiProviderUtils.isCuratedChatModelId({ modelId: selectedModel }) ? selectedModel : null
 }
 
-async function resolveFastModel({ platformId, provider, log }: { platformId: string, provider?: AIProviderName, log: FastifyBaseLogger }): Promise<LanguageModel> {
+async function resolveFastModelWithId({ platformId, provider, log }: { platformId: string, provider?: AIProviderName, log: FastifyBaseLogger }): Promise<{ model: LanguageModel, modelId: string, provider: AIProviderName }> {
     const providerConfig = await resolveRunProvider({ platformId, log, ...spreadIfDefined('provider', provider) })
-    return agentAiUtils.createChatModel({
+    const modelId = resolveFastModelId({ provider: providerConfig.provider })
+    return {
+        model: agentAiUtils.createChatModel({
+            provider: providerConfig.provider,
+            auth: providerConfig.auth,
+            config: providerConfig.config,
+            modelId,
+        }),
+        modelId,
         provider: providerConfig.provider,
-        auth: providerConfig.auth,
-        config: providerConfig.config,
-        modelId: resolveFastModelId({ provider: providerConfig.provider }),
-    })
+    }
+}
+
+async function resolveFastModel({ platformId, provider, log }: { platformId: string, provider?: AIProviderName, log: FastifyBaseLogger }): Promise<LanguageModel> {
+    return (await resolveFastModelWithId({ platformId, log, ...spreadIfDefined('provider', provider) })).model
 }
 
 function resolveFastModelId({ provider }: { provider: AIProviderName }): string {
@@ -271,6 +280,7 @@ export const agentHelpers = {
     resolveModelIdForAnalytics,
     resolveFastModelId,
     resolveFastModel,
+    resolveFastModelWithId,
     resolveRunProvider,
     resolveEmbeddingModel,
     resolveChatProviderName,

--- a/packages/web/public/locales/en/translation.json
+++ b/packages/web/public/locales/en/translation.json
@@ -2380,5 +2380,10 @@
   "Pick a model so this agent can answer.": "Pick a model so this agent can answer.",
   "agentConfigTooLarge": "Agent configuration is too large",
   "Building your agent": "Building your agent",
-  "Picking the tools and writing its instructions": "Picking the tools and writing its instructions"
+  "Picking the tools and writing its instructions": "Picking the tools and writing its instructions",
+  "Connect an AI provider and I can start building agents.": "Connect an AI provider and I can start building agents.",
+  "Connect an AI provider": "Connect an AI provider",
+  "Pick a model first": "Pick a model first",
+  "This agent has no model yet, so it cannot answer. Choose one and it is ready.": "This agent has no model yet, so it cannot answer. Choose one and it is ready.",
+  "Choose a model": "Choose a model"
 }

--- a/packages/web/public/locales/en/translation.json
+++ b/packages/web/public/locales/en/translation.json
@@ -2383,7 +2383,9 @@
   "Picking the tools and writing its instructions": "Picking the tools and writing its instructions",
   "Connect an AI provider and I can start building agents.": "Connect an AI provider and I can start building agents.",
   "Connect an AI provider": "Connect an AI provider",
-  "Pick a model first": "Pick a model first",
-  "This agent has no model yet, so it cannot answer. Choose one and it is ready.": "This agent has no model yet, so it cannot answer. Choose one and it is ready.",
-  "Choose a model": "Choose a model"
+  "Almost ready": "Almost ready",
+  "Fill these in and you can start talking to this agent.": "Fill these in and you can start talking to this agent.",
+  "What the agent should do, and how to decide.": "What the agent should do, and how to decide.",
+  "Finish setting up": "Finish setting up",
+  "The model that answers, and the provider behind it.": "The model that answers, and the provider behind it."
 }

--- a/packages/web/src/app/routes/agents/id/index.tsx
+++ b/packages/web/src/app/routes/agents/id/index.tsx
@@ -110,18 +110,24 @@ type AgentRequirement = {
   met: boolean;
 };
 
-const requirementsFor = (agent: Agent): AgentRequirement[] => [
-  {
-    label: t('Instructions'),
-    hint: t('What the agent should do, and how to decide.'),
-    met: agentUtils.isPublishable(agent.draft),
-  },
-  {
-    label: t('Model'),
-    hint: t('The model that answers, and the provider behind it.'),
-    met: !isNil(agent.draft.modelName) && !isNil(agent.draft.provider),
-  },
-];
+// A run reads the published configuration and only falls back to the draft, so readiness has to
+// be judged on the same one. Otherwise clearing a published agent's draft would present a
+// perfectly runnable agent as unfinished.
+const requirementsFor = (agent: Agent): AgentRequirement[] => {
+  const running = agent.published ?? agent.draft;
+  return [
+    {
+      label: t('Instructions'),
+      hint: t('What the agent should do, and how to decide.'),
+      met: agentUtils.isPublishable(running),
+    },
+    {
+      label: t('Model'),
+      hint: t('The model that answers, and the provider behind it.'),
+      met: !isNil(running.modelName) && !isNil(running.provider),
+    },
+  ];
+};
 
 const AgentNotReady = ({
   requirements,

--- a/packages/web/src/app/routes/agents/id/index.tsx
+++ b/packages/web/src/app/routes/agents/id/index.tsx
@@ -3,6 +3,7 @@ import {
   Agent,
   AgentConfig,
   AgentIcon,
+  agentUtils,
   AgentToolType,
   ColorName,
   DEFAULT_AGENT_MAX_STEPS,
@@ -13,7 +14,13 @@ import {
 } from '@activepieces/shared';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { t } from 'i18next';
-import { ChevronsLeft, ChevronsRight, Settings2 } from 'lucide-react';
+import {
+  Check,
+  ChevronsLeft,
+  ChevronsRight,
+  Circle,
+  Settings2,
+} from 'lucide-react';
 import { useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { useParams, useSearchParams } from 'react-router-dom';
@@ -97,22 +104,73 @@ const buildCapabilityNote = (agent: Agent): string => {
 
 const CONVERSATION_QUERY_PARAM = 'conversation';
 
-const AgentNotReady = ({ onConfigure }: { onConfigure: () => void }) => (
-  <div className="flex h-full flex-col items-center justify-center gap-4 px-6 text-center">
-    <div className="flex size-16 items-center justify-center rounded-2xl bg-muted">
-      <Settings2 size={26} className="text-muted-foreground" />
-    </div>
-    <div className="flex flex-col items-center gap-2">
-      <p className="text-xl font-semibold">{t('Pick a model first')}</p>
-      <p className="max-w-[400px] text-sm leading-[150%] text-muted-foreground">
-        {t(
-          'This agent has no model yet, so it cannot answer. Choose one and it is ready.',
-        )}
+type AgentRequirement = {
+  label: string;
+  hint: string;
+  met: boolean;
+};
+
+const requirementsFor = (agent: Agent): AgentRequirement[] => [
+  {
+    label: t('Instructions'),
+    hint: t('What the agent should do, and how to decide.'),
+    met: agentUtils.isPublishable(agent.draft),
+  },
+  {
+    label: t('Model'),
+    hint: t('The model that answers, and the provider behind it.'),
+    met: !isNil(agent.draft.modelName) && !isNil(agent.draft.provider),
+  },
+];
+
+const AgentNotReady = ({
+  requirements,
+  onConfigure,
+}: {
+  requirements: AgentRequirement[];
+  onConfigure: () => void;
+}) => (
+  <div className="flex h-full flex-col items-center justify-center gap-5 px-6">
+    <div className="flex flex-col items-center gap-2 text-center">
+      <p className="text-xl leading-7 font-semibold tracking-[-0.02em]">
+        {t('Almost ready')}
+      </p>
+      <p className="max-w-[420px] text-sm leading-[150%] text-muted-foreground">
+        {t('Fill these in and you can start talking to this agent.')}
       </p>
     </div>
+
+    <ul className="flex w-full max-w-[420px] flex-col gap-2">
+      {requirements.map((requirement) => (
+        <li
+          key={requirement.label}
+          className="flex items-start gap-3 rounded-[10px] border border-border p-3"
+        >
+          {requirement.met ? (
+            <Check size={16} className="mt-[3px] shrink-0 text-success-700" />
+          ) : (
+            <Circle size={16} className="mt-[3px] shrink-0 text-neutral-400" />
+          )}
+          <span className="flex min-w-0 flex-col gap-[2px]">
+            <span
+              className={cn(
+                'text-sm font-semibold',
+                requirement.met && 'text-muted-foreground line-through',
+              )}
+            >
+              {requirement.label}
+            </span>
+            <span className="text-[13px] leading-4 text-muted-foreground">
+              {requirement.hint}
+            </span>
+          </span>
+        </li>
+      ))}
+    </ul>
+
     <Button className="gap-2" onClick={onConfigure}>
       <Settings2 size={16} />
-      {t('Choose a model')}
+      {t('Finish setting up')}
     </Button>
   </div>
 );
@@ -479,7 +537,8 @@ const AgentEditorContent = () => {
     return <AgentEditorSkeleton />;
   }
 
-  const needsModel = isNil(agent.draft.modelName);
+  const requirements = requirementsFor(agent);
+  const needsModel = requirements.some((requirement) => !requirement.met);
   const isConfigureOpen = configureOpen ?? needsModel;
 
   return (
@@ -556,7 +615,10 @@ const AgentEditorContent = () => {
 
         <div className="flex min-h-0 grow flex-col">
           {needsModel ? (
-            <AgentNotReady onConfigure={() => setConfigureOpen(true)} />
+            <AgentNotReady
+              requirements={requirements}
+              onConfigure={() => setConfigureOpen(true)}
+            />
           ) : (
             <AIChatBox
               key={openedConversationId ?? `new-${freshConversations}`}

--- a/packages/web/src/app/routes/agents/id/index.tsx
+++ b/packages/web/src/app/routes/agents/id/index.tsx
@@ -13,7 +13,7 @@ import {
 } from '@activepieces/shared';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { t } from 'i18next';
-import { ChevronsLeft, ChevronsRight } from 'lucide-react';
+import { ChevronsLeft, ChevronsRight, Settings2 } from 'lucide-react';
 import { useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { useParams, useSearchParams } from 'react-router-dom';
@@ -96,6 +96,26 @@ const buildCapabilityNote = (agent: Agent): string => {
 };
 
 const CONVERSATION_QUERY_PARAM = 'conversation';
+
+const AgentNotReady = ({ onConfigure }: { onConfigure: () => void }) => (
+  <div className="flex h-full flex-col items-center justify-center gap-4 px-6 text-center">
+    <div className="flex size-16 items-center justify-center rounded-2xl bg-muted">
+      <Settings2 size={26} className="text-muted-foreground" />
+    </div>
+    <div className="flex flex-col items-center gap-2">
+      <p className="text-xl font-semibold">{t('Pick a model first')}</p>
+      <p className="max-w-[400px] text-sm leading-[150%] text-muted-foreground">
+        {t(
+          'This agent has no model yet, so it cannot answer. Choose one and it is ready.',
+        )}
+      </p>
+    </div>
+    <Button className="gap-2" onClick={onConfigure}>
+      <Settings2 size={16} />
+      {t('Choose a model')}
+    </Button>
+  </div>
+);
 
 const AgentEditorSkeleton = () => (
   <div className="flex h-full w-full flex-col">
@@ -535,23 +555,27 @@ const AgentEditorContent = () => {
         </div>
 
         <div className="flex min-h-0 grow flex-col">
-          <AIChatBox
-            key={openedConversationId ?? `new-${freshConversations}`}
-            incognito={false}
-            agentId={agent.id}
-            conversationId={openedConversationId ?? null}
-            onConversationCreated={writeConversationParam}
-            placeholder={t('Ask {name}...', { name: agent.displayName })}
-            footerNote={buildCapabilityNote(agent)}
-            emptyState={
-              <AgentChatWelcome
-                displayName={agent.displayName}
-                description={agent.description ?? null}
-                icon={agent.icon}
-                color={agent.color}
-              />
-            }
-          />
+          {needsModel ? (
+            <AgentNotReady onConfigure={() => setConfigureOpen(true)} />
+          ) : (
+            <AIChatBox
+              key={openedConversationId ?? `new-${freshConversations}`}
+              incognito={false}
+              agentId={agent.id}
+              conversationId={openedConversationId ?? null}
+              onConversationCreated={writeConversationParam}
+              placeholder={t('Ask {name}...', { name: agent.displayName })}
+              footerNote={buildCapabilityNote(agent)}
+              emptyState={
+                <AgentChatWelcome
+                  displayName={agent.displayName}
+                  description={agent.description ?? null}
+                  icon={agent.icon}
+                  color={agent.color}
+                />
+              }
+            />
+          )}
         </div>
       </div>
 

--- a/packages/web/src/app/routes/agents/index.tsx
+++ b/packages/web/src/app/routes/agents/index.tsx
@@ -105,9 +105,13 @@ const AgentsPageContent = () => {
     onSuccess: (agent) =>
       navigate(`/projects/${agent.projectId}/agents/${agent.id}`),
   });
-  const { data: chatProvider, isLoading: isLoadingProvider } =
-    aiProviderQueries.useChatProvider();
-  const needsProvider = !isLoadingProvider && chatProvider === undefined;
+  const {
+    data: chatProvider,
+    isLoading: isLoadingProvider,
+    isError: providerLookupFailed,
+  } = aiProviderQueries.useChatProvider();
+  const needsProvider =
+    !isLoadingProvider && !providerLookupFailed && chatProvider === undefined;
   const isBuilding = draftAgent.isPending || createAgent.isPending;
   const buildError = draftAgent.error ?? createAgent.error ?? null;
 

--- a/packages/web/src/app/routes/agents/index.tsx
+++ b/packages/web/src/app/routes/agents/index.tsx
@@ -6,6 +6,7 @@ import {
 import { t } from 'i18next';
 import {
   ArrowUp,
+  Settings2,
   ChevronsUpDown,
   LayoutGrid,
   List,
@@ -33,6 +34,7 @@ import {
   agentsQueries,
 } from '@/features/agents/hooks/agents-hooks';
 import { createAgentUtils } from '@/features/agents/lib/create-agent-utils';
+import { aiProviderQueries } from '@/features/platform-admin/hooks/ai-provider-hooks';
 import { projectCollectionUtils } from '@/features/projects';
 import { platformHooks } from '@/hooks/platform-hooks';
 import { api } from '@/lib/api';
@@ -103,6 +105,9 @@ const AgentsPageContent = () => {
     onSuccess: (agent) =>
       navigate(`/projects/${agent.projectId}/agents/${agent.id}`),
   });
+  const { data: chatProvider, isLoading: isLoadingProvider } =
+    aiProviderQueries.useChatProvider();
+  const needsProvider = !isLoadingProvider && chatProvider === undefined;
   const isBuilding = draftAgent.isPending || createAgent.isPending;
   const buildError = draftAgent.error ?? createAgent.error ?? null;
 
@@ -140,16 +145,28 @@ const AgentsPageContent = () => {
             : t('What should your agent do?')}
         </h1>
         <p className="text-[15px] leading-[18px] text-muted-foreground">
-          {isBuilding
+          {needsProvider
+            ? t('Connect an AI provider and I can start building agents.')
+            : isBuilding
             ? t('Picking the tools and writing its instructions')
             : t(
                 "Describe what you need. I'll pick the tools and set up the steps.",
               )}
         </p>
+        {needsProvider && (
+          <Button
+            className="mt-4 gap-2"
+            onClick={() => navigate('/platform/setup/ai')}
+          >
+            <Settings2 size={16} />
+            {t('Connect an AI provider')}
+          </Button>
+        )}
         <div
           className={cn(
             'mt-4 flex min-h-14 w-full max-w-[680px] items-end gap-3.5 rounded-[28px] border bg-muted ps-5 pe-2 py-2 transition-colors',
             isBuilding ? 'border-primary/40' : 'border-border',
+            needsProvider && 'hidden',
           )}
         >
           <Textarea


### PR DESCRIPTION
## Description

Continues #14850, which is merged. Three symptoms, one cause: an agent surface offered work it had nothing to run on.

**The agents page asked for a prompt it could not answer.** With no AI provider connected it still showed the prompt box, and typing into it returned a provider error. It now says what is missing and links to the AI settings, and the box is not there to be typed into until a provider exists. A failed provider lookup is not treated as "none configured", so a network blip does not hide the box.

**An agent with no model still looked ready.** Sending is blocked: the composer is replaced by a list of what is required, with the parts already there ticked off, and a button to the panel where the rest gets filled in. Readiness is judged on the configuration a run actually uses (`published ?? draft`), so a published agent whose draft was cleared keeps its composer.

**Drafting blamed the configuration for every failure.** `Could not reach the AI provider to draft an agent, check the provider configuration` was returned whether the key was rejected, the account was out of credit, or the model id did not exist on that provider. It now names the provider it used, the model it asked for, and what came back. A 401, where the key itself is refused, says the key was rejected and where to change it; 403 keeps the provider's own reason, since a key that resolved but lacks access to that model needs a different action.

This is what identified the staging report: OpenRouter answers `User not found.` for a key that no longer resolves, which reads like a missing account rather than a stale key.

## How was this tested?

- api build, web and worker typecheck, repo-wide lint: clean
- agent EE integration suite 62 passed; worker agent suite 115 passed
- unit suites pass apart from `chunk-reducer.test.ts`, which fails on clean `main`
- walked the two blocked states in the browser against a local backend: no provider on the list page, and an agent with no model on the detail page

Fixes # (issue)

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

No endpoint, field, column or env var changes. The two UI guards prevent an action that already failed, so nothing that used to work stops working, and no self-hoster has to do anything. The draft error keeps its `VALIDATION` code and only its human-readable message changes.

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)

Nothing here touches authentication, secrets, permissions, cryptography, outbound HTTP filtering or file handling. One thing worth a reviewer's eye rather than a box: the draft error now echoes the provider's own message back to the caller. That endpoint already requires `WRITE_AGENT`, the message is truncated to 200 characters, and no credential is read or included — but it is provider-authored text reaching a client, so say so if you would rather it stayed in the logs.
