### PR TITLE
fix(agents): clear the model warning when a model is chosen

### DIFF
--- a/packages/server/worker/src/lib/execute/jobs/ee/agent/execute-agent-run.ts
+++ b/packages/server/worker/src/lib/execute/jobs/ee/agent/execute-agent-run.ts
@@ -59,6 +59,8 @@ export const executeAgentRunJob: JobHandler<ExecuteAgentRunJobData, FireAndForge
         let turnWallClockTimer: NodeJS.Timeout | undefined
         let cancelCheckInterval: NodeJS.Timeout | undefined
         let heartbeatInterval: NodeJS.Timeout | undefined
+        let runProvider: string | undefined
+        let runModelId: string | undefined
         let answer: AgentResult | undefined
         const structured: { output?: Record<string, unknown> } = {}
 
@@ -93,6 +95,8 @@ export const executeAgentRunJob: JobHandler<ExecuteAgentRunJobData, FireAndForge
             })
 
             const provider = config.provider as AIProviderName
+            runProvider = provider
+            runModelId = config.modelId
             source = config.source
             const aiTools = config.aiTools
             // Tavily takes precedence; native LLM web search is only the no-Tavily fallback.
@@ -351,13 +355,17 @@ export const executeAgentRunJob: JobHandler<ExecuteAgentRunJobData, FireAndForge
             })
         }
         catch (err) {
-            log.error({ error: err, conversation: { id: conversationId } }, '[executeAgentRun] Agent job failed')
+            log.error({ error: err, conversation: { id: conversationId }, provider: runProvider, model: { id: runModelId } }, '[executeAgentRun] Agent job failed')
             const errorMessage = err instanceof Error ? err.message : 'An unexpected error occurred'
             const isCreditError = isCreditExhaustedError(errorMessage)
             const errorCode = isCreditError ? ErrorCode.QUOTA_EXCEEDED : undefined
+            // "User not found" is OpenRouter refusing a key, and reads like a missing account.
+            const attributed = isNil(runProvider) || isCreditError || isTransientFailureText(errorMessage)
+                ? errorMessage
+                : `${runProvider}${isNil(runModelId) ? '' : ` (${runModelId})`}: ${errorMessage}`
             const clientMessage = !isCreditError && isTransientFailureText(errorMessage)
                 ? 'The AI provider is temporarily unavailable. Please try again in a moment.'
-                : errorMessage
+                : attributed
             const failedResult = answer ?? stepResultFrom({ prompt: userMessage, uiParts: [], timestamp: new Date().toISOString(), tools: configuredPieceTools, structuredOutput: structured.output, failure: clientMessage })
             reportFinal(failedResult)
             const { error: releaseError } = await tryCatch(() => releaseFlowStep({ ctx, conversationId, flowRunId, waitpointId, output: failedResult, source, log }))

--- a/packages/web/src/app/routes/agents/id/index.tsx
+++ b/packages/web/src/app/routes/agents/id/index.tsx
@@ -390,7 +390,6 @@ const ConfigurePanel = ({
   icon,
   color,
   displayName,
-  needsModel,
   defaults,
   onCollapse,
 }: {
@@ -398,7 +397,6 @@ const ConfigurePanel = ({
   icon: AgentIcon;
   color: ColorName;
   displayName: string;
-  needsModel: boolean;
   defaults: ConfigureAgentInput;
   onCollapse: () => void;
 }) => {
@@ -409,6 +407,12 @@ const ConfigurePanel = ({
     mode: 'onChange',
   });
   const updateAgent = agentsMutations.useUpdateAgent({ id: agentId });
+
+  const values = form.watch();
+  const formNeedsModel =
+    isNil(values.draft?.modelName) || isNil(values.draft?.provider);
+  // The model selector fills itself in on mount, which react-hook-form counts as the user editing.
+  const hasChanges = JSON.stringify(values) !== JSON.stringify(defaults);
 
   const handleSubmit = (values: ConfigureAgentValues) => {
     form.clearErrors('root.serverError');
@@ -463,7 +467,7 @@ const ConfigurePanel = ({
                 className="gap-2"
               >
                 {t('Configure')}
-                {needsModel && (
+                {formNeedsModel && (
                   <span className="size-[7px] rounded-full bg-destructive" />
                 )}
               </TabsTrigger>
@@ -477,7 +481,7 @@ const ConfigurePanel = ({
         <ScrollArea className="min-h-0 grow">
           <div className="flex flex-col gap-5 p-[18px]">
             {tab === 'configure' ? (
-              <ConfigureFields form={form} needsModel={needsModel} />
+              <ConfigureFields form={form} needsModel={formNeedsModel} />
             ) : (
               <SettingsFields form={form} />
             )}
@@ -493,7 +497,7 @@ const ConfigurePanel = ({
           <Button
             type="submit"
             loading={updateAgent.isPending}
-            disabled={!form.formState.isDirty}
+            disabled={!hasChanges}
             className="h-[38px] rounded-lg px-[18px]"
           >
             {t('Save changes')}
@@ -660,7 +664,6 @@ const AgentEditorContent = () => {
             icon={agent.icon}
             color={agent.color}
             displayName={agent.displayName}
-            needsModel={needsModel}
             defaults={{
               displayName: agent.displayName,
               description: agent.description ?? '',


### PR DESCRIPTION
## Description

Two things that made the configuration panel argue with itself.

Choosing a model left the warning and the red dot up until the save landed, because both read the last saved agent rather than the form. They read the form now. The blocked composer still reads the saved agent, since an unsaved model cannot answer anything.

Save was enabled without anyone typing. The model selector fills itself in on mount when a provider is set and no model is, and react-hook-form counts that as an edit, so the button offered to save something nobody had touched. It now compares against the values the panel opened with.

A failed turn also names the provider and the model it ran on. `User not found` is OpenRouter refusing a key and reads like a missing account until something says which provider said it — the same attribution drafting already got in #14883.

## How was this tested?

- web typecheck clean, repo-wide lint 0 errors, worker agent suite 115 passed, web unit 475 passed
- walked the panel: opened an agent with no model, confirmed the warning clears on selection and Save stays disabled until a value differs from what was loaded

Fixes # (issue)

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)
