### PR TITLE
fix(secret-managers): stop members seeing other projects' connections

### DIFF
--- a/packages/server/api/src/app/ee/secret-managers/secret-managers.controller.ts
+++ b/packages/server/api/src/app/ee/secret-managers/secret-managers.controller.ts
@@ -1,8 +1,12 @@
-import { ConnectSecretManagerRequestSchema, PrincipalType } from '@activepieces/shared'
+import { ActivepiecesError, ErrorCode, isNil, Permission } from '@activepieces/core-utils'
+import { ConnectSecretManagerRequestSchema, PlatformRole, Principal, PrincipalType } from '@activepieces/shared'
+import { FastifyBaseLogger } from 'fastify'
 import { FastifyPluginAsyncZod } from 'fastify-type-provider-zod'
 import { StatusCodes } from 'http-status-codes'
 import { z } from 'zod'
 import { securityAccess } from '../../core/security/authorization/fastify-security'
+import { userService } from '../../user/user-service'
+import { rbacService } from '../authentication/project-role/rbac-service'
 import { secretManagerCache } from './secret-manager-cache'
 import { secretManagersService } from './secret-managers.service'
 
@@ -10,9 +14,15 @@ export const secretManagersController: FastifyPluginAsyncZod = async (app) => {
     const service = secretManagersService(app.log)
 
     app.get('/', ListSecretManagerConnections, async (request) => {
+        const projectId = request.query.projectId
+        await assertPrincipalCanListSecretManagers({
+            principal: request.principal,
+            projectId,
+            log: request.log,
+        })
         return service.list({
             platformId: request.principal.platform.id,
-            projectId: request.query.projectId,
+            projectId,
         })
     })
 
@@ -40,6 +50,26 @@ export const secretManagersController: FastifyPluginAsyncZod = async (app) => {
     app.delete('/cache', ClearSecretManagerCache, async (request, reply) => {
         await secretManagerCache.invalidateConnectionEntries({ platformId: request.principal.platform.id, connectionId: request.query.connectionId })
         return reply.status(StatusCodes.NO_CONTENT).send()
+    })
+}
+
+async function assertPrincipalCanListSecretManagers({ principal, projectId, log }: AssertCanListParams): Promise<void> {
+    const user = await userService(log).getOneOrFail({ id: principal.id })
+    if (user.platformRole === PlatformRole.ADMIN) {
+        return
+    }
+    if (isNil(projectId)) {
+        throw new ActivepiecesError({
+            code: ErrorCode.AUTHORIZATION,
+            params: {
+                message: 'Listing secret manager connections across the platform requires a platform admin.',
+            },
+        })
+    }
+    await rbacService(log).assertPrinicpalAccessToProject({
+        principal,
+        permission: Permission.READ_APP_CONNECTION,
+        projectId,
     })
 }
 
@@ -95,4 +125,10 @@ const ClearSecretManagerCache = {
             connectionId: z.string().optional(),
         }),
     },
+}
+
+type AssertCanListParams = {
+    principal: Principal
+    projectId: string | undefined
+    log: FastifyBaseLogger
 }

--- a/packages/server/api/test/integration/ee/secret-managers/secret-managers.test.ts
+++ b/packages/server/api/test/integration/ee/secret-managers/secret-managers.test.ts
@@ -1,6 +1,6 @@
 import { ErrorCode } from '@activepieces/core-utils'
 import { safeHttp } from '@activepieces/server-utils'
-import { AppConnectionScope, AppConnectionType, PrincipalType, SecretManagerConnectionScope, SecretManagerFieldsSeparator, SecretManagerProviderId, UpsertGlobalConnectionRequestBody } from '@activepieces/shared'
+import { AppConnectionScope, AppConnectionType, DefaultProjectRole, PrincipalType, SecretManagerConnectionScope, SecretManagerFieldsSeparator, SecretManagerProviderId, UpsertGlobalConnectionRequestBody } from '@activepieces/shared'
 import { FastifyBaseLogger, FastifyInstance } from 'fastify'
 import { StatusCodes } from 'http-status-codes'
 import { MockInstance } from 'vitest'
@@ -9,6 +9,7 @@ import { validatePathFormat } from '../../../../src/app/ee/secret-managers/secre
 import { secretManagersService } from '../../../../src/app/ee/secret-managers/secret-managers.service'
 import { generateMockToken } from '../../../helpers/auth'
 import { mockAndSaveBasicSetup, mockPieceMetadata } from '../../../helpers/mocks'
+import { createMemberContext, createTestContext } from '../../../helpers/test-context'
 import { setupTestEnvironment, teardownTestEnvironment } from '../../../helpers/test-setup'
 import {
     hashicorpMock,
@@ -458,6 +459,64 @@ describe('Secret Managers API', () => {
                     code: ErrorCode.VALIDATION,
                 }),
             })
+        })
+    })
+
+    describe('List Secret Manager Connections authorization', () => {
+        it('should deny a non-admin member listing across the whole platform', async () => {
+            const ctx = await createTestContext(app!, {
+                plan: { secretManagersEnabled: true },
+            })
+            const memberCtx = await createMemberContext(app!, ctx, {
+                projectRole: DefaultProjectRole.EDITOR,
+            })
+
+            const response = await memberCtx.get('/v1/secret-managers')
+
+            expect(response?.statusCode).toBe(StatusCodes.FORBIDDEN)
+        })
+
+        it('should allow a non-admin member listing within their own project', async () => {
+            const ctx = await createTestContext(app!, {
+                plan: { secretManagersEnabled: true },
+            })
+            const memberCtx = await createMemberContext(app!, ctx, {
+                projectRole: DefaultProjectRole.EDITOR,
+            })
+
+            const response = await memberCtx.get('/v1/secret-managers', {
+                projectId: ctx.project.id,
+            })
+
+            expect(response?.statusCode).toBe(StatusCodes.OK)
+        })
+
+        it('should deny a non-admin member listing another project', async () => {
+            const ctx = await createTestContext(app!, {
+                plan: { secretManagersEnabled: true },
+            })
+            const otherCtx = await createTestContext(app!, {
+                plan: { secretManagersEnabled: true },
+            })
+            const memberCtx = await createMemberContext(app!, ctx, {
+                projectRole: DefaultProjectRole.EDITOR,
+            })
+
+            const response = await memberCtx.get('/v1/secret-managers', {
+                projectId: otherCtx.project.id,
+            })
+
+            expect(response?.statusCode).toBe(StatusCodes.FORBIDDEN)
+        })
+
+        it('should allow a platform admin listing across the whole platform', async () => {
+            const ctx = await createTestContext(app!, {
+                plan: { secretManagersEnabled: true },
+            })
+
+            const response = await ctx.get('/v1/secret-managers')
+
+            expect(response?.statusCode).toBe(StatusCodes.OK)
         })
     })
 })


### PR DESCRIPTION
## Description

Any member could list every secret manager connection on the platform, including ones for projects they are not part of. Admins keep the full list; everyone else now sees only their own project's connections.


### Breaking change?  (required — CI fails if this is left unedited)

<!-- Tick exactly one box. If either "yes", apply the "⛓️‍💥 breaking-change" label AND add an entry to docs/install/reference/breaking-changes.mdx (what changed + the action self-hosters must take). -->

- [X] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

<!-- Tick exactly one box. "Security-sensitive" = touches authentication, secrets, permissions/roles, cryptography, SSRF / outbound HTTP, or file handling. -->

- [ ] no — reviewed, no security impact
- [X] yes — security-sensitive (call out the risk and mitigation in the description above)
