### PR TITLE
fix(web): show the expected translated core piece names in the builder 

### DIFF
--- a/packages/web/public/locales/en/translation.json
+++ b/packages/web/public/locales/en/translation.json
@@ -2262,6 +2262,7 @@
   "Others": "Others",
   "Powerful Node.js & TypeScript code with npm": "Powerful Node.js & TypeScript code with npm",
   "Loop on Items": "Loop on Items",
+  "Iterate over a list of items": "Iterate over a list of items",
   "Router": "Router",
   "Split your flow into branches depending on condition(s)": "Split your flow into branches depending on condition(s)",
   "Empty Trigger": "Empty Trigger",

--- a/packages/web/src/app/builder/pieces-selector/piece-actions-or-triggers-list.tsx
+++ b/packages/web/src/app/builder/pieces-selector/piece-actions-or-triggers-list.tsx
@@ -16,7 +16,7 @@ import {
   PieceSelectorOperation,
   StepMetadataWithSuggestions,
   pieceSelectorUtils,
-  CORE_ACTIONS_METADATA,
+  stepUtils,
   usePieceSearchContext,
 } from '@/features/pieces';
 
@@ -55,9 +55,9 @@ export const convertStepMetadataToPieceSelectorItems = (
     case FlowActionType.CODE:
     case FlowActionType.LOOP_ON_ITEMS:
     case FlowActionType.ROUTER: {
-      return CORE_ACTIONS_METADATA.filter(
-        (step) => step.type === stepMetadataWithSuggestions.type,
-      );
+      return stepUtils
+        .coreActionsMetadata()
+        .filter((step) => step.type === stepMetadataWithSuggestions.type);
     }
     default: {
       return [];

--- a/packages/web/src/features/pieces/hooks/steps-hooks.ts
+++ b/packages/web/src/features/pieces/hooks/steps-hooks.ts
@@ -13,14 +13,11 @@ import { authenticationSession } from '@/lib/authentication-session';
 
 import { piecesApi } from '../api/pieces-api';
 import {
+  PrimitiveStepMetadata,
   StepMetadataWithActionOrTriggerOrAgentDisplayName,
   StepMetadataWithSuggestions,
 } from '../types';
-import {
-  CORE_ACTIONS_METADATA,
-  CORE_STEP_METADATA,
-  stepUtils,
-} from '../utils/step-utils';
+import { stepUtils } from '../utils/step-utils';
 
 export const stepsHooks = {
   useStepMetadata: ({ step }: UseStepMetadata) => {
@@ -94,9 +91,9 @@ export const stepsHooks = {
 
         switch (type) {
           case 'action': {
-            const filteredCoreActions = CORE_ACTIONS_METADATA.filter((step) =>
-              passSearch(searchQuery, step),
-            );
+            const filteredCoreActions = stepUtils
+              .coreActionsMetadata()
+              .filter((step) => passSearch(searchQuery, step));
             return [...filteredCoreActions, ...piecesMetadata];
           }
           case 'trigger':
@@ -115,7 +112,7 @@ export const stepsHooks = {
 };
 function passSearch(
   searchQuery: string | undefined,
-  data: (typeof CORE_STEP_METADATA)[keyof typeof CORE_STEP_METADATA],
+  data: PrimitiveStepMetadata,
 ) {
   if (!searchQuery) {
     return true;

--- a/packages/web/src/features/pieces/index.ts
+++ b/packages/web/src/features/pieces/index.ts
@@ -41,7 +41,6 @@ export {
   pieceSelectorUtils,
 } from './utils/piece-selector-utils';
 export {
-  CORE_ACTIONS_METADATA,
   extractPieceNamesAndCoreMetadata,
   stepUtils,
 } from './utils/step-utils';

--- a/packages/web/src/features/pieces/utils/step-utils.tsx
+++ b/packages/web/src/features/pieces/utils/step-utils.tsx
@@ -24,42 +24,15 @@ import {
   StepMetadataWithActionOrTriggerOrAgentDisplayName,
 } from '../types';
 
-export const CORE_STEP_METADATA: Record<
-  Exclude<FlowActionType, FlowActionType.PIECE> | FlowTriggerType.EMPTY,
-  PrimitiveStepMetadata
-> = {
-  [FlowActionType.CODE]: {
-    displayName: t('Code'),
-    logoUrl: 'https://cdn.activepieces.com/pieces/new-core/code.svg',
-    description: t('Powerful Node.js & TypeScript code with npm'),
-    type: FlowActionType.CODE as const,
-  },
-  [FlowActionType.LOOP_ON_ITEMS]: {
-    displayName: t('Loop on Items'),
-    logoUrl: 'https://cdn.activepieces.com/pieces/new-core/loop.svg',
-    description: 'Iterate over a list of items',
-    type: FlowActionType.LOOP_ON_ITEMS as const,
-  },
-  [FlowActionType.ROUTER]: {
-    displayName: t('Router'),
-    logoUrl: 'https://cdn.activepieces.com/pieces/new-core/router.svg',
-    description: t('Split your flow into branches depending on condition(s)'),
-    type: FlowActionType.ROUTER as const,
-  },
-  [FlowTriggerType.EMPTY]: {
-    displayName: t('Empty Trigger'),
-    logoUrl: 'https://cdn.activepieces.com/pieces/new-core/empty-trigger.svg',
-    description: t('Empty Trigger'),
-    type: FlowTriggerType.EMPTY as const,
-  },
-} as const;
-export const CORE_ACTIONS_METADATA = [
-  CORE_STEP_METADATA[FlowActionType.CODE],
-  CORE_STEP_METADATA[FlowActionType.LOOP_ON_ITEMS],
-  CORE_STEP_METADATA[FlowActionType.ROUTER],
-] as const;
-
 export const stepUtils = {
+  coreActionsMetadata(): PrimitiveStepMetadata[] {
+    const coreStepMetadata = buildCoreStepMetadata();
+    return [
+      coreStepMetadata[FlowActionType.CODE],
+      coreStepMetadata[FlowActionType.LOOP_ON_ITEMS],
+      coreStepMetadata[FlowActionType.ROUTER],
+    ];
+  },
   getKeys(
     step: FlowAction | FlowTrigger,
     locale: LocalesEnum,
@@ -88,7 +61,7 @@ export const stepUtils = {
       case FlowActionType.CODE:
       case FlowTriggerType.EMPTY:
         return {
-          ...CORE_STEP_METADATA[step.type],
+          ...buildCoreStepMetadata()[step.type],
           ...spreadIfDefined('logoUrl', customLogoUrl),
           actionOrTriggerOrAgentDisplayName: '',
           actionOrTriggerOrAgentDescription: '',
@@ -164,6 +137,7 @@ export function extractPieceNamesAndCoreMetadata(
 ): { pieceNames: string[]; coreMetadata: StepMetadata[] } {
   const pieceNamesSet = new Set<string>();
   const coreMetadata: StepMetadata[] = [];
+  const coreStepMetadata = excludeCore ? undefined : buildCoreStepMetadata();
 
   for (const step of steps) {
     if (
@@ -171,9 +145,8 @@ export function extractPieceNamesAndCoreMetadata(
       step.type === FlowTriggerType.PIECE
     ) {
       pieceNamesSet.add(step.settings.pieceName);
-    } else if (!excludeCore) {
-      const coreMeta =
-        CORE_STEP_METADATA[step.type as keyof typeof CORE_STEP_METADATA];
+    } else if (coreStepMetadata) {
+      const coreMeta = coreStepMetadata[step.type];
       if (coreMeta) {
         coreMetadata.push(coreMeta);
       }
@@ -181,6 +154,38 @@ export function extractPieceNamesAndCoreMetadata(
   }
 
   return { pieceNames: Array.from(pieceNamesSet), coreMetadata };
+}
+
+function buildCoreStepMetadata(): Record<
+  Exclude<FlowActionType, FlowActionType.PIECE> | FlowTriggerType.EMPTY,
+  PrimitiveStepMetadata
+> {
+  return {
+    [FlowActionType.CODE]: {
+      displayName: t('Code'),
+      logoUrl: 'https://cdn.activepieces.com/pieces/new-core/code.svg',
+      description: t('Powerful Node.js & TypeScript code with npm'),
+      type: FlowActionType.CODE,
+    },
+    [FlowActionType.LOOP_ON_ITEMS]: {
+      displayName: t('Loop on Items'),
+      logoUrl: 'https://cdn.activepieces.com/pieces/new-core/loop.svg',
+      description: t('Iterate over a list of items'),
+      type: FlowActionType.LOOP_ON_ITEMS,
+    },
+    [FlowActionType.ROUTER]: {
+      displayName: t('Router'),
+      logoUrl: 'https://cdn.activepieces.com/pieces/new-core/router.svg',
+      description: t('Split your flow into branches depending on condition(s)'),
+      type: FlowActionType.ROUTER,
+    },
+    [FlowTriggerType.EMPTY]: {
+      displayName: t('Empty Trigger'),
+      logoUrl: 'https://cdn.activepieces.com/pieces/new-core/empty-trigger.svg',
+      description: t('Empty Trigger'),
+      type: FlowTriggerType.EMPTY,
+    },
+  };
 }
 
 function mapErrorHandlingOptions(

--- a/packages/web/test/features/pieces/utils/step-utils.test.ts
+++ b/packages/web/test/features/pieces/utils/step-utils.test.ts
@@ -30,7 +30,7 @@ const loopStep: FlowAction = {
   settings: { items: '' },
 };
 
-let stepUtils: typeof import('@/features/pieces').stepUtils;
+let stepUtils: typeof import('@/features/pieces/utils/step-utils').stepUtils;
 
 describe('core step metadata translation', () => {
   beforeAll(async () => {
@@ -42,7 +42,7 @@ describe('core step metadata translation', () => {
       resources: {},
     });
 
-    ({ stepUtils } = await import('@/features/pieces'));
+    ({ stepUtils } = await import('@/features/pieces/utils/step-utils'));
 
     i18n.addResourceBundle(
       LocalesEnum.JAPANESE,
@@ -50,7 +50,7 @@ describe('core step metadata translation', () => {
       JAPANESE_BUNDLE,
     );
     await i18n.changeLanguage(LocalesEnum.JAPANESE);
-  });
+  }, 60000);
 
   it('translates a core step resolved through getMetadata', async () => {
     const metadata = await stepUtils.getMetadata(

--- a/packages/web/test/features/pieces/utils/step-utils.test.ts
+++ b/packages/web/test/features/pieces/utils/step-utils.test.ts
@@ -1,0 +1,92 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { readFileSync } from 'fs';
+import path from 'path';
+
+import { LocalesEnum } from '@activepieces/core-utils';
+import { FlowAction, FlowActionType } from '@activepieces/shared';
+import i18n from 'i18next';
+import { beforeAll, describe, expect, it } from 'vitest';
+
+const JAPANESE_BUNDLE = {
+  Code: 'コード',
+  'Powerful Node.js & TypeScript code with npm':
+    'npm の強力な Node.js & TypeScript コード',
+  'Loop on Items': 'アイテムでループ',
+  'Iterate over a list of items': '項目のリストを反復処理します',
+  Router: 'ルーター',
+  'Split your flow into branches depending on condition(s)':
+    '条件に応じてフローを分岐します',
+  'Empty Trigger': '空のトリガー',
+};
+
+const loopStep: FlowAction = {
+  name: 'step_1',
+  displayName: 'Loop on Items',
+  valid: true,
+  lastUpdatedDate: '2026-08-24T00:00:00.000Z',
+  type: FlowActionType.LOOP_ON_ITEMS,
+  settings: { items: '' },
+};
+
+let stepUtils: typeof import('@/features/pieces').stepUtils;
+
+describe('core step metadata translation', () => {
+  beforeAll(async () => {
+    await i18n.init({
+      lng: LocalesEnum.ENGLISH,
+      fallbackLng: LocalesEnum.ENGLISH,
+      keySeparator: false,
+      nsSeparator: false,
+      resources: {},
+    });
+
+    ({ stepUtils } = await import('@/features/pieces'));
+
+    i18n.addResourceBundle(
+      LocalesEnum.JAPANESE,
+      'translation',
+      JAPANESE_BUNDLE,
+    );
+    await i18n.changeLanguage(LocalesEnum.JAPANESE);
+  });
+
+  it('translates a core step resolved through getMetadata', async () => {
+    const metadata = await stepUtils.getMetadata(
+      loopStep,
+      LocalesEnum.JAPANESE,
+    );
+
+    expect(metadata.displayName).toBe('アイテムでループ');
+    expect(metadata.description).toBe('項目のリストを反復処理します');
+  });
+
+  it('translates every core action offered by the piece selector', () => {
+    const coreActions = stepUtils.coreActionsMetadata();
+
+    expect(coreActions).toHaveLength(3);
+    for (const step of coreActions) {
+      expect(Object.values(JAPANESE_BUNDLE)).toContain(step.displayName);
+      expect(Object.values(JAPANESE_BUNDLE)).toContain(step.description);
+    }
+  });
+
+  it('exposes every core step string in the english translation file', () => {
+    const englishKeys = Object.keys(
+      JSON.parse(
+        readFileSync(
+          path.resolve(
+            __dirname,
+            '../../../../public/locales/en/translation.json',
+          ),
+          'utf-8',
+        ),
+      ),
+    );
+
+    for (const key of Object.keys(JAPANESE_BUNDLE)) {
+      expect(englishKeys).toContain(key);
+    }
+  });
+});


### PR DESCRIPTION
Fixes [GIT-1791](https://linear.app/activepieces/issue/GIT-1791)
Closes #15018

## Problem

1. In every non-English locale the step picker showed the built-in steps in English: `Code`, `Loop on Items`, `Empty Trigger`. Japanese translations for all three already shipped (コード / アイテムでループ / 空のトリガー) and were never used. `Router` was correctly English, ja has no translation for that key.
2. The Loop on Items description `Iterate over a list of items` had no translation key at all, so it never appeared in Crowdin and could not be translated by anyone.

Reported against the Japanese locale. Ref: Pylon 5735

## Fix

- `step-utils.tsx` — `CORE_STEP_METADATA` / `CORE_ACTIONS_METADATA` were module-scope consts, so `t()` ran at import time, before `i18next-http-backend` had fetched the locale, and the English keys were frozen there forever. Replaced with `buildCoreStepMetadata()` plus `stepUtils.coreActionsMetadata()`, resolved per call.
- `step-utils.tsx` — wrapped the loop description in `t()`.
- `en/translation.json` — added `"Iterate over a list of items"` so Crowdin picks it up. Only the `en` source is touched; the locale files stay Crowdin's.
- `steps-hooks.ts`, `piece-actions-or-triggers-list.tsx`, `index.ts` — call the function; `passSearch` now takes `PrimitiveStepMetadata` directly instead of a `typeof` of the deleted const.

## Verification

- `npm run lint-dev` clean, 32/32 tasks, 0 errors.
- `tsc --noEmit -p tsconfig.app.json` clean.
- `npx vitest run` in `packages/web`: 57 files, 525 tests pass.
- New regression test `packages/web/test/features/pieces/utils/step-utils.test.ts`, red-first proven: 3/3 fail against pre-fix code (`expected 'Loop on Items' to be 'アイテムでループ'`, `expected [...] to include 'Iterate over a list of items'`), 3/3 pass with the fix. The test initialises i18next before importing the module and adds the bundle after, which is the real production ordering.
- Visual: piece picker driven in the running app at `?lng=ja` (built-in steps now コード / アイテムでループ, `Router` still English as it has no ja translation) and inverse-driven at `?lng=en` (unchanged). Single theme, the change is text-only and not theme-sensitive.
- Consequence worth knowing: a built-in step added in a non-English locale now stores the localised label as its `displayName`. Piece steps already behave this way, `displayName` is free text and step identity is `name`, so nothing reads it semantically.
- The description itself still renders in English in the app until Crowdin supplies a ja string. That is the intended end state of this PR: the key now exists to be translated.
- Other affected paths: the same eager-`t()` pattern exists in 6 unrelated module-scope consts and is NOT fixed here, since each belongs to a different feature with its own UI to verify: `features/agents/ai-providers.ts:4`, `features/members/components/role-selector.tsx:21`, `features/members/components/role-selector.tsx:43`, `app/routes/platform/setup/ai-capabilities/catalog.ts:18`, `app/routes/platform/setup/ai/providers-tab/provider-credentials.ts:24`, `app/builder/step-settings/branch-settings/branch-single-condition.tsx:25`. Worth a follow-up ticket.

<details>
<summary>Plan & reasoning</summary>

## Plan
- Root cause is evaluation timing, not a missing string, so the fix deletes the frozen value rather than refreshing it. There is no const left to go stale.
- `buildCoreStepMetadata()` is a non-exported helper below `stepUtils` per the repo file-order rule; only `coreActionsMetadata()` is public, since the other consumers needed either one entry or just a type.
- Footprint estimated at 4 files + 1 locale key / ~45 lines; actual 5 files / 55 lines of product code plus the test.
- React Query keys in `steps-hooks.ts` already carry `i18n.language`, so no locale-stale cache had to be addressed.

## Non-happy scenarios considered
- Key with no translation in the target locale (`Router`) -> i18next falls back to the English source, verified in the browser.
- Locale file arrives after first paint -> the whole point; every read now happens at render or query time.
- `extractPieceNamesAndCoreMetadata` with `excludeCore: true` -> metadata is not built at all, guarded before the loop rather than inside it.
- Large flows -> the record is built once per call, hoisted out of the per-step loop.

## Alternatives rejected
- Lazy getters on the existing const: ~10 lines instead of ~55, but the laziness is invisible at every read site and any future module-scope spread silently reintroduces the bug.
- Re-translating at each of the 5 render sites with `useTranslation()`: larger, and spreads the same trap wider.
- An eslint rule banning module-scope `t()`: the right long-term fix, but it fails immediately on the 6 pre-existing violations and would drag three unrelated features into this PR.
</details>

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)
