### PR TITLE
fix(flows): publishing no longer silently strands a flow with a dead or wrong schedule

### DIFF
--- a/packages/server/api/src/app/trigger/trigger-events/trigger-event.service.ts
+++ b/packages/server/api/src/app/trigger/trigger-events/trigger-event.service.ts
@@ -1,4 +1,4 @@
-import { ActivepiecesError, apId, Cursor, ErrorCode, FlowId, ProjectId, SeekPage } from '@activepieces/core-utils'
+import { ActivepiecesError, apId, Cursor, ErrorCode, FlowId, isNil, ProjectId, SeekPage } from '@activepieces/core-utils'
 import { EngineResponse, EngineResponseStatus, ExecuteTriggerResponse, FileCompression, FileType, FlowTrigger, FlowTriggerType, getPieceMajorAndMinorVersion, PieceTrigger, PopulatedFlow, TriggerEventWithPayload, TriggerHookType, WorkerJobType } from '@activepieces/shared'
 import { FastifyBaseLogger } from 'fastify'
 import { repoFactory } from '../../core/db/repo-factory'
@@ -67,18 +67,18 @@ export const triggerEventService = (log: FastifyBaseLogger) => ({
                     jobType: WorkerJobType.EXECUTE_TRIGGER_HOOK,
                     platformId,
                 }, log)
+                if (engineResponse.status !== EngineResponseStatus.OK || isNil(engineResponse.response)) {
+                    throw new ActivepiecesError({
+                        code: ErrorCode.TEST_TRIGGER_FAILED,
+                        params: {
+                            message: engineResponse.error ?? 'The worker skipped the trigger test hook',
+                        },
+                    })
+                }
                 await triggerEventRepo().delete({
                     projectId,
                     flowId: flow.id,
                 })
-                if (engineResponse.status !== EngineResponseStatus.OK) {
-                    throw new ActivepiecesError({
-                        code: ErrorCode.TEST_TRIGGER_FAILED,
-                        params: {
-                            message: engineResponse.error ?? 'Unknown trigger error',
-                        },
-                    })
-                }
 
                 for (const output of engineResponse.response.output) {
                     await this.saveEvent({

--- a/packages/server/api/src/app/trigger/trigger-source/flow-trigger-side-effect.ts
+++ b/packages/server/api/src/app/trigger/trigger-source/flow-trigger-side-effect.ts
@@ -38,6 +38,9 @@ export const flowTriggerSideEffect = (log: FastifyBaseLogger) => {
             }, log)
 
             assertEngineResponseIsOk(engineHelperResponse, flowId, flowVersionId)
+            if (isNil(engineHelperResponse.response)) {
+                throwTriggerUpdateFailed({ flowId, flowVersionId, standardError: 'The worker skipped the trigger enable hook' })
+            }
 
             switch (pieceTrigger.type) {
                 case TriggerStrategy.APP_WEBHOOK: {
@@ -199,18 +202,21 @@ async function handlePollingTrigger({ engineHelperResponse, flowId, flowVersionI
 
 function assertEngineResponseIsOk(engineHelperResponse: EngineResponse<ExecuteTriggerResponse<TriggerHookType.ON_ENABLE | TriggerHookType.ON_DISABLE>>, flowId: FlowId, flowVersionId: FlowVersionId) {
     if (isNil(engineHelperResponse) || engineHelperResponse.status !== EngineResponseStatus.OK) {
-        throw new ActivepiecesError({
-            code: ErrorCode.TRIGGER_UPDATE_STATUS,
-            params: {
-                flowId,
-                flowVersionId,
-                standardOutput: '',
-                standardError: engineHelperResponse?.error ?? 'Engine response is undefined',
-            },
-        }, `flowId=${flowId} standardError=${engineHelperResponse?.error ?? 'Engine response is undefined'}`)
+        throwTriggerUpdateFailed({ flowId, flowVersionId, standardError: engineHelperResponse?.error ?? 'Engine response is undefined' })
     }
 }
 
+function throwTriggerUpdateFailed({ flowId, flowVersionId, standardError }: ThrowTriggerUpdateFailedParams): never {
+    throw new ActivepiecesError({
+        code: ErrorCode.TRIGGER_UPDATE_STATUS,
+        params: {
+            flowId,
+            flowVersionId,
+            standardOutput: '',
+            standardError,
+        },
+    }, `flowId=${flowId} standardError=${standardError}`)
+}
 
 
 type EnableFlowTriggerParams = {
@@ -234,4 +240,10 @@ type ActiveTriggerParams = EnableFlowTriggerParams & {
 
 type ActiveTriggerReturn = {
     scheduleOptions?: ScheduleOptions
+}
+
+type ThrowTriggerUpdateFailedParams = {
+    flowId: FlowId
+    flowVersionId: FlowVersionId
+    standardError: string
 }

--- a/packages/server/api/src/app/trigger/trigger-source/trigger-source-service.ts
+++ b/packages/server/api/src/app/trigger/trigger-source/trigger-source-service.ts
@@ -1,4 +1,4 @@
-import { ActivepiecesError, apId, ErrorCode, FlowId, isNil } from '@activepieces/core-utils'
+import { ActivepiecesError, apId, ErrorCode, FlowId, isNil, tryCatch } from '@activepieces/core-utils'
 import { FlowVersion, PopulatedTriggerSource, TemplateTelemetryEventType, TriggerSource } from '@activepieces/shared'
 import { FastifyBaseLogger } from 'fastify'
 import { In } from 'typeorm'
@@ -52,15 +52,35 @@ export const triggerSourceService = (log: FastifyBaseLogger) => {
                 simulate,
             }
             const triggerSource = await triggerSourceRepo().save(triggerSourceWithouSchedule)
-            const { scheduleOptions } = await flowTriggerSideEffect(log).enable({
-                flowId: flowVersion.flowId,
-                flowVersionId: flowVersion.id,
-                projectId,
-                pieceName: flowVersion.trigger.settings.pieceName,
-                pieceTrigger,
-                simulate,
-                isRepublish,
+            const enableResult = await tryCatch(async () => {
+                const { scheduleOptions } = await flowTriggerSideEffect(log).enable({
+                    flowId: flowVersion.flowId,
+                    flowVersionId: flowVersion.id,
+                    projectId,
+                    pieceName: flowVersion.trigger.settings.pieceName,
+                    pieceTrigger,
+                    simulate,
+                    isRepublish,
+                })
+                return triggerSourceRepo().save({
+                    ...triggerSource,
+                    schedule: scheduleOptions,
+                })
             })
+            if (enableResult.error !== null) {
+                const { error: rollbackError } = await tryCatch(() => triggerSourceRepo().softDelete({
+                    id: triggerSource.id,
+                    projectId,
+                }))
+                log.warn({
+                    flow: { id: flowVersion.flowId },
+                    flowVersion: { id: flowVersion.id },
+                    project: { id: projectId },
+                    error: enableResult.error.message,
+                    ...(isNil(rollbackError) ? {} : { rollbackError: rollbackError.message }),
+                }, '[triggerSourceService#enable] Rolled back trigger source after enable failure')
+                throw enableResult.error
+            }
 
             if (templateId) {
                 templateTelemetryService(log).sendEvent({
@@ -71,10 +91,7 @@ export const triggerSourceService = (log: FastifyBaseLogger) => {
             }
 
             log.info('[triggerSourceService#enable] Enabled flow trigger side effect')
-            return triggerSourceRepo().save({
-                ...triggerSource,
-                schedule: scheduleOptions,
-            })
+            return enableResult.data
         },
         async get(params: GetTriggerParams): Promise<TriggerSource | null> {
             const { projectId, id } = params

--- a/packages/server/api/test/unit/app/flows/trigger/flow-trigger-side-effect.test.ts
+++ b/packages/server/api/test/unit/app/flows/trigger/flow-trigger-side-effect.test.ts
@@ -142,6 +142,19 @@ describe('flowTriggerSideEffect', () => {
             })
         })
 
+        it('should throw when the worker skipped the enable hook (OK with undefined response)', async () => {
+            mockSubmitAndWaitForResponse.mockResolvedValue({ ...okEngineResponse(), response: undefined })
+
+            await expect(
+                flowTriggerSideEffect(mockLog).enable({
+                    ...BASE_PARAMS,
+                    pieceTrigger: makePollingTrigger(),
+                }),
+            ).rejects.toThrow(ActivepiecesError)
+
+            expect(mockAddJob).not.toHaveBeenCalled()
+        })
+
         it('should keep engine-provided schedule options untouched', async () => {
             const engineSchedule = {
                 type: TriggerSourceScheduleType.CRON_EXPRESSION,

--- a/packages/server/api/test/unit/app/flows/trigger/trigger-source-enable-rollback.test.ts
+++ b/packages/server/api/test/unit/app/flows/trigger/trigger-source-enable-rollback.test.ts
@@ -1,0 +1,127 @@
+import { TriggerStrategy } from '@activepieces/pieces-framework'
+import { TriggerSourceScheduleType } from '@activepieces/shared'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mockFindOne = vi.fn()
+const mockSoftDelete = vi.fn()
+const mockSave = vi.fn()
+const mockRemoveRepeatingJob = vi.fn()
+const mockSideEffectEnable = vi.fn()
+const mockGetPieceTriggerOrThrow = vi.fn()
+
+vi.mock('../../../../../src/app/core/db/repo-factory', () => ({
+    repoFactory: vi.fn(() => () => ({
+        findOne: mockFindOne,
+        softDelete: mockSoftDelete,
+        save: mockSave,
+    })),
+}))
+
+vi.mock('../../../../../src/app/flows/flow-version/flow-version.service', () => ({
+    flowVersionService: vi.fn(() => ({})),
+}))
+
+vi.mock('../../../../../src/app/template/template-telemetry/template-telemetry.service', () => ({
+    templateTelemetryService: vi.fn(() => ({ sendEvent: vi.fn() })),
+}))
+
+vi.mock('../../../../../src/app/workers/job-queue/job-queue', () => ({
+    jobQueue: vi.fn(() => ({
+        removeRepeatingJob: mockRemoveRepeatingJob,
+    })),
+}))
+
+vi.mock('../../../../../src/app/trigger/trigger-source/flow-trigger-side-effect', () => ({
+    flowTriggerSideEffect: vi.fn(() => ({
+        enable: mockSideEffectEnable,
+    })),
+}))
+
+vi.mock('../../../../../src/app/trigger/trigger-source/trigger-utils', () => ({
+    triggerUtils: vi.fn(() => ({
+        getPieceTriggerOrThrow: mockGetPieceTriggerOrThrow,
+    })),
+}))
+
+import { triggerSourceService } from '../../../../../src/app/trigger/trigger-source/trigger-source-service'
+
+const mockLog = { info: vi.fn(), warn: vi.fn() } as never
+
+const FLOW_VERSION = {
+    id: 'fv-1',
+    flowId: 'flow-1',
+    trigger: {
+        settings: {
+            pieceName: '@activepieces/piece-schedule',
+            pieceVersion: '0.1.22',
+        },
+    },
+} as never
+
+describe('triggerSourceService.enable rollback', () => {
+    beforeEach(() => {
+        vi.clearAllMocks()
+        mockGetPieceTriggerOrThrow.mockResolvedValue({
+            name: 'every_x_minutes',
+            type: TriggerStrategy.POLLING,
+        })
+        mockFindOne.mockResolvedValue(null)
+        mockSave.mockImplementation(async (row: Record<string, unknown>) => row)
+    })
+
+    it('soft-deletes the saved trigger source when the side effect fails, so no live row without a schedule survives', async () => {
+        mockSideEffectEnable.mockRejectedValue(new Error('Worker did not respond within the safety timeout'))
+
+        await expect(triggerSourceService(mockLog).enable({
+            flowVersion: FLOW_VERSION,
+            projectId: 'proj-1',
+            simulate: false,
+        })).rejects.toThrow('Worker did not respond within the safety timeout')
+
+        const savedRow = mockSave.mock.calls[0][0]
+        expect(mockSoftDelete).toHaveBeenLastCalledWith({
+            id: savedRow.id,
+            projectId: 'proj-1',
+        })
+        expect(mockRemoveRepeatingJob).not.toHaveBeenCalled()
+        expect(mockSave).toHaveBeenCalledTimes(1)
+    })
+
+    it('rolls back when persisting the schedule fails after the side effect succeeded', async () => {
+        mockSideEffectEnable.mockResolvedValue({ scheduleOptions: { type: TriggerSourceScheduleType.INTERVAL, intervalMs: 60_000 } })
+        mockSave.mockImplementationOnce(async (row: Record<string, unknown>) => row)
+        mockSave.mockRejectedValueOnce(new Error('connection reset'))
+
+        await expect(triggerSourceService(mockLog).enable({
+            flowVersion: FLOW_VERSION,
+            projectId: 'proj-1',
+            simulate: false,
+        })).rejects.toThrow('connection reset')
+
+        const savedRow = mockSave.mock.calls[0][0]
+        expect(mockSoftDelete).toHaveBeenLastCalledWith({
+            id: savedRow.id,
+            projectId: 'proj-1',
+        })
+    })
+
+    it('keeps the trigger source and persists the schedule when the side effect succeeds', async () => {
+        const scheduleOptions = { type: TriggerSourceScheduleType.INTERVAL, intervalMs: 60_000 }
+        mockSideEffectEnable.mockResolvedValue({ scheduleOptions })
+
+        const result = await triggerSourceService(mockLog).enable({
+            flowVersion: FLOW_VERSION,
+            projectId: 'proj-1',
+            simulate: false,
+        })
+
+        expect(result.schedule).toEqual(scheduleOptions)
+        expect(mockRemoveRepeatingJob).not.toHaveBeenCalled()
+        expect(mockSoftDelete).toHaveBeenCalledTimes(1)
+        expect(mockSoftDelete).toHaveBeenCalledWith({
+            flowId: 'flow-1',
+            projectId: 'proj-1',
+            simulate: false,
+        })
+    })
+})


### PR DESCRIPTION
Fixes [GIT-1815](https://linear.app/activepieces/issue/GIT-1815)
Closes #15114

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)

## Problem

1. Publishing or enabling a schedule flow while no worker answers within the 5-minute safety timeout removed the old schedule, never registered the new one, and left a live `trigger_source` row with `schedule = NULL`. The flow stopped firing with zero errors, and nothing can heal that state (the zombie interceptor keys on row existence; the refill migration skips NULL schedules). Reproduced live. Ref: Pylon 5759.
2. When the worker skips the ON_ENABLE hook (flow version unresolvable, piece missing) it reports OK with an empty response; the server treated that as success and silently registered the DEFAULT 5-minute schedule instead of the configured interval, persisting it. Customer symptom: "changed 5 to 2 minutes, still fires at 5".
3. The trigger TEST path dereferenced the same empty response (TypeError 500) after already wiping the flow's captured trigger events.

## Fix

- `trigger-source-service.ts` — the engine ON_ENABLE round-trip and the schedule save now run in one guarded scope; on any failure the just-saved `trigger_source` row is soft-deleted (rollback error captured, original error rethrown), so no live NULL-schedule row can survive. Scheduler cleanup on failure is deliberately left to the zombie-polling interceptor: it removes orphaned schedulers with an ownership check at fire time, whereas removing by bare `flowVersionId` in the rollback could kill a healthy concurrent or simulate-shared scheduler.
- `flow-trigger-side-effect.ts` — enable throws `TRIGGER_UPDATE_STATUS` ("The worker skipped the trigger enable hook") on an OK-but-empty engine response, at the shared choke point before all strategy branches. The 5-minute default stays for a real response without `scheduleOptions` (intended behavior for generic polling pieces, pinned by existing test). Shared `throwTriggerUpdateFailed` helper replaces the duplicated throw block.
- `trigger-event.service.ts` — TEST path guards the empty response with `TEST_TRIGGER_FAILED` and no longer deletes existing trigger events before the guard.

Product decision embedded: publish/enable now fails loudly for ALL trigger strategies when the worker skipped the hook; alternative considered: keep the silent 5-minute fallback, or scope the guard to polling only — rejected because a skipped hook means the flow version was unresolvable, so a "successful" enable hides a flow that cannot run (webhook registration never happened, listeners never created).

## Verification

- Regression tests, red-first proven: the skipped-hook throw test and both rollback tests fail on base and pass with the fix (14/14 across the two trigger unit suites).
- Live full stack (api + engine + worker + Postgres + Redis, schedule piece 0.1.22): 1-minute schedule flow publishes and fires every 60s; interval 1→2→1 swaps the BullMQ scheduler `every` correctly; disable/enable recovers; publish with an unresponsive worker now leaves NO live `trigger_source` row (pre-fix: live NULL-schedule row).
- `npm run lint-dev` clean; `tsc --noEmit` clean on server-api; unit suites green.
- Repro: freeze reproduced on main with worker frozen during an interval-change publish, re-driven on this branch — full steps in the Reproduction block.
- Visual: none - backend-only; the new failure surfaces through the existing publish-failed dialog (`TRIGGER_UPDATE_STATUS` handling in `flow-hooks.tsx`), no UI change. The skipped-hook state is not reachable on a healthy local stack without mocking the worker; unit tests pin the throw.
- Other affected paths: checked - `webhook-handshake.ts` tolerates the empty response by design; ON_DISABLE deliberately keeps tolerating skipped hooks (failing loud there would make flows with missing pieces undisablable); `useSimulateTrigger`'s toast shows a generic message for the new error (pre-existing frontend handling); APP_WEBHOOK partial-listener rollback and the `EngineResponse.response` type claiming non-optional are follow-ups (see ticket "Out of scope").

<details>
<summary>Plan & reasoning</summary>

## Plan

- Scoped to fix directions 1+2 of [GIT-1815](https://linear.app/activepieces/issue/GIT-1815) (enable atomicity + fail-loud on skipped hook); the ticket lists scheduler-key namespacing, reconciliation, and publish phase-reset as follow-ups.
- Footprint estimate: 2 files ~15 lines; actual: 3 files ~45 product lines. Growth: the guarded scope was widened over the final schedule save (review finding: a save failure reproduces the exact NULL-schedule freeze) and the TEST-path sibling guard was added (same defect class, same worker contract).
- Rollback is row-only by design; the zombie interceptor is the safe scheduler remover because it checks row liveness at fire time.

## Non-happy scenarios considered

- Worker timeout during publish → flow lands DISABLED (visible), row rolled back, retry re-enables cleanly. Pre-fix: flow looked scheduled with a dead schedule.
- Failure AFTER a successful engine hook (schedule-save blip) → row rolled back; a registered scheduler is discarded by the zombie interceptor on first fire; a piece-side remote registration persists until the next enable re-registers (same as pre-fix crash behavior).
- Concurrent enable after redlock expiry → rollback touches only its own row by primary key; it does not remove schedulers or listeners keyed by shared ids, so it cannot destroy the winner's state.
- Rollback soft-delete itself failing → wrapped in `tryCatch`; the original enable error still propagates, both errors logged.

## Alternatives rejected

- Worker-side fix (return non-OK on skipped hooks) → regresses disable: flows with missing pieces become undisablable for `ignoreError: false` callers; hookType-conditional worker behavior is a worse special case.
- Full compensator via `flowTriggerSideEffect.disable` in the rollback → adds a second 5-minute engine wait during the exact worker outage being fixed, and deletes listeners/schedulers by shared keys, which can destroy a concurrent enable's healthy state.
- Reordering enable to save the row after the side effect → the row must exist during ON_ENABLE (webhook handshake and app-event routing read it mid-hook), and the interceptor would discard schedulers registered before the row exists.
- `transaction()` → cannot cover the engine round-trip or BullMQ, and an uncommitted row is invisible to the mid-hook readers above.

</details>

<details>
<summary>Reproduction</summary>

## Environment

Local full stack from source: api + engine + worker via `npx turbo run serve --filter=api --filter=@activepieces/engine --filter=worker --env-mode=loose`, env `AP_DB_TYPE=POSTGRES AP_QUEUE_MODE=REDIS AP_POSTGRES_* AP_REDIS_*` pointing at `docker-compose.dev.yml` containers, `AP_DEV_PIECES=schedule` (piece 0.1.22 built locally), `AP_JWT_SECRET=<s>` with `AP_WORKER_TOKEN` a JWT signed with `<s>` (payload `{id: uuid, type: 'WORKER'}`, HS256, keyid `1`, issuer `activepieces`, same recipe as `docker-entrypoint.sh`).

## Harness

Driver: https://gist.github.com/majewskibartosz/1d485e83deea267ee5c582fbe44fc130 — run `node repro.mjs <scenario> [flowId] [minutes]` against `http://localhost:3000/api` (dev seed login). Scenarios: `setup` creates + publishes an Every X Minutes (1 min) flow over the REST API; `state` dumps flow status, `trigger_source` rows, and the BullMQ job scheduler (`ZSCORE bull:workerJobs:repeat <flowVersionId>`, `HGETALL bull:workerJobs:repeat:<id>` via `docker exec`); `change-interval` and `toggle` replay the customer actions.

## Trigger

`kill -STOP <worker pid>` so no worker serves the ON_ENABLE user-interaction job within `WATCHER_SAFETY_TIMEOUT_MS` (5 min), then edit the interval and `LOCK_AND_PUBLISH`.

## Results

- main (pre-fix): old scheduler removed, new version published, no scheduler in Redis, flow DISABLED, live `trigger_source` row with `schedule = NULL`; run list empty, no errors; `refill-polling-jobs` skips NULL schedules so the state never heals. Disable+enable with healthy workers was the only recovery.
- this branch: same trigger → publish fails with `TRIGGER_UPDATE_STATUS` and NO live `trigger_source` row remains; with healthy workers, publish / toggle / interval changes verified live (scheduler `every` follows the configured interval, runs fire on cadence).

</details>
