### PR TITLE
fix(builder): give LongText props a taller editor than ShortText

### DIFF
--- a/packages/web/src/app/builder/piece-properties/properties-utils.tsx
+++ b/packages/web/src/app/builder/piece-properties/properties-utils.tsx
@@ -356,6 +356,11 @@ export const selectGenericFormComponentForProperty = ({
                 'placeholder' in property ? property.placeholder : undefined
               }
               enableMarkdown={enableMarkdownForInputWithMention}
+              minHeightClassName={
+                property.type === PropertyType.LONG_TEXT
+                  ? 'min-h-20'
+                  : undefined
+              }
             ></TextInputWithMentions>
           ) : (
             <SecretInput

--- a/packages/web/src/app/builder/piece-properties/text-input-with-mentions/index.tsx
+++ b/packages/web/src/app/builder/piece-properties/text-input-with-mentions/index.tsx
@@ -10,6 +10,7 @@ type TextInputWithMentionsProps = {
   enableMarkdown?: boolean;
   autoFocus?: boolean;
   outputFormat?: 'text' | 'html';
+  minHeightClassName?: string;
 };
 
 export const TextInputWithMentions = (props: TextInputWithMentionsProps) => {

--- a/packages/web/src/app/builder/piece-properties/text-input-with-mentions/tiptap-editor.tsx
+++ b/packages/web/src/app/builder/piece-properties/text-input-with-mentions/tiptap-editor.tsx
@@ -79,6 +79,8 @@ type TiptapEditorProps = {
    * Defaults to 'text' (plain value via the mention text converter).
    */
   outputFormat?: 'text' | 'html';
+  /** Overrides the editor's initial min-height (e.g. 'min-h-20' for LONG_TEXT props). */
+  minHeightClassName?: string;
 };
 
 const INITIAL_SLASH_STATE: SlashCommandState = {
@@ -233,6 +235,7 @@ export const TiptapEditor = ({
   enableMarkdown,
   autoFocus,
   outputFormat,
+  minHeightClassName,
 }: TiptapEditorProps) => {
   const isHtml = outputFormat === 'html';
   const { embedState } = useEmbedding();
@@ -458,7 +461,12 @@ export const TiptapEditor = ({
         class: cn(
           isHtml
             ? 'block min-h-20 max-h-72 overflow-y-auto px-2.5 py-2 outline-none'
-            : className ?? cn(inputClass, 'py-2 h-[unset] block   min-h-9  '),
+            : className ??
+                cn(
+                  inputClass,
+                  'py-2 h-[unset] block',
+                  minHeightClassName ?? 'min-h-9',
+                ),
           textMentionUtils.inputWithMentionsCssClass,
           { 'cursor-not-allowed opacity-50': disabled },
         ),


### PR DESCRIPTION
## Description

`Property.LongText` and `Property.ShortText` render **identically** in the builder: both fall into the same switch case in `properties-utils.tsx` and mount the same `TextInputWithMentions` with a fixed `min-h-9`, so every text prop starts as a one-line box. Meanwhile the docs properties page shows Long Text as a taller textarea (`LongTextPreview` in `docs/snippets/prop-previews.jsx`), so what piece authors are promised and what users see don't match — a LongText "Description"/"Message" field gives no visual cue that longer content belongs there.

This PR threads an optional `minHeightClassName` through `TextInputWithMentions` → `TiptapEditor`, and passes `min-h-20` when the property is `LONG_TEXT`. `min-h-20` is the same initial height the editor already uses in its rich-text (`outputFormat: 'html'`) mode, so LongText now sits visually between ShortText (1 line) and RichText. The prop defaults to `min-h-9`, so every other consumer renders byte-identically to before; callers that pass `className` (RichText, mention chips) bypass the line entirely.

## How was this tested?

- `turbo run lint test --filter=web` passes (vitest suite plus eslint/prettier).
- Consumer audit: 11 usages of `TextInputWithMentions`; only the `LONG_TEXT` branch passes the new prop, and `className`-overriding callers are untouched.
- Headless-browser check against a CE dev instance (real clicks, fresh profile):
  - a WhatsApp "Message" (`LongText`) field mounts with `min-h-20` (80px computed);
  - a Mollie "Create Payment" step renders 34 text editors: 31 × `min-h-9` (ShortText etc., unchanged) and 3 × `min-h-20` — exactly its 3 declared `LongText` props (`redirectUrl`, `cancelUrl`, `webhookUrl`);
  - no console errors, no error-boundary fallbacks.

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
