### PR TITLE
fix(migrations): set breaking = false for some new non-breaking migra…

### DIFF
--- a/packages/server/api/src/app/database/migration/postgres/1830000000000-AddAiProviderScopes.ts
+++ b/packages/server/api/src/app/database/migration/postgres/1830000000000-AddAiProviderScopes.ts
@@ -13,7 +13,7 @@ import { Migration } from '../../migration'
 // key exists the old shape no longer fits the data, so the rollback is one-way.
 export class AddAiProviderScopes1830000000000 implements Migration {
     name = 'AddAiProviderScopes1830000000000'
-    breaking = true
+    breaking = false
     release = '0.88.3'
     transaction = false
 

--- a/packages/server/api/src/app/database/migration/postgres/1833000000000-ClearRoleFromCompanyPersonalization.ts
+++ b/packages/server/api/src/app/database/migration/postgres/1833000000000-ClearRoleFromCompanyPersonalization.ts
@@ -3,7 +3,7 @@ import { Migration } from '../../migration'
 
 export class ClearRoleFromCompanyPersonalization1833000000000 implements Migration {
     name = 'ClearRoleFromCompanyPersonalization1833000000000'
-    breaking = true
+    breaking = false
     release = '0.88.2'
     transaction = true
 

--- a/packages/server/api/src/app/database/migration/postgres/1836000000000-DropTeamsBotInstallation.ts
+++ b/packages/server/api/src/app/database/migration/postgres/1836000000000-DropTeamsBotInstallation.ts
@@ -3,7 +3,7 @@ import { Migration } from '../../migration'
 
 export class DropTeamsBotInstallation1836000000000 implements Migration {
     name = 'DropTeamsBotInstallation1836000000000'
-    breaking = true
+    breaking = false
     release = '0.88.4'
     transaction = true
 


### PR DESCRIPTION


### Breaking change?  (required — CI fails if this is left unedited)

<!-- Tick exactly one box. If either "yes", apply the "⛓️‍💥 breaking-change" label AND add an entry to docs/install/reference/breaking-changes.mdx (what changed + the action self-hosters must take). -->

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

<!-- Tick exactly one box. "Security-sensitive" = touches authentication, secrets, permissions/roles, cryptography, SSRF / outbound HTTP, or file handling. -->

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)
