### PR TITLE
fix(webhook): show a failed run when a webhook request fails authentication

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -10588,7 +10588,7 @@
     },
     "packages/pieces/core/webhook": {
       "name": "@activepieces/piece-webhook",
-      "version": "0.1.40",
+      "version": "0.1.41",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",

--- a/packages/pieces/core/webhook/package.json
+++ b/packages/pieces/core/webhook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-webhook",
-  "version": "0.1.40",
+  "version": "0.1.41",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {

--- a/packages/pieces/core/webhook/src/lib/triggers/catch-hook.ts
+++ b/packages/pieces/core/webhook/src/lib/triggers/catch-hook.ts
@@ -46,7 +46,7 @@ export const catchWebhook = createTrigger({
   description:
     'Receive incoming HTTP/webhooks using any HTTP method such as GET, POST, PUT, DELETE, etc.',
   aiMetadata: {
-    description: 'Fires once for every request delivered to the unique webhook URL generated for this flow, under any HTTP method. Use it as the entry point for any system that can call a URL; Authentication must be set explicitly to None, Basic credentials, a shared header value, or an HMAC signature over the raw body, and requests that fail verification are silently dropped without starting a run. Appending /sync to the URL makes the caller wait for a Return Response action, while /test generates sample data without triggering the published flow.',
+    description: 'Fires once for every request delivered to the unique webhook URL generated for this flow, under any HTTP method. Use it as the entry point for any system that can call a URL; Authentication must be set explicitly to None, Basic credentials, a shared header value, or an HMAC signature over the raw body, and requests that fail verification are rejected and recorded as a failed run instead of starting the flow. Appending /sync to the URL makes the caller wait for a Return Response action, while /test generates sample data without triggering the published flow.',
   },
   props: {
     liveMarkdown: Property.MarkDown({
@@ -198,7 +198,9 @@ export const catchWebhook = createTrigger({
       context.payload.rawBody
     );
     if (!verified) {
-      return [];
+      throw new Error(
+        `Webhook authentication failed: request did not pass the configured ${authenticationType} check`
+      );
     }
     return [context.payload];
   },

--- a/packages/pieces/core/webhook/test/auth-rejection.test.ts
+++ b/packages/pieces/core/webhook/test/auth-rejection.test.ts
@@ -1,0 +1,138 @@
+/// <reference types="vitest/globals" />
+
+import { createHmac } from 'crypto';
+import { catchWebhook } from '../src/lib/triggers/catch-hook';
+
+type AuthProps = {
+  authType: string;
+  authFields: Record<string, unknown>;
+};
+
+type WebhookPayload = {
+  headers: Record<string, string>;
+  rawBody?: unknown;
+};
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const buildContext = (propsValue: AuthProps, payload: WebhookPayload): any => ({
+  propsValue,
+  payload,
+});
+
+function basicHeader(username: string, password: string): string {
+  return `Basic ${Buffer.from(`${username}:${password}`).toString('base64')}`;
+}
+
+describe('catchWebhook.run authentication', () => {
+  test('returns the payload when no auth is configured', async () => {
+    const payload = { headers: {}, rawBody: '' };
+    const result = await catchWebhook.run(
+      buildContext({ authType: 'none', authFields: {} }, payload)
+    );
+    expect(result).toEqual([payload]);
+  });
+
+  test('returns the payload when basic auth matches', async () => {
+    const payload = {
+      headers: { authorization: basicHeader('user', 'pass') },
+      rawBody: '',
+    };
+    const result = await catchWebhook.run(
+      buildContext(
+        { authType: 'basic', authFields: { username: 'user', password: 'pass' } },
+        payload
+      )
+    );
+    expect(result).toEqual([payload]);
+  });
+
+  test('throws when basic auth credentials are wrong', async () => {
+    const payload = {
+      headers: { authorization: basicHeader('user', 'wrong') },
+      rawBody: '',
+    };
+    await expect(
+      catchWebhook.run(
+        buildContext(
+          { authType: 'basic', authFields: { username: 'user', password: 'pass' } },
+          payload
+        )
+      )
+    ).rejects.toThrow('Webhook authentication failed');
+  });
+
+  test('throws when basic auth header is missing', async () => {
+    await expect(
+      catchWebhook.run(
+        buildContext(
+          { authType: 'basic', authFields: { username: 'user', password: 'pass' } },
+          { headers: {}, rawBody: '' }
+        )
+      )
+    ).rejects.toThrow('Webhook authentication failed');
+  });
+
+  test('returns the payload when header auth matches', async () => {
+    const payload = { headers: { 'x-secret': 'expected' }, rawBody: '' };
+    const result = await catchWebhook.run(
+      buildContext(
+        { authType: 'header', authFields: { headerName: 'x-secret', headerValue: 'expected' } },
+        payload
+      )
+    );
+    expect(result).toEqual([payload]);
+  });
+
+  test('throws when header auth value does not match', async () => {
+    await expect(
+      catchWebhook.run(
+        buildContext(
+          { authType: 'header', authFields: { headerName: 'x-secret', headerValue: 'expected' } },
+          { headers: { 'x-secret': 'wrong' }, rawBody: '' }
+        )
+      )
+    ).rejects.toThrow('Webhook authentication failed');
+  });
+
+  test('returns the payload when hmac signature is valid', async () => {
+    const rawBody = JSON.stringify({ event: 'push' });
+    const signature = createHmac('sha256', 'secret').update(rawBody).digest('hex');
+    const payload = { headers: { 'x-signature': signature }, rawBody };
+    const result = await catchWebhook.run(
+      buildContext(
+        {
+          authType: 'hmac',
+          authFields: {
+            hmacHeaderName: 'x-signature',
+            hmacSecret: 'secret',
+            hmacAlgorithm: 'sha256',
+            hmacEncoding: 'hex',
+            hmacSignaturePrefix: '',
+          },
+        },
+        payload
+      )
+    );
+    expect(result).toEqual([payload]);
+  });
+
+  test('throws when hmac signature is invalid', async () => {
+    await expect(
+      catchWebhook.run(
+        buildContext(
+          {
+            authType: 'hmac',
+            authFields: {
+              hmacHeaderName: 'x-signature',
+              hmacSecret: 'secret',
+              hmacAlgorithm: 'sha256',
+              hmacEncoding: 'hex',
+              hmacSignaturePrefix: '',
+            },
+          },
+          { headers: { 'x-signature': 'deadbeef' }, rawBody: '{}' }
+        )
+      )
+    ).rejects.toThrow('Webhook authentication failed');
+  });
+});

--- a/packages/server/worker/src/lib/execute/jobs/execute-webhook.ts
+++ b/packages/server/worker/src/lib/execute/jobs/execute-webhook.ts
@@ -146,6 +146,9 @@ export const executeWebhookJob: JobHandler<WebhookJobData, FireAndForgetJobResul
                 })
             }
         }
+        else {
+            ctx.log.warn({ flow: { id: data.flowId }, flowVersion: { id: flowVersion.id }, status: execResult.status, error: execResult.error }, 'Webhook trigger run did not complete successfully')
+        }
 
         await recordTriggerRun({ apiClient: ctx.apiClient, log: ctx.log, flowVersion, platformId: data.platformId, status: execResult.status })
 


### PR DESCRIPTION
Fixes [GIT-1749](https://linear.app/activepieces/issue/GIT-1749)
Closes #14808

## Problem
1. A `Catch Webhook` trigger with Basic/Header/HMAC auth that receives wrong or missing credentials returned HTTP 200 with no run, no log, and the trigger run recorded COMPLETED. Indistinguishable from "nobody called the webhook", so a misconfigured secret can't be self-diagnosed.
2. On the `/sync` path the trigger step was marked SUCCEEDED with a null payload, so downstream steps crashed on the null trigger output instead of reporting the rejection.

## Fix
- `catch-hook.ts` — `run()` now throws on failed verification instead of returning `[]`, mirroring the existing app-webhook `verifyAppWebhook` pattern. Async path → the trigger run is recorded FAILED (was COMPLETED); sync path → `reportFailedRun` produces a visible FAILED run carrying the auth message. `aiMetadata` description updated to match.
- `execute-webhook.ts` — warn-log with `flowId` when a trigger run does not complete OK.
- webhook piece `0.1.40 → 0.1.41`.

## Verification
- Piece unit tests (8, `test/auth-rejection.test.ts`): none/basic/header/HMAC valid → returns payload; basic/header/HMAC wrong or missing → throws. **Red-first proven**: against pre-fix source the 4 throw-tests fail (received `[]`); pass with the fix.
- Lint `piece-webhook` + `worker`: 0 errors (pre-existing warnings only, none in changed lines).
- Existing `execute-flow-e2e` webhook tests all use `authType: none` (verification always passes), so unaffected; no test asserted the old silent-drop behavior.
- `/verify`: driving a real webhook request through API + worker + engine sandbox is beyond the API-only `/verify` harness; behavior verified via the unit tests (both directions, all 3 auth modes) and a full code trace of both consumption paths.
- Visual: none - backend/runtime-only; no web component, route, locale string, email, or embed change (a rejected webhook now surfaces through the existing FAILED-run display).
- Other affected paths: checked - none. App-webhook triggers already throw on failed verification; `catch_webhook` was the only auth path returning `[]`, and one throw covers both the async and sync consumption paths.
- Product decision embedded: rejections surface as a FAILED trigger run + warn log, not one flow run per request; alternative considered: a visible FAILED flow run per rejected request (rejected: floods the runs list on public URLs hit by bot/probe traffic).

Out of scope: returning HTTP 401 to the caller ([GIT-628](https://linear.app/activepieces/issue/GIT-628)) — the async endpoint returns 200 before the trigger runs, so 401 requires moving auth verification out of the sandbox piece into the API layer; tracked separately.

<details>
<summary>Plan &amp; reasoning</summary>

## Plan
- Root cause (verified in code): `catch_webhook.run()` returned `[]` on auth failure, which is indistinguishable from "no events" for both the async worker (`triggerResult.output.length > 0` gate) and the sync path (`output[0]` = undefined, trigger marked SUCCEEDED).
- Shape chosen: one throw at the single verification choke point, reusing the engine's existing `USER_FAILURE` → FAILED-trigger-run machinery and `reportFailedRun`. This is the same idiom app-webhooks already use, so no new code path, field, or run-creation logic.
- Footprint: ~5 lines product code across 3 files + a regression test. Matches estimate.

## Non-happy scenarios considered
- Public webhook URL hit by probe/bot traffic with bad auth → each request now records a FAILED trigger-run stat + warn log (was silent). Intended (the whole point is visibility); handled by NOT creating a flow run per request, so the runs list is not flooded.
- Sample-data generation (`/test`, saveSampleData) with bad auth → throw skips saving sample data, same net result as the old empty return.
- No-auth (`authType: none`) flows → `verifyAuth` returns true, never throws; completely unaffected.
- Worker job retry/paging → a piece throw is a non-ENGINE (USER) error → `USER_FAILURE`, not `INTERNAL_ERROR`, so no BullMQ retry and no oncall page.

## Alternatives rejected
- Return HTTP 401 (GIT-628): requires auth verification at the API layer; async endpoint already returned 200 before the trigger ran. Separate ticket.
- Create a visible FAILED flow run per rejected request on the async path: floods the runs list on public URLs; more code.
- Special-case empty output in both `execute-webhook.ts` and `flow.operation.ts`: two bandaids on shared infra vs one fix at the choke point.
</details>

## Breaking change?

- [x] no — reviewed, not breaking

## Security impact?

- [x] yes — security-sensitive

Touches the webhook authentication-rejection path. The change makes an already-failing verification visible (throw → FAILED run/stat) rather than silently returning `[]`; it does not alter the verification logic (`verifyAuth`/`verifyHmacAuth` with `timingSafeEqual` unchanged) and introduces no bypass. `/security-review` found no findings; the thrown message and warn-log contain only the auth-type name and flowId, no credentials or PII.