### PR TITLE
feat(pieces): classification param on createCustomApiCallAction, default WRITE

### DIFF
--- a/packages/pieces/common/package.json
+++ b/packages/pieces/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/pieces-common",
-  "version": "0.12.8",
+  "version": "0.12.9",
   "type": "commonjs",
   "sideEffects": false,
   "main": "./dist/src/index.js",

--- a/packages/pieces/common/src/lib/helpers/index.ts
+++ b/packages/pieces/common/src/lib/helpers/index.ts
@@ -1,4 +1,5 @@
 import {
+  ActionClassification,
   OAuth2PropertyValue,
   PieceAuthProperty,
   Property,
@@ -148,6 +149,7 @@ export function createCustomApiCallAction<
   props,
   extraProps,
   authLocation = 'headers',
+  classification = 'WRITE',
 }: {
   auth?: PieceAuth;
   baseUrl: BaseUrlGetter<PieceAuth>;
@@ -172,10 +174,13 @@ export function createCustomApiCallAction<
   };
   extraProps?: InputPropertyMap;
   authLocation?: 'headers' | 'queryParams';
+  // The method is caller-supplied at runtime, so a single tag has to assume mutation.
+  classification?: ActionClassification;
 }) {
   return createAction({
     audience: 'human',
     name: name ? name : 'custom_api_call',
+    classification,
     displayName: displayName ? displayName : 'Custom API Call',
     description: description
       ? description


### PR DESCRIPTION
## Description

`createCustomApiCallAction` cannot carry a `classification` (#14501, #14852): the factory takes no such param, so every one of the ~700 pieces that ship it carries one permanently untaggable action — and it's the action that performs arbitrary authenticated HTTP requests. One factory change tags them all.

This adds an optional `classification` param, forwarded into the wrapped `createAction`, **defaulting to `WRITE`**:

```ts
createCustomApiCallAction({ baseUrl, auth, authMapping })              // -> classification: 'WRITE'
createCustomApiCallAction({ ..., classification: 'READ' })            // per-piece override
```

`pieces-common` bumped `0.12.8` → `0.12.9`. Existing published pieces pick the default up whenever they next rebuild/publish — same propagation as any factory change, no piece edits needed.

### @AhmadTash — one taxonomy call to rule on: should the default be `WRITE` or `DESTRUCTIVE`?

The HTTP method is caller-supplied at runtime, so a single static tag has to state the worst case, and the honest worst case of an arbitrary request is arguably `DESTRUCTIVE` (a `DELETE` to any endpoint is reachable). That's the case for `DESTRUCTIVE`.

The case for `WRITE` (what this PR does):

- The badge's only red variant is `DESTRUCTIVE`, and this action appears in ~700 pieces. A red pill on every piece's "Custom API Call" becomes a warning users see everywhere and learn to ignore — the same reasoning that kept `WRITE` grey in #14852.
- The typical use of the escape hatch is calling an endpoint the piece doesn't cover yet, which is overwhelmingly reads and ordinary writes, not deletes.
- The classification rubric being applied to the catalog backfill tags arbitrary-operation actions (raw SQL, raw HTTP, caller-supplied method) as `WRITE` and flags them, so your ruling here settles the default for that whole family in one place — flipping either is a one-line change.

If you rule `DESTRUCTIVE`, the default flips in this PR and the rubric follows.

## How was this tested?

- `turbo run build lint --filter=@activepieces/pieces-common` — both clean.
- `turbo run build --filter=@activepieces/piece-gmail` — a downstream piece that ships the factory action with no args compiles unchanged against the new signature (the param is optional with a default).
- `ActionClassification` import verified exported from `@activepieces/pieces-framework` (`src/lib/piece-metadata.ts:61`, re-exported via `lib/index.ts`).
- No behavioural change: the field is inert metadata — nothing in execution, permissions, or the agent path consults it today; the piece-selector badge is the only consumer.

Fixes # (n/a)

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

<!-- Optional param with a default; existing call sites compile unchanged. The only observable change is new optional metadata on custom_api_call actions after their piece republishes. -->

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact

<!-- Metadata only; the request execution path is untouched. -->
