### PR TITLE
fix(engine): unwrap pieceRunner.call result so connections can be saved

### DIFF
--- a/packages/server/engine/src/lib/core/piece/piece-auth.ts
+++ b/packages/server/engine/src/lib/core/piece/piece-auth.ts
@@ -32,7 +32,7 @@ export const pieceAuth = {
         return {
             called: true,
             property: selected.property,
-            result: await pieceRunner.call({ piece, path, args: [{ auth: argument.argument, server }] }),
+            result: (await pieceRunner.call({ piece, path, args: [{ auth: argument.argument, server }] })).result,
         }
     },
 }


### PR DESCRIPTION
## Description

**`main` currently cannot save a connection for any piece that defines a `validate` — 224 of 727 community pieces.** Regression from #14889 (`1c6efa0389`, 2026-08-18). Unreleased: not in any tag, and cloud prod runs `0.88.1` (tagged 2026-08-14), so **production is unaffected**. Anything deploying from `main` is. Release blocker for 0.89.0.

### Symptom

```json
POST /api/v1/app-connections -> 500
{ "code": "INVALID_APP_CONNECTION", "params": { "error": "Connection validation failed" } }
```

Credentials are irrelevant — correct ones fail identically.

### Root cause

`pieceRunner.call` resolves a **wrapper**, not the piece's return value:

```ts
// piece-runner.ts:57
resolve({ result: message.result, hooks: message.hooks })
// piece-runner.ts:150
export type CallResult = { result: unknown; hooks?: CollectedHooks }
```

Every other caller destructures it. `pieceAuth.callMethod` did not:

| file | | |
|---|---|---|
| `handler/piece-executor.ts:73` | `const { result: output, hooks } = await pieceRunner.call(…)` | ✅ |
| `operations/property.operation.ts:63` | `const { result } = await pieceRunner.call(…)` | ✅ |
| `core/piece/trigger-runner.ts:138` | `const { result } = await pieceRunner.call(…)` | ✅ |
| `core/piece/piece-runner.ts:15` (`describe`) | `.then(({ result }) => …)` | ✅ |
| **`core/piece/piece-auth.ts:35`** | `result: await pieceRunner.call(…)` | ❌ |

`auth-validation.operation.ts:23` then reads `.valid` off the wrapper:

```
piece returns                  | before                                       | after
------------------------------ | -------------------------------------------- | ---------------------------------
{valid:true}                   | {valid:false,"Connection validation failed"}  | {valid:true}
{valid:false,error:"Bad key"}   | {valid:false,"Connection validation failed"}  | {valid:false,error:"Bad key"}
```

Both outcomes collapsed to the same string, so a valid credential was rejected **and** an invalid one gave the wrong reason.

### Also fixed by the same line

- `operations/auth-refresh.operation.ts:26` — `call.result.access_token` was always `undefined`, breaking CUSTOM_AUTH token refresh.
- `operations/resolve-connection-identifier.operation.ts:12` — used the wrapper as the connection identifier.

### Why it looked intermittent, and why CI missed it

Pieces **without** a `validate` never hit the bug: `hasPath(['auth','validate'])` is false, so the operation returns `{valid:true}` without calling anything. Those save fine (they were never validated). Split is unrelated to auth *type* — saves: `claude`, `google-sheets`, `hubspot`, `telegram-bot`, `discord`; fails: `jira-cloud`, `openai`, `slack`, `github`, `clockify`, `airtable`, `notion`, `stripe`.

`AuthCallResult.result` is typed `unknown` (same commit), so the compiler could not flag `.valid` on the wrong object, and no test covers the validate path.

### Follow-ups (not in this PR)

- Regression test on the CUSTOM_AUTH validate path.
- Narrow `AuthCallResult.result` from `unknown` so this cannot recur.
- `jira-cloud`'s `validate` swallows a non-JSON error body (`response.body.message` on a string body) and reports `'Invalid credentials'` for every failure mode, incl. network errors — separate papercut.

## How was this tested?

- **End-to-end against a real child process** (spawned `piece-child.ts` over IPC with a real built piece, `path: ['auth','validate']`): child returned `{"valid":false,"error":"Invalid credentials"}`; `piece-runner` wrapped it to `{"result":{…}}`; the old code produced `"Connection validation failed"` (reproducing the reported symptom byte-for-byte) and the unwrap produces the piece's own answer.
- Confirmed the credential itself was good independently: `GET /rest/api/3/myself` → `HTTP 200`, and the piece's `validate()` → `{"valid":true}` when invoked directly.
- `npx turbo run build --filter=@activepieces/engine` — clean.
- `npx turbo run lint --filter=@activepieces/engine` — 0 errors.
- `npx turbo run test --filter=@activepieces/engine` — **467/467**. (The 5 `flow-with-delay.test.ts` failures on a cold tree are the documented missing-`dist` issue; they pass after `npx turbo run build --filter=@activepieces/piece-delay`.)
- Edition paths: engine-level, identical on CE / EE / Cloud.

### Manual repro for reviewers (no valid credentials needed)

1. On `main`, create a **Clockify** connection with any garbage API key → `"Connection validation failed"`. Expected (and what this PR restores): Clockify's own `'Invalid API Key.'`, the only failure string its `validate` can return.
2. Control: create a **Claude** connection with a garbage key → saves either way, because it has no `validate`.

Fixes # (no issue filed — found while testing #14863)

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

- [ ] no — reviewed, no security impact
- [x] yes — security-sensitive (call out the risk and mitigation in the description above)

Touches the connection credential-validation path, so flagging it for review. **No exposure was created by the bug**: the broken state was fail-closed — every credential was rejected, none were wrongly accepted. This PR restores the intended check. Note the pre-existing behaviour that pieces without a `validate` are not validated at all is unchanged by this PR.
