### PR TITLE
fix(builder): long links in step info panels no longer get cut off

### DIFF
--- a/packages/web/src/components/custom/markdown.tsx
+++ b/packages/web/src/components/custom/markdown.tsx
@@ -63,7 +63,9 @@ const Container = ({
           )}
         </>
       )}
-      <AlertDescription className="grow w-full">{children}</AlertDescription>
+      <AlertDescription className="grow w-full min-w-0">
+        {children}
+      </AlertDescription>
     </Alert>
   );
 };
@@ -155,7 +157,7 @@ const ApMarkdown = React.memo(
             ),
             p: ({ node: _node, ref: _ref, ...props }) => (
               <p
-                className="leading-5 first-of-type:mt-1 not-first-of-type:mt-2 w-full mb-2"
+                className="leading-5 first-of-type:mt-1 not-first-of-type:mt-2 w-full mb-2 break-words"
                 {...props}
               />
             ),
@@ -168,7 +170,7 @@ const ApMarkdown = React.memo(
             li: ({ node: _node, ref: _ref, ...props }) => <li {...props} />,
             a: ({ node: _node, ref: _ref, ...props }) => (
               <a
-                className="font-medium text-primary underline underline-offset-4"
+                className="font-medium text-primary underline underline-offset-4 break-words"
                 target="_blank"
                 rel="noreferrer noopener"
                 {...props}


### PR DESCRIPTION
Fixes [GIT-1766](https://linear.app/activepieces/issue/GIT-1766)
Closes #14924

## Problem
1. A long unbreakable link/token in a piece `Property.MarkDown` info panel (INFO/BORDERLESS) overflows the fixed-width step-settings panel and is clipped at the right edge, with no wrap and no scroll. The whole panel (link + every paragraph) gets cut off.

The current webhook piece renders its URL in a copy box, so the webhook case is masked on latest; the defect is in the shared markdown renderer and hits any piece markdown containing a long link or unbreakable token.

## Fix
- `packages/web/src/components/custom/markdown.tsx`:
  - `AlertDescription` → `min-w-0` so the alert's `1fr` grid track can shrink below the token's intrinsic width.
  - `<a>` and `<p>` → `break-words` so long URLs/tokens wrap.
  - Both required: `min-w-0` alone won't wrap the URL; `break-words` alone won't shrink the grid track.

## Verification
- Lint: `turbo run lint --filter=web` — 0 errors.
- Real-app before/after (dev instance, webhook trigger pinned to piece v0.1.0, which renders the URL as a bare link): before — alert `scrollWidth 475px` vs `clientWidth 366px` (109px clipped); after — `366 == 366`, no overflow; computed `overflow-wrap: break-word`, `min-width: 0`.
- Regression test: N/A — CSS wrapping/overflow is not observable in jsdom (no layout engine); verified via the real-browser measurements above and the visual evidence.
- Security review: N/A — presentational CSS only, no auth/input/data/network/secret surface.
- Visual: builder step info panel (webhook trigger), light + dark, overflow state — link and paragraphs wrap within the panel.
- Other affected paths: checked - `ApMarkdown` is the single render path for every `Property.MarkDown`; this choke-point fix covers all pieces, no sibling patch needed.
- Pre-existing unrelated failures on upstream/main (not caused by this diff): `@activepieces/engine` `flow-with-delay.test.ts` and a sandbox heap-OOM in the local full-suite pre-push run; CI is the gate.
- Repro: pin a webhook trigger to piece v0.1.0 and open its settings — full steps in the Reproduction block.

<details>
<summary>Plan & reasoning</summary>

## Plan
- Fix the shared `ApMarkdown` / `Alert` render path, not the webhook piece: the webhook case is one instance, the defect is in the component. Footprint: 1 file, 3 class additions (estimate held).

## Non-happy scenarios considered
- BORDERLESS variant (no icon, so no grid): `min-w-0` / `break-words` are no-ops, no layout change.
- Markdown tables (`w-full`): `min-w-0` lets the container shrink; tables already scroll, no regression.
- Descriptive link text (not a URL): `break-words` breaks only when a word can't fit, so normal prose is unaffected.

## Alternatives rejected
- Editing the shared `ui/alert.tsx` primitive: broader blast radius across every Alert in the app.
- Fixing the webhook piece markdown only: leaves the defect latent for every other piece with a long link/token.
</details>

<details>
<summary>Reproduction</summary>

## Environment
Local dev (`npm run dev`), any flow containing a Catch Webhook trigger.

## Trigger
Pin the flow's trigger to the old piece version that renders the URL as a bare link, then reload the builder and open the trigger:
```sql
update flow_version
set trigger = jsonb_set(trigger, '{settings,pieceVersion}', '"0.1.0"')
where id = '<flowVersionId>';
```
Equivalent without the DB step: any piece whose `Property.MarkDown` contains a long bare URL.

## Results
- Before fix: alert `scrollWidth 475` > `clientWidth 366`; grid columns `16px 435px`; URL and paragraphs clipped at the right edge.
- After fix: `scrollWidth == clientWidth == 366`; URL wraps onto two lines; computed `overflow-wrap: break-word`, `min-width: 0`.
</details>

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)