### PR TITLE
fix(flows): chips no longer hide the rest of an expression after the variable

### DIFF
--- a/packages/web/src/app/builder/piece-properties/text-input-with-mentions/text-input-utils.ts
+++ b/packages/web/src/app/builder/piece-properties/text-input-with-mentions/text-input-utils.ts
@@ -296,28 +296,36 @@ const removeIntroplationBrackets = (text: string) => {
   return text;
 };
 
+const pureAccessorRegex =
+  /^[\p{L}_$][\p{L}\p{N}_$]*(?:\.[\p{L}\p{N}_$]+|\[\s*(?:'(?:\\.|[^'\\])*'|"(?:\\.|[^"\\])*"|\d+)\s*\])*$/u;
+
 function parseStepAndNameFromMention(mention: string) {
-  const mentionWithoutInterpolationBrackets =
-    removeIntroplationBrackets(mention);
-  const { isValid, stepName, arrayPath } = parseFlattenArrayPath(
-    mentionWithoutInterpolationBrackets,
-  );
+  const expression = removeIntroplationBrackets(mention);
+  const { isValid, stepName, arrayPath } = parseFlattenArrayPath(expression);
   if (isValid) {
     return {
       stepName,
       path: arrayPath ?? [],
+      expression,
+      isPureAccessor: true,
     };
   }
-  const keys = keysWithinPath(mentionWithoutInterpolationBrackets);
+  const keys = pureAccessorRegex.test(expression)
+    ? keysWithinPath(expression)
+    : [];
   if (keys.length === 0) {
     return {
       stepName: null,
       path: [],
+      expression,
+      isPureAccessor: false,
     };
   }
   return {
     stepName: keys[0],
     path: keys.slice(1),
+    expression,
+    isPureAccessor: true,
   };
 }
 
@@ -327,7 +335,16 @@ function parseLabelFromMention(
   stepsMetadata: (StepMetadataWithDisplayName | undefined)[],
   variableByName?: Map<string, string>,
 ) {
-  const { stepName, path } = parseStepAndNameFromMention(mention);
+  const { stepName, path, expression, isPureAccessor } =
+    parseStepAndNameFromMention(mention);
+  if (!isPureAccessor) {
+    return {
+      displayText: expression,
+      serverValue: mention,
+      logoUrl: undefined,
+      isVariable: expression.startsWith('variables'),
+    };
+  }
   if (stepName === 'variables') {
     const name = path[0] ?? '';
     const displayName = variableByName?.get(name) ?? name;

--- a/packages/web/test/app/builder/piece-properties/text-input-with-mentions/text-input-utils.test.ts
+++ b/packages/web/test/app/builder/piece-properties/text-input-with-mentions/text-input-utils.test.ts
@@ -23,6 +23,73 @@ describe('textMentionUtils.parseLabelFromMention — flattenNestedKeys', () => {
   });
 });
 
+describe('textMentionUtils.parseLabelFromMention: expressions render raw', () => {
+  it('shows the || fallback on a variable chip', () => {
+    const label = textMentionUtils.parseLabelFromMention(
+      "{{ variables['X'] || 'fallback' }}",
+      [],
+      [],
+    );
+    expect(label.displayText).toBe("variables['X'] || 'fallback'");
+    expect(label.isVariable).toBe(true);
+    expect(label.serverValue).toBe("{{ variables['X'] || 'fallback' }}");
+  });
+
+  it('keeps a plain variable chip label friendly', () => {
+    const label = textMentionUtils.parseLabelFromMention(
+      "{{ variables['X'] }}",
+      [],
+      [],
+    );
+    expect(label.displayText).toBe('Variable · X');
+  });
+
+  it('shows a step expression whole instead of dot-splitting it', () => {
+    const label = textMentionUtils.parseLabelFromMention(
+      '{{ step_1.body.x || step_1.body.y }}',
+      [],
+      [],
+    );
+    expect(label.displayText).toBe('step_1.body.x || step_1.body.y');
+  });
+
+  it('shows a parenthesized expression whole', () => {
+    const label = textMentionUtils.parseLabelFromMention(
+      '{{ (step_1.body.x || step_1.body.y) }}',
+      [],
+      [],
+    );
+    expect(label.displayText).toBe('(step_1.body.x || step_1.body.y)');
+  });
+
+  it('keeps a pure accessor with array index on the friendly path', () => {
+    const label = textMentionUtils.parseLabelFromMention(
+      "{{ step_1['output'].items[0] }}",
+      [],
+      [],
+    );
+    expect(label.displayText).toBe('(Missing) step_1');
+  });
+
+  it('keeps an escaped-quote bracket key on the friendly path', () => {
+    const label = textMentionUtils.parseLabelFromMention(
+      "{{ step_1['output']['it\\'s here'] }}",
+      [],
+      [],
+    );
+    expect(label.displayText).toBe('(Missing) step_1');
+  });
+
+  it('keeps a non-ascii dot key on the friendly path', () => {
+    const label = textMentionUtils.parseLabelFromMention(
+      '{{ trigger.body.pełna }}',
+      [],
+      [],
+    );
+    expect(label.displayText).toBe('(Missing) trigger');
+  });
+});
+
 const convert = (text: string) =>
   textMentionUtils.convertTextToTipTapJsonContent(text, [], []);
 
@@ -58,7 +125,7 @@ describe('textMentionUtils.convertTextToTipTapJsonContent', () => {
 
   describe('references inside quotes keep their mention node', () => {
     it.each([
-      '"{{step_4[\'output\'][\'result\']}}"',
+      "\"{{step_4['output']['result']}}\"",
       '"{{step_4["output"]["result"]}}"',
       "'{{step_4.result}}'",
       'fullText contains "{{step_4.result}}',
@@ -72,7 +139,7 @@ describe('textMentionUtils.convertTextToTipTapJsonContent', () => {
     });
 
     it.each([
-      '"{{step_4[\'output\'][\'result\']}}"',
+      "\"{{step_4['output']['result']}}\"",
       '"{{step_4["output"]["result"]}}"',
       '"{{step_1.name}} upper(x)"',
       'ap-formula-v1::{upper("(CEO); still inside")}::ap-formula-v1',


### PR DESCRIPTION
## Description

Fixes [GIT-1768](https://linear.app/activepieces/issue/GIT-1768)
Closes #14932

**Problem** (Pylon 5679): `{{ variables['X'] || 'fallback' }}` renders as a chip labelled only "Variable · X" — the `|| 'fallback'` is invisible and uneditable. Users who can't see the fallback delete the chip and retype, silently changing behavior. Step expressions fared no better: the label dot-split the whole expression into mangled path fragments.

**Fix** (`text-input-utils.ts`): all-or-nothing labelling. If the mention is a pure accessor (`step_1['output'].items[0]`, `variables['X']`, escaped-quote and non-ASCII keys included), the friendly label is unchanged. Anything else — trailing `||`, parenthesized or negated forms, any operator — renders the whole expression verbatim on the chip, unshredded. `serverValue` untouched, so stored flows are byte-identical.

Deliberately verbatim rather than a prettified "Variable · X || 'fallback'": the engine does not evaluate `||` on `variables` tokens — `parseVariableName` (`packages/server/engine/src/lib/variables/variable-token.ts`) extracts only the first `['...']` key and discards the rest, so a friendly rendering would legitimize syntax that silently never runs. Showing the raw code shows exactly what is stored. The engine gap itself is out of scope here and noted on the Linear ticket.

## How was this tested?

- `text-input-utils.test.ts`: 31 tests, red-first — 3 fail on base (raw-expression cases), 31 pass with the fix; friendly-path guards (escaped-quote bracket keys, non-ASCII dot keys, array indexes) pass on both, proving no label regressions on selector-generated mentions.
- Full web suite 56 files / 529 tests green; `npm run lint-dev` clean. CE path (builder is edition-independent here).
- Live drive (real app + Postgres): `{{ variables['retry_delay'] || 5 }}` in the Delay Amount field renders the full expression on the chip; focus/blur round trip leaves the stored value byte-identical (API-verified).
- Repro: chip for a variable-with-fallback hides the fallback on base, shows it with the fix — full steps in the Reproduction block.
- Visual: driven states — variable chip with fallback (before/after) in the Visual verification comment.
- Other affected paths: checked — `flattenNestedKeys(...) || []` still routes to the raw branch via the identifier-only match (label shows the full expression, acceptable); the engine's `variables`-token fallback discard is a separate runtime gap noted on GIT-1768.

<details>
<summary>Plan & reasoning</summary>

## Plan
- One rule in `parseLabelFromMention`: validate the whole inner text against a pure-accessor grammar (unicode identifiers, escaped-quote bracket keys); pure → existing friendly path, otherwise → verbatim expression label with the variable icon when the token starts with `variables` (mirrors the engine's prefix routing).
- Footprint estimate: 2 files ~20 lines; actual ~25 product lines.

## Non-happy scenarios considered
- Selector-generated keys with apostrophes (`['it\'s here']`, via `escapeMentionKey`) stay on the friendly path — the grammar is escape-aware.
- Non-ASCII keys (`trigger.body.pełna`) stay friendly via `\p{L}`/`\p{N}` classes.
- Hyphenated dot keys (`body.user-agent`) now render verbatim — the engine evaluates them as subtraction, so the raw form is more honest than the old friendly split.
- Mid-typing fragments (`step_1.`) render verbatim until the accessor is complete.

## Alternatives rejected
- Accessor + appended trailing text (first draft): produced half-friendly/half-raw labels (`1. Step items 1 || step_1.items[0]` — same index shown 1-based and 0-based), duplicated an accessor grammar the engine owns, and prettified fallback syntax the engine discards for `variables` tokens.
- Tokenizing the trailing expression outside the mention: tokenizer + editor round-trip risk, far larger blast radius.
- Tooltip only: hover-gated; the misleading label would remain.
</details>

<details>
<summary>Reproduction</summary>

## Environment
Local dev stack: `npx vite` on packages/web (this branch; base for the before-run) against the repo dev backend + Postgres.

## Trigger
1. `POST /api/v1/flows/<id>` UPDATE_ACTION setting a mention-capable input to `{{ variables['retry_delay'] || 5 }}`.
2. Open the flow in the builder and open the step.

## Results
| Code | Chip label |
|---|---|
| base (93e548171b) | `Variable · retry_delay` — fallback invisible |
| this branch | `variables['retry_delay'] || 5` — full expression visible |

Stored `settings.input` verified byte-identical before/after via `GET /api/v1/flows/<id>` in both runs.
</details>

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)
