### PR TITLE
fix(logging): stringify Error fields at every log level so raw errors never hang the event loop

### DIFF
--- a/packages/server/utils/src/ap-logger.ts
+++ b/packages/server/utils/src/ap-logger.ts
@@ -29,13 +29,14 @@ function buildLogger(bindings: Record<string, unknown>): ApLogger {
         },
         info(...args: unknown[]) {
             try {
-                const { message, fields } = normalizePinoArgs(args)
+                const { message, fields, err } = normalizePinoArgsWithError(args)
+                const safeFields = err ? { error: stringifyError(err), ...fields } : fields
                 const wide = wideEvent.current()
                 if (wide) {
-                    wide.info(message ?? 'log', { ...bindings, ...fields })
+                    wide.info(message ?? 'log', { ...bindings, ...safeFields })
                 }
                 else {
-                    log.info({ msg: message, ...bindings, ...fields })
+                    log.info({ msg: message, ...bindings, ...safeFields })
                 }
             }
             catch {
@@ -44,13 +45,14 @@ function buildLogger(bindings: Record<string, unknown>): ApLogger {
         },
         warn(...args: unknown[]) {
             try {
-                const { message, fields } = normalizePinoArgs(args)
+                const { message, fields, err } = normalizePinoArgsWithError(args)
+                const safeFields = err ? { error: stringifyError(err), ...fields } : fields
                 const wide = wideEvent.current()
                 if (wide) {
-                    wide.warn(message ?? 'log', { ...bindings, ...fields })
+                    wide.warn(message ?? 'log', { ...bindings, ...safeFields })
                 }
                 else {
-                    log.warn({ msg: message, ...bindings, ...fields })
+                    log.warn({ msg: message, ...bindings, ...safeFields })
                 }
             }
             catch {
@@ -68,7 +70,7 @@ function buildLogger(bindings: Record<string, unknown>): ApLogger {
                 }
                 else {
                     if (err) {
-                        log.error({ msg: message ?? err.message, error: `${err.message}\n${err.stack ?? ''}`, ...bindings, ...fields })
+                        log.error({ msg: message ?? err.message, error: stringifyError(err), ...bindings, ...fields })
                     }
                     else {
                         log.error({ msg: message, ...bindings, ...fields })
@@ -88,7 +90,7 @@ function buildLogger(bindings: Record<string, unknown>): ApLogger {
                 }
                 else {
                     if (err) {
-                        log.error({ msg: message ?? err.message, error: `${err.message}\n${err.stack ?? ''}`, ...bindings, ...fields })
+                        log.error({ msg: message ?? err.message, error: stringifyError(err), ...bindings, ...fields })
                     }
                     else {
                         log.error({ msg: message, ...bindings, ...fields })
@@ -101,8 +103,9 @@ function buildLogger(bindings: Record<string, unknown>): ApLogger {
         },
         debug(...args: unknown[]) {
             try {
-                const { message, fields } = normalizePinoArgs(args)
-                log.debug({ msg: message, ...bindings, ...fields })
+                const { message, fields, err } = normalizePinoArgsWithError(args)
+                const safeFields = err ? { error: stringifyError(err), ...fields } : fields
+                log.debug({ msg: message, ...bindings, ...safeFields })
             }
             catch {
                 // never throw
@@ -110,8 +113,9 @@ function buildLogger(bindings: Record<string, unknown>): ApLogger {
         },
         trace(...args: unknown[]) {
             try {
-                const { message, fields } = normalizePinoArgs(args)
-                log.debug({ msg: message, ...bindings, ...fields })
+                const { message, fields, err } = normalizePinoArgsWithError(args)
+                const safeFields = err ? { error: stringifyError(err), ...fields } : fields
+                log.debug({ msg: message, ...bindings, ...safeFields })
             }
             catch {
                 // never throw
@@ -128,17 +132,8 @@ function isRecord(value: unknown): value is Record<string, unknown> {
     return value !== null && typeof value === 'object' && !Array.isArray(value)
 }
 
-function normalizePinoArgs(args: unknown[]): { message: string | undefined, fields: Record<string, unknown> } {
-    const first = args[0]
-    if (typeof first === 'string') {
-        return { message: first, fields: {} }
-    }
-    if (isRecord(first)) {
-        const second = args[1]
-        const message = typeof second === 'string' ? second : undefined
-        return { message, fields: first }
-    }
-    return { message: String(first ?? ''), fields: {} }
+function stringifyError(err: Error): string {
+    return `${err.message}\n${err.stack ?? ''}`
 }
 
 function normalizePinoArgsWithError(args: unknown[]): { message: string | undefined, fields: Record<string, unknown>, err: Error | undefined } {

--- a/packages/server/utils/test/ap-logger.test.ts
+++ b/packages/server/utils/test/ap-logger.test.ts
@@ -204,4 +204,58 @@ describe('apLogger', () => {
             apLogger.setCurrentLevel('info') // restore
         })
     })
+
+    describe('Error fields are stringified at every level', () => {
+        function makeCyclicAxiosLikeError(): Error {
+            const err = new Error('Request failed with status code 521')
+            const request: Record<string, unknown> = { host: 'console.activepieces.com' }
+            const response: Record<string, unknown> = { status: 521, request }
+            request['res'] = response
+            Object.assign(err, { isAxiosError: true, code: 'ERR_BAD_RESPONSE', request, response })
+            return err
+        }
+
+        it('warn({ error: Error }) sends a string error field to the wide event, never the raw object', () => {
+            ambientState.active = true
+            const logger = apLogger.create({})
+            logger.warn({ error: makeCyclicAxiosLikeError(), platform: { id: 'p1' } }, 'enrollment failed')
+            expect(spies.wideWarnSpy).toHaveBeenCalledOnce()
+            const [msg, ctx] = spies.wideWarnSpy.mock.calls[0]
+            expect(msg).toBe('enrollment failed')
+            expect(typeof ctx.error).toBe('string')
+            expect(ctx.error).toContain('Request failed with status code 521')
+            expect(ctx.platform).toEqual({ id: 'p1' })
+        })
+
+        it('warn({ err: Error }) removes err and emits the canonical string error field', () => {
+            ambientState.active = true
+            const logger = apLogger.create({})
+            logger.warn({ err: makeCyclicAxiosLikeError() }, 'failed')
+            const [, ctx] = spies.wideWarnSpy.mock.calls[0]
+            expect(typeof ctx.error).toBe('string')
+            expect(ctx.err).toBeUndefined()
+        })
+
+        it('info({ error: Error }) sends a string error field to the wide event', () => {
+            ambientState.active = true
+            const logger = apLogger.create({})
+            logger.info({ error: makeCyclicAxiosLikeError() }, 'soft failure')
+            const [, ctx] = spies.wideInfoSpy.mock.calls[0]
+            expect(typeof ctx.error).toBe('string')
+        })
+
+        it('warn({ error: Error }) without ambient wide event logs a string error field', () => {
+            const logger = apLogger.create({})
+            logger.warn({ error: makeCyclicAxiosLikeError() }, 'failed')
+            const arg = spies.logWarnSpy.mock.calls[0][0]
+            expect(typeof arg.error).toBe('string')
+        })
+
+        it('debug({ error: Error }) logs a string error field', () => {
+            const logger = apLogger.create({})
+            logger.debug({ error: makeCyclicAxiosLikeError() }, 'debugging')
+            const arg = spies.logDebugSpy.mock.calls[0][0]
+            expect(typeof arg.error).toBe('string')
+        })
+    })
 })


### PR DESCRIPTION
## Description

On 2026-08-23 two production app containers hung permanently at 100% CPU (Cloudflare `CODE_MISMATCH` alerts on pool `app-prod-activepieces`). Root cause, confirmed by pausing the hung VM with the V8 inspector:

1. During `POST /api/v1/authentication/complete-sign-up`, billing enrollment against `console.activepieces.com` failed with HTTP 521 (console origin was down).
2. `enrollBillingProviderOnCreate` (`platform-plan.service.ts`) logged the **raw AxiosError**: `log.warn({ error, ... })`.
3. `ap-logger`'s `warn()` (unlike `error()`) did not extract Error instances, so the raw error — carrying the live `ClientRequest`/`IncomingMessage` graph with its circular `req ↔ res` references — was merged into the wide event.
4. At emit, evlog's `cloneForRedaction` failed both `structuredClone` (functions) and `JSON.stringify` (cycle), fell back to a shallow clone, and its cycle-blind `redactPathsInTree` walker recursed forever around the `req ↔ res` cycle (captured live: 3,612 frames deep, a 14 KB path string, ~50 redact-glob regexes per level). Event loop pinned at 100% CPU; the container answers nothing but stays up.

### Fix

`info`/`warn`/`debug`/`trace` in `ap-logger` now extract `err`/`error` Error instances exactly like `error`/`fatal` already did, and every level serializes them to a `message + stack` string (the canonical `error` field) before the fields reach evlog. This covers every `log.warn({ error })`-style call site in one place; no call-site changes needed.

## How was this tested?

- `packages/server/utils/test/ap-logger.test.ts`: 5 new tests including a cyclic AxiosError-shaped fixture asserting the wide event receives a string `error` field at warn/info/debug, plus the 18 existing tests — 23/23 pass.
- Root cause diagnosed against the live production process (V8 inspector pause + stack/heap interrogation).

Fixes # (issue)

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)