### PR TITLE
feat(flows): audit piece upgrades and add admin revert endpoint

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "activepieces",
@@ -162,7 +161,7 @@
     },
     "packages/core/shared": {
       "name": "@activepieces/shared",
-      "version": "0.143.0",
+      "version": "0.144.0",
       "dependencies": {
         "@activepieces/core-execution": "workspace:*",
         "@activepieces/core-formula": "workspace:*",

--- a/packages/core/shared/package.json
+++ b/packages/core/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/shared",
-  "version": "0.143.0",
+  "version": "0.144.0",
   "type": "commonjs",
   "sideEffects": false,
   "main": "./dist/src/index.js",

--- a/packages/core/shared/src/lib/ee/audit-events/index.ts
+++ b/packages/core/shared/src/lib/ee/audit-events/index.ts
@@ -22,6 +22,8 @@ export enum ApplicationEventName {
     FLOW_CREATED = 'flow.created',
     FLOW_DELETED = 'flow.deleted',
     FLOW_UPDATED = 'flow.updated',
+    FLOW_PIECES_UPGRADED = 'flow.pieces.upgraded',
+    FLOW_PIECES_REVERTED = 'flow.pieces.reverted',
     FLOW_PUBLISHED = 'flow.published',
     FLOW_ACTIVATED = 'flow.activated',
     FLOW_DEACTIVATED = 'flow.deactivated',
@@ -319,6 +321,41 @@ export const FlowUpdatedEvent = z.object({
 
 export type FlowUpdatedEvent = z.infer<typeof FlowUpdatedEvent>
 
+export const FlowPiecesUpgradedEvent = z.object({
+    ...BaseAuditEventProps,
+    action: z.literal(ApplicationEventName.FLOW_PIECES_UPGRADED),
+    data: z.object({
+        flowId: z.string(),
+        flowVersionId: z.string(),
+        steps: z.array(z.object({
+            stepName: z.string(),
+            actionOrTriggerName: z.string(),
+            decision: z.enum(['UPGRADED', 'KEPT']),
+            prevVersion: z.string(),
+            newVersion: Nullable(z.string()),
+        })),
+    }),
+})
+
+export type FlowPiecesUpgradedEvent = z.infer<typeof FlowPiecesUpgradedEvent>
+
+export const FlowPiecesRevertedEvent = z.object({
+    ...BaseAuditEventProps,
+    action: z.literal(ApplicationEventName.FLOW_PIECES_REVERTED),
+    data: z.object({
+        flowId: z.string(),
+        flowVersionId: z.string(),
+        steps: z.array(z.object({
+            stepName: z.string(),
+            actionOrTriggerName: z.string(),
+            prevVersion: z.string(),
+            newVersion: z.string(),
+        })),
+    }),
+})
+
+export type FlowPiecesRevertedEvent = z.infer<typeof FlowPiecesRevertedEvent>
+
 const FlowLifecycleEventData = z.object({
     flow: Flow.pick({ id: true, externalId: true, created: true, updated: true }),
     flowVersion: FlowVersion.pick({
@@ -511,6 +548,8 @@ export const ApplicationEvent = z.union([
     FlowCreatedEvent,
     FlowDeletedEvent,
     FlowUpdatedEvent,
+    FlowPiecesUpgradedEvent,
+    FlowPiecesRevertedEvent,
     FlowPublishedEvent,
     FlowActivatedEvent,
     FlowDeactivatedEvent,
@@ -544,6 +583,13 @@ export function summarizeApplicationEvent(event: ApplicationEvent) {
         }
         case ApplicationEventName.FLOW_CREATED:
             return `Flow ${event.data.flow.id} is created`
+        case ApplicationEventName.FLOW_PIECES_UPGRADED: {
+            const upgradedCount = event.data.steps.filter((step) => step.decision === 'UPGRADED').length
+            const keptCount = event.data.steps.length - upgradedCount
+            return `Flow ${event.data.flowId} piece versions upgraded (${upgradedCount} upgraded, ${keptCount} kept)`
+        }
+        case ApplicationEventName.FLOW_PIECES_REVERTED:
+            return `Flow ${event.data.flowId} piece versions reverted (${event.data.steps.length} steps)`
         case ApplicationEventName.FLOW_DELETED:
             return `Flow ${event.data.flow.id} (${event.data.flowVersion.displayName}) is deleted`
         case ApplicationEventName.FLOW_PUBLISHED:

--- a/packages/core/shared/src/lib/ee/audit-events/mock-event-builder.ts
+++ b/packages/core/shared/src/lib/ee/audit-events/mock-event-builder.ts
@@ -10,6 +10,8 @@ import {
     FlowCreatedEvent,
     FlowDeactivatedEvent,
     FlowDeletedEvent,
+    FlowPiecesRevertedEvent,
+    FlowPiecesUpgradedEvent,
     FlowPublishedEvent,
     FlowRunEvent,
     FlowUpdatedEvent,
@@ -79,6 +81,35 @@ export const buildMockEvent = ({ event, platformId, projectId }: BuildMockEventP
                 ...baseEnvelope,
                 action: ApplicationEventName.FLOW_CREATED,
                 data: { flow, project },
+            }
+            return mock
+        }
+        case ApplicationEventName.FLOW_PIECES_UPGRADED: {
+            const mock: FlowPiecesUpgradedEvent = {
+                ...baseEnvelope,
+                action: ApplicationEventName.FLOW_PIECES_UPGRADED,
+                data: {
+                    flowId: flow.id,
+                    flowVersionId: flowVersion.id,
+                    steps: [
+                        { stepName: 'step_1', actionOrTriggerName: 'send_email', decision: 'UPGRADED', prevVersion: '0.1.0', newVersion: '0.2.0' },
+                        { stepName: 'step_2', actionOrTriggerName: 'delete_row', decision: 'KEPT', prevVersion: '0.1.0', newVersion: null },
+                    ],
+                },
+            }
+            return mock
+        }
+        case ApplicationEventName.FLOW_PIECES_REVERTED: {
+            const mock: FlowPiecesRevertedEvent = {
+                ...baseEnvelope,
+                action: ApplicationEventName.FLOW_PIECES_REVERTED,
+                data: {
+                    flowId: flow.id,
+                    flowVersionId: flowVersion.id,
+                    steps: [
+                        { stepName: 'step_1', actionOrTriggerName: 'send_email', prevVersion: '0.2.0', newVersion: '0.1.0' },
+                    ],
+                },
             }
             return mock
         }

--- a/packages/server/api/src/app/app.ts
+++ b/packages/server/api/src/app/app.ts
@@ -1,7 +1,7 @@
 import { isNil, spreadIfDefined } from '@activepieces/core-utils'
 import { PieceMetadata } from '@activepieces/pieces-framework'
 import { apVersionUtil, onCallService, UNKNOWN_VERSION, wideEvent } from '@activepieces/server-utils'
-import { AddAllowedEmbedOriginsRequestBody, ApEdition, ApEnvironment, AppConnectionWithoutSensitiveData, ApplicationEventName, ConnectionDeletedEvent, ConnectionUpsertedEvent, Flow, FlowActivatedEvent, FlowCreatedEvent, FlowDeactivatedEvent, FlowDeletedEvent, FlowPublishedEvent, FlowRun, FlowRunFinishedEvent, FlowRunRetriedEvent, FlowRunStartedEvent, FlowUpdatedEvent, Folder, FolderCreatedEvent, FolderDeletedEvent, FolderUpdatedEvent, GitRepoWithoutSensitiveData, ProjectMember, ProjectRelease, ProjectReleaseEvent, ProjectRoleEvent, ProjectWithLimits, SigningKeyEvent, SignUpEvent, Template, UserEmailVerifiedEvent, UserInvitation, UserPasswordResetEvent, UserSignedInEvent, UserWithMetaInformation } from '@activepieces/shared'
+import { AddAllowedEmbedOriginsRequestBody, ApEdition, ApEnvironment, AppConnectionWithoutSensitiveData, ApplicationEventName, ConnectionDeletedEvent, ConnectionUpsertedEvent, Flow, FlowActivatedEvent, FlowCreatedEvent, FlowDeactivatedEvent, FlowDeletedEvent, FlowPiecesRevertedEvent, FlowPiecesUpgradedEvent, FlowPublishedEvent, FlowRun, FlowRunFinishedEvent, FlowRunRetriedEvent, FlowRunStartedEvent, FlowUpdatedEvent, Folder, FolderCreatedEvent, FolderDeletedEvent, FolderUpdatedEvent, GitRepoWithoutSensitiveData, ProjectMember, ProjectRelease, ProjectReleaseEvent, ProjectRoleEvent, ProjectWithLimits, SigningKeyEvent, SignUpEvent, Template, UserEmailVerifiedEvent, UserInvitation, UserPasswordResetEvent, UserSignedInEvent, UserWithMetaInformation } from '@activepieces/shared'
 import replyFrom from '@fastify/reply-from'
 import swagger from '@fastify/swagger'
 import { createAdapter } from '@socket.io/redis-adapter'
@@ -483,6 +483,8 @@ function extractProjectId(principal: { projectId?: string } | null | undefined):
 function registerOpenApiSchemas() {
     globalRegistry.add(FlowCreatedEvent, { id: ApplicationEventName.FLOW_CREATED })
     globalRegistry.add(FlowUpdatedEvent, { id: ApplicationEventName.FLOW_UPDATED })
+    globalRegistry.add(FlowPiecesUpgradedEvent, { id: ApplicationEventName.FLOW_PIECES_UPGRADED })
+    globalRegistry.add(FlowPiecesRevertedEvent, { id: ApplicationEventName.FLOW_PIECES_REVERTED })
     globalRegistry.add(FlowDeletedEvent, { id: ApplicationEventName.FLOW_DELETED })
     globalRegistry.add(FlowPublishedEvent, { id: ApplicationEventName.FLOW_PUBLISHED })
     globalRegistry.add(FlowActivatedEvent, { id: ApplicationEventName.FLOW_ACTIVATED })

--- a/packages/server/api/src/app/flows/flow-version/piece-upgrade.module.ts
+++ b/packages/server/api/src/app/flows/flow-version/piece-upgrade.module.ts
@@ -17,6 +17,10 @@ const pieceUpgradeController: FastifyPluginAsyncZod = async (app) => {
     app.post('/upgrade-pieces', UpgradeFlowPiecesRequest, async (req) => {
         return pieceUpgradeService(req.log).upgradeFlows(req.body)
     })
+
+    app.post('/revert-upgrade', RevertFlowPiecesRequest, async (req) => {
+        return pieceUpgradeService(req.log).revertFlows(req.body)
+    })
 }
 
 async function checkAdminApiKeyPreHandler(req: FastifyRequest, res: FastifyReply): Promise<void> {
@@ -33,6 +37,17 @@ const UpgradeFlowPiecesRequest = {
         body: z.object({
             flowIds: z.array(z.string()).min(1),
             projectId: z.string().optional(),
+        }),
+    },
+    config: {
+        security: securityAccess.public(),
+    },
+}
+
+const RevertFlowPiecesRequest = {
+    schema: {
+        body: z.object({
+            flowIds: z.array(z.string()).min(1),
         }),
     },
     config: {

--- a/packages/server/api/src/app/flows/flow-version/piece-upgrade.service.ts
+++ b/packages/server/api/src/app/flows/flow-version/piece-upgrade.service.ts
@@ -1,6 +1,10 @@
 import { isNil, spreadIfDefined, unique } from '@activepieces/core-utils'
-import { FlowAction, FlowActionType, flowStructureUtil, FlowTrigger, FlowTriggerType, FlowVersion } from '@activepieces/shared'
+import { ApplicationEventName, Flow, FlowAction, FlowActionType, FlowPiecesUpgradedEvent, flowStructureUtil, FlowTrigger, FlowTriggerType, FlowVersion } from '@activepieces/shared'
 import { FastifyBaseLogger } from 'fastify'
+import { repoFactory } from '../../core/db/repo-factory'
+import { AuditEventEntity } from '../../ee/audit-logs/audit-event-entity'
+import { applicationEvents } from '../../helper/application-events'
+import { projectService } from '../../project/project-service'
 import { flowRepo } from '../flow/flow.repo'
 import { flowVersionRepo } from './flow-version.service'
 import { pieceUpgradeRegister } from './piece-upgrade-register'
@@ -9,7 +13,107 @@ export const pieceUpgradeService = (log: FastifyBaseLogger) => ({
     async upgradeFlows({ flowIds, projectId }: UpgradeFlowsParams): Promise<FlowPieceUpgradeResult[]> {
         return Promise.all(unique(flowIds).map((flowId) => upgradeFlow({ flowId, projectId, log })))
     },
+    async revertFlows({ flowIds }: RevertFlowsParams): Promise<FlowPieceUpgradeResult[]> {
+        return Promise.all(unique(flowIds).map((flowId) => revertFlow({ flowId, log })))
+    },
 })
+
+const auditEventRepo = repoFactory(AuditEventEntity)
+
+async function revertFlow({ flowId, log }: RevertFlowParams): Promise<FlowPieceUpgradeResult> {
+    const flow = await flowRepo().findOneBy({ id: flowId })
+    if (isNil(flow)) {
+        return { flowId, found: false, upgradedSteps: [] }
+    }
+    const platformId = await projectService(log).getPlatformId(flow.projectId)
+    const events = await auditEventRepo().createQueryBuilder('event')
+        .where('event.platformId = :platformId', { platformId })
+        .andWhere('event.action = :action', { action: ApplicationEventName.FLOW_PIECES_UPGRADED })
+        .andWhere('event.data->>\'flowId\' = :flowId', { flowId })
+        .orderBy('event.created', 'DESC')
+        .getMany()
+    const upgradeEvents = events.map((event) => FlowPiecesUpgradedEvent.shape.data.parse(event.data))
+    if (upgradeEvents.length === 0) {
+        return { flowId, found: false, upgradedSteps: [] }
+    }
+
+    const revertsByVersion = new Map<string, Map<string, StepRevert>>()
+    for (const eventData of upgradeEvents) {
+        const versionReverts = revertsByVersion.get(eventData.flowVersionId) ?? new Map<string, StepRevert>()
+        for (const step of eventData.steps) {
+            if (step.decision === 'UPGRADED' && !isNil(step.newVersion) && !versionReverts.has(step.stepName)) {
+                versionReverts.set(step.stepName, { prevVersion: step.prevVersion, newVersion: step.newVersion })
+            }
+        }
+        revertsByVersion.set(eventData.flowVersionId, versionReverts)
+    }
+
+    const revertedSteps: UpgradedStep[] = []
+    for (const [flowVersionId, versionReverts] of revertsByVersion) {
+        const flowVersion = await flowVersionRepo().findOneBy({ id: flowVersionId, flowId })
+        if (isNil(flowVersion)) {
+            continue
+        }
+        revertedSteps.push(...await revertFlowVersion({ flow, platformId, flowVersion, versionReverts, log }))
+    }
+    return { flowId, found: true, upgradedSteps: revertedSteps }
+}
+
+async function revertFlowVersion({ flow, platformId, flowVersion, versionReverts, log }: RevertFlowVersionParams): Promise<UpgradedStep[]> {
+    const steps = flowStructureUtil.getAllSteps(flowVersion.trigger)
+    const applied = steps.flatMap((step) => {
+        if (step.type !== FlowActionType.PIECE && step.type !== FlowTriggerType.PIECE) {
+            return []
+        }
+        const revert = versionReverts.get(step.name)
+        const usedStepName = getUsedStepName(step)
+        if (isNil(revert) || isNil(usedStepName) || step.settings.pieceVersion !== revert.newVersion) {
+            return []
+        }
+        return [{
+            flowVersionId: flowVersion.id,
+            stepName: step.name,
+            pieceName: step.settings.pieceName,
+            actionOrTriggerName: usedStepName,
+            fromVersion: revert.newVersion,
+            toVersion: revert.prevVersion,
+        }]
+    })
+    if (applied.length === 0) {
+        return []
+    }
+    const stepNameToPrevVersion = Object.fromEntries(applied.map((step) => [step.stepName, step.toVersion]))
+    const newFlowVersion = flowStructureUtil.transferFlow(flowVersion, (step) => {
+        const prevVersion = stepNameToPrevVersion[step.name]
+        if (isNil(prevVersion)) {
+            return step
+        }
+        return {
+            ...step,
+            settings: {
+                ...step.settings,
+                pieceVersion: prevVersion,
+            },
+        }
+    })
+    await flowVersionRepo().update(flowVersion.id, { trigger: newFlowVersion.trigger })
+
+    applicationEvents(log).sendUserEvent({ platformId, projectId: flow.projectId }, {
+        action: ApplicationEventName.FLOW_PIECES_REVERTED,
+        data: {
+            flowId: flow.id,
+            flowVersionId: flowVersion.id,
+            steps: applied.map((step) => ({
+                stepName: step.stepName,
+                actionOrTriggerName: step.actionOrTriggerName,
+                prevVersion: step.fromVersion,
+                newVersion: step.toVersion,
+            })),
+        },
+    })
+
+    return applied.map(({ actionOrTriggerName: _actionOrTriggerName, ...upgradedStep }) => upgradedStep)
+}
 
 async function upgradeFlow({ flowId, projectId, log }: UpgradeFlowParams): Promise<FlowPieceUpgradeResult> {
     const flow = await flowRepo().findOneBy({ id: flowId, ...spreadIfDefined('projectId', projectId) })
@@ -26,50 +130,74 @@ async function upgradeFlow({ flowId, projectId, log }: UpgradeFlowParams): Promi
         if (isNil(version)) {
             continue
         }
-        upgradedSteps.push(...await upgradeFlowVersion({ flowVersion: version, log }))
+        upgradedSteps.push(...await upgradeFlowVersion({ flow, flowVersion: version, log }))
     }
     return { flowId, found: true, upgradedSteps }
 }
 
-async function upgradeFlowVersion({ flowVersion, log }: UpgradeFlowVersionParams): Promise<UpgradedStep[]> {
+async function upgradeFlowVersion({ flow, flowVersion, log }: UpgradeFlowVersionParams): Promise<UpgradedStep[]> {
     const steps = flowStructureUtil.getAllSteps(flowVersion.trigger)
 
-    const upgradedSteps: UpgradedStep[] = []
+    const decisions: StepUpgradeDecision[] = []
     for (const step of steps) {
-        const upgradedVersion = await resolveStepUpgrade({ step, flowVersion, log })
-        if (!isNil(upgradedVersion)) {
-            upgradedSteps.push({
-                flowVersionId: flowVersion.id,
-                stepName: step.name,
-                pieceName: step.settings.pieceName,
-                fromVersion: step.settings.pieceVersion,
-                toVersion: upgradedVersion,
-            })
+        const decision = await resolveStepDecision({ step, flowVersion, log })
+        if (!isNil(decision)) {
+            decisions.push(decision)
         }
     }
-    if (upgradedSteps.length === 0) {
+    if (decisions.length === 0) {
         return []
     }
 
-    const stepNameToNewVersion = Object.fromEntries(upgradedSteps.map((upgrade) => [upgrade.stepName, upgrade.toVersion]))
-    const newFlowVersion = flowStructureUtil.transferFlow(flowVersion, (step) => {
-        const newVersion = stepNameToNewVersion[step.name]
-        if (isNil(newVersion)) {
-            return step
-        }
-        return {
-            ...step,
-            settings: {
-                ...step.settings,
-                pieceVersion: newVersion,
-            },
-        }
+    const upgraded = decisions.filter((decision): decision is UpgradedStepDecision => decision.decision === 'UPGRADED')
+    if (upgraded.length > 0) {
+        const stepNameToNewVersion = Object.fromEntries(upgraded.map((decision) => [decision.stepName, decision.newVersion]))
+        const newFlowVersion = flowStructureUtil.transferFlow(flowVersion, (step) => {
+            const newVersion = stepNameToNewVersion[step.name]
+            if (isNil(newVersion)) {
+                return step
+            }
+            return {
+                ...step,
+                settings: {
+                    ...step.settings,
+                    pieceVersion: newVersion,
+                },
+            }
+        })
+        await flowVersionRepo().update(flowVersion.id, { trigger: newFlowVersion.trigger })
+    }
+
+    const platformId = await projectService(log).getPlatformId(flow.projectId)
+    applicationEvents(log).sendUserEvent({ platformId, projectId: flow.projectId }, {
+        action: ApplicationEventName.FLOW_PIECES_UPGRADED,
+        data: {
+            flowId: flow.id,
+            flowVersionId: flowVersion.id,
+            steps: decisions.map(toLogStep),
+        },
     })
-    await flowVersionRepo().update(flowVersion.id, { trigger: newFlowVersion.trigger })
-    return upgradedSteps
+
+    return upgraded.map((decision) => ({
+        flowVersionId: flowVersion.id,
+        stepName: decision.stepName,
+        pieceName: decision.pieceName,
+        fromVersion: decision.prevVersion,
+        toVersion: decision.newVersion,
+    }))
 }
 
-async function resolveStepUpgrade({ step, flowVersion, log }: ResolveStepUpgradeParams): Promise<string | undefined> {
+function toLogStep(decision: StepUpgradeDecision): PieceUpgradeAuditStep {
+    return {
+        stepName: decision.stepName,
+        actionOrTriggerName: decision.actionOrTriggerName,
+        decision: decision.decision,
+        prevVersion: decision.prevVersion,
+        newVersion: decision.newVersion,
+    }
+}
+
+async function resolveStepDecision({ step, flowVersion, log }: ResolveStepDecisionParams): Promise<StepUpgradeDecision | undefined> {
     if (step.type !== FlowActionType.PIECE && step.type !== FlowTriggerType.PIECE) {
         return undefined
     }
@@ -90,14 +218,20 @@ async function resolveStepUpgrade({ step, flowVersion, log }: ResolveStepUpgrade
         return undefined
     }
 
+    const base = {
+        stepName: step.name,
+        pieceName,
+        actionOrTriggerName: usedStepName,
+        prevVersion: pieceVersion,
+    }
     const decision = pieceUpgradeRegister.resolveDecision({ entry, usedStepName })
     switch (decision.outcome) {
         case 'upgraded':
             log.info({ ...logContext, upgrade: { toVersion: decision.toVersion } }, '[pieceUpgradeService] piece upgrade pass')
-            return decision.toVersion
+            return { ...base, decision: 'UPGRADED', newVersion: decision.toVersion }
         case 'kept':
             log.warn({ ...logContext, upgrade: { target: entry.target, flaggedStep: usedStepName } }, '[pieceUpgradeService] step flagged unsafe in upgrade register, keeping current version')
-            return undefined
+            return { ...base, decision: 'KEPT', newVersion: null }
     }
 }
 
@@ -125,9 +259,58 @@ export type FlowPieceUpgradeResult = {
     upgradedSteps: UpgradedStep[]
 }
 
+type PieceUpgradeAuditStep = {
+    stepName: string
+    actionOrTriggerName: string
+    decision: 'UPGRADED' | 'KEPT'
+    prevVersion: string
+    newVersion: string | null
+}
+
+type StepUpgradeDecisionBase = {
+    stepName: string
+    pieceName: string
+    actionOrTriggerName: string
+    prevVersion: string
+}
+
+type UpgradedStepDecision = StepUpgradeDecisionBase & {
+    decision: 'UPGRADED'
+    newVersion: string
+}
+
+type KeptStepDecision = StepUpgradeDecisionBase & {
+    decision: 'KEPT'
+    newVersion: null
+}
+
+type StepUpgradeDecision = UpgradedStepDecision | KeptStepDecision
+
 type UpgradeFlowsParams = {
     flowIds: string[]
     projectId?: string
+}
+
+type RevertFlowsParams = {
+    flowIds: string[]
+}
+
+type RevertFlowParams = {
+    flowId: string
+    log: FastifyBaseLogger
+}
+
+type StepRevert = {
+    prevVersion: string
+    newVersion: string
+}
+
+type RevertFlowVersionParams = {
+    flow: Flow
+    platformId: string
+    flowVersion: FlowVersion
+    versionReverts: Map<string, StepRevert>
+    log: FastifyBaseLogger
 }
 
 type UpgradeFlowParams = {
@@ -137,11 +320,12 @@ type UpgradeFlowParams = {
 }
 
 type UpgradeFlowVersionParams = {
+    flow: Flow
     flowVersion: FlowVersion
     log: FastifyBaseLogger
 }
 
-type ResolveStepUpgradeParams = {
+type ResolveStepDecisionParams = {
     step: FlowAction | FlowTrigger
     flowVersion: FlowVersion
     log: FastifyBaseLogger

--- a/packages/server/api/src/app/flows/flow-version/piece-upgrade.service.ts
+++ b/packages/server/api/src/app/flows/flow-version/piece-upgrade.service.ts
@@ -19,7 +19,6 @@ export const pieceUpgradeService = (log: FastifyBaseLogger) => ({
 })
 
 const auditEventRepo = repoFactory(AuditEventEntity)
-const MAX_UPGRADE_EVENTS_PER_FLOW = 100
 
 async function revertFlow({ flowId, log }: RevertFlowParams): Promise<FlowPieceUpgradeResult> {
     const flow = await flowRepo().findOneBy({ id: flowId })
@@ -29,11 +28,9 @@ async function revertFlow({ flowId, log }: RevertFlowParams): Promise<FlowPieceU
     const platformId = await projectService(log).getPlatformId(flow.projectId)
     const events = await auditEventRepo().createQueryBuilder('event')
         .where('event.platformId = :platformId', { platformId })
-        .andWhere('event.projectId = :projectId', { projectId: flow.projectId })
         .andWhere('event.action = :action', { action: ApplicationEventName.FLOW_PIECES_UPGRADED })
         .andWhere('event.data->>\'flowId\' = :flowId', { flowId })
         .orderBy('event.created', 'DESC')
-        .limit(MAX_UPGRADE_EVENTS_PER_FLOW)
         .getMany()
     const upgradeEvents = events.map((event) => FlowPiecesUpgradedEvent.shape.data.parse(event.data))
     if (upgradeEvents.length === 0) {

--- a/packages/server/api/src/app/flows/flow-version/piece-upgrade.service.ts
+++ b/packages/server/api/src/app/flows/flow-version/piece-upgrade.service.ts
@@ -19,6 +19,7 @@ export const pieceUpgradeService = (log: FastifyBaseLogger) => ({
 })
 
 const auditEventRepo = repoFactory(AuditEventEntity)
+const MAX_UPGRADE_EVENTS_PER_FLOW = 100
 
 async function revertFlow({ flowId, log }: RevertFlowParams): Promise<FlowPieceUpgradeResult> {
     const flow = await flowRepo().findOneBy({ id: flowId })
@@ -28,9 +29,11 @@ async function revertFlow({ flowId, log }: RevertFlowParams): Promise<FlowPieceU
     const platformId = await projectService(log).getPlatformId(flow.projectId)
     const events = await auditEventRepo().createQueryBuilder('event')
         .where('event.platformId = :platformId', { platformId })
+        .andWhere('event.projectId = :projectId', { projectId: flow.projectId })
         .andWhere('event.action = :action', { action: ApplicationEventName.FLOW_PIECES_UPGRADED })
         .andWhere('event.data->>\'flowId\' = :flowId', { flowId })
         .orderBy('event.created', 'DESC')
+        .limit(MAX_UPGRADE_EVENTS_PER_FLOW)
         .getMany()
     const upgradeEvents = events.map((event) => FlowPiecesUpgradedEvent.shape.data.parse(event.data))
     if (upgradeEvents.length === 0) {
@@ -96,7 +99,11 @@ async function revertFlowVersion({ flow, platformId, flowVersion, versionReverts
             },
         }
     })
-    await flowVersionRepo().update(flowVersion.id, { trigger: newFlowVersion.trigger })
+    const updated = await updateTriggerIfUnchanged({ flowVersion, newTrigger: newFlowVersion.trigger })
+    if (!updated) {
+        log.warn({ flowVersion: { id: flowVersion.id } }, '[pieceUpgradeService] flow version changed concurrently, skipping revert')
+        return []
+    }
 
     applicationEvents(log).sendUserEvent({ platformId, projectId: flow.projectId }, {
         action: ApplicationEventName.FLOW_PIECES_REVERTED,
@@ -165,7 +172,11 @@ async function upgradeFlowVersion({ flow, flowVersion, log }: UpgradeFlowVersion
                 },
             }
         })
-        await flowVersionRepo().update(flowVersion.id, { trigger: newFlowVersion.trigger })
+        const updated = await updateTriggerIfUnchanged({ flowVersion, newTrigger: newFlowVersion.trigger })
+        if (!updated) {
+            log.warn({ flowVersion: { id: flowVersion.id } }, '[pieceUpgradeService] flow version changed concurrently, skipping upgrade')
+            return []
+        }
     }
 
     const platformId = await projectService(log).getPlatformId(flow.projectId)
@@ -233,6 +244,16 @@ async function resolveStepDecision({ step, flowVersion, log }: ResolveStepDecisi
             log.warn({ ...logContext, upgrade: { target: entry.target, flaggedStep: usedStepName } }, '[pieceUpgradeService] step flagged unsafe in upgrade register, keeping current version')
             return { ...base, decision: 'KEPT', newVersion: null }
     }
+}
+
+async function updateTriggerIfUnchanged({ flowVersion, newTrigger }: UpdateTriggerIfUnchangedParams): Promise<boolean> {
+    const updateResult = await flowVersionRepo().createQueryBuilder()
+        .update()
+        .set({ trigger: newTrigger })
+        .where('id = :id', { id: flowVersion.id })
+        .andWhere('trigger = CAST(:snapshot AS jsonb)', { snapshot: JSON.stringify(flowVersion.trigger) })
+        .execute()
+    return updateResult.affected === 1
 }
 
 function getUsedStepName(step: FlowAction | FlowTrigger): string | undefined {
@@ -303,6 +324,11 @@ type RevertFlowParams = {
 type StepRevert = {
     prevVersion: string
     newVersion: string
+}
+
+type UpdateTriggerIfUnchangedParams = {
+    flowVersion: FlowVersion
+    newTrigger: FlowVersion['trigger']
 }
 
 type RevertFlowVersionParams = {

--- a/packages/server/api/src/app/flows/flow-version/piece-upgrade.service.ts
+++ b/packages/server/api/src/app/flows/flow-version/piece-upgrade.service.ts
@@ -28,6 +28,7 @@ async function revertFlow({ flowId, log }: RevertFlowParams): Promise<FlowPieceU
     const platformId = await projectService(log).getPlatformId(flow.projectId)
     const events = await auditEventRepo().createQueryBuilder('event')
         .where('event.platformId = :platformId', { platformId })
+        .andWhere('event.projectId = :projectId', { projectId: flow.projectId })
         .andWhere('event.action = :action', { action: ApplicationEventName.FLOW_PIECES_UPGRADED })
         .andWhere('event.data->>\'flowId\' = :flowId', { flowId })
         .orderBy('event.created', 'DESC')

--- a/packages/web/public/locales/en/translation.json
+++ b/packages/web/public/locales/en/translation.json
@@ -2515,5 +2515,8 @@
   "Recently used": "Recently used",
   "Resets in {days, plural, =1 {# day} other {# days}}": "Resets in {days, plural, =1 {# day} other {# days}}",
   "Show all projects": "Show all projects",
-  "Sort pinned projects": "Sort pinned projects"
+  "Sort pinned projects": "Sort pinned projects",
+  "Flow pieces upgraded": "Flow pieces upgraded",
+  "kept at {version}": "kept at {version}",
+  "Flow pieces reverted": "Flow pieces reverted"
 }

--- a/packages/web/src/app/routes/platform/infra/event-destinations/lib/use-event-labels.ts
+++ b/packages/web/src/app/routes/platform/infra/event-destinations/lib/use-event-labels.ts
@@ -26,6 +26,12 @@ export const useEventLabels = (): EventLabelsMap => {
     [ApplicationEventName.FLOW_CREATED]: { label: t('Flow created') },
     [ApplicationEventName.FLOW_UPDATED]: { label: t('Flow updated') },
     [ApplicationEventName.FLOW_DELETED]: { label: t('Flow deleted') },
+    [ApplicationEventName.FLOW_PIECES_UPGRADED]: {
+      label: t('Flow pieces upgraded'),
+    },
+    [ApplicationEventName.FLOW_PIECES_REVERTED]: {
+      label: t('Flow pieces reverted'),
+    },
     [ApplicationEventName.FOLDER_CREATED]: { label: t('Folder created') },
     [ApplicationEventName.FOLDER_UPDATED]: { label: t('Folder updated') },
     [ApplicationEventName.FOLDER_DELETED]: { label: t('Folder deleted') },

--- a/packages/web/src/app/routes/platform/security/audit-logs/index.tsx
+++ b/packages/web/src/app/routes/platform/security/audit-logs/index.tsx
@@ -7,12 +7,14 @@ import {
 import { t } from 'i18next';
 import {
   CheckIcon,
+  CircleArrowUp,
   Eye,
   Folder,
   History,
   Key,
   Link2,
   Logs,
+  Undo2,
   Users,
   Wand,
   Workflow,
@@ -358,6 +360,16 @@ function convertToIcon(event: ApplicationEvent) {
         icon: <Workflow className="size-4" />,
         tooltip: t('Flow'),
       };
+    case ApplicationEventName.FLOW_PIECES_UPGRADED:
+      return {
+        icon: <CircleArrowUp className="size-4" />,
+        tooltip: t('Flow pieces upgraded'),
+      };
+    case ApplicationEventName.FLOW_PIECES_REVERTED:
+      return {
+        icon: <Undo2 className="size-4" />,
+        tooltip: t('Flow pieces reverted'),
+      };
     case ApplicationEventName.FOLDER_CREATED:
     case ApplicationEventName.FOLDER_DELETED:
     case ApplicationEventName.FOLDER_UPDATED:
@@ -468,6 +480,30 @@ function extractEventDetails(event: ApplicationEvent): EventDetailRow[] {
     case ApplicationEventName.FLOW_ACTIVATED:
     case ApplicationEventName.FLOW_DEACTIVATED:
       return [{ label: t('Flow'), value: event.data.flowVersion.displayName }];
+    case ApplicationEventName.FLOW_PIECES_UPGRADED: {
+      const { flowId, steps } = event.data;
+      return [
+        { label: t('Flow'), value: flowId },
+        ...steps.map((step) => ({
+          label: step.stepName,
+          value: `${step.actionOrTriggerName}: ${
+            step.decision === 'UPGRADED'
+              ? `${step.prevVersion} → ${step.newVersion}`
+              : t('kept at {version}', { version: step.prevVersion })
+          }`,
+        })),
+      ];
+    }
+    case ApplicationEventName.FLOW_PIECES_REVERTED: {
+      const { flowId, steps } = event.data;
+      return [
+        { label: t('Flow'), value: flowId },
+        ...steps.map((step) => ({
+          label: step.stepName,
+          value: `${step.actionOrTriggerName}: ${step.prevVersion} → ${step.newVersion}`,
+        })),
+      ];
+    }
     case ApplicationEventName.CONNECTION_UPSERTED:
     case ApplicationEventName.CONNECTION_DELETED: {
       const { connection } = event.data;


### PR DESCRIPTION
## Description

Follow-up to #15050 (piece upgrade register + admin upgrade endpoint). This PR adds an audit trail and a revert path for piece upgrades:

- **Audit events**: every `POST /v1/admin/flows/upgrade-pieces` run now records a `flow.pieces.upgraded` audit event per touched flow version, with `data: { flowId, flowVersionId, steps: [{ stepName, actionOrTriggerName, decision (UPGRADED | KEPT), prevVersion, newVersion }] }`. Events flow through the existing `applicationEvents` pipeline, so they inherit audit-log retention, the platform audit-log UI, and `auditLogEnabled` plan gating.
- **Revert endpoint**: new `POST /v1/admin/flows/revert-upgrade` (same module, same `api-key` gate) takes `{ flowIds }`, reads the flow's `flow.pieces.upgraded` audit history (platformId-filtered to hit `audit_event_platform_id_action_idx`), and reverts each UPGRADED step back to its recorded previous version — only when the step still sits at the audited upgraded version, so manual changes are never clobbered. Reverts are themselves audited as `flow.pieces.reverted` events.
- **Web**: audit-log page renders both event types (labels, per-step detail rows, icons); event-destination picker labels added.
- `@activepieces/shared` bumped 0.143.0 → 0.144.0 (new `ApplicationEventName` members + event schemas).

## How was this tested?

Local EE server E2E with seeded flows pinned to old piece versions:
- upgrade emits `flow.pieces.upgraded` rows with mixed UPGRADED/KEPT step decisions (verified in `audit_event`)
- revert restores exactly the audited steps (`0.1.18→0.0.2`, `0.6.16→0.2.0`), skips steps changed since upgrade, is idempotent, returns `found: false` for flows without upgrade history, and emits `flow.pieces.reverted`
- flows whose steps never matched the register produce no audit rows
- `tsc` clean on `server/api` and `web`; unit tests for the register decision logic pass

The upgrade endpoint itself was previously E2E-tested on staging across 10 real flows (34 step upgrades).

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)