### PR TITLE
fix(api): a handled 4xx no longer logs as a server error

### DIFF
--- a/packages/server/api/src/app/helper/error-handler.ts
+++ b/packages/server/api/src/app/helper/error-handler.ts
@@ -44,7 +44,7 @@ export const enrichWideEventWithError = (error: unknown): void => {
         if (statusCode >= StatusCodes.INTERNAL_SERVER_ERROR) {
             wideErrorFields.stack = error.stack
         }
-        wideEvent.set({ error: wideErrorFields })
+        wideEvent.set({ status: statusCode, error: wideErrorFields })
         return
     }
     const parsed = parseError(error)
@@ -65,7 +65,7 @@ export const enrichWideEventWithError = (error: unknown): void => {
     if (statusCode >= StatusCodes.INTERNAL_SERVER_ERROR.valueOf() && error instanceof Error) {
         wideErrorFields.stack = error.stack
     }
-    wideEvent.set({ error: wideErrorFields })
+    wideEvent.set({ status: statusCode, error: wideErrorFields })
 }
 
 function hasStatusCode(error: unknown): error is { statusCode: number } {

--- a/packages/server/api/test/unit/app/helper/error-handler-wide-event.test.ts
+++ b/packages/server/api/test/unit/app/helper/error-handler-wide-event.test.ts
@@ -1,0 +1,40 @@
+import { ActivepiecesError, ErrorCode } from '@activepieces/core-utils'
+import { StatusCodes } from 'http-status-codes'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { mockSet } = vi.hoisted(() => ({ mockSet: vi.fn() }))
+
+vi.mock('@activepieces/server-utils', async (importOriginal) => ({
+    ...await importOriginal<typeof import('@activepieces/server-utils')>(),
+    wideEvent: { set: mockSet },
+}))
+
+import { enrichWideEventWithError } from '../../../../src/app/helper/error-handler'
+
+function loggedStatus(): unknown {
+    return mockSet.mock.calls[0][0].status
+}
+
+describe('enrichWideEventWithError — a handled 4xx must not log as a 500', () => {
+    beforeEach(() => {
+        mockSet.mockClear()
+    })
+
+    it('records a quota rejection as payment required, not a server error', () => {
+        enrichWideEventWithError(new ActivepiecesError({ code: ErrorCode.QUOTA_EXCEEDED, params: { metric: 'credits', quota: 0 } }))
+
+        expect(loggedStatus()).toBe(StatusCodes.PAYMENT_REQUIRED)
+    })
+
+    it('records a missing entity as not found', () => {
+        enrichWideEventWithError(new ActivepiecesError({ code: ErrorCode.ENTITY_NOT_FOUND, params: { entityType: 'AIProvider' } }))
+
+        expect(loggedStatus()).toBe(StatusCodes.NOT_FOUND)
+    })
+
+    it('still records a genuine server fault as a 500', () => {
+        enrichWideEventWithError(new Error('Cannot read properties of undefined'))
+
+        expect(loggedStatus()).toBe(StatusCodes.INTERNAL_SERVER_ERROR)
+    })
+})


### PR DESCRIPTION
## Description

Every handled `ActivepiecesError` is logged with `status: 500`, whatever it actually returned. The client gets the right code — `statusCodeMap` is correct and unchanged — but the wide event says server error, so the api error-rate dashboard counts ordinary user rejections as our faults.

Measured on 30 days of production logs, `POST /api/v1/agents/runs` alone produced **12,325 of these in two days**: 10,985 `QUOTA_EXCEEDED` (a platform out of AI credits) and 1,340 `ENTITY_NOT_FOUND` (no AI provider configured), each logged `status: 500` while `error.status` correctly read 402 / 404. That route is just where it was noticed — this applies to **every route and every error code**.

### Why it happens

`enrichWideEventWithError` sets the code on the nested `error.status`, but never the top-level `status`. evlog's `onError` hook finishes the request without a status:

```js
fastify.addHook('onError', async (request, _reply, error) => { … await state.finish({ error: err }) })
```

That marks the request emitted, so the `onResponse` hook that would have passed `reply.statusCode` returns early. evlog then falls back to its default (`evlog/dist/index.mjs`):

```js
status: status ?? entry.status ?? 500
```

`entry.status` was never set, so every thrown error logs 500.

The fix is to set it alongside the value already being computed. The non-error path is untouched: `onResponse` passes `status` explicitly, and that takes precedence over `entry.status`.

## How was this tested?

- 3 new unit tests in `error-handler-wide-event.test.ts` pinning the mapping: a quota rejection logs 402, a missing entity logs 404, and a genuine fault still logs 500. Verified all three fail without the change (`expected undefined to be 402/404/500`), so the test is a real gate rather than a tautology. The mock uses `importOriginal` so the real `parseError` still runs on the non-`ActivepiecesError` branch.
- `cd packages/server/api && npx vitest run test/unit` — 1001 passed, 18 failed. All 18 are pre-existing: the baseline on the same tree is 21 failed, and the difference is exactly the 3 new tests flipping from red to green.
- `npx turbo run lint --filter=api` — zero errors (488 pre-existing warnings).
- Edition-independent: this is the shared Fastify error handler, so CE, EE and Cloud all get the corrected value. No new env var, secret, or setup step.
- Not verified live: I have not watched a real request land in the warehouse with the corrected status. Worth one check after deploy — the api error rate should drop by roughly the handled-4xx volume, which is not a regression but the metric finally telling the truth.

Fixes # (issue)

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

No HTTP response changes — clients already received the correct status. Only the logged value is corrected. Anyone alerting on logged `status: 500` will see a drop; that is the false positives going away, not behaviour changing. No API field, column, env var, or setup step is touched.

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)

Sets an integer status code on a log entry. No authentication, authorization, secret, crypto, outbound HTTP, or file handling is touched, and no new data is logged — `statusCode` was already written to `error.status` on the same event. Worth noting the opposite is a small improvement: an authorization denial now logs as 403 rather than being indistinguishable from a crash.
