### PR TITLE
fix(flows): dropdown values are no longer erased when switching off dynamic mode

### DIFF
--- a/packages/web/src/app/builder/piece-properties/auto-form-field-wrapper.tsx
+++ b/packages/web/src/app/builder/piece-properties/auto-form-field-wrapper.tsx
@@ -176,6 +176,9 @@ export function getValueForInputOnDynamicToggleChange(
       ) {
         return currentValue;
       }
+      if (currentValue === null) {
+        return '';
+      }
       return JSON.stringify(currentValue);
     }
     case PropertyExecutionType.MANUAL: {

--- a/packages/web/src/features/pieces/utils/form-utils.tsx
+++ b/packages/web/src/features/pieces/utils/form-utils.tsx
@@ -1,5 +1,6 @@
 import {
   Metadata,
+  extractMustacheTokens,
   isNil,
   parseToJsonIfPossible,
 } from '@activepieces/core-utils';
@@ -105,14 +106,34 @@ function parseDynamicValue({
 }: {
   property: PieceProperty;
   value: unknown;
-}): unknown[] | boolean | undefined {
+}): unknown {
   const parsed = parseToJsonIfPossible(value);
+  const isExpression =
+    typeof value === 'string' && extractMustacheTokens(value).length > 0;
   switch (property.type) {
     case PropertyType.MULTI_SELECT_DROPDOWN:
     case PropertyType.STATIC_MULTI_SELECT_DROPDOWN:
-      return Array.isArray(parsed) ? parsed : undefined;
+      if (Array.isArray(parsed)) {
+        return parsed;
+      }
+      return isExpression ? value : undefined;
     case PropertyType.CHECKBOX:
-      return typeof parsed === 'boolean' ? parsed : undefined;
+      if (typeof parsed === 'boolean') {
+        return parsed;
+      }
+      return isExpression ? value : undefined;
+    case PropertyType.DROPDOWN:
+    case PropertyType.STATIC_DROPDOWN: {
+      if (typeof value === 'number') {
+        return value;
+      }
+      if (typeof value !== 'string' || value === '') {
+        return undefined;
+      }
+      const restoredJsonStringifiedValue =
+        /^\s*[[{]/.test(value) && parsed !== value;
+      return restoredJsonStringifiedValue ? parsed : value;
+    }
     default:
       return undefined;
   }

--- a/packages/web/test/features/pieces/parse-dynamic-value.test.ts
+++ b/packages/web/test/features/pieces/parse-dynamic-value.test.ts
@@ -14,6 +14,11 @@ const checkbox = Property.Checkbox({
   required: false,
 });
 const shortText = Property.ShortText({ displayName: 'Text', required: false });
+const staticDropdown = Property.StaticDropdown({
+  displayName: 'Channel',
+  required: true,
+  options: { options: [{ label: 'General', value: 'C0123' }] },
+});
 
 describe('formUtils.parseDynamicValue', () => {
   it.each([
@@ -26,11 +31,44 @@ describe('formUtils.parseDynamicValue', () => {
   });
 
   it.each([
+    ["{{ variables['channel'] }}", staticDropdown],
+    ['{{ trigger.body.channel || "C0123" }}', staticDropdown],
     ['{{ trigger.body.units }}', multiSelect],
+    ['{{ trigger.body.enabled }}', checkbox],
+  ])('preserves the expression %s across the toggle', (value, property) => {
+    expect(formUtils.parseDynamicValue({ property, value })).toEqual(value);
+  });
+
+  it('restores a stringified array whose item holds an expression', () => {
+    expect(
+      formUtils.parseDynamicValue({
+        property: multiSelect,
+        value: '["{{ trigger.body.unit }}","year"]',
+      }),
+    ).toEqual(['{{ trigger.body.unit }}', 'year']);
+  });
+
+  it.each([
+    ['C0123', staticDropdown, 'C0123'],
+    ['5', staticDropdown, '5'],
+    [5, staticDropdown, 5],
+    ['true', staticDropdown, 'true'],
+    ['null', staticDropdown, 'null'],
+    ['price {{high', staticDropdown, 'price {{high'],
+    ['{"tier":"pro"}', staticDropdown, { tier: 'pro' }],
+    ['["a","b"]', staticDropdown, ['a', 'b']],
+  ])('keeps the dropdown literal %s as %s', (value, property, expected) => {
+    expect(formUtils.parseDynamicValue({ property, value })).toEqual(expected);
+  });
+
+  it.each([
     ['year', multiSelect],
     ['{"not":"an array"}', multiSelect],
+    ['price {{high', multiSelect],
     ['1', checkbox],
     ['["year","day"]', shortText],
+    ['', staticDropdown],
+    [undefined, staticDropdown],
   ])('has nothing unambiguous to restore in %s', (value, property) => {
     expect(formUtils.parseDynamicValue({ property, value })).toBeUndefined();
   });


### PR DESCRIPTION
## Description

Fixes [GIT-1767](https://linear.app/activepieces/issue/GIT-1767)
Closes #14931

**Problem** (Pylon 5679):
1. A dropdown in f(x) mode holding an expression (`{{ variables['X'] }}`) or a typed literal (Slack channel ID) is silently overwritten with `defaultValue ?? null` when f(x) is toggled off — unrecoverable. The Slack piece's markdown tells users to type the channel ID in f(x) mode, walking them into the trap.
2. Toggling an empty dropdown to f(x) shows the literal string `null`.

**Fix**:
- `form-utils.tsx` `parseDynamicValue`: DROPDOWN/STATIC_DROPDOWN keep string/number values as typed and JSON-restore only container-shaped strings (the exact inverse of the dynamic direction's `JSON.stringify`); MULTI_SELECT/CHECKBOX preserve expression strings when nothing parseable is present (parse wins, so stringified arrays keep restoring). Expression detection via the shared `extractMustacheTokens` tokenizer.
- `auto-form-field-wrapper.tsx`: `null` → `''` on toggle-to-f(x) (never `undefined`, so required-field validation still fails for never-set dropdowns).

Product decision embedded: a preserved expression renders as an unselected dropdown / truthy checkbox until the user picks a value; alternative considered: confirm dialog before discard.

## How was this tested?

- `parse-dynamic-value.test.ts`: 24 tests, red-first proven — 12 fail on base, 24 pass with the fix. Full web suite 56 files / 537 tests green; `npm run lint-dev` clean. CE path (builder is edition-independent here).
- Live drive on a real app + Postgres: expression survives f(x)→manual→f(x) (API-verified `settings.input` after each toggle); base code reproduces the wipe on the same flow; null-valued dropdown → empty f(x) field.
- Visual: driven states — f(x) expression chip, toggle-off preserved, toggle-back restored, null→empty; before/after screenshots in the Visual verification comment.
- Repro: expression-holding dropdown toggled off — base wipes to the default, this branch preserves it — full steps in the Reproduction block.
- Other affected paths: checked — JSON, OBJECT, COLOR also render the toggle and still lose values on toggle-off (pre-existing `default: return undefined` path, each widget needs its own tolerance check); ARRAY discards on toggle-to-f(x) by design; tabs-grouped properties share this choke point and are covered for the fixed types. Left unfixed deliberately.

<details>
<summary>Plan & reasoning</summary>

## Plan
- Fix at the shared choke point `parseDynamicValue` (both toggle call sites route through it) rather than per-widget guards in 6 components.
- Restore rule mirrors the dynamic direction exactly: strings/numbers pass through raw there, so they come back raw; only container-shaped strings (`^[[{]`) are JSON-restored. Scalar strings like `'true'`/`'5'` are never coerced — real pieces (service-now, wafeq) use string `'true'` option values.
- Footprint estimate: 3 files ~20 lines; actual ~30 product lines after review-driven revisions.

## Non-happy scenarios considered
- Multi-select holding `'["{{ x }}","year"]'` → parse-first order restores the array; expression-first would regress it to a raw string.
- String option values parsing as JSON booleans (`'true'`) → kept raw so they still match their option.
- Never-set required dropdown toggled to f(x) → stays `undefined`, still fails required validation (only `null` maps to `''`).
- Checkbox preserving an expression renders ON (truthy string) until the user acts; toggling back to f(x) restores it; clicking the switch overwrites it — same as picking a different option.
- Refresher/connection changes still reset dependent dropdowns (pre-existing design), clearing preserved expressions too — parity with manual selections.

## Alternatives rejected
- Confirm dialog before discarding — new UI for what lossless preservation solves.
- Stashing the pre-toggle value in `propertySettings` — exact restore, but changes the stored flow shape (flow-schema impact) for a builder-only bug.
- Blanket expression guard above the switch — unsafe: ARRAY/OBJECT manual widgets can't render a raw string (`ArrayPieceProperty` calls `.map` on the value).
</details>

<details>
<summary>Reproduction</summary>

## Environment
Local dev stack: `npx vite` on packages/web (this branch, and base for the before-run) against the repo dev backend (`localhost:3000`) + Postgres. Any flow with a Delay "Delay For" step works; the customer case is Slack "Channel" (dynamic dropdown, no defaultValue).

## Trigger
1. Set the step's Unit dropdown to f(x) mode holding an expression, via API (matches a customer's saved flow):
   `POST /api/v1/flows/<id>` with `{"type":"UPDATE_ACTION","request":{...,"settings":{"input":{"unit":"{{ trigger.unit }}",...},"propertySettings":{"unit":{"type":"DYNAMIC"}}}}}`
2. Open the flow in the builder, open the step, click the f(x) toggle off.

## Results
| Code | `input.unit` after toggle-off (`GET /api/v1/flows/<id>`) |
|---|---|
| base (93e548171b) | `"seconds"` — expression replaced with the property default (`null` when the property has no default, e.g. Slack Channel) |
| this branch | `"{{ trigger.unit }}"` — preserved; toggling back on restores the expression chip |

Same drive with `input.unit = null` + f(x) on: base renders the literal string `null`; this branch renders an empty field.
</details>

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)

