### PR TITLE
refactor(ai-providers): share one constant for AI provider entity-type names

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -148,7 +148,7 @@
     },
     "packages/core/piece-types": {
       "name": "@activepieces/core-piece-types",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "dependencies": {
         "@activepieces/core-utils": "workspace:*",
         "tslib": "2.6.2",
@@ -161,7 +161,7 @@
     },
     "packages/core/shared": {
       "name": "@activepieces/shared",
-      "version": "0.146.0",
+      "version": "0.147.0",
       "dependencies": {
         "@activepieces/core-execution": "workspace:*",
         "@activepieces/core-formula": "workspace:*",

--- a/packages/core/piece-types/package.json
+++ b/packages/core/piece-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/core-piece-types",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "scripts": {

--- a/packages/core/piece-types/src/lib/ai-providers.ts
+++ b/packages/core/piece-types/src/lib/ai-providers.ts
@@ -364,6 +364,11 @@ export const aiProviderUtils = {
     isCuratedChatModelId,
 }
 
+export const AI_PROVIDER_ENTITY_TYPES = {
+    provider: 'AIProvider',
+    chatProvider: 'ChatAiProvider',
+} as const
+
 export type AIWebSearchMode = 'native' | 'plugin'
 
 export type OpenAiCompatibleVendor =

--- a/packages/core/shared/package.json
+++ b/packages/core/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/shared",
-  "version": "0.146.0",
+  "version": "0.147.0",
   "type": "commonjs",
   "sideEffects": false,
   "main": "./dist/src/index.js",

--- a/packages/core/shared/src/lib/management/ai-providers/index.ts
+++ b/packages/core/shared/src/lib/management/ai-providers/index.ts
@@ -412,6 +412,7 @@ export function splitCloudflareGatewayModelId(modelId: string): {
 }
 
 export {
+    AI_PROVIDER_ENTITY_TYPES,
     ALLOWED_CHAT_MODELS_BY_PROVIDER,
     ACTIVEPIECES_CHAT_TIERS,
     DEFAULT_CHAT_TIER_ID,

--- a/packages/server/api/src/app/ai/ai-provider-service.ts
+++ b/packages/server/api/src/app/ai/ai-provider-service.ts
@@ -1,5 +1,5 @@
 import { ActivepiecesError, AIProviderName, apId, ErrorCode, isNil, PlatformId, spreadIfDefined, unique } from '@activepieces/core-utils'
-import { ActivePiecesProviderAuthConfig, AIProviderAuthConfig, AIProviderConfig, AIProviderModel, AiProviderProjectScope, AIProviderWithoutSensitiveData, CreateAIProviderRequest, GetProviderConfigResponse, ProjectAIProvider, UpdateAIProviderRequest } from '@activepieces/shared'
+import { ActivePiecesProviderAuthConfig, AI_PROVIDER_ENTITY_TYPES, AIProviderAuthConfig, AIProviderConfig, AIProviderModel, AiProviderProjectScope, AIProviderWithoutSensitiveData, CreateAIProviderRequest, GetProviderConfigResponse, ProjectAIProvider, UpdateAIProviderRequest } from '@activepieces/shared'
 import { FastifyBaseLogger } from 'fastify'
 import cron from 'node-cron'
 import { repoFactory } from '../core/db/repo-factory'
@@ -89,7 +89,7 @@ export const aiProviderService = (log: FastifyBaseLogger) => ({
         if (isNil(aiProvider)) {
             throw new ActivepiecesError({
                 code: ErrorCode.ENTITY_NOT_FOUND,
-                params: { entityId: providerId, entityType: 'AIProvider' },
+                params: { entityId: providerId, entityType: AI_PROVIDER_ENTITY_TYPES.provider },
             })
         }
 
@@ -314,7 +314,7 @@ async function resolveEligibleRow({ platformId, provider, scope }: { platformId:
             code: ErrorCode.ENTITY_NOT_FOUND,
             params: {
                 entityId: provider,
-                entityType: 'AIProvider',
+                entityType: AI_PROVIDER_ENTITY_TYPES.provider,
             },
         }, scope.type === 'platform'
             ? `the ${provider} AI provider is not configured on this platform`
@@ -334,7 +334,7 @@ async function resolveRowForScope({ platformId, provider, scope, configId }: { p
             code: ErrorCode.ENTITY_NOT_FOUND,
             params: {
                 entityId: configId,
-                entityType: 'AIProvider',
+                entityType: AI_PROVIDER_ENTITY_TYPES.provider,
             },
         }, scope.type === 'platform'
             ? `the ${provider} AI provider key is not configured on this platform`
@@ -364,7 +364,7 @@ async function getRowByIdOrThrow({ platformId, configId }: { platformId: Platfor
             code: ErrorCode.ENTITY_NOT_FOUND,
             params: {
                 entityId: configId,
-                entityType: 'AIProvider',
+                entityType: AI_PROVIDER_ENTITY_TYPES.provider,
             },
         })
     }

--- a/packages/server/api/src/app/ee/agent/agent-helpers.ts
+++ b/packages/server/api/src/app/ee/agent/agent-helpers.ts
@@ -1,6 +1,6 @@
 import { ActivepiecesError, AIProviderName, apId, ErrorCode, isNil, spreadIfDefined, tryCatch, unique } from '@activepieces/core-utils'
 import { agentAiUtils } from '@activepieces/server-utils'
-import { ACTIVEPIECES_CHAT_TIERS, AgentConversation, AgentConversationStatus, aiProviderUtils, DEFAULT_CHAT_TIER_ID, GetAgentMemoryResponse, GetProviderConfigResponse, Project, ProjectType, UserMemory } from '@activepieces/shared'
+import { ACTIVEPIECES_CHAT_TIERS, AgentConversation, AgentConversationStatus, AI_PROVIDER_ENTITY_TYPES, aiProviderUtils, DEFAULT_CHAT_TIER_ID, GetAgentMemoryResponse, GetProviderConfigResponse, Project, ProjectType, UserMemory } from '@activepieces/shared'
 import { SharedV3ProviderOptions } from '@ai-sdk/provider'
 import { EmbeddingModel, LanguageModel } from 'ai'
 import { FastifyBaseLogger } from 'fastify'
@@ -118,7 +118,7 @@ async function resolveChatProvider({ platformId, scope, log }: { platformId: str
     if (isNil(chatProvider)) {
         throw new ActivepiecesError({
             code: ErrorCode.ENTITY_NOT_FOUND,
-            params: { entityId: platformId, entityType: 'ChatAiProvider' },
+            params: { entityId: platformId, entityType: AI_PROVIDER_ENTITY_TYPES.chatProvider },
         }, 'no AI provider on this platform is enabled for chat')
     }
     return chatProvider
@@ -130,7 +130,7 @@ async function assertRunProviderConfigured({ platformId, provider, providerConfi
         if (isNil(chatProvider)) {
             throw new ActivepiecesError({
                 code: ErrorCode.ENTITY_NOT_FOUND,
-                params: { entityId: platformId, entityType: 'ChatAiProvider' },
+                params: { entityId: platformId, entityType: AI_PROVIDER_ENTITY_TYPES.chatProvider },
             }, 'no AI provider on this platform is enabled for chat')
         }
         return
@@ -139,7 +139,7 @@ async function assertRunProviderConfigured({ platformId, provider, providerConfi
     if (!configured) {
         throw new ActivepiecesError({
             code: ErrorCode.ENTITY_NOT_FOUND,
-            params: { entityId: provider, entityType: 'AIProvider' },
+            params: { entityId: provider, entityType: AI_PROVIDER_ENTITY_TYPES.provider },
         }, scope.type === 'platform'
             ? `the ${provider} AI provider is not configured on this platform`
             : `no ${provider} AI provider key is available to this project`)


### PR DESCRIPTION
## Description

The entity-type names `AIProvider` and `ChatAiProvider` were hand-written as `entityType:` string literals at 7 production throw sites. #15094 adds an agent-run error classifier that decides whether a failed job is a user misconfiguration or our own bug by matching those exact strings, so a typo or drift at any one site would silently mis-classify real failures.

This pulls the two names into one shared constant, `AI_PROVIDER_ENTITY_TYPES`, next to the other AI-provider domain constants in `packages/core/piece-types/src/lib/ai-providers.ts`, re-exported through `@activepieces/shared` the same way `ALLOWED_CHAT_MODELS_BY_PROVIDER` and `AI_PROVIDER_CAPABILITIES` already are. All 7 production sites now read from it:

- `packages/server/api/src/app/ee/agent/agent-helpers.ts` — 2x `chatProvider`, 1x `provider`
- `packages/server/api/src/app/ai/ai-provider-service.ts` — 4x `provider`

The string values are byte-identical to what was there before (`'AIProvider'`, `'ChatAiProvider'`), so nothing on the wire or in persisted error params changes. No behaviour change at all.

Test files were deliberately left with their literals. A test asserting `'ChatAiProvider'` is pinning the wire value it expects to see, which is arguably the right thing for a test to do; swapping them for the constant would add diff and let a value change slip past the assertions.

Versions bumped for the new export: `@activepieces/core-piece-types` 0.5.0 -> 0.6.0, `@activepieces/shared` 0.146.0 -> 0.147.0.

## How was this tested?

- `npx turbo run build --filter=@activepieces/core-piece-types --filter=@activepieces/shared` — clean.
- `npx turbo run test --filter=@activepieces/shared --filter=@activepieces/core-execution --filter=worker` — 12/13 tasks pass. `worker#test` fails only in `worker-settings-override.test.ts` (9 tests), which fails identically on a clean tree at the same base commit.
- `packages/server/api`: `npx vitest run test/unit` — 961 passed / 42 failed, byte-for-byte the same counts and the same 8 files as the untouched baseline (they need infra this environment does not have). The two suites that exercise these throw sites, `agent-fast-model-provider.test.ts` and `execute-agent-run-config-failure.test.ts`, pass.
- `npx tsc -p tsconfig.lib.json --noEmit` in `packages/core/piece-types` — clean.
- `npm run lint-dev` — 33/33 tasks successful, 0 errors (warnings are pre-existing).
- Pure refactor with identical string values, so no edition-specific behaviour to check across CE / EE / Cloud.

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)
