### PR TITLE
docs: require classification on new actions and triggers in the piece-builder skill

### DIFF
--- a/.agents/skills/piece-builder/SKILL.md
+++ b/.agents/skills/piece-builder/SKILL.md
@@ -70,7 +70,7 @@ The condensed rules in this file (Quick Auth Reference, Quick Piece Definition T
 | Shared API helper, pagination, or `createCustomApiCallAction` | `common-patterns.md` |
 | An advanced UX pattern (source selectors, AWS-style auth) | `ux-guidelines.md` |
 | Flattening a deeply nested API response | `output-quality.md` |
-| Tagging an action/trigger for AI agents | `ai-metadata.md` |
+| Tagging an action/trigger (`audience`, `aiMetadata`, `classification`) | `ai-metadata.md` |
 
 ### Step 5: WIRE & VERIFY
 
@@ -79,6 +79,7 @@ The condensed rules in this file (Quick Auth Reference, Quick Piece Definition T
 - [ ] Import every action in `src/index.ts` → add to `actions: [...]`
 - [ ] Import every trigger in `src/index.ts` → add to `triggers: [...]`
 - [ ] Add `createCustomApiCallAction` to `actions: [...]`
+- [ ] Every hand-written action carries `audience`, `aiMetadata`, and `classification`; every trigger carries `aiMetadata` and `classification: 'READ'` (see `ai-metadata.md`)
 - [ ] Register in `tsconfig.base.json` at repo root (insert **alphabetically** — build fails without this):
     ```json
     "@activepieces/piece-<name>": ["packages/pieces/community/<name>/src/index.ts"]
@@ -224,8 +225,9 @@ Full patterns and examples: read `output-quality.md`
 
 - **`audience`** (actions only): `'human' | 'ai' | 'both'` — written explicitly on every action (`'both'` for normal integration actions; `'human'` for LLM-wrappers/utilities). Downstream filters only see it when physically present.
 - **`aiMetadata`**: `{ description, idempotent }` on every action, `{ description }` on every trigger — agent-facing description (what + when-to-pick + key constraint) and safe-retry hint derived from `run()`.
+- **`classification`** (actions **and** triggers): `'READ' | 'SEARCH' | 'WRITE' | 'DESTRUCTIVE'` — what the step does to external state, judged from the `run()` body (never from the name). Renders as a badge in the builder's piece selector. **Every trigger is `'READ'`.**
 
-The catalog is fully curated; a new action or trigger without these is a regression. Writing rules, `idempotent` derivation, factory gotchas: read `ai-metadata.md`
+A new action or trigger without these is a regression. Writing rules, `idempotent` derivation, the classification rubric, factory gotchas: read `ai-metadata.md`
 
 ---
 

--- a/.agents/skills/piece-builder/ai-metadata.md
+++ b/.agents/skills/piece-builder/ai-metadata.md
@@ -1,13 +1,14 @@
 # AI-Ready Metadata
 
-Pieces power both human flow-builders and AI agents (via the MCP server and the agent tooling). Two fields declare how an action or trigger appears to agents. They are additive — they change nothing for human users — but the catalog is now fully curated (every existing action carries them), so **new actions and triggers must ship with them**: a piece authored without AI metadata is a regression that has to be backfilled later.
+Pieces power both human flow-builders and AI agents (via the MCP server and the agent tooling). Three fields declare how an action or trigger appears to agents and to flow-builders. They are additive — they change nothing about execution — and **new actions and triggers must ship with all of them**: a piece authored without them is a regression that has to be backfilled later.
 
 | Field | Where | Shape | New code |
 |---|---|---|---|
 | `audience` | actions only | `'human' \| 'ai' \| 'both'` | **required, written explicitly** |
 | `aiMetadata` | actions **and** triggers | `{ description?: string; idempotent?: boolean }` | **required** — `{ description, idempotent }` on actions, `{ description }` on triggers |
+| `classification` | actions **and** triggers | `'READ' \| 'SEARCH' \| 'WRITE' \| 'DESTRUCTIVE'` | **required** — derived from `run()`; triggers are always `'READ'` |
 
-Both are plain values on the `createAction` / `createTrigger` object — no import is needed. Triggers accept `aiMetadata` but **not** `audience`: a trigger is an event, not an agent-callable operation.
+All three are plain values on the `createAction` / `createTrigger` object — no import is needed. Triggers accept `aiMetadata` and `classification` but **not** `audience`: a trigger is an event, not an agent-callable operation.
 
 ---
 
@@ -16,6 +17,7 @@ Both are plain values on the `createAction` / `createTrigger` object — no impo
 ```typescript
 export const createRecordAction = createAction({
   name: 'create_record',
+  classification: 'WRITE',
   displayName: 'Create Record',
   description: 'Creates a new record in My App',   // human-facing
   audience: 'both',                                // 'human' | 'ai' | 'both'
@@ -41,6 +43,7 @@ export const createRecordAction = createAction({
 ```typescript
 export const createRecordAction = createAction({
   name: 'create_record',
+  classification: 'WRITE',
   displayName: 'Create Record',
   description: 'Creates a new record in My App',
   audience: 'both',
@@ -81,13 +84,39 @@ Agents use this to reason about safe retries; it maps to the MCP `idempotentHint
 
 ---
 
+## `classification` — what the step does to external state
+
+Renders as a badge in the builder's piece selector (`READ`/`SEARCH`/`WRITE` as quiet grey pills, `DESTRUCTIVE` in red) and is the declared read/write signal for future consumers. Convention: place it right after `name:` in the config object.
+
+Classify from the `run()` body and the API call it makes — the name and description are hints, never evidence. **Precedence, first match wins:**
+
+| Value | Means | Typical verbs |
+|---|---|---|
+| `DESTRUCTIVE` | removes or disables external state; a retry cannot restore it | delete, purge, revoke, cancel, archive, stop/teardown of a subscription or watch |
+| `WRITE` | creates or changes external state, recoverably | create, send, post, update, upsert, move, assign, tag |
+| `SEARCH` | reads by query or enumeration, zero-or-more results, no mutation | list, search, find, query |
+| `READ` | reads a specific known resource or fixed state | get, retrieve, describe, download |
+
+Rules that settle the recurring edge cases:
+
+- **All triggers → `'READ'`**, polling and webhook alike. The badge answers "does this step change anything?"; the READ/SEARCH split is about how you address data (by id vs by query), which is meaningless for an event you did not ask for.
+- **Sending is `WRITE`, not `DESTRUCTIVE`** — a sent email/message adds state, it doesn't destroy any.
+- **AI/LLM inference or generation** that persists no artifact to an external system → `READ`. "Generate and upload/store" → `WRITE`.
+- **Pure in-flow transforms** (text/math/date/json/csv/crypto helpers) → `READ`.
+- **Key-value store style pieces**: get → `READ`, put/append → `WRITE`, delete → `DESTRUCTIVE`.
+- **One action, multiple operations** (an `operation` prop that can read *or* delete) → tag the worst case reachable.
+- **Arbitrary-operation actions** (raw SQL, raw HTTP, caller-supplied method) → `WRITE`. Factory-built actions (`createCustomApiCallAction`) are tagged at the factory level, not per piece.
+
+---
+
 ## Triggers
 
-Triggers take `aiMetadata` with `description` only — no `audience`, no `idempotent`:
+Triggers take `aiMetadata` with `description` only — no `audience`, no `idempotent` — plus `classification: 'READ'` (always, see above):
 
 ```typescript
 export const newRecordTrigger = createTrigger({
   name: 'new_record',
+  classification: 'READ',
   displayName: 'New Record',
   description: 'Triggers when a new record is created',
   aiMetadata: {
@@ -103,12 +132,12 @@ Describe **when the event fires and what one payload represents** (per record? p
 
 ## Factory-built actions and triggers
 
-If actions/triggers are produced by a shared factory (a helper that wraps `createAction`/`createTrigger`), the factory's params type must declare `audience`/`aiMetadata` and forward them into the wrapped call — otherwise the fields in your config objects silently fail to compile or never reach the framework. Add the fields to the factory's param type and pass them through.
+If actions/triggers are produced by a shared factory (a helper that wraps `createAction`/`createTrigger`), the factory's params type must declare `audience`/`aiMetadata`/`classification` and forward them into the wrapped call — otherwise the fields in your config objects silently fail to compile or never reach the framework. Add the fields to the factory's param type and pass them through.
 
 ---
 
 ## When to add this
 
-- **New actions and triggers: always.** `audience: 'both'` + `aiMetadata { description, idempotent }` on every action, `aiMetadata { description }` on every trigger.
+- **New actions and triggers: always.** `audience: 'both'` + `aiMetadata { description, idempotent }` + `classification` on every action; `aiMetadata { description }` + `classification: 'READ'` on every trigger.
 - Set `audience: 'human'` instead when the action is an ask-an-LLM wrapper, a generic transform, or otherwise meaningless as an agent tool.
 - Touching an existing untagged action anyway? Tag it while you're there.


### PR DESCRIPTION
## Description

The piece-builder skill is the strongest lever on new-piece quality, and it does not know `classification` exists. `.agents/skills/piece-builder/SKILL.md` mandates `audience` and `aiMetadata` on every new action and trigger — *"a new action or trigger without these is a regression"* — but says nothing about the `classification` field that shipped in #14501 and was widened to `READ | SEARCH | WRITE | DESTRUCTIVE` in #14852. So every piece merged from here ships untagged, and the gap the catalog backfill has to cover widens with each PR.

This closes the authoring-time gap:

- **`SKILL.md`** — `classification` joins the required AI-ready metadata (actions **and** triggers), with a new item on the Step 5 wire & verify checklist so it gets caught at review time, and the Step 4 pointer row updated.
- **`ai-metadata.md`** — a full `classification` section: the four values ordered by precedence (first match wins), classify-from-`run()`-not-the-name, and the rules that settle the recurring edge cases — all triggers → `READ`, sending is `WRITE` not `DESTRUCTIVE`, LLM inference with nothing persisted → `READ`, pure transforms → `READ`, multiplex actions take the worst case reachable, arbitrary-op actions → `WRITE`. Both code examples now show the field with its placement convention (right after `name:`). The factory-forwarding note covers `classification` too.

The rubric text is the same one applied in the first adopter PR (Gmail, #14913) and the one the catalog backfill will apply, so authored tags and backfilled tags stay consistent.

Same precedent as #14854: the skill is actively maintained and this is a docs-only change to it.

## How was this tested?

Docs-only — no code paths. Verified the rules against the framework as merged: `classification?: ActionClassification` exists on both `createAction` and `createTrigger` params (`packages/pieces/framework/src/lib/action/action.ts:43`, `trigger/trigger.ts:62`), and the Gmail pilot tagging written to exactly these rules builds and lints clean (#14913).

Fixes # (n/a)

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
