### PR TITLE
fix(chat): the role reaches the agent without waiting on company research

### DIFF
--- a/packages/server/api/src/app/ee/agent/personalization/chat-personalization-service.ts
+++ b/packages/server/api/src/app/ee/agent/personalization/chat-personalization-service.ts
@@ -395,15 +395,14 @@ export const chatPersonalizationService = (log: FastifyBaseLogger) => ({
 
     async getIdentityEnrichment({ platformId, userId }: { platformId: string, userId: string }): Promise<PersonalizationIdentity | null> {
         const view = await this.getEffectiveView({ platformId, userId })
-        if (view.status !== ChatPersonalizationStatus.READY || isNil(view.profile)) {
+        const company = view.status === ChatPersonalizationStatus.READY && !isNil(view.profile)
+            ? { name: view.profile.companyName, description: view.profile.description, industry: view.profile.industry }
+            : null
+        const role = view.roleInput ?? null
+        if (isNil(company) && isNil(role)) {
             return null
         }
-        return {
-            companyName: view.profile.companyName,
-            description: view.profile.description,
-            industry: view.profile.industry,
-            role: view.roleInput ?? null,
-        }
+        return { company, role }
     },
 
 })
@@ -844,8 +843,12 @@ type ValidatedResult = {
 }
 
 export type PersonalizationIdentity = {
-    companyName: string
+    company: PersonalizationIdentityCompany | null
+    role: string | null
+}
+
+export type PersonalizationIdentityCompany = {
+    name: string
     description: string
     industry: string
-    role: string | null
 }

--- a/packages/server/api/src/app/ee/agent/prompt/agent-user-identity.ts
+++ b/packages/server/api/src/app/ee/agent/prompt/agent-user-identity.ts
@@ -38,17 +38,19 @@ function buildUserIdentityNote({ firstName, lastName, email, platformName, ident
             : `You're helping the person at **${email}**.`,
     ]
 
-    if (!isNil(identity)) {
-        lines.push(`- They work at **${identity.companyName}**, ${identity.description} (industry: ${identity.industry}). This is researched, not a guess, so use it to ground your suggestions in their world.`)
-        if (!isNil(identity.role)) {
-            lines.push(`- Their own role is **${identity.role}**. Pick examples and defaults that fit that role, and never attribute it to anyone else on their team.`)
-        }
+    const company = identity?.company ?? null
+    if (!isNil(company)) {
+        lines.push(`- They work at **${company.name}**, ${company.description} (industry: ${company.industry}). This is researched, not a guess, so use it to ground your suggestions in their world.`)
     }
     else {
         const hint = companyHintFromEmail({ email })
         if (!isNil(hint)) {
             lines.push(`- Their email domain is **${hint.domain}**, so the company is likely **${hint.company}**. Treat this as a hint for grounding your help, and verify before stating it as fact.`)
         }
+    }
+
+    if (!isNil(identity?.role)) {
+        lines.push(`- Their own role is **${identity.role}**, which they told us themselves. Pick examples and defaults that fit that role, and never attribute it to anyone else on their team.`)
     }
 
     if (!isNil(platformName)) {

--- a/packages/server/api/test/integration/ee/agent/chat-identity-note.test.ts
+++ b/packages/server/api/test/integration/ee/agent/chat-identity-note.test.ts
@@ -1,0 +1,114 @@
+import { apId } from '@activepieces/core-utils'
+import { ChatPersonalizationStatus, PlatformRole } from '@activepieces/shared'
+import { FastifyInstance } from 'fastify'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { chatPersonalizationService } from '../../../../src/app/ee/agent/personalization/chat-personalization-service'
+import { agentUserIdentity } from '../../../../src/app/ee/agent/prompt/agent-user-identity'
+import { db } from '../../../helpers/db'
+import { mockBasicUser } from '../../../helpers/mocks'
+import { createTestContext, TestContext } from '../../../helpers/test-context'
+import { setupTestEnvironment, teardownTestEnvironment } from '../../../helpers/test-setup'
+
+let app: FastifyInstance
+
+beforeAll(async () => {
+    app = await setupTestEnvironment()
+})
+
+afterAll(async () => {
+    await teardownTestEnvironment()
+})
+
+const PROFILE = {
+    companyName: 'Acme',
+    displayName: 'Acme',
+    website: 'acme.com',
+    description: 'a logistics company',
+    industry: 'Transport',
+    userRole: 'Warehouse Manager',
+}
+
+async function savePersonalization({ platformId, userId, role, status, profile }: {
+    platformId: string
+    userId: string | null
+    role: string | null
+    status: ChatPersonalizationStatus
+    profile: typeof PROFILE | null
+}) {
+    await db.save('chat_personalization', {
+        id: apId(),
+        platformId,
+        userId,
+        domain: 'acme.com',
+        companyText: null,
+        role,
+        status,
+        researchToken: null,
+        profile,
+        useCases: profile ? [{ title: 'a', description: 'b' }] : null,
+    })
+}
+
+async function noteFor(ctx: TestContext): Promise<string> {
+    const identity = await chatPersonalizationService(app.log).getIdentityEnrichment({
+        platformId: ctx.platform.id,
+        userId: ctx.user.id,
+    })
+    return agentUserIdentity.buildNote({
+        firstName: 'Dana',
+        lastName: 'Okwu',
+        email: 'dana@acme.com',
+        platformName: 'Acme Automate',
+        identity,
+    })
+}
+
+describe('what the agent is told about the person it is talking to', () => {
+    it('carries the role even when the company was never researched', async () => {
+        const ctx = await createTestContext(app)
+        await savePersonalization({ platformId: ctx.platform.id, userId: null, role: null, status: ChatPersonalizationStatus.SKIPPED, profile: null })
+        await savePersonalization({ platformId: ctx.platform.id, userId: ctx.user.id, role: 'Operations Lead', status: ChatPersonalizationStatus.SKIPPED, profile: null })
+
+        const note = await noteFor(ctx)
+
+        expect(note).toContain('Operations Lead')
+        expect(note).toContain('the company is likely')
+        expect(note).not.toContain('a logistics company')
+    })
+
+    it('replaces the domain guess with the researched company once it lands, keeping the role', async () => {
+        const ctx = await createTestContext(app)
+        await savePersonalization({ platformId: ctx.platform.id, userId: null, role: null, status: ChatPersonalizationStatus.READY, profile: PROFILE })
+        await savePersonalization({ platformId: ctx.platform.id, userId: ctx.user.id, role: 'Operations Lead', status: ChatPersonalizationStatus.SKIPPED, profile: null })
+
+        const note = await noteFor(ctx)
+
+        expect(note).toContain('a logistics company')
+        expect(note).toContain('Operations Lead')
+        expect(note).not.toContain('the company is likely')
+    })
+
+    it('never attributes a teammate\'s role, or the one the research guessed, to the caller', async () => {
+        const ctx = await createTestContext(app)
+        await savePersonalization({ platformId: ctx.platform.id, userId: null, role: null, status: ChatPersonalizationStatus.READY, profile: PROFILE })
+        const { mockUser: teammate } = await mockBasicUser({ user: { platformId: ctx.platform.id, platformRole: PlatformRole.MEMBER } })
+        await savePersonalization({ platformId: ctx.platform.id, userId: teammate.id, role: 'Night Shift Lead', status: ChatPersonalizationStatus.READY, profile: null })
+        await savePersonalization({ platformId: ctx.platform.id, userId: ctx.user.id, role: 'Operations Lead', status: ChatPersonalizationStatus.SKIPPED, profile: null })
+
+        const note = await noteFor(ctx)
+
+        expect(note).toContain('Operations Lead')
+        expect(note).not.toContain('Night Shift Lead')
+        expect(note).not.toContain('Warehouse Manager')
+    })
+
+    it('says nothing about a role for someone who never answered', async () => {
+        const ctx = await createTestContext(app)
+        await savePersonalization({ platformId: ctx.platform.id, userId: null, role: null, status: ChatPersonalizationStatus.READY, profile: PROFILE })
+
+        const note = await noteFor(ctx)
+
+        expect(note).not.toContain('Their own role is')
+        expect(note).toContain('a logistics company')
+    })
+})

--- a/packages/server/api/test/unit/app/ee/agent/agent-surface-notes.test.ts
+++ b/packages/server/api/test/unit/app/ee/agent/agent-surface-notes.test.ts
@@ -19,9 +19,7 @@ const IDENTITY = {
     email: 'dana@acme.com',
     platformName: 'Acme Automate',
     identity: {
-        companyName: 'Acme',
-        description: 'a logistics company',
-        industry: 'Transport',
+        company: { name: 'Acme', description: 'a logistics company', industry: 'Transport' },
         role: 'Operations Lead',
     },
 }
@@ -138,6 +136,16 @@ describe('who the agent is told it is talking to', () => {
         expect(notes).toContain('dana@acme.com')
         expect(notes).toContain('the company is likely')
         expect(notes).not.toContain('a logistics company')
+    })
+
+    it('still names the role when only the company research is missing', () => {
+        const notes = identityNoteFor({
+            source: AgentRunSource.CHAT,
+            userIdentity: { ...IDENTITY, identity: { company: null, role: 'Operations Lead' } },
+        })
+
+        expect(notes).toContain('Operations Lead')
+        expect(notes).toContain('the company is likely')
     })
 
     it('guesses no company from a personal mailbox', () => {


### PR DESCRIPTION
## Description

The identity note from #15062 shipped, and the agent still could not name a role:

> **where do i work at?**
> You work at **Activepieces** — that's what your email domain tells me (ahmad@activepieces.com).
>
> **what is my role?**
> I don't have that information yet.

"that's what your email domain tells me" is the *fallback* line, word for word. The researched block never rendered, and the role was trapped inside it. Both gates were mine:

```ts
// the service returned nothing at all without a researched company
if (view.status !== READY || isNil(view.profile)) {
    return null
}

// and the role line was nested inside the company line
if (!isNil(identity)) {
    lines.push(`- They work at **${identity.companyName}**…`)
    if (!isNil(identity.role)) {
        lines.push(`- Their own role is **${identity.role}**…`)
    }
}
else {
    // domain hint — a company guess, and no role
}
```

So the role only reached the prompt if a background job had finished reading the company's website. The role was stored correctly the whole time; nothing on the prompt path would look at it.

**A role is a fact someone typed.** It is known the moment they answer and owes nothing to that job, so it no longer waits on one. The profile keeps its `READY` gate, the role does not, and the two render independently — a researched company replaces the domain guess, and the role line stays put either way.

This is also why it looked half-working rather than broken: research is routinely refused on staging, for want of a chat AI provider or against the five-runs-per-platform-per-day cap, so the company was never `READY` and the domain guess happened to land on the right name.

## How was this tested?

A new integration test, `chat-identity-note.test.ts`, drives the real service against a real database through the harness — no stubbing of the thing under test:

| case | asserts |
| --- | --- |
| role answered, company never researched | the role is named, alongside the domain guess |
| research lands | the researched company replaces the guess, the role stays |
| a teammate answered too | neither their role nor the research's guessed `userRole` is attributed to the caller |
| someone who never answered | no role line at all |

Run against `main`'s code, with the fix reverted and the tests kept, the first case fails with exactly the reported symptom:

```
× carries the role even when the company was never researched
  → expected '…## Who you're talking to…' to contain 'Operations Lead'
✓ replaces the domain guess with the researched company once it lands, keeping the role
✓ never attributes a teammate's role, or the one the research guessed, to the caller
✓ says nothing about a role for someone who never answered
```

With the fix, 4/4 pass. The whole `test/integration/ee/agent` folder is green at 87/87, and `agent-surface-notes.test.ts` covers the note builder at 14/14, including a new case for company-missing-but-role-present.

The live API was checked against the same state staging is in, to confirm the shape that triggers it:

```
status = SKIPPED   profile = None   roleInput = 'Software Engineer'
```

Automated: api typecheck clean via `tsc -p packages/server/api/tsconfig.app.json`, lint 0 errors, api unit suite 981 passed against a 975-passed baseline with the same 18 pre-existing environment failures on both sides.

Editions: personalization is Cloud/Enterprise only and reachable through chat. The note itself renders on any edition; only the researched company depends on personalization having run.

Fixes # (issue)

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

No schema change, no migration, no API field added or removed. `getIdentityEnrichment` changes shape, but it is internal and has one caller.

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)

No authentication, secrets or outbound HTTP is touched. The role still comes from the caller's own row, and a test now pins that a teammate's role cannot reach it.
