### PR TITLE
fix(agents): an agent keeps both tools when two apps name their action the same

### DIFF
--- a/packages/server/api/src/app/ee/agent/tools/agent-tools.ts
+++ b/packages/server/api/src/app/ee/agent/tools/agent-tools.ts
@@ -342,10 +342,19 @@ async function removeAgentToolFromChat({ toolInput, agent, projectId, userId, lo
     const targets = agent.draft.tools.flatMap((tool) => pieceActionOf(tool) ?? [])
         .filter((action) => actionNames.includes(action.actionName))
         .filter((action) => isNil(scopedPiece) || action.pieceName === scopedPiece)
-    const ambiguous = actionNames.filter((actionName) => unique(targets.filter((target) => target.actionName === actionName).map((target) => target.pieceName)).length > 1)
+    const resolved = actionNames.map((actionName) => ({
+        actionName,
+        pieces: unique(targets.filter((target) => target.actionName === actionName).map((target) => target.pieceName)),
+    }))
+    const ambiguous = resolved.filter((entry) => entry.pieces.length > 1)
     if (ambiguous.length > 0) {
-        const pieces = unique(targets.filter((target) => ambiguous.includes(target.actionName)).map((target) => target.pieceName))
-        return { error: `${ambiguous.join(' and ')} is on more than one piece here: ${pieces.join(', ')}. Call this again with pieceName set to the one you mean.` }
+        return { error: `${ambiguous.map((entry) => entry.actionName).join(' and ')} is on more than one piece here: ${unique(ambiguous.flatMap((entry) => entry.pieces)).join(', ')}. Call this again with pieceName set to the one you mean.` }
+    }
+    const unmatched = resolved.filter((entry) => entry.pieces.length === 0).map((entry) => entry.actionName)
+    if (unmatched.length > 0) {
+        return { error: isNil(scopedPiece)
+            ? `${agent.displayName} has no tool for ${unmatched.join(' or ')}, so there is nothing to remove. List its tools with ap_list_agents.`
+            : `${unmatched.join(' and ')} is not on ${scopedPiece}, so there is nothing to remove. Take those away in their own call, without pieceName.` }
     }
     const removing = new Set(targets.map((target) => `${target.pieceName}:${target.actionName}`))
     const updated = await agentService(log).editDraftTools({

--- a/packages/server/api/src/app/ee/agent/tools/agent-tools.ts
+++ b/packages/server/api/src/app/ee/agent/tools/agent-tools.ts
@@ -337,14 +337,17 @@ async function removeAgentToolFromChat({ toolInput, agent, projectId, userId, lo
     if (actionNames.length === 0) {
         return { error: 'Removing tools needs at least one action name.' }
     }
-    const matched = agent.draft.tools.flatMap((tool) => {
-        const action = pieceActionOf(tool)
-        return !isNil(action) && actionNames.includes(action.actionName) ? action.pieceName : []
-    })
-    const pieces = unique(matched)
-    if (pieces.length > 1) {
-        return { error: `More than one piece on ${agent.displayName} has an action by that name: ${pieces.join(', ')}. Say which piece to take it from.` }
+    const requestedPiece = nonEmpty(toolInput.pieceName)
+    const scopedPiece = isNil(requestedPiece) ? undefined : mcpUtils.normalizePieceName(requestedPiece) ?? requestedPiece
+    const targets = agent.draft.tools.flatMap((tool) => pieceActionOf(tool) ?? [])
+        .filter((action) => actionNames.includes(action.actionName))
+        .filter((action) => isNil(scopedPiece) || action.pieceName === scopedPiece)
+    const ambiguous = actionNames.filter((actionName) => unique(targets.filter((target) => target.actionName === actionName).map((target) => target.pieceName)).length > 1)
+    if (ambiguous.length > 0) {
+        const pieces = unique(targets.filter((target) => ambiguous.includes(target.actionName)).map((target) => target.pieceName))
+        return { error: `${ambiguous.join(' and ')} is on more than one piece here: ${pieces.join(', ')}. Call this again with pieceName set to the one you mean.` }
     }
+    const removing = new Set(targets.map((target) => `${target.pieceName}:${target.actionName}`))
     const updated = await agentService(log).editDraftTools({
         id: agent.id,
         projectId,
@@ -352,7 +355,7 @@ async function removeAgentToolFromChat({ toolInput, agent, projectId, userId, lo
         edit: (tools) => {
             const kept = tools.filter((tool) => {
                 const action = pieceActionOf(tool)
-                return isNil(action) || !actionNames.includes(action.actionName)
+                return isNil(action) || !removing.has(`${action.pieceName}:${action.actionName}`)
             })
             return kept.length === tools.length ? null : kept
         },

--- a/packages/server/api/src/app/ee/agent/tools/agent-tools.ts
+++ b/packages/server/api/src/app/ee/agent/tools/agent-tools.ts
@@ -1,6 +1,6 @@
-import { isNil, isObject, isString, parseToJsonIfPossible, Permission, spreadIfDefined, tryCatch } from '@activepieces/core-utils'
+import { isNil, isObject, isString, parseToJsonIfPossible, Permission, spreadIfDefined, tryCatch, unique } from '@activepieces/core-utils'
 import { agentAiUtils } from '@activepieces/server-utils'
-import { Agent, AgentIcon, AgentTool, agentToolClassification, AgentToolType, AppConnectionStatus, AppConnectionType, ColorName, DEFAULT_AGENT_MAX_STEPS, FileCompression, FileType, FlowRunStatus, FlowStatus, Project, RunEnvironment } from '@activepieces/shared'
+import { Agent, AgentIcon, AgentTool, agentToolClassification, AgentToolType, AppConnectionStatus, AppConnectionType, ColorName, DEFAULT_AGENT_MAX_STEPS, FileCompression, FileType, FlowRunStatus, FlowStatus, mcpToolNameUtils, Project, RunEnvironment } from '@activepieces/shared'
 import { FastifyBaseLogger } from 'fastify'
 import { appConnectionService } from '../../../app-connection/app-connection-service/app-connection-service'
 import { fileService } from '../../../file/file.service'
@@ -303,7 +303,7 @@ async function addAgentToolFromChat({ toolInput, agent, projectId, platformId, u
     }
     const added: AgentTool[] = actionNames.map((actionName) => ({
         type: AgentToolType.PIECE,
-        toolName: actionName,
+        toolName: mcpToolNameUtils.createPieceToolName(normalizedPiece, actionName),
         pieceMetadata: {
             pieceName: normalizedPiece,
             pieceVersion: piece.version,
@@ -315,7 +315,10 @@ async function addAgentToolFromChat({ toolInput, agent, projectId, platformId, u
         id: agent.id,
         projectId,
         userId,
-        edit: (tools) => tools.some((tool) => actionNames.includes(tool.toolName)) ? null : [...tools, ...added],
+        edit: (tools) => tools.some((tool) => {
+            const action = pieceActionOf(tool)
+            return action?.pieceName === normalizedPiece && actionNames.includes(action.actionName)
+        }) ? null : [...tools, ...added],
     })
     if (isNil(updated)) {
         return { error: `${agent.displayName} already has one of those tools. List them with ap_list_agents before adding.` }
@@ -334,18 +337,36 @@ async function removeAgentToolFromChat({ toolInput, agent, projectId, userId, lo
     if (actionNames.length === 0) {
         return { error: 'Removing tools needs at least one action name.' }
     }
+    const matched = agent.draft.tools.flatMap((tool) => {
+        const action = pieceActionOf(tool)
+        return !isNil(action) && actionNames.includes(action.actionName) ? action.pieceName : []
+    })
+    const pieces = unique(matched)
+    if (pieces.length > 1) {
+        return { error: `More than one piece on ${agent.displayName} has an action by that name: ${pieces.join(', ')}. Say which piece to take it from.` }
+    }
     const updated = await agentService(log).editDraftTools({
         id: agent.id,
         projectId,
         userId,
-        edit: (tools) => tools.some((tool) => actionNames.includes(tool.toolName))
-            ? tools.filter((tool) => !actionNames.includes(tool.toolName))
-            : null,
+        edit: (tools) => {
+            const kept = tools.filter((tool) => {
+                const action = pieceActionOf(tool)
+                return isNil(action) || !actionNames.includes(action.actionName)
+            })
+            return kept.length === tools.length ? null : kept
+        },
     })
     if (isNil(updated)) {
         return { error: `${agent.displayName} has none of those tools, so there is nothing to remove.` }
     }
     return afterDraftChange({ agent: updated, publish: toolInput.publish === true, projectId, userId, log })
+}
+
+function pieceActionOf(tool: AgentTool): { pieceName: string, actionName: string } | undefined {
+    return tool.type === AgentToolType.PIECE
+        ? { pieceName: tool.pieceMetadata.pieceName, actionName: tool.pieceMetadata.actionName }
+        : undefined
 }
 
 function toolNamesFrom(toolInput: Record<string, unknown>): string[] {

--- a/packages/server/api/test/integration/ee/agent/chat-agent-tools.test.ts
+++ b/packages/server/api/test/integration/ee/agent/chat-agent-tools.test.ts
@@ -278,8 +278,33 @@ describe('the chat tools that build agents, against the real service', () => {
 
         const result = await runTool(ctx, conversationId, 'ap_remove_agent_tool', { agentId, actionNames: ['save_note'] }) as { error?: string }
 
-        expect(result.error).toContain('More than one piece')
+        expect(result.error).toContain('more than one piece')
         expect((await agentRow(agentId)).draft.tools).toHaveLength(2)
+
+        const resolved = await runTool(ctx, conversationId, 'ap_remove_agent_tool', {
+            agentId, actionNames: ['save_note'], pieceName: RIVAL_PIECE,
+        }) as { error?: string }
+
+        expect(resolved.error).toBeUndefined()
+        const left = (await agentRow(agentId)).draft.tools as Array<{ pieceMetadata: { pieceName: string } }>
+        expect(left.map((tool) => tool.pieceMetadata.pieceName)).toEqual([TOOL_PIECE])
+    })
+
+    it('removes two actions that live on different pieces without asking anything', async () => {
+        const ctx = await context()
+        const conversationId = await startConversation(ctx)
+        const { agentId } = await runTool(ctx, conversationId, 'ap_create_agent', {
+            displayName: 'Storer', instructions: 'Keep notes.',
+        }) as { agentId: string }
+        await runTool(ctx, conversationId, 'ap_add_agent_tool', { agentId, pieceName: TOOL_PIECE, actionNames: ['read_note'] })
+        await runTool(ctx, conversationId, 'ap_add_agent_tool', { agentId, pieceName: RIVAL_PIECE, actionNames: ['save_note'] })
+
+        const result = await runTool(ctx, conversationId, 'ap_remove_agent_tool', {
+            agentId, actionNames: ['read_note', 'save_note'],
+        }) as { error?: string }
+
+        expect(result.error).toBeUndefined()
+        expect((await agentRow(agentId)).draft.tools).toHaveLength(0)
     })
 
     it('keeps both tools when the model adds two at once', async () => {

--- a/packages/server/api/test/integration/ee/agent/chat-agent-tools.test.ts
+++ b/packages/server/api/test/integration/ee/agent/chat-agent-tools.test.ts
@@ -1,5 +1,6 @@
 import { apId } from '@activepieces/core-utils'
-import { AgentToolType, PackageType, PieceType } from '@activepieces/shared'
+import { unique } from '@activepieces/core-utils'
+import { AgentToolType, mcpToolNameUtils, PackageType, PieceType } from '@activepieces/shared'
 import { FastifyInstance } from 'fastify'
 import { StatusCodes } from 'http-status-codes'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
@@ -13,6 +14,7 @@ let app: FastifyInstance
 
 const TOOL_PIECE = '@activepieces/piece-test-notes'
 const TOOL_PIECE_VERSION = '0.4.2'
+const RIVAL_PIECE = '@activepieces/piece-test-memos'
 
 beforeAll(async () => {
     process.env.AP_AGENTS_ENABLED = 'true'
@@ -36,6 +38,23 @@ beforeAll(async () => {
                 name: 'read_note',
                 displayName: 'Read Note',
                 description: 'Read a note',
+                requireAuth: true,
+                props: {},
+            },
+        },
+    }))
+    await db.save('piece_metadata', createMockPieceMetadata({
+        name: RIVAL_PIECE,
+        displayName: 'Test Memos',
+        version: '1.0.0',
+        pieceType: PieceType.OFFICIAL,
+        packageType: PackageType.REGISTRY,
+        platformId: undefined,
+        actions: {
+            save_note: {
+                name: 'save_note',
+                displayName: 'Save Note',
+                description: 'Save a memo',
                 requireAuth: true,
                 props: {},
             },
@@ -71,6 +90,11 @@ async function runTool(ctx: TestContext, conversationId: string, toolName: strin
         conversationId,
         log: app.log,
     })
+}
+
+async function actionNamesOn(id: string): Promise<string[]> {
+    const tools = (await agentRow(id)).draft.tools as Array<{ pieceMetadata?: { actionName: string } }>
+    return tools.flatMap((tool) => tool.pieceMetadata?.actionName ?? [])
 }
 
 async function agentRow(id: string) {
@@ -142,9 +166,10 @@ describe('the chat tools that build agents, against the real service', () => {
 
         expect(result).toEqual(expect.objectContaining({ published: true }))
         const stored = await agentRow(agentId)
-        const [tool] = stored.draft.tools as Array<{ type: string, toolName: string, pieceMetadata: { pieceVersion: string, predefinedInput?: { auth: string } } }>
+        const [tool] = stored.draft.tools as Array<{ type: string, toolName: string, pieceMetadata: { actionName: string, pieceVersion: string, predefinedInput?: { auth: string } } }>
         expect(tool.type).toBe(AgentToolType.PIECE)
-        expect(tool.toolName).toBe('save_note')
+        expect(tool.pieceMetadata.actionName).toBe('save_note')
+        expect(tool.toolName).toBe(mcpToolNameUtils.createPieceToolName(TOOL_PIECE, 'save_note'))
         expect(tool.pieceMetadata.pieceVersion).toBe(TOOL_PIECE_VERSION)
         expect(tool.pieceMetadata.predefinedInput?.auth).toBe(connection.externalId)
         expect((stored.published?.tools as unknown[])).toHaveLength(1)
@@ -227,6 +252,36 @@ describe('the chat tools that build agents, against the real service', () => {
         expect(result.error).toContain('not available')
     })
 
+    it('keeps two pieces that name their action the same, under distinct tool names', async () => {
+        const ctx = await context()
+        const conversationId = await startConversation(ctx)
+        const { agentId } = await runTool(ctx, conversationId, 'ap_create_agent', {
+            displayName: 'Storer', instructions: 'Keep notes.',
+        }) as { agentId: string }
+
+        await runTool(ctx, conversationId, 'ap_add_agent_tool', { agentId, pieceName: TOOL_PIECE, actionNames: ['save_note'] })
+        await runTool(ctx, conversationId, 'ap_add_agent_tool', { agentId, pieceName: RIVAL_PIECE, actionNames: ['save_note'] })
+
+        const tools = (await agentRow(agentId)).draft.tools as Array<{ toolName: string, pieceMetadata: { pieceName: string } }>
+        expect(tools.map((tool) => tool.pieceMetadata.pieceName).sort()).toEqual([RIVAL_PIECE, TOOL_PIECE])
+        expect(unique(tools.map((tool) => tool.toolName))).toHaveLength(2)
+    })
+
+    it('asks which piece when an action name is on more than one of them', async () => {
+        const ctx = await context()
+        const conversationId = await startConversation(ctx)
+        const { agentId } = await runTool(ctx, conversationId, 'ap_create_agent', {
+            displayName: 'Storer', instructions: 'Keep notes.',
+        }) as { agentId: string }
+        await runTool(ctx, conversationId, 'ap_add_agent_tool', { agentId, pieceName: TOOL_PIECE, actionNames: ['save_note'] })
+        await runTool(ctx, conversationId, 'ap_add_agent_tool', { agentId, pieceName: RIVAL_PIECE, actionNames: ['save_note'] })
+
+        const result = await runTool(ctx, conversationId, 'ap_remove_agent_tool', { agentId, actionNames: ['save_note'] }) as { error?: string }
+
+        expect(result.error).toContain('More than one piece')
+        expect((await agentRow(agentId)).draft.tools).toHaveLength(2)
+    })
+
     it('keeps both tools when the model adds two at once', async () => {
         const ctx = await context()
         const conversationId = await startConversation(ctx)
@@ -239,8 +294,7 @@ describe('the chat tools that build agents, against the real service', () => {
             runTool(ctx, conversationId, 'ap_add_agent_tool', { agentId, pieceName: TOOL_PIECE, actionNames: ['read_note'] }),
         ])
 
-        const tools = (await agentRow(agentId)).draft.tools as Array<{ toolName: string }>
-        expect(tools.map((tool) => tool.toolName).sort()).toEqual(['read_note', 'save_note'])
+        expect((await actionNamesOn(agentId)).sort()).toEqual(['read_note', 'save_note'])
     })
 
     it('takes a tool away again, and says so when there is none to take', async () => {

--- a/packages/server/api/test/integration/ee/agent/chat-agent-tools.test.ts
+++ b/packages/server/api/test/integration/ee/agent/chat-agent-tools.test.ts
@@ -290,6 +290,23 @@ describe('the chat tools that build agents, against the real service', () => {
         expect(left.map((tool) => tool.pieceMetadata.pieceName)).toEqual([TOOL_PIECE])
     })
 
+    it('removes nothing when pieceName would silently skip one of the actions asked for', async () => {
+        const ctx = await context()
+        const conversationId = await startConversation(ctx)
+        const { agentId } = await runTool(ctx, conversationId, 'ap_create_agent', {
+            displayName: 'Storer', instructions: 'Keep notes.',
+        }) as { agentId: string }
+        await runTool(ctx, conversationId, 'ap_add_agent_tool', { agentId, pieceName: TOOL_PIECE, actionNames: ['save_note', 'read_note'] })
+        await runTool(ctx, conversationId, 'ap_add_agent_tool', { agentId, pieceName: RIVAL_PIECE, actionNames: ['save_note'] })
+
+        const result = await runTool(ctx, conversationId, 'ap_remove_agent_tool', {
+            agentId, actionNames: ['save_note', 'read_note'], pieceName: RIVAL_PIECE,
+        }) as { error?: string }
+
+        expect(result.error).toContain('read_note is not on')
+        expect((await agentRow(agentId)).draft.tools).toHaveLength(3)
+    })
+
     it('removes two actions that live on different pieces without asking anything', async () => {
         const ctx = await context()
         const conversationId = await startConversation(ctx)

--- a/packages/server/worker/src/lib/execute/jobs/ee/agent/agent-worker-tools.ts
+++ b/packages/server/worker/src/lib/execute/jobs/ee/agent/agent-worker-tools.ts
@@ -729,10 +729,11 @@ function createAgentSurfaceTools({ executeTool }: {
         }),
 
         ap_remove_agent_tool: tool({
-            description: 'Take piece actions away from a saved agent, when the user no longer wants it doing that or a tool was added by mistake. Pass every action to remove in one call.',
+            description: 'Take piece actions away from a saved agent, when the user no longer wants it doing that or a tool was added by mistake. Pass every action to remove in one call. If two of the agent\'s pieces share an action name, pass pieceName to say which one.',
             inputSchema: z.object({
                 agentId: z.string().describe('The id returned by ap_list_agents'),
                 actionNames: z.array(z.string()).describe('Action names to remove, e.g. ["gmail_search_mail"]'),
+                pieceName: z.string().optional().describe('Full piece name, only needed when the same action name is on two of the agent\'s pieces'),
                 publish: z.boolean().optional().describe('Make the agent live without these tools in the same step'),
             }),
             execute: async (toolInput) => {


### PR DESCRIPTION
## Description

Continues after #15035, which merged yesterday. Not stacked on it — this branches from `main`.

A piece tool's `toolName` is the key the model calls it by: `createConfiguredPieceTools` builds the ToolSet with `Object.fromEntries(tools.map((t) => [t.toolName, ...]))`, and `agent-step-result.ts` keys its attribution map on the same value. The agent editor has always built that name as piece-plus-action through `mcpToolNameUtils.createPieceToolName` (`pieces-tools.ts`), while the chat tools added in #15035 wrote the bare `actionName`.

That is two encodings of one rule, and the bare one collides. Several pieces ship an action called `save_note` or `send_message`, so an agent given two of them kept one:

- the ToolSet drops the earlier entry, so one tool is simply not available to the run;
- the step-result map does the same, so the surviving tool's results are attributed to the wrong piece in the timeline;
- and `editDraftTools` refused the second add as "already has one of those tools", which told the user the agent had a tool it did not.

Adding and removing now match on the **piece and action** rather than on the display name, since that is the identity that does not depend on which convention is in force. Removing an action name that two pieces both carry asks which one instead of silently taking both, and `ap_remove_agent_tool` takes an optional `pieceName` so that question can be answered — the first version of this guard asked for something the tool set could not express, which review caught. The ambiguity check is per action name, not per request, so removing two unambiguous actions that happen to sit on different pieces is not refused.

One rule governs the whole request: **every action name asked for has to resolve to exactly one tool, or nothing is removed.** The first two attempts at this were special cases and review found a hole in each — scoping to a piece scoped the entire batch, so naming a piece to settle one ambiguous action silently skipped a second action living elsewhere while still reporting success. Stating the rule once also closes a case nobody had reported: an action name the agent never had used to pass unnoticed whenever some other name in the same call did match, so a typo in a batch removed the rest and said it worked.

**No migration.** Nothing reads the name back — grepped for the `_mcp` suffix and for any parse of `toolName`, and the only consumers are the two maps above plus log fields. Existing agents keep working. Only tools added through chat since #15035 merged carry the short name, and re-adding them fixes it.

## How was this tested?

`test/integration/ee/agent/chat-agent-tools.test.ts` is now 16 tests. Two are new and both fail without the fix:

- **two pieces that name their action the same** both land, with distinct tool names — this is the collision, and with the fix reverted it fails on the duplicate name;
- **removing an ambiguous action name** asks which piece and leaves both tools in place.

The existing pinned-version test now asserts the semantic identity (`pieceMetadata.actionName`) plus the shared naming helper, rather than restating the literal string, so it cannot pass while the two encodings disagree. A second fixture piece (`@activepieces/piece-test-memos`) exists purely to carry the colliding action name.

Two more cover the review findings, each mutation-checked against its own half:

- **removing two actions that live on different pieces** asks nothing and empties the agent — restoring the whole-request ambiguity check fails exactly this one;
- **the ambiguous case** is refused, then resolved by passing `pieceName`, leaving the other piece in place — dropping the scope filter fails exactly this one.

- **a batch that `pieceName` would only partly satisfy** removes nothing, names the action that failed, and leaves all three tools in place — deleting the resolve-everything guard fails exactly this one.

Mutation-checked: restoring `toolName: actionName` fails exactly the two collision tests and no others.

Also run: `test/integration/ee/agent` + `test/unit/app/ee/agent` (223 tests), `test/lib/execute/jobs/ee/agent` (115 tests), `tsc` on api and worker, lint on api and worker.

Fixes # (issue)

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

The stored shape is unchanged and nothing parses the name. The only agents affected are ones equipped through chat in the last day, and they keep running — one of two same-named tools was already unreachable before this.

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)

Naming only. Permissions, visibility and the plan gate are untouched.


