### PR TITLE
docs: clarify piece bundles come from npm by default (CDN opt-in)

### DIFF
--- a/docs/install/architecture/benchmark.mdx
+++ b/docs/install/architecture/benchmark.mdx
@@ -118,7 +118,7 @@ This is the time the **worker** is occupied per job — and at concurrency 1 it 
 - **Worker**: 0.5 vCPU / 1 GB, concurrency 1, `SANDBOX_CODE_ONLY` (Node fork + `isolated-vm`). Idle RSS ~145 Mi
 - **App**: 1 vCPU / 1 GB
 - **Object store**: same-region GCS bucket (`europe-west1`) over the S3-interop endpoint, path-style SigV4 presigned URLs (`AP_S3_USE_SIGNED_URLS=true`)
-- **Piece bundles**: official tarballs served from the Activepieces CDN (`AP_USE_CDN_FOR_BUNDLES=true`)
+- **Piece bundles**: official tarballs served from the Activepieces CDN (`AP_USE_CDN_FOR_BUNDLES=true`; non-default — the platform default is `false`, which serves from npm)
 - **Postgres + Redis**: in-cluster singletons, deliberately generous — Postgres requesting 3 vCPU / 3 GB with `max_connections=2000` (the default 100 would starve the app pools past ~10 apps), durability off, and its data dir on tmpfs; Redis requesting 2 vCPU / 2 GB with `io-threads`. Neither has a CPU *limit*, so both may burst above their request; Postgres consumed 2738m at the top tier
 - **Load**: `hey` **run inside the cluster**, against the app Service, concurrency matched to worker count (40/80/120/160) so requests don't queue behind the concurrency-1 workers — latency reflects real service time, not backlog. 400 requests per worker per tier (16k/32k/48k/64k), preceded by an unmeasured warmup pass
 

--- a/docs/install/reference/breaking-changes.mdx
+++ b/docs/install/reference/breaking-changes.mdx
@@ -113,6 +113,10 @@ In the AI piece, picking the Activepieces-provided AI now lists only the named t
 #### Official piece bundles are served from the Activepieces CDN by default
 `AP_USE_CDN_FOR_BUNDLES` now defaults to `true`. When an official piece bundle is not already cached in your own S3 bucket, the engine is redirected to `cdn.activepieces.com` for the tarball instead of `registry.npmjs.org`. If the CDN does not have that piece version, the download falls back to npm automatically, so installs keep working either way. Custom pieces and pieces from a private registry never use the CDN and are unaffected.
 
+<Note>
+Reverted in 0.88.2: `AP_USE_CDN_FOR_BUNDLES` defaults to `false` again, so official bundles are served from npm by default. Set it to `true` to opt back into the CDN.
+</Note>
+
 ### Do you need to take action?
 - Only if your network policy restricts outbound traffic. Allow `cdn.activepieces.com`, or set `AP_USE_CDN_FOR_BUNDLES=false` to keep serving official bundles from npm.
 


### PR DESCRIPTION
## Description

Docs said `AP_USE_CDN_FOR_BUNDLES` defaults to `true` (official piece bundles served from `cdn.activepieces.com`). The code default was reverted to `false` in 0.88.2, so official bundles come from **npm** by default. Verified at tag `0.88.3`.

The `true` default shipped in 0.87.0–0.88.1, then [PR #14774](https://github.com/activepieces/activepieces/pull/14774) flipped it back to `false`. The docs were never updated.

## Fix

- `docs/install/reference/breaking-changes.mdx`: kept the historical 0.87.0 entry accurate, added a `<Note>` stating the default was reverted to `false` in 0.88.2 (npm by default again).
- `docs/install/architecture/benchmark.mdx`: annotated `AP_USE_CDN_FOR_BUNDLES=true` in the test environment as a non-default opt-in (default is `false`, serves from npm).

## How was this tested?

- Verified the code default at `packages/server/api/src/app/helper/system/system.ts` (`USE_CDN_FOR_BUNDLES: 'false'`) and the npm fallback path at `packages/server/api/src/app/pieces/piece-bundle.ts` at tag 0.88.3.
- `<Note>` confirmed a valid in-repo Mintlify component (used in 35 docs).
- Docs-only change: lint/unit/api/security gates have no code surface.

Visual: none - docs-only content edit, no app UI change.
Other affected paths: checked - `docs/` grep for `AP_USE_CDN_FOR_BUNDLES` / CDN default; only these two files assert the default.

Fixes [GIT-1771](https://linear.app/activepieces/issue/GIT-1771)
Closes #14952

<details>
<summary>Plan &amp; reasoning</summary>

## Plan
- Root cause pinned (doc lag behind PR #14774 revert); local docs-only fix. Footprint: 2 files, ~6 lines, matched estimate.
- Annotate rather than rewrite: the 0.87.0 breaking-changes entry was correct at 0.87.0, so history stays intact; a `<Note>` carries the current state.

## Non-happy scenarios considered
- Reader on 0.87.0–0.88.1 (default was genuinely `true`): the historical entry still reads correctly; the Note dates the revert.
- Benchmark reader assuming the CDN is the default: the `non-default` annotation removes the ambiguity while keeping the benchmark's real config accurate.

## Alternatives rejected
- Rewriting the 0.87.0 entry to say `false`: wrong, the default was `true` at 0.87.0; the versioned doc must stay historically accurate.
</details>

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)
