### PR TITLE
fix(docker): keep microsoft-teams-bot in runtime image prune allowlist

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -88,7 +88,7 @@ RUN node -e "\
   process.stdout.write(JSON.stringify(names));\
 " > packages/server/api/dist/src/migration-manifest.json
 
-# Remove workspaces not needed at runtime: pieces except the 4 the api imports,
+# Remove workspaces not needed at runtime: pieces except the 5 the api imports,
 # plus web/cli/tests-e2e/embed-sdk whose deps (react & friends) would otherwise land
 # in the runtime node_modules. dist/packages/web is already built and kept.
 # Then drop the removed entries from the root workspaces list and regenerate bun.lock.
@@ -99,6 +99,7 @@ RUN rm -rf packages/pieces/core packages/pieces/custom \
       ! -name square \
       ! -name facebook-leads \
       ! -name intercom \
+      ! -name microsoft-teams-bot \
       -exec rm -rf {} + && \
     node -e "const fs=require('fs');const p=JSON.parse(fs.readFileSync('package.json','utf8'));p.workspaces=p.workspaces.filter(w=>fs.existsSync(w.replace('/*','')));fs.writeFileSync('package.json',JSON.stringify(p,null,2))" && \
     rm -f bun.lock && bun install


### PR DESCRIPTION
## Description

The staging/production Docker image build prunes `packages/pieces/community` down to only the pieces the API imports directly, then regenerates `bun.lock` and runs `bun install`. `packages/server/api/package.json` depends directly on `@activepieces/piece-microsoft-teams-bot`, but the prune allowlist in the `Dockerfile` wasn't updated when that dependency was added (#15041), so the piece's folder was deleted and `bun install` failed to resolve the workspace dependency:

```
error: Workspace dependency "@activepieces/piece-microsoft-teams-bot" not found
```

This broke the `linux/amd64` and `linux/arm64` image builds. Adding `microsoft-teams-bot` to the keep-list fixes it.

Failed workflow run: https://github.com/activepieces/activepieces/actions/runs/32843216330/job/97787114297

## How was this tested?

Traced the failing CI build log and confirmed `packages/server/api/package.json` lists all 5 direct piece workspace dependencies (`slack`, `square`, `facebook-leads`, `intercom`, `microsoft-teams-bot`), matching them against the Dockerfile allowlist.

Fixes # (issue)

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact