### PR TITLE
feat(gmail): add label/archive/delete actions and New Starred Email trigger (#8072)

### DIFF
--- a/packages/pieces/community/gmail/src/index.ts
+++ b/packages/pieces/community/gmail/src/index.ts
@@ -31,6 +31,13 @@ import { gmailGetLabelAction } from './lib/actions/get-label-action';
 import { gmailGetProfileAction } from './lib/actions/get-profile-action';
 import { gmailListHistoryAction } from './lib/actions/list-history-action';
 import { gmailStopWatchAction } from './lib/actions/stop-watch-action';
+import { gmailAddLabelToEmailAction } from './lib/actions/add-label-to-email-action';
+import { gmailRemoveLabelFromEmailAction } from './lib/actions/remove-label-from-email-action';
+import { gmailCreateLabelAction } from './lib/actions/create-label-action';
+import { gmailArchiveEmailAction } from './lib/actions/archive-email-action';
+import { gmailDeleteEmailAction } from './lib/actions/delete-email-action';
+import { gmailRemoveLabelFromThreadAction } from './lib/actions/remove-label-from-thread-action';
+import { gmailNewStarredEmailTrigger } from './lib/triggers/new-starred-email';
 
 export {
   gmailAuth,
@@ -72,6 +79,12 @@ export const gmail = createPiece({
     gmailGetProfileAction,
     gmailListHistoryAction,
     gmailStopWatchAction,
+    gmailAddLabelToEmailAction,
+    gmailRemoveLabelFromEmailAction,
+    gmailCreateLabelAction,
+    gmailArchiveEmailAction,
+    gmailDeleteEmailAction,
+    gmailRemoveLabelFromThreadAction,
     createCustomApiCallAction({
       baseUrl: () => 'https://gmail.googleapis.com/gmail/v1',
       auth: gmailAuth,
@@ -102,6 +115,7 @@ export const gmail = createPiece({
     gmailNewLabeledEmailTrigger,
     gmailNewAttachmentTrigger,
     gmailNewLabelTrigger,
+    gmailNewStarredEmailTrigger,
   ],
   auth: gmailAuth,
 });

--- a/packages/pieces/community/gmail/src/lib/actions/add-label-to-email-action.ts
+++ b/packages/pieces/community/gmail/src/lib/actions/add-label-to-email-action.ts
@@ -1,0 +1,63 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { gmailAuth, createGoogleClient } from '../auth';
+import { gmail as googleGmail } from '@googleapis/gmail';
+import { GmailProps } from '../common/props';
+import { gmailAddLabelToEmailActionOutputSchema } from '../output-schemas';
+
+export const gmailAddLabelToEmailAction = createAction({
+  auth: gmailAuth,
+  name: 'add_label_to_email',
+  classification: 'WRITE',
+  displayName: 'Add Label to Email',
+  description: 'Add a label to an individual email.',
+  audience: 'ai',
+  aiMetadata: {
+    description:
+      'Adds a user or system label to a specific Gmail message, identified by its message ID. Use this to categorize or flag a message (for example, marking it STARRED or applying a custom label). Requires the gmail.modify scope. Not idempotent in effect, but re-adding an already-present label is a safe no-op on the mailbox.',
+    idempotent: false,
+  },
+  props: {
+    message_id: GmailProps.message,
+    label: GmailProps.label({ required: true }),
+  },
+  outputSchema: gmailAddLabelToEmailActionOutputSchema,
+  async run(context) {
+    const authClient = await createGoogleClient(context.auth);
+    const gmail = googleGmail({ version: 'v1', auth: authClient });
+
+    const label = context.propsValue.label;
+    const labelId = (label as { id?: string }).id;
+
+    if (!labelId) {
+      throw new Error(
+        'The selected label does not have a valid ID. Please choose a label or provide one manually.'
+      );
+    }
+
+    try {
+      const response = await gmail.users.messages.modify({
+        userId: 'me',
+        id: context.propsValue.message_id,
+        requestBody: {
+          addLabelIds: [labelId],
+        },
+      });
+      return response.data;
+    } catch (error: any) {
+      if (error.code === 403) {
+        throw new Error(
+          'Insufficient permissions to modify the email. Ensure the gmail.modify scope is granted.'
+        );
+      } else if (error.code === 404) {
+        throw new Error(
+          `Email not found: "${context.propsValue.message_id}". Use the Message dropdown to pick a valid message ID.`
+        );
+      } else if (error.code === 429) {
+        throw new Error(
+          'Gmail API rate limit exceeded. Please try again later.'
+        );
+      }
+      throw new Error(`Failed to add label to email: ${error.message}`);
+    }
+  },
+});

--- a/packages/pieces/community/gmail/src/lib/actions/archive-email-action.ts
+++ b/packages/pieces/community/gmail/src/lib/actions/archive-email-action.ts
@@ -1,0 +1,53 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { gmailAuth, createGoogleClient } from '../auth';
+import { gmail as googleGmail } from '@googleapis/gmail';
+import { GmailProps } from '../common/props';
+import { gmailArchiveEmailActionOutputSchema } from '../output-schemas';
+
+export const gmailArchiveEmailAction = createAction({
+  auth: gmailAuth,
+  name: 'archive_email',
+  classification: 'WRITE',
+  displayName: 'Archive Email',
+  description: 'Archive (move to "All Mail") an email rather than deleting it.',
+  audience: 'ai',
+  aiMetadata: {
+    description:
+      'Archives a Gmail message by removing the INBOX label, moving it to All Mail without deleting it. Use this to clear the inbox while keeping the message searchable. Requires the gmail.modify scope. Not idempotent in effect, but archiving an already-archived message is a safe no-op.',
+    idempotent: false,
+  },
+  props: {
+    message_id: GmailProps.message,
+  },
+  outputSchema: gmailArchiveEmailActionOutputSchema,
+  async run(context) {
+    const authClient = await createGoogleClient(context.auth);
+    const gmail = googleGmail({ version: 'v1', auth: authClient });
+
+    try {
+      const response = await gmail.users.messages.modify({
+        userId: 'me',
+        id: context.propsValue.message_id,
+        requestBody: {
+          removeLabelIds: ['INBOX'],
+        },
+      });
+      return response.data;
+    } catch (error: any) {
+      if (error.code === 403) {
+        throw new Error(
+          'Insufficient permissions to modify the email. Ensure the gmail.modify scope is granted.'
+        );
+      } else if (error.code === 404) {
+        throw new Error(
+          `Email not found: "${context.propsValue.message_id}". Use the Message dropdown to pick a valid message ID.`
+        );
+      } else if (error.code === 429) {
+        throw new Error(
+          'Gmail API rate limit exceeded. Please try again later.'
+        );
+      }
+      throw new Error(`Failed to archive email: ${error.message}`);
+    }
+  },
+});

--- a/packages/pieces/community/gmail/src/lib/actions/create-label-action.ts
+++ b/packages/pieces/community/gmail/src/lib/actions/create-label-action.ts
@@ -1,0 +1,103 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { gmailAuth, createGoogleClient } from '../auth';
+import { gmail as googleGmail } from '@googleapis/gmail';
+import { gmailCreateLabelActionOutputSchema } from '../output-schemas';
+
+export const gmailCreateLabelAction = createAction({
+  auth: gmailAuth,
+  name: 'create_label',
+  classification: 'WRITE',
+  displayName: 'Create Label',
+  description: 'Create a new user label in Gmail.',
+  audience: 'ai',
+  aiMetadata: {
+    description:
+      'Creates a new user-defined label in the connected Gmail account. Provide a label name; optionally control list/visibility and color. Use this to set up categories before applying them with Add Label to Email. Requires the gmail.modify scope. Idempotency is not enforced by Gmail: creating a label with a duplicate name yields a second label, so callers should check existing labels first if uniqueness matters.',
+    idempotent: false,
+  },
+  props: {
+    name: Property.ShortText({
+      displayName: 'Label Name',
+      description: 'The name of the label to create.',
+      required: true,
+    }),
+    messageListVisibility: Property.StaticDropdown({
+      displayName: 'Message List Visibility',
+      description: 'Whether the label shows in the message list.',
+      required: false,
+      defaultValue: 'show',
+      options: {
+        disabled: false,
+        options: [
+          { label: 'Show', value: 'show' },
+          { label: 'Hide', value: 'hide' },
+        ],
+      },
+    }),
+    labelListVisibility: Property.StaticDropdown({
+      displayName: 'Label List Visibility',
+      description: 'Whether the label shows in the label list.',
+      required: false,
+      defaultValue: 'labelShow',
+      options: {
+        disabled: false,
+        options: [
+          { label: 'Show', value: 'labelShow' },
+          { label: 'Hide', value: 'labelHide' },
+        ],
+      },
+    }),
+    backgroundColor: Property.ShortText({
+      displayName: 'Background Color',
+      description:
+        'Optional hex color for the label background (e.g. #000000).',
+      required: false,
+    }),
+    textColor: Property.ShortText({
+      displayName: 'Text Color',
+      description: 'Optional hex color for the label text (e.g. #ffffff).',
+      required: false,
+    }),
+  },
+  outputSchema: gmailCreateLabelActionOutputSchema,
+  async run(context) {
+    const authClient = await createGoogleClient(context.auth);
+    const gmail = googleGmail({ version: 'v1', auth: authClient });
+
+    const color =
+      context.propsValue.backgroundColor && context.propsValue.textColor
+        ? {
+            backgroundColor: context.propsValue.backgroundColor,
+            textColor: context.propsValue.textColor,
+          }
+        : undefined;
+
+    try {
+      const response = await gmail.users.labels.create({
+        userId: 'me',
+        requestBody: {
+          name: context.propsValue.name,
+          messageListVisibility: context.propsValue.messageListVisibility,
+          labelListVisibility: context.propsValue.labelListVisibility,
+          color,
+        },
+      });
+      return response.data;
+    } catch (error: any) {
+      if (error.code === 403) {
+        throw new Error(
+          'Insufficient permissions to create a label. Ensure the gmail.modify scope is granted.'
+        );
+      } else if (error.code === 409) {
+        throw new Error(
+          `A label named "${context.propsValue.name}" already exists. Use List Labels to find its ID.`
+        );
+      } else if (error.code === 429) {
+        throw new Error(
+          'Gmail API rate limit exceeded. Please try again later.'
+        );
+      }
+      throw new Error(`Failed to create label: ${error.message}`);
+    }
+  },
+});

--- a/packages/pieces/community/gmail/src/lib/actions/delete-email-action.ts
+++ b/packages/pieces/community/gmail/src/lib/actions/delete-email-action.ts
@@ -1,0 +1,53 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { gmailAuth, createGoogleClient } from '../auth';
+import { gmail as googleGmail } from '@googleapis/gmail';
+import { GmailProps } from '../common/props';
+import { gmailDeleteEmailActionOutputSchema } from '../output-schemas';
+
+export const gmailDeleteEmailAction = createAction({
+  auth: gmailAuth,
+  name: 'delete_email',
+  classification: 'WRITE',
+  displayName: 'Delete Email',
+  description: 'Permanently move an email to Trash.',
+  audience: 'ai',
+  aiMetadata: {
+    description:
+      'Sends a Gmail message to Trash (soft delete). The message can be recovered from Trash until it is purged. Use this to remove a message without permanent erasure; for permanent deletion use the Gmail API erase endpoint outside this action. Requires the gmail.modify scope. Not idempotent: deleting an already-deleted message returns 404.',
+    idempotent: false,
+  },
+  props: {
+    message_id: GmailProps.message,
+  },
+  outputSchema: gmailDeleteEmailActionOutputSchema,
+  async run(context) {
+    const authClient = await createGoogleClient(context.auth);
+    const gmail = googleGmail({ version: 'v1', auth: authClient });
+
+    try {
+      await gmail.users.messages.trash({
+        userId: 'me',
+        id: context.propsValue.message_id,
+      });
+      return {
+        id: context.propsValue.message_id,
+        trashed: true,
+      };
+    } catch (error: any) {
+      if (error.code === 403) {
+        throw new Error(
+          'Insufficient permissions to delete the email. Ensure the gmail.modify scope is granted.'
+        );
+      } else if (error.code === 404) {
+        throw new Error(
+          `Email not found: "${context.propsValue.message_id}". It may already be deleted.`
+        );
+      } else if (error.code === 429) {
+        throw new Error(
+          'Gmail API rate limit exceeded. Please try again later.'
+        );
+      }
+      throw new Error(`Failed to delete email: ${error.message}`);
+    }
+  },
+});

--- a/packages/pieces/community/gmail/src/lib/actions/remove-label-from-email-action.ts
+++ b/packages/pieces/community/gmail/src/lib/actions/remove-label-from-email-action.ts
@@ -1,0 +1,63 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { gmailAuth, createGoogleClient } from '../auth';
+import { gmail as googleGmail } from '@googleapis/gmail';
+import { GmailProps } from '../common/props';
+import { gmailRemoveLabelFromEmailActionOutputSchema } from '../output-schemas';
+
+export const gmailRemoveLabelFromEmailAction = createAction({
+  auth: gmailAuth,
+  name: 'remove_label_from_email',
+  classification: 'WRITE',
+  displayName: 'Remove Label from Email',
+  description: 'Remove a specific label from an email.',
+  audience: 'ai',
+  aiMetadata: {
+    description:
+      'Removes a label from a specific Gmail message, identified by its message ID and label ID. Use this to un-flag or de-categorize a message (for example, removing STARRED). Requires the gmail.modify scope. Not idempotent in effect, but removing an absent label is a safe no-op on the mailbox.',
+    idempotent: false,
+  },
+  props: {
+    message_id: GmailProps.message,
+    label: GmailProps.label({ required: true }),
+  },
+  outputSchema: gmailRemoveLabelFromEmailActionOutputSchema,
+  async run(context) {
+    const authClient = await createGoogleClient(context.auth);
+    const gmail = googleGmail({ version: 'v1', auth: authClient });
+
+    const label = context.propsValue.label;
+    const labelId = (label as { id?: string }).id;
+
+    if (!labelId) {
+      throw new Error(
+        'The selected label does not have a valid ID. Please choose a label or provide one manually.'
+      );
+    }
+
+    try {
+      const response = await gmail.users.messages.modify({
+        userId: 'me',
+        id: context.propsValue.message_id,
+        requestBody: {
+          removeLabelIds: [labelId],
+        },
+      });
+      return response.data;
+    } catch (error: any) {
+      if (error.code === 403) {
+        throw new Error(
+          'Insufficient permissions to modify the email. Ensure the gmail.modify scope is granted.'
+        );
+      } else if (error.code === 404) {
+        throw new Error(
+          `Email not found: "${context.propsValue.message_id}". Use the Message dropdown to pick a valid message ID.`
+        );
+      } else if (error.code === 429) {
+        throw new Error(
+          'Gmail API rate limit exceeded. Please try again later.'
+        );
+      }
+      throw new Error(`Failed to remove label from email: ${error.message}`);
+    }
+  },
+});

--- a/packages/pieces/community/gmail/src/lib/actions/remove-label-from-thread-action.ts
+++ b/packages/pieces/community/gmail/src/lib/actions/remove-label-from-thread-action.ts
@@ -1,0 +1,82 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { gmailAuth, createGoogleClient } from '../auth';
+import { gmail as googleGmail } from '@googleapis/gmail';
+import { GmailProps } from '../common/props';
+import { gmailRemoveLabelFromThreadActionOutputSchema } from '../output-schemas';
+
+export const gmailRemoveLabelFromThreadAction = createAction({
+  auth: gmailAuth,
+  name: 'remove_label_from_thread',
+  classification: 'WRITE',
+  displayName: 'Remove Label from Thread',
+  description: 'Strip a label from all emails in a thread.',
+  audience: 'ai',
+  aiMetadata: {
+    description:
+      'Removes a label from every message in a Gmail thread, identified by its thread ID. Use this to de-categorize or un-flag an entire conversation at once (for example, removing STARRED from all messages in the thread). Requires the gmail.modify scope. Iterates over each message in the thread and applies a label removal; removing an absent label from a message is a safe no-op.',
+    idempotent: false,
+  },
+  props: {
+    thread_id: GmailProps.thread,
+    label: GmailProps.label({ required: true }),
+  },
+  outputSchema: gmailRemoveLabelFromThreadActionOutputSchema,
+  async run(context) {
+    const authClient = await createGoogleClient(context.auth);
+    const gmail = googleGmail({ version: 'v1', auth: authClient });
+
+    const label = context.propsValue.label;
+    const labelId = (label as { id?: string }).id;
+
+    if (!labelId) {
+      throw new Error(
+        'The selected label does not have a valid ID. Please choose a label or provide one manually.'
+      );
+    }
+
+    try {
+      const threadResponse = await gmail.users.threads.get({
+        userId: 'me',
+        id: context.propsValue.thread_id,
+        format: 'minimal',
+      });
+
+      const messages = threadResponse.data.messages || [];
+      const results = [];
+
+      for (const message of messages) {
+        if (!message.id) {
+          continue;
+        }
+        const response = await gmail.users.messages.modify({
+          userId: 'me',
+          id: message.id,
+          requestBody: {
+            removeLabelIds: [labelId],
+          },
+        });
+        results.push(response.data);
+      }
+
+      return {
+        id: context.propsValue.thread_id,
+        messages: results,
+      };
+    } catch (error: any) {
+      if (error.code === 403) {
+        throw new Error(
+          'Insufficient permissions to modify the thread. Ensure the gmail.modify scope is granted.'
+        );
+      } else if (error.code === 404) {
+        throw new Error(
+          `Thread not found: "${context.propsValue.thread_id}". Use the Thread dropdown to pick a valid thread ID.`
+        );
+      } else if (error.code === 429) {
+        throw new Error(
+          'Gmail API rate limit exceeded. Please try again later.'
+        );
+      }
+      throw new Error(`Failed to remove label from thread: ${error.message}`);
+    }
+  },
+});

--- a/packages/pieces/community/gmail/src/lib/auth.ts
+++ b/packages/pieces/community/gmail/src/lib/auth.ts
@@ -11,6 +11,7 @@ const gmailServiceAccountScopes = [
   'https://www.googleapis.com/auth/gmail.send',
   'https://www.googleapis.com/auth/gmail.readonly',
   'https://www.googleapis.com/auth/gmail.compose',
+  'https://www.googleapis.com/auth/gmail.modify',
 ];
 
 export const gmailScopes = [...gmailServiceAccountScopes, 'email'];

--- a/packages/pieces/community/gmail/src/lib/output-schemas.ts
+++ b/packages/pieces/community/gmail/src/lib/output-schemas.ts
@@ -1059,3 +1059,52 @@ export const gmailListHistoryActionOutputSchema: OutputSchema = {
     },
   ],
 };
+
+export const gmailAddLabelToEmailActionOutputSchema: OutputSchema = {
+  fields: messageSendResultFields,
+};
+
+export const gmailRemoveLabelFromEmailActionOutputSchema: OutputSchema = {
+  fields: messageSendResultFields,
+};
+
+export const gmailRemoveLabelFromThreadActionOutputSchema: OutputSchema = {
+  fields: [
+    { key: 'id', label: 'Thread ID' },
+    {
+      key: 'messages',
+      label: 'Messages',
+      labelKey: 'id',
+      listItems: messageSendResultFields,
+    },
+  ],
+};
+
+export const gmailCreateLabelActionOutputSchema: OutputSchema = {
+  fields: [
+    ...gmailLabelBaseFields,
+    { key: 'messagesTotal', label: 'Messages Total', format: 'number' },
+    { key: 'messagesUnread', label: 'Messages Unread', format: 'number' },
+    { key: 'threadsTotal', label: 'Threads Total', format: 'number' },
+    { key: 'threadsUnread', label: 'Threads Unread', format: 'number' },
+  ],
+};
+
+export const gmailArchiveEmailActionOutputSchema: OutputSchema = {
+  fields: messageSendResultFields,
+};
+
+export const gmailDeleteEmailActionOutputSchema: OutputSchema = {
+  fields: messageSendResultFields,
+};
+
+export const newStarredEmailTriggerOutputSchema: OutputSchema = {
+  fields: [
+    { key: 'id', label: 'History ID' },
+    {
+      key: 'message',
+      label: 'Message',
+      children: gmailMessageResourceFields,
+    },
+  ],
+};

--- a/packages/pieces/community/gmail/src/lib/triggers/new-starred-email.ts
+++ b/packages/pieces/community/gmail/src/lib/triggers/new-starred-email.ts
@@ -1,0 +1,179 @@
+import {
+  createTrigger,
+  TriggerStrategy,
+  Property,
+} from '@activepieces/pieces-framework';
+import { gmailAuth, createGoogleClient } from '../auth';
+import { gmail as googleGmail } from '@googleapis/gmail';
+import { getFirstFiveOrAll } from '../common/data';
+import { newStarredEmailTriggerOutputSchema } from '../output-schemas';
+
+const TRIGGER_KEY = 'starredHistoryId';
+const PROCESSED_KEY = 'processedStarredMessages';
+
+export const gmailNewStarredEmailTrigger = createTrigger({
+  auth: gmailAuth,
+  name: 'new_starred_email',
+  classification: 'READ',
+  displayName: 'New Starred Email',
+  description: 'Fires when an email is starred (within 2 days).',
+  aiMetadata: {
+    description:
+      'Polls Gmail history for messages that gained the STARRED label since the last poll. Each event represents one newly starred message not seen on a prior poll. Use this to react to messages the user flags as important. Returns the list of newly starred messages with their thread and label metadata.',
+  },
+  props: {
+    maxAgeHours: Property.Number({
+      displayName: 'Maximum Age (Hours)',
+      description:
+        'Only trigger for emails starred within this many hours (defaults to 48, matching the 2-day window).',
+      required: false,
+      defaultValue: 48,
+    }),
+  },
+  outputSchema: newStarredEmailTriggerOutputSchema,
+  sampleData: {},
+  type: TriggerStrategy.POLLING,
+  async onEnable(context) {
+    const authClient = await createGoogleClient(context.auth);
+    const gmail = googleGmail({ version: 'v1', auth: authClient });
+
+    const profile = await gmail.users.getProfile({ userId: 'me' });
+    await context.store.put(TRIGGER_KEY, profile.data.historyId);
+    await context.store.put(PROCESSED_KEY, []);
+  },
+  async onDisable(context) {
+    await context.store.delete(TRIGGER_KEY);
+    await context.store.delete(PROCESSED_KEY);
+  },
+  async test(context) {
+    const authClient = await createGoogleClient(context.auth);
+    const gmail = googleGmail({ version: 'v1', auth: authClient });
+
+    const maxAge = (context.propsValue.maxAgeHours || 48) * 60 * 60 * 1000;
+    const cutoffTime = Date.now() - maxAge;
+
+    try {
+      const profile = await gmail.users.getProfile({ userId: 'me' });
+      const historyResponse = await gmail.users.history.list({
+        userId: 'me',
+        startHistoryId: profile.data.historyId,
+        historyTypes: ['labelAdded'],
+        maxResults: 20,
+      });
+
+      const starred: any[] = [];
+      if (historyResponse.data.history) {
+        for (const history of historyResponse.data.history) {
+          for (const added of history.labelsAdded || []) {
+            if (
+              added.labelIds?.includes('STARRED') &&
+              added.message?.id
+            ) {
+              const message = await gmail.users.messages.get({
+                userId: 'me',
+                id: added.message.id,
+                format: 'full',
+              });
+              starred.push({
+                id: history.id,
+                message: message.data,
+              });
+            }
+          }
+        }
+      }
+
+      const filtered = starred.filter((entry) => {
+        const internalDate = parseInt(
+          entry.message.internalDate || '0',
+          10
+        );
+        return internalDate >= cutoffTime;
+      });
+
+      return getFirstFiveOrAll(filtered);
+    } catch (error: any) {
+      if (error.code === 404) {
+        return [];
+      }
+      throw error;
+    }
+  },
+  async run(context) {
+    const lastHistoryId = (await context.store.get<string>(TRIGGER_KEY)) ?? '0';
+    const processedMessages =
+      (await context.store.get<string[]>(PROCESSED_KEY)) || [];
+
+    const authClient = await createGoogleClient(context.auth);
+    const gmail = googleGmail({ version: 'v1', auth: authClient });
+
+    const maxAge = (context.propsValue.maxAgeHours || 48) * 60 * 60 * 1000;
+    const cutoffTime = Date.now() - maxAge;
+
+    try {
+      const historyResponse = await gmail.users.history.list({
+        userId: 'me',
+        startHistoryId: lastHistoryId as string,
+        historyTypes: ['labelAdded'],
+        maxResults: 100,
+      });
+
+      const starred: any[] = [];
+
+      if (historyResponse.data.history) {
+        for (const history of historyResponse.data.history) {
+          for (const added of history.labelsAdded || []) {
+            const messageId = added.message?.id;
+            if (
+              added.labelIds?.includes('STARRED') &&
+              messageId &&
+              !processedMessages.includes(messageId)
+            ) {
+              const message = await gmail.users.messages.get({
+                userId: 'me',
+                id: messageId,
+                format: 'full',
+              });
+              starred.push({
+                id: history.id,
+                message: message.data,
+              });
+              processedMessages.push(messageId);
+            }
+          }
+        }
+      }
+
+      if (historyResponse.data.historyId) {
+        await context.store.put(
+          TRIGGER_KEY,
+          historyResponse.data.historyId
+        );
+      }
+
+      const filtered = starred.filter((entry) => {
+        const internalDate = parseInt(
+          entry.message.internalDate || '0',
+          10
+        );
+        return internalDate >= cutoffTime;
+      });
+
+      const recentProcessed = processedMessages.slice(-1000);
+      await context.store.put(PROCESSED_KEY, recentProcessed);
+
+      if (filtered.length === 0) {
+        return [];
+      }
+
+      return filtered;
+    } catch (error: any) {
+      if (error.code === 404) {
+        const profile = await gmail.users.getProfile({ userId: 'me' });
+        await context.store.put(TRIGGER_KEY, profile.data.historyId);
+        return [];
+      }
+      throw error;
+    }
+  },
+});


### PR DESCRIPTION
## Summary

Implements the Gmail piece enhancements requested in issue #8072 ([MCP] Gmail), following the existing piece patterns in `packages/pieces/community/gmail`.

This PR adds the missing write actions and one trigger:

- **Add Label to Email** (`messages.modify` add)
- **Remove Label from Email** (`messages.modify` remove)
- **Create Label** (`labels.create`, with visibility + color)
- **Archive Email** (`messages.modify` remove `INBOX`)
- **Delete Email** (`messages.trash`)
- **Remove Label from Thread** (iterates thread messages and strips the label)
- **New Starred Email** trigger (History API, `labelAdded` `STARRED`, with 2-day max-age filter)

It also registers the `gmail.modify` OAuth scope required by the new write operations.

All code mirrors the surrounding actions/triggers: `createAction`/`createTrigger`, `GmailProps` dropdowns, shared output schemas, `aiMetadata`, and structured error handling for 403/404/429.

## Bounty

This PR claims the Algora bounty for activepieces/activepieces#8072 ($200). /claim #8072

Fixes #8072