### PR TITLE
test(worker): run the settings override tests again

### DIFF
--- a/packages/server/worker/test/lib/worker-settings-override.test.ts
+++ b/packages/server/worker/test/lib/worker-settings-override.test.ts
@@ -88,11 +88,7 @@ function buildMinimalHandlers(): WorkerToApiContract {
     }
 }
 
-// Skipped so the worker package can enter the CI test filter at all: these 9 time out, which rotted
-// unnoticed precisely because it was never in that filter. They cover the cloud sandbox-isolation
-// gate in worker.ts, and that production check is intact; only its coverage is parked. DROP THIS
-// SKIP when #15096 merges — it repairs the cause.
-describe.skip('worker settings override', () => {
+describe('worker settings override', () => {
     let httpServer: ReturnType<typeof createServer>
     let ioServer: IOServer
     let port: number


### PR DESCRIPTION
## Description

#15094 added `describe.skip` to `worker-settings-override.test.ts` so the `worker` package could enter the CI test filter at all — all 9 cases were timing out, having rotted unnoticed precisely because the package had never been in that filter. The skip carried a comment marking it for removal once #15096 repaired the cause.

Both have now merged, so `main` carries the repair **and** the skip together: the nine tests pass and none of them run.

They are not idle tests. They cover the cloud sandbox-isolation gate in `worker.ts` that refuses a worker group running anything but `SANDBOX_PROCESS` / `SANDBOX_CODE_AND_PROCESS` on cloud edition, plus the `AP_REUSE_SANDBOX` requirement. That production check was intact throughout — only its coverage was parked — which is why this was worth chasing promptly rather than leaving for a sweep.

Removes the skip and its comment. One file, no production code touched.

## How was this tested?

- `npx vitest run test/lib/worker-settings-override.test.ts` — **9 passed in 1.8s**. Before #15096 these timed out at ~5s each; the fast run is the evidence the repair is real rather than a timeout being masked.
- `npx turbo run test --filter=worker` — **243 passed, 1 skipped** (was 226 passed, 10 skipped). The remaining skip is a pre-existing one elsewhere in the package.
- `npx turbo run lint --filter=worker` — zero errors (29 pre-existing warnings).

Fixes # (issue)

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

Test-only: one `describe.skip` and a comment removed. No production code, API field, column, env var or setup step is touched.

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)

It restores coverage of a sandbox-isolation gate rather than changing it. The production check in `worker.ts` was never modified — only its test was skipped — so this closes a regression-detection gap rather than altering any boundary.
