### PR TITLE
fix(worker): disable piece cache prewarm on startup

### DIFF
--- a/packages/server/worker/src/lib/worker.ts
+++ b/packages/server/worker/src/lib/worker.ts
@@ -184,13 +184,6 @@ async function startPollingWorkers(apiClient: WorkerToApiContract): Promise<void
         getSettings: () => sandboxConfig.getSandboxSettings(),
     })
 
-    // Fire-and-forget: warm the piece cache for this platform's flows without blocking the poll loop.
-    void runtime.prewarm({
-        log: logger, 
-        apiClient,
-        publicApiUrl: ensurePublicApiUrl(workerSettings.getSettings().PUBLIC_URL),
-    })
-
     logger.info({ concurrency }, 'Starting poll loops')
 
     const activeRuntime = runtime


### PR DESCRIPTION
## What
Removes the fire-and-forget `runtime.prewarm` call in `worker.ts` startup. The per-flow prewarm on flow publish (`api-notify-service.ts`) is kept.

**Breaking change?**
- [ ] Yes
- [x] No

🤖 Generated with [Claude Code](https://claude.com/claude-code)