### PR TITLE
fix(jira-cloud): remaining polling triggers no longer permanently miss issues, comments, assignments, and attachments

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -162,7 +162,7 @@
     },
     "packages/core/shared": {
       "name": "@activepieces/shared",
-      "version": "0.142.0",
+      "version": "0.143.0",
       "dependencies": {
         "@activepieces/core-execution": "workspace:*",
         "@activepieces/core-formula": "workspace:*",
@@ -844,7 +844,7 @@
     },
     "packages/pieces/community/attio": {
       "name": "@activepieces/piece-attio",
-      "version": "0.1.22",
+      "version": "0.1.23",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -4608,7 +4608,7 @@
     },
     "packages/pieces/community/jira-cloud": {
       "name": "@activepieces/piece-jira-cloud",
-      "version": "0.3.11",
+      "version": "0.3.12",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -7006,7 +7006,7 @@
     },
     "packages/pieces/community/pollybot-ai": {
       "name": "@activepieces/piece-pollybot-ai",
-      "version": "0.1.7",
+      "version": "0.2.0",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",

--- a/packages/pieces/community/jira-cloud/package.json
+++ b/packages/pieces/community/jira-cloud/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-jira-cloud",
-  "version": "0.3.11",
+  "version": "0.3.12",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "dependencies": {

--- a/packages/pieces/community/jira-cloud/src/lib/common/polling.ts
+++ b/packages/pieces/community/jira-cloud/src/lib/common/polling.ts
@@ -8,6 +8,7 @@ const LOOKBACK_MS = 15 * 60 * 1000;
 const MAX_RESULTS = 1000;
 const MAX_PAGES = 10;
 const MAX_LEDGER_ENTRIES = 2000;
+const TEST_FETCH_LIMIT = 50;
 const TEST_ITEMS_LIMIT = 5;
 const STATE_STORE_KEY = 'pollingState';
 
@@ -44,26 +45,32 @@ function stripTrailingOrderBy(jql: string): string {
 	return (orderByIndex === -1 ? jql : jql.slice(0, orderByIndex)).trim();
 }
 
-async function composeJql({
+async function composeJql<Props extends JiraPollingProps>({
 	auth,
 	propsValue,
 	since,
 	direction,
+	timeField,
+	extraScope,
 }: {
 	auth: JiraAuth;
-	propsValue: JiraPollingContext['propsValue'];
+	propsValue: Props;
 	since: string | null;
 	direction: 'ASC' | 'DESC';
+	timeField: JiraTimeField;
+	extraScope?: JiraPollingConfig<Props>['extraScope'];
 }): Promise<string> {
 	const userJql = isNil(propsValue.jql) ? '' : stripTrailingOrderBy(propsValue.jql);
 	const scope =
 		userJql.length === 0
 			? null
 			: `(${propsValue.sanitizeJql ? await sanitizeJqlQuery({ auth, jql: userJql }) : userJql})`;
-	const conditions = [scope, isNil(since) ? null : `updated > '${since}'`].filter(
-		(condition): condition is string => !isNil(condition),
-	);
-	const orderBy = `ORDER BY updated ${direction}`;
+	const conditions = [
+		scope,
+		extraScope ? extraScope({ propsValue, since }) : null,
+		isNil(since) ? null : `${timeField} > '${since}'`,
+	].filter((condition): condition is string => !isNil(condition));
+	const orderBy = `ORDER BY ${timeField} ${direction}`;
 	return conditions.length === 0 ? orderBy : `${conditions.join(' AND ')} ${orderBy}`;
 }
 
@@ -72,12 +79,16 @@ async function fetchIssues({
 	jql,
 	maxResults,
 	maxPages = 1,
+	fields,
+	expand,
 }: {
 	auth: JiraAuth;
 	jql: string;
 	maxResults: number;
 	maxPages?: number;
-}): Promise<{ items: PollingItem[]; truncated: boolean }> {
+	fields?: string[];
+	expand?: string[];
+}): Promise<{ issues: JiraSearchResponse['issues']; truncated: boolean }> {
 	const issues: JiraSearchResponse['issues'] = [];
 	let nextPageToken: string | undefined;
 	let truncated = false;
@@ -89,6 +100,8 @@ async function fetchIssues({
 			maxResults,
 			sanitizeJql: false,
 			nextPageToken,
+			fields,
+			expand,
 		});
 		issues.push(...(response.issues ?? []));
 		nextPageToken = response.nextPageToken;
@@ -101,18 +114,52 @@ async function fetchIssues({
 		}
 	}
 
-	return { items: toItems(issues), truncated };
+	return { issues, truncated };
 }
 
-function toItems(issues: JiraSearchResponse['issues']): PollingItem[] {
+function issueEpoch({
+	issue,
+	epochField,
+}: {
+	issue: JiraSearchResponse['issues'][number];
+	epochField: string;
+}): number {
+	return Date.parse(issue?.fields?.[epochField]);
+}
+
+function toItems<Props extends JiraPollingProps>({
+	issues,
+	propsValue,
+	extractItems,
+}: {
+	issues: JiraSearchResponse['issues'];
+	propsValue: Props;
+	extractItems: (params: {
+		issue: JiraSearchResponse['issues'][number];
+		propsValue: Props;
+	}) => JiraPollingItem[];
+}): LedgeredItem[] {
 	return issues
-		.flatMap((issue) => {
-			const epochMilliSeconds = Date.parse(issue?.fields?.updated);
-			return Number.isFinite(epochMilliSeconds)
-				? [{ key: `${issue?.id}:${epochMilliSeconds}`, epochMilliSeconds, data: issue }]
-				: [];
-		})
+		.flatMap((issue) => extractItems({ issue, propsValue }))
+		.filter((item) => Number.isFinite(item.epochMilliSeconds))
+		.map((item) => ({ ...item, key: `${item.id}:${item.epochMilliSeconds}` }))
 		.sort((first, second) => first.epochMilliSeconds - second.epochMilliSeconds);
+}
+
+function truncatedWindowStart({
+	issues,
+	timeField,
+	windowStart,
+}: {
+	issues: JiraSearchResponse['issues'];
+	timeField: JiraTimeField;
+	windowStart: number;
+}): number {
+	const highestEpoch = issues.reduce((highest, issue) => {
+		const epoch = issueEpoch({ issue, epochField: timeField });
+		return Number.isFinite(epoch) ? Math.max(highest, epoch) : highest;
+	}, Number.NEGATIVE_INFINITY);
+	return Number.isFinite(highestEpoch) ? Math.max(windowStart, highestEpoch - 1) : windowStart;
 }
 
 function pruneState({
@@ -147,82 +194,131 @@ function initialState(now: number): PollingState {
 	return { windowStart: now, floor: now, entries: [] };
 }
 
-export const jiraPolling = {
-	async onEnable({ context }: { context: JiraPollingContext }): Promise<void> {
-		const { store, isRepublish } = context;
-		if (isRepublish && !isNil(await store.get<PollingState>(STATE_STORE_KEY))) {
-			return;
-		}
-		await store.put(STATE_STORE_KEY, initialState(Date.now()));
-	},
+export function createJiraPolling<Props extends JiraPollingProps = JiraPollingProps>(
+	config: JiraPollingConfig<Props> = {},
+) {
+	const timeField = config.timeField ?? 'updated';
+	const epochField = config.epochField ?? timeField;
+	const fields = isNil(config.fields)
+		? undefined
+		: Array.from(new Set([...config.fields, timeField, epochField]));
+	const extractItems =
+		config.extractItems ??
+		(({ issue }: { issue: JiraSearchResponse['issues'][number] }): JiraPollingItem[] => [
+			{ id: `${issue?.id}`, epochMilliSeconds: issueEpoch({ issue, epochField }), data: issue },
+		]);
 
-	async poll({ context }: { context: JiraPollingContext }): Promise<unknown[]> {
-		const { auth, propsValue, store } = context;
-		const now = Date.now();
-		const state = (await store.get<PollingState>(STATE_STORE_KEY)) ?? initialState(now);
-		const windowStart = Math.max(state.windowStart, state.floor);
+	return {
+		async onEnable({ context }: { context: JiraPollingContext<Props> }): Promise<void> {
+			const { store, isRepublish } = context;
+			if (isRepublish && !isNil(await store.get<PollingState>(STATE_STORE_KEY))) {
+				return;
+			}
+			await store.put(STATE_STORE_KEY, initialState(Date.now()));
+		},
 
-		const { items, truncated } = await fetchIssues({
-			auth,
-			jql: await composeJql({
+		async poll({ context }: { context: JiraPollingContext<Props> }): Promise<unknown[]> {
+			const { auth, propsValue, store } = context;
+			const now = Date.now();
+			const state = (await store.get<PollingState>(STATE_STORE_KEY)) ?? initialState(now);
+			const windowStart = Math.max(state.windowStart, state.floor);
+
+			const { issues, truncated } = await fetchIssues({
 				auth,
-				propsValue,
-				since: toRelativeJqlDate({ sinceEpochMS: windowStart, now }),
-				direction: 'ASC',
-			}),
-			maxResults: MAX_RESULTS,
-			maxPages: MAX_PAGES,
-		});
+				jql: await composeJql({
+					auth,
+					propsValue,
+					since: toRelativeJqlDate({ sinceEpochMS: windowStart, now }),
+					direction: 'ASC',
+					timeField,
+					extraScope: config.extraScope,
+				}),
+				maxResults: MAX_RESULTS,
+				maxPages: MAX_PAGES,
+				fields,
+				expand: config.expand,
+			});
+			const items = toItems({ issues, propsValue, extractItems });
 
-		const alreadyEmitted = new Set(state.entries.map(([key]) => key));
-		const freshItems = items.filter(
-			(item) => item.epochMilliSeconds > windowStart && !alreadyEmitted.has(item.key),
-		);
+			const alreadyEmitted = new Set(state.entries.map(([key]) => key));
+			const freshItems = items.filter(
+				(item) => item.epochMilliSeconds > windowStart && !alreadyEmitted.has(item.key),
+			);
 
-		const highestEpoch = items.at(-1)?.epochMilliSeconds;
-		const nextWindowStart = truncated
-			? Math.max(windowStart, isNil(highestEpoch) ? windowStart : highestEpoch - 1)
-			: Math.max(windowStart, now - LOOKBACK_MS);
+			const nextWindowStart = truncated
+				? truncatedWindowStart({ issues, timeField, windowStart })
+				: Math.max(windowStart, now - LOOKBACK_MS);
 
-		await store.put(
-			STATE_STORE_KEY,
-			pruneState({
-				entries: [
-					...state.entries,
-					...freshItems.map((item): LedgerEntry => [item.key, item.epochMilliSeconds]),
-				],
-				floor: state.floor,
-				windowStart: nextWindowStart,
-			}),
-		);
+			await store.put(
+				STATE_STORE_KEY,
+				pruneState({
+					entries: [
+						...state.entries,
+						...freshItems.map((item): LedgerEntry => [item.key, item.epochMilliSeconds]),
+					],
+					floor: state.floor,
+					windowStart: nextWindowStart,
+				}),
+			);
 
-		return freshItems.map((item) => ({ ...item.data, [DEDUPE_KEY_PROPERTY]: item.key }));
-	},
+			return freshItems.map((item) => ({ ...item.data, [DEDUPE_KEY_PROPERTY]: item.key }));
+		},
 
-	async test({ context }: { context: JiraPollingContext }): Promise<unknown[]> {
-		const { auth, propsValue } = context;
-		const { items } = await fetchIssues({
-			auth,
-			jql: await composeJql({ auth, propsValue, since: null, direction: 'DESC' }),
-			maxResults: TEST_ITEMS_LIMIT,
-		});
+		async test({ context }: { context: JiraPollingContext<Props> }): Promise<unknown[]> {
+			const { auth, propsValue } = context;
+			const { issues } = await fetchIssues({
+				auth,
+				jql: await composeJql({
+					auth,
+					propsValue,
+					since: null,
+					direction: 'DESC',
+					timeField,
+					extraScope: config.extraScope,
+				}),
+				maxResults: TEST_FETCH_LIMIT,
+				fields,
+				expand: config.expand,
+			});
 
-		return items.reverse().map((item) => item.data);
-	},
+			return toItems({ issues, propsValue, extractItems })
+				.slice(-TEST_ITEMS_LIMIT)
+				.map((item) => item.data)
+				.reverse();
+		},
+	};
+}
+
+export type JiraPollingProps = { jql?: string; sanitizeJql?: boolean };
+
+export type JiraPollingItem = {
+	id: string;
+	epochMilliSeconds: number;
+	data: Record<string, unknown>;
 };
 
-type JiraPollingContext = {
+type JiraTimeField = 'updated' | 'created';
+
+type JiraPollingConfig<Props extends JiraPollingProps> = {
+	timeField?: JiraTimeField;
+	epochField?: string;
+	fields?: string[];
+	expand?: string[];
+	extraScope?: (params: { propsValue: Props; since: string | null }) => string | null;
+	extractItems?: (params: {
+		issue: JiraSearchResponse['issues'][number];
+		propsValue: Props;
+	}) => JiraPollingItem[];
+};
+
+type JiraPollingContext<Props extends JiraPollingProps> = {
 	auth: JiraAuth;
-	propsValue: { jql?: string; sanitizeJql?: boolean };
+	propsValue: Props;
 	store: Store;
 	isRepublish?: boolean;
 };
 
-type PollingItem = {
-	key: string;
-	epochMilliSeconds: number;
-	data: Record<string, unknown>;
-};
+type LedgeredItem = JiraPollingItem & { key: string };
 
 type LedgerEntry = [key: string, epochMilliSeconds: number];
 

--- a/packages/pieces/community/jira-cloud/src/lib/common/types.ts
+++ b/packages/pieces/community/jira-cloud/src/lib/common/types.ts
@@ -45,3 +45,19 @@ export const VALID_CUSTOM_FIELD_TYPES = [
 	'project',
 	'people',
 ];
+
+export type ChangelogItem = {
+	field: string;
+	fieldId?: string;
+	from: string | null;
+	fromString: string | null;
+	to: string | null;
+	toString: string | null;
+};
+
+export type ChangelogHistory = {
+	id: string;
+	author?: { accountId: string; displayName: string; emailAddress?: string };
+	created: string;
+	items: ChangelogItem[];
+};

--- a/packages/pieces/community/jira-cloud/src/lib/triggers/issue-assigned.ts
+++ b/packages/pieces/community/jira-cloud/src/lib/triggers/issue-assigned.ts
@@ -2,32 +2,12 @@ import {
   Property,
   TriggerStrategy,
   createTrigger,
+  isNil,
 } from '@activepieces/pieces-framework';
-import {
-  DedupeStrategy,
-  Polling,
-  pollingHelper,
-} from '@activepieces/pieces-common';
-import dayjs from 'dayjs';
-import { JiraAuth, jiraCloudAuth } from '../../auth';
-import { searchIssuesByJql } from '../common';
+import { jiraCloudAuth } from '../../auth';
+import { JiraPollingItem, JiraPollingProps, createJiraPolling } from '../common/polling';
 import { getUsersDropdown } from '../common/props';
-
-type ChangelogItem = {
-  field: string;
-  fieldId?: string;
-  from: string | null;
-  fromString: string | null;
-  to: string | null;
-  toString: string | null;
-};
-
-type ChangelogHistory = {
-  id: string;
-  author?: { accountId: string; displayName: string; emailAddress?: string };
-  created: string;
-  items: ChangelogItem[];
-};
+import { ChangelogHistory } from '../common/types';
 
 type IssueWithChangelog = {
   id: string;
@@ -36,57 +16,46 @@ type IssueWithChangelog = {
   changelog?: { histories: ChangelogHistory[] };
 };
 
-const polling: Polling<
-  JiraAuth,
-  {
-    assignee?: string;
-    assignedToMe?: boolean;
-    jql?: string;
-    sanitizeJql?: boolean;
-  }
-> = {
-  strategy: DedupeStrategy.TIMEBASED,
-  items: async ({ auth, lastFetchEpochMS, propsValue }) => {
-    const { assignee, assignedToMe, jql, sanitizeJql } = propsValue;
+type IssueAssignedProps = JiraPollingProps & {
+  assignee?: string;
+  assignedToMe?: boolean;
+};
 
-    const targetClause = assignedToMe
+const polling = createJiraPolling<IssueAssignedProps>({
+  expand: ['changelog'],
+  extraScope: ({ propsValue, since }) => {
+    const target = propsValue.assignedToMe
       ? 'TO currentUser()'
-      : assignee
-      ? `TO "${assignee}"`
+      : propsValue.assignee
+      ? `TO "${propsValue.assignee}"`
       : '';
+    return ['assignee CHANGED', target, isNil(since) ? '' : `AFTER '${since}'`]
+      .filter((part) => part.length > 0)
+      .join(' ');
+  },
+  extractItems: ({
+    issue,
+    propsValue,
+  }: {
+    issue: IssueWithChangelog;
+    propsValue: IssueAssignedProps;
+  }): JiraPollingItem[] => {
+    const targetAccountId = propsValue.assignedToMe ? undefined : propsValue.assignee;
+    return (issue.changelog?.histories ?? []).flatMap((history) => {
+      const assigneeChange = history.items.find(
+        (item) => item.field === 'assignee' || item.fieldId === 'assignee'
+      );
+      if (isNil(assigneeChange)) {
+        return [];
+      }
+      if (targetAccountId && assigneeChange.to !== targetAccountId) {
+        return [];
+      }
 
-    const since = dayjs(lastFetchEpochMS).format('YYYY-MM-DD HH:mm');
-    const userScope = jql ? `(${jql}) AND ` : '';
-    const searchQuery =
-      `${userScope}assignee CHANGED ${targetClause} AFTER '${since}'`.trim();
-
-    const response = await searchIssuesByJql({
-      auth,
-      jql: searchQuery,
-      maxResults: 50,
-      sanitizeJql: sanitizeJql ?? false,
-      expand: ['changelog'],
-    });
-
-    const issues = response.issues as IssueWithChangelog[];
-    const targetAccountId = assignedToMe ? undefined : assignee;
-    const results: Array<{ epochMilliSeconds: number; data: unknown }> = [];
-
-    for (const issue of issues) {
-      const histories = issue.changelog?.histories ?? [];
-      for (const history of histories) {
-        const changedMS = Date.parse(history.created);
-        if (Number.isNaN(changedMS) || changedMS <= lastFetchEpochMS) continue;
-
-        const assigneeChange = history.items.find(
-          (item) => item.field === 'assignee' || item.fieldId === 'assignee'
-        );
-        if (!assigneeChange) continue;
-
-        if (targetAccountId && assigneeChange.to !== targetAccountId) continue;
-
-        results.push({
-          epochMilliSeconds: changedMS,
+      return [
+        {
+          id: history.id,
+          epochMilliSeconds: Date.parse(history.created),
           data: {
             issue: {
               id: issue.id,
@@ -106,13 +75,11 @@ const polling: Polling<
               at: history.created,
             },
           },
-        });
-      }
-    }
-
-    return results;
+        },
+      ];
+    });
   },
-};
+});
 
 export const issueAssigned = createTrigger({
   name: 'issue_assigned',
@@ -342,15 +309,15 @@ Not sure what to write? Open Jira → Filters → Advanced search, build a filte
     },
   },
   async onEnable(context) {
-    await pollingHelper.onEnable(polling, context);
+    await polling.onEnable({ context });
   },
-  async onDisable(context) {
-    await pollingHelper.onDisable(polling, context);
+  async onDisable() {
+    return;
   },
   async run(context) {
-    return await pollingHelper.poll(polling, context);
+    return await polling.poll({ context });
   },
   async test(context) {
-    return await pollingHelper.test(polling, context);
+    return await polling.test({ context });
   },
 });

--- a/packages/pieces/community/jira-cloud/src/lib/triggers/new-attachment.ts
+++ b/packages/pieces/community/jira-cloud/src/lib/triggers/new-attachment.ts
@@ -2,15 +2,11 @@ import {
   Property,
   TriggerStrategy,
   createTrigger,
+  isNil,
 } from '@activepieces/pieces-framework';
-import {
-  DedupeStrategy,
-  Polling,
-  pollingHelper,
-} from '@activepieces/pieces-common';
-import dayjs from 'dayjs';
-import { JiraAuth, jiraCloudAuth } from '../../auth';
-import { searchIssuesByJql } from '../common';
+import { jiraCloudAuth } from '../../auth';
+import { JiraPollingItem, createJiraPolling } from '../common/polling';
+import { ChangelogHistory } from '../common/types';
 
 type JiraAttachment = {
   id: string;
@@ -23,22 +19,6 @@ type JiraAttachment = {
   author?: { accountId: string; displayName: string; emailAddress?: string };
 };
 
-type ChangelogItem = {
-  field: string;
-  fieldId?: string;
-  from: string | null;
-  fromString: string | null;
-  to: string | null;
-  toString: string | null;
-};
-
-type ChangelogHistory = {
-  id: string;
-  author?: { accountId: string; displayName: string; emailAddress?: string };
-  created: string;
-  items: ChangelogItem[];
-};
-
 type IssueWithAttachments = {
   id: string;
   key: string;
@@ -49,71 +29,45 @@ type IssueWithAttachments = {
   changelog?: { histories: ChangelogHistory[] };
 };
 
-const polling: Polling<JiraAuth, { jql?: string; sanitizeJql?: boolean }> = {
-  strategy: DedupeStrategy.TIMEBASED,
-  items: async ({ auth, lastFetchEpochMS, propsValue }) => {
-    const { jql, sanitizeJql } = propsValue;
+const polling = createJiraPolling({
+  fields: ['summary', 'attachment'],
+  expand: ['changelog'],
+  extractItems: ({ issue }: { issue: IssueWithAttachments }): JiraPollingItem[] => {
+    const attachmentsById = new Map(
+      (issue.fields.attachment ?? []).map((attachment) => [attachment.id, attachment])
+    );
 
-    const since = dayjs(lastFetchEpochMS).format('YYYY-MM-DD HH:mm');
-    const userScope = jql ? `(${jql}) AND ` : '';
-    const searchQuery = `${userScope}updated > '${since}'`;
+    return (issue.changelog?.histories ?? []).flatMap((history) =>
+      history.items.flatMap((item): JiraPollingItem[] => {
+        const isAttachment =
+          item.field === 'Attachment' || item.fieldId === 'attachment';
+        if (!isAttachment || isNil(item.to)) {
+          return [];
+        }
 
-    const response = await searchIssuesByJql({
-      auth,
-      jql: searchQuery,
-      maxResults: 50,
-      sanitizeJql: sanitizeJql ?? false,
-      fields: ['summary', 'attachment'],
-      expand: ['changelog'],
-    });
-
-    const issues = response.issues as IssueWithAttachments[];
-    const results: Array<{ epochMilliSeconds: number; data: unknown }> = [];
-
-    for (const issue of issues) {
-      const attachmentsById = new Map<string, JiraAttachment>();
-      for (const attachment of issue.fields.attachment ?? []) {
-        attachmentsById.set(attachment.id, attachment);
-      }
-
-      const histories = issue.changelog?.histories ?? [];
-      for (const history of histories) {
-        const changedMS = Date.parse(history.created);
-        if (Number.isNaN(changedMS) || changedMS <= lastFetchEpochMS) continue;
-
-        for (const item of history.items) {
-          const isAttachment =
-            item.field === 'Attachment' || item.fieldId === 'attachment';
-          const wasAdded = item.to !== null && item.to !== undefined;
-          if (!isAttachment || !wasAdded) continue;
-
-          const attachmentDetails = item.to
-            ? attachmentsById.get(item.to)
-            : undefined;
-
-          results.push({
-            epochMilliSeconds: changedMS,
+        return [
+          {
+            id: item.to,
+            epochMilliSeconds: Date.parse(history.created),
             data: {
               issue: {
                 id: issue.id,
                 key: issue.key,
                 summary: issue.fields.summary,
               },
-              attachment: attachmentDetails ?? {
+              attachment: attachmentsById.get(item.to) ?? {
                 id: item.to,
                 filename: item.toString,
               },
               addedBy: history.author,
               addedAt: history.created,
             },
-          });
-        }
-      }
-    }
-
-    return results;
+          },
+        ];
+      }),
+    );
   },
-};
+});
 
 export const newAttachment = createTrigger({
   name: 'new_attachment',
@@ -206,15 +160,15 @@ Not sure what to write? Open Jira → Filters → Advanced search, build a filte
     addedAt: '2026-04-23T14:31:39.121+0530',
   },
   async onEnable(context) {
-    await pollingHelper.onEnable(polling, context);
+    await polling.onEnable({ context });
   },
-  async onDisable(context) {
-    await pollingHelper.onDisable(polling, context);
+  async onDisable() {
+    return;
   },
   async run(context) {
-    return await pollingHelper.poll(polling, context);
+    return await polling.poll({ context });
   },
   async test(context) {
-    return await pollingHelper.test(polling, context);
+    return await polling.test({ context });
   },
 });

--- a/packages/pieces/community/jira-cloud/src/lib/triggers/new-comment.ts
+++ b/packages/pieces/community/jira-cloud/src/lib/triggers/new-comment.ts
@@ -3,14 +3,8 @@ import {
 	TriggerStrategy,
 	createTrigger,
 } from '@activepieces/pieces-framework';
-import {
-	DedupeStrategy,
-	Polling,
-	pollingHelper,
-} from '@activepieces/pieces-common';
-import dayjs from 'dayjs';
-import { JiraAuth, jiraCloudAuth } from '../../auth';
-import { searchIssuesByJql } from '../common';
+import { jiraCloudAuth } from '../../auth';
+import { JiraPollingItem, createJiraPolling } from '../common/polling';
 
 type JiraComment = {
 	id: string;
@@ -36,48 +30,22 @@ type IssueWithComments = {
 	};
 };
 
-const polling: Polling<JiraAuth, { jql?: string; sanitizeJql?: boolean }> = {
-	strategy: DedupeStrategy.TIMEBASED,
-	items: async ({ auth, lastFetchEpochMS, propsValue }) => {
-		const { jql, sanitizeJql } = propsValue;
-
-		const searchQuery = `${jql ? jql + ' AND ' : ''}updated > '${dayjs(
-			lastFetchEpochMS,
-		).format('YYYY-MM-DD HH:mm')}'`;
-
-		const searchResponse = await searchIssuesByJql({
-			auth,
-			jql: searchQuery,
-			maxResults: 50,
-			sanitizeJql: sanitizeJql ?? false,
-			fields: ['summary', 'comment'],
-		});
-
-		const issues = searchResponse.issues as IssueWithComments[];
-		const results: Array<{ epochMilliSeconds: number; data: unknown }> = [];
-
-		for (const issue of issues) {
-			const comments = issue.fields?.comment?.comments ?? [];
-			for (const comment of comments) {
-				const createdMS = Date.parse(comment.created);
-				if (Number.isNaN(createdMS) || createdMS <= lastFetchEpochMS) continue;
-				results.push({
-					epochMilliSeconds: createdMS,
-					data: {
-						issue: {
-							id: issue.id,
-							key: issue.key,
-							summary: issue.fields?.summary,
-						},
-						comment,
-					},
-				});
-			}
-		}
-
-		return results;
-	},
-};
+const polling = createJiraPolling({
+	fields: ['summary', 'comment'],
+	extractItems: ({ issue }: { issue: IssueWithComments }): JiraPollingItem[] =>
+		(issue.fields?.comment?.comments ?? []).map((comment) => ({
+			id: comment.id,
+			epochMilliSeconds: Date.parse(comment.created),
+			data: {
+				issue: {
+					id: issue.id,
+					key: issue.key,
+					summary: issue.fields?.summary,
+				},
+				comment,
+			},
+		})),
+});
 
 export const newComment = createTrigger({
 	name: 'new_comment',
@@ -116,15 +84,15 @@ Not sure what to write? Open Jira → Filters → Advanced search, build the fil
 	},
 	sampleData: {},
 	async onEnable(context) {
-		await pollingHelper.onEnable(polling, context);
+		await polling.onEnable({ context });
 	},
-	async onDisable(context) {
-		await pollingHelper.onDisable(polling, context);
+	async onDisable() {
+		return;
 	},
 	async run(context) {
-		return await pollingHelper.poll(polling, context);
+		return await polling.poll({ context });
 	},
 	async test(context) {
-		return await pollingHelper.test(polling, context);
+		return await polling.test({ context });
 	},
 });

--- a/packages/pieces/community/jira-cloud/src/lib/triggers/new-issue.ts
+++ b/packages/pieces/community/jira-cloud/src/lib/triggers/new-issue.ts
@@ -3,37 +3,10 @@ import {
   TriggerStrategy,
   createTrigger,
 } from '@activepieces/pieces-framework';
-import {
-  Polling,
-  DedupeStrategy,
-  pollingHelper,
-} from '@activepieces/pieces-common';
-import { JiraAuth, jiraCloudAuth } from '../../auth';
-import { searchIssuesByJql } from '../common';
-import dayjs from 'dayjs';
+import { jiraCloudAuth } from '../../auth';
+import { createJiraPolling } from '../common/polling';
 
-const polling: Polling<
-  JiraAuth,
-  { jql?: string; sanitizeJql?: boolean }
-> = {
-  strategy: DedupeStrategy.TIMEBASED,
-  items: async ({ auth, lastFetchEpochMS, propsValue }) => {
-    const { jql, sanitizeJql } = propsValue;
-    const searchQuery = `${jql ? jql + ' AND ' : ''}created > '${dayjs(
-      lastFetchEpochMS
-    ).format('YYYY-MM-DD HH:mm')}'`;
-    const response = await searchIssuesByJql({
-      auth,
-      jql: searchQuery,
-      maxResults: 50,
-      sanitizeJql: sanitizeJql ?? false,
-    });
-    return response.issues.map((issue: any) => ({
-      epochMilliSeconds: Date.parse(issue.fields.created),
-      data: issue,
-    }));
-  },
-};
+const polling = createJiraPolling({ timeField: 'created' });
 
 export const newIssue = createTrigger({
   name: 'new_issue',
@@ -59,15 +32,15 @@ export const newIssue = createTrigger({
   },
   sampleData: {},
   async onEnable(context) {
-    await pollingHelper.onEnable(polling, context);
+    await polling.onEnable({ context });
   },
-  async onDisable(context) {
-    await pollingHelper.onDisable(polling, context);
+  async onDisable() {
+    return;
   },
   async run(context) {
-    return await pollingHelper.poll(polling, context);
+    return await polling.poll({ context });
   },
   async test(context) {
-    return await pollingHelper.test(polling, context);
+    return await polling.test({ context });
   },
 });

--- a/packages/pieces/community/jira-cloud/src/lib/triggers/updated-issue-status.ts
+++ b/packages/pieces/community/jira-cloud/src/lib/triggers/updated-issue-status.ts
@@ -3,37 +3,10 @@ import {
   TriggerStrategy,
   createTrigger,
 } from '@activepieces/pieces-framework';
-import {
-  Polling,
-  DedupeStrategy,
-  pollingHelper,
-} from '@activepieces/pieces-common';
-import { JiraAuth, jiraCloudAuth } from '../../auth';
-import { searchIssuesByJql } from '../common';
-import dayjs from 'dayjs';
+import { jiraCloudAuth } from '../../auth';
+import { createJiraPolling } from '../common/polling';
 
-const polling: Polling<
-  JiraAuth,
-  { jql?: string; sanitizeJql?: boolean }
-> = {
-  strategy: DedupeStrategy.TIMEBASED,
-  items: async ({ auth, lastFetchEpochMS, propsValue }) => {
-    const { jql, sanitizeJql } = propsValue;
-    const searchQuery = `${jql ? jql + ' AND ' : ''}updated > '${dayjs(
-      lastFetchEpochMS
-    ).format('YYYY-MM-DD HH:mm')}'`;
-    const response = await searchIssuesByJql({
-      auth,
-      jql: searchQuery,
-      maxResults: 50,
-      sanitizeJql: sanitizeJql ?? false,
-    });
-    return response.issues.map((issue: any) => ({
-      epochMilliSeconds: Date.parse(issue.fields.statuscategorychangedate),
-      data: issue,
-    }));
-  },
-};
+const polling = createJiraPolling({ epochField: 'statuscategorychangedate' });
 
 export const updatedIssueStatus = createTrigger({
   name: 'updated_issue_status',
@@ -59,15 +32,15 @@ export const updatedIssueStatus = createTrigger({
   },
   sampleData: {},
   async onEnable(context) {
-    await pollingHelper.onEnable(polling, context);
+    await polling.onEnable({ context });
   },
-  async onDisable(context) {
-    await pollingHelper.onDisable(polling, context);
+  async onDisable() {
+    return;
   },
   async run(context) {
-    return await pollingHelper.poll(polling, context);
+    return await polling.poll({ context });
   },
   async test(context) {
-    return await pollingHelper.test(polling, context);
+    return await polling.test({ context });
   },
 });

--- a/packages/pieces/community/jira-cloud/src/lib/triggers/updated-issue.ts
+++ b/packages/pieces/community/jira-cloud/src/lib/triggers/updated-issue.ts
@@ -4,7 +4,9 @@ import {
   createTrigger,
 } from '@activepieces/pieces-framework';
 import { jiraCloudAuth } from '../../auth';
-import { jiraPolling } from '../common/polling';
+import { createJiraPolling } from '../common/polling';
+
+const polling = createJiraPolling();
 
 export const updatedIssue = createTrigger({
   name: 'updated_issue',
@@ -30,15 +32,15 @@ export const updatedIssue = createTrigger({
   },
   sampleData: {},
   async onEnable(context) {
-    await jiraPolling.onEnable({ context });
+    await polling.onEnable({ context });
   },
   async onDisable() {
     return;
   },
   async run(context) {
-    return await jiraPolling.poll({ context });
+    return await polling.poll({ context });
   },
   async test(context) {
-    return await jiraPolling.test({ context });
+    return await polling.test({ context });
   },
 });


### PR DESCRIPTION
Fixes [GIT-1807](https://linear.app/activepieces/issue/GIT-1807)
Closes #15069

## Description

## Problem

1. PR #14921 fixed the `DedupeStrategy.TIMEBASED` watermark loss for `updated_issue` only; its Scope section deferred the other five JQL triggers. New customer report 2026-08-26: `new_issue` never fired for a newly created issue.
2. Mechanism (same as #14921): one watermark advances to the max epoch of whatever a single eventually-consistent `/search/jql` fetch returned; anything absent from that fetch is excluded from every later window and fails the `> watermark` filter. Lost silently, permanently.
3. Same secondary defects in all five: wall-clock JQL timestamp parsed in Jira's profile TZ (behind-UTC profiles never fire), one unordered page of 50, no pagination, no `_dedupe_key`.

## Fix

* `common/polling.ts` — the #14921 helper generalized into `createJiraPolling({ timeField, epochField, fields, expand, extraScope, extractItems })`; the helper owns the lookback window, ledger dedupe, key composition (`id:epoch`), non-finite-epoch filtering, pagination resume, and merges `timeField`/`epochField` into any `fields` restriction so the truncation watermark always has its source field.
* `new-issue.ts` → `timeField: 'created'`; `updated-issue-status.ts` → `epochField: 'statuscategorychangedate'`; `new-comment.ts` / `issue-assigned.ts` / `new-attachment.ts` → per-entity `extractItems` keyed by comment id / changelog history id / attachment id. Props, trigger names, and payload shapes unchanged.
* `issue-assigned.ts` keeps its server-side `assignee CHANGED ... AFTER '<since>'` narrowing via `extraScope`.
* `updated-issue.ts` — mechanical rename onto the factory (`createJiraPolling()`), zero behavior change.
* Piece 0.3.11 → 0.3.12.

## How was this tested?

* Red-first regression harness against the **built** piece (`searchIssuesByJql` stubbed, JSON-round-trip store): on pre-fix code all five triggers drop the late-indexed events (`poll2 emitted []`); post-fix all 24 checks pass — late-index recovery, ledger dedupe on re-fetch, `test()` samples, `created`-window JQL for new_issue, `AFTER` bound for issue_assigned, time-field presence in restricted `fields`.
* `npx turbo run build lint --filter=@activepieces/piece-jira-cloud` clean; `npm run lint-dev` clean (33/33); `npm run test-unit` engine 474/474 after building the delay piece (pre-existing worktree setup quirk, unrelated).
* Visual: none - piece polling internals only; no prop, name, or payload changes.
* Other affected paths: checked - `updated_issue` already fixed (#14921); the same `DedupeStrategy.TIMEBASED` watermark pattern remains platform-wide in other pieces' polling triggers (out of scope here, tracked via [GIT-1740](https://linear.app/activepieces/issue/GIT-1740)'s class).
* Repro: eventual-consistency loss reproduced on all five pre-fix triggers via the stubbed-fetch harness — full steps in the Reproduction block.

<details>
<summary>Plan & reasoning</summary>

## Plan

* Reuse the reviewed #14921 engine rather than five self-contained copies: one factory with the smallest per-trigger seams (time field, epoch field, extra JQL scope, item extraction). Footprint estimate 7 files ~180 lines; actual 10 files +324/-375 (net -51).
* Hooks return `{ id, epochMilliSeconds, data }`; the helper composes ledger keys and drops unparsable epochs so dedupe semantics live in one place.
* `test()` fetches 50 issues (old behavior) and returns the 5 newest items, so sub-item triggers still show samples when the 5 most recent issues carry none.

## Non-happy scenarios considered

* Truncated fetch (>10 pages in one window) → resume at `max(timeField epoch) - 1`; `fields` restrictions are force-merged with the time field so the watermark can never parse NaN and wedge.
* Store-state cutover: `pollingHelper`'s `lastPoll` is not migrated — first poll after upgrade starts its window at `now`, identical to re-enabling (same position #14921 shipped and declared).
* Known limitation (inherent to the #14921 lookback design, accepted): sub-item events lagging more than the 15-min lookback (e.g. migration tools backdating `comment.created`), or lagging behind a truncation resume point, are not recovered; the old code lost events in the *common* path, this bounds loss to rare extremes.
* Pre-existing behavior preserved deliberately: `updated_issue_status` keys on `statuscategorychangedate` (category changes only); `assignedToMe` also emits reassignments away (JQL matches, changelog uncapped filter); Jira's embedded `expand=changelog` is capped (~100 entries) on very churned issues.

## Alternatives rejected

* Per-trigger copies of the #14921 logic — 5× the code, five dedupe ledgers to review and keep in sync.
* Fixing `DedupeStrategy.TIMEBASED` in `pieces-common` for every piece — platform-wide blast radius, contradicts #14921's piece-local approach.
* Dropping the `epochField` knob for a hand-written extractor in updated_issue_status — reintroduces the copied key-format drift three review passes flagged.

</details>

<details>
<summary>Reproduction</summary>

## Environment

Built `@activepieces/piece-jira-cloud` dist run in plain node; no server, DB, or live Jira. `searchIssuesByJql` monkey-patched at the module seam; store is in-memory with JSON round-trips (mirrors #14921's verification setup).

## Harness

Public gist: https://gist.github.com/majewskibartosz/806e22cb23dab259866998b12c271f89

```
git clone https://gist.github.com/806e22cb23dab259866998b12c271f89.git git-1807-repro
npx turbo run build --filter=@activepieces/piece-jira-cloud
node git-1807-repro/run-scenarios.js <repo>/packages/pieces/community/jira-cloud
```

## Trigger

Per trigger: enable, then poll 1 returns only item C (epoch T+3s) simulating index lag for A (T+1s) and B (T+2s); poll 2 returns A, B, C; poll 3 repeats the same fetch. The lag-then-appear shape is exactly the `/search/jql` eventual-consistency documented by Atlassian and diagnosed in GIT-1759.

## Results

* Pre-fix (`git stash`, rebuild): all five triggers emit `[]` on poll 2 — A and B lost permanently (the customer bug). 6 failures total.
* Post-fix: poll 2 emits exactly A and B, poll 3 emits nothing (ledger dedupe), `test()` returns samples, new_issue windows on `created ASC`, issue_assigned scopes `assignee CHANGED TO ... AFTER '-Nm'`, restricted `fields` always include `updated`. 24/24 pass.

</details>

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

No action required from self-hosters or API consumers. The per-trigger store key changes from `lastPoll` to `pollingState`; an already-enabled flow starts its window at `now` on the first poll after upgrade (no back-fill, no replay), the same behaviour as re-enabling the trigger — the exact position #14921 shipped for `updated_issue`.

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)
