### PR TITLE
release: v0.87.1

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   app:
-    image: ghcr.io/activepieces/activepieces:0.87.0
+    image: ghcr.io/activepieces/activepieces:0.87.1
     container_name: activepieces-app
     restart: unless-stopped
     ports:
@@ -16,7 +16,7 @@ services:
     networks:
       - activepieces
   worker:
-    image: ghcr.io/activepieces/activepieces:0.87.0
+    image: ghcr.io/activepieces/activepieces:0.87.1
     restart: unless-stopped
     depends_on:
       - app

--- a/docs/install/configure-operate/worker-groups.mdx
+++ b/docs/install/configure-operate/worker-groups.mdx
@@ -33,10 +33,9 @@ AP_WORKER_GROUP_ID=canary
 AP_PROJECT_WORKER=false
 ```
 
-Grouped workers run in a process-isolated execution mode, so set:
+Grouped workers must set:
 
 ```bash
-AP_EXECUTION_MODE=SANDBOX_PROCESS   # or SANDBOX_CODE_AND_PROCESS
 AP_REUSE_SANDBOX=true               # or false, must be set explicitly
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activepieces",
-  "version": "0.87.0",
+  "version": "0.87.1",
   "packageManager": "bun@1.3.3",
   "trustedDependencies": [
     "sqlite3",

--- a/packages/server/api/src/app/database/redis/keys.ts
+++ b/packages/server/api/src/app/database/redis/keys.ts
@@ -17,6 +17,7 @@ export const getCustomerStateFetchLockKey = (platformId: PlatformId): string => 
 export const getProjectConcurrencyPoolKey = (projectId: ProjectId): string => `project:concurrency-pool:${projectId}` // gets pool id for the project
 export const getConcurrencyPoolLimitKey = (poolId: string): string => `concurrency-pool:limit:${poolId}` // gets limit value for the pool
 export const getConcurrencyPoolSetKey = (poolId: string): string => `active_jobs_set:pool:${poolId}`
+export const getConcurrencyPoolParkedKey = (poolId: string): string => `parked_jobs_set:pool:${poolId}`
 
 export const BILLING_ENFORCED_TTL_SECONDS = 24 * 60 * 60
 export const PLATFORM_PLAN_NAME_TTL_SECONDS = 24 * 60 * 60

--- a/packages/server/api/src/app/workers/job-queue/interceptors/rate-limiter-interceptor.ts
+++ b/packages/server/api/src/app/workers/job-queue/interceptors/rate-limiter-interceptor.ts
@@ -1,8 +1,10 @@
-import { isNil, PlatformId, tryCatch } from '@activepieces/core-utils'
+import { isNil, PlatformId, tryCatch, tryCatchSync } from '@activepieces/core-utils'
 import { apDayjsDuration } from '@activepieces/server-utils'
-import { ApEdition, ExecuteFlowJobData, JOB_PRIORITY, JobData, PlanName, RATE_LIMIT_PRIORITY, RunEnvironment, WorkerJobType } from '@activepieces/shared'
+import { ApEdition, ExecuteFlowJobData, getDefaultJobPriority, JOB_PRIORITY, JobData, PlanName, RATE_LIMIT_PRIORITY, RunEnvironment, WorkerJobType } from '@activepieces/shared'
+import { Job } from 'bullmq'
 import { FastifyBaseLogger } from 'fastify'
-import { getConcurrencyPoolSetKey, getPlatformPlanNameKey, PLATFORM_PLAN_NAME_TTL_SECONDS } from '../../../database/redis/keys'
+import { z } from 'zod'
+import { getConcurrencyPoolParkedKey, getConcurrencyPoolSetKey, getPlatformPlanNameKey, PLATFORM_PLAN_NAME_TTL_SECONDS } from '../../../database/redis/keys'
 import { distributedStore, redisConnections } from '../../../database/redis-connections'
 import { concurrencyPoolService } from '../../../ee/platform/concurrency-pool/concurrency-pool.service'
 import { workerGroupService } from '../../../ee/platform/platform-plan/worker-group.service'
@@ -12,8 +14,10 @@ import { platformService } from '../../../platform/platform.service'
 import { projectWorkerGroupService } from '../../../project/project-worker-group.service'
 import { workerCapacity } from '../../machine/worker-capacity'
 import { InterceptorResult, InterceptorVerdict, JobInterceptor } from '../job-interceptor'
+import { jobQueue } from '../job-queue'
 
 const RATE_LIMIT_WORKER_JOB_TYPES = [WorkerJobType.EXECUTE_FLOW]
+const ParkedMember = z.tuple([z.string(), z.string(), z.number()])
 
 const FREE_CONCURRENT_JOBS_LIMIT = 5
 const SELF_SERVE_CONCURRENT_JOBS_LIMIT = 15
@@ -98,7 +102,21 @@ async function resolveRoutedPoolSlots({ platformId, projectId, log }: { platform
     return shared.slots
 }
 
-async function tryAcquireSlot({ jobId, jobData, log }: { jobId: string, jobData: ExecuteFlowJobData, log: FastifyBaseLogger }): Promise<boolean> {
+function encodeParkedMember({ queueName, jobId, priority }: { queueName: string, jobId: string, priority: number }): string {
+    return JSON.stringify([queueName, jobId, priority])
+}
+
+function decodeParkedMember(member: string): { queueName: string, jobId: string, priority: number } | null {
+    const { data: parsed } = tryCatchSync(() => JSON.parse(member))
+    const result = ParkedMember.safeParse(parsed)
+    if (!result.success) {
+        return null
+    }
+    const [queueName, jobId, priority] = result.data
+    return { queueName, jobId, priority }
+}
+
+async function tryAcquireSlot({ jobId, jobData, job, log }: { jobId: string, jobData: ExecuteFlowJobData, job: Job, log: FastifyBaseLogger }): Promise<boolean> {
     const flowTimeoutInMilliseconds = apDayjsDuration(system.getNumberOrThrow(AppSystemProp.FLOW_TIMEOUT_SECONDS), 'seconds').add(1, 'minute').asMilliseconds()
     const { data: poolId } = await tryCatch(() => concurrencyPoolService(log).getProjectPoolId(jobData.projectId))
     const effectivePoolId = poolId ?? jobData.projectId
@@ -109,47 +127,62 @@ async function tryAcquireSlot({ jobId, jobData, log }: { jobId: string, jobData:
         log,
     })
     const setKey = getConcurrencyPoolSetKey(effectivePoolId)
+    const parkedKey = getConcurrencyPoolParkedKey(effectivePoolId)
     const currentTime = Date.now()
     const member = `${jobData.projectId}:${jobId}`
+    const parkedMember = encodeParkedMember({
+        queueName: job.queueName,
+        jobId,
+        priority: JOB_PRIORITY[getDefaultJobPriority(jobData)],
+    })
     const redisConnection = await redisConnections.useExisting()
 
     const result = await redisConnection.eval(
         `
 local setKey = KEYS[1]
+local parkedKey = KEYS[2]
 local currentTime = tonumber(ARGV[1])
 local timeoutMs = tonumber(ARGV[2])
 local maxJobs = tonumber(ARGV[3])
 local member = ARGV[4]
+local parkedMember = ARGV[5]
 
 redis.call('ZREMRANGEBYSCORE', setKey, '-inf', currentTime - timeoutMs)
 
 local existingScore = redis.call('ZSCORE', setKey, member)
 if existingScore then
+    redis.call('ZREM', parkedKey, parkedMember)
     return 0
 end
 
 local currentSize = redis.call('ZCARD', setKey)
 if currentSize >= maxJobs then
+    redis.call('ZREMRANGEBYSCORE', parkedKey, '-inf', currentTime - timeoutMs)
+    redis.call('ZADD', parkedKey, currentTime, parkedMember)
+    redis.call('EXPIRE', parkedKey, math.ceil(timeoutMs / 1000))
     return 1
 end
 
 redis.call('ZADD', setKey, currentTime, member)
 redis.call('EXPIRE', setKey, math.ceil(timeoutMs / 1000))
+redis.call('ZREM', parkedKey, parkedMember)
 
 return 0
 `,
-        1,
+        2,
         setKey,
+        parkedKey,
         currentTime.toString(),
         flowTimeoutInMilliseconds.toString(),
         maxConcurrentJobs.toString(),
         member,
+        parkedMember,
     ) as number
 
     return result === 0
 }
 
-async function releaseSlot({ jobId, jobData, log }: { jobId: string, jobData: ExecuteFlowJobData, log: FastifyBaseLogger }): Promise<void> {
+async function releaseSlot({ jobId, jobData, log }: { jobId: string, jobData: ExecuteFlowJobData, log: FastifyBaseLogger }): Promise<string> {
     const { data: poolId } = await tryCatch(() => concurrencyPoolService(log).getProjectPoolId(jobData.projectId))
     const effectivePoolId = poolId ?? jobData.projectId
     const setKey = getConcurrencyPoolSetKey(effectivePoolId)
@@ -166,6 +199,37 @@ return 1
         setKey,
         member,
     )
+    return effectivePoolId
+}
+
+async function promoteNextParkedJob({ effectivePoolId, log }: { effectivePoolId: string, log: FastifyBaseLogger }): Promise<void> {
+    const redisConnection = await redisConnections.useExisting()
+    const parkedKey = getConcurrencyPoolParkedKey(effectivePoolId)
+    for (let attempt = 0; attempt < 3; attempt++) {
+        const popped = await redisConnection.zpopmin(parkedKey)
+        if (popped.length === 0) {
+            return
+        }
+        const decoded = decodeParkedMember(popped[0])
+        if (isNil(decoded)) {
+            log.warn({ pool: { id: effectivePoolId } }, '[rateLimiterInterceptor] Dropping undecodable parked entry')
+            continue
+        }
+        const queue = await jobQueue(log).getOrCreateQueue({ queueName: decoded.queueName })
+        const parkedJob = await Job.fromId(queue, decoded.jobId)
+        if (isNil(parkedJob)) {
+            log.debug({ job: { id: decoded.jobId }, queueName: decoded.queueName }, '[rateLimiterInterceptor] Parked job no longer exists, dropping')
+            continue
+        }
+        await tryCatch(() => parkedJob.changePriority({ priority: decoded.priority }))
+        const { error } = await tryCatch(() => parkedJob.promote())
+        if (error) {
+            log.debug({ job: { id: decoded.jobId }, queueName: decoded.queueName, error: String(error) }, '[rateLimiterInterceptor] Parked job no longer delayed, dropping')
+            continue
+        }
+        log.info({ job: { id: decoded.jobId }, queueName: decoded.queueName, pool: { id: effectivePoolId } }, '[rateLimiterInterceptor] Promoted parked job on slot release')
+        return
+    }
 }
 
 export const rateLimiterInterceptor: JobInterceptor = {
@@ -174,7 +238,7 @@ export const rateLimiterInterceptor: JobInterceptor = {
             return { verdict: InterceptorVerdict.ALLOW }
         }
 
-        const allowed = await tryAcquireSlot({ jobId, jobData, log })
+        const allowed = await tryAcquireSlot({ jobId, jobData, job, log })
         if (allowed) {
             log.debug({ job: { id: jobId }, project: { id: jobData.projectId } }, '[rateLimiterInterceptor] Job allowed')
             return { verdict: InterceptorVerdict.ALLOW }
@@ -193,7 +257,11 @@ export const rateLimiterInterceptor: JobInterceptor = {
         if (!shouldContinue(jobData)) {
             return
         }
-        await releaseSlot({ jobId, jobData, log })
+        const effectivePoolId = await releaseSlot({ jobId, jobData, log })
         log.debug({ job: { id: jobId }, project: { id: jobData.projectId } }, '[rateLimiterInterceptor] Slot released')
+        const { error } = await tryCatch(() => promoteNextParkedJob({ effectivePoolId, log }))
+        if (error) {
+            log.warn({ pool: { id: effectivePoolId }, error: String(error) }, '[rateLimiterInterceptor] Failed to promote parked job')
+        }
     },
 }

--- a/packages/server/api/test/unit/app/workers/job-queue/interceptors/rate-limiter-interceptor.test.ts
+++ b/packages/server/api/test/unit/app/workers/job-queue/interceptors/rate-limiter-interceptor.test.ts
@@ -3,12 +3,13 @@ import { Job } from 'bullmq'
 import { FastifyBaseLogger } from 'fastify'
 import { Redis } from 'ioredis'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { getConcurrencyPoolLimitKey, getConcurrencyPoolSetKey, getPlatformPlanNameKey, getProjectConcurrencyPoolKey } from '../../../../../../src/app/database/redis/keys'
+import { getConcurrencyPoolLimitKey, getConcurrencyPoolParkedKey, getConcurrencyPoolSetKey, getPlatformPlanNameKey, getProjectConcurrencyPoolKey } from '../../../../../../src/app/database/redis/keys'
 import { distributedStore, redisConnections } from '../../../../../../src/app/database/redis-connections'
 import { system } from '../../../../../../src/app/helper/system/system'
 import { AppSystemProp } from '../../../../../../src/app/helper/system/system-props'
 import { rateLimiterInterceptor } from '../../../../../../src/app/workers/job-queue/interceptors/rate-limiter-interceptor'
 import { InterceptorVerdict } from '../../../../../../src/app/workers/job-queue/job-interceptor'
+import { jobQueue } from '../../../../../../src/app/workers/job-queue/job-queue'
 
 const mockLog: FastifyBaseLogger = {
     debug: vi.fn(),
@@ -42,7 +43,7 @@ function createFlowJobData(overrides?: Record<string, unknown>) {
 }
 
 function createMockJob(overrides?: Record<string, unknown>) {
-    return { attemptsMade: 0, ...overrides } as unknown as Job
+    return { attemptsMade: 0, queueName: 'rate-limit-test-queue', ...overrides } as unknown as Job
 }
 
 function enableRateLimiter() {
@@ -79,6 +80,7 @@ describe('rateLimiterInterceptor', () => {
 
         const redis = await redisConnections.useExisting()
         await deleteKeysByPattern(redis, 'active_jobs_set:*')
+        await deleteKeysByPattern(redis, 'parked_jobs_set:*')
         await deleteKeysByPattern(redis, 'project:max-concurrent-jobs:*')
         await deleteKeysByPattern(redis, 'platform_plan:plan:*')
         await deleteKeysByPattern(redis, 'project:concurrency-pool:*')
@@ -631,6 +633,117 @@ describe('rateLimiterInterceptor', () => {
             const members = await redis.zrange(getConcurrencyPoolSetKey(poolId), 0, -1)
             expect(members).toHaveLength(1)
             expect(members[0]).toBe(`${projectId}:job-1`)
+        })
+    })
+
+    describe('parked job promotion', () => {
+        beforeEach(() => {
+            vi.spyOn(system, 'getNumberOrThrow').mockImplementation((prop) => {
+                if (prop === AppSystemProp.FLOW_TIMEOUT_SECONDS) return 600
+                if (prop === AppSystemProp.DEFAULT_CONCURRENT_JOBS_LIMIT) return 1
+                return 0
+            })
+        })
+
+        it('parks a rejected job in the pool parked set', async () => {
+            const jobData = createFlowJobData()
+            await rateLimiterInterceptor.preDispatch({ jobId: 'filler', jobData, job: createMockJob(), log: mockLog })
+
+            const result = await rateLimiterInterceptor.preDispatch({ jobId: 'parked-1', jobData, job: createMockJob(), log: mockLog })
+            expect(result.verdict).toBe(InterceptorVerdict.REJECT)
+
+            const redis = await redisConnections.useExisting()
+            const members = await redis.zrange(getConcurrencyPoolParkedKey(jobData.projectId), 0, -1)
+            expect(members).toEqual([JSON.stringify(['rate-limit-test-queue', 'parked-1', JOB_PRIORITY.medium])])
+        })
+
+        it('removes the parked entry when the job later acquires a slot', async () => {
+            const jobData = createFlowJobData()
+            await rateLimiterInterceptor.preDispatch({ jobId: 'filler', jobData, job: createMockJob(), log: mockLog })
+            await rateLimiterInterceptor.preDispatch({ jobId: 'parked-1', jobData, job: createMockJob(), log: mockLog })
+
+            const redis = await redisConnections.useExisting()
+            await redis.del(getConcurrencyPoolSetKey(jobData.projectId))
+
+            const result = await rateLimiterInterceptor.preDispatch({ jobId: 'parked-1', jobData, job: createMockJob(), log: mockLog })
+            expect(result.verdict).toBe(InterceptorVerdict.ALLOW)
+
+            const members = await redis.zrange(getConcurrencyPoolParkedKey(jobData.projectId), 0, -1)
+            expect(members).toHaveLength(0)
+        })
+
+        it('promotes a parked delayed job at its default priority when a slot releases', async () => {
+            const queueName = `rate-limit-promote-${crypto.randomUUID()}`
+            const queue = await jobQueue(mockLog).getOrCreateQueue({ queueName })
+            const jobData = createFlowJobData()
+            await queue.add('parked-1', jobData, { jobId: 'parked-1', delay: 300_000, priority: JOB_PRIORITY.lowest })
+
+            await rateLimiterInterceptor.preDispatch({ jobId: 'filler', jobData, job: createMockJob({ queueName }), log: mockLog })
+            const rejected = await rateLimiterInterceptor.preDispatch({ jobId: 'parked-1', jobData, job: createMockJob({ queueName }), log: mockLog })
+            expect(rejected.verdict).toBe(InterceptorVerdict.REJECT)
+
+            await rateLimiterInterceptor.onJobFinished({ jobId: 'filler', jobData, log: mockLog })
+
+            const promoted = await queue.getJob('parked-1')
+            expect(promoted).toBeDefined()
+            expect(await promoted?.getState()).not.toBe('delayed')
+            expect(promoted?.priority).toBe(JOB_PRIORITY.medium)
+
+            const redis = await redisConnections.useExisting()
+            const members = await redis.zrange(getConcurrencyPoolParkedKey(jobData.projectId), 0, -1)
+            expect(members).toHaveLength(0)
+
+            await queue.obliterate({ force: true })
+        })
+
+        it('drops stale parked entries and still promotes a valid one', async () => {
+            const queueName = `rate-limit-stale-${crypto.randomUUID()}`
+            const queue = await jobQueue(mockLog).getOrCreateQueue({ queueName })
+            const jobData = createFlowJobData()
+            await queue.add('parked-1', jobData, { jobId: 'parked-1', delay: 300_000, priority: JOB_PRIORITY.lowest })
+
+            await rateLimiterInterceptor.preDispatch({ jobId: 'filler', jobData, job: createMockJob({ queueName }), log: mockLog })
+            await rateLimiterInterceptor.preDispatch({ jobId: 'parked-1', jobData, job: createMockJob({ queueName }), log: mockLog })
+
+            const redis = await redisConnections.useExisting()
+            const parkedKey = getConcurrencyPoolParkedKey(jobData.projectId)
+            await redis.zadd(parkedKey, 1, 'not-json')
+            await redis.zadd(parkedKey, 2, JSON.stringify([queueName, 'missing-job', JOB_PRIORITY.medium]))
+
+            await rateLimiterInterceptor.onJobFinished({ jobId: 'filler', jobData, log: mockLog })
+
+            const promoted = await queue.getJob('parked-1')
+            expect(await promoted?.getState()).not.toBe('delayed')
+            expect(await redis.zcard(parkedKey)).toBe(0)
+
+            await queue.obliterate({ force: true })
+        })
+
+        it('pops at most three parked entries per release', async () => {
+            const jobData = createFlowJobData()
+            await rateLimiterInterceptor.preDispatch({ jobId: 'filler', jobData, job: createMockJob(), log: mockLog })
+
+            const redis = await redisConnections.useExisting()
+            const parkedKey = getConcurrencyPoolParkedKey(jobData.projectId)
+            for (let i = 0; i < 4; i++) {
+                await redis.zadd(parkedKey, i, `garbage-${i}`)
+            }
+
+            await rateLimiterInterceptor.onJobFinished({ jobId: 'filler', jobData, log: mockLog })
+
+            expect(await redis.zcard(parkedKey)).toBe(1)
+        })
+
+        it('does not touch the parked set when rate limiter is disabled', async () => {
+            disableRateLimiter()
+            const jobData = createFlowJobData()
+            const redis = await redisConnections.useExisting()
+            const parkedKey = getConcurrencyPoolParkedKey(jobData.projectId)
+            await redis.zadd(parkedKey, Date.now(), 'entry')
+
+            await rateLimiterInterceptor.onJobFinished({ jobId: 'job-1', jobData, log: mockLog })
+
+            expect(await redis.zcard(parkedKey)).toBe(1)
         })
     })
 })

--- a/packages/server/worker/src/lib/worker.ts
+++ b/packages/server/worker/src/lib/worker.ts
@@ -3,7 +3,7 @@ import os from 'os'
 import { ActivepiecesError, isNil, spreadIfDefined, tryCatch } from '@activepieces/core-utils'
 import { createResolver, createSandboxRuntime, Runtime } from '@activepieces/sandbox'
 import { apVersionUtil, createLogger, onCallService, systemUsage, UNKNOWN_VERSION, wideEvent } from '@activepieces/server-utils'
-import { ApiToWorkerContract, ConsumeJobRequest, createNotifyServer, createRpcClient, EngineResponseStatus, ExecutionMode, JobData, SandboxInformation, WebsocketServerEvent, WorkerJobType, WorkerMachineHealthcheckRequest, WorkerProps, WorkerSettingsResponse, WorkerToApiContract } from '@activepieces/shared'
+import { ApEdition, ApiToWorkerContract, ConsumeJobRequest, createNotifyServer, createRpcClient, EngineResponseStatus, ExecutionMode, JobData, SandboxInformation, WebsocketServerEvent, WorkerJobType, WorkerMachineHealthcheckRequest, WorkerProps, WorkerSettingsResponse, WorkerToApiContract } from '@activepieces/shared'
 import { nanoid } from 'nanoid'
 import { io, Socket } from 'socket.io-client'
 import { createApiToWorkerHandlers } from './api-notify-service'
@@ -411,9 +411,11 @@ async function fetchAndStoreSettings(sock: Socket): Promise<void> {
             }
             const workerGroupId = system.get(WorkerSystemProp.WORKER_GROUP_ID)
             if (!isNil(workerGroupId)) {
-                const processSandboxedModes = [ExecutionMode.SANDBOX_PROCESS, ExecutionMode.SANDBOX_CODE_AND_PROCESS]
-                if (!processSandboxedModes.includes(response.EXECUTION_MODE as ExecutionMode)) {
-                    throw new Error(`Worker group "${workerGroupId}" requires AP_EXECUTION_MODE to be one of: ${processSandboxedModes.join(', ')}. Got: ${response.EXECUTION_MODE}`)
+                if (response.EDITION === ApEdition.CLOUD) {
+                    const processSandboxedModes: string[] = [ExecutionMode.SANDBOX_PROCESS, ExecutionMode.SANDBOX_CODE_AND_PROCESS]
+                    if (!processSandboxedModes.includes(response.EXECUTION_MODE)) {
+                        throw new Error(`Worker group "${workerGroupId}" requires AP_EXECUTION_MODE to be one of: ${processSandboxedModes.join(', ')}. Got: ${response.EXECUTION_MODE}`)
+                    }
                 }
                 const reuseSandbox = system.get(WorkerSystemProp.REUSE_SANDBOX)
                 if (isNil(reuseSandbox)) {

--- a/packages/server/worker/test/lib/worker-settings-override.test.ts
+++ b/packages/server/worker/test/lib/worker-settings-override.test.ts
@@ -2,6 +2,7 @@ import { createServer } from 'node:http'
 import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest'
 import { Server as IOServer } from 'socket.io'
 import {
+    ApEdition,
     createRpcServer,
     ExecutionMode,
     NetworkMode,
@@ -211,22 +212,47 @@ describe('worker settings override', () => {
         expect(stored.EXECUTION_MODE).toBe(ExecutionMode.SANDBOX_CODE_AND_PROCESS)
     }, 10_000)
 
-    it('worker group + SANDBOX_CODE_ONLY throws error', async () => {
+    it('worker group + UNSANDBOXED passes validation on non-cloud editions', async () => {
         process.env.AP_WORKER_GROUP_ID = 'group-1'
-        process.env.AP_EXECUTION_MODE = ExecutionMode.SANDBOX_CODE_ONLY
-        const serverSettings = buildWorkerSettingsResponse()
+        process.env.AP_EXECUTION_MODE = ExecutionMode.UNSANDBOXED
+        process.env.AP_REUSE_SANDBOX = 'false'
+        const serverSettings = buildWorkerSettingsResponse({ EDITION: ApEdition.ENTERPRISE })
+        await connectAndWaitForSettings(serverSettings)
+
+        expect(mockWorkerSettingsSet).toHaveBeenCalledTimes(1)
+        const stored = mockWorkerSettingsSet.mock.calls[0][0] as WorkerSettingsResponse
+        expect(stored.EXECUTION_MODE).toBe(ExecutionMode.UNSANDBOXED)
+    }, 10_000)
+
+    it('worker group + UNSANDBOXED throws on cloud edition', async () => {
+        process.env.AP_WORKER_GROUP_ID = 'group-1'
+        process.env.AP_EXECUTION_MODE = ExecutionMode.UNSANDBOXED
+        process.env.AP_REUSE_SANDBOX = 'false'
+        const serverSettings = buildWorkerSettingsResponse({ EDITION: ApEdition.CLOUD })
 
         const err = await connectAndExpectCrash(serverSettings)
         expect(err.message).toMatch(/Worker group "group-1" requires AP_EXECUTION_MODE/)
     }, 10_000)
 
-    it('worker group + UNSANDBOXED throws error', async () => {
+    it('worker group + SANDBOX_PROCESS passes validation on cloud edition', async () => {
         process.env.AP_WORKER_GROUP_ID = 'group-1'
-        process.env.AP_EXECUTION_MODE = ExecutionMode.UNSANDBOXED
+        process.env.AP_EXECUTION_MODE = ExecutionMode.SANDBOX_PROCESS
+        process.env.AP_REUSE_SANDBOX = 'false'
+        const serverSettings = buildWorkerSettingsResponse({ EDITION: ApEdition.CLOUD })
+        await connectAndWaitForSettings(serverSettings)
+
+        expect(mockWorkerSettingsSet).toHaveBeenCalledTimes(1)
+        const stored = mockWorkerSettingsSet.mock.calls[0][0] as WorkerSettingsResponse
+        expect(stored.EXECUTION_MODE).toBe(ExecutionMode.SANDBOX_PROCESS)
+    }, 10_000)
+
+    it('worker group without AP_REUSE_SANDBOX throws error', async () => {
+        process.env.AP_WORKER_GROUP_ID = 'group-1'
+        process.env.AP_EXECUTION_MODE = ExecutionMode.SANDBOX_PROCESS
         const serverSettings = buildWorkerSettingsResponse()
 
         const err = await connectAndExpectCrash(serverSettings)
-        expect(err.message).toMatch(/Worker group "group-1" requires AP_EXECUTION_MODE/)
+        expect(err.message).toMatch(/Worker group "group-1" requires AP_REUSE_SANDBOX/)
     }, 10_000)
 
     it('worker group + no local override, server sends SANDBOX_PROCESS → passes', async () => {


### PR DESCRIPTION
## Description

Patch release on top of v0.87.0 with two cherry-picks:

- #15033 — fix(rate-limiter): promote parked jobs when a concurrency slot frees. Rate-limited jobs no longer sit out a 20s timer while workers idle; freed slots immediately promote the next parked job.
- #15022 — chore(worker): remove sandboxed execution mode requirement for worker groups.

Plus the version bump to 0.87.1 (`package.json`, `docker-compose.yml` image tags).

## How was this tested?

Both changes were tested on their original PRs against main (unit tests on real Redis plus a real-server burst test for #15033). Cherry-picks applied without conflicts; the rate-limiter change's dependencies (`getDefaultJobPriority`, `tryCatchSync`, `getOrCreateQueue`, bullmq 5.61.0) are all present on the 0.87 tree.

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)