### PR TITLE
fix(front): attachments are sent as multipart, so they actually arrive

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -3473,7 +3473,7 @@
     },
     "packages/pieces/community/front": {
       "name": "@activepieces/piece-front",
-      "version": "0.1.6",
+      "version": "0.1.7",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -3482,6 +3482,7 @@
       },
       "devDependencies": {
         "tslib": "^2.3.0",
+        "vitest": "3.2.6",
       },
     },
     "packages/pieces/community/gameball": {

--- a/packages/pieces/common/src/lib/http/core/fetch-http-client.ts
+++ b/packages/pieces/common/src/lib/http/core/fetch-http-client.ts
@@ -45,6 +45,7 @@ export class FetchHttpClient extends BaseHttpClient {
       ? serializeBody(request.body, headers)
       : { body: undefined, extraHeaders: {}, isStream: false };
     const finalHeaders = normalizeHeaders({ ...headers, ...extraHeaders });
+    stripUnusableMultipartContentType(finalHeaders, body);
 
     const response = await sendWithRetries(async () => {
       const controller = new AbortController();
@@ -181,6 +182,28 @@ async function sendWithRetries(fn: () => Promise<Response>, retries: number): Pr
 function backoff(attempt: number): Promise<void> {
   const delayMs = Math.min(1000 * 2 ** attempt, 30000);
   return new Promise((resolve) => setTimeout(resolve, delayMs));
+}
+
+/**
+ * A multipart body can only be parsed with the boundary that separates its
+ * parts, and the boundary is chosen by fetch while it encodes the body. Any
+ * Content-Type decided before that point therefore names something the
+ * receiver cannot split on: the JSON default BaseHttpClient applies to every
+ * body, a caller writing `multipart/form-data` by hand with no boundary, and
+ * a caller carrying a boundary left over from an earlier encoding all fail
+ * the same way. Removing the header lets fetch write the whole thing itself.
+ *
+ * Only a global FormData body is affected. A `form-data` package instance has
+ * already been encoded into a stream by the time it reaches here, and its
+ * matching boundary arrives in extraHeaders, so it is left alone.
+ */
+function stripUnusableMultipartContentType(
+  headers: Record<string, string>,
+  body: BodyInit | undefined
+): void {
+  if (typeof FormData !== 'undefined' && body instanceof FormData) {
+    delete headers['content-type'];
+  }
 }
 
 function normalizeHeaders(headers: HttpHeaders): Record<string, string> {

--- a/packages/pieces/community/front/package.json
+++ b/packages/pieces/community/front/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-front",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
@@ -11,11 +11,13 @@
     "@activepieces/core-utils": "workspace:*"
   },
   "devDependencies": {
-    "tslib": "^2.3.0"
+    "tslib": "^2.3.0",
+    "vitest": "3.2.6"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",
     "bundle": "node ../../../../dist/packages/cli/src/index.js pieces bundle",
-    "lint": "eslint 'src/**/*.ts'"
+    "lint": "eslint 'src/**/*.ts'",
+    "test": "vitest run"
   }
 }

--- a/packages/pieces/community/front/src/lib/actions/create-draft-reply.ts
+++ b/packages/pieces/community/front/src/lib/actions/create-draft-reply.ts
@@ -1,6 +1,11 @@
 import { createAction, Property } from '@activepieces/pieces-framework';
 import { frontAuth } from '../common/auth';
-import { makeRequest } from '../common/client';
+import { makeRequest, makeMultipartRequest } from '../common/client';
+import {
+  attachmentsProperty,
+  buildMultipartBody,
+  toApFiles,
+} from '../common/attachments';
 import { HttpMethod } from '@activepieces/pieces-common';
 import {
   channelIdDropdown,
@@ -49,11 +54,7 @@ export const createDraftReply = createAction({
       description: 'List of BCC recipient handles.',
       required: false,
     }),
-    attachments: Property.Array({
-      displayName: 'Attachments',
-      description: 'List of attachment URLs.',
-      required: false,
-    }),
+    attachments: attachmentsProperty,
     mode: Property.StaticDropdown({
       displayName: 'Mode',
       description: 'Mode of the draft reply',
@@ -103,12 +104,24 @@ export const createDraftReply = createAction({
     if (to) requestBody['to'] = to;
     if (cc) requestBody['cc'] = cc;
     if (bcc) requestBody['bcc'] = bcc;
-    if (attachments) requestBody['attachments'] = attachments;
     if (mode) requestBody['mode'] = mode;
     if (signature_id) requestBody['signature_id'] = signature_id;
     if (should_add_default_signature !== undefined)
       requestBody['should_add_default_signature'] =
         should_add_default_signature;
+
+    // A draft with files has to go out as multipart; Front drops the
+    // attachments from a JSON request without complaining.
+    const files = toApFiles(attachments);
+    if (files.length > 0) {
+      return await makeMultipartRequest(
+        auth,
+        HttpMethod.POST,
+        path,
+        buildMultipartBody(requestBody, attachments)
+      );
+    }
+
     return await makeRequest(auth, HttpMethod.POST, path, requestBody);
   },
 });

--- a/packages/pieces/community/front/src/lib/actions/create-draft.ts
+++ b/packages/pieces/community/front/src/lib/actions/create-draft.ts
@@ -1,6 +1,11 @@
 import { createAction, Property } from '@activepieces/pieces-framework';
 import { frontAuth } from '../common/auth';
-import { makeRequest } from '../common/client';
+import { makeRequest, makeMultipartRequest } from '../common/client';
+import {
+  attachmentsProperty,
+  buildMultipartBody,
+  toApFiles,
+} from '../common/attachments';
 import { HttpMethod } from '@activepieces/pieces-common';
 import { channelIdDropdown } from '../common/dropdown';
 
@@ -42,11 +47,7 @@ export const createDraft = createAction({
       description: 'The body of the draft message.',
       required: true,
     }),
-    attachments: Property.Array({
-      displayName: 'Attachments',
-      description: 'List of attachment URLs.',
-      required: false,
-    }),
+    attachments: attachmentsProperty,
     mode: Property.StaticDropdown({
       displayName: 'Mode',
       description: 'Mode of the draft reply',
@@ -94,12 +95,23 @@ export const createDraft = createAction({
     if (cc) requestBody['cc'] = cc;
     if (bcc) requestBody['bcc'] = bcc;
     if (subject) requestBody['subject'] = subject;
-    if (attachments) requestBody['attachments'] = attachments;
     if (mode) requestBody['mode'] = mode;
     if (signature_id) requestBody['signature_id'] = signature_id;
     if (should_add_default_signature !== undefined)
       requestBody['should_add_default_signature'] =
         should_add_default_signature;
+
+    // A draft with files has to go out as multipart; Front drops the
+    // attachments from a JSON request without complaining.
+    const files = toApFiles(attachments);
+    if (files.length > 0) {
+      return await makeMultipartRequest(
+        auth,
+        HttpMethod.POST,
+        `/channels/${channel_id}/drafts`,
+        buildMultipartBody(requestBody, attachments)
+      );
+    }
 
     return await makeRequest(
       auth,

--- a/packages/pieces/community/front/src/lib/actions/send-message.ts
+++ b/packages/pieces/community/front/src/lib/actions/send-message.ts
@@ -1,6 +1,11 @@
 import { createAction, Property } from '@activepieces/pieces-framework';
 import { frontAuth } from '../common/auth';
-import { makeRequest } from '../common/client';
+import { makeRequest, makeMultipartRequest } from '../common/client';
+import {
+  attachmentsProperty,
+  buildMultipartBody,
+  toApFiles,
+} from '../common/attachments';
 import { HttpMethod } from '@activepieces/pieces-common';
 import { channelIdDropdown, tagIdsDropdown } from '../common/dropdown';
 
@@ -43,11 +48,7 @@ export const sendMessage = createAction({
       description: 'The body of the message.',
       required: true,
     }),
-    attachments: Property.Array({
-      displayName: 'Attachments',
-      description: 'List of attachment URLs.',
-      required: false,
-    }),
+    attachments: attachmentsProperty,
     tag_ids: tagIdsDropdown,
   },
   async run({ auth, propsValue }) {
@@ -61,14 +62,20 @@ export const sendMessage = createAction({
     if (cc) requestBody['cc'] = cc;
     if (bcc) requestBody['bcc'] = bcc;
     if (subject) requestBody['subject'] = subject;
-    if (attachments) requestBody['attachments'] = attachments;
     if (tag_ids) requestBody['tag_ids'] = tag_ids;
 
-    return await makeRequest(
-      auth,
-      HttpMethod.POST,
-      `/channels/${channel_id}/messages`,
-      requestBody
-    );
+    // A message with files has to go out as multipart; Front drops the
+    // attachments from a JSON request without complaining.
+    const files = toApFiles(attachments);
+    if (files.length > 0) {
+      return await makeMultipartRequest(
+        auth,
+        HttpMethod.POST,
+        `/channels/${channel_id}/messages`,
+        buildMultipartBody(requestBody, attachments)
+      );
+    }
+
+    return await makeRequest(auth, HttpMethod.POST, `/channels/${channel_id}/messages`, requestBody);
   },
 });

--- a/packages/pieces/community/front/src/lib/actions/send-reply.ts
+++ b/packages/pieces/community/front/src/lib/actions/send-reply.ts
@@ -1,6 +1,11 @@
 import { createAction, Property } from '@activepieces/pieces-framework';
 import { frontAuth } from '../common/auth';
-import { makeRequest } from '../common/client';
+import { makeRequest, makeMultipartRequest } from '../common/client';
+import {
+  attachmentsProperty,
+  buildMultipartBody,
+  toApFiles,
+} from '../common/attachments';
 import { HttpMethod } from '@activepieces/pieces-common';
 import {
   channelIdDropdown,
@@ -48,11 +53,7 @@ export const sendReply = createAction({
       required: false,
     }),
     channel_id: channelIdDropdown,
-    attachments: Property.Array({
-      displayName: 'Attachments',
-      description: 'List of attachment URLs.',
-      required: false,
-    }),
+    attachments: attachmentsProperty,
   },
   async run({ auth, propsValue }) {
     const {
@@ -75,7 +76,18 @@ export const sendReply = createAction({
     if (cc) requestBody['cc'] = cc;
     if (bcc) requestBody['bcc'] = bcc;
     if (channel_id) requestBody['channel_id'] = channel_id;
-    if (attachments) requestBody['attachments'] = attachments;
+
+    // A message with files has to go out as multipart; Front drops the
+    // attachments from a JSON request without complaining.
+    const files = toApFiles(attachments);
+    if (files.length > 0) {
+      return await makeMultipartRequest(
+        auth,
+        HttpMethod.POST,
+        path,
+        buildMultipartBody(requestBody, attachments)
+      );
+    }
 
     return await makeRequest(auth, HttpMethod.POST, path, requestBody);
   },

--- a/packages/pieces/community/front/src/lib/common/attachments.ts
+++ b/packages/pieces/community/front/src/lib/common/attachments.ts
@@ -1,0 +1,91 @@
+import { ApFile, Property } from '@activepieces/pieces-framework';
+
+/**
+ * Front only accepts attachments on a `multipart/form-data` request, as the
+ * bytes of the file. A JSON request carrying a list of URLs is accepted and the
+ * attachments are silently dropped, which is why this property is a list of
+ * files rather than a list of strings.
+ *
+ * `Property.File` resolves a URL, a data URI or an uploaded file into an
+ * `ApFile` before the action runs, so a link from an earlier step is still all
+ * the user has to supply.
+ */
+export const attachmentsProperty = Property.Array({
+  displayName: 'Attachments',
+  description:
+    'Files to attach. Each entry accepts a URL, a base64 data URI, or a file from a previous step. Front allows 25 MB across all attachments on one message.',
+  required: false,
+  properties: {
+    file: Property.File({
+      displayName: 'File',
+      description: 'The file to attach.',
+      required: true,
+    }),
+  },
+});
+
+type AttachmentEntry = { file?: ApFile };
+
+/**
+ * Front's multipart format names array entries by index, so
+ * `{ to: [a, b] }` goes out as the fields `to[0]` and `to[1]`, and a nested
+ * object is addressed with a second pair of brackets: `options[tag_ids][0]`.
+ * Nothing is sent for a value the caller left empty, matching what the JSON
+ * path already does.
+ */
+export function appendField(form: FormData, name: string, value: unknown): void {
+  if (value === null || value === undefined) {
+    return;
+  }
+  if (Array.isArray(value)) {
+    value.forEach((entry, index) => appendField(form, `${name}[${index}]`, entry));
+    return;
+  }
+  if (typeof value === 'object') {
+    for (const [key, nested] of Object.entries(value as Record<string, unknown>)) {
+      appendField(form, `${name}[${key}]`, nested);
+    }
+    return;
+  }
+  if (value === '') {
+    return;
+  }
+  form.append(name, String(value));
+}
+
+/**
+ * Turns the JSON body an action already builds into the equivalent multipart
+ * body, then adds the files. Keeping one shape for both paths means the two
+ * requests cannot drift apart.
+ */
+export function buildMultipartBody(
+  fields: Record<string, unknown>,
+  attachments: unknown
+): FormData {
+  const form = new FormData();
+  for (const [name, value] of Object.entries(fields)) {
+    appendField(form, name, value);
+  }
+  toApFiles(attachments).forEach((file, index) => {
+    form.append(
+      `attachments[${index}]`,
+      new Blob([new Uint8Array(file.data)]),
+      file.filename
+    );
+  });
+  return form;
+}
+
+/**
+ * Drops entries whose file failed to resolve. `Property.File` returns null for
+ * a URL it could not fetch - an expired signed link, most often - and sending
+ * the message without that attachment beats failing the whole step.
+ */
+export function toApFiles(attachments: unknown): ApFile[] {
+  if (!Array.isArray(attachments)) {
+    return [];
+  }
+  return (attachments as AttachmentEntry[])
+    .map((entry) => entry?.file)
+    .filter((file): file is ApFile => !!file && !!file.data);
+}

--- a/packages/pieces/community/front/src/lib/common/client.ts
+++ b/packages/pieces/community/front/src/lib/common/client.ts
@@ -25,3 +25,30 @@ export async function makeRequest(
         throw new Error(`Unexpected error: ${error.message || String(error)}`);
     }
 }
+
+/**
+ * Front accepts attachments only on a `multipart/form-data` request. The
+ * Content-Type header is deliberately absent: fetch has to set it itself so it
+ * can append the boundary, and a hand-written `multipart/form-data` with no
+ * boundary produces a request Front cannot parse.
+ */
+export async function makeMultipartRequest(
+    {secret_text}: AppConnectionValueForAuthProperty<typeof frontAuth>,
+    method: HttpMethod,
+    path: string,
+    form: FormData
+) {
+    try {
+        const response = await httpClient.sendRequest({
+            method,
+            url: `${BASE_URL}${path}`,
+            headers: {
+                Authorization: `Bearer ${secret_text}`,
+            },
+            body: form,
+        });
+        return response.body;
+    } catch (error: any) {
+        throw new Error(`Unexpected error: ${error.message || String(error)}`);
+    }
+}

--- a/packages/pieces/community/front/test/attachments.test.ts
+++ b/packages/pieces/community/front/test/attachments.test.ts
@@ -1,0 +1,188 @@
+import { ApFile } from '@activepieces/pieces-framework';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  appendField,
+  buildMultipartBody,
+  toApFiles,
+} from '../src/lib/common/attachments';
+import { sendMessage } from '../src/lib/actions/send-message';
+import { sendReply } from '../src/lib/actions/send-reply';
+
+const PDF = Buffer.from('%PDF-1.4 a scanned bill of lading');
+const auth = { secret_text: 'tok_test' } as never;
+const file = (name = 'bol.pdf', data = PDF) => new ApFile(name, data, 'pdf');
+
+/** The serialised request as Front would receive it. */
+type Sent = { url: string; contentType: string; body: string; auth: string };
+
+let sent: Sent[] = [];
+
+beforeEach(() => {
+  sent = [];
+  vi.stubGlobal('fetch', async (url: string, init: RequestInit) => {
+    // Building a real Request runs the same body serialisation fetch would, so
+    // the assertions below read the actual wire bytes rather than a FormData
+    // object that has not been encoded yet.
+    const request = new Request('https://example.invalid/', init);
+    sent.push({
+      url: String(url),
+      contentType: request.headers.get('content-type') ?? '',
+      body: Buffer.from(await request.arrayBuffer()).toString('latin1'),
+      auth: request.headers.get('authorization') ?? '',
+    });
+    return new Response(JSON.stringify({ id: 'msg_1' }), {
+      status: 202,
+      headers: { 'content-type': 'application/json' },
+    });
+  });
+});
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe('multipart field naming', () => {
+  it('names array entries by index, the way Front expects', () => {
+    const form = new FormData();
+    appendField(form, 'to', ['a@example.com', 'b@example.com']);
+    expect(form.get('to[0]')).toBe('a@example.com');
+    expect(form.get('to[1]')).toBe('b@example.com');
+  });
+
+  it('addresses a nested object with a second pair of brackets', () => {
+    const form = new FormData();
+    appendField(form, 'options', { tag_ids: ['tag_1', 'tag_2'] });
+    expect(form.get('options[tag_ids][0]')).toBe('tag_1');
+    expect(form.get('options[tag_ids][1]')).toBe('tag_2');
+  });
+
+  it('sends nothing for a value the caller left empty', () => {
+    const form = new FormData();
+    appendField(form, 'subject', '');
+    appendField(form, 'cc', null);
+    appendField(form, 'bcc', undefined);
+    expect([...form.keys()]).toEqual([]);
+  });
+
+  it('keeps a false and a zero, which are values and not omissions', () => {
+    const form = new FormData();
+    appendField(form, 'should_add_default_signature', false);
+    appendField(form, 'count', 0);
+    expect(form.get('should_add_default_signature')).toBe('false');
+    expect(form.get('count')).toBe('0');
+  });
+
+  it('carries the file bytes and its name', async () => {
+    const form = buildMultipartBody({ body: 'hi' }, [{ file: file() }]);
+    const part = form.get('attachments[0]') as File;
+    expect(part).toBeInstanceOf(Blob);
+    expect(part.name).toBe('bol.pdf');
+    expect(Buffer.from(await part.arrayBuffer()).equals(PDF)).toBe(true);
+  });
+});
+
+describe('files that did not resolve', () => {
+  it('drops an entry whose url could not be fetched', () => {
+    // Property.File returns null for a link it could not read - an expired
+    // signed url, most often.
+    expect(toApFiles([{ file: file() }, { file: null }, {}])).toHaveLength(1);
+  });
+
+  it('treats a missing attachments value as no attachments', () => {
+    expect(toApFiles(undefined)).toEqual([]);
+    expect(toApFiles(null)).toEqual([]);
+  });
+});
+
+describe('sendMessage', () => {
+  const base = {
+    channel_id: 'cha_1',
+    to: ['ops@example.com'],
+    cc: [],
+    bcc: [],
+    subject: 'BOL for load 1027576',
+    body: '<p>attached</p>',
+    tag_ids: [],
+  };
+
+  it('sends multipart, with the bytes, when there is an attachment', async () => {
+    await sendMessage.run({
+      auth,
+      propsValue: { ...base, attachments: [{ file: file() }] },
+    } as never);
+
+    expect(sent).toHaveLength(1);
+    const [req] = sent;
+    expect(req.url).toBe('https://api2.frontapp.com/channels/cha_1/messages');
+    expect(req.auth).toBe('Bearer tok_test');
+    // The boundary is the point: a hand-written multipart/form-data without one
+    // is exactly the request Front cannot parse.
+    expect(req.contentType).toMatch(/^multipart\/form-data; boundary=.+/);
+    expect(req.body).toContain('name="to[0]"');
+    expect(req.body).toContain('ops@example.com');
+    expect(req.body).toContain('name="attachments[0]"; filename="bol.pdf"');
+    expect(req.body).toContain(PDF.toString('latin1'));
+  });
+
+  it('still sends plain json when there is no attachment', async () => {
+    await sendMessage.run({
+      auth,
+      propsValue: { ...base, attachments: [] },
+    } as never);
+
+    const [req] = sent;
+    expect(req.contentType).toContain('application/json');
+    expect(JSON.parse(req.body)).toMatchObject({
+      channel_id: 'cha_1',
+      to: ['ops@example.com'],
+      subject: 'BOL for load 1027576',
+    });
+    expect(req.body).not.toContain('attachments');
+  });
+
+  it('sends json, not a broken multipart, when every file failed to resolve', async () => {
+    await sendMessage.run({
+      auth,
+      propsValue: { ...base, attachments: [{ file: null }] },
+    } as never);
+
+    expect(sent[0].contentType).toContain('application/json');
+  });
+
+  it('attaches more than one file, each under its own index', async () => {
+    await sendMessage.run({
+      auth,
+      propsValue: {
+        ...base,
+        attachments: [
+          { file: file('bol.pdf') },
+          { file: file('lumper.jpg', Buffer.from('JPEGDATA')) },
+        ],
+      },
+    } as never);
+
+    expect(sent[0].body).toContain('filename="bol.pdf"');
+    expect(sent[0].body).toContain('filename="lumper.jpg"');
+    expect(sent[0].body).toContain('JPEGDATA');
+  });
+});
+
+describe('sendReply', () => {
+  it('attaches to a reply on an existing conversation', async () => {
+    await sendReply.run({
+      auth,
+      propsValue: {
+        conversation_id: 'cnv_1',
+        body: 'here it is',
+        to: [],
+        cc: [],
+        bcc: [],
+        attachments: [{ file: file() }],
+      },
+    } as never);
+
+    expect(sent[0].url).toBe(
+      'https://api2.frontapp.com/conversations/cnv_1/messages'
+    );
+    expect(sent[0].contentType).toMatch(/^multipart\/form-data; boundary=.+/);
+    expect(sent[0].body).toContain('filename="bol.pdf"');
+  });
+});

--- a/packages/pieces/community/front/vitest.config.ts
+++ b/packages/pieces/community/front/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+  },
+})

--- a/packages/server/engine/src/lib/variables/processors/file.ts
+++ b/packages/server/engine/src/lib/variables/processors/file.ts
@@ -52,6 +52,13 @@ function handleBase64File(propertyValue: string): ApFile | null {
 
 async function handleUrlFile(path: string): Promise<ApFile | null> {
     const fileResponse = await fetch(path)
+    // A 4xx/5xx body is the server's error page, not the file. Buffering it
+    // produced an ApFile named after the url and filled with the error text,
+    // which then travelled on as if it were the attachment. The streaming
+    // path already refuses one; this is the same refusal.
+    if (!fileResponse.ok) {
+        return null
+    }
 
     const filename = getFileName(path, fileResponse.headers.get('content-disposition'), fileResponse.headers.get('content-type') ?? undefined) ?? 'unknown'
     const extension = extensionFromFilename(filename)

--- a/packages/server/engine/test/variables/file-processor.test.ts
+++ b/packages/server/engine/test/variables/file-processor.test.ts
@@ -103,6 +103,25 @@ describe('File Processor', () => {
         expect(file.body.destroyed).toBe(true)
     })
 
+    it('resolves a buffered URL input to null when the URL responds with a non-ok status', async () => {
+        // An expired signed link is the common case: without this the caller
+        // received the storage provider's error page as the file.
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('<Error>AuthenticationFailed</Error>', {
+            status: 403,
+            headers: { 'content-type': 'application/xml' },
+        })))
+
+        const { processedInput } = await propsProcessor.applyProcessorsAndValidators(
+            { file: FILE_URL },
+            { file: Property.File({ displayName: 'File', required: false }) },
+            PieceAuth.None(),
+            false,
+            {},
+        )
+
+        expect(processedInput.file).toBeNull()
+    })
+
     it('resolves a streaming file property to a lazy body without buffering', async () => {
         const props = {
             file: Property.File({ displayName: 'File', required: true, streaming: true }),


### PR DESCRIPTION
## The bug

Put a file URL in the Front piece's **Attachments** field, run the flow, and the message sends with no attachment. No error, no warning, HTTP 202.

The field is a `Property.Array` of plain strings described as "List of attachment URLs", and those strings are posted inside a JSON body. Front only accepts attachments on a `multipart/form-data` request, as the bytes of the file, so it takes the message and drops the `attachments` field on the floor. The same thing happens on `sendMessage`, `sendReply`, `createDraft` and `createDraftReply`.

Fixing it turned out to need three layers, one commit each. They are independent enough to split if you'd rather review them separately.

### 1. `fix(engine): a failed download is not a file`

`handleUrlFile` buffered whatever came back from the URL without checking the status, so a 4xx or 5xx produced an `ApFile` named after the URL and filled with the server's error page. A piece can't tell that apart from the real thing, so it travels on as the attachment: an expired signed link becomes an email with the storage provider's XML error stapled to it.

The streaming branch of the same processor already refuses a non-ok response (`handleStreamingFile`). The buffered branch now does too.

### 2. `fix(pieces-common): let fetch set the multipart boundary`

`BaseHttpClient.getHeaders` stamps `Content-Type: application/json` onto every request that carries a body, so a `FormData` body goes out labelled as JSON. Writing `multipart/form-data` by hand doesn't help either: the boundary that separates the parts is chosen by fetch while it encodes the body, and a Content-Type decided before that point names something the receiver can't split on.

The header is now dropped when the body is a global `FormData`, leaving fetch to write the whole thing.

To be clear about the blast radius: **no existing piece is affected.** `discord`, `instabase` and `image-router` all build their multipart body with the `form-data` package, which supplies its own boundary through `getHeaders()` and takes a different branch of `serializeBody`; I checked each against the unpatched client and all three come out correct. `docusign` doesn't use multipart at all. The Front piece here is the first caller to use a global `FormData`, which `serializeBody` already passes through untouched and which `getHeaders` then mislabels.

### 3. `fix(front): actually attach the files`

Attachments become `Property.File` entries, the same shape `gmail`, `discord` and `docusign` use:

```ts
attachments: Property.Array({
  properties: { file: Property.File({ ... }) },
})
```

A URL is still all the user supplies, because `props-processor` recurses into an ARRAY-with-`properties` and `fileProcessor` resolves each entry into an `ApFile` before the action runs. A step that already holds a file can be wired straight in.

A message with no attachments keeps its JSON path, so nothing changes for a flow that never used the field, and an entry whose file couldn't be resolved is skipped rather than failing the send. Array fields use Front's documented indexed-bracket naming (`to[0]`, `attachments[0]`).

## Breaking change

`attachments` is a list of files rather than a list of strings, so an existing flow has to re-pick the file. That's a change from a setting which silently did nothing to one that works. Piece version bumped 0.1.6 → 0.1.7.

## Verification

- 12 new tests in `packages/pieces/community/front/test/attachments.test.ts`. They build a real `Request` from the init object so the assertions read the actual serialised wire bytes: multipart boundary present, `to[0]` / `attachments[0]` naming, the PDF bytes in the body, the filename on the part, and the JSON path still taken when there are no attachments.
- 1 new test in `packages/server/engine/test/variables/file-processor.test.ts` (9 pass in that file).
- `test/variables` goes 42 → 43 passing with no new failures.
- Also checked end to end against the real `propsProcessor`: a plain URL in the field is fetched by the engine and those exact bytes come out in Front's multipart body.

## Note

Alvys is an existing customer; this came out of a production flow where drivers upload documents that need forwarding to brokers through Front. Happy to split the three commits into separate PRs, or to drop commits 1 and 2 and route around them inside the piece, if that's easier to land.
