### PR TITLE
fix(web): filter-builder Add filter popover clips long lists

### DIFF
--- a/packages/web/src/app/builder/piece-properties/filter-builder-layout.tsx
+++ b/packages/web/src/app/builder/piece-properties/filter-builder-layout.tsx
@@ -304,7 +304,7 @@ function AddFilterPopover({
       <PopoverContent align="start" className="w-72 p-0">
         <Command>
           <CommandInput placeholder={t('Filter by…')} />
-          <CommandList>
+          <CommandList className="overflow-y-auto">
             <CommandEmpty>{t('No filters found')}</CommandEmpty>
             {builderGroups.map((group) => {
               const items = group.props.filter((name) => !!props[name]);


### PR DESCRIPTION
## Description

The shared `Command` UI primitive (`packages/web/src/components/ui/command.tsx`) caps its list at `max-h-[300px]` with `overflow-y-hidden` — so any consumer whose list exceeds that height silently clips content with no way to scroll to it.

This surfaced while building Gmail's Find Email filter-builder UI (PIE-476): once the "Filters" group grew past a handful of items, everything past "Has Attachment" (Attachment Name, Include Spam & Trash, and the whole Time group) became invisible and unreachable in the "Add filter" popover.

Fixed by adding `overflow-y-auto` directly to this popover's `CommandList` instead of changing the shared primitive — several other `Command` consumers (language toggle, searchable-select, autocomplete, etc.) already wrap their own `ScrollArea` and don't need the change, so this keeps the fix scoped to the one component that was actually broken.

## How was this tested?

Manually verified in the local flow builder: opened Gmail's Find Email "Add filter" popover with a long filter list (People, Filters, Time groups) and confirmed all items — including ones previously clipped past 300px — are now reachable via scroll. CE only, no EE/Cloud-specific surface touched.

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact