### PR TITLE
fix(engine): raise flow-rerun test timeout to 30s

### DIFF
--- a/packages/server/engine/test/handler/flow-rerun.test.ts
+++ b/packages/server/engine/test/handler/flow-rerun.test.ts
@@ -44,7 +44,7 @@ describe('flow retry', () => {
         })
         expect(failedResult.verdict.status).toBe(FlowRunStatus.FAILED)
         expect(retryEntireFlow.verdict.status).toBe(FlowRunStatus.RUNNING)
-    }, 10000)
+    }, 30000)
 
     it('should retry flow from failed step', async () => {
         const context = FlowExecutorContext.empty()
@@ -58,5 +58,5 @@ describe('flow retry', () => {
         })
         expect(failedResult.verdict.status).toBe(FlowRunStatus.FAILED)
         expect(retryFromFailed.verdict.status).toBe(FlowRunStatus.RUNNING)
-    }, 10000)
+    }, 30000)
 })


### PR DESCRIPTION
## Description

Bumps the per-test timeout in `packages/server/engine/test/handler/flow-rerun.test.ts` from 10s to 30s (2-line change).

This test is the current top CI flake. Each of its two tests makes **two live HTTP calls to `cloud.activepieces.com`** — one expecting a 404, and one `GET /api/v1/pieces` (the full catalog endpoint) — under a 10s budget. The happy path already takes ~9s, so any elevated cloud latency tips it over the line.

Tonight it failed the `CI / main` job **three times** on #14966 (a pieces-metadata-only PR that does not touch the engine), timing out at **10,022ms / 10,031ms / 10,033ms** — always within ~35ms of the limit:

- https://github.com/activepieces/activepieces/actions/runs/32434894096 (attempt 1)
- https://github.com/activepieces/activepieces/actions/runs/32438798897 (attempts 1 & 2)

**Alternative considered:** mocking the HTTP calls (or pointing the success case at a lighter endpoint like `/api/v1/flags`) would remove the network dependency entirely — happy to do that instead if preferred; this PR is the minimal unblock.

## How was this tested?

CI on this PR runs the engine test suite (`CI / main`), which executes the changed test with the new 30s budget. Test-only change; no runtime code touched.

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)