### PR TITLE
fix(web): preserve dropdown value on dynamic toggle to manual (#14931)

### DIFF
--- a/packages/web/src/features/pieces/utils/form-utils.tsx
+++ b/packages/web/src/features/pieces/utils/form-utils.tsx
@@ -105,7 +105,7 @@ function parseDynamicValue({
 }: {
   property: PieceProperty;
   value: unknown;
-}): unknown[] | boolean | undefined {
+}): unknown[] | boolean | string | number | undefined {
   const parsed = parseToJsonIfPossible(value);
   switch (property.type) {
     case PropertyType.MULTI_SELECT_DROPDOWN:
@@ -113,6 +113,12 @@ function parseDynamicValue({
       return Array.isArray(parsed) ? parsed : undefined;
     case PropertyType.CHECKBOX:
       return typeof parsed === 'boolean' ? parsed : undefined;
+    case PropertyType.DROPDOWN:
+    case PropertyType.STATIC_DROPDOWN:
+      if (typeof value === 'string' || typeof value === 'number') {
+        return value;
+      }
+      return undefined;
     default:
       return undefined;
   }

--- a/packages/web/test/features/pieces/parse-dynamic-value.test.ts
+++ b/packages/web/test/features/pieces/parse-dynamic-value.test.ts
@@ -14,6 +14,17 @@ const checkbox = Property.Checkbox({
   required: false,
 });
 const shortText = Property.ShortText({ displayName: 'Text', required: false });
+const dropdown = Property.Dropdown({
+  displayName: 'Dropdown',
+  required: true,
+  refreshers: [],
+  options: async () => ({ options: [{ label: 'Option 1', value: 'opt1' }] }),
+});
+const staticDropdown = Property.StaticDropdown({
+  displayName: 'Static Dropdown',
+  required: true,
+  options: { options: [{ label: 'Option 1', value: 'opt1' }] },
+});
 
 describe('formUtils.parseDynamicValue', () => {
   it.each([
@@ -21,6 +32,9 @@ describe('formUtils.parseDynamicValue', () => {
     ['[]', multiSelect, []],
     ['true', checkbox, true],
     ['false', checkbox, false],
+    ['{{ variables.channel }}', dropdown, '{{ variables.channel }}'],
+    ['opt1', staticDropdown, 'opt1'],
+    [123, staticDropdown, 123],
   ])('restores %s', (value, property, expected) => {
     expect(formUtils.parseDynamicValue({ property, value })).toEqual(expected);
   });
@@ -31,6 +45,8 @@ describe('formUtils.parseDynamicValue', () => {
     ['{"not":"an array"}', multiSelect],
     ['1', checkbox],
     ['["year","day"]', shortText],
+    [null, dropdown],
+    [undefined, staticDropdown],
   ])('has nothing unambiguous to restore in %s', (value, property) => {
     expect(formUtils.parseDynamicValue({ property, value })).toBeUndefined();
   });


### PR DESCRIPTION
## Description
Fixes #14931

When a Dropdown property (single `DROPDOWN` or `STATIC_DROPDOWN`) holding an expression (e.g. `{{ variables['X'] }}` or a custom string) is toggled from dynamic `f(x)` to manual mode, `parseDynamicValue` previously returned `undefined` because only `MULTI_SELECT` and `CHECKBOX` cases were handled.

This caused `getValueForInputOnDynamicToggleChange` in `auto-form-field-wrapper.tsx` to fall through to `getDefaultPropertyValue`, replacing the user's expression with `property.defaultValue ?? null` with no warning.

### Solution:
- Added `PropertyType.DROPDOWN` and `PropertyType.STATIC_DROPDOWN` handling in `parseDynamicValue` (`form-utils.tsx`), preserving string and number values.
- Added unit tests in `packages/web/test/features/pieces/parse-dynamic-value.test.ts`.
