### PR TITLE
fix(pieces): approval step no longer points to a feature that was removed

### DIFF
--- a/docs/embedding/navigation.mdx
+++ b/docs/embedding/navigation.mdx
@@ -63,8 +63,6 @@ Here is the list for routes the sdk can navigate to:
 | `/connections` | Connections table
 | `/tables` | Tables table
 | `/tables/{tableId}` | Opens up a table
-| `todos` | Todos table
-| `todos/{todoId}` | Opens up a todo
 
 
 ## Navigate to Initial Route

--- a/packages/pieces/core/approval/package.json
+++ b/packages/pieces/core/approval/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-approval",
-  "version": "0.1.25",
+  "version": "0.1.26",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {

--- a/packages/pieces/core/approval/src/i18n/de.json
+++ b/packages/pieces/core/approval/src/i18n/de.json
@@ -4,6 +4,5 @@
   "Create Approval Links": "Links zur Genehmigung erstellen",
   "Pauses the flow and wait for the approval from the user": "Pausiert den Fluss und wartet auf die Genehmigung des Benutzers",
   "Create links only without pausing the flow, use wait for approval to pause": "Erstelle Links nur ohne den Fluss zu pausieren, benutze Wartezeit um zu pausieren",
-  "Markdown": "Markdown",
-  "Please use Manual Task feature instead from 0.48.0 and above": "Bitte verwenden Sie stattdessen die Manuelle Aufgabenfunktion ab 0.48.0 und höher"
+  "Markdown": "Markdown"
 }

--- a/packages/pieces/core/approval/src/i18n/es.json
+++ b/packages/pieces/core/approval/src/i18n/es.json
@@ -4,6 +4,5 @@
   "Create Approval Links": "Crear enlaces de aprobación",
   "Pauses the flow and wait for the approval from the user": "Pausa el flujo y espera la aprobación del usuario",
   "Create links only without pausing the flow, use wait for approval to pause": "Crear enlaces solo sin pausar el flujo, usar esperar aprobación para pausar",
-  "Markdown": "Markdown",
-  "Please use Manual Task feature instead from 0.48.0 and above": "Por favor, utilice la función de tarea manual en lugar de 0.48.0 o superior"
+  "Markdown": "Markdown"
 }

--- a/packages/pieces/core/approval/src/i18n/fr.json
+++ b/packages/pieces/core/approval/src/i18n/fr.json
@@ -4,6 +4,5 @@
   "Create Approval Links": "Créer des liens d'approbation",
   "Pauses the flow and wait for the approval from the user": "Met le flow en pause et attend l'approbation de l'utilisateur",
   "Create links only without pausing the flow, use wait for approval to pause": "Créer des liens uniquement sans interrompre le flow, utiliser attendre l'approbation pour mettre en pause",
-  "Markdown": "Markdown",
-  "Please use Manual Task feature instead from 0.48.0 and above": "Veuillez utiliser la fonctionnalité de tâche manuelle à la place de 0.48.0 et supérieure"
+  "Markdown": "Markdown"
 }

--- a/packages/pieces/core/approval/src/i18n/ja.json
+++ b/packages/pieces/core/approval/src/i18n/ja.json
@@ -4,6 +4,5 @@
   "Create Approval Links": "承認リンクを作成",
   "Pauses the flow and wait for the approval from the user": "フローを一時停止し、ユーザーの承認を待つ",
   "Create links only without pausing the flow, use wait for approval to pause": "フローを一時停止せずにリンクを作成します。承認待ちを使用してください",
-  "Markdown": "Markdown",
-  "Please use Manual Task feature instead from 0.48.0 and above": "0.48.0以降の手動タスク機能を使用してください"
+  "Markdown": "Markdown"
 }

--- a/packages/pieces/core/approval/src/i18n/nl.json
+++ b/packages/pieces/core/approval/src/i18n/nl.json
@@ -4,6 +4,5 @@
   "Create Approval Links": "Maak goedkeuringslinks",
   "Pauses the flow and wait for the approval from the user": "Onderbreekt de stroom en wacht op de goedkeuring van de gebruiker",
   "Create links only without pausing the flow, use wait for approval to pause": "Maak links aan zonder de flow te onderbreken, gebruik wachten op goedkeuring",
-  "Markdown": "Markdown",
-  "Please use Manual Task feature instead from 0.48.0 and above": "Gebruik de handmatige takenfunctie vanaf 0.48.0 en hoger"
+  "Markdown": "Markdown"
 }

--- a/packages/pieces/core/approval/src/i18n/pt.json
+++ b/packages/pieces/core/approval/src/i18n/pt.json
@@ -4,6 +4,5 @@
   "Create Approval Links": "Criar links de aprovação",
   "Pauses the flow and wait for the approval from the user": "Pausa o fluxo e aguarda a aprovação do usuário",
   "Create links only without pausing the flow, use wait for approval to pause": "Criar links apenas sem pausar o fluxo, use esperar por aprovação",
-  "Markdown": "Markdown",
-  "Please use Manual Task feature instead from 0.48.0 and above": "Utilize o recurso de Tarefa Manual ao invés da versão 0.48.0 ou superior"
+  "Markdown": "Markdown"
 }

--- a/packages/pieces/core/approval/src/i18n/ru.json
+++ b/packages/pieces/core/approval/src/i18n/ru.json
@@ -5,6 +5,5 @@
   "Create Approval Links": "Создать ссылки на утверждение",
   "Pauses the flow and wait for the approval from the user": "Приостанавливает поток и ждет одобрения пользователя",
   "Create links only without pausing the flow, use wait for approval to pause": "Создавать ссылки только без паузы потока, ожидать разрешения на паузу",
-  "Markdown": "Markdown",
-  "Please use Manual Task feature instead from 0.48.0 and above": "Используйте Ручную задачу вместо 0.48.0 и выше"
+  "Markdown": "Markdown"
 }

--- a/packages/pieces/core/approval/src/i18n/translation.json
+++ b/packages/pieces/core/approval/src/i18n/translation.json
@@ -5,5 +5,6 @@
   "Pauses the flow and wait for the approval from the user": "Pauses the flow and wait for the approval from the user",
   "Create links only without pausing the flow, use wait for approval to pause": "Create links only without pausing the flow, use wait for approval to pause",
   "Markdown": "Markdown",
-  "Please use Manual Task feature instead from 0.48.0 and above": "Please use Manual Task feature instead from 0.48.0 and above"
+  "This piece is legacy but still supported. For a new flow, prefer the approval actions in the Approvals tab, which deliver the request and wait for the answer in one step.": "This piece is legacy but still supported. For a new flow, prefer the approval actions in the Approvals tab, which deliver the request and wait for the answer in one step.",
+  "This piece is legacy but still supported. Unlike the approval actions in the Approvals tab, it hands out a link without pausing the flow.": "This piece is legacy but still supported. Unlike the approval actions in the Approvals tab, it hands out a link without pausing the flow."
 }

--- a/packages/pieces/core/approval/src/i18n/vi.json
+++ b/packages/pieces/core/approval/src/i18n/vi.json
@@ -5,6 +5,5 @@
   "Create Approval Links": "Create Approval Links",
   "Pauses the flow and wait for the approval from the user": "Pauses the flow and wait for the approval from the user",
   "Create links only without pausing the flow, use wait for approval to pause": "Create links only without pausing the flow, use wait for approval to pause",
-  "Markdown": "Markdown",
-  "Please use Manual Task feature instead from 0.48.0 and above": "Please use Manual Task feature instead from 0.48.0 and above"
+  "Markdown": "Markdown"
 }

--- a/packages/pieces/core/approval/src/i18n/zh.json
+++ b/packages/pieces/core/approval/src/i18n/zh.json
@@ -4,6 +4,5 @@
   "Create Approval Links": "Create Approval Links",
   "Pauses the flow and wait for the approval from the user": "Pauses the flow and wait for the approval from the user",
   "Create links only without pausing the flow, use wait for approval to pause": "Create links only without pausing the flow, use wait for approval to pause",
-  "Markdown": "Markdown",
-  "Please use Manual Task feature instead from 0.48.0 and above": "Please use Manual Task feature instead from 0.48.0 and above"
+  "Markdown": "Markdown"
 }

--- a/packages/pieces/core/approval/src/lib/actions/create-approval-link.ts
+++ b/packages/pieces/core/approval/src/lib/actions/create-approval-link.ts
@@ -8,11 +8,11 @@ export const createApprovalLink = createAction({
   displayName: 'Create Approval Links',
   description:
     'Create links only without pausing the flow, use wait for approval to pause',
-  aiMetadata: { description: 'Mints a resumable approval/disapproval link for the current flow run and returns it immediately without pausing execution, so a later step can email or post it. Pick this when the flow must continue after handing out the link; use Wait for Approval instead when the run should block until someone responds. Takes no inputs and is a legacy piece (prefer the Manual Task feature on 0.48.0 and above); not idempotent, since each call creates a new waitpoint and the previously issued link is not returned.', idempotent: false },
+  aiMetadata: { description: 'Mints a resumable approval/disapproval link for the current flow run and returns it immediately without pausing execution, so a later step can email or post it. Pick this when the flow must continue after handing out the link; use Wait for Approval instead when the run should block until someone responds. Takes no inputs and is a legacy piece that remains supported because, unlike the approval actions in the Approvals tab, it hands out a link without pausing the run. Not idempotent, since each call creates a new waitpoint and the previously issued link is not returned.', idempotent: false },
   props: {
     markdown: Property.MarkDown({
-      variant: MarkdownVariant.WARNING,
-      value: 'Please use Manual Task feature instead from 0.48.0 and above',
+      variant: MarkdownVariant.INFO,
+      value: 'This piece is legacy but still supported. Unlike the approval actions in the Approvals tab, it hands out a link without pausing the flow.',
     }),
   },
   errorHandlingOptions: {

--- a/packages/pieces/core/approval/src/lib/actions/wait-for-approval.ts
+++ b/packages/pieces/core/approval/src/lib/actions/wait-for-approval.ts
@@ -7,11 +7,11 @@ export const waitForApprovalLink = createAction({
   name: 'wait_for_approval',
   displayName: 'Wait for Approval',
   description: 'Pauses the flow and wait for the approval from the user',
-  aiMetadata: { description: 'Pauses the current flow run at a human approval gate and resumes only when the run\'s waitpoint resume URL is called with an approve or disapprove response, reporting the choice. Pick this when execution must block on a human decision; it returns no link itself, so use Create Approval Links when the flow should keep running and hand a link out. Takes no inputs and is a legacy piece (prefer the Manual Task feature on 0.48.0 and above); not idempotent, since each execution creates a new waitpoint.', idempotent: false },
+  aiMetadata: { description: 'Pauses the current flow run at a human approval gate and resumes only when the run\'s waitpoint resume URL is called with an approve or disapprove response, reporting the choice. Pick this when execution must block on a human decision; it returns no link itself, so use Create Approval Links when the flow should keep running and hand a link out. Takes no inputs and is a legacy piece: for a new flow prefer the approval actions in the Approvals tab, which deliver the request and wait in one step. Not idempotent, since each execution creates a new waitpoint.', idempotent: false },
   props: {
     markdown: Property.MarkDown({
-      variant: MarkdownVariant.WARNING,
-      value: 'Please use Manual Task feature instead from 0.48.0 and above',
+      variant: MarkdownVariant.INFO,
+      value: 'This piece is legacy but still supported. For a new flow, prefer the approval actions in the Approvals tab, which deliver the request and wait for the answer in one step.',
     }),
   },
   errorHandlingOptions: {

--- a/packages/pieces/core/approval/test/legacy-notice.test.ts
+++ b/packages/pieces/core/approval/test/legacy-notice.test.ts
@@ -1,0 +1,36 @@
+/// <reference types="vitest/globals" />
+
+import fs from 'fs';
+import path from 'path';
+import { createApprovalLink } from '../src/lib/actions/create-approval-link';
+import { waitForApprovalLink } from '../src/lib/actions/wait-for-approval';
+
+const actions = [
+  { name: 'wait_for_approval', action: waitForApprovalLink },
+  { name: 'create_approval_links', action: createApprovalLink },
+];
+
+const sourceTranslations = JSON.parse(
+  fs.readFileSync(
+    path.join(__dirname, '..', 'src', 'i18n', 'translation.json'),
+    'utf-8',
+  ),
+);
+
+describe.each(actions)('$name legacy notice', ({ action }) => {
+  test('does not point at the removed Manual Task feature', () => {
+    expect(action.props.markdown.description).toEqual(expect.any(String));
+    expect(action.props.markdown.description).not.toMatch(/manual task/i);
+    expect(action.aiMetadata?.description).not.toMatch(/manual task/i);
+  });
+
+  test('points at the Approvals tab that replaced it', () => {
+    expect(action.props.markdown.description).toMatch(/Approvals tab/);
+  });
+
+  test('is translatable from the source translation file', () => {
+    expect(sourceTranslations).toHaveProperty(
+      action.props.markdown.description as string,
+    );
+  });
+});


### PR DESCRIPTION
Fixes [GIT-1775](https://linear.app/activepieces/issue/GIT-1775)
Closes #14971

## Problem

1. Both Approval actions render a builder notice: "Please use Manual Task feature instead from 0.48.0 and above". Manual Task (todos) was deprecated and removed, so the notice points at nothing. `docs/install/reference/breaking-changes.mdx:253` sends Todos users the other way, to the Approvals tab.
2. The same claim is duplicated in both actions' `aiMetadata.description`, so the copilot repeats it when recommending steps, and it is translated into ten locales.
3. `docs/embedding/navigation.mdx` documents `todos` and `todos/{todoId}` embed routes that resolve nowhere.

## Fix

- `wait-for-approval.ts`, `create-approval-link.ts`: notice now points at the Approvals tab; per-action wording, since Create Approval Links has no equivalent there (it hands out a link without pausing). Variant WARNING to INFO, as this is no longer a "stop using this" message.
- Both `aiMetadata.description` strings: same correction, so agent-facing guidance matches.
- `i18n/translation.json`: stale key replaced with the two new source strings; the dead key removed from all ten locale files, letting Crowdin regenerate.
- `package.json`: 0.1.25 to 0.1.26.
- `docs/embedding/navigation.mdx`: two dead route rows deleted.

## Verification

- `test/legacy-notice.test.ts` added: asserts neither action mentions Manual Task, both point at the Approvals tab, and both strings exist as keys in `translation.json`. Red-first against the base commit: 4 of 6 assertions fail; all 8 tests in the piece pass with the fix.
- eslint clean on `@activepieces/piece-approval` and `web`.
- Full pre-push suite green (474 engine tests) after building the delay piece in the worktree.
- Visual: real builder at `/projects/:id/flows/:id` on a local CE instance (own Postgres/Redis, `AP_DEV_PIECES=approval`), both actions added by hand, before and after captured from the same instance. Light theme only; the change is not theme-sensitive.
- Other affected paths: checked. `Manual Task` appears nowhere else in the repo except the Woodpecker piece, where it refers to that product's own concept. Stale `todos` references also checked in the web router and embed SDK; the two doc rows were the only ones left.
- Not covered: piece packages are not in the `turbo run test` matrix in `ci.yml:152`, so this test only runs locally. Pre-existing for the whole `packages/pieces` tree, not introduced here.

Product decision embedded: the notice now recommends the Approvals tab rather than declaring the piece unreplaced; alternative considered: dropping the notice entirely, rejected because the piece stays discoverable and users deserve the newer path.

<details>
<summary>Plan &amp; reasoning</summary>

## Plan

- Root cause is copy in two files plus its translations, so the fix is string-level; no logic touched.
- Wording is per-action rather than shared: the Approvals tab actions replace Wait for Approval, but none of them replaces Create Approval Links, which is the only action handing out a resume link without pausing the run.
- Locale files get the dead key removed but no hand-written translations; `crowdin.yml` treats `translation.json` as source and generates `%two_letters_code%.json`.
- Footprint: 15 files, ~26 lines of product code. Rejected: adding a shared single string for both actions, which would have been shorter but wrong for Create Approval Links.

## Non-happy scenarios considered

- Saved flows using these actions: prop key `markdown` unchanged, MARKDOWN props are skipped by input validation, so stored settings are unaffected.
- Non-English builders: see the English string until Crowdin round-trips. The stale translated warning is gone from all ten locales, so nobody sees the removed-feature claim in the meantime.
- Test giving a false green: the first version of the test read `props.markdown.value`, which is always undefined because `Property.MarkDown` stores the text in `description`. Red-first caught it; the test now asserts the field is a string before matching.

## Alternatives rejected

- Deleting the notice: loses the pointer to the better path, and the piece is still listed in the picker.
- Keeping WARNING variant: the message is informational now, not a deprecation stop sign.
- Editing locale files by hand: Crowdin owns them and machine-overwrites.

</details>

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)
