### PR TITLE
chore(codeowners): unown docs/ and tsconfig.base.json

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -15,4 +15,6 @@
 # The leading slash is required — unanchored patterns would also match the
 # per-piece lockfiles under packages/pieces/.
 /bun.lock
+/docs/
+/tsconfig.base.json
 /brain/


### PR DESCRIPTION
## Description

Releases `/docs/` and `/tsconfig.base.json` from the catch-all `@activepieces/core` ownership in CODEOWNERS, matching how `/bun.lock` is already handled: no team is auto-requested and no code-owner approval is required (one approving review from any write-access collaborator still is).

Adding a new piece updates `tsconfig.base.json` path references, and occasionally requires a docs update — neither should force core-team review on every piece PR.

## How was this tested?

N/A — CODEOWNERS-only change, no application code affected. Not edition-specific.

Fixes # (issue)

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)