### PR TITLE
fix(chat): skip users with orphaned platformId in personalization backfill

### DIFF
--- a/packages/server/api/src/app/database/migration/postgres/1832000000000-BackfillChatPersonalizationForExistingUsers.ts
+++ b/packages/server/api/src/app/database/migration/postgres/1832000000000-BackfillChatPersonalizationForExistingUsers.ts
@@ -16,7 +16,7 @@ export class BackfillChatPersonalizationForExistingUsers1832000000000 implements
                 "user"."id",
                 'DISMISSED_LEGACY'
             FROM "user"
-            WHERE "user"."platformId" IS NOT NULL
+            INNER JOIN "platform" ON "platform"."id" = "user"."platformId"
             ON CONFLICT DO NOTHING
         `)
     }


### PR DESCRIPTION
## Description

The `BackfillChatPersonalizationForExistingUsers1832000000000` migration failed in production (v0.88.3) with:

```
insert or update on table "chat_personalization" violates foreign key constraint "fk_chat_personalization_platform_id"
```

The backfill inserted a `chat_personalization` row for every user with a non-null `platformId`, but the `user` table has no FK to `platform` — some prod users point at a deleted platform. `chat_personalization` does enforce that FK, so the insert aborted the migration and server startup.

The fix replaces `WHERE "user"."platformId" IS NOT NULL` with an `INNER JOIN "platform"`, so only users whose platform still exists are backfilled. Orphaned users get no row, which is fine — their platform no longer exists.

The failed migration ran in a transaction and was never recorded, so it simply re-runs with the corrected query on the next deploy.

## How was this tested?

Verified against the production failure: the FK violation only occurs for users whose `platformId` references a missing platform row, which the join now excludes.

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)