### PR TITLE
fix(builder): the builder no longer crashes while an agent step is running

### DIFF
--- a/packages/web/src/features/agents/agent-timeline/index.tsx
+++ b/packages/web/src/features/agents/agent-timeline/index.tsx
@@ -27,7 +27,7 @@ export const AgentTimeline = ({
   agentResult,
   className = '',
 }: AgentTimelineProps) => {
-  if (isNil(agentResult)) {
+  if (isNil(agentResult) || isNil(agentResult.steps)) {
     return <p>{t('No agent output available')}</p>;
   }
 
@@ -37,7 +37,7 @@ export const AgentTimeline = ({
         <div className="absolute left-2 top-4 bottom-8 w-px bg-border" />
 
         <div className="space-y-7 pb-4">
-          {agentResult.prompt.length > 0 && (
+          {(agentResult.prompt?.length ?? 0) > 0 && (
             <PromptBlock prompt={agentResult.prompt} />
           )}
 


### PR DESCRIPTION
## Description

Pressing **Test flow** on a flow containing an agent step white-screened the whole builder the moment the run reached that step. Reported on the forum, reproduced on Cloud, with this in the console:

```
TypeError: Cannot read properties of undefined (reading 'length')
React Router caught the following error during render
```

The agent step is a thin client: it creates a waitpoint, hands the work to the worker, and returns `{}` until the answer comes back. `AgentTimeline` guarded only against a nil result, so an empty object walked straight past the guard into `agentResult.prompt.length` — a render-time throw, which the route error boundary turns into a blank page rather than a broken panel.

Two things made it easy to miss. The empty object is a perfectly valid intermediate state that only exists for the seconds between "step started" and "agent answered", so it never shows up in a finished run. And the run-details panel reaches the same component through `selectedStepOutput.output as AgentResult` — a cast, so TypeScript had no reason to complain about a shape that does not match.

The fix treats "no `steps` yet" as "nothing to show yet", which is what the placeholder already existed for.

## How was this tested?

The web test setup runs in a node environment with no renderer, so a component test would mean adding a DOM environment and a testing-library dependency for a two-line guard. Instead I ran both versions of the guard expression against the two real inputs:

```
before | paused {} => THROWS: Cannot read properties of undefined (reading 'length')
before | finished  => prompt
after  | paused {} => placeholder
after  | finished  => prompt
```

The thrown message is identical to the one in the reporter's console, and the finished-result path is unchanged. `tsc` clean on web, lint 0 errors.

Worth noting for whoever picks up the follow-up: a stuck agent step waits `AGENT_STEP_TIMEOUT_MS` (3 hours) before it gives up, and the same value applies when only one step is being tested. Now that the builder survives the wait, that timeout is the next thing that will read as "it hangs".

Fixes # (issue)

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)
