### PR TITLE
fix(web): hide the Agents tab again where the feature is turned off

### DIFF
--- a/packages/web/src/app/components/primary-rail/index.tsx
+++ b/packages/web/src/app/components/primary-rail/index.tsx
@@ -1,4 +1,3 @@
-import { Permission } from '@activepieces/core-utils';
 import {
   ApEdition,
   ApFlagId,
@@ -50,6 +49,7 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from '@/components/ui/tooltip';
+import { useAgentsNavVisible } from '@/features/agents';
 import { SidebarUsageLimits } from '@/features/billing';
 import { chatUtils } from '@/features/chat/lib/chat-utils';
 import {
@@ -61,10 +61,7 @@ import {
 import { templatesTelemetryApi } from '@/features/templates';
 import { usePinnedProjects } from '@/features/workspace/lib/pinned-projects';
 import { useRailCollapsed } from '@/features/workspace/lib/rail-collapsed';
-import {
-  useAuthorization,
-  useIsPlatformAdmin,
-} from '@/hooks/authorization-hooks';
+import { useIsPlatformAdmin } from '@/hooks/authorization-hooks';
 import { flagsHooks } from '@/hooks/flags-hooks';
 import { platformHooks } from '@/hooks/platform-hooks';
 import { userHooks } from '@/hooks/user-hooks';
@@ -82,20 +79,17 @@ import { HelpAndFeedback } from '../help-and-feedback';
 export function PrimaryRail() {
   const { embedState } = useEmbedding();
   const { platform } = platformHooks.useCurrentPlatform();
-  const { checkAccess } = useAuthorization();
   const { data: currentUser } = userHooks.useCurrentUser();
   const {
     collapsed,
     setCollapsed,
     toggle: toggleCollapsed,
   } = useRailCollapsed();
+  const showAgents = useAgentsNavVisible();
 
   if (embedState.isEmbedded || embedState.hideSideNav) {
     return null;
   }
-
-  const showAgents =
-    platform.plan.agentsEnabled && checkAccess(Permission.READ_AGENT);
 
   const openSidebar = () => setCollapsed(false);
 

--- a/packages/web/src/app/guards/agents-flag-guard.tsx
+++ b/packages/web/src/app/guards/agents-flag-guard.tsx
@@ -1,17 +1,14 @@
-import { ApFlagId } from '@activepieces/shared';
 import { Navigate } from 'react-router-dom';
 
-import { flagsHooks } from '@/hooks/flags-hooks';
+import { useAgentsEnabled } from '@/features/agents';
 
 type AgentsFlagGuardProps = {
   children: React.ReactNode;
 };
 
 export const AgentsFlagGuard = ({ children }: AgentsFlagGuardProps) => {
-  const { data: agentsEnabled } = flagsHooks.useFlag<boolean>(
-    ApFlagId.AGENTS_ENABLED,
-  );
-  if (agentsEnabled !== true) {
+  const agentsEnabled = useAgentsEnabled();
+  if (!agentsEnabled) {
     return <Navigate to="/flows" replace />;
   }
   return children;

--- a/packages/web/src/features/agents/hooks/agents-hooks.ts
+++ b/packages/web/src/features/agents/hooks/agents-hooks.ts
@@ -1,17 +1,40 @@
 import {
   Agent,
+  ApFlagId,
   CreateAgentRequest,
   DraftAgentRequest,
+  Permission,
   UpdateAgentRequest,
 } from '@activepieces/shared';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
 import { internalErrorToast } from '@/components/ui/sonner';
+import { useAuthorization } from '@/hooks/authorization-hooks';
+import { flagsHooks } from '@/hooks/flags-hooks';
+import { platformHooks } from '@/hooks/platform-hooks';
 
 import { agentsApi } from '../api/agents';
 
 const AGENTS_KEY = 'agents';
 const AGENT_TEMPLATES_KEY = 'agent-templates';
+
+export const useAgentsEnabled = (): boolean => {
+  const { data: agentsEnabled } = flagsHooks.useFlag<boolean>(
+    ApFlagId.AGENTS_ENABLED,
+  );
+  return agentsEnabled === true;
+};
+
+export const useAgentsNavVisible = (): boolean => {
+  const agentsEnabled = useAgentsEnabled();
+  const { platform } = platformHooks.useCurrentPlatform();
+  const { checkAccess } = useAuthorization();
+  return (
+    agentsEnabled &&
+    platform.plan.agentsEnabled &&
+    checkAccess(Permission.READ_AGENT)
+  );
+};
 
 export const agentsQueries = {
   useAgents: ({

--- a/packages/web/src/features/agents/index.ts
+++ b/packages/web/src/features/agents/index.ts
@@ -15,3 +15,4 @@ export { SUPPORTED_AI_PROVIDERS } from './ai-providers';
 export type { AiProviderInfo } from './ai-providers';
 export { AgentStructuredOutput } from './structured-output';
 export { agentQueries, agentMutations } from './hooks/agent-hooks';
+export { useAgentsEnabled, useAgentsNavVisible } from './hooks/agents-hooks';


### PR DESCRIPTION
## Description

The Agents tab came back on Cloud. The new chat-first primary rail (#15005) replaced the project sidebar, and its Agents button checks the plan and the read permission but not the `AGENTS_ENABLED` flag, which is the switch that keeps Agents on staging only while the experience is still being built. So the tab reappeared for everyone the plan allows, including free tier.

The reason it drifted is that the visibility rule was written twice, once in the old sidebar and once in the new rail. This puts it in one place: `useAgentsNavVisible()` in `features/agents`, which answers flag + plan + `READ_AGENT` together. The rail calls that hook, and the route guard calls `useAgentsEnabled()` for the flag half, so a future navigation surface asks the same question instead of reassembling it.

No permission check was lost: `checkAccess(Permission.READ_AGENT)` moved from the rail into the hook.

The `/agents` route was already guarded, so the page itself was never reachable with the flag off. This is about the button being visible and the feature looking available when it isn't.

## How was this tested?

- Flag off (Cloud, EE, CE default): no Agents button in the rail, and `/agents` still redirects to `/flows`.
- Flag on (`AP_AGENTS_ENABLED=true`, as staging runs): button visible for a member with `READ_AGENT`, hidden for one without.
- `tsc` and lint clean on `web`.

Follow-up worth doing separately: `app/components/sidebar/dashboard/index.tsx` is now dead except for its exported `SIDEBAR_ID`, which the two builder drag overlays still import. Left alone here to keep this diff to the gate.

Fixes # (issue)

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

- [ ] no — reviewed, no security impact
- [x] yes — security-sensitive (call out the risk and mitigation in the description above)
