### PR TITLE
fix(ai): keep the provider dropdown working against an API without multi-key

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -334,7 +334,7 @@
     },
     "packages/pieces/community/ai": {
       "name": "@activepieces/piece-ai",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",

--- a/packages/pieces/community/ai/package.json
+++ b/packages/pieces/community/ai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-ai",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/packages/pieces/community/ai/src/lib/common/props.ts
+++ b/packages/pieces/community/ai/src/lib/common/props.ts
@@ -11,8 +11,8 @@ function managedModelLabel(modelId: string): string | undefined {
 
 async function listProviders(ctx: {
   server: { apiUrl: string; token: string };
-}): Promise<ProjectAIProvider[]> {
-  const { body } = await httpClient.sendRequest<ProjectAIProvider[]>({
+}): Promise<ListedProvider[]> {
+  const { body } = await httpClient.sendRequest<ListedProvider[]>({
     method: HttpMethod.GET,
     url: `${ctx.server.apiUrl}v1/ai-providers`,
     headers: {
@@ -20,6 +20,20 @@ async function listProviders(ctx: {
     },
   });
   return body;
+}
+
+function providerOptionsOf(provider: ListedProvider): {
+  label: string;
+  value: AIProviderSelection;
+}[] {
+  const keys = provider.keys ?? [];
+  if (keys.length === 0) {
+    return [{ label: provider.name, value: { provider: provider.provider } }];
+  }
+  return keys.map((key) => ({
+    label: keys.length > 1 ? `${provider.name}: ${key.name}` : provider.name,
+    value: { provider: provider.provider, configId: key.id },
+  }));
 }
 
 function toProviderName(value: string): AIProviderName | undefined {
@@ -69,15 +83,7 @@ export const aiProps = <T extends AIModelType>({
               ? allowedProviders.includes(provider.provider)
               : true
           )
-          .flatMap(provider =>
-            provider.keys.map(key => ({
-              label:
-                provider.keys.length > 1
-                  ? `${provider.name}: ${key.name}`
-                  : provider.name,
-              value: { provider: provider.provider, configId: key.id },
-            }))
-          ),
+          .flatMap(provider => providerOptionsOf(provider)),
       };
     },
   }),
@@ -145,4 +151,8 @@ export type AIProviderSelection = {
 type AIPropsParams<T extends AIModelType> = {
   modelType: T;
   allowedProviders?: AIProviderName[];
+};
+
+type ListedProvider = Omit<ProjectAIProvider, 'keys'> & {
+  keys?: ProjectAIProvider['keys'];
 };


### PR DESCRIPTION
## Description

The AI piece's provider dropdown read `provider.keys` unconditionally. That field only exists on the API since the multi-key release (#14738 / #14825 / #14942), but a piece reaches every instance the moment it is published — including instances still running an older app. There, the response has no `keys`, the options resolver throws a `TypeError`, and every AI step renders with no providers at all:

```json
{ "type": "DROPDOWN", "options": { "disabled": true, "options": [], "placeholder": "Throws an error, reconnect or refresh the page" } }
```

This is live on Cloud right now: `piece-ai@0.7.0` published minutes after the merge to `main`, while the Cloud API is deployed from a release branch that does not yet carry the multi-key work — so the new piece is talking to the old API.

An absent `keys` array now falls back to one option per provider carrying no `configId`, which is exactly what `0.6.1` sent and what the server still resolves by project scope. With `keys` present nothing changes: one option per key, prefixed with the key name when a provider holds more than one.

`minimumSupportedRelease` stays at `0.78.2` on purpose. The piece genuinely supports both API shapes now, and raising it would hide this version from the very instances that need the fix, leaving them on the broken `0.7.0` — whose published metadata cannot be edited retroactively.

The API side was already backward compatible in the other direction, verified against the published `0.6.1` bundle: it reads only `name` and `provider` from the list, and the multi-key changes were additive with optional new query params.

## How was this tested?

- Ran the real dropdown resolver against both response shapes with a stubbed HTTP client: an entry without `keys` yields one option per provider, an entry with two keys yields two prefixed options.
- Verified the check is not vacuous — removing the fallback reproduces the production failure exactly (`TypeError: Cannot read properties of undefined`).
- `tsc -p tsconfig.lib.json --noEmit` and `eslint` clean on the piece.
- Editions: piece-side change only, identical on CE / EE / Cloud; the behaviour that differs is the app version the piece talks to, which is what this PR addresses.

Fixes # (issue)

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)