### PR TITLE
fix(pieces-common): encode arrays and nested objects in form-urlencoded bodies

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "lint-pieces": "turbo run lint --filter='@activepieces/piece-*'",
     "lint-affected": "turbo run lint --affected",
     "lint-dev": "turbo run lint --filter='!@activepieces/piece-*' --force -- --fix",
-    "test-unit": "turbo run test --filter=@activepieces/engine --filter=@activepieces/shared --filter=@activepieces/sandbox --filter=@activepieces/core-utils --filter=@activepieces/server-utils --filter=@activepieces/pieces-framework --filter=web --filter=ee-embed-sdk",
+    "test-unit": "turbo run test --filter=@activepieces/engine --filter=@activepieces/shared --filter=@activepieces/sandbox --filter=@activepieces/core-utils --filter=@activepieces/server-utils --filter=@activepieces/pieces-framework --filter=@activepieces/pieces-common --filter=web --filter=ee-embed-sdk",
     "test-api": "turbo run check-migrations test-ce test-ee test-cloud --filter=api --concurrency=1",
     "agent-evals": "set -a && . ./.env.dev && set +a && tsx --tsconfig packages/server/worker/test/lib/agent-eval/cli/tsconfig.json packages/server/worker/test/lib/agent-eval/cli/index.ts",
     "agent-evals:ci": "if [ -f ./.env.dev ]; then set -a && . ./.env.dev && set +a; fi && vitest run --dir packages/server/worker/test/lib/agent-eval",

--- a/packages/pieces/common/package.json
+++ b/packages/pieces/common/package.json
@@ -7,7 +7,8 @@
   "types": "./dist/src/index.d.ts",
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",
-    "lint": "eslint 'src/**/*.ts'"
+    "lint": "eslint 'src/**/*.ts'",
+    "test": "vitest run --passWithNoTests"
   },
   "dependencies": {
     "@activepieces/pieces-framework": "workspace:*",
@@ -16,6 +17,7 @@
     "zod": "4.3.6"
   },
   "devDependencies": {
+    "vitest": "3.2.6",
     "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/common/src/lib/http/core/fetch-http-client.ts
+++ b/packages/pieces/common/src/lib/http/core/fetch-http-client.ts
@@ -125,9 +125,34 @@ function serializeBody(
   }
   const contentType = headers['Content-Type'] ?? headers['content-type'] ?? '';
   if (contentType.includes('application/x-www-form-urlencoded')) {
-    return { body: new URLSearchParams(body as Record<string, string>).toString(), extraHeaders: {}, isStream: false };
+    const params = new URLSearchParams();
+    for (const [key, value] of Object.entries(body as Record<string, unknown>)) {
+      appendFormValue(params, key, value);
+    }
+    return { body: params.toString(), extraHeaders: {}, isStream: false };
   }
   return { body: JSON.stringify(body), extraHeaders: {}, isStream: false };
+}
+
+function appendFormValue(params: URLSearchParams, key: string, value: unknown): void {
+  if (isNil(value)) {
+    return;
+  }
+  if (Array.isArray(value)) {
+    value.forEach((item, index) => appendFormValue(params, isPlainObject(item) ? `${key}[${index}]` : `${key}[]`, item));
+    return;
+  }
+  if (isPlainObject(value)) {
+    for (const [childKey, childValue] of Object.entries(value)) {
+      appendFormValue(params, `${key}[${childKey}]`, childValue);
+    }
+    return;
+  }
+  params.append(key, value instanceof Date ? value.toISOString() : String(value));
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value) && !(value instanceof Date) && !Buffer.isBuffer(value);
 }
 
 async function parseResponseBody(response: Response, responseType: ResponseType): Promise<unknown> {

--- a/packages/pieces/common/test/fetch-http-client.test.ts
+++ b/packages/pieces/common/test/fetch-http-client.test.ts
@@ -1,0 +1,99 @@
+import { createServer, Server } from 'node:http';
+import { AddressInfo } from 'node:net';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { httpClient } from '../src/lib/http/core/http-client';
+import { HttpMethod } from '../src/lib/http/core/http-method';
+
+let server: Server;
+let baseUrl: string;
+let receivedBody = '';
+
+beforeAll(async () => {
+  server = createServer((request, response) => {
+    const chunks: Buffer[] = [];
+    request.on('data', (chunk) => chunks.push(chunk));
+    request.on('end', () => {
+      receivedBody = Buffer.concat(chunks).toString('utf8');
+      response.writeHead(200, { 'Content-Type': 'application/json' });
+      response.end('{}');
+    });
+  });
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  baseUrl = `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
+});
+
+afterAll(async () => {
+  await new Promise((resolve) => server.close(resolve));
+});
+
+const send = async (body: unknown, contentType = 'application/x-www-form-urlencoded'): Promise<string> => {
+  await httpClient.sendRequest({
+    method: HttpMethod.POST,
+    url: baseUrl,
+    headers: { 'Content-Type': contentType },
+    body,
+  });
+  return receivedBody;
+};
+
+describe('form-urlencoded serialization', () => {
+  it('encodes arrays with bracket notation', async () => {
+    expect(await send({ enabled_events: ['refund.created'], url: 'https://example.com/hook' })).toBe(
+      'enabled_events%5B%5D=refund.created&url=https%3A%2F%2Fexample.com%2Fhook'
+    );
+  });
+
+  it('repeats the bracketed key for every item', async () => {
+    expect(await send({ enabled_events: ['refund.created', 'refund.updated'] })).toBe(
+      'enabled_events%5B%5D=refund.created&enabled_events%5B%5D=refund.updated'
+    );
+  });
+
+  it('omits empty arrays', async () => {
+    expect(await send({ enabled_events: [], url: 'https://example.com' })).toBe('url=https%3A%2F%2Fexample.com');
+  });
+
+  it('encodes nested objects with bracket paths', async () => {
+    expect(await send({ metadata: { order_id: '123', nested: { level: 2 } } })).toBe(
+      'metadata%5Border_id%5D=123&metadata%5Bnested%5D%5Blevel%5D=2'
+    );
+  });
+
+  it('indexes arrays of objects', async () => {
+    expect(await send({ items: [{ price: 100 }, { price: 200 }] })).toBe(
+      'items%5B0%5D%5Bprice%5D=100&items%5B1%5D%5Bprice%5D=200'
+    );
+  });
+
+  it('skips null and undefined values', async () => {
+    expect(await send({ a: null, b: undefined, c: [null, 'kept', undefined], d: 'value' })).toBe(
+      'c%5B%5D=kept&d=value'
+    );
+  });
+
+  it('stringifies primitives and dates', async () => {
+    expect(await send({ count: 0, enabled: false, since: new Date(0) })).toBe(
+      'count=0&enabled=false&since=1970-01-01T00%3A00%3A00.000Z'
+    );
+  });
+
+  it('does not expand buffers into byte indexes', async () => {
+    expect(await send({ payload: Buffer.from('hi') })).toBe('payload=hi');
+  });
+
+  it('leaves a prebuilt URLSearchParams body untouched', async () => {
+    expect(await send(new URLSearchParams({ 'enabled_events[]': 'refund.created' }))).toBe(
+      'enabled_events%5B%5D=refund.created'
+    );
+  });
+
+  it('leaves a string body untouched', async () => {
+    expect(await send('enabled_events[]=refund.created')).toBe('enabled_events[]=refund.created');
+  });
+
+  it('keeps json bodies unaffected', async () => {
+    expect(await send({ enabled_events: ['refund.created'] }, 'application/json')).toBe(
+      '{"enabled_events":["refund.created"]}'
+    );
+  });
+});


### PR DESCRIPTION
Fixes #14972

### Problem

`serializeBody` in the fetch HTTP client passed the request body straight to
`new URLSearchParams(body)` for `application/x-www-form-urlencoded` requests.
`URLSearchParams` coerces every value with `String()`, so an array became a
comma-joined scalar and a nested object became `[object Object]`.

Stripe webhook triggers fail at `onEnable` because
`stripeCommon.subscribeWebhook` sends `{ enabled_events: [eventName], url }`.
The wire body was `enabled_events=refund.created`, and Stripe answered
`400 "Invalid array"` on `enabled_events`, surfacing as `TRIGGER_UPDATE_STATUS`.
Flows already registered under the old axios client keep working, but any
disable/re-enable cycle breaks them. The bug is generic every piece sending
an array through `httpClient` with this content type is affected.

### Fix

Serialize each entry recursively with bracket notation, matching what the
previous axios client produced:

- scalar arrays → `key[]=a&key[]=b`
- arrays of objects → `key[0][child]=…`
- nested objects → `key[child]=…`
- `null` / `undefined` skipped instead of becoming the literal strings
- `Date` → ISO 8601

`string`, `Buffer`, `URLSearchParams`, `FormData`, and stream bodies remain
pass-through, so pieces that build their own form string (chargebee,
formstack) are untouched.

### Tests

Adds `packages/pieces/common/test/fetch-http-client.test.ts`, which sends real
requests through `httpClient` to a local `node:http` server and asserts the raw
wire body covering the Stripe repro, multi-item arrays, empty arrays, nested
and deeply nested objects, arrays of objects, null/undefined, falsy primitives,
dates, buffers, and the pass-through cases. 11 tests; 7 of them fail on the
current serializer.

`@activepieces/pieces-common` had no test target, so this adds the `test`
script and registers the package in the root `test-unit` filter.
