### PR TITLE
chore(pieces): add outputSchema to OpenAI, Grok (xAI), Gemini, SMTP, ClickUp, and Flow Helper actions

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -226,7 +226,7 @@
     },
     "packages/pieces/community/activecampaign": {
       "name": "@activepieces/piece-activecampaign",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -239,7 +239,7 @@
     },
     "packages/pieces/community/activepieces": {
       "name": "@activepieces/piece-activepieces",
-      "version": "0.4.7",
+      "version": "0.4.8",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -252,7 +252,7 @@
     },
     "packages/pieces/community/actualbudget": {
       "name": "@activepieces/piece-actualbudget",
-      "version": "0.1.8",
+      "version": "0.1.9",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -267,7 +267,7 @@
     },
     "packages/pieces/community/acuity-scheduling": {
       "name": "@activepieces/piece-acuity-scheduling",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -280,7 +280,7 @@
     },
     "packages/pieces/community/acumbamail": {
       "name": "@activepieces/piece-acumbamail",
-      "version": "0.2.6",
+      "version": "0.2.7",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -294,7 +294,7 @@
     },
     "packages/pieces/community/add-event": {
       "name": "@activepieces/piece-add-event",
-      "version": "0.0.5",
+      "version": "0.0.6",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -307,7 +307,7 @@
     },
     "packages/pieces/community/afforai": {
       "name": "@activepieces/piece-afforai",
-      "version": "0.1.6",
+      "version": "0.1.7",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -320,7 +320,7 @@
     },
     "packages/pieces/community/agentx": {
       "name": "@activepieces/piece-agentx",
-      "version": "0.1.6",
+      "version": "0.1.7",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -363,7 +363,7 @@
     },
     "packages/pieces/community/aianswer": {
       "name": "@activepieces/piece-aianswer",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -376,7 +376,7 @@
     },
     "packages/pieces/community/aidbase": {
       "name": "@activepieces/piece-aidbase",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -389,7 +389,7 @@
     },
     "packages/pieces/community/aiprise": {
       "name": "@activepieces/piece-aiprise",
-      "version": "0.1.4",
+      "version": "0.1.5",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -402,7 +402,7 @@
     },
     "packages/pieces/community/air-ops": {
       "name": "@activepieces/piece-air-ops",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -415,7 +415,7 @@
     },
     "packages/pieces/community/aircall": {
       "name": "@activepieces/piece-aircall",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -428,7 +428,7 @@
     },
     "packages/pieces/community/airparser": {
       "name": "@activepieces/piece-airparser",
-      "version": "0.1.6",
+      "version": "0.1.7",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -471,7 +471,7 @@
     },
     "packages/pieces/community/alai": {
       "name": "@activepieces/piece-alai",
-      "version": "0.1.5",
+      "version": "0.1.6",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -484,7 +484,7 @@
     },
     "packages/pieces/community/algolia": {
       "name": "@activepieces/piece-algolia",
-      "version": "0.0.5",
+      "version": "0.0.6",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -497,7 +497,7 @@
     },
     "packages/pieces/community/alt-text-ai": {
       "name": "@activepieces/piece-alt-text-ai",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -510,7 +510,7 @@
     },
     "packages/pieces/community/alttextify": {
       "name": "@activepieces/piece-alttextify",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -525,7 +525,7 @@
     },
     "packages/pieces/community/amazon-bedrock": {
       "name": "@activepieces/piece-amazon-bedrock",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -544,7 +544,7 @@
     },
     "packages/pieces/community/amazon-s3": {
       "name": "@activepieces/piece-amazon-s3",
-      "version": "0.6.6",
+      "version": "0.6.7",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -566,7 +566,7 @@
     },
     "packages/pieces/community/amazon-secrets-manager": {
       "name": "@activepieces/piece-amazon-secrets-manager",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -581,7 +581,7 @@
     },
     "packages/pieces/community/amazon-ses": {
       "name": "@activepieces/piece-amazon-ses",
-      "version": "0.1.6",
+      "version": "0.1.7",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -595,7 +595,7 @@
     },
     "packages/pieces/community/amazon-sns": {
       "name": "@activepieces/piece-amazon-sns",
-      "version": "0.1.6",
+      "version": "0.1.7",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -609,7 +609,7 @@
     },
     "packages/pieces/community/amazon-sqs": {
       "name": "@activepieces/piece-amazon-sqs",
-      "version": "0.1.6",
+      "version": "0.1.7",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -623,7 +623,7 @@
     },
     "packages/pieces/community/amazon-textract": {
       "name": "@activepieces/piece-amazon-textract",
-      "version": "0.3.5",
+      "version": "0.3.6",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -637,7 +637,7 @@
     },
     "packages/pieces/community/aminos": {
       "name": "@activepieces/piece-aminos",
-      "version": "0.1.6",
+      "version": "0.1.7",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -663,7 +663,7 @@
     },
     "packages/pieces/community/anyhook-graphql": {
       "name": "@activepieces/piece-anyhook-graphql",
-      "version": "0.1.6",
+      "version": "0.1.7",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -676,7 +676,7 @@
     },
     "packages/pieces/community/anyhook-websocket": {
       "name": "@activepieces/piece-anyhook-websocket",
-      "version": "0.1.6",
+      "version": "0.1.7",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -703,7 +703,7 @@
     },
     "packages/pieces/community/apitable": {
       "name": "@activepieces/piece-apitable",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -717,7 +717,7 @@
     },
     "packages/pieces/community/apitemplate-io": {
       "name": "@activepieces/piece-apitemplate-io",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -730,7 +730,7 @@
     },
     "packages/pieces/community/apollo": {
       "name": "@activepieces/piece-apollo",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -743,7 +743,7 @@
     },
     "packages/pieces/community/appfollow": {
       "name": "@activepieces/piece-appfollow",
-      "version": "0.1.8",
+      "version": "0.1.9",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -757,7 +757,7 @@
     },
     "packages/pieces/community/asana": {
       "name": "@activepieces/piece-asana",
-      "version": "0.4.7",
+      "version": "0.4.8",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -784,7 +784,7 @@
     },
     "packages/pieces/community/ask-handle": {
       "name": "@activepieces/piece-ask-handle",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -797,7 +797,7 @@
     },
     "packages/pieces/community/asknews": {
       "name": "@activepieces/piece-asknews",
-      "version": "0.0.8",
+      "version": "0.0.9",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -810,7 +810,7 @@
     },
     "packages/pieces/community/assembled": {
       "name": "@activepieces/piece-assembled",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -823,7 +823,7 @@
     },
     "packages/pieces/community/assemblyai": {
       "name": "@activepieces/piece-assemblyai",
-      "version": "1.1.8",
+      "version": "1.1.9",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -844,7 +844,7 @@
     },
     "packages/pieces/community/attio": {
       "name": "@activepieces/piece-attio",
-      "version": "0.1.21",
+      "version": "0.1.22",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -857,7 +857,7 @@
     },
     "packages/pieces/community/autocalls": {
       "name": "@activepieces/piece-autocalls",
-      "version": "0.1.6",
+      "version": "0.1.7",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -871,7 +871,7 @@
     },
     "packages/pieces/community/avian": {
       "name": "@activepieces/piece-avian",
-      "version": "0.0.5",
+      "version": "0.0.6",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -886,7 +886,7 @@
     },
     "packages/pieces/community/avoma": {
       "name": "@activepieces/piece-avoma",
-      "version": "0.1.6",
+      "version": "0.1.7",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -899,7 +899,7 @@
     },
     "packages/pieces/community/aws-bedrock": {
       "name": "@activepieces/piece-aws-bedrock",
-      "version": "0.2.3",
+      "version": "0.2.4",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -918,7 +918,7 @@
     },
     "packages/pieces/community/azure-ad": {
       "name": "@activepieces/piece-azure-ad",
-      "version": "0.2.4",
+      "version": "0.2.5",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -932,7 +932,7 @@
     },
     "packages/pieces/community/azure-blob-storage": {
       "name": "@activepieces/piece-azure-blob-storage",
-      "version": "0.1.8",
+      "version": "0.1.9",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -947,7 +947,7 @@
     },
     "packages/pieces/community/azure-communication-services": {
       "name": "@activepieces/piece-azure-communication-services",
-      "version": "0.1.6",
+      "version": "0.1.7",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -961,7 +961,7 @@
     },
     "packages/pieces/community/azure-devops": {
       "name": "@activepieces/piece-azure-devops",
-      "version": "0.0.5",
+      "version": "0.0.6",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -974,7 +974,7 @@
     },
     "packages/pieces/community/azure-openai": {
       "name": "@activepieces/piece-azure-openai",
-      "version": "0.1.8",
+      "version": "0.1.9",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -990,7 +990,7 @@
     },
     "packages/pieces/community/backblaze": {
       "name": "@activepieces/piece-backblaze",
-      "version": "0.1.6",
+      "version": "0.1.7",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -1004,7 +1004,7 @@
     },
     "packages/pieces/community/bamboohr": {
       "name": "@activepieces/piece-bamboohr",
-      "version": "0.2.11",
+      "version": "0.2.12",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -1018,7 +1018,7 @@
     },
     "packages/pieces/community/bannerbear": {
       "name": "@activepieces/piece-bannerbear",
-      "version": "0.4.8",
+      "version": "0.4.9",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -1031,7 +1031,7 @@
     },
     "packages/pieces/community/barcode-lookup": {
       "name": "@activepieces/piece-barcode-lookup",
-      "version": "0.0.8",
+      "version": "0.0.9",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -1044,7 +1044,7 @@
     },
     "packages/pieces/community/baremetrics": {
       "name": "@activepieces/piece-baremetrics",
-      "version": "0.0.8",
+      "version": "0.0.9",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -1057,7 +1057,7 @@
     },
     "packages/pieces/community/base44": {
       "name": "@activepieces/piece-base44",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -1071,7 +1071,7 @@
     },
     "packages/pieces/community/baserow": {
       "name": "@activepieces/piece-baserow",
-      "version": "0.9.6",
+      "version": "0.9.7",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -1084,7 +1084,7 @@
     },
     "packages/pieces/community/beamer": {
       "name": "@activepieces/piece-beamer",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -1097,7 +1097,7 @@
     },
     "packages/pieces/community/beebole": {
       "name": "@activepieces/piece-beebole",
-      "version": "0.1.8",
+      "version": "0.1.9",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -1110,7 +1110,7 @@
     },
     "packages/pieces/community/beehiiv": {
       "name": "@activepieces/piece-beehiiv",
-      "version": "0.3.4",
+      "version": "0.3.5",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -1123,7 +1123,7 @@
     },
     "packages/pieces/community/bettermode": {
       "name": "@activepieces/piece-bettermode",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -1137,7 +1137,7 @@
     },
     "packages/pieces/community/bexio": {
       "name": "@activepieces/piece-bexio",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -1152,7 +1152,7 @@
     },
     "packages/pieces/community/bigcommerce": {
       "name": "@activepieces/piece-bigcommerce",
-      "version": "0.1.11",
+      "version": "0.1.12",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -1165,7 +1165,7 @@
     },
     "packages/pieces/community/bigin-by-zoho": {
       "name": "@activepieces/piece-bigin-by-zoho",
-      "version": "0.1.6",
+      "version": "0.1.7",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -1178,7 +1178,7 @@
     },
     "packages/pieces/community/bika": {
       "name": "@activepieces/piece-bika",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -1191,7 +1191,7 @@
     },
     "packages/pieces/community/billplz": {
       "name": "@activepieces/piece-billplz",
-      "version": "0.0.8",
+      "version": "0.0.9",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -1204,7 +1204,7 @@
     },
     "packages/pieces/community/binance": {
       "name": "@activepieces/piece-binance",
-      "version": "0.4.6",
+      "version": "0.4.7",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -1217,7 +1217,7 @@
     },
     "packages/pieces/community/bitly": {
       "name": "@activepieces/piece-bitly",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -1230,7 +1230,7 @@
     },
     "packages/pieces/community/bland-ai": {
       "name": "@activepieces/piece-bland-ai",
-      "version": "0.1.4",
+      "version": "0.1.5",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -1243,7 +1243,7 @@
     },
     "packages/pieces/community/blockscout": {
       "name": "@activepieces/piece-blockscout",
-      "version": "0.1.6",
+      "version": "0.1.7",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -1256,7 +1256,7 @@
     },
     "packages/pieces/community/bluesky": {
       "name": "@activepieces/piece-bluesky",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -1271,7 +1271,7 @@
     },
     "packages/pieces/community/bocha-search": {
       "name": "@activepieces/piece-bocha-search",
-      "version": "0.0.5",
+      "version": "0.0.6",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -1284,7 +1284,7 @@
     },
     "packages/pieces/community/bokio": {
       "name": "@activepieces/piece-bokio",
-      "version": "0.0.8",
+      "version": "0.0.9",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -1298,7 +1298,7 @@
     },
     "packages/pieces/community/bolna": {
       "name": "@activepieces/piece-bolna",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -1311,7 +1311,7 @@
     },
     "packages/pieces/community/bonjoro": {
       "name": "@activepieces/piece-bonjoro",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -1325,7 +1325,7 @@
     },
     "packages/pieces/community/bookedin": {
       "name": "@activepieces/piece-bookedin",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -1338,7 +1338,7 @@
     },
     "packages/pieces/community/box": {
       "name": "@activepieces/piece-box",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -1351,7 +1351,7 @@
     },
     "packages/pieces/community/brave-search": {
       "name": "@activepieces/piece-brave-search",
-      "version": "0.0.6",
+      "version": "0.0.7",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -1364,7 +1364,7 @@
     },
     "packages/pieces/community/brilliant-directories": {
       "name": "@activepieces/piece-brilliant-directories",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -1377,7 +1377,7 @@
     },
     "packages/pieces/community/browse-ai": {
       "name": "@activepieces/piece-browse-ai",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -1390,7 +1390,7 @@
     },
     "packages/pieces/community/browserless": {
       "name": "@activepieces/piece-browserless",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -1403,7 +1403,7 @@
     },
     "packages/pieces/community/bubble": {
       "name": "@activepieces/piece-bubble",
-      "version": "0.1.6",
+      "version": "0.1.7",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -1416,7 +1416,7 @@
     },
     "packages/pieces/community/buffer": {
       "name": "@activepieces/piece-buffer",
-      "version": "0.0.5",
+      "version": "0.0.6",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -1429,7 +1429,7 @@
     },
     "packages/pieces/community/bumpups": {
       "name": "@activepieces/piece-bumpups",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -1442,7 +1442,7 @@
     },
     "packages/pieces/community/bursty-ai": {
       "name": "@activepieces/piece-bursty-ai",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -1455,7 +1455,7 @@
     },
     "packages/pieces/community/buttondown": {
       "name": "@activepieces/piece-buttondown",
-      "version": "0.0.5",
+      "version": "0.0.6",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -1468,7 +1468,7 @@
     },
     "packages/pieces/community/cal-com": {
       "name": "@activepieces/piece-cal-com",
-      "version": "0.4.8",
+      "version": "0.4.9",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -1481,7 +1481,7 @@
     },
     "packages/pieces/community/calendly": {
       "name": "@activepieces/piece-calendly",
-      "version": "0.4.7",
+      "version": "0.4.8",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -1494,7 +1494,7 @@
     },
     "packages/pieces/community/camb-ai": {
       "name": "@activepieces/piece-camb-ai",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -1508,7 +1508,7 @@
     },
     "packages/pieces/community/campaign-monitor": {
       "name": "@activepieces/piece-campaign-monitor",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -1521,7 +1521,7 @@
     },
     "packages/pieces/community/canny": {
       "name": "@activepieces/piece-canny",
-      "version": "0.1.6",
+      "version": "0.1.7",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -1534,7 +1534,7 @@
     },
     "packages/pieces/community/canva": {
       "name": "@activepieces/piece-canva",
-      "version": "0.0.5",
+      "version": "0.0.6",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -1547,7 +1547,7 @@
     },
     "packages/pieces/community/capsule-crm": {
       "name": "@activepieces/piece-capsule-crm",
-      "version": "0.1.6",
+      "version": "0.1.7",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -1560,7 +1560,7 @@
     },
     "packages/pieces/community/captain-data": {
       "name": "@activepieces/piece-captain-data",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -1573,7 +1573,7 @@
     },
     "packages/pieces/community/carbone": {
       "name": "@activepieces/piece-carbone",
-      "version": "0.0.5",
+      "version": "0.0.6",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -1587,7 +1587,7 @@
     },
     "packages/pieces/community/cartloom": {
       "name": "@activepieces/piece-cartloom",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -1600,7 +1600,7 @@
     },
     "packages/pieces/community/cashfree-payments": {
       "name": "@activepieces/piece-cashfree-payments",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -1613,7 +1613,7 @@
     },
     "packages/pieces/community/certopus": {
       "name": "@activepieces/piece-certopus",
-      "version": "0.2.7",
+      "version": "0.2.8",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -1626,7 +1626,7 @@
     },
     "packages/pieces/community/chain-aware": {
       "name": "@activepieces/piece-chain-aware",
-      "version": "0.0.8",
+      "version": "0.0.9",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -1639,7 +1639,7 @@
     },
     "packages/pieces/community/chainalysis-api": {
       "name": "@activepieces/piece-chainalysis-api",
-      "version": "0.1.6",
+      "version": "0.1.7",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -1652,7 +1652,7 @@
     },
     "packages/pieces/community/chaindesk": {
       "name": "@activepieces/piece-chaindesk",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -1666,7 +1666,7 @@
     },
     "packages/pieces/community/chargebee": {
       "name": "@activepieces/piece-chargebee",
-      "version": "0.0.5",
+      "version": "0.0.6",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -1679,7 +1679,7 @@
     },
     "packages/pieces/community/chargekeep": {
       "name": "@activepieces/piece-chargekeep",
-      "version": "0.3.6",
+      "version": "0.3.7",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -1692,7 +1692,7 @@
     },
     "packages/pieces/community/chartly": {
       "name": "@activepieces/piece-chartly",
-      "version": "0.0.8",
+      "version": "0.0.9",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -1705,7 +1705,7 @@
     },
     "packages/pieces/community/chat-aid": {
       "name": "@activepieces/piece-chat-aid",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -1719,7 +1719,7 @@
     },
     "packages/pieces/community/chat-data": {
       "name": "@activepieces/piece-chat-data",
-      "version": "0.1.6",
+      "version": "0.1.7",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -1734,7 +1734,7 @@
     },
     "packages/pieces/community/chatbase": {
       "name": "@activepieces/piece-chatbase",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -1747,7 +1747,7 @@
     },
     "packages/pieces/community/chatfly": {
       "name": "@activepieces/piece-chatfly",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -1760,7 +1760,7 @@
     },
     "packages/pieces/community/chatling": {
       "name": "@activepieces/piece-chatling",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -1774,7 +1774,7 @@
     },
     "packages/pieces/community/chatnode": {
       "name": "@activepieces/piece-chatnode",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -1787,7 +1787,7 @@
     },
     "packages/pieces/community/chatsistant": {
       "name": "@activepieces/piece-chatsistant",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -1800,7 +1800,7 @@
     },
     "packages/pieces/community/chatwoot": {
       "name": "@activepieces/piece-chatwoot",
-      "version": "0.0.5",
+      "version": "0.0.6",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -1813,7 +1813,7 @@
     },
     "packages/pieces/community/checkout": {
       "name": "@activepieces/piece-checkout",
-      "version": "0.1.6",
+      "version": "0.1.7",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -1826,7 +1826,7 @@
     },
     "packages/pieces/community/chess-com": {
       "name": "@activepieces/piece-chess-com",
-      "version": "0.0.5",
+      "version": "0.0.6",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -1840,7 +1840,7 @@
     },
     "packages/pieces/community/circle": {
       "name": "@activepieces/piece-circle",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -1854,7 +1854,7 @@
     },
     "packages/pieces/community/clarifai": {
       "name": "@activepieces/piece-clarifai",
-      "version": "0.3.8",
+      "version": "0.3.9",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -1886,7 +1886,7 @@
     },
     "packages/pieces/community/clearout": {
       "name": "@activepieces/piece-clearout",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -1900,7 +1900,7 @@
     },
     "packages/pieces/community/clearoutphone": {
       "name": "@activepieces/piece-clearoutphone",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -1913,7 +1913,7 @@
     },
     "packages/pieces/community/clicdata": {
       "name": "@activepieces/piece-clicdata",
-      "version": "0.0.8",
+      "version": "0.0.9",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -1939,7 +1939,7 @@
     },
     "packages/pieces/community/clicksend": {
       "name": "@activepieces/piece-clicksend",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -1952,7 +1952,7 @@
     },
     "packages/pieces/community/clickup": {
       "name": "@activepieces/piece-clickup",
-      "version": "0.7.12",
+      "version": "0.7.13",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -2050,7 +2050,7 @@
     },
     "packages/pieces/community/coda": {
       "name": "@activepieces/piece-coda",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -2150,7 +2150,7 @@
     },
     "packages/pieces/community/connectuc": {
       "name": "@activepieces/piece-connectuc",
-      "version": "0.0.10",
+      "version": "0.0.11",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -2463,7 +2463,7 @@
     },
     "packages/pieces/community/deepgram": {
       "name": "@activepieces/piece-deepgram",
-      "version": "0.1.9",
+      "version": "0.1.10",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -2491,7 +2491,7 @@
     },
     "packages/pieces/community/deepseek": {
       "name": "@activepieces/piece-deepseek",
-      "version": "0.1.6",
+      "version": "0.1.7",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -2506,7 +2506,7 @@
     },
     "packages/pieces/community/deftform": {
       "name": "@activepieces/piece-deftform",
-      "version": "0.0.6",
+      "version": "0.0.7",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -2532,7 +2532,7 @@
     },
     "packages/pieces/community/descript": {
       "name": "@activepieces/piece-descript",
-      "version": "0.0.5",
+      "version": "0.0.6",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -2844,7 +2844,7 @@
     },
     "packages/pieces/community/eden-ai": {
       "name": "@activepieces/piece-eden-ai",
-      "version": "0.2.4",
+      "version": "0.2.5",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -2886,7 +2886,7 @@
     },
     "packages/pieces/community/elevenlabs": {
       "name": "@activepieces/piece-elevenlabs",
-      "version": "0.2.9",
+      "version": "0.2.10",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -3127,7 +3127,7 @@
     },
     "packages/pieces/community/filetopdf": {
       "name": "@activepieces/piece-filetopdf",
-      "version": "0.0.6",
+      "version": "0.0.7",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -3220,7 +3220,7 @@
     },
     "packages/pieces/community/flow-helper": {
       "name": "@activepieces/piece-flow-helper",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -3421,7 +3421,7 @@
     },
     "packages/pieces/community/freshdesk": {
       "name": "@activepieces/piece-freshdesk",
-      "version": "0.2.7",
+      "version": "0.2.8",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -3620,7 +3620,7 @@
     },
     "packages/pieces/community/github": {
       "name": "@activepieces/piece-github",
-      "version": "0.8.10",
+      "version": "0.8.11",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -3637,7 +3637,7 @@
     },
     "packages/pieces/community/gitlab": {
       "name": "@activepieces/piece-gitlab",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -3713,7 +3713,7 @@
     },
     "packages/pieces/community/google-bigquery": {
       "name": "@activepieces/piece-google-bigquery",
-      "version": "0.0.6",
+      "version": "0.0.7",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -3756,7 +3756,7 @@
     },
     "packages/pieces/community/google-contacts": {
       "name": "@activepieces/piece-google-contacts",
-      "version": "0.4.9",
+      "version": "0.4.10",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -3824,7 +3824,7 @@
     },
     "packages/pieces/community/google-gemini": {
       "name": "@activepieces/piece-google-gemini",
-      "version": "0.1.15",
+      "version": "0.1.16",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -3910,7 +3910,7 @@
     },
     "packages/pieces/community/google-slides": {
       "name": "@activepieces/piece-google-slides",
-      "version": "0.1.10",
+      "version": "0.1.11",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -4086,7 +4086,7 @@
     },
     "packages/pieces/community/grist": {
       "name": "@activepieces/piece-grist",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -4100,7 +4100,7 @@
     },
     "packages/pieces/community/grok-xai": {
       "name": "@activepieces/piece-grok-xai",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -4235,7 +4235,7 @@
     },
     "packages/pieces/community/heygen": {
       "name": "@activepieces/piece-heygen",
-      "version": "0.1.9",
+      "version": "0.1.10",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -4275,7 +4275,7 @@
     },
     "packages/pieces/community/housecall-pro": {
       "name": "@activepieces/piece-housecall-pro",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -4319,7 +4319,7 @@
     },
     "packages/pieces/community/hugging-face": {
       "name": "@activepieces/piece-hugging-face",
-      "version": "0.1.6",
+      "version": "0.1.7",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -4387,7 +4387,7 @@
     },
     "packages/pieces/community/iloveapi": {
       "name": "@activepieces/piece-iloveapi",
-      "version": "0.0.5",
+      "version": "0.0.6",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -4401,7 +4401,7 @@
     },
     "packages/pieces/community/image-router": {
       "name": "@activepieces/piece-image-router",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -4415,7 +4415,7 @@
     },
     "packages/pieces/community/imap": {
       "name": "@activepieces/piece-imap",
-      "version": "0.4.8",
+      "version": "0.4.9",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -4595,7 +4595,7 @@
     },
     "packages/pieces/community/jina-ai": {
       "name": "@activepieces/piece-jina-ai",
-      "version": "0.1.6",
+      "version": "0.1.7",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -4723,7 +4723,7 @@
     },
     "packages/pieces/community/kapso": {
       "name": "@activepieces/piece-kapso",
-      "version": "0.1.4",
+      "version": "0.1.5",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -4793,7 +4793,7 @@
     },
     "packages/pieces/community/klaviyo": {
       "name": "@activepieces/piece-klaviyo",
-      "version": "0.1.4",
+      "version": "0.1.5",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -4968,7 +4968,7 @@
     },
     "packages/pieces/community/lemlist": {
       "name": "@activepieces/piece-lemlist",
-      "version": "0.1.9",
+      "version": "0.1.10",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -4981,7 +4981,7 @@
     },
     "packages/pieces/community/lemon-squeezy": {
       "name": "@activepieces/piece-lemon-squeezy",
-      "version": "0.1.9",
+      "version": "0.1.10",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -5074,7 +5074,7 @@
     },
     "packages/pieces/community/linear": {
       "name": "@activepieces/piece-linear",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -5182,7 +5182,7 @@
     },
     "packages/pieces/community/localai": {
       "name": "@activepieces/piece-localai",
-      "version": "0.1.8",
+      "version": "0.1.9",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -5340,7 +5340,7 @@
     },
     "packages/pieces/community/mailchimp": {
       "name": "@activepieces/piece-mailchimp",
-      "version": "0.5.7",
+      "version": "0.5.8",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -5383,7 +5383,7 @@
     },
     "packages/pieces/community/maileroo": {
       "name": "@activepieces/piece-maileroo",
-      "version": "0.2.4",
+      "version": "0.2.5",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -5449,7 +5449,7 @@
     },
     "packages/pieces/community/mastodon": {
       "name": "@activepieces/piece-mastodon",
-      "version": "0.5.7",
+      "version": "0.5.8",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -5745,7 +5745,7 @@
     },
     "packages/pieces/community/microsoft-onedrive": {
       "name": "@activepieces/piece-microsoft-onedrive",
-      "version": "0.4.5",
+      "version": "0.4.6",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -5794,7 +5794,7 @@
     },
     "packages/pieces/community/microsoft-outlook-calendar": {
       "name": "@activepieces/piece-microsoft-outlook-calendar",
-      "version": "0.2.7",
+      "version": "0.2.8",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -5885,7 +5885,7 @@
     },
     "packages/pieces/community/microsoft-todo": {
       "name": "@activepieces/piece-microsoft-todo",
-      "version": "0.3.7",
+      "version": "0.3.8",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -6311,7 +6311,7 @@
     },
     "packages/pieces/community/ntfy": {
       "name": "@activepieces/piece-ntfy",
-      "version": "0.2.7",
+      "version": "0.2.8",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -6350,7 +6350,7 @@
     },
     "packages/pieces/community/odoo": {
       "name": "@activepieces/piece-odoo",
-      "version": "0.1.6",
+      "version": "0.1.7",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -6433,7 +6433,7 @@
     },
     "packages/pieces/community/oneclickimpact": {
       "name": "@activepieces/piece-oneclickimpact",
-      "version": "0.0.8",
+      "version": "0.0.9",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -6462,7 +6462,7 @@
     },
     "packages/pieces/community/open-phone": {
       "name": "@activepieces/piece-open-phone",
-      "version": "0.1.6",
+      "version": "0.1.7",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -6489,7 +6489,7 @@
     },
     "packages/pieces/community/openai": {
       "name": "@activepieces/piece-openai",
-      "version": "0.10.4",
+      "version": "0.10.5",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -6736,7 +6736,7 @@
     },
     "packages/pieces/community/pdf-co": {
       "name": "@activepieces/piece-pdf-co",
-      "version": "0.1.6",
+      "version": "0.1.7",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -6790,7 +6790,7 @@
     },
     "packages/pieces/community/peekshot": {
       "name": "@activepieces/piece-peekshot",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -6940,7 +6940,7 @@
     },
     "packages/pieces/community/placid": {
       "name": "@activepieces/piece-placid",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -7243,7 +7243,7 @@
     },
     "packages/pieces/community/pushbullet": {
       "name": "@activepieces/piece-pushbullet",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -7256,7 +7256,7 @@
     },
     "packages/pieces/community/pushover": {
       "name": "@activepieces/piece-pushover",
-      "version": "0.2.6",
+      "version": "0.2.7",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -7322,7 +7322,7 @@
     },
     "packages/pieces/community/queue": {
       "name": "@activepieces/piece-queue",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -7550,7 +7550,7 @@
     },
     "packages/pieces/community/reddit": {
       "name": "@activepieces/piece-reddit",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -7602,7 +7602,7 @@
     },
     "packages/pieces/community/resend": {
       "name": "@activepieces/piece-resend",
-      "version": "0.4.5",
+      "version": "0.4.6",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -7641,7 +7641,7 @@
     },
     "packages/pieces/community/retable": {
       "name": "@activepieces/piece-retable",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -7707,7 +7707,7 @@
     },
     "packages/pieces/community/robolly": {
       "name": "@activepieces/piece-robolly",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -7763,7 +7763,7 @@
     },
     "packages/pieces/community/runware": {
       "name": "@activepieces/piece-runware",
-      "version": "0.1.6",
+      "version": "0.1.7",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -7913,7 +7913,7 @@
     },
     "packages/pieces/community/scrapeless": {
       "name": "@activepieces/piece-scrapeless",
-      "version": "0.1.8",
+      "version": "0.1.9",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -7955,7 +7955,7 @@
     },
     "packages/pieces/community/send-it": {
       "name": "@activepieces/piece-send-it",
-      "version": "0.1.4",
+      "version": "0.1.5",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -7968,7 +7968,7 @@
     },
     "packages/pieces/community/sender": {
       "name": "@activepieces/piece-sender",
-      "version": "0.1.6",
+      "version": "0.1.7",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -7981,7 +7981,7 @@
     },
     "packages/pieces/community/sendfox": {
       "name": "@activepieces/piece-sendfox",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -8077,7 +8077,7 @@
     },
     "packages/pieces/community/serp-api": {
       "name": "@activepieces/piece-serp-api",
-      "version": "0.1.8",
+      "version": "0.1.9",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -8173,7 +8173,7 @@
     },
     "packages/pieces/community/short-io": {
       "name": "@activepieces/piece-short-io",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -8402,7 +8402,7 @@
     },
     "packages/pieces/community/smartsuite": {
       "name": "@activepieces/piece-smartsuite",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -8470,7 +8470,7 @@
     },
     "packages/pieces/community/socialkit": {
       "name": "@activepieces/piece-socialkit",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -8536,7 +8536,7 @@
     },
     "packages/pieces/community/spotify": {
       "name": "@activepieces/piece-spotify",
-      "version": "0.5.3",
+      "version": "0.5.4",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -8736,7 +8736,7 @@
     },
     "packages/pieces/community/systeme-io": {
       "name": "@activepieces/piece-systeme-io",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -8828,7 +8828,7 @@
     },
     "packages/pieces/community/tavily": {
       "name": "@activepieces/piece-tavily",
-      "version": "0.1.9",
+      "version": "0.1.10",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -8841,7 +8841,7 @@
     },
     "packages/pieces/community/teable": {
       "name": "@activepieces/piece-teable",
-      "version": "0.1.8",
+      "version": "0.1.9",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -8907,7 +8907,7 @@
     },
     "packages/pieces/community/telnyx": {
       "name": "@activepieces/piece-telnyx",
-      "version": "0.0.6",
+      "version": "0.0.7",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -9053,7 +9053,7 @@
     },
     "packages/pieces/community/todoist": {
       "name": "@activepieces/piece-todoist",
-      "version": "0.4.10",
+      "version": "0.4.11",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -9067,7 +9067,7 @@
     },
     "packages/pieces/community/toggl-track": {
       "name": "@activepieces/piece-toggl-track",
-      "version": "0.1.8",
+      "version": "0.1.9",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -9080,7 +9080,7 @@
     },
     "packages/pieces/community/totalcms": {
       "name": "@activepieces/piece-totalcms",
-      "version": "0.1.8",
+      "version": "0.1.9",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -9177,7 +9177,7 @@
     },
     "packages/pieces/community/twitch": {
       "name": "@activepieces/piece-twitch",
-      "version": "0.0.9",
+      "version": "0.0.10",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -9191,7 +9191,7 @@
     },
     "packages/pieces/community/twitter": {
       "name": "@activepieces/piece-twitter",
-      "version": "0.3.6",
+      "version": "0.3.7",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -9353,7 +9353,7 @@
     },
     "packages/pieces/community/vapi": {
       "name": "@activepieces/piece-vapi",
-      "version": "0.0.5",
+      "version": "0.0.6",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -9367,7 +9367,7 @@
     },
     "packages/pieces/community/vbout": {
       "name": "@activepieces/piece-vbout",
-      "version": "0.1.6",
+      "version": "0.1.7",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -9624,7 +9624,7 @@
     },
     "packages/pieces/community/webflow": {
       "name": "@activepieces/piece-webflow",
-      "version": "0.2.9",
+      "version": "0.2.10",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -9822,7 +9822,7 @@
     },
     "packages/pieces/community/wordpress": {
       "name": "@activepieces/piece-wordpress",
-      "version": "0.4.8",
+      "version": "0.4.9",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -9933,7 +9933,7 @@
     },
     "packages/pieces/community/youcanbookme": {
       "name": "@activepieces/piece-youcanbookme",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -10003,7 +10003,7 @@
     },
     "packages/pieces/community/zendesk": {
       "name": "@activepieces/piece-zendesk",
-      "version": "0.2.11",
+      "version": "0.2.12",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -10044,7 +10044,7 @@
     },
     "packages/pieces/community/zerobounce": {
       "name": "@activepieces/piece-zerobounce",
-      "version": "0.1.6",
+      "version": "0.1.7",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -10140,7 +10140,7 @@
     },
     "packages/pieces/community/zoho-mail": {
       "name": "@activepieces/piece-zoho-mail",
-      "version": "0.1.9",
+      "version": "0.1.10",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -10169,7 +10169,7 @@
     },
     "packages/pieces/community/zoom": {
       "name": "@activepieces/piece-zoom",
-      "version": "0.7.1",
+      "version": "0.7.2",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -10349,7 +10349,7 @@
     },
     "packages/pieces/core/graphql": {
       "name": "@activepieces/piece-graphql",
-      "version": "0.0.18",
+      "version": "0.0.19",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -10382,7 +10382,7 @@
     },
     "packages/pieces/core/image-helper": {
       "name": "@activepieces/piece-image-helper",
-      "version": "0.1.20",
+      "version": "0.1.21",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -10450,7 +10450,7 @@
     },
     "packages/pieces/core/qrcode": {
       "name": "@activepieces/piece-qrcode",
-      "version": "0.0.17",
+      "version": "0.0.18",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -10480,7 +10480,7 @@
     },
     "packages/pieces/core/sftp": {
       "name": "@activepieces/piece-sftp",
-      "version": "0.5.6",
+      "version": "0.5.7",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -10500,7 +10500,7 @@
     },
     "packages/pieces/core/smtp": {
       "name": "@activepieces/piece-smtp",
-      "version": "0.4.7",
+      "version": "0.4.8",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",

--- a/packages/pieces/community/clickup/package.json
+++ b/packages/pieces/community/clickup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-clickup",
-  "version": "0.7.12",
+  "version": "0.7.13",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {

--- a/packages/pieces/community/clickup/src/lib/actions/tags/update-space-tag.ts
+++ b/packages/pieces/community/clickup/src/lib/actions/tags/update-space-tag.ts
@@ -6,6 +6,7 @@ import {
 import { HttpMethod, getAccessTokenOrThrow } from '@activepieces/pieces-common';
 import { clickupCommon, callClickUpApi, listTags } from '../../common';
 import { clickupAuth } from '../../auth';
+import { updateSpaceTagOutputSchema } from '../../output-schemas';
 
 export const clickupUpdateSpaceTag = createAction({
   auth: clickupAuth,
@@ -65,6 +66,7 @@ export const clickupUpdateSpaceTag = createAction({
       required: false,
     }),
   },
+  outputSchema: updateSpaceTagOutputSchema,
   async run(configValue) {
     const { space_id, tag_name, new_name, tag_fg, tag_bg } =
       configValue.propsValue;

--- a/packages/pieces/community/clickup/src/lib/actions/tasks/clickup-get-bulk-tasks-time-in-status.ts
+++ b/packages/pieces/community/clickup/src/lib/actions/tasks/clickup-get-bulk-tasks-time-in-status.ts
@@ -4,6 +4,7 @@ import qs from 'qs';
 
 import { callClickUpApi } from '../../common';
 import { clickupAuth } from '../../auth';
+import { getBulkTasksTimeInStatusOutputSchema } from '../../output-schemas';
 
 export const clickupGetBulkTasksTimeInStatusAi = createAction({
   auth: clickupAuth,
@@ -24,6 +25,7 @@ export const clickupGetBulkTasksTimeInStatusAi = createAction({
       required: true,
     }),
   },
+  outputSchema: getBulkTasksTimeInStatusOutputSchema,
   async run(configValue) {
     const taskIds = configValue.propsValue.task_ids as string[];
     if (!taskIds || taskIds.length === 0) {

--- a/packages/pieces/community/clickup/src/lib/output-schemas.ts
+++ b/packages/pieces/community/clickup/src/lib/output-schemas.ts
@@ -1334,6 +1334,20 @@ export const spaceTagsOutputSchema: OutputSchema = {
   fields: [{ key: 'tags', label: 'Tags', labelKey: 'name', listItems: tagFields }],
 };
 
+export const updateSpaceTagOutputSchema: OutputSchema = {
+  fields: [
+    {
+      key: 'tag',
+      label: 'Tag',
+      children: [
+        { key: 'name', label: 'Name' },
+        { key: 'fg_color', label: 'Foreground Color' },
+        { key: 'bg_color', label: 'Background Color' },
+      ],
+    },
+  ],
+};
+
 export const taskWrapperOutputSchema: OutputSchema = {
   fields: [{ key: 'task', label: 'Task', children: taskFields }],
 };
@@ -1378,6 +1392,46 @@ export const timeEntryOutputSchema: OutputSchema = {
 export const listTimeEntriesOutputSchema: OutputSchema = {
   fields: [
     { key: 'data', label: 'Time Entries', labelKey: 'description', listItems: timeEntryFields },
+  ],
+};
+
+const timeInStatusFields: OutputSchemaField[] = [
+  { key: 'by_minute', label: 'Minutes', format: 'number' },
+  { key: 'since', label: 'Since' },
+];
+
+export const getBulkTasksTimeInStatusOutputSchema: OutputSchema = {
+  fields: [
+    {
+      key: 'tasks',
+      label: 'Tasks',
+      value: '',
+      dynamicKey: true,
+      labelKey: 'current_status.status',
+      children: [
+        {
+          key: 'current_status',
+          label: 'Current Status',
+          children: [
+            { key: 'status', label: 'Status' },
+            { key: 'color', label: 'Color' },
+            { key: 'total_time', label: 'Total Time', children: timeInStatusFields },
+          ],
+        },
+        {
+          key: 'status_history',
+          label: 'Status History',
+          labelKey: 'status',
+          listItems: [
+            { key: 'status', label: 'Status' },
+            { key: 'color', label: 'Color' },
+            { key: 'type', label: 'Type' },
+            { key: 'total_time', label: 'Total Time', children: timeInStatusFields },
+            { key: 'orderindex', label: 'Order Index', format: 'number' },
+          ],
+        },
+      ],
+    },
   ],
 };
 

--- a/packages/pieces/community/flow-helper/package.json
+++ b/packages/pieces/community/flow-helper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-flow-helper",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {

--- a/packages/pieces/community/flow-helper/src/lib/actions/get-run-id.ts
+++ b/packages/pieces/community/flow-helper/src/lib/actions/get-run-id.ts
@@ -1,4 +1,5 @@
 import { createAction } from '@activepieces/pieces-framework';
+import { getRunIdActionOutputSchema } from '../output-schemas';
 
 export const getRunId = createAction({
   audience: 'both',
@@ -9,6 +10,7 @@ export const getRunId = createAction({
   description: '',
   aiMetadata: { description: 'Returns the identifier of the flow run that is currently executing, along with a direct link to that run in the Activepieces UI. Use it when a later step needs to reference or report the run itself (e.g. embedding a run link in a Slack alert or a support ticket); it only ever describes the in-progress run and cannot look up a different one. Takes no inputs; read-only and idempotent.', idempotent: true },
   props: {},
+  outputSchema: getRunIdActionOutputSchema,
   async run(context) {
     const publicUrlWithoutApi = context.server.publicUrl.replace('/api', '');
     return {

--- a/packages/pieces/community/flow-helper/src/lib/actions/stop-flow.ts
+++ b/packages/pieces/community/flow-helper/src/lib/actions/stop-flow.ts
@@ -1,4 +1,5 @@
 import { createAction} from '@activepieces/pieces-framework';
+import { stopFlowActionOutputSchema } from '../output-schemas';
 
 export const stopFlow = createAction({
   audience: 'both',
@@ -8,6 +9,7 @@ export const stopFlow = createAction({
   description: 'Stops the flow immediately this step is reached.',
   aiMetadata: { description: 'Ends the current flow run at this step and marks it as stopped rather than failed, so no later steps execute. Use it for an early exit when a condition means there is nothing left to do; prefer Fail Flow when the exit should be recorded as an error instead. Takes no inputs and stops the run without a custom webhook response; idempotent, since it drives the run to the same stopped end state and creates nothing.', idempotent: true },
   props: {},
+  outputSchema: stopFlowActionOutputSchema,
   async run(context) {
     context.run.stop();
 

--- a/packages/pieces/community/flow-helper/src/lib/output-schemas.ts
+++ b/packages/pieces/community/flow-helper/src/lib/output-schemas.ts
@@ -1,0 +1,15 @@
+import { OutputSchema } from '@activepieces/pieces-framework';
+
+export const getRunIdActionOutputSchema: OutputSchema = {
+  fields: [
+    { key: 'id', label: 'Run ID' },
+    { key: 'url', label: 'Run URL', format: 'url' },
+  ],
+};
+
+export const stopFlowActionOutputSchema: OutputSchema = {
+  fields: [
+    { key: 'success', label: 'Success', format: 'boolean' },
+    { key: 'message', label: 'Message' },
+  ],
+};

--- a/packages/pieces/community/google-gemini/package.json
+++ b/packages/pieces/community/google-gemini/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-google-gemini",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "dependencies": {

--- a/packages/pieces/community/google-gemini/src/lib/actions/create-video.action.ts
+++ b/packages/pieces/community/google-gemini/src/lib/actions/create-video.action.ts
@@ -4,6 +4,7 @@ import { googleGeminiAuth } from '../auth';
 import { getGeminiVideoModelOptions } from '../common/common';
 import { GoogleGenAI } from '@google/genai';
 import mime from 'mime-types';
+import { createVideoActionOutputSchema } from '../output-schemas';
 
 export const createVideoAction = createAction({
   audience: 'both',
@@ -120,6 +121,7 @@ export const createVideoAction = createAction({
       },
     }),
   },
+  outputSchema: createVideoActionOutputSchema,
   async run(context) {
     const {
       model,

--- a/packages/pieces/community/google-gemini/src/lib/output-schemas.ts
+++ b/packages/pieces/community/google-gemini/src/lib/output-schemas.ts
@@ -129,3 +129,14 @@ export const textToSpeechActionOutputSchema: OutputSchema = {
     },
   ],
 };
+
+export const createVideoActionOutputSchema: OutputSchema = {
+  fields: [
+    {
+      key: 'videoFile',
+      label: 'Video File URL',
+      value: '',
+      format: 'url',
+    },
+  ],
+};

--- a/packages/pieces/community/grok-xai/package.json
+++ b/packages/pieces/community/grok-xai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-grok-xai",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/packages/pieces/community/grok-xai/src/lib/actions/ask-grok.ts
+++ b/packages/pieces/community/grok-xai/src/lib/actions/ask-grok.ts
@@ -16,6 +16,7 @@ import {
   XaiResponse,
   AskGrokResult
 } from '../common/utils';
+import { askGrokActionOutputSchema } from '../output-schemas';
 import * as z from 'zod/mini'
 
 export const askGrok = createAction({
@@ -205,6 +206,7 @@ export const askGrok = createAction({
       required: false,
     }),
   },
+  outputSchema: askGrokActionOutputSchema,
   async run({ auth, propsValue, store }) {
     await propsValidation.validateZod(propsValue, {
       temperature: z.optional(z.number().check(z.minimum(0), z.maximum(2))),

--- a/packages/pieces/community/grok-xai/src/lib/actions/categorize-text.ts
+++ b/packages/pieces/community/grok-xai/src/lib/actions/categorize-text.ts
@@ -16,6 +16,7 @@ import {
   XaiResponse,
   CategorizationResult
 } from '../common/utils';
+import { categorizeTextActionOutputSchema } from '../output-schemas';
 import * as z from 'zod/mini'
 
 interface Category {
@@ -98,6 +99,7 @@ export const categorizeText = createAction({
       },
     }),
   },
+  outputSchema: categorizeTextActionOutputSchema,
   async run({ auth, propsValue }) {
     await propsValidation.validateZod(propsValue, {
       temperature: z.optional(z.number().check(z.minimum(0), z.maximum(2))),

--- a/packages/pieces/community/grok-xai/src/lib/actions/extract-data.ts
+++ b/packages/pieces/community/grok-xai/src/lib/actions/extract-data.ts
@@ -16,6 +16,7 @@ import {
   XaiResponse,
   ExtractionResult
 } from '../common/utils';
+import { extractDataFromTextActionOutputSchema } from '../output-schemas';
 import * as z from 'zod/mini'
 
 interface ExtractDataField {
@@ -121,6 +122,7 @@ export const extractDataFromText = createAction({
       description: 'Include confidence scores for extracted fields.',
     }),
   },
+  outputSchema: extractDataFromTextActionOutputSchema,
   async run({ auth, propsValue }) {
     await propsValidation.validateZod(propsValue, {
       temperature: z.optional(z.number().check(z.minimum(0), z.maximum(2))),

--- a/packages/pieces/community/grok-xai/src/lib/actions/generate-image.ts
+++ b/packages/pieces/community/grok-xai/src/lib/actions/generate-image.ts
@@ -10,9 +10,10 @@ import {
 } from '@activepieces/pieces-common';
 import { grokAuth } from '../common/auth';
 import { XAI_BASE_URL } from '../common/constants';
-import { 
+import {
   createModelProperty
 } from '../common/utils';
+import { generateImageActionOutputSchema } from '../output-schemas';
 import * as z from 'zod/mini'
 
 export const generateImage = createAction({
@@ -54,6 +55,7 @@ export const generateImage = createAction({
       },
     }),
   },
+  outputSchema: generateImageActionOutputSchema,
   async run({ auth, propsValue }) {
     await propsValidation.validateZod(propsValue, {
       numberOfImages: z.optional(z.number().check(z.minimum(1), z.maximum(10))),

--- a/packages/pieces/community/grok-xai/src/lib/output-schemas.ts
+++ b/packages/pieces/community/grok-xai/src/lib/output-schemas.ts
@@ -1,0 +1,98 @@
+import { OutputSchema, OutputSchemaField } from '@activepieces/pieces-framework';
+
+const usageFields: OutputSchemaField[] = [
+  { key: 'prompt_tokens', label: 'Prompt Tokens', format: 'number' },
+  { key: 'completion_tokens', label: 'Completion Tokens', format: 'number' },
+  { key: 'total_tokens', label: 'Total Tokens', format: 'number' },
+  { key: 'num_sources_used', label: 'Sources Used', format: 'number' },
+];
+
+const toolCallFields: OutputSchemaField[] = [
+  { key: 'id', label: 'Tool Call ID' },
+  { key: 'type', label: 'Type' },
+  {
+    key: 'function',
+    label: 'Function',
+    children: [
+      { key: 'name', label: 'Name' },
+      { key: 'arguments', label: 'Arguments (JSON)' },
+    ],
+  },
+];
+
+export const askGrokActionOutputSchema: OutputSchema = {
+  fields: [
+    { key: 'content', label: 'Content' },
+    { key: 'reasoning_content', label: 'Reasoning Content' },
+    { key: 'refusal', label: 'Refusal' },
+    { key: 'role', label: 'Role' },
+    { key: 'finish_reason', label: 'Finish Reason' },
+    { key: 'model', label: 'Model' },
+    { key: 'id', label: 'Response ID' },
+    { key: 'created', label: 'Created (Unix Seconds)' },
+    { key: 'tool_calls', label: 'Tool Calls', labelKey: 'function.name', listItems: toolCallFields },
+    { key: 'citations', label: 'Citations' },
+    { key: 'usage', label: 'Usage', children: usageFields },
+  ],
+};
+
+export const categorizeTextActionOutputSchema: OutputSchema = {
+  fields: [
+    { key: 'categories', label: 'Categories' },
+    { key: 'primary_category', label: 'Primary Category' },
+    { key: 'total_categories_assigned', label: 'Total Categories Assigned', format: 'number' },
+    { key: 'multiple_categories', label: 'Multiple Categories Allowed', format: 'boolean' },
+    { key: 'reasoning', label: 'Reasoning' },
+    { key: 'reasoning_content', label: 'Reasoning Content' },
+    { key: 'confidence_scores', label: 'Confidence Scores', dynamicKey: true },
+    { key: 'avg_confidence', label: 'Average Confidence', format: 'number' },
+    { key: 'max_confidence', label: 'Max Confidence', format: 'number' },
+    { key: 'min_confidence', label: 'Min Confidence', format: 'number' },
+    { key: 'model', label: 'Model' },
+    { key: 'finish_reason', label: 'Finish Reason' },
+    { key: 'citations', label: 'Citations' },
+    { key: 'usage', label: 'Usage', children: usageFields },
+  ],
+};
+
+export const extractDataFromTextActionOutputSchema: OutputSchema = {
+  fields: [
+    { key: 'extracted_data', label: 'Extracted Data', dynamicKey: true },
+    { key: 'extraction_success', label: 'Extraction Success', format: 'boolean' },
+    { key: 'extraction_notes', label: 'Extraction Notes' },
+    { key: 'fields_extracted', label: 'Fields Extracted', format: 'number' },
+    { key: 'fields_requested', label: 'Fields Requested', format: 'number' },
+    { key: 'completion_rate', label: 'Completion Rate', format: 'number' },
+    { key: 'required_fields_found', label: 'Required Fields Found', format: 'number' },
+    { key: 'required_fields_missing', label: 'Required Fields Missing', format: 'number' },
+    { key: 'confidence_scores', label: 'Confidence Scores', dynamicKey: true },
+    { key: 'avg_confidence', label: 'Average Confidence', format: 'number' },
+    { key: 'max_confidence', label: 'Max Confidence', format: 'number' },
+    { key: 'min_confidence', label: 'Min Confidence', format: 'number' },
+    { key: 'reasoning_content', label: 'Reasoning Content' },
+    { key: 'model', label: 'Model' },
+    { key: 'finish_reason', label: 'Finish Reason' },
+    { key: 'citations', label: 'Citations' },
+    { key: 'usage', label: 'Usage', children: usageFields },
+  ],
+};
+
+export const generateImageActionOutputSchema: OutputSchema = {
+  fields: [
+    {
+      key: 'images',
+      label: 'Images',
+      labelKey: 'revised_prompt',
+      listItems: [
+        { key: 'index', label: 'Index', format: 'number' },
+        { key: 'url', label: 'URL', format: 'url' },
+        { key: 'b64_json', label: 'Base64 JSON' },
+        { key: 'revised_prompt', label: 'Revised Prompt' },
+      ],
+    },
+    { key: 'total_images', label: 'Total Images', format: 'number' },
+    { key: 'prompt_used', label: 'Prompt Used' },
+    { key: 'model_used', label: 'Model Used' },
+    { key: 'response_format', label: 'Response Format' },
+  ],
+};

--- a/packages/pieces/community/openai/package.json
+++ b/packages/pieces/community/openai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-openai",
-  "version": "0.10.4",
+  "version": "0.10.5",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "dependencies": {

--- a/packages/pieces/community/openai/src/lib/actions/analyze-sentiment.ts
+++ b/packages/pieces/community/openai/src/lib/actions/analyze-sentiment.ts
@@ -1,6 +1,7 @@
 import { createAction, Property } from '@activepieces/pieces-framework';
 import OpenAI from 'openai';
 import { openaiAuth } from '../auth';
+import { analyzeSentimentActionOutputSchema } from '../output-schemas';
 
 const sentiments = ['positive', 'negative', 'neutral'] as const;
 
@@ -35,6 +36,7 @@ export const analyzeSentiment = createAction({
       required: true,
     }),
   },
+  outputSchema: analyzeSentimentActionOutputSchema,
   async run(context) {
     const openai = new OpenAI({ apiKey: context.auth.secret_text });
     const { model, text } = context.propsValue;

--- a/packages/pieces/community/openai/src/lib/actions/ask-assistant.ts
+++ b/packages/pieces/community/openai/src/lib/actions/ask-assistant.ts
@@ -8,6 +8,7 @@ import { openaiAuth } from '../auth';
 import { sleep } from '../common/common';
 import * as z from 'zod/mini'
 import { propsValidation } from '@activepieces/pieces-common';
+import { askAssistantActionOutputSchema } from '../output-schemas';
 
 export const askAssistant = createAction({
   audience: 'both',
@@ -67,6 +68,7 @@ export const askAssistant = createAction({
       required: false,
     }),
   },
+  outputSchema: askAssistantActionOutputSchema,
   async run({ auth, propsValue, store }) {
     await propsValidation.validateZod(propsValue, {
       memoryKey: z.optional(z.string().check(z.maxLength(128))),

--- a/packages/pieces/community/openai/src/lib/actions/classify-text.ts
+++ b/packages/pieces/community/openai/src/lib/actions/classify-text.ts
@@ -1,6 +1,7 @@
 import { createAction, Property } from '@activepieces/pieces-framework';
 import OpenAI from 'openai';
 import { openaiAuth } from '../auth';
+import { classifyTextActionOutputSchema } from '../output-schemas';
 
 export const classifyText = createAction({
   audience: 'both',
@@ -31,6 +32,7 @@ export const classifyText = createAction({
       required: true,
     }),
   },
+  outputSchema: classifyTextActionOutputSchema,
   async run(context) {
     const openai = new OpenAI({ apiKey: context.auth.secret_text });
     const { model, input } = context.propsValue;

--- a/packages/pieces/community/openai/src/lib/actions/create-embedding.ts
+++ b/packages/pieces/community/openai/src/lib/actions/create-embedding.ts
@@ -1,6 +1,7 @@
 import { createAction, Property } from '@activepieces/pieces-framework';
 import OpenAI from 'openai';
 import { openaiAuth } from '../auth';
+import { createEmbeddingActionOutputSchema } from '../output-schemas';
 
 export const createEmbedding = createAction({
   audience: 'both',
@@ -43,6 +44,7 @@ export const createEmbedding = createAction({
       required: false,
     }),
   },
+  outputSchema: createEmbeddingActionOutputSchema,
   async run(context) {
     const openai = new OpenAI({ apiKey: context.auth.secret_text });
     const { model, input, dimensions, user } = context.propsValue;

--- a/packages/pieces/community/openai/src/lib/actions/delete-file.ts
+++ b/packages/pieces/community/openai/src/lib/actions/delete-file.ts
@@ -1,6 +1,7 @@
 import { createAction, Property } from '@activepieces/pieces-framework';
 import OpenAI from 'openai';
 import { openaiAuth } from '../auth';
+import { deleteFileActionOutputSchema } from '../output-schemas';
 
 export const deleteFile = createAction({
   audience: 'both',
@@ -17,6 +18,7 @@ export const deleteFile = createAction({
       required: true,
     }),
   },
+  outputSchema: deleteFileActionOutputSchema,
   async run(context) {
     const openai = new OpenAI({ apiKey: context.auth.secret_text });
     const { fileId } = context.propsValue;

--- a/packages/pieces/community/openai/src/lib/actions/edit-image.ts
+++ b/packages/pieces/community/openai/src/lib/actions/edit-image.ts
@@ -4,6 +4,7 @@ import { randomBytes } from 'node:crypto';
 import { kebabCase } from '@activepieces/pieces-framework';
 import mime from 'mime-types';
 import { openaiAuth } from '../auth';
+import { editImageActionOutputSchema } from '../output-schemas';
 
 export const editImage = createAction({
   audience: 'both',
@@ -59,6 +60,7 @@ export const editImage = createAction({
       },
     }),
   },
+  outputSchema: editImageActionOutputSchema,
   async run(context) {
     const openai = new OpenAI({ apiKey: context.auth.secret_text });
     const { image, prompt, mask, size, quality } = context.propsValue;

--- a/packages/pieces/community/openai/src/lib/actions/find-file.ts
+++ b/packages/pieces/community/openai/src/lib/actions/find-file.ts
@@ -1,6 +1,7 @@
 import { createAction, Property } from '@activepieces/pieces-framework';
 import OpenAI from 'openai';
 import { openaiAuth } from '../auth';
+import { findFileActionOutputSchema } from '../output-schemas';
 
 export const findFile = createAction({
   audience: 'both',
@@ -31,6 +32,7 @@ export const findFile = createAction({
       },
     }),
   },
+  outputSchema: findFileActionOutputSchema,
   async run(context) {
     const openai = new OpenAI({ apiKey: context.auth.secret_text });
     const { fileName, purpose } = context.propsValue;

--- a/packages/pieces/community/openai/src/lib/actions/generate-image.ts
+++ b/packages/pieces/community/openai/src/lib/actions/generate-image.ts
@@ -4,6 +4,7 @@ import { kebabCase } from '@activepieces/pieces-framework';
 import { randomBytes } from 'node:crypto';
 import OpenAI from 'openai';
 import { openaiAuth } from '../auth';
+import { generateImageActionOutputSchema } from '../output-schemas';
 
 export const generateImage = createAction({
   audience: 'both',
@@ -84,6 +85,7 @@ export const generateImage = createAction({
       },
     }),
   },
+  outputSchema: generateImageActionOutputSchema,
   async run(context) {
     const openai = new OpenAI({ apiKey: context.auth.secret_text });
     const { quality, resolution, model, prompt } = context.propsValue;

--- a/packages/pieces/community/openai/src/lib/actions/list-files.ts
+++ b/packages/pieces/community/openai/src/lib/actions/list-files.ts
@@ -1,6 +1,7 @@
 import { createAction, Property } from '@activepieces/pieces-framework';
 import OpenAI from 'openai';
 import { openaiAuth } from '../auth';
+import { listFilesActionOutputSchema } from '../output-schemas';
 
 export const listFiles = createAction({
   audience: 'both',
@@ -32,6 +33,7 @@ export const listFiles = createAction({
       defaultValue: 100,
     }),
   },
+  outputSchema: listFilesActionOutputSchema,
   async run(context) {
     const openai = new OpenAI({ apiKey: context.auth.secret_text });
     const { purpose, limit } = context.propsValue;

--- a/packages/pieces/community/openai/src/lib/actions/list-models.ts
+++ b/packages/pieces/community/openai/src/lib/actions/list-models.ts
@@ -1,6 +1,7 @@
 import { createAction, Property } from '@activepieces/pieces-framework';
 import OpenAI from 'openai';
 import { openaiAuth } from '../auth';
+import { listModelsActionOutputSchema } from '../output-schemas';
 
 export const listModels = createAction({
   audience: 'both',
@@ -19,6 +20,7 @@ export const listModels = createAction({
       required: false,
     }),
   },
+  outputSchema: listModelsActionOutputSchema,
   async run(context) {
     const openai = new OpenAI({ apiKey: context.auth.secret_text });
     const { contains } = context.propsValue;

--- a/packages/pieces/community/openai/src/lib/actions/search-embeddings.ts
+++ b/packages/pieces/community/openai/src/lib/actions/search-embeddings.ts
@@ -1,6 +1,7 @@
 import { createAction, Property } from '@activepieces/pieces-framework';
 import OpenAI from 'openai';
 import { openaiAuth } from '../auth';
+import { searchEmbeddingsActionOutputSchema } from '../output-schemas';
 
 export const searchEmbeddings = createAction({
   audience: 'both',
@@ -42,6 +43,7 @@ export const searchEmbeddings = createAction({
       required: false,
     }),
   },
+  outputSchema: searchEmbeddingsActionOutputSchema,
   async run(context) {
     const openai = new OpenAI({ apiKey: context.auth.secret_text });
     const { model, query, topK } = context.propsValue;

--- a/packages/pieces/community/openai/src/lib/actions/transcriptions.ts
+++ b/packages/pieces/community/openai/src/lib/actions/transcriptions.ts
@@ -8,6 +8,7 @@ import { openaiAuth } from '../auth';
 import FormData from 'form-data';
 import mime from 'mime-types';
 import { Languages, baseUrl } from '../common/common';
+import { transcribeActionOutputSchema } from '../output-schemas';
 
 export const transcribeAction = createAction({
   audience: 'both',
@@ -33,6 +34,7 @@ export const transcribeAction = createAction({
       defaultValue: 'en',
     }),
   },
+  outputSchema: transcribeActionOutputSchema,
   run: async (context) => {
     const fileData = context.propsValue.audio;
     const mimeType = mime.lookup(fileData.extension ? fileData.extension : '');

--- a/packages/pieces/community/openai/src/lib/actions/translation.ts
+++ b/packages/pieces/community/openai/src/lib/actions/translation.ts
@@ -8,6 +8,7 @@ import { openaiAuth } from '../auth';
 import FormData from 'form-data';
 import mime from 'mime-types';
 import { baseUrl } from '../common/common';
+import { translateActionOutputSchema } from '../output-schemas';
 
 export const translateAction = createAction({
   audience: 'both',
@@ -24,6 +25,7 @@ export const translateAction = createAction({
       description: 'Audio file to translate',
     }),
   },
+  outputSchema: translateActionOutputSchema,
   run: async (context) => {
     const fileData = context.propsValue.audio;
     const mimeType = mime.lookup(fileData.extension ? fileData.extension : '');

--- a/packages/pieces/community/openai/src/lib/actions/upload-file.ts
+++ b/packages/pieces/community/openai/src/lib/actions/upload-file.ts
@@ -3,6 +3,7 @@ import OpenAI, { toFile } from 'openai';
 import type { FilePurpose } from 'openai/resources/files';
 import mime from 'mime-types';
 import { openaiAuth } from '../auth';
+import { uploadFileActionOutputSchema } from '../output-schemas';
 
 const allowedPurposes: readonly FilePurpose[] = [
   'assistants',
@@ -51,6 +52,7 @@ export const uploadFile = createAction({
       required: false,
     }),
   },
+  outputSchema: uploadFileActionOutputSchema,
   async run(context) {
     const openai = new OpenAI({ apiKey: context.auth.secret_text });
     const { file, purpose, fileName } = context.propsValue;

--- a/packages/pieces/community/openai/src/lib/output-schemas.ts
+++ b/packages/pieces/community/openai/src/lib/output-schemas.ts
@@ -1,0 +1,204 @@
+import { OutputSchema, OutputSchemaField } from '@activepieces/pieces-framework';
+
+const fileFields: OutputSchemaField[] = [
+  { key: 'id', label: 'File ID' },
+  { key: 'filename', label: 'Filename' },
+  { key: 'bytes', label: 'Size', format: 'filesize' },
+  { key: 'purpose', label: 'Purpose' },
+  { key: 'status', label: 'Status' },
+  { key: 'status_details', label: 'Status Details' },
+  { key: 'created_at', label: 'Created At (Unix Seconds)' },
+  { key: 'expires_at', label: 'Expires At (Unix Seconds)' },
+];
+
+const imageUsageFields: OutputSchemaField[] = [
+  { key: 'input_tokens', label: 'Input Tokens', format: 'number' },
+  { key: 'output_tokens', label: 'Output Tokens', format: 'number' },
+  { key: 'total_tokens', label: 'Total Tokens', format: 'number' },
+];
+
+const savedImageFields: OutputSchemaField[] = [
+  { key: 'url', label: 'Image URL', format: 'image' },
+  { key: 'fileName', label: 'File Name' },
+];
+
+const assistantMessageFields: OutputSchemaField[] = [
+  { key: 'id', label: 'Message ID' },
+  { key: 'role', label: 'Role' },
+  { key: 'created_at', label: 'Created At (Unix Seconds)' },
+  { key: 'assistant_id', label: 'Assistant ID' },
+  { key: 'thread_id', label: 'Thread ID' },
+  { key: 'run_id', label: 'Run ID' },
+  {
+    key: 'content',
+    label: 'Content',
+    labelKey: 'type',
+    listItems: [
+      { key: 'type', label: 'Type' },
+      { key: 'text', label: 'Text', children: [{ key: 'value', label: 'Value' }] },
+    ],
+  },
+];
+
+export const analyzeSentimentActionOutputSchema: OutputSchema = {
+  fields: [
+    { key: 'sentiment', label: 'Sentiment' },
+    { key: 'confidence', label: 'Confidence', format: 'number' },
+    { key: 'explanation', label: 'Explanation' },
+  ],
+};
+
+export const classifyTextActionOutputSchema: OutputSchema = {
+  fields: [
+    { key: 'flagged', label: 'Flagged', format: 'boolean' },
+    { key: 'categories', label: 'Categories', dynamicKey: true },
+    { key: 'category_scores', label: 'Category Scores', dynamicKey: true },
+    { key: 'model', label: 'Model' },
+    { key: 'id', label: 'Moderation ID' },
+  ],
+};
+
+export const createEmbeddingActionOutputSchema: OutputSchema = {
+  fields: [
+    { key: 'model', label: 'Model' },
+    { key: 'embedding', label: 'Embedding' },
+    {
+      key: 'usage',
+      label: 'Usage',
+      children: [
+        { key: 'prompt_tokens', label: 'Prompt Tokens', format: 'number' },
+        { key: 'total_tokens', label: 'Total Tokens', format: 'number' },
+      ],
+    },
+  ],
+};
+
+export const searchEmbeddingsActionOutputSchema: OutputSchema = {
+  fields: [
+    {
+      key: 'bestMatch',
+      label: 'Best Match',
+      children: [
+        { key: 'document', label: 'Document' },
+        { key: 'index', label: 'Index', format: 'number' },
+        { key: 'score', label: 'Score', format: 'number' },
+      ],
+    },
+    {
+      key: 'results',
+      label: 'Results',
+      labelKey: 'document',
+      listItems: [
+        { key: 'document', label: 'Document' },
+        { key: 'index', label: 'Index', format: 'number' },
+        { key: 'score', label: 'Score', format: 'number' },
+      ],
+    },
+    {
+      key: 'usage',
+      label: 'Usage',
+      children: [{ key: 'total_tokens', label: 'Total Tokens', format: 'number' }],
+    },
+  ],
+};
+
+export const deleteFileActionOutputSchema: OutputSchema = {
+  fields: [
+    { key: 'id', label: 'File ID' },
+    { key: 'deleted', label: 'Deleted', format: 'boolean' },
+  ],
+};
+
+export const findFileActionOutputSchema: OutputSchema = {
+  fields: [
+    { key: 'found', label: 'Found', format: 'boolean' },
+    { key: 'count', label: 'Match Count', format: 'number' },
+    { key: 'file', label: 'File', children: fileFields },
+    { key: 'files', label: 'Files', labelKey: 'filename', listItems: fileFields },
+  ],
+};
+
+export const listFilesActionOutputSchema: OutputSchema = {
+  fields: [
+    { key: 'files', label: 'Files', labelKey: 'filename', listItems: fileFields },
+    { key: 'count', label: 'Count', format: 'number' },
+  ],
+};
+
+export const uploadFileActionOutputSchema: OutputSchema = { fields: fileFields };
+
+export const listModelsActionOutputSchema: OutputSchema = {
+  fields: [
+    { key: 'count', label: 'Count', format: 'number' },
+    {
+      key: 'models',
+      label: 'Models',
+      labelKey: 'id',
+      listItems: [
+        { key: 'id', label: 'Model ID' },
+        { key: 'created', label: 'Created (Unix Seconds)' },
+        { key: 'owned_by', label: 'Owned By' },
+      ],
+    },
+  ],
+};
+
+export const generateImageActionOutputSchema: OutputSchema = {
+  fields: [
+    { key: 'created', label: 'Created At (Unix Seconds)' },
+    { key: 'background', label: 'Background' },
+    { key: 'output_format', label: 'Output Format' },
+    { key: 'quality', label: 'Quality' },
+    { key: 'size', label: 'Size' },
+    { key: 'usage', label: 'Usage', children: imageUsageFields },
+    {
+      key: 'images',
+      label: 'Images',
+      labelKey: 'fileName',
+      listItems: [...savedImageFields, { key: 'revised_prompt', label: 'Revised Prompt' }],
+    },
+  ],
+};
+
+export const editImageActionOutputSchema: OutputSchema = {
+  fields: [
+    { key: 'created', label: 'Created At (Unix Seconds)' },
+    { key: 'background', label: 'Background' },
+    { key: 'output_format', label: 'Output Format' },
+    { key: 'quality', label: 'Quality' },
+    { key: 'size', label: 'Size' },
+    { key: 'usage', label: 'Usage', children: imageUsageFields },
+    { key: 'images', label: 'Images', labelKey: 'fileName', listItems: savedImageFields },
+  ],
+};
+
+export const transcribeActionOutputSchema: OutputSchema = {
+  fields: [
+    { key: 'text', label: 'Text' },
+    {
+      key: 'usage',
+      label: 'Usage',
+      children: [
+        { key: 'type', label: 'Type' },
+        { key: 'seconds', label: 'Seconds', format: 'number' },
+      ],
+    },
+  ],
+};
+
+export const translateActionOutputSchema: OutputSchema = {
+  fields: [{ key: 'text', label: 'Text' }],
+};
+
+export const askAssistantActionOutputSchema: OutputSchema = {
+  itemLabel: '{role}',
+  fields: [
+    {
+      key: 'messages',
+      label: 'Messages',
+      value: '',
+      labelKey: 'role',
+      listItems: assistantMessageFields,
+    },
+  ],
+};

--- a/packages/pieces/core/smtp/package.json
+++ b/packages/pieces/core/smtp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-smtp",
-  "version": "0.4.7",
+  "version": "0.4.8",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {

--- a/packages/pieces/core/smtp/src/lib/actions/send-email.ts
+++ b/packages/pieces/core/smtp/src/lib/actions/send-email.ts
@@ -3,6 +3,7 @@ import { smtpAuth } from '../..';
 import { smtpCommon } from '../common';
 import { Attachment, Headers } from 'nodemailer/lib/mailer';
 import mime from 'mime-types';
+import { sendEmailActionOutputSchema } from '../output-schemas';
 
 export const sendEmail = createAction({
   audience: 'both',
@@ -84,6 +85,7 @@ export const sendEmail = createAction({
       }
     }),
   },
+  outputSchema: sendEmailActionOutputSchema,
   run: async ({ auth, propsValue }) => {
     const transporter = smtpCommon.createSMTPTransport(auth.props);
 

--- a/packages/pieces/core/smtp/src/lib/output-schemas.ts
+++ b/packages/pieces/core/smtp/src/lib/output-schemas.ts
@@ -1,0 +1,23 @@
+import { OutputSchema } from '@activepieces/pieces-framework';
+
+export const sendEmailActionOutputSchema: OutputSchema = {
+  fields: [
+    { key: 'accepted', label: 'Accepted Recipients' },
+    { key: 'rejected', label: 'Rejected Recipients' },
+    { key: 'pending', label: 'Pending Recipients' },
+    { key: 'messageId', label: 'Message ID' },
+    { key: 'response', label: 'SMTP Response' },
+    {
+      key: 'envelope',
+      label: 'Envelope',
+      children: [
+        { key: 'from', label: 'From' },
+        { key: 'to', label: 'To' },
+      ],
+    },
+    { key: 'envelopeTime', label: 'Envelope Time (ms)', format: 'duration' },
+    { key: 'messageTime', label: 'Message Time (ms)', format: 'duration' },
+    { key: 'messageSize', label: 'Message Size', format: 'filesize' },
+    { key: 'ehlo', label: 'Server Capabilities (EHLO)' },
+  ],
+};


### PR DESCRIPTION
## Description

Adds `outputSchema` to actions/triggers across six pieces so their results render as a curated, labelled tree in the flow builder's data selector and output viewer, instead of a raw JSON dump.

Linear: [PIE-401](https://linear.app/activepieces/issue/PIE-401/add-outputschema-to-openai-grok-xai-gemini-smtp-clickup-and-flow)

- **OpenAI** (`packages/pieces/community/openai`) — added to 12 actions (`analyze_sentiment`, `classify_text`, `create_embedding`, `search_embeddings`, `delete_file`, `find_file`, `list_files`, `upload_file`, `list_models`, `generate_image`, `edit_image`, `transcribe`, `translate`, `ask_assistant`), captured from real OpenAI API responses. Skipped `ask_chatgpt`, `vision_prompt`, `text_to_speech` (plain string/URL output — nothing to curate) and `extract-structured-data` (fields are user-defined per call, no fixed shape).
- **Grok / xAI** (`packages/pieces/community/grok-xai`) — added to all 4 actions (`ask_grok`, `categorize_text`, `extract_data_from_text`, `generate_image`), built from the piece's own hand-curated return objects plus xAI's chat-completions API reference (the provided test key had no credits, so this wasn't verified against a live response — `generate_image`'s shape in particular is inferred, not confirmed live).
- **Gemini** (`packages/pieces/community/google-gemini`) — added the one missing action, `create_video`, matching the sibling `text_to_speech` schema's convention since both just return a `files.write()` URL string.
- **SMTP** (`packages/pieces/core/smtp`) — added to `send-email`, captured from a real `sendMail()` call against a live SMTP server. The real response is richer than the nodemailer TS type documents (adds `ehlo`, `envelopeTime`, `messageTime`, `messageSize` alongside the typed fields); verified the shape is unaffected by attachments.
- **ClickUp** (`packages/pieces/community/clickup`) — added to the 2 of 21 missing actions that return real data: `update-space-tag` and `get-bulk-tasks-time-in-status`. See "Known gap" below for the other 19.
- **Flow Helper** (`packages/pieces/community/flow-helper`) — added to `getRunId` and `stopFlow`. `failFlow` always throws and never returns a value — see "Known gap" below.
- Bumped the patch version of every touched piece's `package.json` per repo convention, and included a `bun.lock` sync commit (piece version fields in the lockfile had drifted from `package.json` before this branch; unrelated to the schema work, no dependency/hash changes).

### Known gap vs. acceptance criteria

PIE-401 asks for delete/remove-style actions to get a minimal schema (e.g. a success indicator) rather than being skipped. That's true for OpenAI's `delete_file` (already returns real `{id, deleted}` data) and is honored here. It is **not** yet done for:

- **ClickUp's other 19 delete/remove actions** (tag attach/detach, dependency add/remove, custom-field set, task/list/checklist/message deletes) — these all return a literal `{}` from ClickUp's API (confirmed against ClickUp's own API docs for each), so satisfying the acceptance criteria means changing each action's `run()` to return a hand-built `{ success: true }`-style object (matching the pattern `stopFlow` already uses), then adding a schema for that — a small behavior change per action, not just a schema addition. Left out of this PR to keep it schema-only; can follow up in a separate PR.
- **`failFlow`** — always `throw`s, so `run()` has no return path at all; there's nothing to attach a schema to.

## How was this tested?

- `npx turbo run build lint --filter=<piece>` for each touched piece — all green (0 errors; pre-existing warnings only, none introduced by this change).
- OpenAI: captured real responses via curl against the live API (models, moderations, embeddings, file upload/list/delete, image generate/edit, TTS→transcribe/translate round-trip, a full Assistants thread/run/message cycle) and validated every schema path resolves against the captured JSON with a throwaway verification script.
- SMTP: sent two real test emails (with and without an attachment) through a live SMTP server and diffed the returned shape — confirmed identical (attachments only change `messageSize`).
- ClickUp/Grok-xAI/Gemini: cross-checked against the respective API docs where a live call wasn't available (grok-xai had no API credits; clickup/gemini calls derived from existing shipped code + docs).
- Not tested in the builder UI itself (no running dev instance in this environment) — worth a visual spot-check of a few trees (e.g. OpenAI `find_file`, ClickUp `get_bulk_tasks_time_in_status`'s dynamic-key rendering) before merge.
- Edition paths: not applicable — these are piece-level metadata changes with no edition-gated behavior.

Fixes # (issue)
<!-- Tracked in Linear PIE-401 (linked above), not a GitHub issue. -->

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)
