### PR TITLE
chore(worker): remove sandboxed execution mode requirement for worker groups

### DIFF
--- a/docs/install/configure-operate/worker-groups.mdx
+++ b/docs/install/configure-operate/worker-groups.mdx
@@ -33,10 +33,9 @@ AP_WORKER_GROUP_ID=canary
 AP_PROJECT_WORKER=false
 ```
 
-Grouped workers run in a process-isolated execution mode, so set:
+Grouped workers must set:
 
 ```bash
-AP_EXECUTION_MODE=SANDBOX_PROCESS   # or SANDBOX_CODE_AND_PROCESS
 AP_REUSE_SANDBOX=true               # or false, must be set explicitly
 ```
 

--- a/packages/server/worker/src/lib/worker.ts
+++ b/packages/server/worker/src/lib/worker.ts
@@ -3,7 +3,7 @@ import os from 'os'
 import { ActivepiecesError, isNil, spreadIfDefined, tryCatch } from '@activepieces/core-utils'
 import { ACTION_RUN_CACHE_FIRST_SWEEP_DELAY_MS, ACTION_RUN_CACHE_SWEEP_INTERVAL_MS, actionRunCache, cacheUtils, createResolver, createSandboxRuntime, Runtime } from '@activepieces/sandbox'
 import { apVersionUtil, createLogger, onCallService, systemUsage, UNKNOWN_VERSION, wideEvent } from '@activepieces/server-utils'
-import { ApiToWorkerContract, ConsumeJobRequest, createNotifyServer, createRpcClient, EngineResponseStatus, ExecutionMode, JobData, SandboxInformation, WebsocketServerEvent, WorkerJobType, WorkerMachineHealthcheckRequest, WorkerProps, WorkerSettingsResponse, WorkerToApiContract } from '@activepieces/shared'
+import { ApiToWorkerContract, ConsumeJobRequest, createNotifyServer, createRpcClient, EngineResponseStatus, JobData, SandboxInformation, WebsocketServerEvent, WorkerJobType, WorkerMachineHealthcheckRequest, WorkerProps, WorkerSettingsResponse, WorkerToApiContract } from '@activepieces/shared'
 import { nanoid } from 'nanoid'
 import { io, Socket } from 'socket.io-client'
 import { createApiToWorkerHandlers } from './api-notify-service'
@@ -416,10 +416,6 @@ async function fetchAndStoreSettings(sock: Socket): Promise<void> {
             }
             const workerGroupId = system.get(WorkerSystemProp.WORKER_GROUP_ID)
             if (!isNil(workerGroupId)) {
-                const processSandboxedModes = [ExecutionMode.SANDBOX_PROCESS, ExecutionMode.SANDBOX_CODE_AND_PROCESS]
-                if (!processSandboxedModes.includes(response.EXECUTION_MODE as ExecutionMode)) {
-                    throw new Error(`Worker group "${workerGroupId}" requires AP_EXECUTION_MODE to be one of: ${processSandboxedModes.join(', ')}. Got: ${response.EXECUTION_MODE}`)
-                }
                 const reuseSandbox = system.get(WorkerSystemProp.REUSE_SANDBOX)
                 if (isNil(reuseSandbox)) {
                     throw new Error(`Worker group "${workerGroupId}" requires AP_REUSE_SANDBOX to be set (true or false)`)

--- a/packages/server/worker/src/lib/worker.ts
+++ b/packages/server/worker/src/lib/worker.ts
@@ -3,7 +3,7 @@ import os from 'os'
 import { ActivepiecesError, isNil, spreadIfDefined, tryCatch } from '@activepieces/core-utils'
 import { ACTION_RUN_CACHE_FIRST_SWEEP_DELAY_MS, ACTION_RUN_CACHE_SWEEP_INTERVAL_MS, actionRunCache, cacheUtils, createResolver, createSandboxRuntime, Runtime } from '@activepieces/sandbox'
 import { apVersionUtil, createLogger, onCallService, systemUsage, UNKNOWN_VERSION, wideEvent } from '@activepieces/server-utils'
-import { ApiToWorkerContract, ConsumeJobRequest, createNotifyServer, createRpcClient, EngineResponseStatus, JobData, SandboxInformation, WebsocketServerEvent, WorkerJobType, WorkerMachineHealthcheckRequest, WorkerProps, WorkerSettingsResponse, WorkerToApiContract } from '@activepieces/shared'
+import { ApEdition, ApiToWorkerContract, ConsumeJobRequest, createNotifyServer, createRpcClient, EngineResponseStatus, ExecutionMode, JobData, SandboxInformation, WebsocketServerEvent, WorkerJobType, WorkerMachineHealthcheckRequest, WorkerProps, WorkerSettingsResponse, WorkerToApiContract } from '@activepieces/shared'
 import { nanoid } from 'nanoid'
 import { io, Socket } from 'socket.io-client'
 import { createApiToWorkerHandlers } from './api-notify-service'
@@ -416,6 +416,12 @@ async function fetchAndStoreSettings(sock: Socket): Promise<void> {
             }
             const workerGroupId = system.get(WorkerSystemProp.WORKER_GROUP_ID)
             if (!isNil(workerGroupId)) {
+                if (response.EDITION === ApEdition.CLOUD) {
+                    const processSandboxedModes: string[] = [ExecutionMode.SANDBOX_PROCESS, ExecutionMode.SANDBOX_CODE_AND_PROCESS]
+                    if (!processSandboxedModes.includes(response.EXECUTION_MODE)) {
+                        throw new Error(`Worker group "${workerGroupId}" requires AP_EXECUTION_MODE to be one of: ${processSandboxedModes.join(', ')}. Got: ${response.EXECUTION_MODE}`)
+                    }
+                }
                 const reuseSandbox = system.get(WorkerSystemProp.REUSE_SANDBOX)
                 if (isNil(reuseSandbox)) {
                     throw new Error(`Worker group "${workerGroupId}" requires AP_REUSE_SANDBOX to be set (true or false)`)

--- a/packages/server/worker/test/lib/worker-settings-override.test.ts
+++ b/packages/server/worker/test/lib/worker-settings-override.test.ts
@@ -211,22 +211,25 @@ describe('worker settings override', () => {
         expect(stored.EXECUTION_MODE).toBe(ExecutionMode.SANDBOX_CODE_AND_PROCESS)
     }, 10_000)
 
-    it('worker group + SANDBOX_CODE_ONLY throws error', async () => {
-        process.env.AP_WORKER_GROUP_ID = 'group-1'
-        process.env.AP_EXECUTION_MODE = ExecutionMode.SANDBOX_CODE_ONLY
-        const serverSettings = buildWorkerSettingsResponse()
-
-        const err = await connectAndExpectCrash(serverSettings)
-        expect(err.message).toMatch(/Worker group "group-1" requires AP_EXECUTION_MODE/)
-    }, 10_000)
-
-    it('worker group + UNSANDBOXED throws error', async () => {
+    it('worker group + UNSANDBOXED passes validation', async () => {
         process.env.AP_WORKER_GROUP_ID = 'group-1'
         process.env.AP_EXECUTION_MODE = ExecutionMode.UNSANDBOXED
+        process.env.AP_REUSE_SANDBOX = 'false'
+        const serverSettings = buildWorkerSettingsResponse()
+        await connectAndWaitForSettings(serverSettings)
+
+        expect(mockWorkerSettingsSet).toHaveBeenCalledTimes(1)
+        const stored = mockWorkerSettingsSet.mock.calls[0][0] as WorkerSettingsResponse
+        expect(stored.EXECUTION_MODE).toBe(ExecutionMode.UNSANDBOXED)
+    }, 10_000)
+
+    it('worker group without AP_REUSE_SANDBOX throws error', async () => {
+        process.env.AP_WORKER_GROUP_ID = 'group-1'
+        process.env.AP_EXECUTION_MODE = ExecutionMode.SANDBOX_PROCESS
         const serverSettings = buildWorkerSettingsResponse()
 
         const err = await connectAndExpectCrash(serverSettings)
-        expect(err.message).toMatch(/Worker group "group-1" requires AP_EXECUTION_MODE/)
+        expect(err.message).toMatch(/Worker group "group-1" requires AP_REUSE_SANDBOX/)
     }, 10_000)
 
     it('worker group + no local override, server sends SANDBOX_PROCESS → passes', async () => {

--- a/packages/server/worker/test/lib/worker-settings-override.test.ts
+++ b/packages/server/worker/test/lib/worker-settings-override.test.ts
@@ -2,6 +2,7 @@ import { createServer } from 'node:http'
 import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest'
 import { Server as IOServer } from 'socket.io'
 import {
+    ApEdition,
     createRpcServer,
     ExecutionMode,
     NetworkMode,
@@ -211,16 +212,38 @@ describe('worker settings override', () => {
         expect(stored.EXECUTION_MODE).toBe(ExecutionMode.SANDBOX_CODE_AND_PROCESS)
     }, 10_000)
 
-    it('worker group + UNSANDBOXED passes validation', async () => {
+    it('worker group + UNSANDBOXED passes validation on non-cloud editions', async () => {
         process.env.AP_WORKER_GROUP_ID = 'group-1'
         process.env.AP_EXECUTION_MODE = ExecutionMode.UNSANDBOXED
         process.env.AP_REUSE_SANDBOX = 'false'
-        const serverSettings = buildWorkerSettingsResponse()
+        const serverSettings = buildWorkerSettingsResponse({ EDITION: ApEdition.ENTERPRISE })
         await connectAndWaitForSettings(serverSettings)
 
         expect(mockWorkerSettingsSet).toHaveBeenCalledTimes(1)
         const stored = mockWorkerSettingsSet.mock.calls[0][0] as WorkerSettingsResponse
         expect(stored.EXECUTION_MODE).toBe(ExecutionMode.UNSANDBOXED)
+    }, 10_000)
+
+    it('worker group + UNSANDBOXED throws on cloud edition', async () => {
+        process.env.AP_WORKER_GROUP_ID = 'group-1'
+        process.env.AP_EXECUTION_MODE = ExecutionMode.UNSANDBOXED
+        process.env.AP_REUSE_SANDBOX = 'false'
+        const serverSettings = buildWorkerSettingsResponse({ EDITION: ApEdition.CLOUD })
+
+        const err = await connectAndExpectCrash(serverSettings)
+        expect(err.message).toMatch(/Worker group "group-1" requires AP_EXECUTION_MODE/)
+    }, 10_000)
+
+    it('worker group + SANDBOX_PROCESS passes validation on cloud edition', async () => {
+        process.env.AP_WORKER_GROUP_ID = 'group-1'
+        process.env.AP_EXECUTION_MODE = ExecutionMode.SANDBOX_PROCESS
+        process.env.AP_REUSE_SANDBOX = 'false'
+        const serverSettings = buildWorkerSettingsResponse({ EDITION: ApEdition.CLOUD })
+        await connectAndWaitForSettings(serverSettings)
+
+        expect(mockWorkerSettingsSet).toHaveBeenCalledTimes(1)
+        const stored = mockWorkerSettingsSet.mock.calls[0][0] as WorkerSettingsResponse
+        expect(stored.EXECUTION_MODE).toBe(ExecutionMode.SANDBOX_PROCESS)
     }, 10_000)
 
     it('worker group without AP_REUSE_SANDBOX throws error', async () => {


### PR DESCRIPTION
## Description

Workers with `AP_WORKER_GROUP_ID` set previously refused to start unless the effective `AP_EXECUTION_MODE` was `SANDBOX_PROCESS` or `SANDBOX_CODE_AND_PROCESS` (thrown in `fetchAndStoreSettings` in `packages/server/worker/src/lib/worker.ts`), on every edition. This scopes that requirement to the **cloud edition only** (`EDITION` from the server-provided worker settings): self-hosted CE/EE grouped workers can now run in any execution mode, while cloud grouped workers keep the process-sandboxed enforcement.

Unchanged: grouped workers still require `AP_REUSE_SANDBOX` to be set explicitly, on all editions.

Docs updated: `docs/install/configure-operate/worker-groups.mdx` (self-hosting docs) no longer lists `AP_EXECUTION_MODE=SANDBOX_PROCESS` as required.

## How was this tested?

Updated `worker-settings-override.test.ts`: worker group + `UNSANDBOXED` passes on EE, throws on cloud; worker group + `SANDBOX_PROCESS` passes on cloud; missing `AP_REUSE_SANDBOX` still throws. Note: most worker test files (including untouched ones) currently fail at import time on a pre-existing evlog ESM/CJS issue in the `server-utils` dist, unrelated to this change.

Fixes # (issue)

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)