### PR TITLE
fix(pieces): ship oracle-database forked runner in the bundle and keep oracledb dep

### DIFF
--- a/docs/build-pieces/misc/bundling-pieces.mdx
+++ b/docs/build-pieces/misc/bundling-pieces.mdx
@@ -46,6 +46,21 @@ If a dependency must not be inlined (for example a native module), add it to a `
 }
 ```
 
+### Files loaded at runtime (forked processes)
+
+A file your piece loads by path at runtime — for example `child_process.fork(path.join(__dirname, 'runner.js'))` — is invisible to the bundler's import graph, so by default it would not exist in the published package. Declare it in `bundleForkedEntries`:
+
+```jsonc
+{
+  "name": "@activepieces/piece-oracle-database",
+  "bundleForkedEntries": ["src/lib/common/oracle-runner.ts"]
+}
+```
+
+Each declared entry is bundled on its own and emitted **next to the main bundle** at `src/<name>.js` — which is where `path.join(__dirname, '<name>.js')` resolves at runtime, since the bundled parent code lives at `src/index.js`. Dependencies that only the forked file imports (e.g. `oracledb`) are still captured into the published `dependencies`.
+
+The bundler **fails the build** if piece code uses `__dirname` without declaring any `bundleForkedEntries`, because such code breaks silently after publishing.
+
 ### Building and publishing
 
 Bundling happens automatically when you build or publish a piece:

--- a/docs/install/reference/breaking-changes.mdx
+++ b/docs/install/reference/breaking-changes.mdx
@@ -8,6 +8,14 @@ icon: "hammer"
 
 ### What has changed?
 
+#### Piece builds fail when piece code uses `__dirname` without declaring `bundleForkedEntries`
+
+The piece bundler now emits files a piece loads by path at runtime (for example a `child_process.fork` target) beside the main bundle, when they are declared in a `bundleForkedEntries` array in the piece's `package.json`, and it keeps dependencies that only those files import in the published manifest. Because an undeclared `__dirname`-relative file access always breaks after publishing — this is exactly how `@activepieces/piece-oracle-database` 0.1.11/0.1.12 shipped with every new connection failing — the build now fails loudly when a piece's source references `__dirname` and declares no forked entries. Previously such a piece built successfully and shipped broken.
+
+#### What you need to do
+
+Nothing for catalog pieces — oracle-database is the only piece that forks a sibling file, and this change fixes it (0.1.13). If you build custom pieces and one references `__dirname`, either declare the runtime-loaded file in `bundleForkedEntries` (see [Bundling Pieces](/build-pieces/misc/bundling-pieces)) or remove the `__dirname` usage. Already-published pieces keep working; the check runs at build time only.
+
 #### MCP OAuth: revoking a token requires a client identity, and registration issues a usable secret
 
 Two changes to the MCP OAuth endpoints:

--- a/packages/cli/src/lib/utils/bundle-piece-utils.test.ts
+++ b/packages/cli/src/lib/utils/bundle-piece-utils.test.ts
@@ -143,4 +143,19 @@ describe('bundlePiece — forked sibling entries (GIT-1772)', () => {
         await expect(bundlePieceUtils.bundlePiece({ piecePath, distPath: join(piecePath, 'dist'), repoRoot: root! }))
             .rejects.toThrow(/no file at/)
     })
+
+    it('fails loudly when two declared entries collide on the same output name', async () => {
+        const piecePath = setupForkingPiece({ declareEntry: true })
+        mkdirSync(join(piecePath, 'src', 'lib', 'other'), { recursive: true })
+        writeFileSync(join(piecePath, 'src', 'lib', 'other', 'runner.ts'), 'export const other = true\n')
+        writeFileSync(join(piecePath, 'package.json'), JSON.stringify({
+            name: 'piece-forking',
+            version: '0.0.1',
+            dependencies: { oracledb: '6.10.0' },
+            bundleForkedEntries: ['src/lib/runner.ts', 'src/lib/other/runner.ts'],
+        }))
+
+        await expect(bundlePieceUtils.bundlePiece({ piecePath, distPath: join(piecePath, 'dist'), repoRoot: root! }))
+            .rejects.toThrow(/collides with another declared entry/)
+    })
 })

--- a/packages/cli/src/lib/utils/bundle-piece-utils.test.ts
+++ b/packages/cli/src/lib/utils/bundle-piece-utils.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs'
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, readFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, describe, expect, it } from 'vitest'
@@ -80,5 +80,67 @@ describe('bundlePiece — external dependency capture', () => {
 
         expect(result.external).toContain('esm-dep')
         expect(result.inlined).not.toContain('esm-dep')
+    })
+})
+
+describe('bundlePiece — forked sibling entries (GIT-1772)', () => {
+    let root: string | undefined
+
+    afterEach(() => {
+        if (root) {
+            rmSync(root, { recursive: true, force: true })
+            root = undefined
+        }
+    })
+
+    function setupForkingPiece({ declareEntry }: { declareEntry: boolean }): string {
+        root = mkdtempSync(join(tmpdir(), 'ap-bundle-'))
+
+        const dbDir = join(root, 'node_modules', 'oracledb')
+        mkdirSync(dbDir, { recursive: true })
+        writeFileSync(join(dbDir, 'package.json'), JSON.stringify({ name: 'oracledb', version: '6.10.0', main: 'index.js' }))
+        writeFileSync(join(dbDir, 'index.js'), 'module.exports = {};\n')
+
+        const piecePath = join(root, 'piece')
+        mkdirSync(join(piecePath, 'src', 'lib'), { recursive: true })
+        writeFileSync(join(piecePath, 'package.json'), JSON.stringify({
+            name: 'piece-forking',
+            version: '0.0.1',
+            dependencies: { oracledb: '6.10.0' },
+            ...(declareEntry ? { bundleForkedEntries: ['src/lib/runner.ts'] } : {}),
+        }))
+        writeFileSync(join(piecePath, 'src', 'index.ts'), 'import { start } from \'./lib/pool\'\nexport const piece = { start }\n')
+        writeFileSync(join(piecePath, 'src', 'lib', 'pool.ts'), 'import { fork } from \'child_process\'\nimport { join } from \'path\'\nexport const start = () => fork(join(__dirname, \'runner.js\'))\n')
+        writeFileSync(join(piecePath, 'src', 'lib', 'protocol.ts'), 'export const READY_MESSAGE = \'runner-ready\'\n')
+        writeFileSync(join(piecePath, 'src', 'lib', 'runner.ts'), 'import db from \'oracledb\'\nimport { READY_MESSAGE } from \'./protocol\'\nconsole.log(READY_MESSAGE, db)\n')
+        mkdirSync(join(piecePath, 'dist'), { recursive: true })
+        return piecePath
+    }
+
+    it('emits a declared forked entry beside the main bundle and keeps its native dep external', async () => {
+        const piecePath = setupForkingPiece({ declareEntry: true })
+
+        const result = await bundlePieceUtils.bundlePiece({ piecePath, distPath: join(piecePath, 'dist'), repoRoot: root! })
+
+        expect(result.extraBundleFiles).toEqual(['src/runner.js'])
+        const runnerBundle = readFileSync(join(piecePath, 'dist', 'src', 'runner.js'), 'utf-8')
+        expect(runnerBundle).toContain('runner-ready')
+        expect(runnerBundle).toContain('require("oracledb")')
+        expect(result.external).toContain('oracledb')
+    })
+
+    it('fails loudly when piece source uses __dirname without declaring a forked entry', async () => {
+        const piecePath = setupForkingPiece({ declareEntry: false })
+
+        await expect(bundlePieceUtils.bundlePiece({ piecePath, distPath: join(piecePath, 'dist'), repoRoot: root! }))
+            .rejects.toThrow(/bundleForkedEntries/)
+    })
+
+    it('fails loudly on a declared entry that does not exist', async () => {
+        const piecePath = setupForkingPiece({ declareEntry: true })
+        rmSync(join(piecePath, 'src', 'lib', 'runner.ts'))
+
+        await expect(bundlePieceUtils.bundlePiece({ piecePath, distPath: join(piecePath, 'dist'), repoRoot: root! }))
+            .rejects.toThrow(/no file at/)
     })
 })

--- a/packages/cli/src/lib/utils/bundle-piece-utils.test.ts
+++ b/packages/cli/src/lib/utils/bundle-piece-utils.test.ts
@@ -158,4 +158,19 @@ describe('bundlePiece — forked sibling entries (GIT-1772)', () => {
         await expect(bundlePieceUtils.bundlePiece({ piecePath, distPath: join(piecePath, 'dist'), repoRoot: root! }))
             .rejects.toThrow(/collides with another declared entry/)
     })
+
+    it('fails loudly when two declared entries collide on output name differing only by case', async () => {
+        const piecePath = setupForkingPiece({ declareEntry: true })
+        mkdirSync(join(piecePath, 'src', 'lib', 'other'), { recursive: true })
+        writeFileSync(join(piecePath, 'src', 'lib', 'other', 'RUNNER.ts'), 'export const other = true\n')
+        writeFileSync(join(piecePath, 'package.json'), JSON.stringify({
+            name: 'piece-forking',
+            version: '0.0.1',
+            dependencies: { oracledb: '6.10.0' },
+            bundleForkedEntries: ['src/lib/runner.ts', 'src/lib/other/RUNNER.ts'],
+        }))
+
+        await expect(bundlePieceUtils.bundlePiece({ piecePath, distPath: join(piecePath, 'dist'), repoRoot: root! }))
+            .rejects.toThrow(/collides with another declared entry/)
+    })
 })

--- a/packages/cli/src/lib/utils/bundle-piece-utils.ts
+++ b/packages/cli/src/lib/utils/bundle-piece-utils.ts
@@ -73,6 +73,9 @@ async function bundleForkedEntries({ piecePath, distPath, repoRoot, manifest, in
         if (outRel === BUNDLE_FILENAME) {
             throw new Error(`[bundlePiece] bundleForkedEntries: "${entry}" collides with the main bundle at ${BUNDLE_FILENAME}`)
         }
+        if (files.includes(outRel)) {
+            throw new Error(`[bundlePiece] bundleForkedEntries: "${entry}" collides with another declared entry at ${outRel}`)
+        }
         const outfile = join(distPath, outRel)
         let pass = await runEsbuild({ entryFile, outfile, repoRoot, inlineAll, inlineList, external: new Set(excludeList) })
         const unsafe = new Set([

--- a/packages/cli/src/lib/utils/bundle-piece-utils.ts
+++ b/packages/cli/src/lib/utils/bundle-piece-utils.ts
@@ -73,7 +73,7 @@ async function bundleForkedEntries({ piecePath, distPath, repoRoot, manifest, in
         if (outRel === BUNDLE_FILENAME) {
             throw new Error(`[bundlePiece] bundleForkedEntries: "${entry}" collides with the main bundle at ${BUNDLE_FILENAME}`)
         }
-        if (files.includes(outRel)) {
+        if (files.some((file) => file.toLowerCase() === outRel.toLowerCase())) {
             throw new Error(`[bundlePiece] bundleForkedEntries: "${entry}" collides with another declared entry at ${outRel}`)
         }
         const outfile = join(distPath, outRel)

--- a/packages/cli/src/lib/utils/bundle-piece-utils.ts
+++ b/packages/cli/src/lib/utils/bundle-piece-utils.ts
@@ -1,6 +1,6 @@
 import { statSync, existsSync, readFileSync } from 'node:fs'
 import { builtinModules } from 'node:module'
-import { join, resolve, isAbsolute } from 'node:path'
+import { join, resolve, isAbsolute, basename, sep } from 'node:path'
 import * as esbuild from 'esbuild'
 
 async function bundlePiece({ piecePath, distPath, repoRoot }: BundlePieceParams): Promise<BundleResult> {
@@ -46,13 +46,82 @@ async function bundlePiece({ piecePath, distPath, repoRoot }: BundlePieceParams)
         }
     }
 
+    assertDirnameUsageDeclared({ piecePath, metafile: pass.result.metafile, manifest })
+    const forked = await bundleForkedEntries({ piecePath, distPath, repoRoot, manifest, inlineAll, inlineList, excludeList })
+    for (const dep of forked.externalized) {
+        pass.externalized.add(dep)
+    }
+
     const bundleBytes = statSync(outfile).size
     const rawBytes = totalInputBytes(pass.result.metafile)
     const external = [...pass.externalized].filter((dep) => !dep.startsWith('@activepieces/') && !BUNDLE_HELPER_DEPS.has(dep))
 
     enforceSizeGate({ piecePath, bundleBytes })
 
-    return { bundleFile: outfile, bundleBytes, rawBytes, external, inlined: [...pass.inlined] }
+    return { bundleFile: outfile, bundleBytes, rawBytes, external, inlined: [...pass.inlined], extraBundleFiles: forked.files }
+}
+
+async function bundleForkedEntries({ piecePath, distPath, repoRoot, manifest, inlineAll, inlineList, excludeList }: ForkedEntriesParams): Promise<ForkedEntriesResult> {
+    const files: string[] = []
+    const externalized = new Set<string>()
+    for (const entry of manifest.bundleForkedEntries ?? []) {
+        const entryFile = join(piecePath, entry)
+        if (!existsSync(entryFile)) {
+            throw new Error(`[bundlePiece] bundleForkedEntries: no file at ${entryFile}`)
+        }
+        const outRel = `src/${basename(entry).replace(/\.ts$/, '.js')}`
+        if (outRel === BUNDLE_FILENAME) {
+            throw new Error(`[bundlePiece] bundleForkedEntries: "${entry}" collides with the main bundle at ${BUNDLE_FILENAME}`)
+        }
+        const outfile = join(distPath, outRel)
+        let pass = await runEsbuild({ entryFile, outfile, repoRoot, inlineAll, inlineList, external: new Set(excludeList) })
+        const unsafe = new Set([
+            ...unsafePackages({ metafile: pass.result.metafile, warnings: pass.result.warnings }),
+            ...importMetaPackages(pass.result.metafile),
+        ])
+        if (unsafe.size > 0) {
+            pass = await runEsbuild({ entryFile, outfile, repoRoot, inlineAll, inlineList, external: new Set([...excludeList, ...unsafe]) })
+        }
+        const issues = gateBundle({ metafile: pass.result.metafile, warnings: pass.result.warnings })
+        if (issues.length > 0) {
+            throw new Error(`[bundlePiece] ${piecePath} forked entry "${entry}" failed the safety gate:\n  - ${issues.join('\n  - ')}`)
+        }
+        enforceSizeGate({ piecePath: `${piecePath} (${entry})`, bundleBytes: statSync(outfile).size })
+        files.push(outRel)
+        for (const dep of pass.externalized) {
+            externalized.add(dep)
+        }
+    }
+    return { files, externalized }
+}
+
+function assertDirnameUsageDeclared({ piecePath, metafile, manifest }: DirnameGateParams): void {
+    if ((manifest.bundleForkedEntries ?? []).length > 0) {
+        return
+    }
+    const pieceRoot = resolve(piecePath)
+    for (const input of Object.keys(metafile.inputs)) {
+        const abs = resolve(process.cwd(), input)
+        if (!abs.startsWith(pieceRoot + sep) || abs.includes(`${sep}node_modules${sep}`)) {
+            continue
+        }
+        if (/\b__dirname\b/.test(safeReadFile(abs))) {
+            throw new Error(
+                `[bundlePiece] ${input} uses __dirname but the piece declares no bundleForkedEntries. `
+                + 'The published piece is a single bundled src/index.js, so __dirname-relative file access breaks after publish. '
+                + 'Declare the runtime-loaded file in package.json "bundleForkedEntries" (it will be emitted beside the bundle), or remove the __dirname usage.',
+            )
+        }
+    }
+}
+
+function safeReadFile(file: string): string {
+    try {
+        return readFileSync(file, 'utf-8')
+    }
+    catch {
+        return ''
+    }
 }
 
 async function runEsbuild({ entryFile, outfile, repoRoot, inlineAll, inlineList, external }: RunEsbuildParams): Promise<EsbuildPass> {
@@ -337,6 +406,7 @@ export type BundleResult = {
     rawBytes: number
     external: string[]
     inlined: string[]
+    extraBundleFiles: string[]
 }
 
 type InlineConfig = {
@@ -363,6 +433,28 @@ type RunEsbuildParams = {
 type PieceManifest = {
     dependencies?: Record<string, string>
     bundleDeps?: boolean | string[]
+    bundleForkedEntries?: string[]
+}
+
+type ForkedEntriesParams = {
+    piecePath: string
+    distPath: string
+    repoRoot: string
+    manifest: PieceManifest
+    inlineAll: boolean
+    inlineList: Set<string>
+    excludeList: Set<string>
+}
+
+type ForkedEntriesResult = {
+    files: string[]
+    externalized: Set<string>
+}
+
+type DirnameGateParams = {
+    piecePath: string
+    metafile: esbuild.Metafile
+    manifest: PieceManifest
 }
 
 type ExternalizeParams = {

--- a/packages/cli/src/lib/utils/prepare-piece-utils.test.ts
+++ b/packages/cli/src/lib/utils/prepare-piece-utils.test.ts
@@ -89,6 +89,16 @@ describe('rewriteManifestForBundle', () => {
         expect(manifestOf(distPath).dependencies).toEqual({ pg: '8.11.3' })
     })
 
+    it('publishes forked entry bundles alongside the main bundle', () => {
+        const { distPath, repoRoot } = setup({ oracledb: '6.10.0' })
+
+        rewriteManifestForBundle({ distPath, external: ['oracledb'], repoRoot, extraBundleFiles: ['src/oracle-runner.js'] })
+
+        const manifest = manifestOf(distPath)
+        expect(manifest.files).toEqual(['src/index.js', 'src/oracle-runner.js', 'package.json', 'src/i18n'])
+        expect(manifest.bundleForkedEntries).toBeUndefined()
+    })
+
     it('leaves an optional peer dependency out instead of failing on it', () => {
         const { distPath, repoRoot } = setup({ pg: '8.11.3' })
 

--- a/packages/cli/src/lib/utils/prepare-piece-utils.ts
+++ b/packages/cli/src/lib/utils/prepare-piece-utils.ts
@@ -39,21 +39,22 @@ async function preparePieceDistForPublish(piecePath: string): Promise<void> {
     copyPackageJson(paths)
     copyI18nAssets(paths)
 
-    const { bundleBytes, rawBytes, external } = await bundlePieceUtils.bundlePiece({ ...paths, repoRoot })
+    const { bundleBytes, rawBytes, external, extraBundleFiles } = await bundlePieceUtils.bundlePiece({ ...paths, repoRoot })
 
-    rewriteManifestForBundle({ distPath, external, repoRoot })
+    rewriteManifestForBundle({ distPath, external, repoRoot, extraBundleFiles })
     pruneDistToPublishedFiles({ distPath })
 
     const ratio = rawBytes > 0 ? (rawBytes / bundleBytes).toFixed(1) : '—'
     const extNote = external.length ? ` external=[${external.join(', ')}]` : ''
-    console.info(`[preparePiece] bundled ${piecePath} → ${(bundleBytes / 1024).toFixed(0)} KB (${ratio}x smaller than ${(rawBytes / 1024).toFixed(0)} KB raw inputs)${extNote}`)
+    const forkNote = extraBundleFiles.length ? ` forked=[${extraBundleFiles.join(', ')}]` : ''
+    console.info(`[preparePiece] bundled ${piecePath} → ${(bundleBytes / 1024).toFixed(0)} KB (${ratio}x smaller than ${(rawBytes / 1024).toFixed(0)} KB raw inputs)${extNote}${forkNote}`)
 }
 
 // The published artifact inlines @activepieces/* workspace code AND third-party deps into the
 // self-contained bundle by default. Only deps that cannot be safely inlined (native addons,
 // dynamic require) stay external and are kept here so the runtime installer resolves them.
 // A piece can force a dep external via bundleDeps in its package.json (escape hatch).
-function rewriteManifestForBundle({ distPath, external, repoRoot }: { distPath: string, external: string[], repoRoot: string }): void {
+function rewriteManifestForBundle({ distPath, external, repoRoot, extraBundleFiles = [] }: { distPath: string, external: string[], repoRoot: string, extraBundleFiles?: string[] }): void {
     const distPackageJsonPath = join(distPath, 'package.json')
     const json = JSON.parse(readFileSync(distPackageJsonPath, 'utf-8'))
 
@@ -79,7 +80,8 @@ function rewriteManifestForBundle({ distPath, external, repoRoot }: { distPath: 
     delete json.scripts
     delete json.types
     delete json.bundleDeps
-    json.files = [bundlePieceUtils.BUNDLE_FILENAME, 'package.json', 'src/i18n']
+    delete json.bundleForkedEntries
+    json.files = [bundlePieceUtils.BUNDLE_FILENAME, ...extraBundleFiles, 'package.json', 'src/i18n']
 
     writeFileSync(distPackageJsonPath, JSON.stringify(json, null, 2) + '\n')
 }

--- a/packages/pieces/community/oracle-database/package.json
+++ b/packages/pieces/community/oracle-database/package.json
@@ -1,9 +1,10 @@
 {
   "name": "@activepieces/piece-oracle-database",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
+  "bundleForkedEntries": ["src/lib/common/oracle-runner.ts"],
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",


### PR DESCRIPTION
## Problem

Every new Oracle Database connection fails with `Oracle runner exited (code 1)` on published `0.1.11`/`0.1.12` (0.1.10 last good). The self-contained bundle pipeline emits a single minified `src/index.js`, but the piece forks `oracle-runner.js` as a child process at runtime — that file was never emitted, and `oracledb` (imported only by the forked child, invisible to esbuild's trace) was dropped from the published `dependencies`. The child dies with `MODULE_NOT_FOUND` before any network attempt, in both thin and thick mode.

## Fix

- **Bundler**: new piece-manifest field `bundleForkedEntries`. Each declared file is bundled separately and emitted at `src/<name>.js` beside the main bundle — which is where the bundled parent's `__dirname` resolves. Dependencies that only the forked file imports are merged into the published `dependencies`.
- **Build gate**: the bundle now fails if piece code uses `__dirname` without declaring `bundleForkedEntries`, so this class of breakage cannot ship silently again. Scanned the whole catalog: oracle-database is the only piece that trips it (the pdf piece's `child_process` use only execs a system binary).
- **Piece**: declares `src/lib/common/oracle-runner.ts`, bumped to `0.1.13`.
- Docs section in `bundling-pieces.mdx`; 4 new tests.

## Verification

Tested against a local Oracle Free 23 container through the actual packed artifacts, exercising the piece's Instant Client self-provisioning for thick mode:

| Artifact | Thin | Thick |
|---|---|---|
| 0.1.10 (last good) | ✅ valid | ✅ valid |
| 0.1.12 (published) | ❌ `Cannot find module .../src/oracle-runner.js` | ❌ same |
| 0.1.13 (this PR, rebuilt) | ✅ valid | ✅ valid |

The rebuilt tarball ships `src/index.js` + `src/oracle-runner.js` with `"oracledb": "6.10.0"` in `dependencies`. All 31 CLI tests pass; lint and turbo build green.

Fixes #14959



### Breaking change?  (required — CI fails if this is left unedited)

- [ ] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [x] yes — functional (default/limit/behaviour change, new self-hosted setup step) — the bundler now fails the build when piece code uses `__dirname` without declaring `bundleForkedEntries` (such builds previously succeeded and shipped broken). Documented in docs/install/reference/breaking-changes.mdx.

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)
