### PR TITLE
fix(pieces): stop offering the deprecated Todos piece where it can no longer run

### DIFF
--- a/packages/server/api/src/app/database/migration/postgres/1830000000000-CapTodosPieceMaxSupportedRelease.ts
+++ b/packages/server/api/src/app/database/migration/postgres/1830000000000-CapTodosPieceMaxSupportedRelease.ts
@@ -1,0 +1,27 @@
+import { QueryRunner } from 'typeorm'
+import { Migration } from '../../migration'
+
+export class CapTodosPieceMaxSupportedRelease1830000000000 implements Migration {
+    name = 'CapTodosPieceMaxSupportedRelease1830000000000'
+    breaking = false
+    release = '0.89.0'
+    transaction = true
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`
+            UPDATE "piece_metadata"
+            SET "maximumSupportedRelease" = '0.78.2'
+            WHERE "name" = '@activepieces/piece-todos'
+            AND "pieceType" = 'OFFICIAL'
+        `)
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`
+            UPDATE "piece_metadata"
+            SET "maximumSupportedRelease" = '99999.99999.9999'
+            WHERE "name" = '@activepieces/piece-todos'
+            AND "pieceType" = 'OFFICIAL'
+        `)
+    }
+}

--- a/packages/server/api/src/app/database/postgres-connection.ts
+++ b/packages/server/api/src/app/database/postgres-connection.ts
@@ -420,6 +420,7 @@ import { AddAgentIdToAgentConversation1826000000000 } from './migration/postgres
 import { AddVersionToOtp1827000000000 } from './migration/postgres/1827000000000-AddVersionToOtp'
 import { DropChatbot1828000000000 } from './migration/postgres/1828000000000-DropChatbot'
 import { AddFilePlatformIdIndex1829000000000 } from './migration/postgres/1829000000000-AddFilePlatformIdIndex'
+import { CapTodosPieceMaxSupportedRelease1830000000000 } from './migration/postgres/1830000000000-CapTodosPieceMaxSupportedRelease'
 
 const getSslConfig = (): boolean | TlsOptions => {
     const useSsl = system.get(AppSystemProp.POSTGRES_USE_SSL)
@@ -855,6 +856,7 @@ export const getMigrations = (): (new () => Migration)[] => {
         AddVersionToOtp1827000000000,
         DropChatbot1828000000000,
         AddFilePlatformIdIndex1829000000000,
+        CapTodosPieceMaxSupportedRelease1830000000000,
     ]
     return migrations
 }


### PR DESCRIPTION
## Description

Fixes [GIT-1778](https://linear.app/activepieces/issue/GIT-1778)
Closes #14979

### Problem

1. `@activepieces/piece-todos` calls `POST /api/v1/todos`; the todos backend was deprecated in 0.78.0 and deleted by the monorepo restructure (#11440), gone since 0.79.0 (module present in tag 0.78.2, absent in 0.79.0; zero `v1/todos` refs in `packages/server` at 0.79.0 and 0.88.1).
2. Its registry rows were never version-capped (`maximumSupportedRelease: 99999.99999.9999`, all 17 versions, verified live for `edition=ce&release=0.88.1`), so the hourly sync installs it and the builder offers it on every server >=0.79.0. Every run fails with `404 Route not found` (hit in prod by a self-hosted customer on 0.88.1, [Pylon 5688](https://app.usepylon.com/issues?issueNumber=5688)).

### Fix

- `1830000000000-CapTodosPieceMaxSupportedRelease.ts` — data migration: `maximumSupportedRelease = '0.78.2'` on `piece_metadata` rows `name = '@activepieces/piece-todos' AND "pieceType" = 'OFFICIAL'`; `down()` restores `99999.99999.9999`, the exact value the rows carry today (verified uniform across versions on the live registry).
- `postgres-connection.ts` — registration.

On cloud this caps the registry source rows; on self-hosted it caps local rows at upgrade; fresh installs are covered by the capped cloud registry. Cloud runs `PIECES_SYNC_MODE: NONE` (verified via cloud `/v1/flags`), so cloud's own rows are never sync-deleted. Servers <=0.78.2 that already hold the rows keep listing and resolving them (registry filters by the requester's `release` param and their sync never deletes them); fresh installs on that window can still list but no longer fetch the metadata, since the per-piece GET filters by cloud's own release — accepted, near-zero population.

Product decision embedded: on >=0.79.0 servers, existing todos steps become unresolvable as soon as the migration runs (`findExactVersion` filters by the server's release), i.e. piece-not-found in the builder and at run start instead of a live-looking step whose every run 404s — the same terminal state the hourly sync-delete produces anyway; alternative considered: keep serving the piece (rejected — every new use walks into a runtime 404; the migration path to the Approvals pieces is documented under 0.78.0 in breaking-changes).

## How was this tested?

- Red-first two-boot against throwaway Postgres 14 (CE edition): base code + `OFFICIAL_AUTO` sync installed `piece-todos 0.0.17` uncapped from the live registry and served it (`/v1/pieces/registry?release=0.88.1`, `/v1/pieces`); same DB booted on this branch ran the migration, row capped to `0.78.2`, registry empty at `release=0.88.1` and `0.79.0`, still serving at `0.78.2`, pieces list clean.
- In-suite red-first regression test not feasible for a data migration (migrations run before tests can seed rows); the two-boot above is the red/green evidence.
- `npm run lint-dev` clean (0 errors); `check-migrations` green (migration runs, no schema drift); `piece-metadata.test.ts` + `piece-sync-service.test.ts` 32/32 pass with the migration in the chain.
- Visual: piece-selector search "todos" before/after on the real app (screenshots in the Visual verification comment); driven state: action piece selector search results, light theme.
- Other affected paths: checked - 5 more registry names absent from the repo (`cashfree-payments`, `blackbaud`, `bloomerang`, `salsa`, `video-ai`); 4 call external APIs and still work (rename-stale pattern, GIT-1611); `piece-video-ai` may share the internal-route dependency, unverified - left out of scope.
- Repro: sync from the live cloud registry into a throwaway Postgres reproduces the served-but-broken state; the migration caps and filters it — full steps in the Reproduction block.

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

No self-hoster action is required: the piece is 100% non-functional on every affected release (all actions 404), existing pinned steps keep resolving (`fetchPieceVersion` applies no release filter), and the migrate-to-approvals action was already mandated by the 0.78.0 breaking-changes entry when the feature was deprecated. Servers <=0.78.2, where todos works, are unaffected.

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)

<details>
<summary>Plan & reasoning</summary>

## Plan

- Fix the DATA, not the code: the version-range filter (`isSupportedRelease`) already exists on both the registry and local listing paths; the defect is an uncapped row. One data migration, 2 files, ~30 lines (estimate matched actual).
- Cap value `0.78.2` = last release whose `/v1/todos` routes exist; `>=0.79.0` is excluded by the existing `release > max` comparison.
- `breaking = false`: plain UPDATE, exact rollback in `down()` (prior value verified uniform across rows on the live registry; the publish-path default `999.999.999` in `piece-install-service.ts` is not what these rows carry).

## Non-happy scenarios considered

- Cloud self-sync deleting capped rows (`deletePiecesIfNotOnCloud`) -> ruled out: cloud `/v1/flags` shows `PIECES_SYNC_MODE: NONE`.
- Servers <=0.78.2 -> existing installs unaffected: registry still lists for them (asserted at `release=0.78.2` post-migration) and their sync never deletes held rows; fresh installs on that window can list but not fetch the metadata (cloud's per-piece GET filters by cloud's own release) — accepted, near-zero population.
- Fresh installs on >=0.79.0 -> migration no-ops on empty DB (proven by `check-migrations`); protection comes from the capped cloud registry rows. During the window before cloud deploys this migration, such an install can sync uncapped rows; the first sync after cloud migrates deletes them.
- Sync-disabled self-hosters -> local rows capped directly by the migration at upgrade.
- Existing flows -> flow versions untouched; steps already fail at runtime; after the migration they resolve as piece-not-found immediately (builder and run start), users migrate to the Approvals pieces per the 0.78.0 breaking-changes entry.
- Rollback -> `down()` on cloud restores the registry rows and synced self-hosted instances re-install them on the next hourly sync; a local `down()` alone cannot restore rows the sync already deleted.

## Alternatives rejected

- Ops-only SQL on cloud -> no durable code, misses sync-disabled self-hosters, invisible to review.
- Hardcoded removed-piece filter in registry/list code -> permanent special case, leaves the source rows wrong.

</details>

<details>
<summary>Reproduction</summary>

## Environment

- `postgres:14` container (`-e POSTGRES_USER=ap -e POSTGRES_PASSWORD=ap -e POSTGRES_DB=activepieces -p 54329:5432`), API booted standalone via `npx tsx packages/server/api/src/bootstrap.ts`, `AP_EDITION=ce`, `AP_ENVIRONMENT=dev`, `AP_REDIS_TYPE=MEMORY`, `AP_CONTAINER_TYPE=APP`, worktree release `0.88.3`.

## Harness

Env file = `packages/server/api/.env.tests` with the overrides above plus `AP_DB_TYPE=POSTGRES`, `AP_POSTGRES_*` pointing at the container. Two boots:

1. RED (base commit, `AP_PIECES_SYNC_MODE=OFFICIAL_AUTO`): boot, wait for `piece_metadata` to contain `@activepieces/piece-todos` (arrives in seconds, latest-first sync order).
2. GREEN (this branch, `AP_PIECES_SYNC_MODE=NONE`, same DB): boot; the migration runs on startup.

## Trigger

The RED boot's initial sync against the live cloud registry (`release=0.88.3`) is the trigger: it installs the uncapped `0.0.17` row exactly as every self-hosted server does hourly.

## Results

| State | `registry?release=0.88.1` | `registry?release=0.79.0` | `registry?release=0.78.2` | `GET /v1/pieces` (server 0.88.3) | DB row max |
|---|---|---|---|---|---|
| RED (base) | serves `0.0.17` | serves `0.0.17` | serves `0.0.17` | listed | `99999.99999.9999` |
| GREEN (fix) | empty | empty | serves `0.0.17` | absent | `0.78.2` |

Migration recorded as `CapTodosPieceMaxSupportedRelease1830000000000` in the `migrations` table.

</details>
