### PR TITLE
fix(pieces): strip incoming payload id to prevent piece_metadata duplicate key collision loop (#14834)

### DIFF
--- a/packages/server/api/src/app/pieces/metadata/piece-metadata-service.ts
+++ b/packages/server/api/src/app/pieces/metadata/piece-metadata-service.ts
@@ -142,6 +142,7 @@ export const pieceMetadataService = (log: FastifyBaseLogger) => {
                 name: pieceMetadata.name,
                 platformId,
             })
+            const { id: _ignoredId, ...cleanPieceMetadata } = pieceMetadata as (typeof pieceMetadata & { id?: string })
             const savedPiece = await pieceRepos().save({
                 id: apId(),
                 packageType,
@@ -149,7 +150,7 @@ export const pieceMetadataService = (log: FastifyBaseLogger) => {
                 archiveId,
                 platformId,
                 created: createdDate,
-                ...pieceMetadata,
+                ...cleanPieceMetadata,
             })
             if (publishCacheRefresh) {
                 await pieceCache(log).invalidate()

--- a/packages/server/api/test/integration/ce/pieces/piece-sync-service.test.ts
+++ b/packages/server/api/test/integration/ce/pieces/piece-sync-service.test.ts
@@ -133,4 +133,52 @@ describe('Piece Metadata Create', () => {
         expect(allPieces).toHaveLength(1)
         expect(allPieces[0].name).toBe('keep-me')
     })
+
+    it('should ignore incoming payload id and generate fresh unique primary key (#14834)', async () => {
+        const service = pieceMetadataService(mockLog)
+
+        const savedPiece1 = await service.create({
+            pieceMetadata: {
+                id: 'UExr6bNYWIwodXeO9vMgL', // Predefined cloud ID
+                name: 'cloud-piece-1',
+                displayName: 'Cloud Piece 1',
+                version: '1.0.0',
+                minimumSupportedRelease: '0.0.0',
+                maximumSupportedRelease: '9.9.9',
+                actions: {},
+                triggers: {},
+                authors: [],
+                logoUrl: 'https://example.com/logo.png',
+            } as any,
+            packageType: PackageType.REGISTRY,
+            pieceType: PieceType.OFFICIAL,
+            publishCacheRefresh: false,
+        })
+
+        const savedPiece2 = await service.create({
+            pieceMetadata: {
+                id: 'UExr6bNYWIwodXeO9vMgL', // Duplicate predefined cloud ID on another piece
+                name: 'cloud-piece-2',
+                displayName: 'Cloud Piece 2',
+                version: '1.0.0',
+                minimumSupportedRelease: '0.0.0',
+                maximumSupportedRelease: '9.9.9',
+                actions: {},
+                triggers: {},
+                authors: [],
+                logoUrl: 'https://example.com/logo.png',
+            } as any,
+            packageType: PackageType.REGISTRY,
+            pieceType: PieceType.OFFICIAL,
+            publishCacheRefresh: false,
+        })
+
+        expect(savedPiece1.id).not.toBe('UExr6bNYWIwodXeO9vMgL')
+        expect(savedPiece2.id).not.toBe('UExr6bNYWIwodXeO9vMgL')
+        expect(savedPiece1.id).not.toBe(savedPiece2.id)
+
+        const repo = databaseConnection().getRepository('piece_metadata')
+        const allPieces = await repo.find()
+        expect(allPieces).toHaveLength(2)
+    })
 })


### PR DESCRIPTION
markdown

## Description
Fixes #14834
### 🐛 Problem
On fresh Docker Compose deployments with `OFFICIAL_AUTO` piece sync enabled, the database is hammered in an infinite loop with:
postgres | DETAIL: Key (id)=(...) already exists. postgres | STATEMENT: INSERT INTO "piece_metadata"(...) VALUES (...) postgres | ERROR: duplicate key value violates unique constraint "PK_b045821e9caf2be9aba520d96da"


### 🔍 Root Cause
In `pieceMetadataService.create()`, the entity was constructed via:
```ts
const savedPiece = await pieceRepos().save({
    id: apId(),
    ...,
    ...pieceMetadata,
})
When pieceMetadata is fetched from the cloud registry API (https://cloud.activepieces.com/api/v1/pieces), the JSON object contains the cloud's predefined id. Because JavaScript object spread evaluates left-to-right, ...pieceMetadata overwrote the freshly generated local id: apId() with the remote cloud id.

When multiple pieces or sync runs occur, TypeORM attempts to insert records with conflicting primary keys, throwing unique constraint violations and triggering an infinite retry loop.

🛠️ Solution
Destructured and stripped incoming id from pieceMetadata (const { id: _ignoredId, ...cleanPieceMetadata } = pieceMetadata) before passing it into pieceRepos().save(), ensuring id: apId() is always preserved as the local primary key.
Added an integration test in piece-sync-service.test.ts verifying that predefined payload IDs are stripped and distinct local IDs are generated without primary key collisions.
Testing
Integration test added in packages/server/api/test/integration/ce/pieces/piece-sync-service.test.ts