### PR TITLE
fix(agents): a failed agent step now fails its flow run

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -116,7 +116,7 @@
     },
     "packages/core/execution": {
       "name": "@activepieces/core-execution",
-      "version": "0.16.0",
+      "version": "0.17.0",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -148,7 +148,7 @@
     },
     "packages/core/piece-types": {
       "name": "@activepieces/core-piece-types",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "dependencies": {
         "@activepieces/core-utils": "workspace:*",
         "tslib": "2.6.2",
@@ -334,7 +334,7 @@
     },
     "packages/pieces/community/ai": {
       "name": "@activepieces/piece-ai",
-      "version": "0.8.0",
+      "version": "0.9.0",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",

--- a/docs/install/reference/breaking-changes.mdx
+++ b/docs/install/reference/breaking-changes.mdx
@@ -23,6 +23,21 @@ The `SMTP Blacklist Sender` checkbox is replaced by a `Blocked Sender Addresses`
 #### What you need to do
 
 Nothing to configure or migrate, and no existing step stops working. Review any flow whose Create or Update Contact step relied on the old behaviour: a step that was silently wiping attributes will now leave them intact, and a step you were relying on to blacklist contacts must have the checkbox explicitly ticked. To block a sender for a contact, list that sender's address in `Blocked Sender Addresses` — it must be an active sender in your Brevo account, or Brevo answers *"One of the sender is invalid or inactive"*.
+#### A Run Agent step whose turn dies now fails its flow run
+
+A Run Agent step whose turn died — no AI provider configured for the chosen vendor, a revoked API key, a model the provider no longer serves — used to report success. The step returned the failed agent result rather than raising it, so the step read SUCCEEDED, the run completed SUCCEEDED, and later steps acted on a payload that carried the failure inside it. Such a run is now FAILED, and the agent's error message is the step's error.
+
+Two cases are deliberately unaffected, because the agent did produce usable output:
+
+- A turn that finished but had a single tool call error. The agent may have recovered from it and reported on it, so those runs keep succeeding exactly as before.
+- A turn that was cut short by the output limit or the run's usage budget. It still returns the work it completed, and the flow still continues.
+
+#### What you need to do
+
+Nothing to configure or migrate, and no new environment variable. Two things to check if either applies to you. If a flow relied on continuing past a dead agent step, tick **Continue on failure** on that step — it now takes effect, where previously the step never failed for it to apply to. If a flow branches on the agent result (a Router reading the step's `status`), that branch no longer runs when the turn dies, because the step raises instead of returning; move that handling onto the step's failure path.
+
+If you alert on run status, expect agent flows that were silently completing on a misconfigured provider to start showing as failed. That is the misconfiguration surfacing, not new breakage.
+
 
 #### Workers no longer pre-warm the flow cache on startup by default
 

--- a/docs/install/reference/breaking-changes.mdx
+++ b/docs/install/reference/breaking-changes.mdx
@@ -23,6 +23,7 @@ The `SMTP Blacklist Sender` checkbox is replaced by a `Blocked Sender Addresses`
 #### What you need to do
 
 Nothing to configure or migrate, and no existing step stops working. Review any flow whose Create or Update Contact step relied on the old behaviour: a step that was silently wiping attributes will now leave them intact, and a step you were relying on to blacklist contacts must have the checkbox explicitly ticked. To block a sender for a contact, list that sender's address in `Blocked Sender Addresses` — it must be an active sender in your Brevo account, or Brevo answers *"One of the sender is invalid or inactive"*.
+
 #### A Run Agent step whose turn dies now fails its flow run
 
 A Run Agent step whose turn died — no AI provider configured for the chosen vendor, a revoked API key, a model the provider no longer serves — used to report success. The step returned the failed agent result rather than raising it, so the step read SUCCEEDED, the run completed SUCCEEDED, and later steps acted on a payload that carried the failure inside it. Such a run is now FAILED, and the agent's error message is the step's error.
@@ -37,7 +38,6 @@ Two cases are deliberately unaffected, because the agent did produce usable outp
 Nothing to configure or migrate, and no new environment variable. Two things to check if either applies to you. If a flow relied on continuing past a dead agent step, tick **Continue on failure** on that step — it now takes effect, where previously the step never failed for it to apply to. If a flow branches on the agent result (a Router reading the step's `status`), that branch no longer runs when the turn dies, because the step raises instead of returning; move that handling onto the step's failure path.
 
 If you alert on run status, expect agent flows that were silently completing on a misconfigured provider to start showing as failed. That is the misconfiguration surfacing, not new breakage.
-
 
 #### Workers no longer pre-warm the flow cache on startup by default
 

--- a/packages/core/execution/package.json
+++ b/packages/core/execution/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/core-execution",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "scripts": {

--- a/packages/core/execution/src/lib/agents/index.ts
+++ b/packages/core/execution/src/lib/agents/index.ts
@@ -28,6 +28,7 @@ export type AgentResult = {
     steps: AgentStepBlock[]
     status: AgentTaskStatus
     structuredOutput?: unknown
+    failure?: string
 }
 
 export const MarkdownContentBlock = z.object({

--- a/packages/core/piece-types/package.json
+++ b/packages/core/piece-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/core-piece-types",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "scripts": {

--- a/packages/core/piece-types/src/lib/agents.ts
+++ b/packages/core/piece-types/src/lib/agents.ts
@@ -297,4 +297,5 @@ export type AgentResult = {
     steps: AgentStepBlock[]
     status: AgentTaskStatus
     structuredOutput?: unknown
+    failure?: string
 }

--- a/packages/pieces/community/ai/package.json
+++ b/packages/pieces/community/ai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-ai",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/packages/pieces/community/ai/src/lib/actions/agents/run-agent.ts
+++ b/packages/pieces/community/ai/src/lib/actions/agents/run-agent.ts
@@ -116,6 +116,9 @@ export const runAgent = createAction({
       if (isNil(result)) {
         throw new Error('The agent did not report a result before this step timed out');
       }
+      if (!isNil(result.failure)) {
+        throw new Error(result.failure);
+      }
       return result;
     }
 

--- a/packages/server/worker/src/lib/execute/jobs/ee/agent/execute-agent-run.ts
+++ b/packages/server/worker/src/lib/execute/jobs/ee/agent/execute-agent-run.ts
@@ -370,7 +370,7 @@ export const executeAgentRunJob: JobHandler<ExecuteAgentRunJobData, FireAndForge
                 : isCreditError || isNil(runProvider)
                     ? errorMessage
                     : `${runProvider}${isNil(runModelId) ? '' : ` (${runModelId})`}: ${errorMessage}`
-            const failedResult = answer ?? stepResultFrom({ prompt: userMessage, uiParts: [], timestamp: new Date().toISOString(), tools: configuredPieceTools, structuredOutput: structured.output, failure: clientMessage })
+            const failedResult = { ...(answer ?? stepResultFrom({ prompt: userMessage, uiParts: [], timestamp: new Date().toISOString(), tools: configuredPieceTools, structuredOutput: structured.output, failure: clientMessage })), failure: clientMessage }
             reportFinal(failedResult)
             const { error: releaseError } = await tryCatch(() => releaseFlowStep({ ctx, conversationId, flowRunId, waitpointId, output: failedResult, source, log }))
             // Empty arrays here mean "mark this turn ERROR" — they do NOT wipe history. The

--- a/packages/server/worker/test/lib/execute/jobs/ee/agent/execute-agent-run-config-failure.test.ts
+++ b/packages/server/worker/test/lib/execute/jobs/ee/agent/execute-agent-run-config-failure.test.ts
@@ -66,6 +66,7 @@ describe('executeAgentRunJob — a config failure must not swallow the turn', ()
         expect(resumed).toHaveLength(1)
         expect(resumed[0].waitpointId).toBe('waitpoint-1')
         expect(JSON.stringify(resumed[0].output)).toContain('FAILED')
+        expect(resumed[0].output).toMatchObject({ failure: expect.stringContaining('ENTITY_NOT_FOUND') })
     })
 
     it('tells the chat client the turn failed instead of leaving it streaming', async () => {

--- a/packages/server/worker/test/lib/execute/jobs/ee/agent/execute-agent-run.test.ts
+++ b/packages/server/worker/test/lib/execute/jobs/ee/agent/execute-agent-run.test.ts
@@ -81,6 +81,17 @@ describe('stepResultFrom', () => {
     })
 })
 
+describe('stepResultFrom — a turn that produced output must not fail the flow step', () => {
+    const at = '2026-08-05T00:00:00.000Z'
+
+    it('leaves the fatal signal unset even when it reports an incomplete reason', () => {
+        const result = stepResultFrom({ tools: [], prompt: 'do it', uiParts: [], timestamp: at, failure: 'The response reached the output limit before the agent finished' })
+
+        expect(result.status).toBe('FAILED')
+        expect(result.failure).toBeUndefined()
+    })
+})
+
 describe('stepResultFrom — a failed tool call must not read as success', () => {
     const at = '2026-08-05T00:00:00.000Z'
     const failedCall = {


### PR DESCRIPTION
## Description

A Run Agent step whose turn died reported success. `run-agent.ts` **returned** the failed `AgentResult` on RESUME instead of raising it, so the step read SUCCEEDED, the flow run completed SUCCEEDED, and the following steps acted on a payload that carried the failure inside it. A platform with no AI provider configured, or a revoked key, produced runs that looked green.

**This completes the invariant the original ticket asked for.** Its table wanted `flow_run` FAILED for a user-config error and only *asserted* that was already the case — it wasn't.

### #15094 made this more pressing, not less

That PR deliberately stopped these jobs landing in the failed set. So as of today:

| Signal | Before #15094 | After #15094 (now) |
|---|---|---|
| BullMQ job | failed | **completed** |
| flow_run status | SUCCEEDED | **SUCCEEDED** |
| Durable trace | failed-set entry | a `warn` log |

**6,150 flow-step agent runs failed in 16 days on Cloud**, every one of them reading SUCCEEDED. #15094 removed the last durable signal, so without this the invariant is half-implemented in the wrong direction.

### Scoped to a turn that produced nothing usable

`AgentResult` gains an optional `failure`, set **only** where the handler catches a dead turn, and the RESUME branch throws only when it is present. `stepResultFrom` is untouched, so the three other paths that pass a `failure` string keep returning their result and the flow keeps going:

- a turn cut short by the **output limit or usage budget**, which still returns the work it completed
- a turn where **one tool call errored** but the agent carried on
- a run **cancelled by the user**

An earlier revision of this PR keyed off `stepResultFrom` and therefore failed the step in all of those too. That was much broader than the problem, and it is the main thing that changed here — the blast radius is now the genuinely-dead turns only.

`isNil` rather than a truthiness check is deliberate: an `Error` with an empty message would give a blank reason, and `isNil` still fails the step for it. Failing with an empty message beats completing as a success.

**Both `AgentResult` declarations carry the field, and that is not redundant.** They are deliberate twins — `core-execution` on `zod` for the server, `core-piece-types` on `zod/mini` for pieces and the engine. Pieces resolve theirs through `pieces-framework`, so patching one leaves the `piece-ai` build unable to see it. I checked whether one could re-export the other: it cannot, because `AgentStepBlock` differs between the two zod flavours.

## How was this tested?

- 2 tests, both verified to fail in the right direction:
  - Reverting the handler line so the dead-turn path stops setting the signal reds the config-failure test (`expected { prompt: 'do it', … } to match object { failure: StringContaining{…} }`).
  - Restoring the over-broad version, where `stepResultFrom` sets it, reds the passthrough test — so the narrowing itself is pinned, not just the fix.
- `npm run test-unit` — 28/28 tasks. `npm run lint-dev` — 33/33, zero errors. All affected packages rebuild clean.
- Edition paths: the agent step is EE/Cloud only (`agentModule` is registered in the CLOUD and ENTERPRISE branches of `app.ts`), so a Community self-hoster is unaffected. No new env var, secret, or setup step.
- **Not verified live:** I have not run a real agent step end to end. Worth one manual check — a Run Agent step on a platform with no provider for the chosen vendor should now produce a FAILED run.

## On the breaking-change classification

Raised in review as possibly not breaking, on the grounds that agents aren't live. The data says the step is:

**10,682 Run Agent flow-step executions across 397 distinct platforms** in 16 days (Cloud only, so that is a floor). 201 platforms used it on 2+ days, 70 on 5+ days, and distinct platforms per day roughly doubled week over week. The action dates to 2025-05-06, is ungated (`auth: PieceAuth.None()`, no plan flag, no `LockedFeatureGuard`), and six flow-version migrations exist purely to rewrite persisted `run_agent` steps inside existing customer flows.

The real distinction: the **new Agents surface** *is* gated — `agentController` sits behind `platformMustHaveFeatureEnabled((p) => p.plan.agentsEnabled)`. But `agentRunController`, which the flow step calls, is registered deliberately **outside** that wrapper, so the step works for every Cloud and EE platform regardless of the flag.

The concrete dependency that makes it breaking: a flow can branch on the agent result today — `Run Agent → Router: if status is FAILED, notify`. That router no longer runs when the step raises. The docs entry tells people to move that handling onto the step's failure path.

Fixes # (issue)

### Breaking change?  (required — CI fails if this is left unedited)

- [ ] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [x] yes — functional (default/limit/behaviour change, new self-hosted setup step)

A flow whose agent step dies now has a FAILED run where it previously had a SUCCEEDED one, and its downstream steps no longer run. No API field, column, env var or setup step changes, and nothing needs migrating. Entry added to `docs/install/reference/breaking-changes.mdx`.

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)

Adds one optional field to an internal result type and one throw. No authentication, authorization, secret handling, crypto, outbound HTTP or file handling is touched. The `failure` string is the same message already shown to the user in the step output today.
