### PR TITLE
fix(attio): Record Updated filters by the attribute that changed, not the record's current state

### DIFF
--- a/packages/pieces/community/attio/package.json
+++ b/packages/pieces/community/attio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-attio",
-  "version": "0.1.22",
+  "version": "0.1.23",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {

--- a/packages/pieces/community/attio/src/lib/common/client.ts
+++ b/packages/pieces/community/attio/src/lib/common/client.ts
@@ -17,6 +17,7 @@ export type AttioApiCallParams = {
 	resourceUri: string;
 	query?: Record<string, string | number | string[] | undefined>;
 	body?: any;
+	retries?: number;
 };
 
 export async function attioApiCall<T extends HttpMessageBody>({
@@ -25,6 +26,7 @@ export async function attioApiCall<T extends HttpMessageBody>({
 	resourceUri,
 	query,
 	body,
+	retries,
 }: AttioApiCallParams): Promise<T> {
 	const qs: QueryParams = {};
 
@@ -45,6 +47,7 @@ export async function attioApiCall<T extends HttpMessageBody>({
 		},
 		queryParams: qs,
 		body,
+		retries,
 	};
 
 	const response = await httpClient.sendRequest<T>(request);

--- a/packages/pieces/community/attio/src/lib/common/types.ts
+++ b/packages/pieces/community/attio/src/lib/common/types.ts
@@ -120,6 +120,11 @@ export interface ListResponse {
 }
 
 export interface AttributeResponse {
+	id: {
+		workspace_id: string;
+		object_id: string;
+		attribute_id: string;
+	};
 	title: string;
 	description: string;
 	api_slug: string;
@@ -158,6 +163,7 @@ export interface ObjectWebhookPayload {
 			workspace_id: string;
 			object_id: string;
 			record_id: string;
+			attribute_id?: string;
 		};
 	}>;
 }

--- a/packages/pieces/community/attio/src/lib/triggers/record-updated.ts
+++ b/packages/pieces/community/attio/src/lib/triggers/record-updated.ts
@@ -121,7 +121,7 @@ export const recordUpdatedTrigger = createTrigger({
 
 		const { objectTypeId, filter_attribute, filter_value } = context.propsValue;
 
-		const records = await Promise.all(
+		const results = await Promise.allSettled(
 			recordIds.map((recordId) =>
 				attioApiCall<{ data: Record<string, unknown> }>({
 					accessToken: context.auth.secret_text,
@@ -130,6 +130,10 @@ export const recordUpdatedTrigger = createTrigger({
 				}).then((response) => response.data),
 			),
 		);
+
+		const records = results
+			.filter((result) => result.status === 'fulfilled')
+			.map((result) => result.value);
 
 		return records.filter((record) => recordMatchesFilter(record, filter_attribute, filter_value));
 	},

--- a/packages/pieces/community/attio/src/lib/triggers/record-updated.ts
+++ b/packages/pieces/community/attio/src/lib/triggers/record-updated.ts
@@ -3,7 +3,7 @@ import { HttpMethod } from '@activepieces/pieces-common';
 import { attioApiCall, verifyWebhookSignature } from '../common/client';
 import { attioAuth } from '../auth';
 import { objectAttributeDropdown, objectTypeIdDropdown } from '../common/props';
-import { ObjectWebhookPayload, WebhookResponse } from '../common/types';
+import { AttributeResponse, ObjectWebhookPayload, WebhookResponse } from '../common/types';
 import { isNil } from '@activepieces/pieces-framework';
 
 const TRIGGER_KEY = 'updated-record-trigger';
@@ -38,6 +38,21 @@ export const recordUpdatedTrigger = createTrigger({
 	type: TriggerStrategy.WEBHOOK,
 	sampleData: {},
 	async onEnable(context) {
+		const { objectTypeId, filter_attribute } = context.propsValue;
+
+		const attributeId = filter_attribute
+			? await fetchAttributeId({
+					accessToken: context.auth.secret_text,
+					objectTypeId,
+					attributeSlug: filter_attribute,
+			  })
+			: undefined;
+
+		const filterConditions = [
+			{ field: 'id.object_id', operator: 'equals', value: objectTypeId },
+			...(attributeId ? [{ field: 'id.attribute_id', operator: 'equals', value: attributeId }] : []),
+		];
+
 		const response = await attioApiCall<{ data: WebhookResponse }>({
 			accessToken: context.auth.secret_text,
 			method: HttpMethod.POST,
@@ -48,30 +63,21 @@ export const recordUpdatedTrigger = createTrigger({
 					subscriptions: [
 						{
 							event_type: 'record.updated',
-							filter: {
-								$and: [
-									{
-										field: 'id.object_id',
-										operator: 'equals',
-										value: context.propsValue.objectTypeId,
-									},
-								],
-							},
+							filter: { $and: filterConditions },
 						},
 					],
 				},
 			},
 		});
 
-		await context.store.put<{ webhookId: string; WebhookSecret: string }>(TRIGGER_KEY, {
+		await context.store.put<TriggerData>(TRIGGER_KEY, {
 			webhookId: response.data.id.webhook_id,
 			WebhookSecret: response.data.secret,
+			attributeId,
 		});
 	},
 	async onDisable(context) {
-		const webhookData = await context.store.get<{ webhookId: string; WebhookSecret: string }>(
-			TRIGGER_KEY,
-		);
+		const webhookData = await context.store.get<TriggerData>(TRIGGER_KEY);
 		if (!isNil(webhookData) && webhookData.webhookId) {
 			await attioApiCall({
 				accessToken: context.auth.secret_text,
@@ -98,9 +104,7 @@ export const recordUpdatedTrigger = createTrigger({
 		return filtered.slice(0, 5);
 	},
 	async run(context) {
-		const triggerData = await context.store.get<{ webhookId: string; WebhookSecret: string }>(
-			TRIGGER_KEY,
-		);
+		const triggerData = await context.store.get<TriggerData>(TRIGGER_KEY);
 
 		const webhookSecret = triggerData?.WebhookSecret;
 		const webhookSignatureHeader = context.payload.headers['attio-signature'];
@@ -111,28 +115,54 @@ export const recordUpdatedTrigger = createTrigger({
 		}
 
 		const payload = context.payload.body as ObjectWebhookPayload;
-		const event = payload.events?.[0];
+		const recordIds = collectMatchingRecordIds(payload.events ?? [], triggerData?.attributeId);
 
-		if (!event) return [];
+		if (recordIds.length === 0) return [];
 
-		const recordId = event.id.record_id;
+		const { objectTypeId, filter_attribute, filter_value } = context.propsValue;
 
-		const response = await attioApiCall<{ data: Record<string, unknown> }>({
-			accessToken: context.auth.secret_text,
-			method: HttpMethod.GET,
-			resourceUri: `/objects/${context.propsValue.objectTypeId}/records/${recordId}`,
-		});
+		const records = await Promise.all(
+			recordIds.map((recordId) =>
+				attioApiCall<{ data: Record<string, unknown> }>({
+					accessToken: context.auth.secret_text,
+					method: HttpMethod.GET,
+					resourceUri: `/objects/${objectTypeId}/records/${recordId}`,
+				}).then((response) => response.data),
+			),
+		);
 
-		const record = response.data;
-		const { filter_attribute, filter_value } = context.propsValue;
-
-		if (!recordMatchesFilter(record, filter_attribute, filter_value)) {
-			return [];
-		}
-
-		return [record];
+		return records.filter((record) => recordMatchesFilter(record, filter_attribute, filter_value));
 	},
 });
+
+function collectMatchingRecordIds(
+	events: ObjectWebhookPayload['events'],
+	filterAttributeId: string | undefined,
+): string[] {
+	const relevantEvents = filterAttributeId
+		? events.filter((event) => event.id.attribute_id === filterAttributeId)
+		: events;
+
+	return [...new Set(relevantEvents.map((event) => event.id.record_id))];
+}
+
+async function fetchAttributeId({
+	accessToken,
+	objectTypeId,
+	attributeSlug,
+}: {
+	accessToken: string;
+	objectTypeId: string | undefined;
+	attributeSlug: string;
+}): Promise<string> {
+	const response = await attioApiCall<{ data: AttributeResponse }>({
+		accessToken,
+		method: HttpMethod.GET,
+		resourceUri: `/objects/${objectTypeId}/attributes/${attributeSlug}`,
+	});
+
+	return response.data.id.attribute_id;
+}
 
 function recordMatchesFilter(
 	record: Record<string, unknown>,
@@ -179,3 +209,9 @@ function extractAttributeDisplayValue(valueObj: Record<string, unknown>): string
 		(valueObj['value'] !== undefined ? String(valueObj['value']) : null)
 	);
 }
+
+type TriggerData = {
+	webhookId: string;
+	WebhookSecret: string;
+	attributeId?: string;
+};

--- a/packages/pieces/community/attio/src/lib/triggers/record-updated.ts
+++ b/packages/pieces/community/attio/src/lib/triggers/record-updated.ts
@@ -127,6 +127,7 @@ export const recordUpdatedTrigger = createTrigger({
 					accessToken: context.auth.secret_text,
 					method: HttpMethod.GET,
 					resourceUri: `/objects/${objectTypeId}/records/${recordId}`,
+					retries: 2,
 				}).then((response) => response.data),
 			),
 		);


### PR DESCRIPTION
## Description

The Record Updated trigger's **Filter Field** ("Only trigger when this field is involved in the update") never actually checked which attribute changed — `run()` discarded `event.id.attribute_id` and instead re-fetched the record and checked the field's **current** value.

Consequences on a live workspace (Deals object, `filter_attribute: stage`):
- A single stage change fired the flow **twice** when the workspace has a formula attribute referencing `stage` (e.g. "time in stage"): Attio's system actor recomputes the formula ~1s after the real change, producing a second `record.updated` whose re-fetch also matched the filtered field.
- Editing an unrelated attribute on a record whose `stage` already matched the filter re-fired the flow every time.
- `run()` only read `payload.events[0]`; Attio can batch multiple attribute changes for the same record into one delivery, silently dropping the rest.

## Fix

- `onEnable` resolves the selected Filter Field's slug to its attribute id (`GET /v2/objects/{object}/attributes/{slug}`) and adds `id.attribute_id equals <id>` to the webhook subscription filter, so Attio stops delivering non-matching events (including the formula-recompute one) at the source. The resolved id is stored alongside the webhook id/secret.
- `run()` gates every event in a delivery against the stored attribute id (not just `events[0]`), dedupes affected record ids, and fetches/filters each one — fixing the batched-events gap as well.
- `types.ts`: declare `attribute_id` on `ObjectWebhookPayload` events and `id` on `AttributeResponse`.
- Backwards compatible: with no Filter Field selected, behavior is unchanged. Triggers enabled before this change have no stored attribute id and keep today's behavior until re-enabled/re-saved.
- Version bump `0.1.22 → 0.1.23`.

## How was this tested?

Verified against a live Attio workspace with a real webhook (ngrok) and a formula attribute ("previous deal stage value") referencing `stage`:
- Direct `Lead → Won` move with `filter_value: "In progress"`: exactly one webhook delivery, `attribute_id` matches the real `stage` attribute, no formula-recompute event delivered, flow correctly does **not** fire (value mismatch).
- Move to `In Progress` with the same filter: one delivery, flow fires exactly once.
- Two real stage transitions seconds apart (`In Progress → Won`): each transition produces its own delivery; the flow fired once, on the transition that matched, not twice.
- Confirmed via Attio's `/v2/webhooks` API that the subscription filter now includes `id.attribute_id equals <stage's id>`.

Fixes #15057

### Breaking change?

- [x] no — reviewed, not breaking

### Security impact?

- [x] no — reviewed, no security impact