### PR TITLE
fix(rate-limiter): promote parked jobs when a concurrency slot frees

### DIFF
--- a/packages/server/api/src/app/database/redis/keys.ts
+++ b/packages/server/api/src/app/database/redis/keys.ts
@@ -17,6 +17,7 @@ export const getCustomerStateFetchLockKey = (platformId: PlatformId): string => 
 export const getProjectConcurrencyPoolKey = (projectId: ProjectId): string => `project:concurrency-pool:${projectId}` // gets pool id for the project
 export const getConcurrencyPoolLimitKey = (poolId: string): string => `concurrency-pool:limit:${poolId}` // gets limit value for the pool
 export const getConcurrencyPoolSetKey = (poolId: string): string => `active_jobs_set:pool:${poolId}`
+export const getConcurrencyPoolParkedKey = (poolId: string): string => `parked_jobs_set:pool:${poolId}`
 
 export const BILLING_ENFORCED_TTL_SECONDS = 24 * 60 * 60
 export const PLATFORM_PLAN_NAME_TTL_SECONDS = 24 * 60 * 60

--- a/packages/server/api/src/app/workers/job-queue/interceptors/rate-limiter-interceptor.ts
+++ b/packages/server/api/src/app/workers/job-queue/interceptors/rate-limiter-interceptor.ts
@@ -1,8 +1,10 @@
-import { isNil, PlatformId, tryCatch } from '@activepieces/core-utils'
+import { isNil, PlatformId, tryCatch, tryCatchSync } from '@activepieces/core-utils'
 import { apDayjsDuration } from '@activepieces/server-utils'
-import { ApEdition, ExecuteFlowJobData, JOB_PRIORITY, JobData, PlanName, RATE_LIMIT_PRIORITY, RunEnvironment, WorkerJobType } from '@activepieces/shared'
+import { ApEdition, ExecuteFlowJobData, getDefaultJobPriority, JOB_PRIORITY, JobData, PlanName, RATE_LIMIT_PRIORITY, RunEnvironment, WorkerJobType } from '@activepieces/shared'
+import { Job } from 'bullmq'
 import { FastifyBaseLogger } from 'fastify'
-import { getConcurrencyPoolSetKey, getPlatformPlanNameKey, PLATFORM_PLAN_NAME_TTL_SECONDS } from '../../../database/redis/keys'
+import { z } from 'zod'
+import { getConcurrencyPoolParkedKey, getConcurrencyPoolSetKey, getPlatformPlanNameKey, PLATFORM_PLAN_NAME_TTL_SECONDS } from '../../../database/redis/keys'
 import { distributedStore, redisConnections } from '../../../database/redis-connections'
 import { concurrencyPoolService } from '../../../ee/platform/concurrency-pool/concurrency-pool.service'
 import { workerGroupService } from '../../../ee/platform/platform-plan/worker-group.service'
@@ -12,8 +14,10 @@ import { platformService } from '../../../platform/platform.service'
 import { projectWorkerGroupService } from '../../../project/project-worker-group.service'
 import { workerCapacity } from '../../machine/worker-capacity'
 import { InterceptorResult, InterceptorVerdict, JobInterceptor } from '../job-interceptor'
+import { jobQueue } from '../job-queue'
 
 const RATE_LIMIT_WORKER_JOB_TYPES = [WorkerJobType.EXECUTE_FLOW]
+const ParkedMember = z.tuple([z.string(), z.string(), z.number()])
 
 const FREE_CONCURRENT_JOBS_LIMIT = 5
 const SELF_SERVE_CONCURRENT_JOBS_LIMIT = 15
@@ -98,7 +102,21 @@ async function resolveRoutedPoolSlots({ platformId, projectId, log }: { platform
     return shared.slots
 }
 
-async function tryAcquireSlot({ jobId, jobData, log }: { jobId: string, jobData: ExecuteFlowJobData, log: FastifyBaseLogger }): Promise<boolean> {
+function encodeParkedMember({ queueName, jobId, priority }: { queueName: string, jobId: string, priority: number }): string {
+    return JSON.stringify([queueName, jobId, priority])
+}
+
+function decodeParkedMember(member: string): { queueName: string, jobId: string, priority: number } | null {
+    const { data: parsed } = tryCatchSync(() => JSON.parse(member))
+    const result = ParkedMember.safeParse(parsed)
+    if (!result.success) {
+        return null
+    }
+    const [queueName, jobId, priority] = result.data
+    return { queueName, jobId, priority }
+}
+
+async function tryAcquireSlot({ jobId, jobData, job, log }: { jobId: string, jobData: ExecuteFlowJobData, job: Job, log: FastifyBaseLogger }): Promise<boolean> {
     const flowTimeoutInMilliseconds = apDayjsDuration(system.getNumberOrThrow(AppSystemProp.FLOW_TIMEOUT_SECONDS), 'seconds').add(1, 'minute').asMilliseconds()
     const { data: poolId } = await tryCatch(() => concurrencyPoolService(log).getProjectPoolId(jobData.projectId))
     const effectivePoolId = poolId ?? jobData.projectId
@@ -109,47 +127,62 @@ async function tryAcquireSlot({ jobId, jobData, log }: { jobId: string, jobData:
         log,
     })
     const setKey = getConcurrencyPoolSetKey(effectivePoolId)
+    const parkedKey = getConcurrencyPoolParkedKey(effectivePoolId)
     const currentTime = Date.now()
     const member = `${jobData.projectId}:${jobId}`
+    const parkedMember = encodeParkedMember({
+        queueName: job.queueName,
+        jobId,
+        priority: JOB_PRIORITY[getDefaultJobPriority(jobData)],
+    })
     const redisConnection = await redisConnections.useExisting()
 
     const result = await redisConnection.eval(
         `
 local setKey = KEYS[1]
+local parkedKey = KEYS[2]
 local currentTime = tonumber(ARGV[1])
 local timeoutMs = tonumber(ARGV[2])
 local maxJobs = tonumber(ARGV[3])
 local member = ARGV[4]
+local parkedMember = ARGV[5]
 
 redis.call('ZREMRANGEBYSCORE', setKey, '-inf', currentTime - timeoutMs)
 
 local existingScore = redis.call('ZSCORE', setKey, member)
 if existingScore then
+    redis.call('ZREM', parkedKey, parkedMember)
     return 0
 end
 
 local currentSize = redis.call('ZCARD', setKey)
 if currentSize >= maxJobs then
+    redis.call('ZREMRANGEBYSCORE', parkedKey, '-inf', currentTime - timeoutMs)
+    redis.call('ZADD', parkedKey, currentTime, parkedMember)
+    redis.call('EXPIRE', parkedKey, math.ceil(timeoutMs / 1000))
     return 1
 end
 
 redis.call('ZADD', setKey, currentTime, member)
 redis.call('EXPIRE', setKey, math.ceil(timeoutMs / 1000))
+redis.call('ZREM', parkedKey, parkedMember)
 
 return 0
 `,
-        1,
+        2,
         setKey,
+        parkedKey,
         currentTime.toString(),
         flowTimeoutInMilliseconds.toString(),
         maxConcurrentJobs.toString(),
         member,
+        parkedMember,
     ) as number
 
     return result === 0
 }
 
-async function releaseSlot({ jobId, jobData, log }: { jobId: string, jobData: ExecuteFlowJobData, log: FastifyBaseLogger }): Promise<void> {
+async function releaseSlot({ jobId, jobData, log }: { jobId: string, jobData: ExecuteFlowJobData, log: FastifyBaseLogger }): Promise<string> {
     const { data: poolId } = await tryCatch(() => concurrencyPoolService(log).getProjectPoolId(jobData.projectId))
     const effectivePoolId = poolId ?? jobData.projectId
     const setKey = getConcurrencyPoolSetKey(effectivePoolId)
@@ -166,6 +199,37 @@ return 1
         setKey,
         member,
     )
+    return effectivePoolId
+}
+
+async function promoteNextParkedJob({ effectivePoolId, log }: { effectivePoolId: string, log: FastifyBaseLogger }): Promise<void> {
+    const redisConnection = await redisConnections.useExisting()
+    const parkedKey = getConcurrencyPoolParkedKey(effectivePoolId)
+    for (let attempt = 0; attempt < 3; attempt++) {
+        const popped = await redisConnection.zpopmin(parkedKey)
+        if (popped.length === 0) {
+            return
+        }
+        const decoded = decodeParkedMember(popped[0])
+        if (isNil(decoded)) {
+            log.warn({ pool: { id: effectivePoolId } }, '[rateLimiterInterceptor] Dropping undecodable parked entry')
+            continue
+        }
+        const queue = await jobQueue(log).getOrCreateQueue({ queueName: decoded.queueName })
+        const parkedJob = await Job.fromId(queue, decoded.jobId)
+        if (isNil(parkedJob)) {
+            log.debug({ job: { id: decoded.jobId }, queueName: decoded.queueName }, '[rateLimiterInterceptor] Parked job no longer exists, dropping')
+            continue
+        }
+        await tryCatch(() => parkedJob.changePriority({ priority: decoded.priority }))
+        const { error } = await tryCatch(() => parkedJob.promote())
+        if (error) {
+            log.debug({ job: { id: decoded.jobId }, queueName: decoded.queueName, error: String(error) }, '[rateLimiterInterceptor] Parked job no longer delayed, dropping')
+            continue
+        }
+        log.info({ job: { id: decoded.jobId }, queueName: decoded.queueName, pool: { id: effectivePoolId } }, '[rateLimiterInterceptor] Promoted parked job on slot release')
+        return
+    }
 }
 
 export const rateLimiterInterceptor: JobInterceptor = {
@@ -174,7 +238,7 @@ export const rateLimiterInterceptor: JobInterceptor = {
             return { verdict: InterceptorVerdict.ALLOW }
         }
 
-        const allowed = await tryAcquireSlot({ jobId, jobData, log })
+        const allowed = await tryAcquireSlot({ jobId, jobData, job, log })
         if (allowed) {
             log.debug({ job: { id: jobId }, project: { id: jobData.projectId } }, '[rateLimiterInterceptor] Job allowed')
             return { verdict: InterceptorVerdict.ALLOW }
@@ -193,7 +257,11 @@ export const rateLimiterInterceptor: JobInterceptor = {
         if (!shouldContinue(jobData)) {
             return
         }
-        await releaseSlot({ jobId, jobData, log })
+        const effectivePoolId = await releaseSlot({ jobId, jobData, log })
         log.debug({ job: { id: jobId }, project: { id: jobData.projectId } }, '[rateLimiterInterceptor] Slot released')
+        const { error } = await tryCatch(() => promoteNextParkedJob({ effectivePoolId, log }))
+        if (error) {
+            log.warn({ pool: { id: effectivePoolId }, error: String(error) }, '[rateLimiterInterceptor] Failed to promote parked job')
+        }
     },
 }

--- a/packages/server/api/test/unit/app/workers/job-queue/interceptors/rate-limiter-interceptor.test.ts
+++ b/packages/server/api/test/unit/app/workers/job-queue/interceptors/rate-limiter-interceptor.test.ts
@@ -3,12 +3,13 @@ import { Job } from 'bullmq'
 import { FastifyBaseLogger } from 'fastify'
 import { Redis } from 'ioredis'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { getConcurrencyPoolLimitKey, getConcurrencyPoolSetKey, getPlatformPlanNameKey, getProjectConcurrencyPoolKey } from '../../../../../../src/app/database/redis/keys'
+import { getConcurrencyPoolLimitKey, getConcurrencyPoolParkedKey, getConcurrencyPoolSetKey, getPlatformPlanNameKey, getProjectConcurrencyPoolKey } from '../../../../../../src/app/database/redis/keys'
 import { distributedStore, redisConnections } from '../../../../../../src/app/database/redis-connections'
 import { system } from '../../../../../../src/app/helper/system/system'
 import { AppSystemProp } from '../../../../../../src/app/helper/system/system-props'
 import { rateLimiterInterceptor } from '../../../../../../src/app/workers/job-queue/interceptors/rate-limiter-interceptor'
 import { InterceptorVerdict } from '../../../../../../src/app/workers/job-queue/job-interceptor'
+import { jobQueue } from '../../../../../../src/app/workers/job-queue/job-queue'
 
 const mockLog: FastifyBaseLogger = {
     debug: vi.fn(),
@@ -42,7 +43,7 @@ function createFlowJobData(overrides?: Record<string, unknown>) {
 }
 
 function createMockJob(overrides?: Record<string, unknown>) {
-    return { attemptsMade: 0, ...overrides } as unknown as Job
+    return { attemptsMade: 0, queueName: 'rate-limit-test-queue', ...overrides } as unknown as Job
 }
 
 function enableRateLimiter() {
@@ -79,6 +80,7 @@ describe('rateLimiterInterceptor', () => {
 
         const redis = await redisConnections.useExisting()
         await deleteKeysByPattern(redis, 'active_jobs_set:*')
+        await deleteKeysByPattern(redis, 'parked_jobs_set:*')
         await deleteKeysByPattern(redis, 'project:max-concurrent-jobs:*')
         await deleteKeysByPattern(redis, 'platform_plan:plan:*')
         await deleteKeysByPattern(redis, 'project:concurrency-pool:*')
@@ -631,6 +633,117 @@ describe('rateLimiterInterceptor', () => {
             const members = await redis.zrange(getConcurrencyPoolSetKey(poolId), 0, -1)
             expect(members).toHaveLength(1)
             expect(members[0]).toBe(`${projectId}:job-1`)
+        })
+    })
+
+    describe('parked job promotion', () => {
+        beforeEach(() => {
+            vi.spyOn(system, 'getNumberOrThrow').mockImplementation((prop) => {
+                if (prop === AppSystemProp.FLOW_TIMEOUT_SECONDS) return 600
+                if (prop === AppSystemProp.DEFAULT_CONCURRENT_JOBS_LIMIT) return 1
+                return 0
+            })
+        })
+
+        it('parks a rejected job in the pool parked set', async () => {
+            const jobData = createFlowJobData()
+            await rateLimiterInterceptor.preDispatch({ jobId: 'filler', jobData, job: createMockJob(), log: mockLog })
+
+            const result = await rateLimiterInterceptor.preDispatch({ jobId: 'parked-1', jobData, job: createMockJob(), log: mockLog })
+            expect(result.verdict).toBe(InterceptorVerdict.REJECT)
+
+            const redis = await redisConnections.useExisting()
+            const members = await redis.zrange(getConcurrencyPoolParkedKey(jobData.projectId), 0, -1)
+            expect(members).toEqual([JSON.stringify(['rate-limit-test-queue', 'parked-1', JOB_PRIORITY.medium])])
+        })
+
+        it('removes the parked entry when the job later acquires a slot', async () => {
+            const jobData = createFlowJobData()
+            await rateLimiterInterceptor.preDispatch({ jobId: 'filler', jobData, job: createMockJob(), log: mockLog })
+            await rateLimiterInterceptor.preDispatch({ jobId: 'parked-1', jobData, job: createMockJob(), log: mockLog })
+
+            const redis = await redisConnections.useExisting()
+            await redis.del(getConcurrencyPoolSetKey(jobData.projectId))
+
+            const result = await rateLimiterInterceptor.preDispatch({ jobId: 'parked-1', jobData, job: createMockJob(), log: mockLog })
+            expect(result.verdict).toBe(InterceptorVerdict.ALLOW)
+
+            const members = await redis.zrange(getConcurrencyPoolParkedKey(jobData.projectId), 0, -1)
+            expect(members).toHaveLength(0)
+        })
+
+        it('promotes a parked delayed job at its default priority when a slot releases', async () => {
+            const queueName = `rate-limit-promote-${crypto.randomUUID()}`
+            const queue = await jobQueue(mockLog).getOrCreateQueue({ queueName })
+            const jobData = createFlowJobData()
+            await queue.add('parked-1', jobData, { jobId: 'parked-1', delay: 300_000, priority: JOB_PRIORITY.lowest })
+
+            await rateLimiterInterceptor.preDispatch({ jobId: 'filler', jobData, job: createMockJob({ queueName }), log: mockLog })
+            const rejected = await rateLimiterInterceptor.preDispatch({ jobId: 'parked-1', jobData, job: createMockJob({ queueName }), log: mockLog })
+            expect(rejected.verdict).toBe(InterceptorVerdict.REJECT)
+
+            await rateLimiterInterceptor.onJobFinished({ jobId: 'filler', jobData, log: mockLog })
+
+            const promoted = await queue.getJob('parked-1')
+            expect(promoted).toBeDefined()
+            expect(await promoted?.getState()).not.toBe('delayed')
+            expect(promoted?.priority).toBe(JOB_PRIORITY.medium)
+
+            const redis = await redisConnections.useExisting()
+            const members = await redis.zrange(getConcurrencyPoolParkedKey(jobData.projectId), 0, -1)
+            expect(members).toHaveLength(0)
+
+            await queue.obliterate({ force: true })
+        })
+
+        it('drops stale parked entries and still promotes a valid one', async () => {
+            const queueName = `rate-limit-stale-${crypto.randomUUID()}`
+            const queue = await jobQueue(mockLog).getOrCreateQueue({ queueName })
+            const jobData = createFlowJobData()
+            await queue.add('parked-1', jobData, { jobId: 'parked-1', delay: 300_000, priority: JOB_PRIORITY.lowest })
+
+            await rateLimiterInterceptor.preDispatch({ jobId: 'filler', jobData, job: createMockJob({ queueName }), log: mockLog })
+            await rateLimiterInterceptor.preDispatch({ jobId: 'parked-1', jobData, job: createMockJob({ queueName }), log: mockLog })
+
+            const redis = await redisConnections.useExisting()
+            const parkedKey = getConcurrencyPoolParkedKey(jobData.projectId)
+            await redis.zadd(parkedKey, 1, 'not-json')
+            await redis.zadd(parkedKey, 2, JSON.stringify([queueName, 'missing-job', JOB_PRIORITY.medium]))
+
+            await rateLimiterInterceptor.onJobFinished({ jobId: 'filler', jobData, log: mockLog })
+
+            const promoted = await queue.getJob('parked-1')
+            expect(await promoted?.getState()).not.toBe('delayed')
+            expect(await redis.zcard(parkedKey)).toBe(0)
+
+            await queue.obliterate({ force: true })
+        })
+
+        it('pops at most three parked entries per release', async () => {
+            const jobData = createFlowJobData()
+            await rateLimiterInterceptor.preDispatch({ jobId: 'filler', jobData, job: createMockJob(), log: mockLog })
+
+            const redis = await redisConnections.useExisting()
+            const parkedKey = getConcurrencyPoolParkedKey(jobData.projectId)
+            for (let i = 0; i < 4; i++) {
+                await redis.zadd(parkedKey, i, `garbage-${i}`)
+            }
+
+            await rateLimiterInterceptor.onJobFinished({ jobId: 'filler', jobData, log: mockLog })
+
+            expect(await redis.zcard(parkedKey)).toBe(1)
+        })
+
+        it('does not touch the parked set when rate limiter is disabled', async () => {
+            disableRateLimiter()
+            const jobData = createFlowJobData()
+            const redis = await redisConnections.useExisting()
+            const parkedKey = getConcurrencyPoolParkedKey(jobData.projectId)
+            await redis.zadd(parkedKey, Date.now(), 'entry')
+
+            await rateLimiterInterceptor.onJobFinished({ jobId: 'job-1', jobData, log: mockLog })
+
+            expect(await redis.zcard(parkedKey)).toBe(1)
         })
     })
 })


### PR DESCRIPTION
## Description

When a project is over its concurrency cap, rejected jobs go to BullMQ `delayed` for 20s and nothing wakes them when a slot frees. Workers idle between 20s cycles, so on dedicated worker-group queues a burst releases a few jobs and then stalls, no matter how high the cap is set.

Fix: rejected jobs are also recorded in a per-pool Redis ZSET (written atomically with the capacity check in the acquire Lua script). When a job finishes and releases its slot, one parked job is popped via `ZPOPMIN`, set back to its default priority, and promoted so the next worker poll picks it up. The pop loop is bounded to 3 attempts, and the 20s timer stays as a fallback. The parked set prunes by the flow-timeout window and carries a TTL, so it cleans itself up, including after a rollback.

## How was this tested?

- 6 new unit tests against real Redis (park on reject, cleanup on acquire, promotion at restored priority, stale-entry drops, pop bound, disabled flag). 38/38 passing.
- Local server (CE, limit 1): burst of 6 webhook runs with a 5s step executed back to back, ~0.4s between a completion and the next start, instead of a 20s wait per cycle.

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)