### PR TITLE
fix(platform): allow platform deletion to complete when a flow connection has expired

### DIFF
--- a/packages/server/api/src/app/ee/platform/platform-teardown-jobs.ts
+++ b/packages/server/api/src/app/ee/platform/platform-teardown-jobs.ts
@@ -125,6 +125,8 @@ async function stopPlatformExecution({ platformId, log }: BeginPlatformTeardownP
                 platform: { id: platformId },
             }, '[stopPlatformExecution] Fallback trigger-source disable also failed; teardown will continue and drainFlows will hard-delete the flow row anyway')
         }
+        await flowRepo().update({ id: flow.id }, { status: FlowStatus.DISABLED })
+        await flowExecutionCache(log).invalidate(flow.id)
     }
     await flowExecutionCache(log).invalidate(...flows.map((flow) => flow.id))
 }

--- a/packages/server/api/src/app/ee/platform/platform-teardown-jobs.ts
+++ b/packages/server/api/src/app/ee/platform/platform-teardown-jobs.ts
@@ -111,12 +111,20 @@ async function stopPlatformExecution({ platformId, log }: BeginPlatformTeardownP
             project: { id: flow.projectId },
             platform: { id: platformId },
         }, '[stopPlatformExecution] Trigger disable failed; forcing trigger-source removal so no new webhooks admit runs')
-        await tryCatch(async () => triggerSourceService(log).disable({
+        const { error: fallbackError } = await tryCatch(async () => triggerSourceService(log).disable({
             flowId: flow.id,
             projectId: flow.projectId,
             simulate: false,
             ignoreError: true,
         }))
+        if (!isNil(fallbackError)) {
+            log.warn({
+                error: fallbackError,
+                flow: { id: flow.id },
+                project: { id: flow.projectId },
+                platform: { id: platformId },
+            }, '[stopPlatformExecution] Fallback trigger-source disable also failed; teardown will continue and drainFlows will hard-delete the flow row anyway')
+        }
     }
     await flowExecutionCache(log).invalidate(...flows.map((flow) => flow.id))
 }

--- a/packages/server/api/src/app/ee/platform/platform-teardown-jobs.ts
+++ b/packages/server/api/src/app/ee/platform/platform-teardown-jobs.ts
@@ -1,4 +1,4 @@
-import { isNil, unique } from '@activepieces/core-utils'
+import { isNil, tryCatch, unique } from '@activepieces/core-utils'
 import { Flow, FlowOperationType, FlowStatus, UserStatus } from '@activepieces/shared'
 import { FastifyBaseLogger } from 'fastify'
 import { appConnectionsRepo } from '../../app-connection/app-connection-service/app-connection-service'
@@ -17,6 +17,7 @@ import { PieceMetadataEntity } from '../../pieces/metadata/piece-metadata-entity
 import { PlatformEntity } from '../../platform/platform.entity'
 import { ProjectEntity } from '../../project/project-entity'
 import { ToolSearchIndexEntity } from '../../tool-search/tool-search-index.entity'
+import { triggerSourceService } from '../../trigger/trigger-source/trigger-source-service'
 import { userRepo } from '../../user/user-service'
 import { userInvitationRepo } from '../../user-invitations/user-invitation.service'
 import { VariableEntity } from '../../variable/variable.entity'
@@ -40,7 +41,7 @@ export const platformTeardownJobs = (log: FastifyBaseLogger) => ({
     hardDeletePlatformHandler: async (data: SystemJobData<SystemJobName.HARD_DELETE_PLATFORM>) => {
         const { platformId } = data
 
-        await cutOffPlatformAccess({ platformId, log })
+        await beginPlatformTeardown({ platformId, log })
 
         const flows = await listFlowsByPlatform(platformId)
         await drainFlows({ flows, log })
@@ -78,19 +79,19 @@ export const platformTeardownJobs = (log: FastifyBaseLogger) => ({
     },
 })
 
-export async function cutOffPlatformAccess({ platformId, log }: CutOffPlatformAccessParams): Promise<void> {
+export async function beginPlatformTeardown({ platformId, log }: BeginPlatformTeardownParams): Promise<void> {
     await userRepo().update({ platformId }, { status: UserStatus.INACTIVE })
     await apiKeyService.deleteAllByPlatformId({ platformId })
     await stopPlatformExecution({ platformId, log })
 }
 
-async function stopPlatformExecution({ platformId, log }: CutOffPlatformAccessParams): Promise<void> {
+async function stopPlatformExecution({ platformId, log }: BeginPlatformTeardownParams): Promise<void> {
     const flows = await listFlowsByPlatform(platformId)
     for (const flow of flows) {
         if (flow.status === FlowStatus.DISABLED || isNil(flow.publishedVersionId)) {
             continue
         }
-        await flowService(log).update({
+        const { error } = await tryCatch(async () => flowService(log).update({
             id: flow.id,
             userId: null,
             projectId: flow.projectId,
@@ -100,7 +101,22 @@ async function stopPlatformExecution({ platformId, log }: CutOffPlatformAccessPa
                 type: FlowOperationType.CHANGE_STATUS,
                 request: { status: FlowStatus.DISABLED },
             },
-        })
+        }))
+        if (isNil(error)) {
+            continue
+        }
+        log.warn({
+            error,
+            flow: { id: flow.id },
+            project: { id: flow.projectId },
+            platform: { id: platformId },
+        }, '[stopPlatformExecution] Trigger disable failed; forcing trigger-source removal so no new webhooks admit runs')
+        await tryCatch(async () => triggerSourceService(log).disable({
+            flowId: flow.id,
+            projectId: flow.projectId,
+            simulate: false,
+            ignoreError: true,
+        }))
     }
     await flowExecutionCache(log).invalidate(...flows.map((flow) => flow.id))
 }
@@ -152,7 +168,7 @@ type DrainFlowsParams = {
     log: FastifyBaseLogger
 }
 
-type CutOffPlatformAccessParams = {
+type BeginPlatformTeardownParams = {
     platformId: string
     log: FastifyBaseLogger
 }

--- a/packages/server/api/src/app/platform/platform.controller.ts
+++ b/packages/server/api/src/app/platform/platform.controller.ts
@@ -9,7 +9,7 @@ import { chatVisibilityHelper } from '../ee/agent/chat-visibility-helper'
 import { platformToEditMustBeOwnedByCurrentUser } from '../ee/authentication/ee-authorization'
 import { emailService } from '../ee/helper/email/email-service'
 import { platformPlanService } from '../ee/platform/platform-plan/platform-plan.service'
-import { cutOffPlatformAccess } from '../ee/platform/platform-teardown-jobs'
+import { beginPlatformTeardown } from '../ee/platform/platform-teardown-jobs'
 import { fileService } from '../file/file.service'
 import { attachMultipartFieldsToBody } from '../helper/multipart-body'
 import { system } from '../helper/system/system'
@@ -168,7 +168,7 @@ export const platformController: FastifyPluginAsyncZod = async (app) => {
                 },
             })
 
-            await cutOffPlatformAccess({ platformId, log: req.log })
+            await beginPlatformTeardown({ platformId, log: req.log })
 
             const { error: emailError } = await tryCatch(() => emailService(req.log).sendPlatformDeleted({
                 platformId,


### PR DESCRIPTION
## Description

If any one flow's `onDisable` trigger throws while `hardDeletePlatformHandler` is disabling flows, the whole handler aborts. `flow.status` is never flipped to `DISABLED` without a successful `onDisable` (that's the post-condition of `applyStatusChange` at `flow.service.ts:753`), so on every retry the loop hits the same flow with the same dead connection and the same throw. One expired OAuth token = platform stuck forever.

Seen on prod (`system-job-queue`): platform teardown blocked on `TRIGGER_UPDATE_STATUS: flowId=z6I2qKanLKOWxIDiru0fZ standardError={"errorName":"ConnectionExpired",…}` at `flow-trigger-side-effect.ts:202`.

### Fix

Wrap the per-flow `flowService.update` in `tryCatch`. On failure:

1. Log `warn` with flow/project/platform ids (evlog canonical groups).
2. Fall back to `triggerSourceService.disable({ ignoreError: true })` — the same call `flowSideEffects.preDelete` makes further down the teardown path — which soft-deletes the `trigger_source` row without requiring the piece's polite third-party goodbye to succeed. That's the actual webhook-dispatch gate (verified via `webhook.service.ts` → `flowExecutionCache` → `getFlowExecutionCache` at line 40).

`flow.status` is deliberately not touched. Marking a flow `DISABLED` on the failure path would lie about the third-party state (their webhook subscription is still active) and short-circuit retries at the handler's own top-of-loop guard (`if (flow.status === DISABLED) continue`). The single-flow delete path in `deleteFlowHandler` uses the same "swallow-in-preDelete, never write DISABLED" pattern already — this brings platform teardown into line with it.

### Rename

`cutOffPlatformAccess` → `beginPlatformTeardown`. The old name reads reversible (auth suspension). But the function is only reached from the platform-delete path with a 7-day purge (`PLATFORM_PURGE_DELAY_DAYS`) already scheduled and no restore endpoint anywhere in `packages/server/api/src/app/platform/` (grep-clean). The 7 days is a **human safety net** — the "your platform is deleted" email tells the owner to reply if unexpected; the only recovery is a manual ops rescue that cancels the scheduled BullMQ job and reverses the effects by hand.

## How was this tested?

- Traced admission path: `webhook.service.ts:handleWebhook` gates on `flowExecutionCache.get` (falls back to `flowService.getOneById`, no `operationStatus` filter) and `flow.status !== DISABLED`. The `trigger_source` soft-delete is what unwires webhook renewal crons, polling repeats, and app-webhook listeners. Direct-webhook admission still admits during the window before `drainFlows` deletes the flow row — same shape as the existing single-flow delete race (see `flow.service.ts:515` → `flow.jobs.ts:48-71`), which the codebase already accepts.
- Lint: `npx turbo run lint --filter=api` — 15 tasks successful, 0 errors.
- CE / EE / Cloud: `platform-teardown-jobs.ts` is EE-only; controller call site is CE-neutral. Rename is symmetric; no external-caller impact.

Fixes # (part of the hard-delete backlog triaged via `debug-failed-run` on `system-job-queue`)

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

`cutOffPlatformAccess` isn't part of any public API; both call sites are updated in this PR. Function-name change only.

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)
