### PR TITLE
feat(gmail): tag all actions and triggers with classification

### DIFF
--- a/packages/pieces/community/gmail/package.json
+++ b/packages/pieces/community/gmail/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-gmail",
-  "version": "0.12.10",
+  "version": "0.13.0",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "dependencies": {

--- a/packages/pieces/community/gmail/src/lib/actions/ai-get-message-action.ts
+++ b/packages/pieces/community/gmail/src/lib/actions/ai-get-message-action.ts
@@ -6,6 +6,7 @@ import { gmailAiGetMessageActionOutputSchema } from '../output-schemas';
 export const gmailAiGetMessageAction = createAction({
   auth: gmailAuth,
   name: 'gmail_get_message',
+  classification: 'READ',
   displayName: 'Get Message',
   description: 'Get a single email message by its ID.',
   audience: 'ai',

--- a/packages/pieces/community/gmail/src/lib/actions/ai-reply-to-thread-action.ts
+++ b/packages/pieces/community/gmail/src/lib/actions/ai-reply-to-thread-action.ts
@@ -6,6 +6,7 @@ import { gmailAiReplyToThreadActionOutputSchema } from '../output-schemas';
 export const gmailAiReplyToThreadAction = createAction({
   auth: gmailAuth,
   name: 'gmail_reply_to_thread',
+  classification: 'WRITE',
   displayName: 'Reply to Thread',
   description: 'Reply to an existing email thread.',
   audience: 'ai',

--- a/packages/pieces/community/gmail/src/lib/actions/ai-search-email-action.ts
+++ b/packages/pieces/community/gmail/src/lib/actions/ai-search-email-action.ts
@@ -6,6 +6,7 @@ import { gmailAiSearchEmailActionOutputSchema } from '../output-schemas';
 export const gmailAiSearchEmailAction = createAction({
   auth: gmailAuth,
   name: 'gmail_search_email',
+  classification: 'SEARCH',
   displayName: 'Search Email',
   description:
     'Search emails using advanced criteria. If no filters are provided, the latest emails are returned.',

--- a/packages/pieces/community/gmail/src/lib/actions/ai-send-email-action.ts
+++ b/packages/pieces/community/gmail/src/lib/actions/ai-send-email-action.ts
@@ -6,6 +6,7 @@ import { gmailAiSendEmailActionOutputSchema } from '../output-schemas';
 export const gmailAiSendEmailAction = createAction({
   auth: gmailAuth,
   name: 'gmail_send_email',
+  classification: 'WRITE',
   displayName: 'Send Email',
   description: 'Send an email through a Gmail account',
   audience: 'ai',

--- a/packages/pieces/community/gmail/src/lib/actions/create-draft-action.ts
+++ b/packages/pieces/community/gmail/src/lib/actions/create-draft-action.ts
@@ -7,6 +7,7 @@ import { gmailCreateDraftActionOutputSchema } from '../output-schemas';
 export const gmailCreateDraftAction = createAction({
   auth: gmailAuth,
   name: 'gmail_create_draft',
+  classification: 'WRITE',
   displayName: 'Create Draft',
   description:
     'Create a new draft email (optionally inside an existing thread).',

--- a/packages/pieces/community/gmail/src/lib/actions/create-draft-reply-action.ts
+++ b/packages/pieces/community/gmail/src/lib/actions/create-draft-reply-action.ts
@@ -10,6 +10,7 @@ import { createDraftReplyActionOutputSchema } from '../output-schemas';
 export const gmailCreateDraftReplyAction = createAction({
   auth: gmailAuth,
   name: 'create_draft_reply',
+  classification: 'WRITE',
   description: 'Creates a draft reply to an existing email.',
   audience: 'human',
   aiMetadata: {

--- a/packages/pieces/community/gmail/src/lib/actions/delete-draft-action.ts
+++ b/packages/pieces/community/gmail/src/lib/actions/delete-draft-action.ts
@@ -5,6 +5,7 @@ import { gmail as googleGmail } from '@googleapis/gmail';
 export const gmailDeleteDraftAction = createAction({
   auth: gmailAuth,
   name: 'gmail_delete_draft',
+  classification: 'DESTRUCTIVE',
   displayName: 'Delete Draft',
   description: 'Permanently delete a draft email by its ID.',
   audience: 'ai',

--- a/packages/pieces/community/gmail/src/lib/actions/forward-message-action.ts
+++ b/packages/pieces/community/gmail/src/lib/actions/forward-message-action.ts
@@ -8,6 +8,7 @@ import { gmailForwardMessageActionOutputSchema } from '../output-schemas';
 export const gmailForwardMessageAction = createAction({
   auth: gmailAuth,
   name: 'gmail_forward_message',
+  classification: 'WRITE',
   displayName: 'Forward Message',
   description: 'Forward an existing email to new recipients.',
   audience: 'ai',

--- a/packages/pieces/community/gmail/src/lib/actions/get-attachment-action.ts
+++ b/packages/pieces/community/gmail/src/lib/actions/get-attachment-action.ts
@@ -6,6 +6,7 @@ import { gmailGetAttachmentActionOutputSchema } from '../output-schemas';
 export const gmailGetAttachmentAction = createAction({
   auth: gmailAuth,
   name: 'gmail_get_attachment',
+  classification: 'READ',
   displayName: 'Get Attachment',
   description: 'Download an email attachment by message ID and attachment ID.',
   audience: 'ai',

--- a/packages/pieces/community/gmail/src/lib/actions/get-draft-action.ts
+++ b/packages/pieces/community/gmail/src/lib/actions/get-draft-action.ts
@@ -6,6 +6,7 @@ import { gmailGetDraftActionOutputSchema } from '../output-schemas';
 export const gmailGetDraftAction = createAction({
   auth: gmailAuth,
   name: 'gmail_get_draft',
+  classification: 'READ',
   displayName: 'Get Draft',
   description: 'Get a single draft email by its ID.',
   audience: 'ai',

--- a/packages/pieces/community/gmail/src/lib/actions/get-label-action.ts
+++ b/packages/pieces/community/gmail/src/lib/actions/get-label-action.ts
@@ -6,6 +6,7 @@ import { gmailGetLabelActionOutputSchema } from '../output-schemas';
 export const gmailGetLabelAction = createAction({
   auth: gmailAuth,
   name: 'gmail_get_label',
+  classification: 'READ',
   displayName: 'Get Label',
   description:
     'Get a single label by its ID, including message and thread counts.',

--- a/packages/pieces/community/gmail/src/lib/actions/get-mail-action.ts
+++ b/packages/pieces/community/gmail/src/lib/actions/get-mail-action.ts
@@ -7,6 +7,7 @@ import { gmailGetMailActionOutputSchema } from '../output-schemas';
 export const gmailGetEmailAction = createAction({
   auth: gmailAuth,
   name: 'gmail_get_mail',
+  classification: 'READ',
   description: 'Get an email via Id.',
   audience: 'human',
   aiMetadata: {

--- a/packages/pieces/community/gmail/src/lib/actions/get-profile-action.ts
+++ b/packages/pieces/community/gmail/src/lib/actions/get-profile-action.ts
@@ -6,6 +6,7 @@ import { gmailGetProfileActionOutputSchema } from '../output-schemas';
 export const gmailGetProfileAction = createAction({
   auth: gmailAuth,
   name: 'gmail_get_profile',
+  classification: 'READ',
   displayName: 'Get Profile',
   description: 'Get the connected mailbox profile.',
   audience: 'ai',

--- a/packages/pieces/community/gmail/src/lib/actions/get-thread-action.ts
+++ b/packages/pieces/community/gmail/src/lib/actions/get-thread-action.ts
@@ -7,6 +7,7 @@ import { gmailGetThreadActionOutputSchema } from '../output-schemas';
 export const gmailGetThread = createAction({
   auth: gmailAuth,
   name: 'gmail_get_thread',
+  classification: 'READ',
   description: 'Get a thread from your Gmail account via Id',
   displayName: 'Get Thread',
   audience: 'ai',

--- a/packages/pieces/community/gmail/src/lib/actions/list-drafts-action.ts
+++ b/packages/pieces/community/gmail/src/lib/actions/list-drafts-action.ts
@@ -6,6 +6,7 @@ import { gmailListDraftsActionOutputSchema } from '../output-schemas';
 export const gmailListDraftsAction = createAction({
   auth: gmailAuth,
   name: 'gmail_list_drafts',
+  classification: 'SEARCH',
   displayName: 'List Drafts',
   description: 'List draft emails in the mailbox.',
   audience: 'ai',

--- a/packages/pieces/community/gmail/src/lib/actions/list-history-action.ts
+++ b/packages/pieces/community/gmail/src/lib/actions/list-history-action.ts
@@ -6,6 +6,7 @@ import { gmailListHistoryActionOutputSchema } from '../output-schemas';
 export const gmailListHistoryAction = createAction({
   auth: gmailAuth,
   name: 'gmail_list_history',
+  classification: 'SEARCH',
   displayName: 'List History',
   description: 'List mailbox changes since a given history ID.',
   audience: 'ai',

--- a/packages/pieces/community/gmail/src/lib/actions/list-labels-action.ts
+++ b/packages/pieces/community/gmail/src/lib/actions/list-labels-action.ts
@@ -6,6 +6,7 @@ import { gmailListLabelsActionOutputSchema } from '../output-schemas';
 export const gmailListLabelsAction = createAction({
   auth: gmailAuth,
   name: 'gmail_list_labels',
+  classification: 'SEARCH',
   displayName: 'List Labels',
   description: 'List all labels in the mailbox.',
   audience: 'ai',

--- a/packages/pieces/community/gmail/src/lib/actions/list-threads-action.ts
+++ b/packages/pieces/community/gmail/src/lib/actions/list-threads-action.ts
@@ -6,6 +6,7 @@ import { gmailListThreadsActionOutputSchema } from '../output-schemas';
 export const gmailListThreadsAction = createAction({
   auth: gmailAuth,
   name: 'gmail_list_threads',
+  classification: 'SEARCH',
   displayName: 'List Threads',
   description: 'List email conversation threads in the mailbox.',
   audience: 'ai',

--- a/packages/pieces/community/gmail/src/lib/actions/reply-to-email-action.ts
+++ b/packages/pieces/community/gmail/src/lib/actions/reply-to-email-action.ts
@@ -10,6 +10,7 @@ import { replyToEmailActionOutputSchema } from '../output-schemas';
 export const gmailReplyToEmailAction = createAction({
   auth: gmailAuth,
   name: 'reply_to_email',
+  classification: 'WRITE',
   displayName: 'Reply to Email',
   description: 'Reply to an existing email.',
   audience: 'human',

--- a/packages/pieces/community/gmail/src/lib/actions/request-approval-in-email.ts
+++ b/packages/pieces/community/gmail/src/lib/actions/request-approval-in-email.ts
@@ -15,6 +15,7 @@ import { requestApprovalInMailActionOutputSchema } from '../output-schemas';
 export const requestApprovalInEmail = createAction({
   auth: gmailAuth,
   name: 'request_approval_in_mail',
+  classification: 'WRITE',
   displayName: 'Request Approval in Email',
   description:
     'Send approval request email and then wait until the email is approved or disapproved',

--- a/packages/pieces/community/gmail/src/lib/actions/search-email-action.ts
+++ b/packages/pieces/community/gmail/src/lib/actions/search-email-action.ts
@@ -9,6 +9,7 @@ import { gmailSearchMailActionOutputSchema } from '../output-schemas';
 export const gmailSearchMailAction = createAction({
   auth: gmailAuth,
   name: 'gmail_search_mail',
+  classification: 'SEARCH',
   displayName: 'Find Email',
   description:
     'Find emails using advanced search criteria. If no filters are provided, the latest emails are returned.',

--- a/packages/pieces/community/gmail/src/lib/actions/send-draft-action.ts
+++ b/packages/pieces/community/gmail/src/lib/actions/send-draft-action.ts
@@ -6,6 +6,7 @@ import { gmailSendDraftActionOutputSchema } from '../output-schemas';
 export const gmailSendDraftAction = createAction({
   auth: gmailAuth,
   name: 'gmail_send_draft',
+  classification: 'WRITE',
   displayName: 'Send Draft',
   description: 'Send an existing draft email by its ID.',
   audience: 'ai',

--- a/packages/pieces/community/gmail/src/lib/actions/send-email-action.ts
+++ b/packages/pieces/community/gmail/src/lib/actions/send-email-action.ts
@@ -9,6 +9,7 @@ import { sendEmailActionOutputSchema } from '../output-schemas';
 export const gmailSendEmailAction = createAction({
   auth: gmailAuth,
   name: 'send_email',
+  classification: 'WRITE',
   description: 'Send an email through a Gmail account',
   audience: 'human',
   aiMetadata: {

--- a/packages/pieces/community/gmail/src/lib/actions/stop-watch-action.ts
+++ b/packages/pieces/community/gmail/src/lib/actions/stop-watch-action.ts
@@ -5,6 +5,7 @@ import { gmail as googleGmail } from '@googleapis/gmail';
 export const gmailStopWatchAction = createAction({
   auth: gmailAuth,
   name: 'gmail_stop_watch',
+  classification: 'DESTRUCTIVE',
   displayName: 'Stop Watch',
   description: 'Stop push notifications on the mailbox.',
   audience: 'ai',

--- a/packages/pieces/community/gmail/src/lib/actions/update-draft-action.ts
+++ b/packages/pieces/community/gmail/src/lib/actions/update-draft-action.ts
@@ -9,6 +9,7 @@ import { AddressObject } from 'mailparser';
 export const gmailUpdateDraftAction = createAction({
   auth: gmailAuth,
   name: 'gmail_update_draft',
+  classification: 'WRITE',
   displayName: 'Update Draft',
   description: 'Replace the content of an existing draft email.',
   audience: 'ai',

--- a/packages/pieces/community/gmail/src/lib/triggers/new-attachment.ts
+++ b/packages/pieces/community/gmail/src/lib/triggers/new-attachment.ts
@@ -27,6 +27,7 @@ type Props = {
 export const gmailNewAttachmentTrigger = createTrigger({
   auth: gmailAuth,
   name: 'new_attachment',
+  classification: 'READ',
   displayName: 'New Attachment',
   description: 'Triggers when an email with an attachment arrives.',
   aiMetadata: {

--- a/packages/pieces/community/gmail/src/lib/triggers/new-conversation.ts
+++ b/packages/pieces/community/gmail/src/lib/triggers/new-conversation.ts
@@ -135,6 +135,7 @@ function extractParticipants(messages: any[]): {
 export const gmailNewConversationTrigger = createTrigger({
   auth: gmailAuth,
   name: 'new_conversation',
+  classification: 'READ',
   displayName: 'New Conversation',
   description: 'Triggers when a new email conversation (thread) begins',
   props: {

--- a/packages/pieces/community/gmail/src/lib/triggers/new-email.ts
+++ b/packages/pieces/community/gmail/src/lib/triggers/new-email.ts
@@ -17,6 +17,7 @@ import { gmailNewEmailReceivedTriggerOutputSchema } from '../output-schemas';
 export const gmailNewEmailTrigger = createTrigger({
   auth: gmailAuth,
   name: 'gmail_new_email_received',
+  classification: 'READ',
   displayName: 'New Email',
   description: 'Triggers when new mail is found in your Gmail inbox',
   aiMetadata: {

--- a/packages/pieces/community/gmail/src/lib/triggers/new-label.ts
+++ b/packages/pieces/community/gmail/src/lib/triggers/new-label.ts
@@ -10,6 +10,7 @@ const TRIGGER_KEY = 'labels';
 export const gmailNewLabelTrigger = createTrigger({
   auth: gmailAuth,
   name: 'new_label',
+  classification: 'READ',
   displayName: 'New Label',
   description: 'Triggers when a new label is created.',
   aiMetadata: {

--- a/packages/pieces/community/gmail/src/lib/triggers/new-labeled-email.ts
+++ b/packages/pieces/community/gmail/src/lib/triggers/new-labeled-email.ts
@@ -57,6 +57,7 @@ async function enrichGmailMessage({
 export const gmailNewLabeledEmailTrigger = createTrigger({
   auth: gmailAuth,
   name: 'new_labeled_email',
+  classification: 'READ',
   displayName: 'New Labeled Email',
   description: 'Triggers when a label is added to an email',
   aiMetadata: {


### PR DESCRIPTION
## Description

First adopter of `classification`. The field shipped in #14501 (`READ | WRITE`) and was widened to four values in #14852 (`READ | SEARCH | WRITE | DESTRUCTIVE`); zero of 727 pieces set it, so no badge appears anywhere in the product today. This tags all 30 Gmail items — 25 actions + 5 triggers — making Gmail the template for the catalog backfill.

Distribution: **12 READ · 6 SEARCH · 10 WRITE · 2 DESTRUCTIVE**. Piece version `0.12.10` → `0.13.0`.

### Judgement calls worth a reviewer's attention

These come from the classification rubric the backfill will apply catalog-wide, so pushback here is cheap and pushback later is a re-run:

- **All triggers are `READ`, not `SEARCH`** — polling and webhook alike. Polling triggers do enumerate under the hood, but the badge answers "does this step change anything?", and the READ/SEARCH split is about how you address data (by id vs by query), which is meaningless for an event you did not ask for.
- **`stop_watch` is `DESTRUCTIVE`** — it tears down the mailbox watch subscription; a retry cannot restore it. `delete_draft` likewise.
- **`request_approval_in_mail` is `WRITE`** — it sends an email. Sending adds state, it doesn't destroy any.
- The `ai_*` actions are tagged by the operation they perform (`ai_search_email` → `SEARCH`, `ai_send_email` → `WRITE`), not by the AI involvement.
- `custom_api_call` stays untagged — it comes from `createCustomApiCallAction`, which cannot carry a classification yet; a factory-level default is proposed separately.

Known quirk, pre-existing: both `DESTRUCTIVE` items are `audience: 'ai'`, so the builder's selector (which requests the `HUMAN` audience) never shows exactly the two badges carrying the most risk information. Noted in #14852; not something this PR can fix.

## How was this tested?

- This exact tagging **is** the set that #14852 was verified with end-to-end: full dev stack (PGLITE + memory queue), `GET /api/v1/pieces/@activepieces/piece-gmail?audience=all` returned every served classification intact — READ 11, SEARCH 6, WRITE 10, DESTRUCTIVE 2, untagged 1 (`custom_api_call`; and `new_conversation` is not registered in the piece's `index.ts`, a pre-existing gap, so its READ tag never reaches the API) — and all four badge variants rendered in the piece selector. The tags were replayed here line-identical onto a fresh branch off `main`.
- On this branch: `turbo run build --filter=@activepieces/piece-gmail` (tsc through the framework dep chain) — clean; `turbo run lint --filter=@activepieces/piece-gmail` — clean.
- Cross-checked against the verb/idempotency derivation rule used to scope the backfill: 25/25 agreement on the actions.
- Still no automated test for the field anywhere in the repo (`packages/web` has no component-test harness) — same gap called out in #14852; not addressed here.

Fixes # (n/a)

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

<!-- Additive optional metadata on every action/trigger + minor version bump. No name, prop, or behaviour changes. -->

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)

<!-- The field is inert outside the piece-selector badge; no execution, permission, or agent path consults it. -->
