### PR TITLE
fix(logging): a thrown non-Error no longer logs as {}

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -186,7 +186,7 @@
     },
     "packages/core/utils": {
       "name": "@activepieces/core-utils",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "dependencies": {
         "deepmerge-ts": "7.1.0",
         "ipaddr.js": "2.3.0",

--- a/packages/core/utils/package.json
+++ b/packages/core/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/core-utils",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "scripts": {

--- a/packages/core/utils/src/lib/try-catch.ts
+++ b/packages/core/utils/src/lib/try-catch.ts
@@ -36,6 +36,17 @@ export function tryCatchSync<T, E = Error>(
     }
 }
 
+export function toError(value: unknown): Error {
+    if (value instanceof Error) {
+        return value
+    }
+    if (typeof value === 'string') {
+        return new Error(value)
+    }
+    const { data: serialized } = tryCatchSync(() => JSON.stringify(value))
+    return new Error(serialized ?? String(value))
+}
+
 export type TypedResult<T> =
     | { success: true, data: T }
     | { success: false, message: string }

--- a/packages/server/utils/src/ap-logger.ts
+++ b/packages/server/utils/src/ap-logger.ts
@@ -1,3 +1,4 @@
+import { toError } from '@activepieces/core-utils'
 import { log } from 'evlog'
 import { wideEvent } from './wide-event'
 
@@ -150,13 +151,12 @@ function normalizePinoArgsWithError(args: unknown[]): { message: string | undefi
         const second = args[1]
         const message = typeof second === 'string' ? second : undefined
 
-        // pino convention: obj.err or obj.error as Error
         const errField = first['err'] ?? first['error']
-        if (errField instanceof Error) {
+        if (isRecord(errField)) {
             const { err: _err, error: _error, ...rest } = first
             void _err
             void _error
-            return { message, fields: rest, err: errField }
+            return { message, fields: rest, err: toError(errField) }
         }
         return { message, fields: first, err: undefined }
     }

--- a/packages/server/utils/src/wide-event.ts
+++ b/packages/server/utils/src/wide-event.ts
@@ -1,3 +1,4 @@
+import { toError } from '@activepieces/core-utils'
 import { AsyncLocalStorage } from 'node:async_hooks'
 import { audit as standaloneAudit, AuditInput, RequestLogger, withAuditMethods } from 'evlog'
 
@@ -14,8 +15,7 @@ function set(fields: Record<string, unknown>): void {
 function error(err: unknown): void {
     const store = als.getStore()
     if (!store) return
-    const wrapped = err instanceof Error ? err : new Error(String(err))
-    store.error(wrapped)
+    store.error(toError(err))
 }
 
 async function timed<T>({ name, fn }: { name: string, fn: () => Promise<T> }): Promise<T> {

--- a/packages/server/utils/test/ap-logger.test.ts
+++ b/packages/server/utils/test/ap-logger.test.ts
@@ -88,6 +88,20 @@ describe('apLogger', () => {
             expect(arg.error).toContain('boom')
         })
 
+        it('error(obj with a thrown object) keeps the payload instead of logging nothing', () => {
+            const logger = apLogger.create({})
+            logger.error({ error: { code: 'TOOL_FAILED', tool: 'ap_web_search' } }, 'agent job failed')
+            expect(spies.logErrorSpy.mock.calls[0][0].error).toContain('TOOL_FAILED')
+        })
+
+        it('error(obj with a string error) leaves it as it is', () => {
+            const logger = apLogger.create({})
+            logger.error({ error: 'connection refused', requestId: 'r1' }, 'context msg')
+            const arg = spies.logErrorSpy.mock.calls[0][0]
+            expect(arg.error).toBe('connection refused')
+            expect(arg.requestId).toBe('r1')
+        })
+
         it('error(obj with .err Error) extracts the error under the error key', () => {
             const logger = apLogger.create({})
             const err = new Error('nested')

--- a/packages/server/utils/test/evlog-wide-event.test.ts
+++ b/packages/server/utils/test/evlog-wide-event.test.ts
@@ -76,6 +76,32 @@ describe('wideEvent', () => {
         expect((err as Error).message).toBe('something went wrong')
     })
 
+    it('error() keeps a thrown object\'s payload, which is the only place it survives', () => {
+        const logger = makeMockLogger()
+        wideEvent.run({
+            logger,
+            fn: () => {
+                wideEvent.error({ code: 'TOOL_FAILED', tool: 'ap_web_search' })
+            },
+        })
+        const [err] = logger._errors[0]
+        expect((err as Error).message).toContain('TOOL_FAILED')
+        expect((err as Error).message).toContain('ap_web_search')
+    })
+
+    it('error() does not throw on a value it cannot serialize', () => {
+        const logger = makeMockLogger()
+        const cyclic: Record<string, unknown> = {}
+        cyclic['self'] = cyclic
+        wideEvent.run({
+            logger,
+            fn: () => {
+                wideEvent.error(cyclic)
+            },
+        })
+        expect(logger._errors).toHaveLength(1)
+    })
+
     it('error() passes an existing Error directly', () => {
         const logger = makeMockLogger()
         const original = new Error('original')


### PR DESCRIPTION
## Description

Throwing something that isn't an `Error` erases it. Thirty days of production logs carry **47 agent-run failures logged as `error: {}`** — no name, no message, no stack, nothing to act on. They cluster tightly: `toolName: ap_web_search` (44 of 47), `phase: discovery`, `ai.calls: 0`, always right after `Repairing malformed tool call` warnings. Very likely one bug, and nobody can tell which.

That makes it the largest group of agent failures #15094 cannot classify — correctly so, since a thrown plain object matches nothing and stays `internal`. It just needs to be *readable*.

### Two entry points lost it

`worker.ts`'s job catch calls both on the same failure:

```ts
log.error({ error }, 'Job execution failed')
wideEvent.error(error)
```

- `normalizePinoArgsWithError` only treated an `err`/`error` field as an error when it was `instanceof Error`. Anything else stayed an ordinary field, and the drain copies only `name`/`message`/`stack` off an error — so a plain object serialised to `{}`.
- `wideEvent.error` did `new Error(String(err))`, which renders any object as the literal `[object Object]`.

Fixing only one would leave the other overwriting it, so both now route through one `toError()` in `core-utils`:

- **A real `Error` is returned by identity**, so its genuine stack survives.
- **A thrown string stays verbatim.** JSON would add quotes and a stack pointing at the wrapper; an existing test in `evlog-wide-event.test.ts` pins this, and caught me getting it wrong first time.
- **Anything else carries its payload as JSON**, with `String()` as the fallback so the logger can never throw while logging an error.

### Three judgement calls, since they are not obvious from the diff

**`toError` lives in `core-utils`, not beside its two consumers.** I tried the smaller version — both callers are in `packages/server/utils`, and `ap-logger.ts` already imports from `./wide-event`, so putting it there would have avoided a version bump and a lockfile line. It fails: `ap-logger.test.ts` mocks `../src/wide-event`, so the import resolved to `undefined`, the call threw, and `error()`'s `catch {}` swallowed it — **error logging died silently**, taking two pre-existing tests with it. A helper the logging path depends on must not live in a module that gets mocked. The bump is the price of a shared util, not waste.

**The `instanceof Error ||` guard was dropped as redundant.** `isRecord` already returns `true` for an `Error` (object, non-null, non-array), and `toError` returns Errors by identity, so `isRecord(errField)` alone is exactly equivalent and reads as one condition instead of two.

**The stale `// pino convention: obj.err or obj.error as Error` comment went with it**, since the branch no longer requires an Error. No comments were added — the reasoning is here and in the commit message.

Net effect: both consumer files are **shorter** than before.

## How was this tested?

- 4 new cases, all verified to be real gates rather than decoration:
  - Reverting `toError` to the old `String()` behaviour reds 2 (the wide-event payload case and the logger payload case).
  - Reverting the `isRecord` branch reds the logger case.
  - Two more pin deliberate choices: a string error field is left exactly as it is, and an unserialisable cyclic value does not throw.
- `cd packages/server/utils && npx vitest run test/` — **153 passed**, including the pre-existing `evlog-wide-event` and `logger-redact` suites that pin the surrounding behaviour.
- `npm run test-unit` — 25/25 tasks. `npm run lint-dev` — 33/33, zero errors. `bun install --frozen-lockfile` — clean, no changes.
- Edition-independent (shared logging utilities). No new env var, secret, or setup step.
- **Not verified live:** I have not watched a normalised error land in the warehouse. The check after deploy is that those 47 rows stop reading `{}` and start naming a cause.

### Scope note

This is instrumentation, not the fix for the `ap_web_search` failure itself. Once deployed those 47 will say what they are, and that becomes a real ticket.

An earlier revision of this description claimed `wide-event.ts` produced the `ai.error: "[object Object]"` field seen beside these rows. That was wrong — `ai.*` comes from evlog's own AI-SDK integration and is untouched here. `String()` on a plain object is the shared mechanism, which is what pointed at the right place.

Fixes # (issue)

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

Log content only, and strictly additive: entries that already carried a value keep it byte-for-byte (Errors by identity, strings verbatim), while entries that carried nothing now carry the payload. No API, column, env var, or setup step is touched. Anyone parsing `error` as an object rather than a string was already getting `{}` for these.

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)

Worth a reviewer's eye, since this does widen what reaches the drain: a thrown object's fields are now serialised into the message where before they were dropped. That is the point of the change, and it is not a new class of exposure — a thrown `Error` already had its full message and stack logged by `stringifyError`, so this makes non-Error throws consistent with Errors rather than more permissive. Redaction runs on the emitted entry, not on error construction, and `logger-redact.test.ts` passes unchanged. No authentication, authorization, secret handling, crypto, outbound HTTP, or file handling is touched.
