### PR TITLE
feat(pieces): add PixelPanda piece

### DIFF
--- a/packages/pieces/community/pixelpanda/.eslintrc.json
+++ b/packages/pieces/community/pixelpanda/.eslintrc.json
@@ -1,0 +1,47 @@
+{
+  "extends": [
+    "../../../../.eslintrc.json"
+  ],
+  "ignorePatterns": [
+    "!**/*"
+  ],
+  "overrides": [
+    {
+      "files": [
+        "*.ts",
+        "*.tsx",
+        "*.js",
+        "*.jsx"
+      ],
+      "rules": {}
+    },
+    {
+      "files": [
+        "*.ts",
+        "*.tsx"
+      ],
+      "rules": {
+        "no-restricted-imports": [
+          "error",
+          {
+            "patterns": [
+              "lodash",
+              "lodash/*",
+              "@activepieces/core-*",
+              "@activepieces/server*",
+              "@activepieces/engine",
+              "@activepieces/shared"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "files": [
+        "*.js",
+        "*.jsx"
+      ],
+      "rules": {}
+    }
+  ]
+}

--- a/packages/pieces/community/pixelpanda/README.md
+++ b/packages/pieces/community/pixelpanda/README.md
@@ -1,0 +1,5 @@
+# PixelPanda
+
+AI product photos, virtual try-on, avatars, UGC video, background removal and upscaling for e-commerce.
+
+Get an API key at https://pixelpanda.ai/profile — docs at https://pixelpanda.ai/developers.

--- a/packages/pieces/community/pixelpanda/package.json
+++ b/packages/pieces/community/pixelpanda/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@activepieces/piece-pixelpanda",
+  "version": "0.1.0",
+  "main": "./dist/src/index.js",
+  "types": "./dist/src/index.d.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.lib.json && cp package.json dist/",
+    "bundle": "node ../../../../dist/packages/cli/src/index.js pieces bundle",
+    "lint": "eslint 'src/**/*.ts'"
+  },
+  "dependencies": {
+    "@activepieces/pieces-common": "workspace:*",
+    "@activepieces/pieces-framework": "workspace:*",
+    "@activepieces/core-piece-types": "workspace:*",
+    "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
+  }
+}

--- a/packages/pieces/community/pixelpanda/src/index.ts
+++ b/packages/pieces/community/pixelpanda/src/index.ts
@@ -1,0 +1,45 @@
+import { createCustomApiCallAction } from '@activepieces/pieces-common';
+import { createPiece, PieceCategory } from '@activepieces/pieces-framework';
+import { pixelpandaAuth } from './lib/auth';
+import { pixelpandaRemoveBackgroundAction } from './lib/actions/remove-background';
+import { pixelpandaUpscaleImageAction } from './lib/actions/upscale-image';
+import { pixelpandaEnhancePhotoAction } from './lib/actions/enhance-photo';
+import { pixelpandaEditImageAction } from './lib/actions/edit-image';
+import { pixelpandaImageToPromptAction } from './lib/actions/image-to-prompt';
+import { pixelpandaGenerateProductPhotosAction } from './lib/actions/generate-product-photos';
+import { pixelpandaCreateAdPackAction } from './lib/actions/create-ad-pack';
+import { pixelpandaGenerateUgcVideoAction } from './lib/actions/generate-ugc-video';
+import { pixelpandaGetJobAction } from './lib/actions/get-job';
+import { pixelpandaGetAdPackAction } from './lib/actions/get-ad-pack';
+import { pixelpandaGetVideoJobAction } from './lib/actions/get-video-job';
+
+export const pixelpanda = createPiece({
+  displayName: 'PixelPanda',
+  description: 'AI product photos, virtual try-on, avatars, UGC video, background removal and upscaling',
+  minimumSupportedRelease: '0.30.0',
+  logoUrl: 'https://cdn.activepieces.com/pieces/pixelpanda.png',
+  categories: [PieceCategory.MARKETING, PieceCategory.CONTENT_AND_FILES],
+  authors: ['RyanKramer'],
+  auth: pixelpandaAuth,
+  actions: [
+    pixelpandaRemoveBackgroundAction,
+    pixelpandaUpscaleImageAction,
+    pixelpandaEnhancePhotoAction,
+    pixelpandaEditImageAction,
+    pixelpandaImageToPromptAction,
+    pixelpandaGenerateProductPhotosAction,
+    pixelpandaCreateAdPackAction,
+    pixelpandaGenerateUgcVideoAction,
+    pixelpandaGetJobAction,
+    pixelpandaGetAdPackAction,
+    pixelpandaGetVideoJobAction,
+    createCustomApiCallAction({
+      baseUrl: () => 'https://pixelpanda.ai/api/v2',
+      auth: pixelpandaAuth,
+      authMapping: async (auth) => ({
+        Authorization: `Bearer ${(auth as { secret_text: string }).secret_text}`,
+      }),
+    }),
+  ],
+  triggers: [],
+});

--- a/packages/pieces/community/pixelpanda/src/lib/actions/create-ad-pack.ts
+++ b/packages/pieces/community/pixelpanda/src/lib/actions/create-ad-pack.ts
@@ -1,0 +1,31 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { pixelpandaAuth } from '../auth';
+import { pixelpandaRequest } from '../common';
+
+export const pixelpandaCreateAdPackAction = createAction({
+  auth: pixelpandaAuth,
+  name: 'pixelpanda_create_ad_pack',
+  displayName: 'Create Ad Pack From Product URL',
+  description: 'Product page URL in — 6 scene photos, a lip-synced UGC video, 8 static ads and captions out (59 credits with video, 9 without); poll with Get Ad Pack',
+  props: {
+    productUrl: Property.ShortText({
+      displayName: 'Product Page URL',
+      description: 'Shopify, WooCommerce, Amazon or any product page with images',
+      required: true,
+    }),
+    includeVideo: Property.Checkbox({
+      displayName: 'Include UGC Video (50 credits)',
+      required: false,
+      defaultValue: true,
+    })
+  },
+  async run({ auth, propsValue }) {
+    return await pixelpandaRequest(
+      { secret_text: auth.secret_text },
+      HttpMethod.POST,
+      '/ad-pack',
+      { url: propsValue.productUrl, include_images: true, include_ads: true, include_captions: true, include_animations: false, include_video: propsValue.includeVideo ?? true },
+    );
+  },
+});

--- a/packages/pieces/community/pixelpanda/src/lib/actions/edit-image.ts
+++ b/packages/pieces/community/pixelpanda/src/lib/actions/edit-image.ts
@@ -1,0 +1,31 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { pixelpandaAuth } from '../auth';
+import { pixelpandaRequest } from '../common';
+
+export const pixelpandaEditImageAction = createAction({
+  auth: pixelpandaAuth,
+  name: 'pixelpanda_edit_image',
+  displayName: 'Edit Image With AI',
+  description: 'Change an image with a text instruction using FLUX Kontext (2 credits)',
+  props: {
+    imageUrl: Property.ShortText({
+      displayName: 'Image URL',
+      description: 'Public URL of the image (JPEG/PNG/WebP, max 10MB)',
+      required: true,
+    }),
+    prompt: Property.LongText({
+      displayName: 'Prompt',
+      description: "What to change, e.g. 'make the car yellow'",
+      required: true,
+    })
+  },
+  async run({ auth, propsValue }) {
+    return await pixelpandaRequest(
+      { secret_text: auth.secret_text },
+      HttpMethod.POST,
+      '/edit',
+      { image_url: propsValue.imageUrl, prompt: propsValue.prompt },
+    );
+  },
+});

--- a/packages/pieces/community/pixelpanda/src/lib/actions/enhance-photo.ts
+++ b/packages/pieces/community/pixelpanda/src/lib/actions/enhance-photo.ts
@@ -1,0 +1,26 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { pixelpandaAuth } from '../auth';
+import { pixelpandaRequest } from '../common';
+
+export const pixelpandaEnhancePhotoAction = createAction({
+  auth: pixelpandaAuth,
+  name: 'pixelpanda_enhance_photo',
+  displayName: 'Enhance Photo',
+  description: 'Sharpen, de-noise and fix lighting with AI (1 credit)',
+  props: {
+    imageUrl: Property.ShortText({
+      displayName: 'Image URL',
+      description: 'Public URL of the image (JPEG/PNG/WebP, max 10MB)',
+      required: true,
+    })
+  },
+  async run({ auth, propsValue }) {
+    return await pixelpandaRequest(
+      { secret_text: auth.secret_text },
+      HttpMethod.POST,
+      '/enhance',
+      { image_url: propsValue.imageUrl },
+    );
+  },
+});

--- a/packages/pieces/community/pixelpanda/src/lib/actions/generate-product-photos.ts
+++ b/packages/pieces/community/pixelpanda/src/lib/actions/generate-product-photos.ts
@@ -1,0 +1,32 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { pixelpandaAuth } from '../auth';
+import { pixelpandaRequest } from '../common';
+
+export const pixelpandaGenerateProductPhotosAction = createAction({
+  auth: pixelpandaAuth,
+  name: 'pixelpanda_generate_product_photos',
+  displayName: 'Generate Product Photos',
+  description: 'Turn one product image into AI lifestyle/studio scene photos (1 credit per photo); returns a job to poll with Get Generation Job',
+  props: {
+    imageUrl: Property.ShortText({
+      displayName: 'Image URL',
+      description: 'Public URL of the image (JPEG/PNG/WebP, max 10MB)',
+      required: true,
+    }),
+    numScenes: Property.Number({
+      displayName: 'Number of Photos',
+      description: '1-12',
+      required: false,
+      defaultValue: 4,
+    })
+  },
+  async run({ auth, propsValue }) {
+    return await pixelpandaRequest(
+      { secret_text: auth.secret_text },
+      HttpMethod.POST,
+      '/generate/scenes-from-url',
+      { image_url: propsValue.imageUrl, num_scenes: propsValue.numScenes ?? 4 },
+    );
+  },
+});

--- a/packages/pieces/community/pixelpanda/src/lib/actions/generate-ugc-video.ts
+++ b/packages/pieces/community/pixelpanda/src/lib/actions/generate-ugc-video.ts
@@ -1,0 +1,31 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { pixelpandaAuth } from '../auth';
+import { pixelpandaRequest } from '../common';
+
+export const pixelpandaGenerateUgcVideoAction = createAction({
+  auth: pixelpandaAuth,
+  name: 'pixelpanda_generate_ugc_video',
+  displayName: 'Generate UGC Video',
+  description: 'Turn a still image into a talking UGC-style video with native AI speech and lip-sync (50 credits); poll with Get Video Job',
+  props: {
+    imageUrl: Property.ShortText({
+      displayName: 'Image URL',
+      description: 'Public URL of the source image to animate (a person or avatar works best)',
+      required: true,
+    }),
+    script: Property.LongText({
+      displayName: 'Spoken Script',
+      description: 'What the person says',
+      required: false,
+    })
+  },
+  async run({ auth, propsValue }) {
+    return await pixelpandaRequest(
+      { secret_text: auth.secret_text },
+      HttpMethod.POST,
+      '/generate/video',
+      { image_url: propsValue.imageUrl, script: propsValue.script ?? '', duration: 5 },
+    );
+  },
+});

--- a/packages/pieces/community/pixelpanda/src/lib/actions/get-ad-pack.ts
+++ b/packages/pieces/community/pixelpanda/src/lib/actions/get-ad-pack.ts
@@ -1,0 +1,25 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { pixelpandaAuth } from '../auth';
+import { pixelpandaRequest } from '../common';
+
+export const pixelpandaGetAdPackAction = createAction({
+  auth: pixelpandaAuth,
+  name: 'pixelpanda_get_ad_pack',
+  displayName: 'Get Ad Pack',
+  description: 'Fetch an ad pack job with its photos, video, static ads and captions',
+  props: {
+    jobId: Property.ShortText({
+      displayName: 'Job ID',
+      required: true,
+    })
+  },
+  async run({ auth, propsValue }) {
+    return await pixelpandaRequest(
+      { secret_text: auth.secret_text },
+      HttpMethod.GET,
+      `/ad-pack/${propsValue.jobId}`,
+      undefined,
+    );
+  },
+});

--- a/packages/pieces/community/pixelpanda/src/lib/actions/get-job.ts
+++ b/packages/pieces/community/pixelpanda/src/lib/actions/get-job.ts
@@ -1,0 +1,25 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { pixelpandaAuth } from '../auth';
+import { pixelpandaRequest } from '../common';
+
+export const pixelpandaGetJobAction = createAction({
+  auth: pixelpandaAuth,
+  name: 'pixelpanda_get_job',
+  displayName: 'Get Generation Job',
+  description: 'Fetch a product-photo generation job and its result image URLs',
+  props: {
+    jobId: Property.ShortText({
+      displayName: 'Job ID',
+      required: true,
+    })
+  },
+  async run({ auth, propsValue }) {
+    return await pixelpandaRequest(
+      { secret_text: auth.secret_text },
+      HttpMethod.GET,
+      `/jobs/${propsValue.jobId}`,
+      undefined,
+    );
+  },
+});

--- a/packages/pieces/community/pixelpanda/src/lib/actions/get-video-job.ts
+++ b/packages/pieces/community/pixelpanda/src/lib/actions/get-video-job.ts
@@ -1,0 +1,25 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { pixelpandaAuth } from '../auth';
+import { pixelpandaRequest } from '../common';
+
+export const pixelpandaGetVideoJobAction = createAction({
+  auth: pixelpandaAuth,
+  name: 'pixelpanda_get_video_job',
+  displayName: 'Get Video Job',
+  description: 'Fetch a UGC video job and its finished video URL',
+  props: {
+    jobId: Property.ShortText({
+      displayName: 'Job ID',
+      required: true,
+    })
+  },
+  async run({ auth, propsValue }) {
+    return await pixelpandaRequest(
+      { secret_text: auth.secret_text },
+      HttpMethod.GET,
+      `/jobs/video/${propsValue.jobId}`,
+      undefined,
+    );
+  },
+});

--- a/packages/pieces/community/pixelpanda/src/lib/actions/image-to-prompt.ts
+++ b/packages/pieces/community/pixelpanda/src/lib/actions/image-to-prompt.ts
@@ -1,0 +1,26 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { pixelpandaAuth } from '../auth';
+import { pixelpandaRequest } from '../common';
+
+export const pixelpandaImageToPromptAction = createAction({
+  auth: pixelpandaAuth,
+  name: 'pixelpanda_image_to_prompt',
+  displayName: 'Image to AI Prompts',
+  description: 'Describe an image as ready-to-use AI art prompts for Flux, Midjourney and Stable Diffusion (1 credit)',
+  props: {
+    imageUrl: Property.ShortText({
+      displayName: 'Image URL',
+      description: 'Public URL of the image (JPEG/PNG/WebP, max 10MB)',
+      required: true,
+    })
+  },
+  async run({ auth, propsValue }) {
+    return await pixelpandaRequest(
+      { secret_text: auth.secret_text },
+      HttpMethod.POST,
+      '/image-to-prompt',
+      { image_url: propsValue.imageUrl },
+    );
+  },
+});

--- a/packages/pieces/community/pixelpanda/src/lib/actions/remove-background.ts
+++ b/packages/pieces/community/pixelpanda/src/lib/actions/remove-background.ts
@@ -1,0 +1,26 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { pixelpandaAuth } from '../auth';
+import { pixelpandaRequest } from '../common';
+
+export const pixelpandaRemoveBackgroundAction = createAction({
+  auth: pixelpandaAuth,
+  name: 'pixelpanda_remove_background',
+  displayName: 'Remove Background',
+  description: 'Cut out the subject and return a transparent PNG (1 credit)',
+  props: {
+    imageUrl: Property.ShortText({
+      displayName: 'Image URL',
+      description: 'Public URL of the image (JPEG/PNG/WebP, max 10MB)',
+      required: true,
+    })
+  },
+  async run({ auth, propsValue }) {
+    return await pixelpandaRequest(
+      { secret_text: auth.secret_text },
+      HttpMethod.POST,
+      '/remove-background',
+      { image_url: propsValue.imageUrl },
+    );
+  },
+});

--- a/packages/pieces/community/pixelpanda/src/lib/actions/upscale-image.ts
+++ b/packages/pieces/community/pixelpanda/src/lib/actions/upscale-image.ts
@@ -1,0 +1,38 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { pixelpandaAuth } from '../auth';
+import { pixelpandaRequest } from '../common';
+
+export const pixelpandaUpscaleImageAction = createAction({
+  auth: pixelpandaAuth,
+  name: 'pixelpanda_upscale_image',
+  displayName: 'Upscale Image',
+  description: 'Increase image resolution 2x, 4x or 8x with AI (1 credit; 8x = 2)',
+  props: {
+    imageUrl: Property.ShortText({
+      displayName: 'Image URL',
+      description: 'Public URL of the image (JPEG/PNG/WebP, max 10MB)',
+      required: true,
+    }),
+    scale: Property.StaticDropdown({
+      displayName: 'Scale Factor',
+      required: true,
+      defaultValue: 2,
+      options: { options: [ { label: '2x', value: 2 }, { label: '4x', value: 4 }, { label: '8x (2 credits)', value: 8 } ] },
+    }),
+    quality: Property.StaticDropdown({
+      displayName: 'Quality',
+      required: false,
+      defaultValue: 'fast',
+      options: { options: [ { label: 'Fast (Real-ESRGAN)', value: 'fast' }, { label: 'Balanced (Clarity)', value: 'balanced' }, { label: 'High (Clarity max detail)', value: 'high' } ] },
+    })
+  },
+  async run({ auth, propsValue }) {
+    return await pixelpandaRequest(
+      { secret_text: auth.secret_text },
+      HttpMethod.POST,
+      '/upscale',
+      { image_url: propsValue.imageUrl, scale: propsValue.scale, quality: propsValue.quality ?? 'fast' },
+    );
+  },
+});

--- a/packages/pieces/community/pixelpanda/src/lib/auth.ts
+++ b/packages/pieces/community/pixelpanda/src/lib/auth.ts
@@ -1,0 +1,7 @@
+import { PieceAuth } from '@activepieces/pieces-framework';
+
+export const pixelpandaAuth = PieceAuth.SecretText({
+  displayName: 'API Key',
+  description: 'PixelPanda API key from https://pixelpanda.ai/profile (starts with pk_live_)',
+  required: true,
+});

--- a/packages/pieces/community/pixelpanda/src/lib/common.ts
+++ b/packages/pieces/community/pixelpanda/src/lib/common.ts
@@ -1,0 +1,25 @@
+import {
+  AuthenticationType,
+  httpClient,
+  HttpMethod,
+} from '@activepieces/pieces-common';
+
+export const PIXELPANDA_API = 'https://pixelpanda.ai/api/v2';
+
+export async function pixelpandaRequest(
+  auth: { secret_text: string },
+  method: HttpMethod,
+  path: string,
+  body?: Record<string, unknown>,
+) {
+  const response = await httpClient.sendRequest({
+    method,
+    url: `${PIXELPANDA_API}${path}`,
+    authentication: {
+      type: AuthenticationType.BEARER_TOKEN,
+      token: auth.secret_text,
+    },
+    body,
+  });
+  return response.body;
+}

--- a/packages/pieces/community/pixelpanda/tsconfig.json
+++ b/packages/pieces/community/pixelpanda/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ],
+  "compilerOptions": {
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  }
+}

--- a/packages/pieces/community/pixelpanda/tsconfig.lib.json
+++ b/packages/pieces/community/pixelpanda/tsconfig.lib.json
@@ -1,0 +1,15 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "rootDir": ".",
+    "baseUrl": ".",
+    "paths": {},
+    "outDir": "./dist",
+    "declaration": true,
+    "declarationMap": true,
+    "types": ["node"]
+  },
+  "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"],
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
## What
Adds a community piece for [PixelPanda](https://pixelpanda.ai) — an AI photo studio for e-commerce (product photos, avatars, UGC video, background removal, upscaling).

**11 actions** over the public REST API (`https://pixelpanda.ai/api/v2`, Bearer API-key auth):
- Remove Background, Upscale Image, Enhance Photo, Edit Image With AI, Image to AI Prompts
- Generate Product Photos, Create Ad Pack From Product URL, Generate UGC Video
- Get Generation Job / Get Ad Pack / Get Video Job (pollers for the async operations)
- plus `createCustomApiCallAction`

Modeled closely on the existing `bannerbear` piece (auth shape, structure, custom API call).

## Notes for reviewers
- API docs: https://pixelpanda.ai/developers
- A free API key for testing can be provided on request (support@pixelpanda.ai)
- Logo (128px PNG, transparent): https://pixelpanda.ai/static/images/pixelpanda-128.png — happy to adjust to your CDN convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GmZNw7gWws6j9uEXbUfoJ1