### PR TITLE
feat(telegram-bot): improve prop UI for human-facing actions

### DIFF
--- a/packages/pieces/community/telegram-bot/package.json
+++ b/packages/pieces/community/telegram-bot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-telegram-bot",
-  "version": "0.6.9",
+  "version": "0.6.10",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {

--- a/packages/pieces/community/telegram-bot/src/index.ts
+++ b/packages/pieces/community/telegram-bot/src/index.ts
@@ -1,4 +1,4 @@
-import { createCustomApiCallAction } from '@activepieces/pieces-common';
+import { createCustomApiCallAction, httpClient, HttpMethod } from '@activepieces/pieces-common';
 import { PieceAuth, createPiece } from '@activepieces/pieces-framework';
 import { PieceCategory } from '@activepieces/pieces-framework';
 import { telegramAnswerCallbackQueryAction } from './lib/action/answer-callback-query.action';
@@ -59,6 +59,24 @@ export const telegramBotAuth = PieceAuth.SecretText({
   displayName: 'Bot Token',
   description: markdownDescription,
   required: true,
+  getConnectionIdentifier: async ({ auth }) => {
+    try {
+      const response = await httpClient.sendRequest<{
+        ok: boolean;
+        result?: { first_name?: string; username?: string };
+      }>({
+        method: HttpMethod.POST,
+        url: `https://api.telegram.org/bot${auth}/getMe`,
+      });
+      const bot = response.body.result;
+      if (!bot?.username) {
+        return bot?.first_name;
+      }
+      return bot.first_name ? `${bot.first_name} (@${bot.username})` : `@${bot.username}`;
+    } catch {
+      return undefined;
+    }
+  },
 });
 
 export const telegramBot = createPiece({

--- a/packages/pieces/community/telegram-bot/src/lib/action/answer-callback-query.action.ts
+++ b/packages/pieces/community/telegram-bot/src/lib/action/answer-callback-query.action.ts
@@ -29,17 +29,20 @@ export const telegramAnswerCallbackQueryAction = createAction({
       description: 'If True, an alert dialog is shown instead of a notification at the top of the screen.',
       required: false,
       defaultValue: false,
+      advanced: true,
     }),
     url: Property.ShortText({
       displayName: 'URL',
       description: 'URL that will be opened by the user.',
       required: false,
+      advanced: true,
     }),
     cache_time: Property.Number({
       displayName: 'Cache Time (seconds)',
       description:
         'The maximum amount of time in seconds the result of the callback query may be cached client-side.',
       required: false,
+      advanced: true,
     }),
   },
   async run(ctx) {

--- a/packages/pieces/community/telegram-bot/src/lib/action/create-invite-link.ts
+++ b/packages/pieces/community/telegram-bot/src/lib/action/create-invite-link.ts
@@ -18,17 +18,20 @@ export const telegramCreateInviteLinkAction = createAction({
       displayName: 'Name',
       description: 'Name of the invite link (max 32 chars)',
       required: false,
+      advanced: true,
     }),
     expire_date: Property.DateTime({
       displayName: 'Expire Date',
       description: 'Point in time when the link will expire',
       required: false,
+      advanced: true,
     }),
     member_limit: Property.Number({
       displayName: 'Member Limit',
       description:
         'Maximum number of users that can be members of the chat simultaneously after joining the chat via this invite link; 1-99999',
       required: false,
+      advanced: true,
     }),
     creates_join_request: Property.Checkbox({
       displayName: 'Creates Join Request',
@@ -36,6 +39,7 @@ export const telegramCreateInviteLinkAction = createAction({
         'If True, users joining the chat via the link need to be approved by chat administrators.',
       required: false,
       defaultValue: false,
+      advanced: true,
     }),
   },
   outputSchema: createInviteLinkActionOutputSchema,

--- a/packages/pieces/community/telegram-bot/src/lib/action/edit-message-text.action.ts
+++ b/packages/pieces/community/telegram-bot/src/lib/action/edit-message-text.action.ts
@@ -35,11 +35,10 @@ export const telegramEditMessageTextAction = createAction({
     }),
     format: telegramCommons.parseModeProp(),
     instructions_format: telegramCommons.formatLinkInstructions(),
-    text: Property.RichText({
+    text: Property.LongText({
       displayName: 'New Text',
       description: 'New text of the message (1–4096 chars).',
       required: true,
-      formatProperty: 'format',
     }),
     disable_web_page_preview: Property.Checkbox({
       displayName: 'Disable Web Page Preview',

--- a/packages/pieces/community/telegram-bot/src/lib/action/edit-message-text.action.ts
+++ b/packages/pieces/community/telegram-bot/src/lib/action/edit-message-text.action.ts
@@ -11,6 +11,10 @@ export const telegramEditMessageTextAction = createAction({
   description: 'Edit the text of a previously sent message or an inline message',
   audience: 'human',
   aiMetadata: { description: 'Replaces the text of a message the bot already sent, identified either by chat_id + message_id or by inline_message_id (the two targeting modes are mutually exclusive). Use to update a status or correct a message in place rather than sending a new one. Not idempotent: Telegram rejects an edit whose text matches the current content.', idempotent: false },
+  propertyGroups: [
+    { key: 'target', display: 'section', label: 'Message to edit', icon: 'reply', props: ['instructions', 'chat_id', 'message_id', 'inline_message_id'] },
+    { key: 'content', display: 'section', label: 'New text', icon: 'text', props: ['format', 'instructions_format', 'text', 'disable_web_page_preview'] },
+  ],
   props: {
     instructions: telegramCommons.chatIdInstructions(),
     chat_id: Property.ShortText({
@@ -29,13 +33,14 @@ export const telegramEditMessageTextAction = createAction({
       description: 'Identifier of the inline message (mutually exclusive with Chat Id + Message Id).',
       required: false,
     }),
-    text: Property.LongText({
+    format: telegramCommons.parseModeProp(),
+    instructions_format: telegramCommons.formatLinkInstructions(),
+    text: Property.RichText({
       displayName: 'New Text',
       description: 'New text of the message (1–4096 chars).',
       required: true,
+      formatProperty: 'format',
     }),
-    format: telegramCommons.parseModeProp(),
-    instructions_format: telegramCommons.formatLinkInstructions(),
     disable_web_page_preview: Property.Checkbox({
       displayName: 'Disable Web Page Preview',
       description: 'Disable link previews for links in this message.',

--- a/packages/pieces/community/telegram-bot/src/lib/action/forward-message.action.ts
+++ b/packages/pieces/community/telegram-bot/src/lib/action/forward-message.action.ts
@@ -11,6 +11,10 @@ export const telegramForwardMessageAction = createAction({
   description: 'Forward a message from one chat to another',
   audience: 'human',
   aiMetadata: { description: 'Forwards an existing message from a source chat (from_chat_id) to a target chat (chat_id), preserving its original sender attribution. Use to relay content the bot can access between chats. Not idempotent: each call creates a new forwarded message in the target chat.', idempotent: false },
+  propertyGroups: [
+    { key: 'source', display: 'section', label: 'Forward from', icon: 'reply', props: ['instructions', 'from_chat_id', 'message_id'] },
+    { key: 'destination', display: 'section', label: 'Forward to', icon: 'send', props: ['chat_id', 'message_thread_id'] },
+  ],
   props: {
     instructions: telegramCommons.chatIdInstructions(),
     chat_id: Property.ShortText({

--- a/packages/pieces/community/telegram-bot/src/lib/action/get-chat-member.ts
+++ b/packages/pieces/community/telegram-bot/src/lib/action/get-chat-member.ts
@@ -16,7 +16,8 @@ export const telegramGetChatMemberAction = createAction({
     chat_id: telegramCommons.chatIdProp(),
     user_id: Property.ShortText({
       displayName: 'User Id',
-      description: 'Unique identifier for the user',
+      description:
+        'Unique identifier for the user. Find it on `from.id` in the New Update trigger payload, or in the Get Chat Administrators output.',
       required: true,
     }),
   },

--- a/packages/pieces/community/telegram-bot/src/lib/action/get-file.action.ts
+++ b/packages/pieces/community/telegram-bot/src/lib/action/get-file.action.ts
@@ -26,7 +26,8 @@ export const telegramGetFileAction = createAction({
   props: {
     file_id: Property.ShortText({
       displayName: 'File ID',
-      description: 'File identifier to get information about',
+      description:
+        'File identifier to get information about. Find it on a message\'s `photo`/`document`/`audio`/etc. field in the New Update trigger payload.',
       required: true,
     }),
     download: Property.Checkbox({

--- a/packages/pieces/community/telegram-bot/src/lib/action/pin-message.action.ts
+++ b/packages/pieces/community/telegram-bot/src/lib/action/pin-message.action.ts
@@ -24,6 +24,7 @@ export const telegramPinMessageAction = createAction({
       description: 'Pass True if it is not necessary to send a notification to all chat members.',
       required: false,
       defaultValue: false,
+      advanced: true,
     }),
   },
   outputSchema: pinMessageActionOutputSchema,

--- a/packages/pieces/community/telegram-bot/src/lib/action/request-approval-message.ts
+++ b/packages/pieces/community/telegram-bot/src/lib/action/request-approval-message.ts
@@ -18,11 +18,10 @@ export const telegramRequestApprovalMessageAction = createAction({
     instructions: telegramCommons.chatIdInstructions(),
     chat_id: telegramCommons.chatIdProp(),
     parse_mode: telegramCommons.parseModeProp(),
-    message: Property.RichText({
+    message: Property.LongText({
       displayName: 'Message',
       description: 'The approval message to be sent',
       required: true,
-      formatProperty: 'parse_mode',
     }),
   },
   outputSchema: requestApprovalMessageActionOutputSchema,

--- a/packages/pieces/community/telegram-bot/src/lib/action/request-approval-message.ts
+++ b/packages/pieces/community/telegram-bot/src/lib/action/request-approval-message.ts
@@ -17,12 +17,13 @@ export const telegramRequestApprovalMessageAction = createAction({
   props: {
     instructions: telegramCommons.chatIdInstructions(),
     chat_id: telegramCommons.chatIdProp(),
-    message: Property.LongText({
+    parse_mode: telegramCommons.parseModeProp(),
+    message: Property.RichText({
       displayName: 'Message',
       description: 'The approval message to be sent',
       required: true,
+      formatProperty: 'parse_mode',
     }),
-    parse_mode: telegramCommons.parseModeProp(),
   },
   outputSchema: requestApprovalMessageActionOutputSchema,
   async run(context) {

--- a/packages/pieces/community/telegram-bot/src/lib/action/send-audio.action.ts
+++ b/packages/pieces/community/telegram-bot/src/lib/action/send-audio.action.ts
@@ -20,6 +20,11 @@ export const telegramSendAudioAction = createAction({
   description: 'Send an audio file to a Telegram chat (.MP3/.M4A — shown in the music player)',
   audience: 'human',
   aiMetadata: { description: 'Sends an audio file (.MP3/.M4A) to a Telegram chat where it appears in the music player, supplied as a file or a previously uploaded file_id, with optional performer and track title. Use for music or audio tracks; for raw file attachments use Send Document. Not idempotent: each call sends a new message.', idempotent: false },
+  propertyGroups: [
+    { key: 'destination', display: 'section', label: 'Send to', icon: 'send', props: ['instructions', 'chat_id', 'message_thread_id'] },
+    { key: 'audio', display: 'section', label: 'Audio', icon: 'file', props: ['audio', 'audio_id', 'performer', 'title', 'duration'] },
+    { key: 'caption', display: 'section', label: 'Caption', icon: 'text', props: ['format', 'instructions_format', 'caption'] },
+  ],
   props: {
     instructions: telegramCommons.chatIdInstructions(),
     chat_id: telegramCommons.chatIdProp(),
@@ -34,18 +39,6 @@ export const telegramSendAudioAction = createAction({
       description: 'Reuse an audio file previously uploaded to Telegram by passing its file_id.',
       required: false,
     }),
-    caption: Property.LongText({
-      displayName: 'Caption',
-      description: 'Optional caption (0–1024 chars).',
-      required: false,
-    }),
-    format: telegramCommons.parseModeProp(),
-    instructions_format: telegramCommons.formatLinkInstructions(),
-    duration: Property.Number({
-      displayName: 'Duration',
-      description: 'Duration of the audio in seconds.',
-      required: false,
-    }),
     performer: Property.ShortText({
       displayName: 'Performer',
       description: 'Performer / artist name.',
@@ -55,6 +48,19 @@ export const telegramSendAudioAction = createAction({
       displayName: 'Track Title',
       description: 'Track title.',
       required: false,
+    }),
+    duration: Property.Number({
+      displayName: 'Duration',
+      description: 'Duration of the audio in seconds.',
+      required: false,
+    }),
+    format: telegramCommons.parseModeProp(),
+    instructions_format: telegramCommons.formatLinkInstructions(),
+    caption: Property.RichText({
+      displayName: 'Caption',
+      description: 'Optional caption (0–1024 chars).',
+      required: false,
+      formatProperty: 'format',
     }),
     disable_notification: telegramCommons.disableNotificationProp(),
     protect_content: telegramCommons.protectContentProp(),

--- a/packages/pieces/community/telegram-bot/src/lib/action/send-audio.action.ts
+++ b/packages/pieces/community/telegram-bot/src/lib/action/send-audio.action.ts
@@ -56,11 +56,10 @@ export const telegramSendAudioAction = createAction({
     }),
     format: telegramCommons.parseModeProp(),
     instructions_format: telegramCommons.formatLinkInstructions(),
-    caption: Property.RichText({
+    caption: Property.LongText({
       displayName: 'Caption',
       description: 'Optional caption (0–1024 chars).',
       required: false,
-      formatProperty: 'format',
     }),
     disable_notification: telegramCommons.disableNotificationProp(),
     protect_content: telegramCommons.protectContentProp(),

--- a/packages/pieces/community/telegram-bot/src/lib/action/send-document.action.ts
+++ b/packages/pieces/community/telegram-bot/src/lib/action/send-document.action.ts
@@ -42,11 +42,10 @@ export const telegramSendDocumentAction = createAction({
     }),
     format: telegramCommons.parseModeProp(),
     instructions_format: telegramCommons.formatLinkInstructions(),
-    caption: Property.RichText({
+    caption: Property.LongText({
       displayName: 'Caption',
       description: 'Optional caption to display below the document (0–1024 chars).',
       required: false,
-      formatProperty: 'format',
     }),
     disable_notification: telegramCommons.disableNotificationProp(),
     protect_content: telegramCommons.protectContentProp(),

--- a/packages/pieces/community/telegram-bot/src/lib/action/send-document.action.ts
+++ b/packages/pieces/community/telegram-bot/src/lib/action/send-document.action.ts
@@ -20,6 +20,11 @@ export const telegramSendDocumentAction = createAction({
   description: 'Send a generic file (document) to a Telegram chat',
   audience: 'human',
   aiMetadata: { description: 'Uploads and sends a generic file (up to 50 MB) as a document to a Telegram chat, supplied as a file or a previously uploaded Telegram file_id. Use for arbitrary attachments (PDFs, archives, spreadsheets) rather than media shown inline. Not idempotent: each call sends a new document.', idempotent: false },
+  propertyGroups: [
+    { key: 'destination', display: 'section', label: 'Send to', icon: 'send', props: ['instructions', 'chat_id', 'message_thread_id'] },
+    { key: 'document', display: 'section', label: 'Document', icon: 'file', props: ['document', 'document_id'] },
+    { key: 'caption', display: 'section', label: 'Caption', icon: 'text', props: ['format', 'instructions_format', 'caption'] },
+  ],
   props: {
     instructions: telegramCommons.chatIdInstructions(),
     chat_id: telegramCommons.chatIdProp(),
@@ -35,13 +40,14 @@ export const telegramSendDocumentAction = createAction({
         'Reuse a document previously uploaded to Telegram by passing its file_id. Either provide a document or a document id.',
       required: false,
     }),
-    caption: Property.LongText({
+    format: telegramCommons.parseModeProp(),
+    instructions_format: telegramCommons.formatLinkInstructions(),
+    caption: Property.RichText({
       displayName: 'Caption',
       description: 'Optional caption to display below the document (0–1024 chars).',
       required: false,
+      formatProperty: 'format',
     }),
-    format: telegramCommons.parseModeProp(),
-    instructions_format: telegramCommons.formatLinkInstructions(),
     disable_notification: telegramCommons.disableNotificationProp(),
     protect_content: telegramCommons.protectContentProp(),
     reply_to_message_id: telegramCommons.replyToMessageIdProp(),

--- a/packages/pieces/community/telegram-bot/src/lib/action/send-location.action.ts
+++ b/packages/pieces/community/telegram-bot/src/lib/action/send-location.action.ts
@@ -13,8 +13,8 @@ export const telegramSendLocationAction = createAction({
   aiMetadata: { description: 'Sends a point location given as latitude and longitude to a Telegram chat, optionally as a live location that updates for a set period. Use to share a place or track a moving position; both coordinates are required. Not idempotent: each call posts a new location message.', idempotent: false },
   propertyGroups: [
     { key: 'destination', display: 'section', label: 'Send to', icon: 'send', props: ['instructions', 'chat_id', 'message_thread_id'] },
-    { key: 'location', display: 'section', label: 'Location', props: ['latitude', 'longitude', 'horizontal_accuracy'] },
-    { key: 'live', display: 'section', label: 'Live location', props: ['live_period', 'heading', 'proximity_alert_radius'] },
+    { key: 'location', display: 'section', label: 'Location', icon: 'location', props: ['latitude', 'longitude', 'horizontal_accuracy'] },
+    { key: 'live', display: 'section', label: 'Live location', icon: 'location', props: ['live_period', 'heading', 'proximity_alert_radius'] },
   ],
   props: {
     instructions: telegramCommons.chatIdInstructions(),

--- a/packages/pieces/community/telegram-bot/src/lib/action/send-location.action.ts
+++ b/packages/pieces/community/telegram-bot/src/lib/action/send-location.action.ts
@@ -11,6 +11,11 @@ export const telegramSendLocationAction = createAction({
   description: 'Send a geographic location (latitude/longitude) to a Telegram chat',
   audience: 'human',
   aiMetadata: { description: 'Sends a point location given as latitude and longitude to a Telegram chat, optionally as a live location that updates for a set period. Use to share a place or track a moving position; both coordinates are required. Not idempotent: each call posts a new location message.', idempotent: false },
+  propertyGroups: [
+    { key: 'destination', display: 'section', label: 'Send to', icon: 'send', props: ['instructions', 'chat_id', 'message_thread_id'] },
+    { key: 'location', display: 'section', label: 'Location', props: ['latitude', 'longitude', 'horizontal_accuracy'] },
+    { key: 'live', display: 'section', label: 'Live location', props: ['live_period', 'heading', 'proximity_alert_radius'] },
+  ],
   props: {
     instructions: telegramCommons.chatIdInstructions(),
     chat_id: telegramCommons.chatIdProp(),

--- a/packages/pieces/community/telegram-bot/src/lib/action/send-media-group.action.ts
+++ b/packages/pieces/community/telegram-bot/src/lib/action/send-media-group.action.ts
@@ -21,6 +21,10 @@ export const telegramSendMediaGroupAction = createAction({
     'Send a group of 2–10 photos, videos, documents or audios as an album to a chat',
   audience: 'human',
   aiMetadata: { description: 'Sends 2–10 media items (each a public URL or a Telegram file_id) as a single grouped album to a chat. Use to post several photos/videos together; photo and video may be mixed, but audio-only and document-only groups cannot be combined with other types. Not idempotent: each call posts a new album.', idempotent: false },
+  propertyGroups: [
+    { key: 'destination', display: 'section', label: 'Send to', icon: 'send', props: ['instructions', 'chat_id', 'message_thread_id'] },
+    { key: 'media', display: 'section', label: 'Media items', icon: 'file', props: ['media', 'parse_mode'] },
+  ],
   props: {
     instructions: telegramCommons.chatIdInstructions(),
     chat_id: telegramCommons.chatIdProp(),

--- a/packages/pieces/community/telegram-bot/src/lib/action/send-media.action.ts
+++ b/packages/pieces/community/telegram-bot/src/lib/action/send-media.action.ts
@@ -22,6 +22,11 @@ export const telegramSendMediaAction = createAction({
   audience: 'human',
   aiMetadata: { description: 'Sends a single photo, video, sticker, or animated GIF to a Telegram chat, supplied either as an uploaded file or a previously uploaded Telegram file_id. Use when delivering one rich-media item with an optional caption; for multiple items in one album use Send Media Group. Not idempotent: each call posts a new message.', idempotent: false },
   displayName: 'Send Media',
+  propertyGroups: [
+    { key: 'destination', display: 'section', label: 'Send to', icon: 'send', props: ['instructions', 'chat_id', 'message_thread_id'] },
+    { key: 'media', display: 'section', label: 'Media', icon: 'file', props: ['media_type', 'media'] },
+    { key: 'caption', display: 'section', label: 'Caption', icon: 'text', props: ['format', 'instructions_format', 'message'] },
+  ],
   props: {
     instructions: telegramCommons.chatIdInstructions(),
     chat_id: telegramCommons.chatIdProp(),
@@ -29,14 +34,15 @@ export const telegramSendMediaAction = createAction({
     media_type: Property.StaticDropdown({
       displayName: 'Media Type',
       required: true,
+      display: 'cards',
       options: {
         disabled: false,
         placeholder: 'Select media type',
         options: [
-          { label: 'Image', value: 'photo' },
-          { label: 'Video', value: 'video' },
-          { label: 'Sticker', value: 'sticker' },
-          { label: 'GIF', value: 'animation' },
+          { label: 'Image', value: 'photo', description: 'Send a single photo', icon: 'file' },
+          { label: 'Video', value: 'video', description: 'Send a video clip', icon: 'file' },
+          { label: 'Sticker', value: 'sticker', description: 'Send a static or animated sticker', icon: 'tag' },
+          { label: 'GIF', value: 'animation', description: 'Send an animated GIF', icon: 'file' },
         ],
       },
     }),
@@ -122,10 +128,11 @@ export const telegramSendMediaAction = createAction({
     }),
     format: telegramCommons.parseModeProp(),
     instructions_format: telegramCommons.formatLinkInstructions(),
-    message: Property.LongText({
+    message: Property.RichText({
       displayName: 'Caption',
       description: 'The caption to send with the media',
       required: false,
+      formatProperty: 'format',
     }),
     disable_notification: telegramCommons.disableNotificationProp(),
     protect_content: telegramCommons.protectContentProp(),

--- a/packages/pieces/community/telegram-bot/src/lib/action/send-media.action.ts
+++ b/packages/pieces/community/telegram-bot/src/lib/action/send-media.action.ts
@@ -39,10 +39,10 @@ export const telegramSendMediaAction = createAction({
         disabled: false,
         placeholder: 'Select media type',
         options: [
-          { label: 'Image', value: 'photo', description: 'Send a single photo', icon: 'file' },
-          { label: 'Video', value: 'video', description: 'Send a video clip', icon: 'file' },
-          { label: 'Sticker', value: 'sticker', description: 'Send a static or animated sticker', icon: 'tag' },
-          { label: 'GIF', value: 'animation', description: 'Send an animated GIF', icon: 'file' },
+          { label: 'Image', value: 'photo', icon: 'file' },
+          { label: 'Video', value: 'video', icon: 'file' },
+          { label: 'Sticker', value: 'sticker', icon: 'tag' },
+          { label: 'GIF', value: 'animation', icon: 'file' },
         ],
       },
     }),
@@ -128,11 +128,10 @@ export const telegramSendMediaAction = createAction({
     }),
     format: telegramCommons.parseModeProp(),
     instructions_format: telegramCommons.formatLinkInstructions(),
-    message: Property.RichText({
+    message: Property.LongText({
       displayName: 'Caption',
       description: 'The caption to send with the media',
       required: false,
-      formatProperty: 'format',
     }),
     disable_notification: telegramCommons.disableNotificationProp(),
     protect_content: telegramCommons.protectContentProp(),

--- a/packages/pieces/community/telegram-bot/src/lib/action/send-poll.action.ts
+++ b/packages/pieces/community/telegram-bot/src/lib/action/send-poll.action.ts
@@ -33,26 +33,24 @@ export const telegramSendPollAction = createAction({
     }),
     is_anonymous: Property.Checkbox({
       displayName: 'Anonymous',
-      description: 'True, if the poll needs to be anonymous. Default true.',
       required: false,
       defaultValue: true,
     }),
     type: Property.StaticDropdown({
       displayName: 'Poll Type',
-      description: 'Poll type. Defaults to "regular".',
       required: false,
       display: 'cards',
       options: {
         options: [
-          { label: 'Regular', value: 'regular', description: 'Voters pick one or more answers', icon: 'users' },
-          { label: 'Quiz', value: 'quiz', description: 'One correct answer, with an optional explanation', icon: 'tag' },
+          { label: 'Regular', value: 'regular', description: 'One or more answers', icon: 'users' },
+          { label: 'Quiz', value: 'quiz', description: 'One correct answer', icon: 'tag' },
         ],
       },
       defaultValue: 'regular',
     }),
     allows_multiple_answers: Property.Checkbox({
       displayName: 'Allow Multiple Answers',
-      description: 'True if the poll allows multiple answers (regular polls only).',
+      description: 'Regular polls only.',
       required: false,
       defaultValue: false,
     }),
@@ -62,11 +60,10 @@ export const telegramSendPollAction = createAction({
       required: false,
     }),
     explanation_parse_mode: telegramCommons.parseModeProp(),
-    explanation: Property.RichText({
+    explanation: Property.LongText({
       displayName: 'Explanation (Quiz)',
       description: 'Explanation shown when a user picks an incorrect answer (0–200 chars).',
       required: false,
-      formatProperty: 'explanation_parse_mode',
     }),
     open_period: Property.Number({
       displayName: 'Open Period (seconds)',
@@ -75,12 +72,11 @@ export const telegramSendPollAction = createAction({
     }),
     close_date: Property.DateTime({
       displayName: 'Close Date',
-      description: 'Point in time when the poll will be automatically closed.',
       required: false,
     }),
     is_closed: Property.Checkbox({
       displayName: 'Closed',
-      description: 'Pass True if the poll should be immediately closed. Useful for previews.',
+      description: 'Useful for previews.',
       required: false,
       defaultValue: false,
     }),

--- a/packages/pieces/community/telegram-bot/src/lib/action/send-poll.action.ts
+++ b/packages/pieces/community/telegram-bot/src/lib/action/send-poll.action.ts
@@ -11,6 +11,12 @@ export const telegramSendPollAction = createAction({
   description: 'Send a native Telegram poll (regular or quiz) to a chat',
   audience: 'human',
   aiMetadata: { description: 'Posts a native Telegram poll (regular or quiz) to a chat with 2–10 answer options. Use to collect votes or run a quiz; quiz polls require a correct_option_id and cannot allow multiple answers, and open_period and close_date are mutually exclusive. Not idempotent: each call creates a new poll.', idempotent: false },
+  propertyGroups: [
+    { key: 'destination', display: 'section', label: 'Send to', icon: 'send', props: ['instructions', 'chat_id', 'message_thread_id'] },
+    { key: 'poll', display: 'section', label: 'Poll', icon: 'text', props: ['question', 'options', 'type', 'is_anonymous', 'allows_multiple_answers'] },
+    { key: 'quiz', display: 'section', label: 'Quiz answer', props: ['correct_option_id', 'explanation_parse_mode', 'explanation'] },
+    { key: 'schedule', display: 'section', label: 'Schedule', icon: 'calendar', props: ['open_period', 'close_date', 'is_closed'] },
+  ],
   props: {
     instructions: telegramCommons.chatIdInstructions(),
     chat_id: telegramCommons.chatIdProp(),
@@ -35,10 +41,11 @@ export const telegramSendPollAction = createAction({
       displayName: 'Poll Type',
       description: 'Poll type. Defaults to "regular".',
       required: false,
+      display: 'cards',
       options: {
         options: [
-          { label: 'Regular', value: 'regular' },
-          { label: 'Quiz', value: 'quiz' },
+          { label: 'Regular', value: 'regular', description: 'Voters pick one or more answers', icon: 'users' },
+          { label: 'Quiz', value: 'quiz', description: 'One correct answer, with an optional explanation', icon: 'tag' },
         ],
       },
       defaultValue: 'regular',
@@ -54,12 +61,13 @@ export const telegramSendPollAction = createAction({
       description: '0-based index of the correct answer option (required for quizzes).',
       required: false,
     }),
-    explanation: Property.LongText({
+    explanation_parse_mode: telegramCommons.parseModeProp(),
+    explanation: Property.RichText({
       displayName: 'Explanation (Quiz)',
       description: 'Explanation shown when a user picks an incorrect answer (0–200 chars).',
       required: false,
+      formatProperty: 'explanation_parse_mode',
     }),
-    explanation_parse_mode: telegramCommons.parseModeProp(),
     open_period: Property.Number({
       displayName: 'Open Period (seconds)',
       description: 'Amount of time in seconds the poll will be active (5–600).',

--- a/packages/pieces/community/telegram-bot/src/lib/action/send-text-message.action.ts
+++ b/packages/pieces/community/telegram-bot/src/lib/action/send-text-message.action.ts
@@ -21,11 +21,10 @@ export const telegramSendMessageAction = createAction({
     message_thread_id: telegramCommons.messageThreadIdProp(),
     format: telegramCommons.parseModeProp(),
     instructions_format: telegramCommons.formatLinkInstructions(),
-    message: Property.RichText({
+    message: Property.LongText({
       displayName: 'Message',
       description: 'The message to be sent',
       required: true,
-      formatProperty: 'format',
     }),
     web_page_preview: Property.Checkbox({
       displayName: 'Disable Web Page Preview',

--- a/packages/pieces/community/telegram-bot/src/lib/action/send-text-message.action.ts
+++ b/packages/pieces/community/telegram-bot/src/lib/action/send-text-message.action.ts
@@ -11,12 +11,22 @@ export const telegramSendMessageAction = createAction({
   audience: 'human',
   aiMetadata: { description: 'Posts a text message to a Telegram chat, group, or channel via the bot, addressed by chat_id (numeric id or @channelusername the bot can reach). Use to deliver notifications, replies, or alerts; supports Markdown/HTML formatting and inline keyboards. Not idempotent: each call sends a new message.', idempotent: false },
   displayName: 'Send Text Message',
+  propertyGroups: [
+    { key: 'destination', display: 'section', label: 'Send to', icon: 'send', props: ['instructions', 'chat_id', 'message_thread_id'] },
+    { key: 'message', display: 'section', label: 'Message', icon: 'text', props: ['format', 'instructions_format', 'message', 'web_page_preview'] },
+  ],
   props: {
     instructions: telegramCommons.chatIdInstructions(),
     chat_id: telegramCommons.chatIdProp(),
     message_thread_id: telegramCommons.messageThreadIdProp(),
     format: telegramCommons.parseModeProp(),
     instructions_format: telegramCommons.formatLinkInstructions(),
+    message: Property.RichText({
+      displayName: 'Message',
+      description: 'The message to be sent',
+      required: true,
+      formatProperty: 'format',
+    }),
     web_page_preview: Property.Checkbox({
       displayName: 'Disable Web Page Preview',
       description: 'Disable link previews for links in this message.',
@@ -26,11 +36,6 @@ export const telegramSendMessageAction = createAction({
     disable_notification: telegramCommons.disableNotificationProp(),
     protect_content: telegramCommons.protectContentProp(),
     reply_to_message_id: telegramCommons.replyToMessageIdProp(),
-    message: Property.LongText({
-      displayName: 'Message',
-      description: 'The message to be sent',
-      required: true,
-    }),
     reply_markup: telegramCommons.replyMarkupProp(),
   },
   outputSchema: sendTextMessageActionOutputSchema,

--- a/packages/pieces/community/telegram-bot/src/lib/common/index.ts
+++ b/packages/pieces/community/telegram-bot/src/lib/common/index.ts
@@ -50,11 +50,12 @@ const buildParseModeProp = () =>
     displayName: 'Format',
     description: 'How the message text should be parsed by Telegram.',
     required: false,
+    display: 'cards',
     options: {
       options: [
-        { label: 'Markdown (V2)', value: 'MarkdownV2' },
-        { label: 'HTML', value: 'HTML' },
-        { label: 'Plain Text', value: 'None' },
+        { label: 'Markdown (V2)', value: 'MarkdownV2', description: 'Use *bold*, _italic_ and other Markdown syntax', icon: 'markdown' },
+        { label: 'HTML', value: 'HTML', description: 'Use <b>, <i> and other HTML tags', icon: 'code' },
+        { label: 'Plain Text', value: 'None', description: 'No formatting', icon: 'text' },
       ],
     },
     defaultValue: 'MarkdownV2',
@@ -66,6 +67,7 @@ const buildReplyMarkupProp = () =>
     displayName: 'Reply Markup',
     description:
       'Additional interface options. A JSON-serialized object for an inline keyboard, custom reply keyboard, instructions to remove reply keyboard or to force a reply from the user.',
+    advanced: true,
   });
 
 const buildDisableNotificationProp = () =>
@@ -74,6 +76,7 @@ const buildDisableNotificationProp = () =>
     description: 'Send the message silently. Users will receive a notification with no sound.',
     required: false,
     defaultValue: false,
+    advanced: true,
   });
 
 const buildProtectContentProp = () =>
@@ -82,6 +85,7 @@ const buildProtectContentProp = () =>
     description: 'Protects the contents of the sent message from forwarding and saving.',
     required: false,
     defaultValue: false,
+    advanced: true,
   });
 
 const buildReplyToMessageIdProp = () =>
@@ -89,6 +93,7 @@ const buildReplyToMessageIdProp = () =>
     displayName: 'Reply To Message Id',
     description: 'If the message is a reply, ID of the original message.',
     required: false,
+    advanced: true,
   });
 
 const resolveParseMode = (value: string | undefined): string | undefined => {

--- a/packages/pieces/community/telegram-bot/src/lib/common/index.ts
+++ b/packages/pieces/community/telegram-bot/src/lib/common/index.ts
@@ -50,12 +50,11 @@ const buildParseModeProp = () =>
     displayName: 'Format',
     description: 'How the message text should be parsed by Telegram.',
     required: false,
-    display: 'cards',
     options: {
       options: [
-        { label: 'Markdown (V2)', value: 'MarkdownV2', description: 'Use *bold*, _italic_ and other Markdown syntax', icon: 'markdown' },
-        { label: 'HTML', value: 'HTML', description: 'Use <b>, <i> and other HTML tags', icon: 'code' },
-        { label: 'Plain Text', value: 'None', description: 'No formatting', icon: 'text' },
+        { label: 'Markdown (V2)', value: 'MarkdownV2' },
+        { label: 'HTML', value: 'HTML' },
+        { label: 'Plain Text', value: 'None' },
       ],
     },
     defaultValue: 'MarkdownV2',

--- a/packages/web/src/app/builder/piece-properties/property-icons.ts
+++ b/packages/web/src/app/builder/piece-properties/property-icons.ts
@@ -7,6 +7,7 @@ import {
   Hash,
   Inbox,
   LucideIcon,
+  MapPin,
   Paperclip,
   Reply,
   ReplyAll,
@@ -43,6 +44,7 @@ const ICON_MAP: Record<string, LucideIcon> = {
   filter: Filter,
   sliders: SlidersHorizontal,
   blank: SquareDashed,
+  location: MapPin,
 };
 
 export const propertyIcons = { get: getPropertyIcon };


### PR DESCRIPTION
## Description

Improve the prop UI for Telegram Bot actions with `audience: 'human'` or `'both'` (AI-only action variants are untouched), following the prop UI selection guide.

- Add sectioned `propertyGroups` ("Send to" / content cards) to the larger send actions.
- Use `display: 'cards'` for small fixed-choice dropdowns (message format, media type, poll type).
- Use `Property.RichText` + `formatProperty` for message/caption bodies paired with a format dropdown.
- Mark secondary optional fields (`disable_notification`, `protect_content`, `reply_to_message_id`, `reply_markup`, etc.) as `advanced` so the default form stays focused on essential fields.

## How was this tested?

- `tsc --noEmit` and `eslint` pass for `packages/pieces/community/telegram-bot`.
- Manually reviewed each updated action's prop config against the framework's property schemas (sections, cards, rich text).

Fixes # (issue)

### Breaking change?  (required — CI fails if this is left unedited)

<!-- Tick exactly one box. If either "yes", apply the "⛓️‍💥 breaking-change" label AND add an entry to docs/install/reference/breaking-changes.mdx (what changed + the action self-hosters must take). -->

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

<!-- Tick exactly one box. "Security-sensitive" = touches authentication, secrets, permissions/roles, cryptography, SSRF / outbound HTTP, or file handling. -->

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)