### PR TITLE
fix(connections): surface the provider error when a cloud OAuth2 claim fails

### DIFF
--- a/packages/server/api/src/app/app-connection/app-connection-service/oauth2/services/cloud-oauth2-service.ts
+++ b/packages/server/api/src/app/app-connection/app-connection-service/oauth2/services/cloud-oauth2-service.ts
@@ -3,6 +3,7 @@ import { ActivepiecesError, ErrorCode } from '@activepieces/core-utils'
 import { OAuth2AuthorizationMethod } from '@activepieces/pieces-framework'
 import { safeHttp } from '@activepieces/server-utils'
 import { AppConnectionType, CloudOAuth2ConnectionValue } from '@activepieces/shared'
+import { isAxiosError } from 'axios'
 import { FastifyBaseLogger } from 'fastify'
 import { system } from '../../../../helper/system/system'
 import {
@@ -66,7 +67,12 @@ export const cloudOAuth2Service = (log: FastifyBaseLogger): OAuth2Service<CloudO
             }
         }
         catch (e: unknown) {
-            log.error(e)
+            log.error({
+                piece: { name: pieceName },
+                claimResponse: isAxiosError(e)
+                    ? { status: e.response?.status, body: e.response?.data }
+                    : { message: e instanceof Error ? e.message : String(e) },
+            }, 'Cloud OAuth2 claim failed')
             throw new ActivepiecesError({
                 code: ErrorCode.INVALID_CLOUD_CLAIM,
                 params: {


### PR DESCRIPTION
## Description

This PR was originally a `getCode` decode change for the `INVALID_CLOUD_CLAIM` regression; that turned out to be a half-fix (it re-broke self-hosted codes containing a literal `%XX`, e.g. `k1%2Fk2` → `k1/k2`). Reworked to **option A**.

### Root cause (unchanged, for context)
`getCode` (`web/.../connections/utils/oauth2-utils.ts`) receives the OAuth code from **two** redirect pages with **opposite** encoding contracts:
- `secrets.activepieces.com/redirect` (external, used by `CLOUD_OAUTH2`) posts the code **raw / URL-encoded**.
- `redirect.tsx` (`app/routes/redirect.tsx:30`) has **already decoded** it via `URLSearchParams` before posting.

So no single decode/passthrough policy in `getCode` is correct for both. #14879 flipped `getCode` decode→passthrough to fix a self-hosted `%XX` report and broke **every** cloud Google/MS connection (codes contain `/` → `%2F` → `invalid_grant` → `INVALID_CLOUD_CLAIM`; prod incident 2026-08-19, 25+ tenants).

### Option A — fix the contract at the source, not in `getCode`
The correct fix is to make the two redirects agree by having **`secrets.activepieces.com/redirect` decode the code once (via `URLSearchParams`) like `redirect.tsx` already does**, and keep `getCode` as **pass-through** (#14879). That change lives in the external `secrets` service, so **there is no `getCode` change in this repo** — `main` is already pass-through and #14879’s test already guards the double-decode.

⚠️ **Deploy coordination:** cloud OAuth stays broken until the `secrets` redirect is fixed to decode. Keep the current prod-level revert (or `getCode` decode) in place until the `secrets` change ships; then un-revert so prod matches `main` (pass-through).

### What this PR actually changes — observability
Since the behavioral fix is external, this PR makes the failure **diagnosable**. `cloudOAuth2Service.claim` swallowed every failure into a generic `INVALID_CLOUD_CLAIM` after a bare `log.error(e)` that produced **no usable log line** (verified absent from both docker logs and the ClickHouse `otel_logs` drain). It now logs the provider’s **status + response body** (`invalid_grant`, `redirect_uri_mismatch`, …) — the signal that would have identified this incident in minutes. It deliberately does **not** log the full `AxiosError` (whose config carries the request body incl. the code) — that noise-reduction was the point of a0129747858; this restores signal without the sensitive dump.

## How was this tested?

Type-checks; edition-agnostic logging-only change on the API. The behavioral cloud fix is validated on the `secrets` side.

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)

<!-- Logs only the provider status + error body; the request body (with the code) is not logged. -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)