### PR TITLE
fix(analytics): show each user only the projects they can access

### DIFF
--- a/packages/server/api/src/app/analytics/platform-analytics-report.service.ts
+++ b/packages/server/api/src/app/analytics/platform-analytics-report.service.ts
@@ -5,10 +5,12 @@ import { FastifyBaseLogger } from 'fastify'
 import { IsNull } from 'typeorm'
 import { repoFactory } from '../core/db/repo-factory'
 import { distributedLock } from '../database/redis-connections'
+import { flowRepo } from '../flows/flow/flow.repo'
 import { flowService } from '../flows/flow/flow.service'
 import { flowRunRepo } from '../flows/flow-run/flow-run-service'
 import { ProjectEntity } from '../project/project-entity'
-import { userRepo } from '../user/user-service'
+import { projectService } from '../project/project-service'
+import { userRepo, userService } from '../user/user-service'
 import { PlatformAnalyticsReportEntity } from './platform-analytics-report.entity'
 
 export const platformAnalyticsReportRepo = repoFactory(PlatformAnalyticsReportEntity)
@@ -50,7 +52,73 @@ export const platformAnalyticsReportService = (log: FastifyBaseLogger) => ({
         }
         return filterReportByTimePeriod(report, timePeriod)
     },
+    getReportForUser: async ({ platformId, userId, timePeriod }: GetReportForUserParams): Promise<PlatformAnalyticsReport> => {
+        const report = await platformAnalyticsReportService(log).getOrGenerateReport(platformId, timePeriod)
+        return scopeReportForUser({ report, platformId, userId, log })
+    },
+    refreshReportForUser: async ({ platformId, userId }: RefreshReportForUserParams): Promise<PlatformAnalyticsReport> => {
+        const report = await platformAnalyticsReportService(log).refreshReport(platformId)
+        return scopeReportForUser({ report, platformId, userId, log })
+    },
 })
+
+async function scopeReportForUser({ report, platformId, userId, log }: ScopeReportForUserParams): Promise<PlatformAnalyticsReport> {
+    const user = await userService(log).getOneOrFail({ id: userId })
+    if (userService(log).isUserPrivileged(user)) {
+        return report
+    }
+    const projects = await projectService(log).getAllForUser({
+        platformId,
+        userId,
+        isPrivileged: false,
+    })
+    const projectIds = projects.map((project) => project.id)
+    const [visibleUserIds, visibleFlowIds] = await Promise.all([
+        listUserIdsForProjects({ platformId, projectIds }),
+        listFlowIdsForProjects({ projectIds }),
+    ])
+    return scopeReportToProjects({ report, projectIds, visibleUserIds, visibleFlowIds })
+}
+
+async function listUserIdsForProjects({ platformId, projectIds }: ListUserIdsForProjectsParams): Promise<string[]> {
+    if (projectIds.length === 0) {
+        return []
+    }
+    const rows = await userRepo()
+        .createQueryBuilder('u')
+        .select('u.id', 'id')
+        .where('u."platformId" = :platformId', { platformId })
+        .andWhere(
+            '(u.id IN (SELECT pm."userId" FROM project_member pm WHERE pm."projectId" IN (:...projectIds)) OR u.id IN (SELECT p."ownerId" FROM project p WHERE p.id IN (:...projectIds)))',
+            { projectIds },
+        )
+        .getRawMany<{ id: string }>()
+    return rows.map((row) => row.id)
+}
+
+async function listFlowIdsForProjects({ projectIds }: ListFlowIdsForProjectsParams): Promise<string[]> {
+    if (projectIds.length === 0) {
+        return []
+    }
+    const rows = await flowRepo()
+        .createQueryBuilder('flow')
+        .select('flow.id', 'id')
+        .where('flow."projectId" IN (:...projectIds)', { projectIds })
+        .getRawMany<{ id: string }>()
+    return rows.map((row) => row.id)
+}
+
+function scopeReportToProjects({ report, projectIds, visibleUserIds, visibleFlowIds }: ScopeReportToProjectsParams): PlatformAnalyticsReport {
+    const allowedProjectIds = new Set(projectIds)
+    const allowedUserIds = new Set(visibleUserIds)
+    const allowedFlowIds = new Set(visibleFlowIds)
+    return {
+        ...report,
+        flows: report.flows.filter((flow) => allowedProjectIds.has(flow.projectId)),
+        runs: report.runs.filter((run) => allowedFlowIds.has(run.flowId)),
+        users: report.users.filter((user) => allowedUserIds.has(user.id)),
+    }
+}
 
 
 
@@ -194,4 +262,38 @@ function getDateRange(timePeriod: AnalyticsTimePeriod): string {
         default:
             throw new Error(`Invalid time period: ${timePeriod}`)
     }
+}
+
+type GetReportForUserParams = {
+    platformId: PlatformId
+    userId: string
+    timePeriod?: AnalyticsTimePeriod
+}
+
+type RefreshReportForUserParams = {
+    platformId: PlatformId
+    userId: string
+}
+
+type ScopeReportForUserParams = {
+    report: PlatformAnalyticsReport
+    platformId: PlatformId
+    userId: string
+    log: FastifyBaseLogger
+}
+
+type ListUserIdsForProjectsParams = {
+    platformId: PlatformId
+    projectIds: string[]
+}
+
+type ListFlowIdsForProjectsParams = {
+    projectIds: string[]
+}
+
+type ScopeReportToProjectsParams = {
+    report: PlatformAnalyticsReport
+    projectIds: string[]
+    visibleUserIds: string[]
+    visibleFlowIds: string[]
 }

--- a/packages/server/api/src/app/analytics/platform-analytics.module.ts
+++ b/packages/server/api/src/app/analytics/platform-analytics.module.ts
@@ -20,13 +20,20 @@ const platformAnalyticsController: FastifyPluginAsyncZod = async (app) => {
         const { platform, id } = request.principal
         await assertUserIsNotEmbedded(id, request.log)
         const { timePeriod } = request.query
-        return platformAnalyticsReportService(request.log).getOrGenerateReport(platform.id, timePeriod)
+        return platformAnalyticsReportService(request.log).getReportForUser({
+            platformId: platform.id,
+            userId: id,
+            timePeriod,
+        })
     })
 
     app.post('/refresh', RefreshPlatformAnalyticsRequest, async (request) => {
         const { platform, id } = request.principal
         await assertUserIsNotEmbedded(id, request.log)
-        return platformAnalyticsReportService(request.log).refreshReport(platform.id)
+        return platformAnalyticsReportService(request.log).refreshReportForUser({
+            platformId: platform.id,
+            userId: id,
+        })
     })
 
     app.post('/mark-outdated', MarkAsOutdatedRequest, async (request) => {

--- a/packages/server/api/test/integration/ce/analytics/platform-analytics.test.ts
+++ b/packages/server/api/test/integration/ce/analytics/platform-analytics.test.ts
@@ -1,0 +1,215 @@
+import { DefaultProjectRole, FlowStatus, FlowVersionState, PlatformRole, ProjectType, RunEnvironment } from '@activepieces/shared'
+import dayjs from 'dayjs'
+import { FastifyInstance } from 'fastify'
+import { StatusCodes } from 'http-status-codes'
+import { db } from '../../../helpers/db'
+import { createMockFlow, createMockFlowRun, createMockFlowVersion, createMockProject, mockBasicUser } from '../../../helpers/mocks'
+import { createMemberContext, createTestContext, TestContext } from '../../../helpers/test-context'
+import { setupTestEnvironment, teardownTestEnvironment } from '../../../helpers/test-setup'
+
+let app: FastifyInstance | null = null
+
+beforeAll(async () => {
+    app = await setupTestEnvironment()
+})
+
+afterAll(async () => {
+    await teardownTestEnvironment()
+})
+
+async function createEnabledFlowWithRun(projectId: string, displayName: string) {
+    const flow = createMockFlow({ projectId, status: FlowStatus.ENABLED })
+    await db.save('flow', flow)
+    const flowVersion = createMockFlowVersion({
+        flowId: flow.id,
+        state: FlowVersionState.DRAFT,
+        displayName,
+    })
+    await db.save('flow_version', flowVersion)
+    await db.save('flow_run', createMockFlowRun({
+        projectId,
+        flowId: flow.id,
+        flowVersionId: flowVersion.id,
+        environment: RunEnvironment.PRODUCTION,
+        created: dayjs().subtract(1, 'hour').toISOString(),
+    }))
+    return flow
+}
+
+async function seedTwoProjects(ctx: TestContext) {
+    const { mockUser: foreignUser } = await mockBasicUser({
+        user: {
+            platformId: ctx.platform.id,
+            platformRole: PlatformRole.MEMBER,
+        },
+    })
+
+    const foreignProject = createMockProject({
+        platformId: ctx.platform.id,
+        ownerId: foreignUser.id,
+        type: ProjectType.TEAM,
+    })
+    await db.save('project', foreignProject)
+
+    const ownFlow = await createEnabledFlowWithRun(ctx.project.id, 'own-project-flow')
+    const foreignFlow = await createEnabledFlowWithRun(foreignProject.id, 'foreign-project-flow')
+
+    return { foreignUser, foreignProject, ownFlow, foreignFlow }
+}
+
+describe('Platform Analytics API', () => {
+    describe('GET /v1/analytics', () => {
+        it('should return the whole platform report to a platform admin', async () => {
+            const ctx = await createTestContext(app!, {
+                plan: { analyticsEnabled: true },
+            })
+            const { ownFlow, foreignFlow, foreignUser } = await seedTwoProjects(ctx)
+
+            const response = await ctx.get('/v1/analytics')
+
+            expect(response?.statusCode).toBe(StatusCodes.OK)
+            const report = response!.json()
+            const flowIds = report.flows.map((flow: { flowId: string }) => flow.flowId)
+            expect(flowIds).toContain(ownFlow.id)
+            expect(flowIds).toContain(foreignFlow.id)
+            expect(report.users.map((user: { id: string }) => user.id)).toContain(foreignUser.id)
+        })
+
+        it('should scope flows to the projects the caller can access', async () => {
+            const ctx = await createTestContext(app!, {
+                plan: { analyticsEnabled: true },
+            })
+            const { ownFlow, foreignFlow } = await seedTwoProjects(ctx)
+            const memberCtx = await createMemberContext(app!, ctx, {
+                projectRole: DefaultProjectRole.EDITOR,
+            })
+
+            const response = await memberCtx.get('/v1/analytics')
+
+            expect(response?.statusCode).toBe(StatusCodes.OK)
+            const report = response!.json()
+            const flowIds = report.flows.map((flow: { flowId: string }) => flow.flowId)
+            expect(flowIds).toContain(ownFlow.id)
+            expect(flowIds).not.toContain(foreignFlow.id)
+        })
+
+        it('should not disclose runs of flows outside the caller projects', async () => {
+            const ctx = await createTestContext(app!, {
+                plan: { analyticsEnabled: true },
+            })
+            const { foreignFlow } = await seedTwoProjects(ctx)
+            const memberCtx = await createMemberContext(app!, ctx, {
+                projectRole: DefaultProjectRole.EDITOR,
+            })
+
+            const response = await memberCtx.get('/v1/analytics')
+
+            expect(response?.statusCode).toBe(StatusCodes.OK)
+            const report = response!.json()
+            const runFlowIds = report.runs.map((run: { flowId: string }) => run.flowId)
+            expect(runFlowIds).not.toContain(foreignFlow.id)
+        })
+
+        it('should not disclose users outside the caller projects', async () => {
+            const ctx = await createTestContext(app!, {
+                plan: { analyticsEnabled: true },
+            })
+            const { foreignUser } = await seedTwoProjects(ctx)
+            const memberCtx = await createMemberContext(app!, ctx, {
+                projectRole: DefaultProjectRole.EDITOR,
+            })
+
+            const response = await memberCtx.get('/v1/analytics')
+
+            expect(response?.statusCode).toBe(StatusCodes.OK)
+            const report = response!.json()
+            const userIds = report.users.map((user: { id: string }) => user.id)
+            expect(userIds).not.toContain(foreignUser.id)
+            expect(userIds).toContain(memberCtx.user.id)
+        })
+
+        it('should keep the report reachable for a viewer', async () => {
+            const ctx = await createTestContext(app!, {
+                plan: { analyticsEnabled: true },
+            })
+            await seedTwoProjects(ctx)
+            const viewerCtx = await createMemberContext(app!, ctx, {
+                projectRole: DefaultProjectRole.VIEWER,
+            })
+
+            const response = await viewerCtx.get('/v1/analytics')
+
+            expect(response?.statusCode).toBe(StatusCodes.OK)
+            expect(response!.json().users.map((user: { id: string }) => user.id)).toContain(viewerCtx.user.id)
+        })
+    })
+})
+
+describe('Platform Analytics API — disabled flows', () => {
+    it('should keep runs of a disabled flow in an accessible project', async () => {
+        const ctx = await createTestContext(app!, {
+            plan: { analyticsEnabled: true },
+        })
+        await createEnabledFlowWithRun(ctx.project.id, 'own-enabled-flow')
+        const disabledFlow = createMockFlow({ projectId: ctx.project.id, status: FlowStatus.DISABLED })
+        await db.save('flow', disabledFlow)
+        const disabledVersion = createMockFlowVersion({
+            flowId: disabledFlow.id,
+            state: FlowVersionState.DRAFT,
+            displayName: 'own-disabled-flow',
+        })
+        await db.save('flow_version', disabledVersion)
+        await db.save('flow_run', createMockFlowRun({
+            projectId: ctx.project.id,
+            flowId: disabledFlow.id,
+            flowVersionId: disabledVersion.id,
+            environment: RunEnvironment.PRODUCTION,
+            created: dayjs().subtract(1, 'hour').toISOString(),
+        }))
+        const memberCtx = await createMemberContext(app!, ctx, {
+            projectRole: DefaultProjectRole.EDITOR,
+        })
+
+        const adminResponse = await ctx.get('/v1/analytics')
+        const memberResponse = await memberCtx.get('/v1/analytics')
+
+        const adminRunFlowIds = adminResponse!.json().runs.map((run: { flowId: string }) => run.flowId)
+        const memberRunFlowIds = memberResponse!.json().runs.map((run: { flowId: string }) => run.flowId)
+        expect(adminRunFlowIds).toContain(disabledFlow.id)
+        expect(memberRunFlowIds).toContain(disabledFlow.id)
+    })
+})
+
+describe('POST /v1/analytics/refresh', () => {
+    it('should not disclose other projects to a non-admin member', async () => {
+        const ctx = await createTestContext(app!, {
+            plan: { analyticsEnabled: true },
+        })
+        const { foreignFlow, foreignUser, ownFlow } = await seedTwoProjects(ctx)
+        const memberCtx = await createMemberContext(app!, ctx, {
+            projectRole: DefaultProjectRole.EDITOR,
+        })
+
+        const response = await memberCtx.post('/v1/analytics/refresh')
+
+        expect(response?.statusCode).toBe(StatusCodes.OK)
+        const report = response!.json()
+        const flowIds = report.flows.map((flow: { flowId: string }) => flow.flowId)
+        expect(flowIds).toContain(ownFlow.id)
+        expect(flowIds).not.toContain(foreignFlow.id)
+        expect(report.users.map((user: { id: string }) => user.id)).not.toContain(foreignUser.id)
+    })
+
+    it('should return the whole platform report to a platform admin', async () => {
+        const ctx = await createTestContext(app!, {
+            plan: { analyticsEnabled: true },
+        })
+        const { foreignFlow } = await seedTwoProjects(ctx)
+
+        const response = await ctx.post('/v1/analytics/refresh')
+
+        expect(response?.statusCode).toBe(StatusCodes.OK)
+        const flowIds = response!.json().flows.map((flow: { flowId: string }) => flow.flowId)
+        expect(flowIds).toContain(foreignFlow.id)
+    })
+})


### PR DESCRIPTION
## Description

The Impact page loaded the whole platform's report for everyone, so any member could see every user's name and email and every project's flows. Admins still get the full picture; everyone else now sees only their own projects.


### Breaking change?  (required — CI fails if this is left unedited)


- [X] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

<!-- Tick exactly one box. "Security-sensitive" = touches authentication, secrets, permissions/roles, cryptography, SSRF / outbound HTTP, or file handling. -->

- [ ] no — reviewed, no security impact
- [X] yes — security-sensitive (call out the risk and mitigation in the description above)
