### PR TITLE
fix(attio): Record Updated filter matches the attribute that changed, not the record's current state

### DIFF
--- a/packages/pieces/community/attio/package.json
+++ b/packages/pieces/community/attio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-attio",
-  "version": "0.1.22",
+  "version": "0.1.23",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {

--- a/packages/pieces/community/attio/src/lib/common/types.ts
+++ b/packages/pieces/community/attio/src/lib/common/types.ts
@@ -158,6 +158,7 @@ export interface ObjectWebhookPayload {
 			workspace_id: string;
 			object_id: string;
 			record_id: string;
+			attribute_id?: string;
 		};
 	}>;
 }

--- a/packages/pieces/community/attio/src/lib/triggers/record-updated.ts
+++ b/packages/pieces/community/attio/src/lib/triggers/record-updated.ts
@@ -8,6 +8,12 @@ import { isNil } from '@activepieces/pieces-framework';
 
 const TRIGGER_KEY = 'updated-record-trigger';
 
+type TriggerData = {
+	webhookId: string;
+	WebhookSecret: string;
+	attributeId?: string;
+};
+
 export const recordUpdatedTrigger = createTrigger({
 	name: 'record_updated',
 	classification: 'READ',
@@ -38,6 +44,29 @@ export const recordUpdatedTrigger = createTrigger({
 	type: TriggerStrategy.WEBHOOK,
 	sampleData: {},
 	async onEnable(context) {
+		const { objectTypeId, filter_attribute } = context.propsValue;
+
+		// Attio emits one record.updated event per changed attribute, including
+		// writes made by its own system actor. Resolve the selected attribute's id
+		// so the webhook subscription only receives events about that attribute --
+		// the event id is the only place that says WHICH attribute changed.
+		let attributeId: string | undefined;
+		if (filter_attribute) {
+			const attribute = await attioApiCall<{ data: { id: { attribute_id: string } } }>({
+				accessToken: context.auth.secret_text,
+				method: HttpMethod.GET,
+				resourceUri: `/objects/${objectTypeId}/attributes/${filter_attribute}`,
+			});
+			attributeId = attribute.data.id.attribute_id;
+		}
+
+		const conditions = [
+			{ field: 'id.object_id', operator: 'equals', value: objectTypeId },
+		];
+		if (attributeId) {
+			conditions.push({ field: 'id.attribute_id', operator: 'equals', value: attributeId });
+		}
+
 		const response = await attioApiCall<{ data: WebhookResponse }>({
 			accessToken: context.auth.secret_text,
 			method: HttpMethod.POST,
@@ -48,30 +77,21 @@ export const recordUpdatedTrigger = createTrigger({
 					subscriptions: [
 						{
 							event_type: 'record.updated',
-							filter: {
-								$and: [
-									{
-										field: 'id.object_id',
-										operator: 'equals',
-										value: context.propsValue.objectTypeId,
-									},
-								],
-							},
+							filter: { $and: conditions },
 						},
 					],
 				},
 			},
 		});
 
-		await context.store.put<{ webhookId: string; WebhookSecret: string }>(TRIGGER_KEY, {
+		await context.store.put<TriggerData>(TRIGGER_KEY, {
 			webhookId: response.data.id.webhook_id,
 			WebhookSecret: response.data.secret,
+			attributeId,
 		});
 	},
 	async onDisable(context) {
-		const webhookData = await context.store.get<{ webhookId: string; WebhookSecret: string }>(
-			TRIGGER_KEY,
-		);
+		const webhookData = await context.store.get<TriggerData>(TRIGGER_KEY);
 		if (!isNil(webhookData) && webhookData.webhookId) {
 			await attioApiCall({
 				accessToken: context.auth.secret_text,
@@ -98,9 +118,7 @@ export const recordUpdatedTrigger = createTrigger({
 		return filtered.slice(0, 5);
 	},
 	async run(context) {
-		const triggerData = await context.store.get<{ webhookId: string; WebhookSecret: string }>(
-			TRIGGER_KEY,
-		);
+		const triggerData = await context.store.get<TriggerData>(TRIGGER_KEY);
 
 		const webhookSecret = triggerData?.WebhookSecret;
 		const webhookSignatureHeader = context.payload.headers['attio-signature'];
@@ -114,6 +132,20 @@ export const recordUpdatedTrigger = createTrigger({
 		const event = payload.events?.[0];
 
 		if (!event) return [];
+
+		// Second line of defence behind the subscription filter (and the only one
+		// for triggers enabled by an older version of this piece, whose stored
+		// data has no attributeId): drop events about other attributes before
+		// re-fetching. Checking the record's current state below cannot tell which
+		// attribute changed, so without this every update to a record whose
+		// filtered field already matches would fire the flow again.
+		if (
+			triggerData?.attributeId &&
+			event.id.attribute_id &&
+			event.id.attribute_id !== triggerData.attributeId
+		) {
+			return [];
+		}
 
 		const recordId = event.id.record_id;
 


### PR DESCRIPTION
## Description

The Record Updated trigger's **Filter Field** option says *"Only trigger when this field is involved in the update"*, but the implementation re-fetches the record and checks the field's **current value**. The event's `attribute_id` — the only information saying which attribute actually changed — was discarded in `run()`.

Consequence: any update to a record whose filtered field already matches fires the flow again. Two concrete cases observed on a self-hosted workspace (deals object, `filter_attribute: stage`, `filter_value: Planned`):

- A stage change fired the flow **twice**: Attio's own system actor wrote an internal attribute right after the stage write, producing a second `record.updated` whose re-fetch also saw `stage = Planned`. Captured payloads, same record, one second apart:
  ```json
  {"events":[{"event_type":"record.updated","id":{"...","attribute_id":"a560d0aa-…"},"actor":{"type":"workspace-member","id":"…"}}]}
  {"events":[{"event_type":"record.updated","id":{"...","attribute_id":"206c9051-…"},"actor":{"type":"system","id":null}}]}
  ```
- Editing an unrelated field (e.g. a date attribute) on a record whose stage is already "Planned" re-fires the flow every time — duplicate downstream side effects (emails, in our case).

### What this PR changes

- **`onEnable`**: when a Filter Field is selected, resolve its slug to the attribute id (`GET /v2/objects/{object}/attributes/{slug}`) and add `{ field: "id.attribute_id", operator: "equals" }` to the webhook subscription filter, so Attio no longer delivers non-matching events at all. The resolved id is stored alongside the webhook id.
- **`run()`**: drop events whose `attribute_id` differs from the stored one before the re-fetch — second line of defence, and it saves the record-fetch API call for every discarded event.
- **`types.ts`**: declare `attribute_id?` on `ObjectWebhookPayload` events; Attio has always sent it.
- Version bump `0.1.22 → 0.1.23`.

**Backwards compatibility**: with no Filter Field selected, behaviour is byte-identical. Triggers enabled by an older version have no stored `attributeId`, so the new check is skipped and they keep today's behaviour until re-enabled. `filter_value` semantics are unchanged (still evaluated against the re-fetched record).

## How was this tested?

- `bun run build` on the piece (tsc) — clean.
- Filter syntax verified against the Attio webhook docs (`id.attribute_id` with `equals` is supported) and against captured production payloads shown above; the state-based double-fire was reproduced live before the change (two flow runs for one stage change, 2.8 s apart).
- Self-hosted CE/EE path; not tested on Cloud.

Fixes # (no open issue; happy to file one if preferred)

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)