### PR TITLE
fix(platform): drop deprecated chatbot table to unblock project delete

### DIFF
--- a/packages/server/api/src/app/database/migration/postgres/1828000000000-DropChatbot.ts
+++ b/packages/server/api/src/app/database/migration/postgres/1828000000000-DropChatbot.ts
@@ -1,0 +1,45 @@
+import { QueryRunner } from 'typeorm'
+import { Migration } from '../../migration'
+
+export class DropChatbot1828000000000 implements Migration {
+    name = 'DropChatbot1828000000000'
+    breaking = true
+    release = '0.88.1'
+    transaction = true
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`
+            DROP TABLE IF EXISTS "chatbot" CASCADE
+        `)
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`
+            CREATE TABLE "chatbot" (
+                "id" character varying(21) NOT NULL,
+                "created" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+                "updated" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+                "type" character varying NOT NULL,
+                "displayName" character varying NOT NULL,
+                "projectId" character varying NOT NULL,
+                "connectionId" character varying,
+                "dataSources" jsonb NOT NULL,
+                "prompt" character varying,
+                "visibilityStatus" character varying NOT NULL DEFAULT 'PRIVATE',
+                CONSTRAINT "PK_1ee1961e62c5cec278314f1d68e" PRIMARY KEY ("id")
+            )
+        `)
+        await queryRunner.query(`
+            ALTER TABLE "chatbot"
+            ADD CONSTRAINT "FK_d2f5f245c27541cd70f13f169eb"
+            FOREIGN KEY ("projectId") REFERENCES "project"("id")
+            ON DELETE NO ACTION ON UPDATE NO ACTION
+        `)
+        await queryRunner.query(`
+            ALTER TABLE "chatbot"
+            ADD CONSTRAINT "FK_13f7ad52cefa43433864732c384"
+            FOREIGN KEY ("connectionId") REFERENCES "app_connection"("id")
+            ON DELETE NO ACTION ON UPDATE NO ACTION
+        `)
+    }
+}

--- a/packages/server/api/src/app/database/postgres-connection.ts
+++ b/packages/server/api/src/app/database/postgres-connection.ts
@@ -417,8 +417,8 @@ import { AddRenamedChatTableCompatViews1823000000000 } from './migration/postgre
 import { AddAttemptsToOtp1824000000000 } from './migration/postgres/1824000000000-AddAttemptsToOtp'
 import { AddAgentTable1825000000000 } from './migration/postgres/1825000000000-AddAgentTable'
 import { AddAgentIdToAgentConversation1826000000000 } from './migration/postgres/1826000000000-AddAgentIdToAgentConversation'
-import { DropChatbot1828000000000 } from './migration/postgres/1828000000000-DropChatbot'
 import { AddVersionToOtp1827000000000 } from './migration/postgres/1827000000000-AddVersionToOtp'
+import { DropChatbot1828000000000 } from './migration/postgres/1828000000000-DropChatbot'
 
 const getSslConfig = (): boolean | TlsOptions => {
     const useSsl = system.get(AppSystemProp.POSTGRES_USE_SSL)

--- a/packages/server/api/src/app/database/postgres-connection.ts
+++ b/packages/server/api/src/app/database/postgres-connection.ts
@@ -417,6 +417,7 @@ import { AddRenamedChatTableCompatViews1823000000000 } from './migration/postgre
 import { AddAttemptsToOtp1824000000000 } from './migration/postgres/1824000000000-AddAttemptsToOtp'
 import { AddAgentTable1825000000000 } from './migration/postgres/1825000000000-AddAgentTable'
 import { AddAgentIdToAgentConversation1826000000000 } from './migration/postgres/1826000000000-AddAgentIdToAgentConversation'
+import { DropChatbot1828000000000 } from './migration/postgres/1828000000000-DropChatbot'
 import { AddVersionToOtp1827000000000 } from './migration/postgres/1827000000000-AddVersionToOtp'
 
 const getSslConfig = (): boolean | TlsOptions => {
@@ -851,6 +852,7 @@ export const getMigrations = (): (new () => Migration)[] => {
         AddAgentTable1825000000000,
         AddAgentIdToAgentConversation1826000000000,
         AddVersionToOtp1827000000000,
+        DropChatbot1828000000000,
     ]
     return migrations
 }


### PR DESCRIPTION
## Description

`hard-delete-project` fails on any project that ever had a chatbot, forever. `chatbot`'s two `ManyToOne` relations (`projectId`, `connectionId`) omitted `onDelete` in the entity, so TypeORM defaulted both FKs to `NO ACTION` in the generated migration:

```sql
FK_d2f5f245c27541cd70f13f169eb  chatbot.projectId    → project.id         ON DELETE NO ACTION
FK_13f7ad52cefa43433864732c384  chatbot.connectionId → app_connection.id  ON DELETE NO ACTION
```

Every other project-child cascades. Chatbot is the only outlier. This is the source of both the FK-on-`chatbot` and FK-on-`app_connection` failures in the `system-job-queue` backlog (the second is the chatbot→app_connection FK, not the connection itself).

The feature was deprecated in PR #3480 (~3 years ago). Repo grep for `chatbotService`/`ChatbotEntity`/`chatbotRepo` returns only migration files — no live writers. Prod holds 1,628 stale rows. Dropping the table is safer than patching the two FKs on something we don't use.

Migration `1828000000000-DropChatbot.ts`: `DROP TABLE IF EXISTS "chatbot" CASCADE`. `breaking = true` per the rollback-safety convention (destructive DDL). `down()` recreates the schema; row data does not survive a rollback.

## How was this tested?

- Prod DB confirms chatbot has 1,628 rows, all referenced by nothing outside the two FKs.
- Repo-wide grep confirms no live code touches the entity — only migrations reference it.
- Lint: `npx turbo run lint --filter=api` — 15 tasks successful, 0 errors.
- CE / EE / Cloud: migration runs on any Postgres edition. No API/UI/env changes ship. Not customer-facing.

Fixes # (part of the hard-delete backlog triaged via `debug-failed-run` on `system-job-queue`)

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

`DropChatbot` sets `breaking = true` on the migration class per the rollback-safety convention, but nothing customer-facing changes — the table has been deprecated for years, has no live code paths, and no API/env/UI changes ship. Nothing for a self-hoster to do.

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)
