### PR TITLE
fix(platform): batch cascade deletes so hard-delete jobs stop timing out

### DIFF
--- a/packages/server/api/src/app/ee/platform/platform-teardown-jobs.ts
+++ b/packages/server/api/src/app/ee/platform/platform-teardown-jobs.ts
@@ -1,7 +1,7 @@
 import { isNil, tryCatch, unique } from '@activepieces/core-utils'
 import { Flow, FlowOperationType, FlowStatus, UserStatus } from '@activepieces/shared'
 import { FastifyBaseLogger } from 'fastify'
-import { IsNull } from 'typeorm'
+import { IsNull, ObjectLiteral, Repository } from 'typeorm'
 import { appConnectionsRepo } from '../../app-connection/app-connection-service/app-connection-service'
 import { userIdentityRepository } from '../../authentication/user-identity/user-identity-service'
 import { repoFactory } from '../../core/db/repo-factory'
@@ -11,18 +11,24 @@ import { flowSideEffects } from '../../flows/flow/flow-service-side-effects'
 import { batchDeleteByFlowId } from '../../flows/flow/flow.jobs'
 import { flowRepo } from '../../flows/flow/flow.repo'
 import { flowService } from '../../flows/flow/flow.service'
+import { flowRunRepo } from '../../flows/flow-run/flow-run-service'
 import { SystemJobData, SystemJobName } from '../../helper/system-jobs/common'
 import { McpOAuthAuthorizationCodeEntity } from '../../mcp/oauth/code/mcp-oauth-code.entity'
 import { McpOAuthTokenEntity } from '../../mcp/oauth/token/mcp-oauth-token.entity'
 import { PieceMetadataEntity } from '../../pieces/metadata/piece-metadata-entity'
 import { PlatformEntity } from '../../platform/platform.entity'
 import { ProjectEntity } from '../../project/project-entity'
+import { FieldEntity } from '../../tables/field/field.entity'
+import { CellEntity } from '../../tables/record/cell.entity'
+import { recordRepo, tableRepo } from '../../tables/table/table.service'
 import { ToolSearchIndexEntity } from '../../tool-search/tool-search-index.entity'
+import { TriggerEventEntity } from '../../trigger/trigger-events/trigger-event.entity'
 import { triggerSourceService } from '../../trigger/trigger-source/trigger-source-service'
 import { userRepo } from '../../user/user-service'
 import { userInvitationRepo } from '../../user-invitations/user-invitation.service'
 import { VariableEntity } from '../../variable/variable.entity'
 import { apiKeyService } from '../api-keys/api-key-service'
+import { auditLogRepo } from '../audit-logs/audit-event-service'
 import { ProjectRoleEntity } from '../projects/project-role/project-role.entity'
 import { SigningKeyEntity } from '../signing-key/signing-key-entity'
 import { ConcurrencyPoolEntity } from './concurrency-pool/concurrency-pool.entity'
@@ -37,6 +43,9 @@ const mcpOAuthCodeRepo = repoFactory(McpOAuthAuthorizationCodeEntity)
 const variableRepo = repoFactory(VariableEntity)
 const concurrencyPoolRepo = repoFactory(ConcurrencyPoolEntity)
 const toolSearchIndexRepo = repoFactory(ToolSearchIndexEntity)
+const cellRepo = repoFactory(CellEntity)
+const fieldRepo = repoFactory(FieldEntity)
+const triggerEventRepo = repoFactory(TriggerEventEntity)
 
 export const platformTeardownJobs = (log: FastifyBaseLogger) => ({
     hardDeletePlatformHandler: async (data: SystemJobData<SystemJobName.HARD_DELETE_PLATFORM>) => {
@@ -52,6 +61,7 @@ export const platformTeardownJobs = (log: FastifyBaseLogger) => ({
 
         const projectIds = await listProjectIdsByPlatform(platformId)
         for (const projectId of projectIds) {
+            await cleanProjectDescendants({ projectId })
             await projectRepo().delete({ id: projectId, platformId })
         }
 
@@ -66,6 +76,7 @@ export const platformTeardownJobs = (log: FastifyBaseLogger) => ({
         await concurrencyPoolRepo().delete({ platformId })
         await toolSearchIndexRepo().delete({ platformId })
 
+        await batchDeleteBy(auditLogRepo(), 'audit_event', '"platformId" = :platformId', { platformId })
         await platformRepo().delete({ id: platformId })
 
         const identityIds = await deletePlatformUsers(platformId)
@@ -173,6 +184,35 @@ async function deleteUnreferencedIdentities(identityIds: string[]): Promise<void
         await userIdentityRepository().delete({ id: identityId })
     }
 }
+
+export async function cleanProjectDescendants({ projectId }: { projectId: string }): Promise<void> {
+    await batchDeleteBy(cellRepo(), 'cell', '"projectId" = :projectId', { projectId })
+    await batchDeleteBy(recordRepo(), 'record', '"projectId" = :projectId', { projectId })
+    await batchDeleteBy(fieldRepo(), 'field', '"projectId" = :projectId', { projectId })
+    await batchDeleteBy(tableRepo(), 'table', '"projectId" = :projectId', { projectId })
+    await batchDeleteBy(flowRunRepo(), 'flow_run', '"projectId" = :projectId', { projectId })
+    await batchDeleteBy(triggerEventRepo(), 'trigger_event', '"projectId" = :projectId', { projectId })
+    await batchDeleteBy(fileRepo(), 'file', '"projectId" = :projectId', { projectId })
+}
+
+async function batchDeleteBy(
+    repo: Repository<ObjectLiteral>,
+    tableName: string,
+    whereClause: string,
+    params: Record<string, unknown>,
+): Promise<void> {
+    let deleted: number
+    do {
+        const result = await repo
+            .createQueryBuilder()
+            .delete()
+            .where(`id IN (SELECT id FROM "${tableName}" WHERE ${whereClause} LIMIT ${BATCH_DELETE_CHUNK_SIZE})`, params)
+            .execute()
+        deleted = result.affected ?? 0
+    } while (deleted > 0)
+}
+
+const BATCH_DELETE_CHUNK_SIZE = 5000
 
 type DrainFlowsParams = {
     flows: Flow[]

--- a/packages/server/api/src/app/ee/platform/platform-teardown-jobs.ts
+++ b/packages/server/api/src/app/ee/platform/platform-teardown-jobs.ts
@@ -61,7 +61,7 @@ export const platformTeardownJobs = (log: FastifyBaseLogger) => ({
 
         const projectIds = await listProjectIdsByPlatform(platformId)
         for (const projectId of projectIds) {
-            await cleanProjectDescendants({ projectId })
+            await deleteProjectLinkedEntities({ projectId })
             await projectRepo().delete({ id: projectId, platformId })
         }
 
@@ -76,7 +76,15 @@ export const platformTeardownJobs = (log: FastifyBaseLogger) => ({
         await concurrencyPoolRepo().delete({ platformId })
         await toolSearchIndexRepo().delete({ platformId })
 
-        await batchDeleteBy(auditLogRepo(), 'audit_event', '"platformId" = :platformId', { platformId })
+        let deletedAuditEvents: number
+        do {
+            const result = await auditLogRepo()
+                .createQueryBuilder()
+                .delete()
+                .where(`id IN (SELECT id FROM "audit_event" WHERE "platformId" = :platformId LIMIT ${BATCH_DELETE_CHUNK_SIZE})`, { platformId })
+                .execute()
+            deletedAuditEvents = result.affected ?? 0
+        } while (deletedAuditEvents > 0)
         await platformRepo().delete({ id: platformId })
 
         const identityIds = await deletePlatformUsers(platformId)
@@ -185,28 +193,24 @@ async function deleteUnreferencedIdentities(identityIds: string[]): Promise<void
     }
 }
 
-export async function cleanProjectDescendants({ projectId }: { projectId: string }): Promise<void> {
-    await batchDeleteBy(cellRepo(), 'cell', '"projectId" = :projectId', { projectId })
-    await batchDeleteBy(recordRepo(), 'record', '"projectId" = :projectId', { projectId })
-    await batchDeleteBy(fieldRepo(), 'field', '"projectId" = :projectId', { projectId })
-    await batchDeleteBy(tableRepo(), 'table', '"projectId" = :projectId', { projectId })
-    await batchDeleteBy(flowRunRepo(), 'flow_run', '"projectId" = :projectId', { projectId })
-    await batchDeleteBy(triggerEventRepo(), 'trigger_event', '"projectId" = :projectId', { projectId })
-    await batchDeleteBy(fileRepo(), 'file', '"projectId" = :projectId', { projectId })
+export async function deleteProjectLinkedEntities({ projectId }: { projectId: string }): Promise<void> {
+    await batchDeleteByProjectId({ repo: cellRepo(), projectId })
+    await batchDeleteByProjectId({ repo: recordRepo(), projectId })
+    await batchDeleteByProjectId({ repo: fieldRepo(), projectId })
+    await batchDeleteByProjectId({ repo: tableRepo(), projectId })
+    await batchDeleteByProjectId({ repo: flowRunRepo(), projectId })
+    await batchDeleteByProjectId({ repo: triggerEventRepo(), projectId })
+    await batchDeleteByProjectId({ repo: fileRepo(), projectId })
 }
 
-async function batchDeleteBy(
-    repo: Repository<ObjectLiteral>,
-    tableName: string,
-    whereClause: string,
-    params: Record<string, unknown>,
-): Promise<void> {
+async function batchDeleteByProjectId({ repo, projectId }: BatchDeleteByProjectIdParams): Promise<void> {
+    const tableName = repo.metadata.tableName
     let deleted: number
     do {
         const result = await repo
             .createQueryBuilder()
             .delete()
-            .where(`id IN (SELECT id FROM "${tableName}" WHERE ${whereClause} LIMIT ${BATCH_DELETE_CHUNK_SIZE})`, params)
+            .where(`id IN (SELECT id FROM "${tableName}" WHERE "projectId" = :projectId LIMIT ${BATCH_DELETE_CHUNK_SIZE})`, { projectId })
             .execute()
         deleted = result.affected ?? 0
     } while (deleted > 0)
@@ -222,4 +226,9 @@ type DrainFlowsParams = {
 type BeginPlatformTeardownParams = {
     platformId: string
     log: FastifyBaseLogger
+}
+
+type BatchDeleteByProjectIdParams = {
+    repo: Repository<ObjectLiteral>
+    projectId: string
 }

--- a/packages/server/api/src/app/ee/projects/platform-project-jobs.ts
+++ b/packages/server/api/src/app/ee/projects/platform-project-jobs.ts
@@ -12,6 +12,7 @@ import { flowRepo } from '../../flows/flow/flow.repo'
 import { SystemJobData, SystemJobName } from '../../helper/system-jobs/common'
 import { systemJobsSchedule } from '../../helper/system-jobs/system-job'
 import { ProjectEntity } from '../../project/project-entity'
+import { cleanProjectDescendants } from '../platform/platform-teardown-jobs'
 
 const projectRepo = repoFactory(ProjectEntity)
 
@@ -47,6 +48,8 @@ export const platformProjectBackgroundJobs = (log: FastifyBaseLogger) => ({
             await batchDeleteByFlowId(flowId)
             await flowRepo().delete({ id: flowId })
         }
+
+        await cleanProjectDescendants({ projectId })
 
         await transaction(async (entityManager) => {
             await appConnectionsRepo(entityManager).delete({

--- a/packages/server/api/src/app/ee/projects/platform-project-jobs.ts
+++ b/packages/server/api/src/app/ee/projects/platform-project-jobs.ts
@@ -12,7 +12,7 @@ import { flowRepo } from '../../flows/flow/flow.repo'
 import { SystemJobData, SystemJobName } from '../../helper/system-jobs/common'
 import { systemJobsSchedule } from '../../helper/system-jobs/system-job'
 import { ProjectEntity } from '../../project/project-entity'
-import { cleanProjectDescendants } from '../platform/platform-teardown-jobs'
+import { deleteProjectLinkedEntities } from '../platform/platform-teardown-jobs'
 
 const projectRepo = repoFactory(ProjectEntity)
 
@@ -49,7 +49,7 @@ export const platformProjectBackgroundJobs = (log: FastifyBaseLogger) => ({
             await flowRepo().delete({ id: flowId })
         }
 
-        await cleanProjectDescendants({ projectId })
+        await deleteProjectLinkedEntities({ projectId })
 
         await transaction(async (entityManager) => {
             await appConnectionsRepo(entityManager).delete({


### PR DESCRIPTION
## Description

`hardDeletePlatformHandler` and `hardDeleteProjectHandler` both call `projectRepo.delete` / `platformRepo.delete`, which fires an FK `ON DELETE CASCADE` across 30+ child tables atomically. For any tenant with non-trivial usage that cascade doesn't fit in the 60 s `statement_timeout`.

Even after the earlier fixes shipped (`beginPlatformTeardown` rename + guard in #14912, partial `file(platformId)` index + tightened DELETE in #14911, deprecated `chatbot` table drop in #14910), one platform on prod was still stuck for **27 attempts** — first on the project-cascade DELETE (a project with ~22k `file` rows), then on the platform-cascade DELETE (**151 k `audit_event` rows**) once the project phase cleared.

Root cause is design: **FK cascades are for correctness (no orphans), not a deletion mechanism.** Any child that grows with tenant usage makes the atomic cascade unbounded, and no amount of retries changes the size of the atomic work.

## Fix

Batch every child that grows with usage, before the parent DELETE. Same idiom `batchDeleteByFlowId` in `flow.jobs.ts:17` already uses one level down, extended up two.

Extracted **`cleanProjectDescendants({ projectId })`** in `platform-teardown-jobs.ts`. Batches (5 000-row chunks, one transaction per chunk) all growth-prone project children in leaf-first order so each batch does its own work and no cascade fires between them:

- `cell` — one row per `record × field`, fastest-growing table for Tables-heavy tenants
- `record` — one row per user table row
- `field` — one row per column × table
- `table` — one row per user-created table
- `flow_run` — defensive; `drainFlows` normally handles this per flow, but any race leaves stragglers
- `trigger_event` — 236 k rows in prod today, grows per webhook fire
- `file` — logs / sample data / step files / package archives

Called from **both** entry points:

- `hardDeletePlatformHandler`'s project loop (right before `projectRepo.delete`)
- `hardDeleteProjectHandler` (right before its own `projectRepo.delete`, standalone project delete path)

Similarly, batch `audit_event` by `platformId` right before `platformRepo.delete`. 2 M rows globally in prod, one row per audit action for the platform's lifetime.

**Empty / dead tables left to cascade** — verified globally: `trigger_run` (entity removed in migration `1760992394073`, table empty), `step_file` (empty), `activity` (empty), `knowledge_base_file` (10 rows globally). If any of these turn live later they'd need adding, but there's no evidence today.

**Index coverage verified for every WHERE column** used by the batch deletes via `pg_indexes`. The only case with no usable leading-column index was `trigger_run.platformId` (only referenced by a composite `(created, platformId, pieceName)`), and that's handled by batching `trigger_run` at the *project* level instead (where `(projectId, triggerSourceId)` exists) — but as noted the table is empty globally, so this is defensive.

## What FK cascades keep doing

They stay as `ON DELETE CASCADE`. If a future teardown misses a new table, cascade still sweeps up the orphans (correctness). Steady-state performance goes through the explicit batches.

## Impact / edition

- `hardDeletePlatformHandler` is EE-only (`ee/platform/platform-teardown-jobs.ts`), scheduled by the Cloud-only `DELETE /v1/platforms/:id` endpoint (7-day delayed BullMQ job).
- `hardDeleteProjectHandler` fires from `platform-project-service.ts:241`'s `scheduleHardDeleteProjectJob` after any project soft-delete.
- Both are fully async BullMQ jobs — no UI waits for the response — so the trade-off of "many small transactions instead of one big cascade" is entirely on the good side: no user-visible latency, per-chunk time bounded.

## How was this tested?

- Prod diagnosis of the stuck `hard-delete-platform-kNc6hql3cTcK4qw27X4zZ` job, timed each cascade phase in a rolled-back txn — `EXPLAIN (ANALYZE)` was the missing tool in the earlier passes.
- Verified index coverage across all 13 batched-column tuples against prod indexes.
- Verified globally-empty status of the tables left to cascade.
- Lint: `npx turbo run lint --filter=api` — 15 tasks successful, 0 errors.
- CE / EE / Cloud: EE-only handler; CE has no platform-delete path.

Fixes # (part of the hard-delete backlog triaged via `debug-failed-run`)

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)
