### PR TITLE
fix(mcp): accept OAuth state parameters longer than 512 characters

### DIFF
--- a/packages/server/api/src/app/database/migration/postgres/1835000000000-WidenMcpOAuthState.ts
+++ b/packages/server/api/src/app/database/migration/postgres/1835000000000-WidenMcpOAuthState.ts
@@ -1,0 +1,17 @@
+import { QueryRunner } from 'typeorm'
+import { Migration } from '../../migration'
+
+export class WidenMcpOAuthState1835000000000 implements Migration {
+    name = 'WidenMcpOAuthState1835000000000'
+    release = '0.88.3'
+    breaking = true
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query('ALTER TABLE "mcp_oauth_authorization_code" ALTER COLUMN "state" TYPE character varying(2048)')
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query('UPDATE "mcp_oauth_authorization_code" SET "state" = NULL WHERE length("state") > 512')
+        await queryRunner.query('ALTER TABLE "mcp_oauth_authorization_code" ALTER COLUMN "state" TYPE character varying(512)')
+    }
+}

--- a/packages/server/api/src/app/database/postgres-connection.ts
+++ b/packages/server/api/src/app/database/postgres-connection.ts
@@ -426,6 +426,7 @@ import { AddChatPersonalization1831000000000 } from './migration/postgres/183100
 import { BackfillChatPersonalizationForExistingUsers1832000000000 } from './migration/postgres/1832000000000-BackfillChatPersonalizationForExistingUsers'
 import { ClearRoleFromCompanyPersonalization1833000000000 } from './migration/postgres/1833000000000-ClearRoleFromCompanyPersonalization'
 import { AddAutoCreatePersonalProjectsToPlatform1834000000000 } from './migration/postgres/1834000000000-AddAutoCreatePersonalProjectsToPlatform'
+import { WidenMcpOAuthState1835000000000 } from './migration/postgres/1835000000000-WidenMcpOAuthState'
 
 const getSslConfig = (): boolean | TlsOptions => {
     const useSsl = system.get(AppSystemProp.POSTGRES_USE_SSL)
@@ -867,6 +868,7 @@ export const getMigrations = (): (new () => Migration)[] => {
         BackfillChatPersonalizationForExistingUsers1832000000000,
         ClearRoleFromCompanyPersonalization1833000000000,
         AddAutoCreatePersonalProjectsToPlatform1834000000000,
+        WidenMcpOAuthState1835000000000,
     ]
     return migrations
 }

--- a/packages/server/api/src/app/mcp/oauth/code/mcp-oauth-authorize.controller.ts
+++ b/packages/server/api/src/app/mcp/oauth/code/mcp-oauth-authorize.controller.ts
@@ -66,7 +66,7 @@ const AuthorizeRequest = {
             response_type: z.string().max(64),
             code_challenge: mcpOAuthValidation.storableText(256).refine((value) => value.length >= 43, { message: 'code_challenge is too short' }),
             code_challenge_method: z.string().max(8).default('S256'),
-            state: mcpOAuthValidation.storableText(512).optional(),
+            state: mcpOAuthValidation.storableText(2048).optional(),
             scope: mcpOAuthValidation.storableText(512).optional(),
             resource: mcpOAuthValidation.storableText(2048).optional(),
         }),

--- a/packages/server/api/src/app/mcp/oauth/code/mcp-oauth-code.entity.ts
+++ b/packages/server/api/src/app/mcp/oauth/code/mcp-oauth-code.entity.ts
@@ -45,7 +45,7 @@ export const McpOAuthAuthorizationCodeEntity = new EntitySchema<McpOAuthAuthoriz
         },
         state: {
             type: String,
-            length: 512,
+            length: 2048,
             nullable: true,
         },
         expiresAt: {

--- a/packages/server/api/test/integration/ce/mcp/mcp-oauth-chatgpt-conformance.test.ts
+++ b/packages/server/api/test/integration/ce/mcp/mcp-oauth-chatgpt-conformance.test.ts
@@ -34,6 +34,19 @@ function authRequestIdFrom(location: string): string {
     return new URL(location, MCP_OAUTH_REDIRECT_URI).searchParams.get('authRequestId') ?? ''
 }
 
+async function consentThenApprove({ state }: { state: string }): Promise<URL> {
+    const consent = await authorize({ state })
+    expect(consent.statusCode).toBe(302)
+
+    const approved = await ctx.post('/v1/mcp-oauth/approve', {
+        authRequestId: authRequestIdFrom(String(consent.headers.location)),
+        projectId: ctx.project.id,
+    })
+    expect(approved.statusCode).toBe(200)
+
+    return new URL(approved.json().redirectUrl)
+}
+
 describe('ChatGPT platform connector conformance', () => {
     beforeAll(async () => {
         app = await setupTestEnvironment({ fresh: true })
@@ -43,24 +56,18 @@ describe('ChatGPT platform connector conformance', () => {
     it('returns the relay state to the connector unchanged after consent', async () => {
         expect(CHATGPT_RELAY_STATE.length).toBeGreaterThan(512)
 
-        const consent = await authorize({ state: CHATGPT_RELAY_STATE })
-        expect(consent.statusCode).toBe(302)
-
-        const approved = await ctx.post('/v1/mcp-oauth/approve', {
-            authRequestId: authRequestIdFrom(String(consent.headers.location)),
-            projectId: ctx.project.id,
-        })
-        expect(approved.statusCode).toBe(200)
-
-        const redirect = new URL(approved.json().redirectUrl)
+        const redirect = await consentThenApprove({ state: CHATGPT_RELAY_STATE })
         expect(redirect.searchParams.get('state')).toBe(CHATGPT_RELAY_STATE)
         expect(redirect.searchParams.get('code')).toEqual(expect.any(String))
     })
 
-    it('accepts a relay state at the length limit', async () => {
-        const consent = await authorize({ state: 'a'.repeat(STATE_LIMIT) })
+    it('stores and returns a relay state at the length limit', async () => {
+        const state = 'a'.repeat(STATE_LIMIT)
 
-        expect(consent.statusCode).toBe(302)
+        const redirect = await consentThenApprove({ state })
+
+        expect(redirect.searchParams.get('state')).toBe(state)
+        expect(redirect.searchParams.get('code')).toEqual(expect.any(String))
     })
 
     it('refuses a relay state beyond the length limit without a 5xx', async () => {

--- a/packages/server/api/test/integration/ce/mcp/mcp-oauth-chatgpt-conformance.test.ts
+++ b/packages/server/api/test/integration/ce/mcp/mcp-oauth-chatgpt-conformance.test.ts
@@ -1,0 +1,71 @@
+import { FastifyInstance } from 'fastify'
+import { beforeAll, describe, expect, it } from 'vitest'
+import { MCP_OAUTH_REDIRECT_URI, mcpOAuthTestHelpers } from '../../../helpers/mcp-oauth'
+import { createTestContext, TestContext } from '../../../helpers/test-context'
+import { setupTestEnvironment } from '../../../helpers/test-setup'
+
+let app: FastifyInstance
+let ctx: TestContext
+
+const CHATGPT_RELAY_STATE = 'openai_platform_oauth_relay__eyJvYXV0aF9pZCI6Im9hdXRoX3NfMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAiLCJhcHBfaWQiOiJhc2RrX2FwcF8xMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMSIsInZlcnNpb25faWQiOiJhc2RrX2FwcF92XzIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyIiwib3JnX2lkIjoib3JnLTMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMyIsInRhcmdldF91cmkiOiJodHRwczovL3BsYXRmb3JtLm9wZW5haS5jb20vcGx1Z2lucy9lZGl0L2FzZGtfYXBwXzExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExL2FzZGtfYXBwX3ZfMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjI/c2VjdGlvbj1NQ1ArU2VydmVyIn0='
+
+const STATE_LIMIT = 2048
+
+async function authorize({ state }: { state: string }): ReturnType<FastifyInstance['inject']> {
+    const client = await mcpOAuthTestHelpers.registerClient({ app, tokenEndpointAuthMethod: 'none' })
+    const { challenge } = mcpOAuthTestHelpers.generatePkce()
+
+    return app.inject({
+        method: 'GET',
+        url: '/authorize?' + new URLSearchParams({
+            client_id: client.client_id,
+            redirect_uri: MCP_OAUTH_REDIRECT_URI,
+            response_type: 'code',
+            code_challenge: challenge,
+            code_challenge_method: 'S256',
+            scope: 'mcp',
+            resource: 'https://cloud.activepieces.com/mcp/platform',
+            state,
+        }).toString(),
+    })
+}
+
+function authRequestIdFrom(location: string): string {
+    return new URL(location, MCP_OAUTH_REDIRECT_URI).searchParams.get('authRequestId') ?? ''
+}
+
+describe('ChatGPT platform connector conformance', () => {
+    beforeAll(async () => {
+        app = await setupTestEnvironment({ fresh: true })
+        ctx = await createTestContext(app)
+    })
+
+    it('returns the relay state to the connector unchanged after consent', async () => {
+        expect(CHATGPT_RELAY_STATE.length).toBeGreaterThan(512)
+
+        const consent = await authorize({ state: CHATGPT_RELAY_STATE })
+        expect(consent.statusCode).toBe(302)
+
+        const approved = await ctx.post('/v1/mcp-oauth/approve', {
+            authRequestId: authRequestIdFrom(String(consent.headers.location)),
+            projectId: ctx.project.id,
+        })
+        expect(approved.statusCode).toBe(200)
+
+        const redirect = new URL(approved.json().redirectUrl)
+        expect(redirect.searchParams.get('state')).toBe(CHATGPT_RELAY_STATE)
+        expect(redirect.searchParams.get('code')).toEqual(expect.any(String))
+    })
+
+    it('accepts a relay state at the length limit', async () => {
+        const consent = await authorize({ state: 'a'.repeat(STATE_LIMIT) })
+
+        expect(consent.statusCode).toBe(302)
+    })
+
+    it('refuses a relay state beyond the length limit without a 5xx', async () => {
+        const consent = await authorize({ state: 'a'.repeat(STATE_LIMIT + 1) })
+
+        expect(consent.statusCode).toBe(400)
+    })
+})


### PR DESCRIPTION
## Description

Adding the Activepieces MCP server from the ChatGPT plugin editor failed at the very first step with:

```
FST_ERR_VALIDATION  querystring/state Too big: expected string to have <=512 characters
```

ChatGPT's platform connector sends a **521-character** `state`: the literal prefix `openai_platform_oauth_relay__` followed by base64 of a JSON payload:

```json
{
  "oauth_id": "oauth_s_…", "app_id": "asdk_app_…", "version_id": "asdk_app_v_…",
  "org_id": "org-…",
  "target_uri": "https://platform.openai.com/plugins/edit/asdk_app_…/asdk_app_v_…?section=MCP+Server"
}
```

The bulk of it is `target_uri` — a 145-character deep link back into the editor. Base64 inflates the JSON by 4/3, so every extra character in that return URL costs ~1.33 in `state`. 521 is not a stable ceiling: a different editor route or an extra field pushes it higher.

`state` is opaque to us — RFC 6749 §4.1.1 puts no bound on it, and we only echo it back — so the cap is a transport limit, not a correctness one. Raised to **2048**, matching `redirect_uri` and `resource` in the same schema. `state` is re-emitted into the auth-request JWT that rides `/mcp-authorize?authRequestId=…` in a `Location` header, and base64url of the payload runs ~1.35–1.4×, so a worst-case 2048 lands around 2.8KB — comfortably inside nginx's default 8k request line and Node's 16KB header default (no `maxHeaderSize` override in `server.ts`).

**Why the migration is needed:** `mcp_oauth_authorization_code.state` was `varchar(512)` — the same 512, not a coincidence. Raising the querystring cap alone would relocate the failure rather than fix it: a clean `400 invalid_request` at `/authorize` would become a **500 at `/v1/mcp-oauth/approve`** when the row is inserted, after the user already clicked Approve, leaving the connector with no actionable OAuth error. The column is widened to match.

**On the migration's `breaking = true`:** that is the rollback-safety flag, not the customer-facing label. `ALTER COLUMN … TYPE` is destructive DDL per `check-migration-rollback.ts`, and `down()` shrinks back to 512 — so it must null any `state` that used the new width first, or the ALTER fails with `value too long for type character varying(512)`. Rollback therefore discards over-length states; acceptable for rows with a 10-minute TTL. **No self-hoster action is required on upgrade**, so per the handbook this is not a breaking change for the label/docs purposes.

## How was this tested?

New `mcp-oauth-chatgpt-conformance.test.ts`, following the existing `mcp-oauth-copilot-conformance.test.ts` convention:

- **Round trip** — a 521-character relay state (same shape and exact length as the real one; placeholder ids, since the real payload embeds a customer's org/app ids) goes `/authorize` → consent JWT → `/approve`, and is asserted to come back on the redirect **byte-identical** alongside a `code`. This is the test that would have caught the bug, and it also exercises the real insert into the widened column.
- **Boundary** — 2048 accepted (302); 2049 refused with **400, not 5xx**.

```
test/integration/ce/mcp        12 files, 234 passed, 3 skipped
turbo lint --filter=api        0 errors
DDL scanner                    destructive: true, breaking: true → satisfies the CI rule
check-migrations               no mcp_oauth_authorization_code / state drift → migration ⇄ entity agree
```

Migration verified against real Postgres in a throwaway database, both directions:

- `up()`: `state` 512 → 2048.
- `down()`: 2048 → 512, nulling the over-length row. Confirmed the unguarded shrink genuinely fails with `value too long`, so that `UPDATE` is load-bearing rather than defensive.

**Edition paths:** the code path is CE (`src/app/mcp/oauth`), not edition-gated, and the CE integration suite covers it. EE/Cloud inherit it unchanged — no edition-specific behaviour touched.

Fixes # (issue)

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

- [ ] no — reviewed, no security impact
- [x] yes — security-sensitive (call out the risk and mitigation in the description above)

Touches the OAuth authorization endpoint, so flagging it for review even though the change is a length limit. Risk and mitigation:

- `state` stays opaque and is only ever echoed back to a `redirect_uri` that `validateRedirectUri` already checked against the registered client — raising the cap does not widen where it can be sent.
- `mcpOAuthValidation.storableText` still rejects control characters and unpaired surrogates at the new length, so the Postgres-safety property is unchanged.
- The extra 1536 bytes are bounded and echoed, not stored unbounded; the column now matches the cap, so there is no truncation or insert-failure path.
