### PR TITLE
fix(pieces-common): encode structured form-urlencoded bodies

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "lint-pieces": "turbo run lint --filter='@activepieces/piece-*'",
     "lint-affected": "turbo run lint --affected",
     "lint-dev": "turbo run lint --filter='!@activepieces/piece-*' --force -- --fix",
-    "test-unit": "turbo run test --filter=@activepieces/engine --filter=@activepieces/shared --filter=@activepieces/sandbox --filter=@activepieces/core-utils --filter=@activepieces/server-utils --filter=@activepieces/pieces-framework --filter=web --filter=ee-embed-sdk",
+    "test-unit": "turbo run test --filter=@activepieces/engine --filter=@activepieces/shared --filter=@activepieces/sandbox --filter=@activepieces/core-utils --filter=@activepieces/server-utils --filter=@activepieces/pieces-framework --filter=@activepieces/pieces-common --filter=web --filter=ee-embed-sdk",
     "test-api": "turbo run check-migrations test-ce test-ee test-cloud --filter=api --concurrency=1",
     "agent-evals": "set -a && . ./.env.dev && set +a && tsx --tsconfig packages/server/worker/test/lib/agent-eval/cli/tsconfig.json packages/server/worker/test/lib/agent-eval/cli/index.ts",
     "agent-evals:ci": "if [ -f ./.env.dev ]; then set -a && . ./.env.dev && set +a; fi && vitest run --dir packages/server/worker/test/lib/agent-eval",

--- a/packages/pieces/common/package.json
+++ b/packages/pieces/common/package.json
@@ -7,7 +7,8 @@
   "types": "./dist/src/index.d.ts",
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",
-    "lint": "eslint 'src/**/*.ts'"
+    "lint": "eslint 'src/**/*.ts'",
+    "test": "vitest run --passWithNoTests"
   },
   "dependencies": {
     "@activepieces/pieces-framework": "workspace:*",
@@ -16,6 +17,7 @@
     "zod": "4.3.6"
   },
   "devDependencies": {
+    "vitest": "3.2.6",
     "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/common/src/lib/http/core/fetch-http-client.ts
+++ b/packages/pieces/common/src/lib/http/core/fetch-http-client.ts
@@ -126,25 +126,29 @@ function serializeBody(
   const contentType = headers['Content-Type'] ?? headers['content-type'] ?? '';
   if (contentType.includes('application/x-www-form-urlencoded')) {
     const params = new URLSearchParams();
-    for (const [key, value] of Object.entries(body as Record<string, unknown>)) {
-      appendFormValue(params, key, value);
+    for (const [key, value] of Object.entries(body)) {
+      appendFormValue({ params, key, value });
     }
     return { body: params.toString(), extraHeaders: {}, isStream: false };
   }
   return { body: JSON.stringify(body), extraHeaders: {}, isStream: false };
 }
 
-function appendFormValue(params: URLSearchParams, key: string, value: unknown): void {
+function appendFormValue({ params, key, value }: AppendFormValueParams): void {
   if (isNil(value)) {
     return;
   }
   if (Array.isArray(value)) {
-    value.forEach((item, index) => appendFormValue(params, isPlainObject(item) ? `${key}[${index}]` : `${key}[]`, item));
+    value.forEach((item, index) => appendFormValue({
+      params,
+      key: isPlainObject(item) ? `${key}[${index}]` : `${key}[]`,
+      value: item,
+    }));
     return;
   }
   if (isPlainObject(value)) {
     for (const [childKey, childValue] of Object.entries(value)) {
-      appendFormValue(params, `${key}[${childKey}]`, childValue);
+      appendFormValue({ params, key: `${key}[${childKey}]`, value: childValue });
     }
     return;
   }
@@ -253,6 +257,12 @@ type FetchInit = RequestInit & { duplex?: 'half', dispatcher?: unknown };
 
 export type SendRequestOptions = {
   dispatcher?: unknown;
+};
+
+type AppendFormValueParams = {
+  params: URLSearchParams;
+  key: string;
+  value: unknown;
 };
 
 export { FetchHttpClient as AxiosHttpClient };

--- a/packages/pieces/common/src/lib/http/core/fetch-http-client.ts
+++ b/packages/pieces/common/src/lib/http/core/fetch-http-client.ts
@@ -125,9 +125,34 @@ function serializeBody(
   }
   const contentType = headers['Content-Type'] ?? headers['content-type'] ?? '';
   if (contentType.includes('application/x-www-form-urlencoded')) {
-    return { body: new URLSearchParams(body as Record<string, string>).toString(), extraHeaders: {}, isStream: false };
+    const params = new URLSearchParams();
+    for (const [key, value] of Object.entries(body as Record<string, unknown>)) {
+      appendFormValue(params, key, value);
+    }
+    return { body: params.toString(), extraHeaders: {}, isStream: false };
   }
   return { body: JSON.stringify(body), extraHeaders: {}, isStream: false };
+}
+
+function appendFormValue(params: URLSearchParams, key: string, value: unknown): void {
+  if (isNil(value)) {
+    return;
+  }
+  if (Array.isArray(value)) {
+    value.forEach((item, index) => appendFormValue(params, isPlainObject(item) ? `${key}[${index}]` : `${key}[]`, item));
+    return;
+  }
+  if (isPlainObject(value)) {
+    for (const [childKey, childValue] of Object.entries(value)) {
+      appendFormValue(params, `${key}[${childKey}]`, childValue);
+    }
+    return;
+  }
+  params.append(key, value instanceof Date ? value.toISOString() : String(value));
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value) && !(value instanceof Date) && !Buffer.isBuffer(value);
 }
 
 async function parseResponseBody(response: Response, responseType: ResponseType): Promise<unknown> {

--- a/packages/pieces/common/test/fetch-http-client.test.ts
+++ b/packages/pieces/common/test/fetch-http-client.test.ts
@@ -1,5 +1,5 @@
-import { createServer, Server } from 'node:http';
-import { AddressInfo } from 'node:net';
+import { createServer } from 'node:http';
+import type { Server } from 'node:http';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { httpClient } from '../src/lib/http/core/http-client';
 import { HttpMethod } from '../src/lib/http/core/http-method';
@@ -19,14 +19,14 @@ beforeAll(async () => {
     });
   });
   await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
-  baseUrl = `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
+  baseUrl = `http://127.0.0.1:${getServerPort(server)}`;
 });
 
 afterAll(async () => {
   await new Promise((resolve) => server.close(resolve));
 });
 
-const send = async (body: unknown, contentType = 'application/x-www-form-urlencoded'): Promise<string> => {
+async function send({ body, contentType = 'application/x-www-form-urlencoded' }: SendParams): Promise<string> {
   await httpClient.sendRequest({
     method: HttpMethod.POST,
     url: baseUrl,
@@ -34,66 +34,79 @@ const send = async (body: unknown, contentType = 'application/x-www-form-urlenco
     body,
   });
   return receivedBody;
-};
+}
+
+function getServerPort(httpServer: Server): number {
+  const address = httpServer.address();
+  if (address === null || typeof address === 'string') {
+    throw new Error('Expected the test server to listen on a TCP port');
+  }
+  return address.port;
+}
 
 describe('form-urlencoded serialization', () => {
   it('encodes arrays with bracket notation', async () => {
-    expect(await send({ enabled_events: ['refund.created'], url: 'https://example.com/hook' })).toBe(
+    expect(await send({ body: { enabled_events: ['refund.created'], url: 'https://example.com/hook' } })).toBe(
       'enabled_events%5B%5D=refund.created&url=https%3A%2F%2Fexample.com%2Fhook'
     );
   });
 
   it('repeats the bracketed key for every item', async () => {
-    expect(await send({ enabled_events: ['refund.created', 'refund.updated'] })).toBe(
+    expect(await send({ body: { enabled_events: ['refund.created', 'refund.updated'] } })).toBe(
       'enabled_events%5B%5D=refund.created&enabled_events%5B%5D=refund.updated'
     );
   });
 
   it('omits empty arrays', async () => {
-    expect(await send({ enabled_events: [], url: 'https://example.com' })).toBe('url=https%3A%2F%2Fexample.com');
+    expect(await send({ body: { enabled_events: [], url: 'https://example.com' } })).toBe('url=https%3A%2F%2Fexample.com');
   });
 
   it('encodes nested objects with bracket paths', async () => {
-    expect(await send({ metadata: { order_id: '123', nested: { level: 2 } } })).toBe(
+    expect(await send({ body: { metadata: { order_id: '123', nested: { level: 2 } } } })).toBe(
       'metadata%5Border_id%5D=123&metadata%5Bnested%5D%5Blevel%5D=2'
     );
   });
 
   it('indexes arrays of objects', async () => {
-    expect(await send({ items: [{ price: 100 }, { price: 200 }] })).toBe(
+    expect(await send({ body: { items: [{ price: 100 }, { price: 200 }] } })).toBe(
       'items%5B0%5D%5Bprice%5D=100&items%5B1%5D%5Bprice%5D=200'
     );
   });
 
   it('skips null and undefined values', async () => {
-    expect(await send({ a: null, b: undefined, c: [null, 'kept', undefined], d: 'value' })).toBe(
+    expect(await send({ body: { a: null, b: undefined, c: [null, 'kept', undefined], d: 'value' } })).toBe(
       'c%5B%5D=kept&d=value'
     );
   });
 
   it('stringifies primitives and dates', async () => {
-    expect(await send({ count: 0, enabled: false, since: new Date(0) })).toBe(
+    expect(await send({ body: { count: 0, enabled: false, since: new Date(0) } })).toBe(
       'count=0&enabled=false&since=1970-01-01T00%3A00%3A00.000Z'
     );
   });
 
   it('does not expand buffers into byte indexes', async () => {
-    expect(await send({ payload: Buffer.from('hi') })).toBe('payload=hi');
+    expect(await send({ body: { payload: Buffer.from('hi') } })).toBe('payload=hi');
   });
 
   it('leaves a prebuilt URLSearchParams body untouched', async () => {
-    expect(await send(new URLSearchParams({ 'enabled_events[]': 'refund.created' }))).toBe(
+    expect(await send({ body: new URLSearchParams({ 'enabled_events[]': 'refund.created' }) })).toBe(
       'enabled_events%5B%5D=refund.created'
     );
   });
 
   it('leaves a string body untouched', async () => {
-    expect(await send('enabled_events[]=refund.created')).toBe('enabled_events[]=refund.created');
+    expect(await send({ body: 'enabled_events[]=refund.created' })).toBe('enabled_events[]=refund.created');
   });
 
   it('keeps json bodies unaffected', async () => {
-    expect(await send({ enabled_events: ['refund.created'] }, 'application/json')).toBe(
+    expect(await send({ body: { enabled_events: ['refund.created'] }, contentType: 'application/json' })).toBe(
       '{"enabled_events":["refund.created"]}'
     );
   });
 });
+
+type SendParams = {
+  body: unknown;
+  contentType?: string;
+};

--- a/packages/pieces/common/test/fetch-http-client.test.ts
+++ b/packages/pieces/common/test/fetch-http-client.test.ts
@@ -1,0 +1,99 @@
+import { createServer, Server } from 'node:http';
+import { AddressInfo } from 'node:net';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { httpClient } from '../src/lib/http/core/http-client';
+import { HttpMethod } from '../src/lib/http/core/http-method';
+
+let server: Server;
+let baseUrl: string;
+let receivedBody = '';
+
+beforeAll(async () => {
+  server = createServer((request, response) => {
+    const chunks: Buffer[] = [];
+    request.on('data', (chunk) => chunks.push(chunk));
+    request.on('end', () => {
+      receivedBody = Buffer.concat(chunks).toString('utf8');
+      response.writeHead(200, { 'Content-Type': 'application/json' });
+      response.end('{}');
+    });
+  });
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  baseUrl = `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
+});
+
+afterAll(async () => {
+  await new Promise((resolve) => server.close(resolve));
+});
+
+const send = async (body: unknown, contentType = 'application/x-www-form-urlencoded'): Promise<string> => {
+  await httpClient.sendRequest({
+    method: HttpMethod.POST,
+    url: baseUrl,
+    headers: { 'Content-Type': contentType },
+    body,
+  });
+  return receivedBody;
+};
+
+describe('form-urlencoded serialization', () => {
+  it('encodes arrays with bracket notation', async () => {
+    expect(await send({ enabled_events: ['refund.created'], url: 'https://example.com/hook' })).toBe(
+      'enabled_events%5B%5D=refund.created&url=https%3A%2F%2Fexample.com%2Fhook'
+    );
+  });
+
+  it('repeats the bracketed key for every item', async () => {
+    expect(await send({ enabled_events: ['refund.created', 'refund.updated'] })).toBe(
+      'enabled_events%5B%5D=refund.created&enabled_events%5B%5D=refund.updated'
+    );
+  });
+
+  it('omits empty arrays', async () => {
+    expect(await send({ enabled_events: [], url: 'https://example.com' })).toBe('url=https%3A%2F%2Fexample.com');
+  });
+
+  it('encodes nested objects with bracket paths', async () => {
+    expect(await send({ metadata: { order_id: '123', nested: { level: 2 } } })).toBe(
+      'metadata%5Border_id%5D=123&metadata%5Bnested%5D%5Blevel%5D=2'
+    );
+  });
+
+  it('indexes arrays of objects', async () => {
+    expect(await send({ items: [{ price: 100 }, { price: 200 }] })).toBe(
+      'items%5B0%5D%5Bprice%5D=100&items%5B1%5D%5Bprice%5D=200'
+    );
+  });
+
+  it('skips null and undefined values', async () => {
+    expect(await send({ a: null, b: undefined, c: [null, 'kept', undefined], d: 'value' })).toBe(
+      'c%5B%5D=kept&d=value'
+    );
+  });
+
+  it('stringifies primitives and dates', async () => {
+    expect(await send({ count: 0, enabled: false, since: new Date(0) })).toBe(
+      'count=0&enabled=false&since=1970-01-01T00%3A00%3A00.000Z'
+    );
+  });
+
+  it('does not expand buffers into byte indexes', async () => {
+    expect(await send({ payload: Buffer.from('hi') })).toBe('payload=hi');
+  });
+
+  it('leaves a prebuilt URLSearchParams body untouched', async () => {
+    expect(await send(new URLSearchParams({ 'enabled_events[]': 'refund.created' }))).toBe(
+      'enabled_events%5B%5D=refund.created'
+    );
+  });
+
+  it('leaves a string body untouched', async () => {
+    expect(await send('enabled_events[]=refund.created')).toBe('enabled_events[]=refund.created');
+  });
+
+  it('keeps json bodies unaffected', async () => {
+    expect(await send({ enabled_events: ['refund.created'] }, 'application/json')).toBe(
+      '{"enabled_events":["refund.created"]}'
+    );
+  });
+});


### PR DESCRIPTION
## Description

Fixes form-urlencoded request serialization so arrays and nested objects use bracket notation instead of being coerced to scalar strings. This restores Stripe webhook registration and fixes the same behavior for every piece using the shared HTTP client.

The serializer now:

- encodes scalar arrays as key[]=value
- encodes arrays of objects and nested objects with indexed bracket paths
- skips null and undefined values
- serializes dates as ISO 8601 strings
- preserves wire-ready string, Buffer, URLSearchParams, FormData, Blob, ArrayBuffer, and stream bodies

This incorporates the original fix by @addyCooks from #14974 while preserving their commit authorship, with a follow-up alignment to current repository conventions.

Security impact: this changes outbound form-urlencoded body serialization, but does not change destination resolution, authentication, headers, SSRF controls, or transport behavior. Pass-through cases and JSON serialization are covered by regression tests to limit the behavior change to structured form bodies.

## How was this tested?

- bun run --filter @activepieces/pieces-common test (11 tests passed)
- bunx turbo run build --filter=@activepieces/pieces-common... (4 packages built)
- bunx turbo run lint --filter=@activepieces/pieces-common --force -- --fix (0 errors; 13 pre-existing warnings)
- bunx eslint on the changed source and test files (0 errors; 1 pre-existing any warning)

A live Stripe call was not made because no Stripe credentials are available. Edition-specific testing is not applicable to this shared HTTP serialization path.

Fixes #14972

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

- [ ] no — reviewed, no security impact
- [x] yes — security-sensitive (call out the risk and mitigation in the description above)