### PR TITLE
fix(chat): the company belongs to the platform, not to whoever answered last

### DIFF
--- a/packages/server/api/src/app/ee/agent/agent-rpc-handlers.ts
+++ b/packages/server/api/src/app/ee/agent/agent-rpc-handlers.ts
@@ -16,6 +16,7 @@ import { system } from '../../helper/system/system'
 import { AppSystemProp } from '../../helper/system/system-props'
 import { knowledgeBaseService } from '../../knowledge-base/knowledge-base.service'
 import { runFlowAsTool } from '../../mcp/mcp-server-builder'
+import { platformService } from '../../platform/platform.service'
 import { userService } from '../../user/user-service'
 import { smtpEmailSender } from '../helper/email/email-sender/smtp-email-sender'
 import { emailService } from '../helper/email/email-service'
@@ -26,8 +27,10 @@ import { agentHelpers } from './agent-helpers'
 import { chatAnalyticsTelemetry } from './chat-analytics-sync'
 import { chatUsageTracker } from './chat-usage-tracker'
 import { agentMcp } from './mcp/agent-mcp'
+import { chatPersonalizationService } from './personalization/chat-personalization-service'
 import { agentPrompt } from './prompt/agent-prompt'
 import { agentSurfaceNotes } from './prompt/agent-surface-notes'
+import { UserIdentity } from './prompt/agent-user-identity'
 import { executeCrossProjectTool } from './tools/agent-tools'
 import { pieceToolRunner } from './tools/piece-tool-runner'
 
@@ -88,13 +91,25 @@ export const agentRpcHandlers = (log: FastifyBaseLogger) => ({
             aiToolConfigService(log).getEnabledTools({ platformId }),
         ])
 
-        const [scopedMcpCredentials, runMemory, runUserEmail] = !carriesChatContext
-            ? [{ mcpServerUrl: null, mcpToken: null }, { instructions: null, memories: [] as string[] }, '']
+        const [scopedMcpCredentials, runMemory, runUser, platformResult, identityResult] = !carriesChatContext
+            ? [{ mcpServerUrl: null, mcpToken: null }, { instructions: null, memories: [] as string[] }, null, null, null]
             : await Promise.all([
                 agentMcp.getCredentials({ platformId, userId, log }),
                 agentHelpers.getUserMemory({ platformId, userId }),
-                userService(log).getMetaInformation({ id: userId }).then((meta) => meta.email),
+                userService(log).getMetaInformation({ id: userId }),
+                tryCatch(() => platformService(log).getOneOrThrow(platformId)),
+                tryCatch(() => chatPersonalizationService(log).getIdentityEnrichment({ platformId, userId })),
             ])
+        const runUserEmail = runUser?.email ?? ''
+        const userIdentity: UserIdentity | null = isNil(runUser)
+            ? null
+            : {
+                firstName: runUser.firstName,
+                lastName: runUser.lastName,
+                email: runUser.email,
+                platformName: platformResult && !platformResult.error ? platformResult.data.name : null,
+                identity: identityResult && !identityResult.error ? identityResult.data : null,
+            }
 
         if (isFlowStep !== (conversation.source === AgentRunSource.FLOW_STEP)) {
             throw new ActivepiecesError({ code: ErrorCode.AUTHORIZATION, params: { message: 'The run asked for a different surface than the conversation it belongs to' } })
@@ -200,6 +215,7 @@ export const agentRpcHandlers = (log: FastifyBaseLogger) => ({
             emailAvailable: emailEnabled,
             agentsAvailable,
             userEmail: runUserEmail,
+            userIdentity,
             connections: inventoryResult && !inventoryResult.error
                 ? { connections: inventoryResult.data.data, truncated: inventoryResult.data.data.length >= CONNECTION_INVENTORY_LIMIT }
                 : null,

--- a/packages/server/api/src/app/ee/agent/personalization/chat-personalization-service.ts
+++ b/packages/server/api/src/app/ee/agent/personalization/chat-personalization-service.ts
@@ -393,12 +393,17 @@ export const chatPersonalizationService = (log: FastifyBaseLogger) => ({
         log.info({ platform: { id: platformId }, user: { id: userId }, hasRole: !isNil(role), confidence }, '[chatPersonalization] Prefill cached')
     },
 
-    async getIdentityEnrichment({ platformId, userId }: { platformId: string, userId: string }): Promise<PersonalizationProfile | null> {
+    async getIdentityEnrichment({ platformId, userId }: { platformId: string, userId: string }): Promise<PersonalizationIdentity | null> {
         const view = await this.getEffectiveView({ platformId, userId })
         if (view.status !== ChatPersonalizationStatus.READY || isNil(view.profile)) {
             return null
         }
-        return view.profile
+        return {
+            companyName: view.profile.companyName,
+            description: view.profile.description,
+            industry: view.profile.industry,
+            role: view.roleInput ?? null,
+        }
     },
 
 })
@@ -836,4 +841,11 @@ type ValidatedResult = {
     status: ChatPersonalizationStatus
     profile: PersonalizationProfile | null
     useCases: PersonalizationUseCase[] | null
+}
+
+export type PersonalizationIdentity = {
+    companyName: string
+    description: string
+    industry: string
+    role: string | null
 }

--- a/packages/server/api/src/app/ee/agent/personalization/chat-personalization-service.ts
+++ b/packages/server/api/src/app/ee/agent/personalization/chat-personalization-service.ts
@@ -15,6 +15,7 @@ import {
     PersonalizationProfile,
     PersonalizationScope,
     PersonalizationUseCase,
+    PlatformRole,
     SavePersonalizationPrefillRequest,
     SavePersonalizationResultRequest,
     SendPersonalizationProgressRequest,
@@ -52,7 +53,10 @@ export const chatPersonalizationService = (log: FastifyBaseLogger) => ({
     async upsert({ platformId, userId, website, role: roleInput, personalize }: UpsertParams): Promise<ChatPersonalizationView> {
         const companyRow = await findRow({ platformId, userId: null })
         const trimmedInput = isNil(website) ? null : website.trim()
-        const hasCompanyInput = !isNil(trimmedInput) && trimmedInput.length > 0
+        const submittedCompany = !isNil(trimmedInput) && trimmedInput.length > 0
+        const companyIsSet = !isNil(companyRow) && (!isNil(companyRow.domain) || !isNil(companyRow.companyText))
+        const hasCompanyInput = submittedCompany
+            && (!companyIsSet || await callerMayEditCompany({ platformId, userId, log }))
         const normalizedWebsite = hasCompanyInput ? normalizeWebsite({ input: trimmedInput }) : null
         const freeTextCompany = hasCompanyInput && isNil(normalizedWebsite) ? trimmedInput.slice(0, 255) : null
         const role = isNil(roleInput) ? null : normalizeRoleTitle({ input: roleInput })
@@ -116,15 +120,16 @@ export const chatPersonalizationService = (log: FastifyBaseLogger) => ({
 
         const allowed = await guardsAllowResearch({ platformId, log })
         if (!allowed) {
+            const discardStaleResearch = inputsChanged ? { profile: null, useCases: null } : {}
             await writeCompanyRow({
                 platformId,
                 existing: companyRow,
-                patch: { domain, companyText, status: ChatPersonalizationStatus.SKIPPED },
+                patch: { domain, companyText, status: ChatPersonalizationStatus.SKIPPED, ...discardStaleResearch },
             })
             await writeUserRow({
                 platformId,
                 userId,
-                patch: { domain, companyText, role, status: ChatPersonalizationStatus.SKIPPED },
+                patch: { domain, companyText, role, status: ChatPersonalizationStatus.SKIPPED, ...discardStaleResearch },
             })
             return this.getEffectiveView({ platformId, userId })
         }
@@ -580,6 +585,23 @@ async function writeCompanyRow({ platformId, existing, patch }: {
         }
     }
     await personalizationRepo().update({ platformId, userId: IsNull() }, patch)
+}
+
+async function callerMayEditCompany({ platformId, userId, log }: {
+    platformId: string
+    userId: string
+    log: FastifyBaseLogger
+}): Promise<boolean> {
+    const user = await tryCatch(() => userService(log).getMetaInformation({ id: userId }))
+    if (user.error) {
+        log.warn({ platform: { id: platformId }, user: { id: userId }, error: user.error }, '[chatPersonalization] Could not read the platform role, leaving the company as it is')
+        return false
+    }
+    if (user.data.platformRole === PlatformRole.ADMIN) {
+        return true
+    }
+    log.info({ platform: { id: platformId }, user: { id: userId } }, '[chatPersonalization] Company edit ignored, the platform company is admin-owned')
+    return false
 }
 
 async function writeUserRow({ platformId, userId, patch }: {

--- a/packages/server/api/src/app/ee/agent/prompt/agent-surface-notes.ts
+++ b/packages/server/api/src/app/ee/agent/prompt/agent-surface-notes.ts
@@ -1,7 +1,8 @@
 import { isNil } from '@activepieces/core-utils'
 import { AgentRunSource } from '@activepieces/shared'
+import { agentUserIdentity, UserIdentity } from './agent-user-identity'
 
-function buildRunNotes({ source, messageSource, currentDate, searchAvailable, fetchAvailable, scrapeAvailable, imageAvailable, emailAvailable, agentsAvailable, userEmail, connections, memory }: {
+function buildRunNotes({ source, messageSource, currentDate, searchAvailable, fetchAvailable, scrapeAvailable, imageAvailable, emailAvailable, agentsAvailable, userEmail, userIdentity, connections, memory }: {
     source: AgentRunSource
     messageSource?: 'onboarding'
     currentDate: string
@@ -12,19 +13,21 @@ function buildRunNotes({ source, messageSource, currentDate, searchAvailable, fe
     emailAvailable: boolean
     agentsAvailable: boolean
     userEmail: string
+    userIdentity: UserIdentity | null
     connections: ConnectionInventory | null
     memory: RunMemory
 }): string {
     const isChat = source === AgentRunSource.CHAT
-    return buildCapabilitiesNote({
-        currentDate,
-        searchAvailable,
-        fetchAvailable,
-        scrapeAvailable,
-        imageAvailable: imageAvailable && source !== AgentRunSource.FLOW_STEP,
-        emailAvailable: emailAvailable && isChat,
-        userEmail,
-    })
+    return (isChat && !isNil(userIdentity) ? agentUserIdentity.buildNote(userIdentity) : '')
+        + buildCapabilitiesNote({
+            currentDate,
+            searchAvailable,
+            fetchAvailable,
+            scrapeAvailable,
+            imageAvailable: imageAvailable && source !== AgentRunSource.FLOW_STEP,
+            emailAvailable: emailAvailable && isChat,
+            userEmail,
+        })
         + (isChat && agentsAvailable ? AGENTS_NOTE : '')
         + (isChat && !isNil(connections) ? buildConnectionInventoryNote(connections) : '')
         + (isChat ? buildMemoryNote(memory) : '')

--- a/packages/server/api/src/app/ee/agent/prompt/agent-user-identity.ts
+++ b/packages/server/api/src/app/ee/agent/prompt/agent-user-identity.ts
@@ -1,0 +1,82 @@
+import { isNil } from '@activepieces/core-utils'
+import { PersonalizationIdentity } from '../personalization/chat-personalization-service'
+
+function fullName({ firstName, lastName }: { firstName: string, lastName: string }): string {
+    return [firstName, lastName].map((part) => part.trim()).filter((part) => part.length > 0).join(' ')
+}
+
+function companyHintFromEmail({ email }: { email: string }): { domain: string, company: string } | null {
+    const at = email.lastIndexOf('@')
+    if (at < 0) {
+        return null
+    }
+    const domain = email.slice(at + 1).toLowerCase().trim()
+    if (domain.length === 0 || GENERIC_EMAIL_DOMAINS.has(domain)) {
+        return null
+    }
+    const label = domain.split('.')[0]
+    if (isNil(label) || label.length === 0) {
+        return null
+    }
+    return { domain, company: label.charAt(0).toUpperCase() + label.slice(1) }
+}
+
+function buildUserIdentityNote({ firstName, lastName, email, platformName, identity }: {
+    firstName: string
+    lastName: string
+    email: string
+    platformName: string | null
+    identity: PersonalizationIdentity | null
+}): string {
+    const name = fullName({ firstName, lastName })
+    const lines = [
+        '',
+        '',
+        '## Who you\'re talking to',
+        name.length > 0
+            ? `You're helping **${name}** (${email}). Use their first name when it feels natural.`
+            : `You're helping the person at **${email}**.`,
+    ]
+
+    if (!isNil(identity)) {
+        lines.push(`- They work at **${identity.companyName}**, ${identity.description} (industry: ${identity.industry}). This is researched, not a guess, so use it to ground your suggestions in their world.`)
+        if (!isNil(identity.role)) {
+            lines.push(`- Their own role is **${identity.role}**. Pick examples and defaults that fit that role, and never attribute it to anyone else on their team.`)
+        }
+    }
+    else {
+        const hint = companyHintFromEmail({ email })
+        if (!isNil(hint)) {
+            lines.push(`- Their email domain is **${hint.domain}**, so the company is likely **${hint.company}**. Treat this as a hint for grounding your help, and verify before stating it as fact.`)
+        }
+    }
+
+    if (!isNil(platformName)) {
+        lines.push(`- The product they are using is branded **${platformName}**. Call it that, and never assume the name "Activepieces" in anything the user sees.`)
+    }
+
+    lines.push('- This is who "email me" refers to, and whose world your suggestions should fit.')
+
+    return lines.join('\n')
+}
+
+const GENERIC_EMAIL_DOMAINS = new Set([
+    'gmail.com', 'googlemail.com', 'outlook.com', 'hotmail.com', 'hotmail.co.uk',
+    'live.com', 'msn.com', 'yahoo.com', 'yahoo.co.uk', 'ymail.com', 'icloud.com',
+    'me.com', 'mac.com', 'aol.com', 'proton.me', 'protonmail.com', 'pm.me',
+    'gmx.com', 'gmx.net', 'mail.com', 'zoho.com', 'yandex.com', 'yandex.ru',
+    'fastmail.com', 'hey.com', 'tutanota.com', 'qq.com', '163.com', '126.com',
+])
+
+export const agentUserIdentity = {
+    buildNote: buildUserIdentityNote,
+    companyHintFromEmail,
+}
+
+export type UserIdentity = {
+    firstName: string
+    lastName: string
+    email: string
+    platformName: string | null
+    identity: PersonalizationIdentity | null
+}

--- a/packages/server/api/test/unit/app/ee/agent/agent-surface-notes.test.ts
+++ b/packages/server/api/test/unit/app/ee/agent/agent-surface-notes.test.ts
@@ -13,6 +13,19 @@ const CHAT_ONLY_TOOLS = [
     'ap_discover_action_auth',
 ]
 
+const IDENTITY = {
+    firstName: 'Dana',
+    lastName: 'Okwu',
+    email: 'dana@acme.com',
+    platformName: 'Acme Automate',
+    identity: {
+        companyName: 'Acme',
+        description: 'a logistics company',
+        industry: 'Transport',
+        role: 'Operations Lead',
+    },
+}
+
 const EVERYTHING_AVAILABLE = { searchAvailable: true, fetchAvailable: true, scrapeAvailable: true, imageAvailable: true, emailAvailable: true, agentsAvailable: true }
 
 function notesFor(source: AgentRunSource): string {
@@ -21,6 +34,7 @@ function notesFor(source: AgentRunSource): string {
         currentDate: 'Tuesday, August 18, 2026',
         ...EVERYTHING_AVAILABLE,
         userEmail: 'owner@acme.com',
+        userIdentity: IDENTITY,
         connections: { connections: [{ displayName: 'Gmail', pieceName: '@activepieces/piece-gmail', status: 'ACTIVE' }], truncated: true },
         memory: { instructions: 'Answer in Arabic', memories: ['Prefers TypeScript'] },
     })
@@ -83,6 +97,7 @@ describe('what each surface is told it can do', () => {
             currentDate: 'Tuesday, August 18, 2026',
             searchAvailable: false, fetchAvailable: false, scrapeAvailable: false, imageAvailable: false, emailAvailable: false, agentsAvailable: false,
             userEmail: 'owner@acme.com',
+            userIdentity: null,
             connections: null,
             memory: { instructions: null, memories: [] },
         })
@@ -91,5 +106,66 @@ describe('what each surface is told it can do', () => {
         expect(notes).not.toContain('Saved agents')
         expect(notes).not.toContain('ap_web_search')
         expect(notes).not.toContain('ap_send_email')
+    })
+})
+
+describe('who the agent is told it is talking to', () => {
+    function identityNoteFor({ source, userIdentity }: { source: AgentRunSource, userIdentity: typeof IDENTITY | null }): string {
+        return agentSurfaceNotes.buildRunNotes({
+            source,
+            currentDate: 'Tuesday, August 18, 2026',
+            ...EVERYTHING_AVAILABLE,
+            userEmail: userIdentity?.email ?? 'owner@acme.com',
+            userIdentity,
+            connections: null,
+            memory: { instructions: null, memories: [] },
+        })
+    }
+
+    it('gives a chat run the researched company and the caller\'s own role', () => {
+        const notes = identityNoteFor({ source: AgentRunSource.CHAT, userIdentity: IDENTITY })
+
+        expect(notes).toContain('Who you\'re talking to')
+        expect(notes).toContain('Dana Okwu')
+        expect(notes).toContain('Acme')
+        expect(notes).toContain('Operations Lead')
+        expect(notes).toContain('Acme Automate')
+    })
+
+    it('falls back to the email domain when nothing has been researched', () => {
+        const notes = identityNoteFor({ source: AgentRunSource.CHAT, userIdentity: { ...IDENTITY, identity: null } })
+
+        expect(notes).toContain('dana@acme.com')
+        expect(notes).toContain('the company is likely')
+        expect(notes).not.toContain('a logistics company')
+    })
+
+    it('guesses no company from a personal mailbox', () => {
+        const notes = identityNoteFor({
+            source: AgentRunSource.CHAT,
+            userIdentity: { ...IDENTITY, email: 'dana@gmail.com', identity: null },
+        })
+
+        expect(notes).not.toContain('the company is likely')
+    })
+
+    it('leaves the person out of a surface with nobody in the room', () => {
+        expect(identityNoteFor({ source: AgentRunSource.FLOW_STEP, userIdentity: IDENTITY })).not.toContain('Who you\'re talking to')
+        expect(identityNoteFor({ source: AgentRunSource.AGENT, userIdentity: IDENTITY })).not.toContain('Who you\'re talking to')
+    })
+
+    it('puts the person above the first-message note that points back at them', () => {
+        const notes = agentSurfaceNotes.buildRunNotes({
+            source: AgentRunSource.CHAT,
+            messageSource: 'onboarding',
+            currentDate: 'Tuesday, August 18, 2026',
+            ...EVERYTHING_AVAILABLE,
+            userEmail: IDENTITY.email,
+            userIdentity: IDENTITY,
+            connections: null,
+            memory: { instructions: null, memories: [] },
+        })
+
+        expect(notes.indexOf('Who you\'re talking to')).toBeLessThan(notes.indexOf('FIRST message ever'))
     })
 })

--- a/packages/web/src/app/routes/chat-with-ai/ai-chat-box.tsx
+++ b/packages/web/src/app/routes/chat-with-ai/ai-chat-box.tsx
@@ -3,6 +3,7 @@ import {
   AgentConversation,
   AgentMessageSource,
   ChatPersonalizationStatus,
+  PlatformRole,
 } from '@activepieces/shared';
 import { useQueryClient } from '@tanstack/react-query';
 import { t } from 'i18next';
@@ -30,6 +31,7 @@ import { useCreditsState } from '@/features/chat/lib/use-credits-state';
 import { usePersonalization } from '@/features/chat/lib/use-personalization';
 import { aiProviderQueries } from '@/features/platform-admin';
 import { platformHooks } from '@/hooks/platform-hooks';
+import { userHooks } from '@/hooks/user-hooks';
 
 import { AssistantMessage } from './components/assistant-message';
 import { ChatBottomBar } from './components/chat-bottom-bar';
@@ -188,6 +190,7 @@ function ChatBoxContent({
   const [hasInput, setHasInput] = useState(false);
   const [promptOpen, setPromptOpen] = useState(false);
   const { platform } = platformHooks.useCurrentPlatform();
+  const { data: currentUser } = userHooks.useCurrentUser();
   const personalization = usePersonalization({ enabled: !incognito });
 
   const isAwaitingLoad =
@@ -202,7 +205,8 @@ function ChatBoxContent({
   const isFirstRun =
     personalization.personalStatus === ChatPersonalizationStatus.UNSET;
   const companyLocked =
-    isFirstRun && (personalization.companyInput ?? '').trim().length > 0;
+    (personalization.companyInput ?? '').trim().length > 0 &&
+    currentUser?.platformRole !== PlatformRole.ADMIN;
   const showOnboardingCard =
     isEmpty && !incognito && (isFirstRun || promptOpen);
   const showPersonalizationDonut =


### PR DESCRIPTION
## Description

Reported from staging: someone set up as "Software Engineer at Activepieces" yesterday, came back today to "Software Engineer at **Windows**", and opening the edit card offered "**John Doe**" as the company. Three names for one company, none of them chosen by the person reading them.

The role was correct throughout — that part belongs to the person now. The company is the mess, and it had two causes on top of an unguarded field.

### The stale profile

Changing the company discards the research that described the previous one, but only on the path that queues a new run:

```ts
patch: { domain, companyText, status: PENDING, researchToken,
         ...(inputsChanged ? { profile: null, useCases: null } : {}) }
```

The refused path — no chat AI provider, credits blocked, or the five-runs-per-platform-per-day cap — rewrote the inputs and kept the profile. The two surfaces read different fields, so they drifted apart:

```
chip:  profile?.companyName ?? companyInput
form:  companyInput ?? platform.name
```

Reproduced on an instance where research is always refused, which is what makes this common on staging:

```
seeded  company researched as windows.com → profile.companyName = "Windows"
then    the company is edited to "John Doe"

before  chip='Windows'   form='John Doe'
after   chip='John Doe'  form='John Doe'
```

### The unguarded field

`companyLocked` was `isFirstRun && companyInput non-empty`, so the lock only ever applied during someone's first run. Reopening the card through the chip cleared `isFirstRun`, and any teammate could rename the platform's company from a chat surface — which is how "Windows" and "John Doe" got in.

It is now locked whenever a company is already set and the caller is not a platform admin, on both paths. The server enforces the same rule rather than trusting the client to have hidden the field: a company sent by anyone else is ignored, their role is still recorded against them, and a member can still name the company when there is none, so nobody is locked out of onboarding.

```
MEMBER edits activepieces.com → "Windows"    company unchanged, role recorded
ADMIN  edits activepieces.com → "Windows"    company changed
MEMBER names a company on a platform with none    accepted
```

The company staying one row per platform is unchanged and deliberate — it is what keeps a company from being researched once per teammate.

## Also in this PR — the agent is finally told who it is talking to

Same report, next question: asking the chat *"what company do I work at?"* got *"I don't have any information about what company you work at."* It was right. The system prompt carried three things — the project list, the selected project, the frontend URL — and the onboarding answer sat in a table nothing on the turn path read.

The first-message note already assumed otherwise:

> They just signed up and told you their role and company, **both of which are above**.

Nothing was above. This adds the block that sentence was written for, ahead of it in the same chain:

```
## Who you're talking to
You're helping **Dana Okwu** (dana@acme.com). Use their first name when it feels natural.
- They work at **Acme**, a logistics company (industry: Transport). This is researched, not a guess…
- Their own role is **Operations Lead**. Pick examples and defaults that fit that role, and never
  attribute it to anyone else on their team.
- The product they are using is branded **Acme Automate**…
- This is who "email me" refers to, and whose world your suggestions should fit.
```

Ported from the `onboarding` branch, with one deliberate change. There, the role is read off `profile.userRole`. Here it cannot be: the profile belongs to the platform-wide company row, and its `userRole` was derived for whoever triggered the research — so reading it there would put a teammate's job title in the prompt, which is exactly what the rest of this branch fixes on the way in. The role comes from the caller's own row instead. `getIdentityEnrichment` already existed and returned the raw profile, called by nothing; it now returns the caller's role alongside the company.

Without research there is a fallback to the email domain, skipped for the consumer mailboxes that say nothing about where someone works. A run with nobody in the room — a flow step, a saved agent — gets no block at all.

## How was this tested?

Against a running Cloud-edition instance, driving the real endpoint and reading the rows back. The four cases above are that run: the stale-profile repro before and after, the admin gate in both directions, and a member onboarding on a platform with no company. Role edits were checked to still land while the company is refused.

The identity note is covered by five new cases in `agent-surface-notes.test.ts`: the researched company with the caller's own role, the email-domain fallback, no guess from a personal mailbox, no block on a surface with nobody in the room, and the ordering against the first-message note that points back at it.

Automated: `api` and `web` typecheck clean (`tsc -p packages/server/api/tsconfig.app.json`, not the empty `turbo typecheck` task the api package does not define), lint 0 errors on both, 524/524 web unit tests, and the api unit suite at 980 passed against a 975-passed baseline — the same 18 pre-existing environment failures on both sides.

Editions: personalization is Cloud/Enterprise only and reachable through chat. The admin gate reads `platformRole`, which every edition has.

Fixes # (issue)

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

No schema change, no migration, no API field added or removed. A non-admin can no longer overwrite a company that is already set — that is the fix, and it restores the behaviour the first-run lock already intended.

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)

No authentication, secrets or outbound HTTP is touched. It narrows an authorization gap rather than opening one: a platform-wide value that any member could rewrite is now admin-only, enforced server-side.
