### PR TITLE
fix(tables): index cell(recordId) so record deletes stop seq scanning

### DIFF
--- a/brain/knowledge/data-storage-observability/tables.md
+++ b/brain/knowledge/data-storage-observability/tables.md
@@ -29,6 +29,7 @@ A built-in relational database inside Activepieces: users store structured data 
 - The per-create `field.validateCount()` check alone races on bulk paths: all concurrent creates read the same pre-save count and pass. Bulk/import paths (`table.create` with fields, project-state/project-replace apply) MUST call it once up front with the batch size **before** their `Promise.all`.
 - Concurrent field reorders are last-write-wins, same as rename — no distributed lock. Reordering *existing* fields through project-release apply is not supported: `FieldState` carries no position, so array order only applies to newly created fields.
 - The web client stores positional `cell.fieldIndex` references, so it must remap every record's cells when fields move.
+- `cell` FKs cascade from `record`, `field` and `project`, so any delete on those parents needs a leading-column index on the matching `cell` column or Postgres seq-scans `cell` once per deleted row. `idx_cell_project_id_field_id_record_id_unique` does **not** serve the record cascade (`recordId` is its 3rd column) — a production `DELETE FROM "record"` built a 15-session lock convoy off that seq scan until `idx_cell_record_id` was added. Same trap applies to any new cascading child table.
 
 ### Key files
 Entry point: `tablesModule`, registered in `packages/server/api/src/app/app.ts` and mounting the three controllers under `/v1/tables`, `/v1/fields`, `/v1/records`.

--- a/packages/server/api/src/app/database/migration/postgres/1830000000000-AddCellRecordIdIndex.ts
+++ b/packages/server/api/src/app/database/migration/postgres/1830000000000-AddCellRecordIdIndex.ts
@@ -1,0 +1,33 @@
+import { QueryRunner } from 'typeorm'
+import { system } from '../../../helper/system/system'
+import { AppSystemProp } from '../../../helper/system/system-props'
+import { DatabaseType } from '../../database-type'
+import { Migration } from '../../migration'
+
+export class AddCellRecordIdIndex1830000000000 implements Migration {
+    name = 'AddCellRecordIdIndex1830000000000'
+    breaking = false
+    release = '0.88.4'
+    transaction = false
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        if (isPGlite()) {
+            await queryRunner.query(`
+                CREATE INDEX IF NOT EXISTS "idx_cell_record_id"
+                ON "cell" ("recordId")
+            `)
+        }
+        else {
+            await queryRunner.query(`
+                CREATE INDEX CONCURRENTLY IF NOT EXISTS "idx_cell_record_id"
+                ON "cell" ("recordId")
+            `)
+        }
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query('DROP INDEX IF EXISTS "idx_cell_record_id"')
+    }
+}
+
+const isPGlite = (): boolean => system.get(AppSystemProp.DB_TYPE) === DatabaseType.PGLITE

--- a/packages/server/api/src/app/database/postgres-connection.ts
+++ b/packages/server/api/src/app/database/postgres-connection.ts
@@ -420,6 +420,7 @@ import { AddAgentIdToAgentConversation1826000000000 } from './migration/postgres
 import { AddVersionToOtp1827000000000 } from './migration/postgres/1827000000000-AddVersionToOtp'
 import { DropChatbot1828000000000 } from './migration/postgres/1828000000000-DropChatbot'
 import { AddFilePlatformIdIndex1829000000000 } from './migration/postgres/1829000000000-AddFilePlatformIdIndex'
+import { AddCellRecordIdIndex1830000000000 } from './migration/postgres/1830000000000-AddCellRecordIdIndex'
 
 const getSslConfig = (): boolean | TlsOptions => {
     const useSsl = system.get(AppSystemProp.POSTGRES_USE_SSL)
@@ -855,6 +856,7 @@ export const getMigrations = (): (new () => Migration)[] => {
         AddVersionToOtp1827000000000,
         DropChatbot1828000000000,
         AddFilePlatformIdIndex1829000000000,
+        AddCellRecordIdIndex1830000000000,
     ]
     return migrations
 }

--- a/packages/server/api/src/app/tables/record/cell.entity.ts
+++ b/packages/server/api/src/app/tables/record/cell.entity.ts
@@ -34,6 +34,10 @@ export const CellEntity = new EntitySchema<CellSchema>({
             columns: ['projectId', 'fieldId', 'recordId'],
             unique: true,
         },
+        {
+            name: 'idx_cell_record_id',
+            columns: ['recordId'],
+        },
     ],
     relations: {
         record: {


### PR DESCRIPTION
## Description

Adds a plain index on `cell("recordId")`, created with `CREATE INDEX CONCURRENTLY`.

**Why:** `cell.fk_cell_record_id` is `ON DELETE CASCADE` to `record`, but the only index containing `recordId` today is `idx_cell_project_id_field_id_record_id_unique ("projectId", "fieldId", "recordId")` — `recordId` is the 3rd column, so Postgres cannot use it for the cascade lookup. Every deleted `record` row therefore forces a full scan of `cell`.

On a production instance this took down the database: a routine business-hours `DELETE FROM "record"` built a lock convoy that grew 8 → 11 → 15 sessions in 15 minutes, oldest session open for 22m56s, 79–150 lock waits/hour. `EXPLAIN` on the cascade lookup, against a 254 MB `cell` table:

```
Parallel Seq Scan on cell  (cost=0.00..16055.91)
  Filter: (("recordId")::text = ($0)::text)
```

After `CREATE INDEX CONCURRENTLY idx_cell_record_id ON cell ("recordId")` the same lookup becomes an `Index Only Scan` at ~0.1 ms, and the convoy disappeared.

This is not specific to that instance: any deployment whose Tables usage grows enough that a record delete (single record, table delete, or retention cleanup) touches a large `cell` table will hit the same seq scan, and the cost grows with `cell` size. It is a missing-index bug in the schema, not a tuning knob.

Changes:
- migration `1830000000000-AddCellRecordIdIndex` — `CREATE INDEX CONCURRENTLY IF NOT EXISTS` outside a transaction (`transaction = false`), with the plain `CREATE INDEX` fallback for PGLite, mirroring `1829000000000-AddFilePlatformIdIndex`
- `CellEntity.indices` gets the matching entry so `migration:generate` does not try to drop it
- `down()` drops the index — fully rollbackable, `breaking = false`

## How was this tested?

- `npx tsx tools/scripts/check-migration-rollback.ts` — passes
- `npx turbo run lint --filter=api` — 0 errors
- Verified on the affected Postgres instance: cascade plan goes from `Parallel Seq Scan on cell` to `Index Only Scan using idx_cell_record_id` (~0.1 ms), lock waits on `DELETE FROM "record"` stop
- Schema-only change, no edition-specific code paths (CE / EE / Cloud all share the `cell` table)

Fixes # (issue)

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)
