### PR TITLE
fix(tests): unbreak the platform response assertion on main

### DIFF
--- a/packages/server/api/test/integration/cloud/platform/platform.test.ts
+++ b/packages/server/api/test/integration/cloud/platform/platform.test.ts
@@ -575,7 +575,33 @@ describe('Platform API', () => {
             // assert
             expect(response?.statusCode).toBe(StatusCodes.OK)
 
-            expect(Object.keys(responseBody).length).toBe(24)
+            expect(Object.keys(responseBody).sort()).toStrictEqual([
+                'allowedAuthDomains',
+                'allowedEmbedOrigins',
+                'autoCreatePersonalProjects',
+                'billingEnforced',
+                'cloudAuthEnabled',
+                'created',
+                'emailAuthEnabled',
+                'enforceAllowedAuthDomains',
+                'favIconUrl',
+                'federatedAuthProviders',
+                'fullLogoUrl',
+                'googleAuthEnabled',
+                'id',
+                'logoIconUrl',
+                'name',
+                'ownerId',
+                'pieceSelectorConfig',
+                'pinnedPieces',
+                'plan',
+                'primaryColor',
+                'ssoDomain',
+                'ssoDomainVerification',
+                'themeColors',
+                'updated',
+                'usage',
+            ])
             expect(responseBody.id).toBe(mockPlatform.id)
             expect(responseBody.ownerId).toBe(mockOwner.id)
             expect(responseBody.name).toBe(mockPlatform.name)


### PR DESCRIPTION
## Description

`main` is red. The `GET /api/v1/platforms/:id` test asserted the response has exactly **24** keys:

```ts
expect(Object.keys(responseBody).length).toBe(24)
```

[#14724](https://github.com/activepieces/activepieces/pull/14724) (platform toggle to disable automatic personal project creation) added `autoCreatePersonalProjects` to `PlatformWithoutSensitiveData`, making it 25. The test was not updated, so every PR branched or rebased after that merge fails `test-cloud` with:

```
AssertionError: expected 25 to be 24
 ❯ packages/server/api/test/integration/cloud/platform/platform.test.ts:578:54
```

**Why the key set instead of `toBe(25)`.** The assertion is a tripwire: it proves no sensitive field silently enters a public platform response. A count fires correctly but says only *that* the shape changed, never *which* field — so the failure looks unrelated to the PR that hits it (it cost a bisect against `main` to attribute this one), and clearing it invites bumping the number without checking what was added. Asserting the sorted key list keeps the same tripwire and names the field in the diff, so whoever adds one decides in place whether it belongs in a response served to any platform member. Same reason the number stays hardcoded rather than derived from `PlatformWithoutSensitiveData.shape` — deriving it would make the test tautological and remove the tripwire entirely.

## How was this tested?

```
vitest run test/integration/cloud/platform/platform.test.ts   28 passed
turbo lint --filter=api                                       0 errors
```

Run against a real Postgres and Redis (`AP_REDIS_TYPE=DEFAULT`), `AP_EDITION=cloud`. Confirmed the failure reproduces on `main` at `0b758bdca9` before the change and is gone after.

Test-only change, no source touched, so no edition-path matrix applies — the assertion lives in the cloud suite, which is the only suite that exercises this endpoint's key set.

Fixes the `test-cloud` failure on `main` introduced by #14724.

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)

The assertion guards a public response shape; this change strengthens what it reports without altering the endpoint.
