### PR TITLE
fix(tests): the e2e suite can start its own server again

### DIFF
--- a/packages/tests-e2e/playwright.config.ts
+++ b/packages/tests-e2e/playwright.config.ts
@@ -64,10 +64,11 @@ const config: PlaywrightTestConfig = {
   webServer: {
     command: process.env.CI
       ? 'npm run dev'
-      : 'export $(cat .env.e2e | xargs) && npm run dev',
+      : 'export $(cat packages/tests-e2e/.env.e2e | xargs) && npm run dev',
+    cwd: path.resolve(__dirname, '../..'),
     url: 'http://localhost:4200/api/v1/flags',
     reuseExistingServer: !process.env.CI,
-    timeout: 100000,
+    timeout: 300000,
     stdout: 'pipe',
   },
 };


### PR DESCRIPTION
## Description

The e2e suite could not start the server it tests against. Playwright runs `webServer` with its cwd defaulting to the directory of the config file, so `npm run dev` resolved against `packages/tests-e2e`, which has no `dev` script:

```
[WebServer] npm error workspace tests-e2e@0.0.1
[WebServer] npm error Missing script: "dev"
Error: Process from config.webServer was not able to start. Exit code: 1
```

Every run died there, before the first test. The suite only runs behind a label, which is why nobody noticed.

Three changes, all in the `webServer` block:

- Run the command from the repo root, where the `dev` script lives.
- Address the local env file from the root too, since the old `cat .env.e2e` only worked while cwd was the package.
- Raise the readiness timeout from 100s to 300s. Booting web plus api plus engine plus worker took about 90s locally on a warm cache, so the old value left almost no headroom on a cold CI runner.

## How was this tested?

Ran the suite the way CI does, `CI=true npm run test:e2e` with CI's own env, on a throwaway database and with no server already running, so Playwright had to start its own:

```
Running 2 tests using 2 workers
  2 passed (1.2m)
```

Both CE specs pass: `piece-isolation` and `webhook-should-return-response`. Before this change the same command never reached a test.

One thing this does not fix: on a cold first run the two specs race, and `webhook-should-return-response` can time out waiting for its sync response while `piece-isolation` is still syncing pieces. It passes once piece sync is warm. Worth a look separately if it shows up in CI.

Fixes # (issue)

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)
