### PR TITLE
feat(ai): add OrcaRouter as an AI model provider

### DIFF
--- a/brain/knowledge/ai-intelligence/ai-providers.md
+++ b/brain/knowledge/ai-intelligence/ai-providers.md
@@ -9,7 +9,7 @@ Lets platform admins configure one or more LLM backends for AI pieces in flows. 
 ### Entities & services
 - **AIProvider** — platform-scoped: `displayName`, `platformId` (unique with `provider`), `provider` (AIProviderName enum), `auth` (EncryptedObject, AES-256 at rest), `config` (JSON), `enabledForChat`.
 - Backend under `packages/server/api/src/app/ai/`; shared schemas in `core/shared/.../ai-providers/`.
-- Supported providers (10): `openai`, `anthropic`, `google`, `azure`, `openrouter`, `bedrock`, `mistral`, `cloudflare-gateway`, `custom` (OpenAI-compatible, e.g. Ollama/LM Studio), `activepieces` (auto-provisioned via OpenRouter).
+- Supported providers (11): `openai`, `anthropic`, `google`, `azure`, `openrouter`, `orcarouter`, `bedrock`, `mistral`, `cloudflare-gateway`, `custom` (OpenAI-compatible, e.g. Ollama/LM Studio), `activepieces` (auto-provisioned via OpenRouter).
 
 ### How it works
 - `GET /` list (auto-creates ACTIVEPIECES when `aiCreditsEnabled`); `GET /:provider/config` returns decrypted auth (engine-only); `GET /:provider/models` (cached); `POST /` create (validates creds first); `POST /:id` update; `DELETE /:id`.

--- a/docs/admin-guide/guides/setup-ai-providers.mdx
+++ b/docs/admin-guide/guides/setup-ai-providers.mdx
@@ -11,6 +11,7 @@ AI providers are configured by the platform admin to centrally manage credential
 - **OpenAI**
 - **Anthropic**
 - **Gemini**
+- **OrcaRouter**
 - **Vercel AI Gateway**
 - **Cloudflare AI Gateway**
 

--- a/packages/core/ai-providers/src/lib/create-language-model.test.ts
+++ b/packages/core/ai-providers/src/lib/create-language-model.test.ts
@@ -40,6 +40,7 @@ describe('createLanguageModel', () => {
         expect(identify(buildFor(AIProviderName.BEDROCK)).provider).toBe('amazon-bedrock')
         expect(identify(buildFor(AIProviderName.CUSTOM)).provider).toBe('openai-compatible.chat')
         expect(identify(buildFor(AIProviderName.OPENROUTER)).provider).toBe('openrouter')
+        expect(identify(buildFor(AIProviderName.ORCAROUTER)).provider).toBe('orcarouter.chat')
     })
 
     it('uses the OpenAI Chat API by default and the Responses API when asked', () => {

--- a/packages/core/ai-providers/src/lib/create-language-model.ts
+++ b/packages/core/ai-providers/src/lib/create-language-model.ts
@@ -10,6 +10,7 @@ import { createOpenRouter, OpenRouterChatSettings } from '@openrouter/ai-sdk-pro
 import { LanguageModel } from 'ai'
 
 const MISTRAL_BASE_URL = 'https://api.mistral.ai/v1'
+const ORCAROUTER_BASE_URL = 'https://api.orcarouter.ai/v1'
 
 export function createLanguageModel({ provider, auth, config, modelId, options = {} }: CreateLanguageModelParams): LanguageModel {
     switch (provider) {
@@ -56,6 +57,10 @@ export function createLanguageModel({ provider, auth, config, modelId, options =
         case AIProviderName.ACTIVEPIECES: {
             const { apiKey } = auth as BaseAIProviderAuthConfig
             return createOpenRouterChatModel({ apiKey, modelId, options })
+        }
+        case AIProviderName.ORCAROUTER: {
+            const { apiKey } = auth as BaseAIProviderAuthConfig
+            return createOpenAICompatible({ name: 'orcarouter', baseURL: ORCAROUTER_BASE_URL, apiKey }).chatModel(modelId)
         }
         case AIProviderName.CLOUDFLARE_GATEWAY:
             throw new Error('Cloudflare Gateway routing is caller-specific and is not handled by the shared language-model factory')

--- a/packages/core/piece-types/src/lib/ai-providers.ts
+++ b/packages/core/piece-types/src/lib/ai-providers.ts
@@ -22,6 +22,7 @@ const AzureProviderAuthConfig = BaseAIProviderAuthConfig
 const GoogleProviderAuthConfig = BaseAIProviderAuthConfig
 const OpenAIProviderAuthConfig = BaseAIProviderAuthConfig
 const OpenRouterProviderAuthConfig = BaseAIProviderAuthConfig
+const OrcaRouterProviderAuthConfig = BaseAIProviderAuthConfig
 const MistralProviderAuthConfig = BaseAIProviderAuthConfig
 
 export const BedrockProviderAuthConfig = z.object({
@@ -35,6 +36,7 @@ const ActivePiecesProviderConfig = z.object({})
 const GoogleProviderConfig = z.object({})
 const OpenAIProviderConfig = z.object({})
 const OpenRouterProviderConfig = z.object({})
+const OrcaRouterProviderConfig = z.object({})
 const MistralProviderConfig = z.object({})
 
 export const ProviderModelConfig = z.object({
@@ -81,6 +83,7 @@ export const AIProviderAuthConfig = z.union([
     GoogleProviderAuthConfig,
     OpenAIProviderAuthConfig,
     OpenRouterProviderAuthConfig,
+    OrcaRouterProviderAuthConfig,
     CloudflareGatewayProviderAuthConfig,
     OpenAICompatibleProviderAuthConfig,
     ActivePiecesProviderAuthConfig,
@@ -99,6 +102,7 @@ export const AIProviderConfig = z.union([
     GoogleProviderConfig,
     OpenAIProviderConfig,
     OpenRouterProviderConfig,
+    OrcaRouterProviderConfig,
     ActivePiecesProviderConfig,
     MistralProviderConfig,
 ])
@@ -258,6 +262,7 @@ const PROVIDER_MAX_CONTEXT_TOKENS: Partial<Record<AIProviderName, number>> = {
     [AIProviderName.BEDROCK]: 200_000,
     [AIProviderName.AZURE]: 128_000,
     [AIProviderName.OPENROUTER]: 128_000,
+    [AIProviderName.ORCAROUTER]: 128_000,
     [AIProviderName.ACTIVEPIECES]: 200_000,
     [AIProviderName.MISTRAL]: 128_000,
 }
@@ -273,6 +278,7 @@ const DEFAULT_EMBEDDING_MODELS: Partial<Record<AIProviderName, string>> = {
     [AIProviderName.AZURE]: 'text-embedding-3-small',
     [AIProviderName.ACTIVEPIECES]: 'text-embedding-3-small',
     [AIProviderName.OPENROUTER]: 'openai/text-embedding-3-small',
+    [AIProviderName.ORCAROUTER]: 'openai/text-embedding-3-small',
 }
 
 const WEB_SEARCH_MODE_BY_PROVIDER: Partial<Record<AIProviderName, AIWebSearchMode>> = {
@@ -312,6 +318,7 @@ export const AI_PROVIDER_CAPABILITIES: Record<AIProviderName, AIProviderCapabili
     [AIProviderName.OPENAI]: buildProviderCapabilities(AIProviderName.OPENAI),
     [AIProviderName.ANTHROPIC]: buildProviderCapabilities(AIProviderName.ANTHROPIC),
     [AIProviderName.OPENROUTER]: buildProviderCapabilities(AIProviderName.OPENROUTER),
+    [AIProviderName.ORCAROUTER]: buildProviderCapabilities(AIProviderName.ORCAROUTER),
     [AIProviderName.AZURE]: buildProviderCapabilities(AIProviderName.AZURE),
     [AIProviderName.GOOGLE]: buildProviderCapabilities(AIProviderName.GOOGLE),
     [AIProviderName.CLOUDFLARE_GATEWAY]: buildProviderCapabilities(AIProviderName.CLOUDFLARE_GATEWAY),

--- a/packages/core/shared/package.json
+++ b/packages/core/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/shared",
-  "version": "0.137.0",
+  "version": "0.138.0",
   "type": "commonjs",
   "sideEffects": false,
   "main": "./dist/src/index.js",

--- a/packages/core/shared/src/lib/management/ai-providers/index.ts
+++ b/packages/core/shared/src/lib/management/ai-providers/index.ts
@@ -37,6 +37,9 @@ export type OpenAIProviderAuthConfig = z.infer<typeof OpenAIProviderAuthConfig>
 export const OpenRouterProviderAuthConfig = BaseAIProviderAuthConfig
 export type OpenRouterProviderAuthConfig = z.infer<typeof OpenRouterProviderAuthConfig>
 
+export const OrcaRouterProviderAuthConfig = BaseAIProviderAuthConfig
+export type OrcaRouterProviderAuthConfig = z.infer<typeof OrcaRouterProviderAuthConfig>
+
 export const BedrockProviderAuthConfig = z.object({
     accessKeyId: z.string().min(1),
     secretAccessKey: z.string().min(1),
@@ -95,6 +98,9 @@ export type OpenAIProviderConfig = z.infer<typeof OpenAIProviderConfig>
 export const OpenRouterProviderConfig = z.object({})
 export type OpenRouterProviderConfig = z.infer<typeof OpenRouterProviderConfig>
 
+export const OrcaRouterProviderConfig = z.object({})
+export type OrcaRouterProviderConfig = z.infer<typeof OrcaRouterProviderConfig>
+
 export const BedrockProviderConfig = z.object({
     region: z.string().min(1),
 })
@@ -109,6 +115,7 @@ export const AIProviderAuthConfig = z.union([
     GoogleProviderAuthConfig,
     OpenAIProviderAuthConfig,
     OpenRouterProviderAuthConfig,
+    OrcaRouterProviderAuthConfig,
     CloudflareGatewayProviderAuthConfig,
     OpenAICompatibleProviderAuthConfig,
     ActivePiecesProviderAuthConfig,
@@ -126,6 +133,7 @@ export const AIProviderConfig = z.union([
     GoogleProviderConfig,
     OpenAIProviderConfig,
     OpenRouterProviderConfig,
+    OrcaRouterProviderConfig,
     ActivePiecesProviderConfig,
     MistralProviderConfig,
 ])
@@ -143,6 +151,12 @@ const ProviderConfigUnion = z.discriminatedUnion('provider', [
         provider: z.literal(AIProviderName.OPENROUTER),
         config: OpenRouterProviderConfig,
         auth: OpenRouterProviderAuthConfig,
+    }),
+    z.object({
+        displayName: z.string().min(1),
+        provider: z.literal(AIProviderName.ORCAROUTER),
+        config: OrcaRouterProviderConfig,
+        auth: OrcaRouterProviderAuthConfig,
     }),
     z.object({
         displayName: z.string().min(1),

--- a/packages/core/utils/src/lib/permission.ts
+++ b/packages/core/utils/src/lib/permission.ts
@@ -48,6 +48,7 @@ export const STEP_NAME_REGEX = /^[a-zA-Z_][a-zA-Z0-9_]*$/
 export enum AIProviderName {
     OPENAI = 'openai',
     OPENROUTER = 'openrouter',
+    ORCAROUTER = 'orcarouter',
     ANTHROPIC = 'anthropic',
     AZURE = 'azure',
     GOOGLE = 'google',

--- a/packages/pieces/community/ai/src/lib/actions/image/generate-image.ts
+++ b/packages/pieces/community/ai/src/lib/actions/image/generate-image.ts
@@ -248,6 +248,7 @@ const getGeneratedImage = async ({
       case AIProviderName.GOOGLE:
       case AIProviderName.ACTIVEPIECES:
       case AIProviderName.OPENROUTER:
+      case AIProviderName.ORCAROUTER:
       case AIProviderName.CLOUDFLARE_GATEWAY:
         return generateImageUsingGenerateText({
           model: model as unknown as LanguageModel,

--- a/packages/pieces/community/ai/src/lib/common/ai-sdk.ts
+++ b/packages/pieces/community/ai/src/lib/common/ai-sdk.ts
@@ -102,6 +102,10 @@ export async function createEmbeddingModel({
             const openRouterProvider = createOpenRouter({ apiKey })
             return { model: openRouterProvider.textEmbeddingModel(embeddingModelId), embeddingModelId, providerOptions: OPENAI_EMBEDDING_PROVIDER_OPTIONS }
         }
+        case AIProviderName.ORCAROUTER: {
+            const p = createOpenAICompatible({ name: 'orcarouter', baseURL: 'https://api.orcarouter.ai/v1', apiKey })
+            return { model: p.textEmbeddingModel(embeddingModelId), embeddingModelId, providerOptions: OPENAI_EMBEDDING_PROVIDER_OPTIONS }
+        }
         default:
             throw new Error(`Provider ${provider} does not support embedding models`)
     }
@@ -167,6 +171,10 @@ function buildLanguageModel({ provider, auth, config, modelId, openaiResponsesMo
         case AIProviderName.OPENROUTER: {
             const { apiKey } = auth as BaseAIProviderAuthConfig
             return createOpenRouter({ apiKey }).chat(modelId) as LanguageModel
+        }
+        case AIProviderName.ORCAROUTER: {
+            const { apiKey } = auth as BaseAIProviderAuthConfig
+            return createOpenAICompatible({ name: 'orcarouter', baseURL: 'https://api.orcarouter.ai/v1', apiKey }).chatModel(modelId)
         }
         default:
             throw new Error(`Provider ${provider} is not supported`)

--- a/packages/server/api/src/app/ai/providers/index.ts
+++ b/packages/server/api/src/app/ai/providers/index.ts
@@ -10,11 +10,13 @@ import { mistralProvider } from './mistral-provider'
 import { openAICompatibleProvider } from './openai-compatible-gateway-provider'
 import { openaiProvider } from './openai-provider'
 import { openRouterProvider } from './openrouter-provider'
+import { orcarouterProvider } from './orcarouter-provider'
 
 export const aiProviders: Record<AIProviderName, AIProviderStrategy<AIProviderAuthConfig, AIProviderConfig>> = {
     [AIProviderName.OPENAI]: openaiProvider,
     [AIProviderName.ANTHROPIC]: anthropicProvider,
     [AIProviderName.OPENROUTER]: openRouterProvider,
+    [AIProviderName.ORCAROUTER]: orcarouterProvider,
     [AIProviderName.AZURE]: azureProvider,
     [AIProviderName.GOOGLE]: googleProvider,
     [AIProviderName.CLOUDFLARE_GATEWAY]: cloudflareGatewayProvider,

--- a/packages/server/api/src/app/ai/providers/orcarouter-provider.ts
+++ b/packages/server/api/src/app/ai/providers/orcarouter-provider.ts
@@ -1,0 +1,39 @@
+import { httpClient, HttpMethod } from '@activepieces/pieces-common'
+import { AIProviderModel, AIProviderModelType, OrcaRouterProviderAuthConfig, OrcaRouterProviderConfig } from '@activepieces/shared'
+import { FastifyBaseLogger } from 'fastify'
+import { AIProviderStrategy } from './ai-provider'
+
+export const orcarouterProvider: AIProviderStrategy<OrcaRouterProviderAuthConfig, OrcaRouterProviderConfig> = {
+    name: 'OrcaRouter',
+    async validateConnection(authConfig: OrcaRouterProviderAuthConfig, config: OrcaRouterProviderConfig, _log: FastifyBaseLogger): Promise<void> {
+        await orcarouterProvider.listModels(authConfig, config)
+    },
+    async listModels(authConfig: OrcaRouterProviderAuthConfig, _config: OrcaRouterProviderConfig): Promise<AIProviderModel[]> {
+        const res = await httpClient.sendRequest<{ data: OrcaRouterModel[] }>({
+            url: 'https://api.orcarouter.ai/v1/models',
+            method: HttpMethod.GET,
+            headers: {
+                'Authorization': `Bearer ${authConfig.apiKey}`,
+                'Content-Type': 'application/json',
+            },
+        })
+
+        const { data } = res.body
+
+        return data.map((model: OrcaRouterModel) => ({
+            id: model.id,
+            name: model.id,
+            type: isImageModel({ modelId: model.id }) ? AIProviderModelType.IMAGE : AIProviderModelType.TEXT,
+        }))
+    },
+}
+
+function isImageModel({ modelId }: { modelId: string }): boolean {
+    return modelId.includes('image') || DALL_E_MODELS.includes(modelId)
+}
+
+const DALL_E_MODELS = ['dall-e-3', 'dall-e-2']
+
+type OrcaRouterModel = {
+    id: string
+}

--- a/packages/server/api/src/app/ee/agent/agent-helpers.ts
+++ b/packages/server/api/src/app/ee/agent/agent-helpers.ts
@@ -114,7 +114,7 @@ function resolveModelIdForProvider({ provider, selectedModel }: { provider: AIPr
         return selectedModel
     }
     const tierModelId = resolveTier({ tierId: selectedModel }).modelId
-    if (provider === AIProviderName.ACTIVEPIECES || provider === AIProviderName.OPENROUTER) {
+    if (provider === AIProviderName.ACTIVEPIECES || provider === AIProviderName.OPENROUTER || provider === AIProviderName.ORCAROUTER) {
         return tierModelId
     }
     const nativeModelId = tierModelId.replace(/^[^/]+\//, '').replace(/\./g, '-')

--- a/packages/server/api/src/app/mcp/tools/ap-setup-guide.ts
+++ b/packages/server/api/src/app/mcp/tools/ap-setup-guide.ts
@@ -220,6 +220,7 @@ async function aiProviderGuide(mcp: ProjectScopedMcpServer, log: FastifyBaseLogg
         `  - ${AIProviderName.GOOGLE} — requires API key from aistudio.google.com`,
         `  - ${AIProviderName.AZURE} — requires API key + resource name`,
         `  - ${AIProviderName.OPENROUTER} — requires API key from openrouter.ai`,
+        `  - ${AIProviderName.ORCAROUTER} — requires API key from www.orcarouter.ai`,
         '',
         '5. Click Save',
         '',

--- a/packages/server/utils/src/agent-ai-utils.ts
+++ b/packages/server/utils/src/agent-ai-utils.ts
@@ -127,6 +127,8 @@ function createEmbeddingModel({ provider, auth, config }: {
         case AIProviderName.ACTIVEPIECES:
         case AIProviderName.OPENROUTER:
             return { model: createOpenRouter({ apiKey }).textEmbeddingModel(embeddingModelId), providerOptions: OPENROUTER_EMBEDDING_PROVIDER_OPTIONS }
+        case AIProviderName.ORCAROUTER:
+            return { model: createOpenAICompatible({ name: 'orcarouter', baseURL: 'https://api.orcarouter.ai/v1', apiKey }).textEmbeddingModel(embeddingModelId), providerOptions: OPENAI_EMBEDDING_PROVIDER_OPTIONS }
         default:
             throw new Error(`Provider ${provider} does not support knowledge base search`)
     }

--- a/packages/web/src/features/agents/ai-model/index.tsx
+++ b/packages/web/src/features/agents/ai-model/index.tsx
@@ -29,6 +29,7 @@ export const PROVIDER_EMBEDDING_MODELS: Partial<
   [AIProviderName.AZURE]: 'text-embedding-3-small',
   [AIProviderName.ACTIVEPIECES]: 'text-embedding-3-small',
   [AIProviderName.OPENROUTER]: 'openai/text-embedding-3-small',
+  [AIProviderName.ORCAROUTER]: 'openai/text-embedding-3-small',
 };
 
 type AIModelSelectorProps = {

--- a/packages/web/src/features/agents/ai-providers.ts
+++ b/packages/web/src/features/agents/ai-providers.ts
@@ -85,6 +85,14 @@ It is strongly recommended that you add your credit card information to your Ope
 2. Once on the website, locate and click on the option to obtain your OpenRouter API Key.`),
   },
   {
+    provider: AIProviderName.ORCAROUTER,
+    name: 'OrcaRouter',
+    logoUrl: 'https://cdn.activepieces.com/pieces/new-core/text-ai.svg',
+    markdown: t(`Follow these instructions to get your OrcaRouter API Key:
+1. Go to https://www.orcarouter.ai.
+2. Once on the website, locate and click on the option to obtain your OrcaRouter API Key.`),
+  },
+  {
     provider: AIProviderName.CUSTOM,
     name: 'Other (OpenAI Compatible)',
     logoUrl: 'https://cdn.activepieces.com/pieces/new-core/text-ai.svg',


### PR DESCRIPTION
## Description

Adds [OrcaRouter](https://www.orcarouter.ai) as a model provider. OrcaRouter is an OpenAI-compatible model routing gateway that exposes 150+ models from OpenAI, Anthropic, Google, DeepSeek, Qwen, MiniMax, xAI and others behind a single endpoint and API key. It also provides gateway-level security controls for AI agents.

This wires OrcaRouter through the existing AI provider registry the same way OpenRouter is wired:

- New `orcarouter` entry in the `AIProviderName` enum and in the shared zod provider schemas (`AIProviderConfig` / `AIProviderAuthConfig`).
- `orcarouter-provider.ts` strategy with `validateConnection` (live `GET /v1/models`) and `listModels`, mirroring `openrouter-provider.ts`.
- `createLanguageModel` dispatches `orcarouter` to an OpenAI-compatible client pinned to `https://api.orcarouter.ai/v1`.
- The AI piece builds chat and embedding models against the same endpoint, so flows and knowledge bases can use OrcaRouter.
- The agent model selector lists OrcaRouter and defaults knowledge-base embeddings to `openai/text-embedding-3-small`.
- The admin AI setup docs and the MCP setup guide list OrcaRouter as a supported provider.

Security: the OrcaRouter API key is stored in the existing encrypted provider auth column and is only sent over HTTPS to the hardcoded `https://api.orcarouter.ai/v1` endpoint (not user-configurable), exactly mirroring the existing OpenRouter provider. No new SSRF or user-supplied-URL surface is introduced.

I'm an engineer on the OrcaRouter team.

## How was this tested?

- Live API checks against the OrcaRouter endpoint using the exact wire paths this provider uses: `GET /v1/models` returned 200 with 207 models, `POST /v1/chat/completions` with `openai/gpt-4o` returned 200, and `POST /v1/embeddings` with `openai/text-embedding-3-small` returned 200 with a 1536-dim vector.
- Added a `createLanguageModel` unit test asserting the `orcarouter` provider builds the expected OpenAI-compatible client (`orcarouter.chat`).
- Full monorepo typecheck/lint could not be completed in the sandbox because the workspace dependency install stalled; CI runs the repo's own checks on this PR.

Fixes #

### Breaking change?  (required — CI fails if this is left unedited)

<!-- Tick exactly one box. If either "yes", apply the "⛓️‍💥 breaking-change" label AND add an entry to docs/install/reference/breaking-changes.mdx (what changed + the action self-hosters must take). -->

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

<!-- Tick exactly one box. "Security-sensitive" = touches authentication, secrets, permissions/roles, cryptography, SSRF / outbound HTTP, or file handling. -->

- [ ] no — reviewed, no security impact
- [x] yes — security-sensitive (call out the risk and mitigation in the description above)
