### PR TITLE
feat(agents): a new agent comes with a model, so you can talk to it right away

### DIFF
--- a/docs/install/reference/breaking-changes.mdx
+++ b/docs/install/reference/breaking-changes.mdx
@@ -10,13 +10,11 @@ icon: "hammer"
 
 #### A newly created agent comes with a model already chosen
 
-Creating an agent without naming a model used to leave `draft.modelName` empty, which meant the agent could not be talked to until someone opened it and picked one. A starter template, a blank agent, and an agent built for you by chat all landed on that screen. Creation now fills in the platform's own default chat model, so a new agent is ready to answer immediately.
-
-Naming a model still wins: a request that sends `draft.modelName` gets exactly that model. And when the platform has no AI provider configured there is nothing to choose from, so the field stays empty and the agent keeps asking for one, which is the honest state on a fresh install.
+Creating an agent without naming a model used to leave `draft.modelName` empty, so nobody could talk to that agent until someone opened it and picked one. Creation now fills in the platform's default chat model. A request that names a model still gets exactly that model, and with no AI provider configured the field stays empty.
 
 #### What you need to do
 
-Nothing. No configuration and nothing to migrate, and existing agents are untouched. If you create agents through the API and assert that a new one has no model, update that assertion: `POST /v1/agents` now answers with a model whenever your platform has a provider configured.
+Nothing, and existing agents are untouched. If you create agents through the API and assert that a new one has no model, drop that assertion.
 
 #### Workers no longer pre-warm the flow cache on startup by default
 

--- a/docs/install/reference/breaking-changes.mdx
+++ b/docs/install/reference/breaking-changes.mdx
@@ -8,14 +8,6 @@ icon: "hammer"
 
 ### What has changed?
 
-#### A newly created agent comes with a model already chosen
-
-Creating an agent without naming a model used to leave `draft.modelName` empty, so nobody could talk to that agent until someone opened it and picked one. Creation now fills in the platform's default chat model. A request that names a model still gets exactly that model, and with no AI provider configured the field stays empty.
-
-#### What you need to do
-
-Nothing, and existing agents are untouched. If you create agents through the API and assert that a new one has no model, drop that assertion.
-
 #### Workers no longer pre-warm the flow cache on startup by default
 
 Since v0.86.1 every worker pre-filled its local piece and code cache on startup by resolving and compiling every enabled flow on the platform. That warm-up costs memory and CPU proportional to the number of enabled flows: on instances with many flows it pinned each worker at its CPU limit for the duration and spiked memory enough to OOM-kill small workers, especially during upgrades when all workers restart at once. The warm-up is now opt-in behind the new `AP_PREWARM_CACHE_ON_STARTUP` worker environment variable, which defaults to `false`. When disabled, caches fill lazily on each flow's first run after a worker starts, exactly as they did before v0.86.1.

--- a/docs/install/reference/breaking-changes.mdx
+++ b/docs/install/reference/breaking-changes.mdx
@@ -8,6 +8,16 @@ icon: "hammer"
 
 ### What has changed?
 
+#### A newly created agent comes with a model already chosen
+
+Creating an agent without naming a model used to leave `draft.modelName` empty, which meant the agent could not be talked to until someone opened it and picked one. A starter template, a blank agent, and an agent built for you by chat all landed on that screen. Creation now fills in the platform's own default chat model, so a new agent is ready to answer immediately.
+
+Naming a model still wins: a request that sends `draft.modelName` gets exactly that model. And when the platform has no AI provider configured there is nothing to choose from, so the field stays empty and the agent keeps asking for one, which is the honest state on a fresh install.
+
+#### What you need to do
+
+Nothing. No configuration and nothing to migrate, and existing agents are untouched. If you create agents through the API and assert that a new one has no model, update that assertion: `POST /v1/agents` now answers with a model whenever your platform has a provider configured.
+
 #### Workers no longer pre-warm the flow cache on startup by default
 
 Since v0.86.1 every worker pre-filled its local piece and code cache on startup by resolving and compiling every enabled flow on the platform. That warm-up costs memory and CPU proportional to the number of enabled flows: on instances with many flows it pinned each worker at its CPU limit for the duration and spiked memory enough to OOM-kill small workers, especially during upgrades when all workers restart at once. The warm-up is now opt-in behind the new `AP_PREWARM_CACHE_ON_STARTUP` worker environment variable, which defaults to `false`. When disabled, caches fill lazily on each flow's first run after a worker starts, exactly as they did before v0.86.1.

--- a/packages/server/api/src/app/ee/agent/agent-controller.ts
+++ b/packages/server/api/src/app/ee/agent/agent-controller.ts
@@ -22,6 +22,7 @@ export const agentController: FastifyPluginAsyncZod = async (app) => {
     app.post('/', CreateAgentRoute, async (request, reply) => {
         const ownerId = await resolveUserId(request)
         const agent = await agentService(request.log).create({
+            platformId: request.principal.platform.id,
             projectId: request.projectId,
             ownerId,
             request: request.body,

--- a/packages/server/api/src/app/ee/agent/agent-controller.ts
+++ b/packages/server/api/src/app/ee/agent/agent-controller.ts
@@ -22,7 +22,6 @@ export const agentController: FastifyPluginAsyncZod = async (app) => {
     app.post('/', CreateAgentRoute, async (request, reply) => {
         const ownerId = await resolveUserId(request)
         const agent = await agentService(request.log).create({
-            platformId: request.principal.platform.id,
             projectId: request.projectId,
             ownerId,
             request: request.body,

--- a/packages/server/api/src/app/ee/agent/agent-helpers.ts
+++ b/packages/server/api/src/app/ee/agent/agent-helpers.ts
@@ -222,11 +222,15 @@ async function resolveEmbeddingModel({ platformId, provider, providerConfigId, s
 // Analytics and billing label a turn with the provider that served it. A conversation with no
 // project has no key to name, and guessing platform-wide would report a credential the run was
 // never allowed to use, so the provider stays unknown.
+async function chatProviderNameOrThrow({ platformId, projectId, log }: { platformId: string, projectId: string, log: FastifyBaseLogger }): Promise<AIProviderName | null> {
+    return aiProviderService(log).getChatProviderName({ platformId, scope: { type: 'project', projectId } })
+}
+
 async function resolveChatProviderName({ platformId, projectId, log }: { platformId: string, projectId: string | null, log: FastifyBaseLogger }): Promise<AIProviderName | null> {
     if (isNil(projectId)) {
         return null
     }
-    const result = await tryCatch(() => aiProviderService(log).getChatProviderName({ platformId, scope: { type: 'project', projectId } }))
+    const result = await tryCatch(() => chatProviderNameOrThrow({ platformId, projectId, log }))
     return result.error ? null : result.data
 }
 
@@ -349,6 +353,7 @@ export const agentHelpers = {
     resolveRunProvider,
     resolveEmbeddingModel,
     resolveChatProviderName,
+    chatProviderNameOrThrow,
     runScopeOrThrow,
     selectRunProject,
     assertProjectSwitchKeepsKey,

--- a/packages/server/api/src/app/ee/agent/agent-helpers.ts
+++ b/packages/server/api/src/app/ee/agent/agent-helpers.ts
@@ -222,16 +222,11 @@ async function resolveEmbeddingModel({ platformId, provider, providerConfigId, s
 // Analytics and billing label a turn with the provider that served it. A conversation with no
 // project has no key to name, and guessing platform-wide would report a credential the run was
 // never allowed to use, so the provider stays unknown.
-async function chatProviderNameOrThrow({ platformId, projectId, log }: { platformId: string, projectId: string, log: FastifyBaseLogger }): Promise<AIProviderName | null> {
-    return aiProviderService(log).getChatProviderName({ platformId, scope: { type: 'project', projectId } })
-}
-
 async function resolveChatProviderName({ platformId, projectId, log }: { platformId: string, projectId: string | null, log: FastifyBaseLogger }): Promise<AIProviderName | null> {
     if (isNil(projectId)) {
         return null
     }
-    const result = await tryCatch(() => chatProviderNameOrThrow({ platformId, projectId, log }))
-    return result.error ? null : result.data
+    return aiProviderService(log).getChatProviderName({ platformId, scope: runScopeOrThrow({ projectId }) })
 }
 
 async function recoverAllStaleStreamingConversations({ log }: { log: FastifyBaseLogger }): Promise<{ recovered: number }> {
@@ -353,7 +348,6 @@ export const agentHelpers = {
     resolveRunProvider,
     resolveEmbeddingModel,
     resolveChatProviderName,
-    chatProviderNameOrThrow,
     runScopeOrThrow,
     selectRunProject,
     assertProjectSwitchKeepsKey,

--- a/packages/server/api/src/app/ee/agent/agent-service.ts
+++ b/packages/server/api/src/app/ee/agent/agent-service.ts
@@ -202,7 +202,7 @@ async function withDefaultModel({ draft, projectId, log }: {
         return draft
     }
     const platformId = await projectService(log).getPlatformId(projectId)
-    const provider = await agentHelpers.resolveChatProviderName({ platformId, projectId, log })
+    const provider = await agentHelpers.chatProviderNameOrThrow({ platformId, projectId, log })
     if (isNil(provider)) {
         return draft
     }

--- a/packages/server/api/src/app/ee/agent/agent-service.ts
+++ b/packages/server/api/src/app/ee/agent/agent-service.ts
@@ -22,9 +22,9 @@ export const agentAudit = { describePublished }
 export const agentRedaction = { withoutToolSecrets }
 
 export const agentService = (log: FastifyBaseLogger) => ({
-    async create({ projectId, ownerId, request }: CreateParams): Promise<Agent> {
+    async create({ platformId, projectId, ownerId, request }: CreateParams): Promise<Agent> {
         const visibility = request.visibility ?? AgentVisibility.PROJECT
-        const draft = await withDefaultModel({ draft: request.draft, projectId, log })
+        const draft = await withDefaultModel({ draft: request.draft, platformId, projectId, log })
         return agentRepo().save({
             id: apId(),
             projectId,
@@ -193,16 +193,16 @@ async function isProjectAdministrator({ projectId, userId, log }: { projectId: P
     return role?.name === DefaultProjectRole.ADMIN
 }
 
-async function withDefaultModel({ draft, projectId, log }: {
+async function withDefaultModel({ draft, platformId, projectId, log }: {
     draft: AgentConfig
+    platformId: PlatformId
     projectId: ProjectId
     log: FastifyBaseLogger
 }): Promise<AgentConfig> {
     if (!isNil(draft.modelName)) {
         return draft
     }
-    const platformId = await projectService(log).getPlatformId(projectId)
-    const provider = await agentHelpers.chatProviderNameOrThrow({ platformId, projectId, log })
+    const provider = await agentHelpers.resolveChatProviderName({ platformId, projectId, log })
     if (isNil(provider)) {
         return draft
     }
@@ -310,6 +310,7 @@ function agentNotFound(id: ApId): ActivepiecesError {
 }
 
 type CreateParams = {
+    platformId: PlatformId
     projectId: ProjectId
     ownerId: UserId
     request: CreateAgentRequest

--- a/packages/server/api/src/app/ee/agent/agent-service.ts
+++ b/packages/server/api/src/app/ee/agent/agent-service.ts
@@ -1,7 +1,7 @@
 import { createHash } from 'node:crypto'
 import { AgentToolType, McpAuthType } from '@activepieces/core-piece-types'
-import { ActivepiecesError, ApId, apId, Cursor, ErrorCode, isNil, omit, Permission, PlatformId, ProjectId, sanitizeObjectForPostgresql, SeekPage, UserId } from '@activepieces/core-utils'
-import { Agent, AgentConfig, AgentSummary, agentUtils, AgentVisibility, CreateAgentRequest, DefaultProjectRole, Project, ProjectType, UpdateAgentRequest } from '@activepieces/shared'
+import { ActivepiecesError, ApId, apId, Cursor, ErrorCode, isNil, omit, Permission, PlatformId, ProjectId, sanitizeObjectForPostgresql, SeekPage, tryCatch, UserId } from '@activepieces/core-utils'
+import { Agent, AgentConfig, AgentSummary, agentUtils, AgentVisibility, CreateAgentRequest, DEFAULT_CHAT_TIER_ID, DefaultProjectRole, Project, ProjectType, UpdateAgentRequest } from '@activepieces/shared'
 import { FastifyBaseLogger } from 'fastify'
 import { Brackets, In, SelectQueryBuilder } from 'typeorm'
 import { repoFactory } from '../../core/db/repo-factory'
@@ -22,8 +22,9 @@ export const agentAudit = { describePublished }
 export const agentRedaction = { withoutToolSecrets }
 
 export const agentService = (log: FastifyBaseLogger) => ({
-    async create({ projectId, ownerId, request }: CreateParams): Promise<Agent> {
+    async create({ projectId, platformId, ownerId, request }: CreateParams): Promise<Agent> {
         const visibility = request.visibility ?? AgentVisibility.PROJECT
+        const draft = await withDefaultModel({ draft: request.draft, projectId, platformId, log })
         return agentRepo().save({
             id: apId(),
             projectId,
@@ -35,7 +36,7 @@ export const agentService = (log: FastifyBaseLogger) => ({
             color: request.color,
             visibility,
             sharedWithUserIds: await resolveShare({ visibility, requested: request.sharedWithUserIds, stored: [], projectId, log }),
-            draft: sanitizeObjectForPostgresql(request.draft),
+            draft: sanitizeObjectForPostgresql(draft),
             published: null,
         })
     },
@@ -192,6 +193,27 @@ async function isProjectAdministrator({ projectId, userId, log }: { projectId: P
     return role?.name === DefaultProjectRole.ADMIN
 }
 
+async function withDefaultModel({ draft, projectId, platformId, log }: {
+    draft: AgentConfig
+    projectId: ProjectId
+    platformId: PlatformId
+    log: FastifyBaseLogger
+}): Promise<AgentConfig> {
+    if (!isNil(draft.modelName)) {
+        return draft
+    }
+    const { data: resolved } = await tryCatch(() => agentHelpers.resolveTierModel({
+        platformId,
+        tierId: DEFAULT_CHAT_TIER_ID,
+        scope: agentHelpers.runScopeOrThrow({ projectId }),
+        log,
+    }))
+    if (isNil(resolved)) {
+        return draft
+    }
+    return { ...draft, provider: resolved.provider, modelName: resolved.modelId }
+}
+
 async function resolveShare({ visibility, requested, stored, projectId, log }: ResolveShareParams): Promise<UserId[]> {
     if (visibility === AgentVisibility.PROJECT) {
         return []
@@ -294,6 +316,7 @@ function agentNotFound(id: ApId): ActivepiecesError {
 
 type CreateParams = {
     projectId: ProjectId
+    platformId: PlatformId
     ownerId: UserId
     request: CreateAgentRequest
 }

--- a/packages/server/api/src/app/ee/agent/agent-service.ts
+++ b/packages/server/api/src/app/ee/agent/agent-service.ts
@@ -1,6 +1,6 @@
 import { createHash } from 'node:crypto'
 import { AgentToolType, McpAuthType } from '@activepieces/core-piece-types'
-import { ActivepiecesError, ApId, apId, Cursor, ErrorCode, isNil, omit, Permission, PlatformId, ProjectId, sanitizeObjectForPostgresql, SeekPage, tryCatch, UserId } from '@activepieces/core-utils'
+import { ActivepiecesError, ApId, apId, Cursor, ErrorCode, isNil, omit, Permission, PlatformId, ProjectId, sanitizeObjectForPostgresql, SeekPage, UserId } from '@activepieces/core-utils'
 import { Agent, AgentConfig, AgentSummary, agentUtils, AgentVisibility, CreateAgentRequest, DEFAULT_CHAT_TIER_ID, DefaultProjectRole, Project, ProjectType, UpdateAgentRequest } from '@activepieces/shared'
 import { FastifyBaseLogger } from 'fastify'
 import { Brackets, In, SelectQueryBuilder } from 'typeorm'
@@ -22,9 +22,9 @@ export const agentAudit = { describePublished }
 export const agentRedaction = { withoutToolSecrets }
 
 export const agentService = (log: FastifyBaseLogger) => ({
-    async create({ projectId, platformId, ownerId, request }: CreateParams): Promise<Agent> {
+    async create({ projectId, ownerId, request }: CreateParams): Promise<Agent> {
         const visibility = request.visibility ?? AgentVisibility.PROJECT
-        const draft = await withDefaultModel({ draft: request.draft, projectId, platformId, log })
+        const draft = await withDefaultModel({ draft: request.draft, projectId, log })
         return agentRepo().save({
             id: apId(),
             projectId,
@@ -193,25 +193,20 @@ async function isProjectAdministrator({ projectId, userId, log }: { projectId: P
     return role?.name === DefaultProjectRole.ADMIN
 }
 
-async function withDefaultModel({ draft, projectId, platformId, log }: {
+async function withDefaultModel({ draft, projectId, log }: {
     draft: AgentConfig
     projectId: ProjectId
-    platformId: PlatformId
     log: FastifyBaseLogger
 }): Promise<AgentConfig> {
     if (!isNil(draft.modelName)) {
         return draft
     }
-    const { data: resolved } = await tryCatch(() => agentHelpers.resolveTierModel({
-        platformId,
-        tierId: DEFAULT_CHAT_TIER_ID,
-        scope: agentHelpers.runScopeOrThrow({ projectId }),
-        log,
-    }))
-    if (isNil(resolved)) {
+    const platformId = await projectService(log).getPlatformId(projectId)
+    const provider = await agentHelpers.resolveChatProviderName({ platformId, projectId, log })
+    if (isNil(provider)) {
         return draft
     }
-    return { ...draft, provider: resolved.provider, modelName: resolved.modelId }
+    return { ...draft, provider, modelName: agentHelpers.resolveModelIdForProvider({ provider, selectedModel: DEFAULT_CHAT_TIER_ID }) }
 }
 
 async function resolveShare({ visibility, requested, stored, projectId, log }: ResolveShareParams): Promise<UserId[]> {
@@ -316,7 +311,6 @@ function agentNotFound(id: ApId): ActivepiecesError {
 
 type CreateParams = {
     projectId: ProjectId
-    platformId: PlatformId
     ownerId: UserId
     request: CreateAgentRequest
 }

--- a/packages/server/api/src/app/ee/agent/chat-analytics-sync.ts
+++ b/packages/server/api/src/app/ee/agent/chat-analytics-sync.ts
@@ -144,7 +144,7 @@ async function resolveLookups({ conversations, log }: {
         Promise.all(uniquePlatformIds.map(async (platformId): Promise<[string, string | null]> => [platformId, await resolvePlatformName({ platformId, log })])),
         Promise.all(uniqueScopes.map(async (conversation): Promise<[string, AIProviderName | null]> => [
             chatProviderCacheKey(conversation),
-            await agentHelpers.resolveChatProviderName({ platformId: conversation.platformId, projectId: conversation.projectId ?? null, log }),
+            await resolveProviderName({ platformId: conversation.platformId, projectId: conversation.projectId ?? null, log }),
         ])),
     ])
 
@@ -217,7 +217,7 @@ async function toSyncPayload({ conversation, licenseKey, log, userCache, platfor
 }): Promise<Record<string, unknown>> {
     const userEmail = userCache?.get(conversation.userId) ?? await resolveUserEmail({ userId: conversation.userId, log })
     const platformName = platformCache?.get(conversation.platformId) ?? await resolvePlatformName({ platformId: conversation.platformId, log })
-    const provider = providerCache?.get(chatProviderCacheKey(conversation)) ?? await agentHelpers.resolveChatProviderName({ platformId: conversation.platformId, projectId: conversation.projectId ?? null, log })
+    const provider = providerCache?.get(chatProviderCacheKey(conversation)) ?? await resolveProviderName({ platformId: conversation.platformId, projectId: conversation.projectId ?? null, log })
 
     const messages = agentHistory.resolveMessages({ conversation, log })
 
@@ -273,6 +273,11 @@ async function resolveUserEmail({ userId, log }: { userId: string, log: FastifyB
 async function resolvePlatformName({ platformId, log }: { platformId: string, log: FastifyBaseLogger }): Promise<string | null> {
     const result = await tryCatch(() => platformService(log).getOneOrThrow(platformId))
     return result.error ? null : result.data.name
+}
+
+async function resolveProviderName({ platformId, projectId, log }: { platformId: string, projectId: string | null, log: FastifyBaseLogger }): Promise<AIProviderName | null> {
+    const result = await tryCatch(() => agentHelpers.resolveChatProviderName({ platformId, projectId, log }))
+    return result.error ? null : result.data
 }
 
 type ConversationLookups = {

--- a/packages/server/api/src/app/ee/agent/tools/agent-tools.ts
+++ b/packages/server/api/src/app/ee/agent/tools/agent-tools.ts
@@ -219,9 +219,10 @@ function nonEmpty(value: unknown): string | undefined {
     return isString(value) && value.trim().length > 0 ? value.trim() : undefined
 }
 
-async function createAgentFromChat({ toolInput, projectId, userId, log }: {
+async function createAgentFromChat({ toolInput, projectId, platformId, userId, log }: {
     toolInput: Record<string, unknown>
     projectId: string
+    platformId: string
     userId: string
     log: FastifyBaseLogger
 }): Promise<unknown> {
@@ -231,6 +232,7 @@ async function createAgentFromChat({ toolInput, projectId, userId, log }: {
         return { error: 'An agent needs a name and instructions.' }
     }
     const agent = await agentService(log).create({
+        platformId,
         projectId,
         ownerId: userId,
         request: {
@@ -535,7 +537,7 @@ async function executeCrossProjectTool({ toolName, toolInput, platformId, userId
                 return data.map(({ id, displayName, description, isPublished, toolCount }) => ({ agentId: id, displayName, description, published: isPublished, toolCount }))
             }
             if (toolName === 'ap_create_agent') {
-                return createAgentFromChat({ toolInput, projectId, userId, log })
+                return createAgentFromChat({ toolInput, projectId, platformId, userId, log })
             }
             const agentId = nonEmpty(toolInput.agentId)
             if (isNil(agentId)) {

--- a/packages/server/api/src/app/ee/agent/tools/agent-tools.ts
+++ b/packages/server/api/src/app/ee/agent/tools/agent-tools.ts
@@ -219,10 +219,9 @@ function nonEmpty(value: unknown): string | undefined {
     return isString(value) && value.trim().length > 0 ? value.trim() : undefined
 }
 
-async function createAgentFromChat({ toolInput, projectId, platformId, userId, log }: {
+async function createAgentFromChat({ toolInput, projectId, userId, log }: {
     toolInput: Record<string, unknown>
     projectId: string
-    platformId: string
     userId: string
     log: FastifyBaseLogger
 }): Promise<unknown> {
@@ -232,7 +231,6 @@ async function createAgentFromChat({ toolInput, projectId, platformId, userId, l
         return { error: 'An agent needs a name and instructions.' }
     }
     const agent = await agentService(log).create({
-        platformId,
         projectId,
         ownerId: userId,
         request: {
@@ -537,7 +535,7 @@ async function executeCrossProjectTool({ toolName, toolInput, platformId, userId
                 return data.map(({ id, displayName, description, isPublished, toolCount }) => ({ agentId: id, displayName, description, published: isPublished, toolCount }))
             }
             if (toolName === 'ap_create_agent') {
-                return createAgentFromChat({ toolInput, projectId, platformId, userId, log })
+                return createAgentFromChat({ toolInput, projectId, userId, log })
             }
             const agentId = nonEmpty(toolInput.agentId)
             if (isNil(agentId)) {

--- a/packages/server/api/src/app/ee/agent/tools/agent-tools.ts
+++ b/packages/server/api/src/app/ee/agent/tools/agent-tools.ts
@@ -219,8 +219,9 @@ function nonEmpty(value: unknown): string | undefined {
     return isString(value) && value.trim().length > 0 ? value.trim() : undefined
 }
 
-async function createAgentFromChat({ toolInput, projectId, userId, log }: {
+async function createAgentFromChat({ toolInput, platformId, projectId, userId, log }: {
     toolInput: Record<string, unknown>
+    platformId: string
     projectId: string
     userId: string
     log: FastifyBaseLogger
@@ -231,6 +232,7 @@ async function createAgentFromChat({ toolInput, projectId, userId, log }: {
         return { error: 'An agent needs a name and instructions.' }
     }
     const agent = await agentService(log).create({
+        platformId,
         projectId,
         ownerId: userId,
         request: {
@@ -535,7 +537,7 @@ async function executeCrossProjectTool({ toolName, toolInput, platformId, userId
                 return data.map(({ id, displayName, description, isPublished, toolCount }) => ({ agentId: id, displayName, description, published: isPublished, toolCount }))
             }
             if (toolName === 'ap_create_agent') {
-                return createAgentFromChat({ toolInput, projectId, userId, log })
+                return createAgentFromChat({ toolInput, platformId, projectId, userId, log })
             }
             const agentId = nonEmpty(toolInput.agentId)
             if (isNil(agentId)) {

--- a/packages/server/api/test/integration/ee/agent/agent-builder-conversation.test.ts
+++ b/packages/server/api/test/integration/ee/agent/agent-builder-conversation.test.ts
@@ -109,11 +109,15 @@ describe('whose model a builder run answers on', () => {
     // An agent that names no model cannot be talked to, and that is the point of the guard. The
     // builder is not that agent: refusing it here would leave a half-made agent unbuildable, which
     // is exactly the state the builder exists to get you out of.
-    it('builds an agent that names no model, where talking to that agent is refused', async () => {
+    it('builds an agent whose model was cleared, where talking to that agent is refused', async () => {
         const ctx = await context()
         const saved = await mockAndSaveAIProvider({ platformId: ctx.platform.id, provider: AIProviderName.OPENROUTER })
         await db.update('ai_provider', saved.id, { enabledForChat: true })
         const agent = await createAgent(ctx)
+        const cleared = await ctx.post(`/v1/agents/${agent.id}`, {
+            draft: { ...agent.draft, provider: null, modelName: null },
+        })
+        expect(cleared.json().draft.modelName).toBeNull()
 
         const asAgent = await ctx.post(CONVERSATIONS_URL, { agentId: agent.id })
         const refused = await ctx.post(`${CONVERSATIONS_URL}/${asAgent.json().id}/messages`, { content: 'hello' })

--- a/packages/server/api/test/integration/ee/agent/agent-builder-conversation.test.ts
+++ b/packages/server/api/test/integration/ee/agent/agent-builder-conversation.test.ts
@@ -109,15 +109,10 @@ describe('whose model a builder run answers on', () => {
     // An agent that names no model cannot be talked to, and that is the point of the guard. The
     // builder is not that agent: refusing it here would leave a half-made agent unbuildable, which
     // is exactly the state the builder exists to get you out of.
-    it('builds an agent whose model was cleared, where talking to that agent is refused', async () => {
+    it('builds an agent that names no model, where talking to that agent is refused', async () => {
         const ctx = await context()
-        const saved = await mockAndSaveAIProvider({ platformId: ctx.platform.id, provider: AIProviderName.OPENROUTER })
-        await db.update('ai_provider', saved.id, { enabledForChat: true })
         const agent = await createAgent(ctx)
-        const cleared = await ctx.post(`/v1/agents/${agent.id}`, {
-            draft: { ...agent.draft, provider: null, modelName: null },
-        })
-        expect(cleared.json().draft.modelName).toBeNull()
+        await mockAndSaveAIProvider({ platformId: ctx.platform.id, provider: AIProviderName.OPENROUTER, enabledForChat: true })
 
         const asAgent = await ctx.post(CONVERSATIONS_URL, { agentId: agent.id })
         const refused = await ctx.post(`${CONVERSATIONS_URL}/${asAgent.json().id}/messages`, { content: 'hello' })

--- a/packages/server/api/test/integration/ee/agent/agent-controller.test.ts
+++ b/packages/server/api/test/integration/ee/agent/agent-controller.test.ts
@@ -46,12 +46,9 @@ afterAll(async () => {
 })
 
 describe('agent crud', () => {
-    // An agent with no model cannot be talked to, so a created one is given the platform's default
-    // rather than landing the person on a checklist before they can say anything to it.
     it('fills in the platform model when the request names none', async () => {
         const ctx = await context()
-        const saved = await mockAndSaveAIProvider({ platformId: ctx.platform.id, provider: AIProviderName.OPENROUTER })
-        await db.update('ai_provider', saved.id, { enabledForChat: true })
+        await mockAndSaveAIProvider({ platformId: ctx.platform.id, provider: AIProviderName.OPENROUTER, enabledForChat: true })
 
         const agent = await createAgent(ctx)
 
@@ -61,26 +58,11 @@ describe('agent crud', () => {
 
     it('keeps a model the request did name', async () => {
         const ctx = await context()
-        const saved = await mockAndSaveAIProvider({ platformId: ctx.platform.id, provider: AIProviderName.OPENROUTER })
-        await db.update('ai_provider', saved.id, { enabledForChat: true })
         const body = agentBody(ctx.project.id)
 
-        const response = await ctx.post('/v1/agents', {
-            ...body,
-            draft: { ...body.draft, provider: AIProviderName.OPENROUTER, modelName: 'anthropic/claude-haiku-4.5' },
-        })
+        const agent = await createAgent(ctx, { draft: { ...body.draft, provider: AIProviderName.OPENROUTER, modelName: 'anthropic/claude-haiku-4.5' } })
 
-        expect(response.json().draft.modelName).toBe('anthropic/claude-haiku-4.5')
-    })
-
-    // On a fresh install there is nothing to pick, and saying so beats inventing a model that
-    // cannot run.
-    it('leaves the model empty when the platform has no provider to answer on', async () => {
-        const ctx = await context()
-
-        const agent = await createAgent(ctx)
-
-        expect(agent.draft.modelName).toBeNull()
+        expect(agent.draft.modelName).toBe('anthropic/claude-haiku-4.5')
     })
 
     it('creates an agent owned by the caller, in draft, unpublished', async () => {
@@ -92,6 +74,7 @@ describe('agent crud', () => {
         expect(agent.visibility).toBe(AgentVisibility.PROJECT)
         expect(agent.published).toBeNull()
         expect(agent.draft.instructions).toBe('Draft launch posts.')
+        expect(agent.draft.modelName).toBeNull()
     })
 
     it('updates only the fields the request names', async () => {

--- a/packages/server/api/test/integration/ee/agent/agent-controller.test.ts
+++ b/packages/server/api/test/integration/ee/agent/agent-controller.test.ts
@@ -1,8 +1,9 @@
-import { apId } from '@activepieces/core-utils'
+import { AIProviderName, apId } from '@activepieces/core-utils'
 import { AgentIcon, AgentVisibility, ColorName, DEFAULT_AGENT_MAX_STEPS, DefaultProjectRole, MAX_DRAFT_PROMPT_LENGTH } from '@activepieces/shared'
 import { FastifyInstance } from 'fastify'
 import { StatusCodes } from 'http-status-codes'
 import { db } from '../../../helpers/db'
+import { mockAndSaveAIProvider } from '../../../helpers/mocks'
 import { createMemberContext, createTestContext, TestContext } from '../../../helpers/test-context'
 import { DRAFTS_PER_MINUTE } from '../../../../src/app/ee/agent/agent-controller'
 import { AGENT_TEMPLATES } from '../../../../src/app/ee/agent/agent-templates'
@@ -45,6 +46,43 @@ afterAll(async () => {
 })
 
 describe('agent crud', () => {
+    // An agent with no model cannot be talked to, so a created one is given the platform's default
+    // rather than landing the person on a checklist before they can say anything to it.
+    it('fills in the platform model when the request names none', async () => {
+        const ctx = await context()
+        const saved = await mockAndSaveAIProvider({ platformId: ctx.platform.id, provider: AIProviderName.OPENROUTER })
+        await db.update('ai_provider', saved.id, { enabledForChat: true })
+
+        const agent = await createAgent(ctx)
+
+        expect(agent.draft.modelName).not.toBeNull()
+        expect(agent.draft.provider).toBe(AIProviderName.OPENROUTER)
+    })
+
+    it('keeps a model the request did name', async () => {
+        const ctx = await context()
+        const saved = await mockAndSaveAIProvider({ platformId: ctx.platform.id, provider: AIProviderName.OPENROUTER })
+        await db.update('ai_provider', saved.id, { enabledForChat: true })
+        const body = agentBody(ctx.project.id)
+
+        const response = await ctx.post('/v1/agents', {
+            ...body,
+            draft: { ...body.draft, provider: AIProviderName.OPENROUTER, modelName: 'anthropic/claude-haiku-4.5' },
+        })
+
+        expect(response.json().draft.modelName).toBe('anthropic/claude-haiku-4.5')
+    })
+
+    // On a fresh install there is nothing to pick, and saying so beats inventing a model that
+    // cannot run.
+    it('leaves the model empty when the platform has no provider to answer on', async () => {
+        const ctx = await context()
+
+        const agent = await createAgent(ctx)
+
+        expect(agent.draft.modelName).toBeNull()
+    })
+
     it('creates an agent owned by the caller, in draft, unpublished', async () => {
         const ctx = await context()
         const agent = await createAgent(ctx)

--- a/packages/server/api/test/integration/ee/agent/agent-controller.test.ts
+++ b/packages/server/api/test/integration/ee/agent/agent-controller.test.ts
@@ -52,17 +52,25 @@ describe('agent crud', () => {
 
         const agent = await createAgent(ctx)
 
-        expect(agent.draft.modelName).not.toBeNull()
+        expect(agent.draft.modelName).toBe('anthropic/claude-sonnet-4.6')
         expect(agent.draft.provider).toBe(AIProviderName.OPENROUTER)
     })
 
-    it('keeps a model the request did name', async () => {
+    it('keeps a model the request did name, even where a default was available', async () => {
         const ctx = await context()
-        const body = agentBody(ctx.project.id)
+        await mockAndSaveAIProvider({ platformId: ctx.platform.id, provider: AIProviderName.OPENROUTER, enabledForChat: true })
 
-        const agent = await createAgent(ctx, { draft: { ...body.draft, provider: AIProviderName.OPENROUTER, modelName: 'anthropic/claude-haiku-4.5' } })
+        const agent = await createAgent(ctx, { draft: { ...agentBody(ctx.project.id).draft, provider: AIProviderName.OPENROUTER, modelName: 'anthropic/claude-haiku-4.5' } })
 
         expect(agent.draft.modelName).toBe('anthropic/claude-haiku-4.5')
+    })
+
+    it('leaves the model empty where the platform has no chat provider', async () => {
+        const ctx = await context()
+
+        const agent = await createAgent(ctx)
+
+        expect(agent.draft.modelName).toBeNull()
     })
 
     it('creates an agent owned by the caller, in draft, unpublished', async () => {
@@ -74,7 +82,6 @@ describe('agent crud', () => {
         expect(agent.visibility).toBe(AgentVisibility.PROJECT)
         expect(agent.published).toBeNull()
         expect(agent.draft.instructions).toBe('Draft launch posts.')
-        expect(agent.draft.modelName).toBeNull()
     })
 
     it('updates only the fields the request names', async () => {

--- a/packages/server/api/test/integration/ee/agent/agent-turn.test.ts
+++ b/packages/server/api/test/integration/ee/agent/agent-turn.test.ts
@@ -98,9 +98,6 @@ describe('an agent conversation', () => {
 })
 
 describe('the model an agent answers on', () => {
-    // Creating an agent fills in the platform's default model, so the model-less state now comes
-    // from clearing it afterwards. The guard still matters: an agent must answer on its own model
-    // or not at all, never by silently falling back to whatever chat runs on.
     it('refuses to run an agent whose model was cleared, even when the platform has a chat provider', async () => {
         const ctx = await context()
         await enableForChat(ctx.platform.id, AIProviderName.OPENROUTER)

--- a/packages/server/api/test/integration/ee/agent/agent-turn.test.ts
+++ b/packages/server/api/test/integration/ee/agent/agent-turn.test.ts
@@ -98,10 +98,18 @@ describe('an agent conversation', () => {
 })
 
 describe('the model an agent answers on', () => {
-    it('refuses to run an agent that names no model, even when the platform has a chat provider', async () => {
+    // Creating an agent fills in the platform's default model, so the model-less state now comes
+    // from clearing it afterwards. The guard still matters: an agent must answer on its own model
+    // or not at all, never by silently falling back to whatever chat runs on.
+    it('refuses to run an agent whose model was cleared, even when the platform has a chat provider', async () => {
         const ctx = await context()
         await enableForChat(ctx.platform.id, AIProviderName.OPENROUTER)
-        const agent = await createAgent(ctx, { provider: null, modelName: null })
+        const agent = await createAgent(ctx)
+        const cleared = await ctx.post(`/v1/agents/${agent.id}`, {
+            draft: { ...agent.draft, provider: null, modelName: null },
+        })
+        expect(cleared.statusCode).toBe(StatusCodes.OK)
+        expect(cleared.json().draft.modelName).toBeNull()
         const conversation = await startConversation(ctx, agent.id)
 
         const response = await ctx.post(`${CONVERSATIONS_URL}/${conversation.id}/messages`, {

--- a/packages/server/api/test/integration/ee/agent/agent-turn.test.ts
+++ b/packages/server/api/test/integration/ee/agent/agent-turn.test.ts
@@ -98,15 +98,10 @@ describe('an agent conversation', () => {
 })
 
 describe('the model an agent answers on', () => {
-    it('refuses to run an agent whose model was cleared, even when the platform has a chat provider', async () => {
+    it('refuses to run an agent that names no model, even when the platform has a chat provider', async () => {
         const ctx = await context()
-        await enableForChat(ctx.platform.id, AIProviderName.OPENROUTER)
         const agent = await createAgent(ctx)
-        const cleared = await ctx.post(`/v1/agents/${agent.id}`, {
-            draft: { ...agent.draft, provider: null, modelName: null },
-        })
-        expect(cleared.statusCode).toBe(StatusCodes.OK)
-        expect(cleared.json().draft.modelName).toBeNull()
+        await enableForChat(ctx.platform.id, AIProviderName.OPENROUTER)
         const conversation = await startConversation(ctx, agent.id)
 
         const response = await ctx.post(`${CONVERSATIONS_URL}/${conversation.id}/messages`, {

--- a/packages/server/api/test/unit/app/ee/agent/agent-model-resolution.test.ts
+++ b/packages/server/api/test/unit/app/ee/agent/agent-model-resolution.test.ts
@@ -113,21 +113,17 @@ describe('resolveChatProviderName', () => {
         await expect(agentHelpers.resolveChatProviderName({ platformId: 'plat-1', projectId: null, log })).resolves.toBeNull()
     })
 
-    it('reads a lookup failure as no provider, so telemetry and billing keep going', async () => {
+    it('lets a lookup failure surface, so no caller reads a fault as a platform with no provider', async () => {
         getChatProviderName.mockRejectedValueOnce(new Error('connection terminated'))
 
-        await expect(agentHelpers.resolveChatProviderName({ platformId: 'plat-1', projectId: 'proj-1', log })).resolves.toBeNull()
+        await expect(agentHelpers.resolveChatProviderName({ platformId: 'plat-1', projectId: 'proj-1', log })).rejects.toThrow('connection terminated')
     })
 
-    it('lets a lookup failure surface, so nothing saves an agent nobody can talk to', async () => {
-        getChatProviderName.mockRejectedValueOnce(new Error('connection terminated'))
+    it('asks only for keys the project may use, never platform-wide', async () => {
+        getChatProviderName.mockResolvedValueOnce(AIProviderName.OPENROUTER)
 
-        await expect(agentHelpers.chatProviderNameOrThrow({ platformId: 'plat-1', projectId: 'proj-1', log })).rejects.toThrow('connection terminated')
-    })
+        await agentHelpers.resolveChatProviderName({ platformId: 'plat-1', projectId: 'proj-1', log })
 
-    it('still reports an unconfigured platform as no provider', async () => {
-        getChatProviderName.mockResolvedValueOnce(null)
-
-        await expect(agentHelpers.chatProviderNameOrThrow({ platformId: 'plat-1', projectId: 'proj-1', log })).resolves.toBeNull()
+        expect(getChatProviderName).toHaveBeenCalledWith({ platformId: 'plat-1', scope: { type: 'project', projectId: 'proj-1' } })
     })
 })

--- a/packages/server/api/test/unit/app/ee/agent/agent-model-resolution.test.ts
+++ b/packages/server/api/test/unit/app/ee/agent/agent-model-resolution.test.ts
@@ -1,6 +1,12 @@
 import { AIProviderName } from '@activepieces/core-utils'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { agentHelpers } from '../../../../../src/app/ee/agent/agent-helpers'
+
+const getChatProviderName = vi.fn()
+
+vi.mock('../../../../../src/app/ai/ai-provider-service', () => ({
+    aiProviderService: () => ({ getChatProviderName }),
+}))
 
 const resolve = ({ provider, selectedModel }: { provider: AIProviderName, selectedModel: string | null }) =>
     agentHelpers.resolveModelIdForProvider({ provider, selectedModel })
@@ -101,8 +107,27 @@ describe('runScopeOrThrow', () => {
 })
 
 describe('resolveChatProviderName', () => {
+    const log = { info: () => undefined, warn: () => undefined, error: () => undefined, debug: () => undefined } as never
+
     it('reports no provider for a conversation with no project, rather than guessing one platform-wide', async () => {
-        const log = { info: () => undefined, warn: () => undefined, error: () => undefined, debug: () => undefined }
-        await expect(agentHelpers.resolveChatProviderName({ platformId: 'plat-1', projectId: null, log: log as never })).resolves.toBeNull()
+        await expect(agentHelpers.resolveChatProviderName({ platformId: 'plat-1', projectId: null, log })).resolves.toBeNull()
+    })
+
+    it('reads a lookup failure as no provider, so telemetry and billing keep going', async () => {
+        getChatProviderName.mockRejectedValueOnce(new Error('connection terminated'))
+
+        await expect(agentHelpers.resolveChatProviderName({ platformId: 'plat-1', projectId: 'proj-1', log })).resolves.toBeNull()
+    })
+
+    it('lets a lookup failure surface, so nothing saves an agent nobody can talk to', async () => {
+        getChatProviderName.mockRejectedValueOnce(new Error('connection terminated'))
+
+        await expect(agentHelpers.chatProviderNameOrThrow({ platformId: 'plat-1', projectId: 'proj-1', log })).rejects.toThrow('connection terminated')
+    })
+
+    it('still reports an unconfigured platform as no provider', async () => {
+        getChatProviderName.mockResolvedValueOnce(null)
+
+        await expect(agentHelpers.chatProviderNameOrThrow({ platformId: 'plat-1', projectId: 'proj-1', log })).resolves.toBeNull()
     })
 })


### PR DESCRIPTION
## Description

An agent with no model cannot be talked to. `agent-conversation-controller` refuses the turn with *"Pick a model for this agent before talking to it"*, and the agent page shows an **Almost ready** checklist instead of a composer.

Every create path left the model empty unless the caller named one. So a **starter template**, a **blank agent**, or **one chat built for you** all landed on that checklist, and you had to go and choose a model before you could say a single thing to the agent you just made. Found while testing the agents surface on the UI: a freshly created agent greets you with a form, not a conversation.

Creating one now fills in the platform's default: the same concrete model id the AI draft already writes (`DEFAULT_CHAT_TIER_ID` resolved for the project's provider). It lands in `agentService.create`, so all three paths get it at once rather than each remembering to.

**It stays empty when the platform has no provider.** On a fresh install there is nothing to pick, and the checklist is the honest answer there. Inventing a model that cannot run would be the failure the zero-setup rule exists to prevent.

**A caller that names a model keeps it.** The default only fills a gap.

**The guard stays.** An agent answers on its own model or not at all, never by silently falling back to whatever chat runs on, which is the trap that shipped a step configured for Sonnet 4.5 running 4.6.

## How was this tested?

Three new cases in `agent-controller.test.ts`:

- a create that names no model comes back with one, and with the provider it belongs to;
- a create that does name a model keeps it (`anthropic/claude-haiku-4.5` survives);
- a platform with no provider gets `modelName: null` rather than a guess.

Mutation-checked: returning the draft unchanged fails the first and nothing else.

**One existing test changed, deliberately.** `agent-turn.test.ts` pinned "refuses to run an agent that names no model" by creating one with `modelName: null`, which this change fills in. The refusal still matters and is still reachable, so the test now clears the model through an update and asserts the refusal from there. It is the same guard, reached the way a user would now reach it.

Verified on the running UI as well as in tests: creating from the prompt hero lands you in a conversation with the model badge filled, rather than on the checklist.

Also run: `test/integration/ee` (224), `test/integration/ce` (996), `tsc` and lint on api.

Fixes # (issue)

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)

`POST /v1/agents` now returns a `draft.modelName` where it previously returned `null` for callers that omitted it. Nothing is removed and no field changes shape.

I first marked this breaking on the shape of the change alone. It is not, because there is nobody on the other side of it: the agents surface sits behind `plan.agentsEnabled` and is not exposed to customers, so no consumer has an assertion to update. Existing agents are untouched, and a caller that names a model still gets exactly that model.

**Scope grew during review, deliberately.** Greptile found that the provider lookup collapsed a genuine fault into the same `null` that means "no provider configured", so a transient failure persisted a model-less agent behind a 201. Fixing that turned up the same swallow on two billing paths — `chat-usage-tracker` and `debitDraft` both branch on `provider === ACTIVEPIECES` to pick between the managed tier weight and `CHAT_BYOK_CREDIT_WEIGHT`, so a database blip silently charged the BYOK amount. My first fix routed around the swallow for creation only and left that in place; I had told the reviewer only creation needed it, and that was wrong.

The swallow is now gone from `resolveChatProviderName` entirely, so every caller states its own policy. Creation and both billing paths let a fault surface: creation as a 500 the caller can retry, and billing as a skipped charge with a logged rejection, which both callers already tolerate. The two analytics call sites keep tolerance through a local wrapper beside the two identical ones already in that file, because a throw in `resolveLookups` would kill the whole batch for a telemetry label. One lookup, three policies, each visible where it is chosen.

One thing a reviewer should know, since it is the only case that could make this wrong. I first wrote that a self-hosted EE instance has no billing provider so the entitlements refresh never overwrites `agentsEnabled`, leaving it at its column default of `true`. **That was wrong and I am correcting it here.** `app.ts` registers the Autumn provider for ENTERPRISE exactly as it does for CLOUD, enrolment skips only COMMUNITY, and license activation calls `refreshEntitlements` directly, which sets the flag from the Autumn entitlement. So on the upgrade path the flag is overwritten, not defaulted.

What survives of it: `agentsEnabled` really does default to `true` (both the column and `AUTUMN_FREE_PLAN`, which the ENTERPRISE seed uses), so an EE instance that never successfully enrols — offline, or an unreachable console, where the enrolment failure is only logged — keeps the routes live. That is a narrower case than I claimed. The judgement is unchanged: nobody is calling `POST /v1/agents` on a surface that is days old and undocumented. If we would rather not lean on that, flipping the seed to `false` for ENTERPRISE is the honest fix, not an upgrade note for a change with no audience.

Also worth knowing while looking here: the `agentsEnabled` gate is on the `agentController` sub-surface only. `agentConversationController` and `agentRunController` are registered outside it, so "the /v1/agents routes" are not uniformly gated by that flag. Not this PR's to fix.

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)

The model is resolved from the platform's own configured provider through the existing resolver, scoped to the project the agent is created in. No new surface and no new entitlement.


