### PR TITLE
fix(logs): stop the warning flood after requests finish and keep those logs

### DIFF
--- a/packages/server/utils/src/agent-ai-utils.ts
+++ b/packages/server/utils/src/agent-ai-utils.ts
@@ -285,7 +285,7 @@ function buildSystemPromptWithCaching({ systemPrompt, provider }: { systemPrompt
 }
 
 function buildTelemetry({ functionId }: { functionId: string }): TelemetryOptions | undefined {
-    const logger = wideEvent.current()
+    const logger = wideEvent.capture()
     if (isNil(logger)) {
         return undefined
     }

--- a/packages/server/utils/src/ap-logger.ts
+++ b/packages/server/utils/src/ap-logger.ts
@@ -35,7 +35,7 @@ function buildLogger(bindings: Record<string, unknown>): ApLogger {
                     wide.info(message ?? 'log', { ...bindings, ...fields })
                 }
                 else {
-                    log.info({ msg: message, ...bindings, ...fields })
+                    log.info({ msg: message, ...wideEvent.correlation(), ...bindings, ...fields })
                 }
             }
             catch {
@@ -50,7 +50,7 @@ function buildLogger(bindings: Record<string, unknown>): ApLogger {
                     wide.warn(message ?? 'log', { ...bindings, ...fields })
                 }
                 else {
-                    log.warn({ msg: message, ...bindings, ...fields })
+                    log.warn({ msg: message, ...wideEvent.correlation(), ...bindings, ...fields })
                 }
             }
             catch {
@@ -68,10 +68,10 @@ function buildLogger(bindings: Record<string, unknown>): ApLogger {
                 }
                 else {
                     if (err) {
-                        log.error({ msg: message ?? err.message, error: `${err.message}\n${err.stack ?? ''}`, ...bindings, ...fields })
+                        log.error({ msg: message ?? err.message, error: `${err.message}\n${err.stack ?? ''}`, ...wideEvent.correlation(), ...bindings, ...fields })
                     }
                     else {
-                        log.error({ msg: message, ...bindings, ...fields })
+                        log.error({ msg: message, ...wideEvent.correlation(), ...bindings, ...fields })
                     }
                 }
             }
@@ -88,10 +88,10 @@ function buildLogger(bindings: Record<string, unknown>): ApLogger {
                 }
                 else {
                     if (err) {
-                        log.error({ msg: message ?? err.message, error: `${err.message}\n${err.stack ?? ''}`, ...bindings, ...fields })
+                        log.error({ msg: message ?? err.message, error: `${err.message}\n${err.stack ?? ''}`, ...wideEvent.correlation(), ...bindings, ...fields })
                     }
                     else {
-                        log.error({ msg: message, ...bindings, ...fields })
+                        log.error({ msg: message, ...wideEvent.correlation(), ...bindings, ...fields })
                     }
                 }
             }

--- a/packages/server/utils/src/wide-event.ts
+++ b/packages/server/utils/src/wide-event.ts
@@ -1,20 +1,35 @@
 import { AsyncLocalStorage } from 'node:async_hooks'
-import { audit as standaloneAudit, AuditInput, RequestLogger, withAuditMethods } from 'evlog'
+import { audit as standaloneAudit, AuditInput, log, RequestLogger, withAuditMethods } from 'evlog'
 
 const als = new AsyncLocalStorage<RequestLogger>()
+const emittedRequestIds = new WeakMap<RequestLogger, string | undefined>()
+const wrappedLoggers = new WeakSet<RequestLogger>()
 
 function run<T>({ logger, fn }: { logger: RequestLogger, fn: () => T }): T {
+    if (!wrappedLoggers.has(logger)) {
+        wrappedLoggers.add(logger)
+        const originalEmit = logger.emit.bind(logger)
+        logger.emit = (overrides) => {
+            const requestId = logger.getContext()['requestId']
+            emittedRequestIds.set(logger, typeof requestId === 'string' ? requestId : undefined)
+            return originalEmit(overrides)
+        }
+    }
     return als.run(logger, fn)
 }
 
 function set(fields: Record<string, unknown>): void {
-    als.getStore()?.set(fields)
+    current()?.set(fields)
 }
 
 function error(err: unknown): void {
     const store = als.getStore()
     if (!store) return
     const wrapped = err instanceof Error ? err : new Error(String(err))
+    if (emittedRequestIds.has(store)) {
+        log.error({ msg: wrapped.message, error: `${wrapped.message}\n${wrapped.stack ?? ''}`, ...correlation() })
+        return
+    }
     store.error(wrapped)
 }
 
@@ -23,18 +38,18 @@ async function timed<T>({ name, fn }: { name: string, fn: () => Promise<T> }): P
     try {
         const result = await fn()
         const ms = Math.round(Date.now() - start)
-        als.getStore()?.set({ timings: { [`${name}Ms`]: ms } })
+        set({ timings: { [`${name}Ms`]: ms } })
         return result
     }
     catch (err) {
         const ms = Math.round(Date.now() - start)
-        als.getStore()?.set({ timings: { [`${name}Ms`]: ms } })
+        set({ timings: { [`${name}Ms`]: ms } })
         throw err
     }
 }
 
 function audit(input: AuditInput): void {
-    const store = als.getStore()
+    const store = current()
     if (store) {
         withAuditMethods(store).audit(input)
         return
@@ -43,7 +58,32 @@ function audit(input: AuditInput): void {
 }
 
 function current(): RequestLogger | undefined {
-    return als.getStore()
+    const store = als.getStore()
+    if (!store || emittedRequestIds.has(store)) {
+        return undefined
+    }
+    return store
+}
+
+function correlation(): Record<string, unknown> {
+    const store = als.getStore()
+    const requestId = store ? emittedRequestIds.get(store) : undefined
+    return requestId ? { requestId } : {}
+}
+
+function capture(): RequestLogger | undefined {
+    const store = current()
+    if (!store) {
+        return undefined
+    }
+    return {
+        ...store,
+        set: (fields) => {
+            if (!emittedRequestIds.has(store)) {
+                store.set(fields)
+            }
+        },
+    }
 }
 
 export const wideEvent = {
@@ -53,4 +93,6 @@ export const wideEvent = {
     timed,
     audit,
     current,
+    correlation,
+    capture,
 }

--- a/packages/server/utils/test/ap-logger-post-emit.test.ts
+++ b/packages/server/utils/test/ap-logger-post-emit.test.ts
@@ -1,0 +1,131 @@
+import { createRequestLogger, initLogger } from 'evlog'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { apLogger } from '../src/ap-logger'
+import { wideEvent } from '../src/wide-event'
+
+function evlogWarnings(warnSpy: ReturnType<typeof vi.spyOn>): string[] {
+    return warnSpy.mock.calls
+        .map((call) => String(call[0]))
+        .filter((line) => line.includes('[evlog]'))
+}
+
+describe('post-emit logging', () => {
+    let warnSpy: ReturnType<typeof vi.spyOn>
+    let infoSpy: ReturnType<typeof vi.spyOn>
+    let errorSpy: ReturnType<typeof vi.spyOn>
+
+    beforeEach(() => {
+        initLogger({ env: { service: 'post-emit-test' }, pretty: false, redact: false })
+        warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+        infoSpy = vi.spyOn(console, 'info').mockImplementation(() => undefined)
+        errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    })
+
+    afterEach(() => {
+        vi.restoreAllMocks()
+    })
+
+    it('apLogger.info after emit falls back to a standalone event with requestId instead of warning', () => {
+        const logger = createRequestLogger({ method: 'GET', path: '/v1/files', requestId: 'req_test123' })
+        wideEvent.run({
+            logger,
+            fn: () => {
+                logger.emit()
+                apLogger.create({}).info({ s3Key: 'project/p1/file' }, 'streaming file to s3')
+            },
+        })
+        expect(evlogWarnings(warnSpy)).toEqual([])
+        const printed = infoSpy.mock.calls.map((call) => String(call[0]))
+        const line = printed.find((entry) => entry.includes('streaming file to s3'))
+        expect(line).toBeDefined()
+        expect(JSON.parse(line ?? '{}')).toMatchObject({ msg: 'streaming file to s3', s3Key: 'project/p1/file', requestId: 'req_test123' })
+    })
+
+    it('apLogger.error after emit reaches stdout at error level instead of being dropped', () => {
+        const logger = createRequestLogger({ method: 'POST', path: '/v1/authentication/sign-in', requestId: 'req_err1' })
+        wideEvent.run({
+            logger,
+            fn: () => {
+                logger.emit()
+                apLogger.create({ bindings: { route: '/v1/authentication/sign-in' } }).error({ error: new Error('boom') }, 'Unhandled exception')
+            },
+        })
+        expect(evlogWarnings(warnSpy)).toEqual([])
+        const printed = errorSpy.mock.calls.map((call) => String(call[0]))
+        const line = printed.find((entry) => entry.includes('Unhandled exception'))
+        expect(line).toBeDefined()
+        expect(JSON.parse(line ?? '{}')).toMatchObject({ msg: 'Unhandled exception', route: '/v1/authentication/sign-in', requestId: 'req_err1' })
+    })
+
+    it('wideEvent.set after emit is silently skipped', () => {
+        const logger = createRequestLogger({ method: 'GET', path: '/v1/webhooks', requestId: 'req_set1' })
+        wideEvent.run({
+            logger,
+            fn: () => {
+                logger.emit()
+                wideEvent.set({ outcome: 'late' })
+            },
+        })
+        expect(evlogWarnings(warnSpy)).toEqual([])
+    })
+
+    it('wideEvent.error after emit falls back to a standalone error event', () => {
+        const logger = createRequestLogger({ method: 'GET', path: '/v1/runs', requestId: 'req_werr' })
+        wideEvent.run({
+            logger,
+            fn: () => {
+                logger.emit()
+                wideEvent.error(new Error('late failure'))
+            },
+        })
+        expect(evlogWarnings(warnSpy)).toEqual([])
+        const printed = errorSpy.mock.calls.map((call) => String(call[0]))
+        const line = printed.find((entry) => entry.includes('late failure'))
+        expect(line).toBeDefined()
+        expect(JSON.parse(line ?? '{}')).toMatchObject({ msg: 'late failure', requestId: 'req_werr' })
+    })
+
+    it('pre-emit logging still lands on the wide event', () => {
+        const logger = createRequestLogger({ method: 'GET', path: '/v1/flows', requestId: 'req_pre1' })
+        wideEvent.run({
+            logger,
+            fn: () => {
+                apLogger.create({}).info({ step: 'load' }, 'loading flow')
+                wideEvent.set({ flowId: 'f1' })
+            },
+        })
+        const context = logger.getContext()
+        expect(context.flowId).toBe('f1')
+        expect(context.requestLogs).toMatchObject([{ level: 'info', message: 'loading flow' }])
+        expect(evlogWarnings(warnSpy)).toEqual([])
+        expect(infoSpy.mock.calls.map((call) => String(call[0])).filter((entry) => entry.includes('loading flow'))).toEqual([])
+    })
+
+    it('captured logger keeps writing before emit and silently drops after emit', () => {
+        const logger = createRequestLogger({ method: 'POST', path: '/v1/agents', requestId: 'req_cap1' })
+        wideEvent.run({
+            logger,
+            fn: () => {
+                const captured = wideEvent.capture()
+                captured?.set({ ai: { model: 'gpt' } })
+                logger.emit()
+                captured?.set({ ai: { tokens: 5 } })
+            },
+        })
+        expect(evlogWarnings(warnSpy)).toEqual([])
+        expect(logger.getContext()['ai']).toEqual({ model: 'gpt' })
+    })
+
+    it('emit called through the logger reference held by the framework still seals for wideEvent callers', () => {
+        const logger = createRequestLogger({ method: 'GET', path: '/v1/jobs', requestId: 'req_job1' })
+        wideEvent.run({ logger, fn: () => undefined })
+        logger.emit()
+        wideEvent.run({
+            logger,
+            fn: () => {
+                expect(wideEvent.current()).toBeUndefined()
+                expect(wideEvent.correlation()).toEqual({ requestId: 'req_job1' })
+            },
+        })
+    })
+})

--- a/packages/server/utils/test/ap-logger.test.ts
+++ b/packages/server/utils/test/ap-logger.test.ts
@@ -39,6 +39,7 @@ vi.mock('../src/wide-event', () => ({
             }
             : undefined,
         set: spies.wideSetSpy,
+        correlation: () => ({}),
     },
 }))
 


### PR DESCRIPTION
Fixes [GIT-1750](https://linear.app/activepieces/issue/GIT-1750)
Closes #14809

## Description

### Problem
1. Any log call that runs after a request's wide event is emitted (streamed S3 uploads, `exceptionHandler.handle` on 500s, webhook/background continuations, worker jobs after `emit()`) makes evlog print `[evlog] log.info() called after the wide event was emitted — Keys dropped: ...` per call. A self-hosted 0.86.3 instance logged 78k of these in 15 minutes (Pylon 5648).
2. The dropped keys (`message`, `route`, `s3Key`, `error`) never reach stdout or the drain, so the real errors are invisible exactly when an incident is being investigated.

### Fix
- `packages/server/utils/src/wide-event.ts` - `wideEvent.run` wraps the logger's `emit` to record the sealed logger (and its `requestId`) in a `WeakMap`; `current()` stops handing out sealed loggers; new `correlation()` exposes the sealed request's id; `set`/`timed` no-op after emit, `error` and `audit` fall back to evlog's standalone `log.error` / `audit`.
- `packages/server/utils/src/ap-logger.ts` - post-emit `info/warn/error/fatal` now fall through to the global evlog `log` (stdout + drain, redaction applied) with `requestId` for correlation, instead of hitting the sealed logger.
- `packages/server/utils/src/agent-ai-utils.ts` - AI telemetry now holds a seal-safe `wideEvent.capture()` facade, so telemetry callbacks that fire after emit stop warning too (evlog's integration calls `set` on the raw logger, bypassing the other guards).

## How was this tested?
- `npm run lint-dev` clean.
- New regression tests (`packages/server/utils/test/ap-logger-post-emit.test.ts`), red-first: 5/6 fail on base (the passing one is the pre-emit control), all pass with the fix; full `server-utils` suite 151/151.
- Repro: booted the API against a throwaway Postgres, drove a healthy sign-in, a DB-down sign-in 500, and recovery on the same process; pre-fix build printed the exact `Keys dropped: route, error` warn and lost the data, fixed build emitted a standalone `Unhandled exception` event with matching `requestId` and zero `[evlog]` lines — full steps in the Reproduction block.
- Visual: none - backend-only logging change, no user-visible surface.
- Other affected paths: checked - `wideEvent.set/error/timed/audit`, `apLogger.child`, AI telemetry (`capture()` facade), worker `jobLogger.emit()` - all sealed via the same choke point. Left as-is: `debug`/`trace` log without `requestId` (pre-existing, hot path), and post-emit worker logs carry no job id (only `requestId` is snapshotted at emit).

<details>
<summary>Plan & reasoning</summary>

## Plan
- Root cause: `ap-logger` routes every `request.log` call into the ALS-stored evlog `RequestLogger` with no awareness that the evlog fastify plugin seals it in its `onResponse`/`onError` hooks; the custom `errorHandler` (and any post-reply work) then logs into the sealed logger.
- One choke point: every logger that can be reached by `apLogger`/`wideEvent` passes through `wideEvent.run`, so wrapping `emit` there seals-marks all of them (fastify plugin emits via property access on the same object; worker emits directly).
- Fallback to evlog's standalone `log` keeps the data on stdout and the drain with the global redact config; `requestId` captured once at emit (WeakMap) keeps correlation without per-line `getContext()` copies.
- Footprint estimate 2 files ~45 lines; actual 3 product files +~50 (third file and the `capture()` facade came out of the review pass closing the AI-telemetry bypass).

## Non-happy scenarios considered
- emit returning `null` (tail-sampled) → logger still sealed, fallback still fires.
- Routes excluded from evlog (health checks) → no ALS logger, unchanged global path.
- Worker job loggers → same wrapper via `wideEvent.run` in `worker.ts`; post-`emit()` logs go standalone.
- evlog `log.fork` children run in the plugin's own storage, not this ALS - unused in this repo today, behavior unchanged.
- `enabled:false` noopLogger singleton would be shared across requests; not reachable (evlog-setup never disables logging).

## Alternatives rejected
- Per-call-site `log.fork()`/reordering (ticket suggestion) → 6+ files, regresses on every future post-emit call site; fastify adapter fork also emits one child wide event per stray line.
- Structured `parseError` shape for the post-emit `wideEvent.error` fallback → standalone events in this codebase already carry `error` as a string; matching that beats introducing a third shape.
- Marking sealed from fastify `onResponse`/`onError` hooks → misses the worker's manual `emit()` and races plugin hook ordering.
- evlog plugin hooks (`onRequestFinish`) → only fires for middleware-created loggers, misses manual emits.
- evlog offers no public sealed-state accessor or post-emit behavior config (verified in 2.22.4 dist), so the property wrap is the narrowest available seam.
</details>

<details>
<summary>Reproduction</summary>

## Environment
- Throwaway Postgres 14 in Docker (`-p 54329:5432`), API booted standalone via `npx tsx packages/server/api/src/bootstrap.ts`, `AP_EDITION=ce`, `AP_REDIS_TYPE=MEMORY`, `AP_LOG_PRETTY=false`, `AP_LOG_LEVEL=info`, `AP_ENVIRONMENT=dev` (seeds `dev@ap.com`).

## Harness
```bash
docker run -d --name ap-verify-pg -e POSTGRES_PASSWORD=ap -e POSTGRES_USER=ap \
  -e POSTGRES_DB=activepieces -p 54329:5432 postgres:14
bun install && npx turbo run build --filter=@activepieces/server-utils \
  --filter=@activepieces/shared --filter=@activepieces/core-utils \
  --filter=@activepieces/core-piece-types --filter=@activepieces/core-formula \
  --filter=@activepieces/core-execution --filter=@activepieces/ai-providers \
  --filter=@activepieces/piece-delay --filter=@activepieces/piece-facebook-leads \
  --filter=@activepieces/piece-intercom --filter=@activepieces/piece-slack \
  --filter=@activepieces/piece-square
# env: packages/server/api/.env.tests + the overrides above + AP_DB_TYPE=POSTGRES,
# AP_POSTGRES_HOST=127.0.0.1, AP_POSTGRES_PORT=54329, AP_POSTGRES_USERNAME=ap,
# AP_POSTGRES_PASSWORD=ap, AP_POSTGRES_DATABASE=activepieces, AP_QUEUE_MODE=MEMORY,
# AP_CONTAINER_TYPE=APP, AP_PIECES_SYNC_MODE=NONE, AP_PORT=3111
npx tsx --tsconfig packages/server/api/tsconfig.app.json packages/server/api/src/bootstrap.ts
```

## Trigger
```bash
docker stop ap-verify-pg
curl -s -X POST http://127.0.0.1:3111/api/v1/authentication/sign-in \
  -H 'Content-Type: application/json' -d '{"email":"dev@ap.com","password":"12345678"}'
```
The evlog fastify plugin seals the wide event in its own `onError` hook; the custom `errorHandler` then calls `exceptionHandler.handle(error, request.log)`, a post-emit `log.error()`. DB-down sign-in is the deterministic stand-in for the customer's sign-in 500.

## Results
| Build | stdout after the 500 |
|---|---|
| base (43320560fa) | wide event, then `[evlog] log.error() called after the wide event was emitted — Keys dropped: route, error. ...`; the "Unhandled exception" data is lost |
| this PR | wide event, then `{"level":"error","msg":"Unhandled exception","error":"connect ECONNREFUSED...","requestId":"req_...","route":"/api/v1/authentication/sign-in"}`; zero `[evlog]` lines |

Inverse drive on the same fixed process: `docker start ap-verify-pg`, sign-in → 200, wide event carries `requestLogs` normally.
</details>

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)
