### PR TITLE
fix(ci): don't let one failed piece publish block the whole release

### DIFF
--- a/tools/scripts/pieces/publish-pieces-to-npm.ts
+++ b/tools/scripts/pieces/publish-pieces-to-npm.ts
@@ -36,7 +36,9 @@ const main = async () => {
 
   if (failedPaths.length > 0) {
     console.error(`[publishPieces] ${failedPaths.length}/${piecesSource.length} piece(s) failed to publish:\n  ${failedPaths.join('\n  ')}`)
-    process.exit(1)
+    // exitCode instead of process.exit(): an immediate exit can truncate the summary
+    // above when stderr is a pipe (CI); this lets pending writes flush before exiting.
+    process.exitCode = 1
   }
 }
 

--- a/tools/scripts/pieces/publish-pieces-to-npm.ts
+++ b/tools/scripts/pieces/publish-pieces-to-npm.ts
@@ -17,10 +17,26 @@ const main = async () => {
   console.info(`[publishPieces] publishing ${piecesSource.length} pieces${changedPaths ? ' (scoped to changed)' : ' (all)'}`)
 
   const piecesSourceChunks = chunk(piecesSource, 30)
+  const failedPaths: string[] = []
 
   for (const chunk of piecesSourceChunks) {
-    await Promise.all(chunk.map((path) => publishNpmPackage(path)))
+    // One piece's failed publish must not block the rest of the release — a single
+    // rejected publish (e.g. an npm permission error on one new package) would otherwise
+    // strand every other piece queued in the same run. Collect failures, publish the
+    // rest, and fail the run at the end so alerting still fires.
+    const results = await Promise.allSettled(chunk.map((path) => publishNpmPackage(path)))
+    results.forEach((result, index) => {
+      if (result.status === 'rejected') {
+        console.error(`[publishPieces] FAILED path=${chunk[index]}`, result.reason)
+        failedPaths.push(chunk[index])
+      }
+    })
     await new Promise(resolve => setTimeout(resolve, 5000))
+  }
+
+  if (failedPaths.length > 0) {
+    console.error(`[publishPieces] ${failedPaths.length}/${piecesSource.length} piece(s) failed to publish:\n  ${failedPaths.join('\n  ')}`)
+    process.exit(1)
   }
 }
 

--- a/tools/scripts/pieces/publish-pieces-to-npm.ts
+++ b/tools/scripts/pieces/publish-pieces-to-npm.ts
@@ -20,10 +20,6 @@ const main = async () => {
   const failedPaths: string[] = []
 
   for (const chunk of piecesSourceChunks) {
-    // One piece's failed publish must not block the rest of the release — a single
-    // rejected publish (e.g. an npm permission error on one new package) would otherwise
-    // strand every other piece queued in the same run. Collect failures, publish the
-    // rest, and fail the run at the end so alerting still fires.
     const results = await Promise.allSettled(chunk.map((path) => publishNpmPackage(path)))
     results.forEach((result, index) => {
       if (result.status === 'rejected') {
@@ -36,8 +32,6 @@ const main = async () => {
 
   if (failedPaths.length > 0) {
     console.error(`[publishPieces] ${failedPaths.length}/${piecesSource.length} piece(s) failed to publish:\n  ${failedPaths.join('\n  ')}`)
-    // exitCode instead of process.exit(): an immediate exit can truncate the summary
-    // above when stderr is a pipe (CI); this lets pending writes flush before exiting.
     process.exitCode = 1
   }
 }


### PR DESCRIPTION
## Description

**Incident context:** `Release Pieces` has failed 4 consecutive times since #14668 merged (2026-08-18 13:39 UTC, runs [32143678620](https://github.com/activepieces/activepieces/actions/runs/32143678620) → [32239840965](https://github.com/activepieces/activepieces/actions/runs/32239840965), incl. two manual re-dispatches). Every run dies the same way: `npm publish` of the brand-new `@activepieces/piece-ringcentral@0.0.1` is rejected with `E404 PUT … not found or no permission`, and because `publish-pieces-to-npm.ts` runs a bare `Promise.all`, that single rejection kills the process before anything else publishes. Concretely: `piece-gmail@0.13.0` (#14913, merged this morning) is stranded behind it — npm still serves 0.12.10 — and **every piece merged from now on joins the stuck queue** until the npm-side issue is resolved (being chased separately; npm accepted new packages from this same pipeline as recently as Aug 12–13 with this tooling unchanged, so it's a registry/token-side change, not a tooling regression).

**The fix:** `Promise.allSettled` per chunk — publish everything that can publish, log each failure with its path, and `process.exit(1)` at the end if anything failed. The run still goes red and the Discord alert still fires; one poisoned package just no longer takes the rest of the release down with it.

As a side effect, the next run's log becomes the diagnostic we currently can't get: if gmail publishes while ringcentral still 404s, the npm token is alive and the problem is specific to creating that package (permission scope or npm name moderation on `ringcentral`); if gmail also 404s, the token itself is dead.

## How was this tested?

Ran the script locally via the exact CI invocation (`npx ts-node -r tsconfig-paths/register -P packages/server/engine/tsconfig.lib.json tools/scripts/pieces/publish-pieces-to-npm.ts`) with `CHANGED_PIECES` set:

- **Skip path** (piece with no `dist/`): logs `skipping, no build output`, exit 0 — behavior unchanged.
- **Failure isolation** (one deliberately broken piece + one healthy skip piece): the broken piece's throw is caught and logged (`[publishPieces] FAILED path=…` + stack), the healthy piece still processes, the summary lists `1/2 piece(s) failed`, exit 1.

No npm publish is attempted in either test (both pieces stop before the `npm publish` call). The real E404 path exercises the same rejection route via `execSync` throwing.

Fixes # (n/a — incident tracked on Discord/Linear)

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

<!-- CI-internal script; the only behavior change is publishing more (not fewer) packages per run and a clearer failure summary. Exit semantics preserved: any failure still fails the workflow. -->

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
