### PR TITLE
fix(flows): the Versions option no longer disappears when editing a flow from a run

### DIFF
--- a/packages/web/src/app/builder/builder-header/builder-header.tsx
+++ b/packages/web/src/app/builder/builder-header/builder-header.tsx
@@ -1,4 +1,4 @@
-import { Permission } from '@activepieces/core-utils';
+import { isNil, Permission } from '@activepieces/core-utils';
 import {
   ApFlagId,
   FlowOperationType,
@@ -66,12 +66,14 @@ export const BuilderHeader = () => {
     moveToFolderClientSide,
     applyOperation,
     setRightSidebar,
+    run,
   ] = useBuilderStateContext((state) => [
     state.flow,
     state.flowVersion,
     state.moveToFolderClientSide,
     state.applyOperation,
     state.setRightSidebar,
+    state.run,
   ]);
 
   const { embedState } = useEmbedding();
@@ -149,6 +151,7 @@ export const BuilderHeader = () => {
                       setRightSidebar(RightSideBarType.VERSIONS);
                     }}
                     insideBuilder={true}
+                    viewingRun={!isNil(run)}
                     flow={flow}
                     flowVersion={flowVersion}
                     readonly={!isLatestVersion}

--- a/packages/web/src/app/components/flow-actions-menu.tsx
+++ b/packages/web/src/app/components/flow-actions-menu.tsx
@@ -21,7 +21,6 @@ import {
   User,
 } from 'lucide-react';
 import React, { useState } from 'react';
-import { useLocation } from 'react-router-dom';
 import { toast } from 'sonner';
 
 import { ConfirmationDeleteDialog } from '@/components/custom/delete-dialog';
@@ -62,8 +61,12 @@ type FlowActionMenuProps = {
   onDelete: () => void;
   onOwnerChange?: () => void;
 } & (
-  | { insideBuilder: true; onVersionsListClick: () => void }
-  | { insideBuilder: false; onVersionsListClick: null }
+  | {
+      insideBuilder: true;
+      onVersionsListClick: () => void;
+      viewingRun: boolean;
+    }
+  | { insideBuilder: false; onVersionsListClick: null; viewingRun: null }
 );
 
 const FlowActionMenu: React.FC<FlowActionMenuProps> = ({
@@ -78,8 +81,8 @@ const FlowActionMenu: React.FC<FlowActionMenuProps> = ({
   onOwnerChange,
   onVersionsListClick,
   insideBuilder,
+  viewingRun,
 }) => {
-  const isRunsPage = useLocation().pathname.includes('/runs');
   const { platform } = platformHooks.useCurrentPlatform();
   const openNewWindow = useNewWindow();
   const { gitSync } = gitSyncHooks.useGitSync(
@@ -301,7 +304,7 @@ const FlowActionMenu: React.FC<FlowActionMenuProps> = ({
             </PermissionNeededTooltip>
           )}
 
-          {insideBuilder && !isRunsPage && (
+          {insideBuilder && !viewingRun && (
             <DropdownMenuItem onClick={onVersionsListClick}>
               <div className="flex cursor-pointer  flex-row gap-2 items-center">
                 <GalleryVerticalEnd className="h-4 w-4" />

--- a/packages/web/test/app/builder/builder-header/versions-entry.test.tsx
+++ b/packages/web/test/app/builder/builder-header/versions-entry.test.tsx
@@ -1,0 +1,235 @@
+/**
+ * @vitest-environment jsdom
+ * Regression: https://github.com/activepieces/activepieces/issues/13556
+ */
+/* eslint-disable testing-library/no-unnecessary-act */
+import {
+  FlowOperationStatus,
+  FlowRun,
+  FlowRunStatus,
+  FlowStatus,
+  FlowTriggerType,
+  FlowVersionState,
+  PopulatedFlow,
+  RunEnvironment,
+} from '@activepieces/shared';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { MemoryRouter } from 'react-router-dom';
+import { io } from 'socket.io-client';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const captured = vi.hoisted(() => ({
+  viewingRun: undefined as boolean | undefined,
+}));
+
+vi.mock('@/app/components/flow-actions-menu', () => ({
+  default: ({ viewingRun }: { viewingRun: boolean }) => {
+    captured.viewingRun = viewingRun;
+    return null;
+  },
+}));
+
+vi.mock('i18next', () => ({ t: (key: string) => key }));
+
+vi.mock('@/components/custom/active-users-widget', () => ({
+  ActiveUsersWidget: () => null,
+}));
+
+vi.mock('@/components/custom/editable-text', () => ({
+  default: () => null,
+}));
+
+vi.mock('@/components/custom/home-button', () => ({ HomeButton: () => null }));
+
+vi.mock('@/components/providers/embed-provider', () => ({
+  useEmbedding: () => ({
+    embedState: {
+      isEmbedded: false,
+      hideFlowNameInBuilder: false,
+      disableNavigationInBuilder: false,
+      hideHomeButtonInBuilder: false,
+      hidePageHeader: false,
+      hideActiveUsers: false,
+    },
+  }),
+}));
+
+vi.mock('@/features/flows', () => ({
+  flowHooks: { invalidateFlowsQuery: vi.fn() },
+}));
+
+vi.mock('@/features/flows/components/flow-created-by-badge', () => ({
+  FlowCreatedByBadge: () => null,
+}));
+
+vi.mock('@/features/folders', () => ({
+  foldersHooks: { useFolder: () => ({ data: null }) },
+}));
+
+vi.mock('@/features/projects', () => ({
+  getProjectName: () => 'project',
+  projectCollectionUtils: { useCurrentProject: () => ({ project: null }) },
+}));
+
+vi.mock('@/hooks/authorization-hooks', () => ({
+  useAuthorization: () => ({ checkAccess: () => true }),
+}));
+
+vi.mock('@/hooks/flags-hooks', () => ({
+  flagsHooks: { useFlag: () => ({ data: false }) },
+}));
+
+vi.mock('@/lib/authentication-session', () => ({
+  authenticationSession: {
+    getProjectId: () => 'project-1',
+    appendProjectRoutePrefix: (route: string) => route,
+  },
+}));
+
+vi.mock('@/lib/navigation-utils', () => ({ useNewWindow: () => vi.fn() }));
+
+vi.mock('@/app/builder/builder-header/flow-status', () => ({
+  BuilderFlowStatusSection: () => null,
+}));
+
+// eslint-disable-next-line import/first
+import { BuilderHeader } from '@/app/builder/builder-header/builder-header';
+import {
+  BuilderStateContext,
+  BuilderStore,
+  createBuilderStore,
+} from '@/app/builder/builder-hooks';
+// eslint-disable-next-line import/first
+
+declare global {
+  // eslint-disable-next-line no-var
+  var IS_REACT_ACT_ENVIRONMENT: boolean;
+}
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+function buildFlow(): PopulatedFlow {
+  const now = new Date().toISOString();
+  return {
+    id: 'flow-1',
+    created: now,
+    updated: now,
+    projectId: 'project-1',
+    externalId: 'flow-1',
+    ownerId: null,
+    folderId: null,
+    status: FlowStatus.DISABLED,
+    publishedVersionId: 'version-1',
+    metadata: null,
+    operationStatus: FlowOperationStatus.NONE,
+    timeSavedPerRun: null,
+    templateId: null,
+    createdBy: null,
+    version: {
+      id: 'version-1',
+      created: now,
+      updated: now,
+      flowId: 'flow-1',
+      displayName: 'Test flow',
+      updatedBy: null,
+      valid: true,
+      schemaVersion: null,
+      agentIds: [],
+      state: FlowVersionState.DRAFT,
+      connectionIds: [],
+      backupFiles: null,
+      notes: [],
+      trigger: {
+        name: 'trigger',
+        valid: true,
+        displayName: 'Trigger',
+        type: FlowTriggerType.EMPTY,
+        settings: {},
+        lastUpdatedDate: now,
+      },
+    },
+  };
+}
+
+function buildRun(): FlowRun {
+  const now = new Date().toISOString();
+  return {
+    id: 'run-1',
+    created: now,
+    updated: now,
+    projectId: 'project-1',
+    flowId: 'flow-1',
+    flowVersionId: 'version-1',
+    failParentOnFailure: false,
+    logsFileId: null,
+    status: FlowRunStatus.SUCCEEDED,
+    environment: RunEnvironment.TESTING,
+    steps: {},
+    tags: [],
+    archivedAt: null,
+  };
+}
+
+const queryClient = new QueryClient();
+
+function createStore(run: FlowRun | null): BuilderStore {
+  const flow = buildFlow();
+  return createBuilderStore({
+    flow,
+    flowVersion: flow.version,
+    readonly: false,
+    hideTestWidget: false,
+    run,
+    outputSampleData: {},
+    inputSampleData: {},
+    socket: io('http://localhost', { autoConnect: false }),
+    queryClient,
+  });
+}
+
+let container: HTMLDivElement | null = null;
+let root: Root | null = null;
+
+function renderHeader(run: FlowRun | null): void {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+  const mountedRoot = root;
+  act(() => {
+    mountedRoot.render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter initialEntries={['/projects/project-1/runs/run-1']}>
+          <BuilderStateContext.Provider value={createStore(run)}>
+            <BuilderHeader />
+          </BuilderStateContext.Provider>
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+  });
+}
+
+afterEach(() => {
+  act(() => {
+    root?.unmount();
+  });
+  container?.remove();
+  root = null;
+  container = null;
+  captured.viewingRun = undefined;
+});
+
+describe('builder header versions entry', () => {
+  it('reports no run being viewed while the route still points at a run', () => {
+    renderHeader(null);
+
+    expect(captured.viewingRun).toBe(false);
+  });
+
+  it('reports a run being viewed when builder state holds one', () => {
+    renderHeader(buildRun());
+
+    expect(captured.viewingRun).toBe(true);
+  });
+});

--- a/packages/web/test/app/components/flow-actions-menu-versions.test.tsx
+++ b/packages/web/test/app/components/flow-actions-menu-versions.test.tsx
@@ -1,0 +1,249 @@
+/**
+ * @vitest-environment jsdom
+ * Regression: https://github.com/activepieces/activepieces/issues/13556
+ */
+/* eslint-disable testing-library/no-unnecessary-act */
+import {
+  FlowOperationStatus,
+  FlowStatus,
+  FlowTriggerType,
+  FlowVersionState,
+  PopulatedFlow,
+} from '@activepieces/shared';
+import { act, type ReactNode } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { MemoryRouter } from 'react-router-dom';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('i18next', () => ({ t: (key: string) => key }));
+
+vi.mock('lucide-react', () => ({
+  Copy: () => null,
+  CornerUpLeft: () => null,
+  Download: () => null,
+  GalleryVerticalEnd: () => null,
+  Import: () => null,
+  Pencil: () => null,
+  Share2: () => null,
+  Trash2: () => null,
+  UploadCloud: () => null,
+  User: () => null,
+}));
+
+vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+
+vi.mock('@tanstack/react-query', () => ({
+  useMutation: () => ({ mutate: vi.fn(), isPending: false }),
+}));
+
+vi.mock('@/components/ui/dropdown-menu', () => ({
+  DropdownMenu: ({ children }: { children?: ReactNode }) => children,
+  DropdownMenuContent: ({ children }: { children?: ReactNode }) => children,
+  DropdownMenuItem: ({ children }: { children?: ReactNode }) => children,
+  DropdownMenuTrigger: ({ children }: { children?: ReactNode }) => children,
+}));
+
+vi.mock('@/components/custom/delete-dialog', () => ({
+  ConfirmationDeleteDialog: ({ children }: { children?: ReactNode }) =>
+    children,
+}));
+
+vi.mock('@/components/custom/permission-needed-tooltip', () => ({
+  PermissionNeededTooltip: ({ children }: { children?: ReactNode }) => children,
+}));
+
+vi.mock('@/components/custom/spinner', () => ({ LoadingSpinner: () => null }));
+
+vi.mock('@/components/providers/embed-provider', () => ({
+  useEmbedding: () => ({
+    embedState: {
+      isEmbedded: false,
+      hideFolders: false,
+      hideDuplicateFlow: false,
+      hideExportAndImportFlow: false,
+      disableNavigationInBuilder: false,
+    },
+  }),
+}));
+
+vi.mock('@/features/automations/components/move-to-folder-dialog', () => ({
+  MoveToFolderDialog: () => null,
+}));
+
+vi.mock('@/features/automations/components/rename-dialog', () => ({
+  RenameDialog: () => null,
+}));
+
+vi.mock('@/features/flows', () => ({
+  flowHooks: { useExportFlows: () => ({ mutate: vi.fn(), isPending: false }) },
+  flowsApi: { update: vi.fn(), create: vi.fn(), delete: vi.fn() },
+}));
+
+vi.mock('@/features/flows/components/change-owner-dialog', () => ({
+  ChangeOwnerDialog: ({ children }: { children?: ReactNode }) => children,
+}));
+
+vi.mock('@/features/flows/components/import-flow-dialog', () => ({
+  ImportFlowDialog: ({ children }: { children?: ReactNode }) => children,
+}));
+
+vi.mock('@/features/flows/components/share-template-dialog', () => ({
+  ShareTemplateDialog: ({ children }: { children?: ReactNode }) => children,
+}));
+
+vi.mock('@/features/folders', () => ({
+  foldersHooks: { useFolders: () => ({ folders: [] }) },
+}));
+
+vi.mock('@/features/members', () => ({
+  projectMembersHooks: { useProjectMembers: () => ({ projectMembers: [] }) },
+}));
+
+vi.mock('@/features/project-releases', () => ({
+  gitSyncHooks: { useGitSync: () => ({ gitSync: null }) },
+}));
+
+vi.mock('@/features/project-releases/components/published-tooltip', () => ({
+  PublishedNeededTooltip: ({ children }: { children?: ReactNode }) => children,
+}));
+
+vi.mock('@/features/project-releases/components/push-to-git-dialog', () => ({
+  PushToGitDialog: ({ children }: { children?: ReactNode }) => children,
+}));
+
+vi.mock('@/hooks/authorization-hooks', () => ({
+  useAuthorization: () => ({ checkAccess: () => true }),
+}));
+
+vi.mock('@/hooks/platform-hooks', () => ({
+  platformHooks: {
+    useCurrentPlatform: () => ({
+      platform: { plan: { environmentsEnabled: false } },
+    }),
+  },
+}));
+
+vi.mock('@/lib/authentication-session', () => ({
+  authenticationSession: { getProjectId: () => 'project-1' },
+}));
+
+vi.mock('@/lib/navigation-utils', () => ({ useNewWindow: () => vi.fn() }));
+
+// eslint-disable-next-line import/first
+import FlowActionMenu from '@/app/components/flow-actions-menu';
+
+declare global {
+  // eslint-disable-next-line no-var
+  var IS_REACT_ACT_ENVIRONMENT: boolean;
+}
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+function buildFlow(): PopulatedFlow {
+  const now = new Date().toISOString();
+  return {
+    id: 'flow-1',
+    created: now,
+    updated: now,
+    projectId: 'project-1',
+    externalId: 'flow-1',
+    ownerId: null,
+    folderId: null,
+    status: FlowStatus.DISABLED,
+    publishedVersionId: 'version-1',
+    metadata: null,
+    operationStatus: FlowOperationStatus.NONE,
+    timeSavedPerRun: null,
+    templateId: null,
+    createdBy: null,
+    version: {
+      id: 'version-1',
+      created: now,
+      updated: now,
+      flowId: 'flow-1',
+      displayName: 'Test flow',
+      updatedBy: null,
+      valid: true,
+      schemaVersion: null,
+      agentIds: [],
+      state: FlowVersionState.DRAFT,
+      connectionIds: [],
+      backupFiles: null,
+      notes: [],
+      trigger: {
+        name: 'trigger',
+        valid: true,
+        displayName: 'Trigger',
+        type: FlowTriggerType.EMPTY,
+        settings: {},
+        lastUpdatedDate: now,
+      },
+    },
+  };
+}
+
+function menuTextFor({
+  viewingRun,
+  pathname,
+}: {
+  viewingRun: boolean;
+  pathname: string;
+}): string {
+  const flow = buildFlow();
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+  act(() => {
+    root?.render(
+      <MemoryRouter initialEntries={[pathname]}>
+        <FlowActionMenu
+          flow={flow}
+          flowVersion={flow.version}
+          readonly={false}
+          insideBuilder={true}
+          viewingRun={viewingRun}
+          onVersionsListClick={() => undefined}
+          onRename={() => undefined}
+          onMoveTo={() => undefined}
+          onDuplicate={() => undefined}
+          onDelete={() => undefined}
+        >
+          <button>menu</button>
+        </FlowActionMenu>
+      </MemoryRouter>,
+    );
+  });
+  return container.textContent ?? '';
+}
+
+let container: HTMLDivElement | null = null;
+let root: Root | null = null;
+
+afterEach(() => {
+  act(() => {
+    root?.unmount();
+  });
+  container?.remove();
+  root = null;
+  container = null;
+});
+
+describe('flow actions menu versions entry', () => {
+  it('shows Versions in edit mode while the route still points at a run', () => {
+    const text = menuTextFor({
+      viewingRun: false,
+      pathname: '/projects/project-1/runs/run-1',
+    });
+
+    expect(text).toContain('Versions');
+  });
+
+  it('hides Versions while a run is being viewed', () => {
+    const text = menuTextFor({
+      viewingRun: true,
+      pathname: '/projects/project-1/runs/run-1',
+    });
+
+    expect(text).not.toContain('Versions');
+  });
+});


### PR DESCRIPTION
Fixes [GIT-1531](https://linear.app/activepieces/issue/GIT-1531)
Closes #13556

## Problem

1. In the flow menu, "Versions" is hidden whenever the router path contains `/runs`, and in an embedded builder it never comes back after switching to edit mode: the user is editing the draft with no way to reach version history.
2. The gate and the Edit-flow button read two different locations: `flow-actions-menu.tsx` used `useLocation()` from `react-router-dom` (the in-app router), while `view-draft-or-edit-flow-button.tsx` reads `useLocation` from `react-use` (`window.location`). Embeds mount a memory router, so `window.location` never contains `/runs`, Edit flow takes the in-place `switchToDraft()` branch, and the router path stays on the run for the rest of the session.

## Fix

- `flow-actions-menu.tsx`: gate "Versions" on a `viewingRun` prop instead of `useLocation().pathname`; the `react-router-dom` import is gone from this component.
- `builder-header.tsx`: derive `viewingRun={!isNil(run)}` from builder state. It is the only caller with `insideBuilder: true`, and `clearRun` nulls `run`, so the entry returns the moment the user leaves the run, embed or not.

Product decision embedded: "Versions" is now hidden whenever a run is displayed on the canvas, including in-builder test runs where it used to show; alternative considered: restrict the gate to PRODUCTION runs, rejected because picking a version mid-run desyncs the canvas from the run overlay in either case (`flow-versions-card.tsx` calls `setVersion` without clearing the run).

## Verification

- `packages/web`: lint 0 errors, `tsc --noEmit` clean, 541 tests pass (60 files).
- Regression tests, red-first proven against the pre-fix code: menu case "shows Versions in edit mode while the route still points at a run" fails pre-fix (`expected 'menuRenamePush to Git…' to contain 'Versions'`); both builder-header wiring cases fail pre-fix (`expected undefined to be false/true`). The unchanged case (run being viewed → hidden) passes in both.
- Driven on a local instance (real API, Postgres, seeded flow with production runs): run view → menu has no Versions; Edit flow → menu has Versions.
- Visual: run view (Versions hidden), edit mode after leaving the run (Versions shown), light theme, local instance. Before/after is not observable outside an embed: pre-fix, non-embed edit mode already showed the entry because the navigation changed the URL. The embed condition is covered by the red-first tests.
- Other affected paths: the same URL-derived-state pattern lives in `flow-canvas/hooks.tsx` `useListenToExistingRun` (live production-run polling never enables in an embed, so the run view goes stale) and in `view-draft-or-edit-flow-button.tsx` (embedded users edit a draft while the URL still says `/runs/<runId>`, so refresh and deep links reopen the run). Both are left unfixed here per the ticket's Out of scope, and both are recorded on GIT-1531.
- Pre-existing failures unrelated to this change: `@activepieces/engine` delay-piece tests and `@activepieces/sandbox` (heap OOM) fail on untouched code in a clean worktree.

<details>
<summary>Plan & reasoning</summary>

## Plan
- Root cause is a state/URL mismatch, so the fix belongs where the state lives: one prop from the builder header, no new abstraction.
- `BuilderHeader` is the only consumer of `FlowActionMenu`, so the prop plumbing is a 2-file change; the component stays free of builder-store coupling because it lives in `app/components/`, not `app/builder/`.
- Footprint: 2 product files, 12 insertions / 6 deletions; rejected the larger alternatives: plumbing a route-aware flag from `FlowRunPage`, and switching the Edit-flow button's `react-use` import (wider blast radius, out of ticket scope).
- Two test files rather than one: the menu test covers the gate, the builder-header test covers the derivation from `state.run` so the wiring cannot silently break.

## Non-happy scenarios considered
- Test run inside the builder: run is set with `readonly: true`, so Versions hides. Deliberate, see the product-decision line.
- Run selected from the builder's Runs panel: navigates to `/runs/<runId>`, so it is the ordinary run-view case.
- `insideBuilder: false` arm: currently unreachable (no caller); left in place with `viewingRun: null` rather than deleted, to keep this diff scoped to the fix.
- Version panel already open when a run loads: unchanged behavior, the sidebar keeps its own state; only the menu entry is gated.

## Alternatives rejected
- Drop the guard entirely and allow Versions during run view: picking a version while a run is displayed desyncs canvas and run overlay; that needs its own product call.
- Have `FlowActionMenu` read the builder store itself: couples a shared component to the builder context.
- Keep the pathname check and special-case embeds: leaves two sources of truth, which is the bug.
</details>

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)