### PR TITLE
fix(web): line the platform admin nav up with the rail

### DIFF
--- a/packages/web/src/app/components/primary-rail/index.tsx
+++ b/packages/web/src/app/components/primary-rail/index.tsx
@@ -106,7 +106,7 @@ export function PrimaryRail() {
         title={collapsed ? t('Open sidebar') : undefined}
         className={cn(
           'flex h-svh shrink-0 flex-col bg-sidebar py-3 transition-[width] duration-150',
-          collapsed ? 'w-14 cursor-ew-resize items-center' : 'w-60',
+          collapsed ? 'w-14 cursor-ew-resize items-center' : 'w-62',
         )}
       >
         <RailHeader collapsed={collapsed} onToggle={toggleCollapsed} />

--- a/packages/web/src/app/components/sidebar/platform/index.tsx
+++ b/packages/web/src/app/components/sidebar/platform/index.tsx
@@ -254,7 +254,7 @@ export function PlatformSidebar() {
         </SidebarContent>
       </div>
 
-      <SidebarFooter>
+      <SidebarFooter className="pb-3">
         <SidebarUser />
       </SidebarFooter>
     </Sidebar>

--- a/packages/web/src/app/components/sidebar/sidebar-user.tsx
+++ b/packages/web/src/app/components/sidebar/sidebar-user.tsx
@@ -53,7 +53,7 @@ export function SidebarUser() {
         <DropdownMenu modal>
           <DropdownMenuTrigger asChild className="w-full">
             <SidebarMenuButton className="h-10! pl-2! group-data-[collapsible=icon]:h-10! group-data-[collapsible=icon]:pl-2!">
-              <div className="size-[18px] shrink-0 overflow-hidden flex items-center justify-center rounded-full">
+              <div className="size-[22px] shrink-0 overflow-hidden flex items-center justify-center rounded-full">
                 <UserAvatar
                   className={cn('size-full object-cover', {
                     'scale-150': isNil(user.imageUrl),
@@ -61,7 +61,7 @@ export function SidebarUser() {
                   name={user.firstName + ' ' + user.lastName}
                   email={user.email}
                   imageUrl={user.imageUrl}
-                  size={18}
+                  size={22}
                   disableTooltip={true}
                 />
               </div>

--- a/packages/web/src/components/ui/sidebar-shadcn.tsx
+++ b/packages/web/src/components/ui/sidebar-shadcn.tsx
@@ -26,7 +26,7 @@ import { cn } from '@/lib/utils';
 
 const SIDEBAR_COOKIE_NAME = 'sidebar_state';
 const SIDEBAR_COOKIE_MAX_AGE = 60 * 60 * 24 * 7;
-const SIDEBAR_WIDTH = '14.375rem';
+const SIDEBAR_WIDTH = '15rem';
 const SIDEBAR_WIDTH_MOBILE = '18rem';
 const SIDEBAR_WIDTH_ICON = '3rem';
 const SIDEBAR_KEYBOARD_SHORTCUT = 'b';


### PR DESCRIPTION
## Description

Moving between the home rail and platform admin shifted the account row and the edge of the nav, which reads as the page jumping. Four measurements differed and none of them were meant to.

**The nav region.** The rail was 240px sitting flush against the content, while platform admin was a 240px column plus an 8px inset before its panel. That inset is the same colour as the sidebar (`oklch(0.985 0 0)`), so admin's nav *reads* as 248px wide. The rail widens to match, and the content now begins at 248 on both.

**The account row.** Admin's avatar was 18px against the rail's 22px, and it sat 8px off the bottom against the rail's 12px, because `SidebarFooter` carries `p-2` where the rail has `py-3`.

Measured before and after, at 1440×900:

| | rail (before) | admin (before) | both (after) |
|---|---|---|---|
| nav region | 240 | 248 | **248** |
| avatar | 22px | 18px | **22px** |
| bottom inset | 12px | 8px | **12px** |
| row left edge / height | 8 / 40 | 8 / 40 | 8 / 40 |

**Neither row's appearance changes.** The rail keeps its settings button outside the row, admin keeps its chevrons inside, so the row's right edge still differs by design — 200 against 232. Only size and placement were touched.

One judgement call worth a reviewer's eye: the rail's grey band is now 248 while admin's is a 240 band plus an 8px grey gap. They read as identical because the gap is the same colour, but a border or a different background on either would expose that 8px. The alternative was giving the rail the same 8px content inset, which shifts the entire chat surface right — a much larger change for the same result.

`SIDEBAR_WIDTH` looks shared, but the platform sidebar is the only `<Sidebar>` still rendered; the dashboard and project sidebars were replaced by the rail and are now unreferenced.

## How was this tested?

Manually against a local Cloud-edition instance, comparing `/chat` with Platform Admin at 1440×900. Every number in the table above was read off the rendered DOM rather than judged by eye — which mattered, because both grey columns measured 240 and the real difference was the 8px content inset, invisible to a naive width check.

Automated: `web` typecheck clean, lint 0 errors, 524/524 unit tests.

Editions: the rail and platform admin render the same on CE, EE and Cloud — nothing here is edition-gated.

Fixes # (issue)

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

Four CSS values in the web app. No API, no schema, no configuration, and nothing a self-hoster must act on.

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)

No authentication, permissions, secrets, outbound HTTP or file handling is touched.
