### PR TITLE
fix(templates): keep the packaged flow when an update omits it

### DIFF
--- a/packages/server/api/src/app/ee/template/platform-template.service.ts
+++ b/packages/server/api/src/app/ee/template/platform-template.service.ts
@@ -1,4 +1,4 @@
-import { apId, Metadata, sanitizeObjectForPostgresql, spreadIfDefined } from '@activepieces/core-utils'
+import { apId, isNil, Metadata, sanitizeObjectForPostgresql, spreadIfDefined } from '@activepieces/core-utils'
 import { flowPieceUtil, FlowVersionTemplate, Template, TemplateStatus, TemplateTag, TemplateType, UpdateTemplateRequestBody } from '@activepieces/shared'
 import { repoFactory } from '../../core/db/repo-factory'
 import { TemplateEntity } from '../../template/template.entity'
@@ -29,7 +29,10 @@ export const platformTemplateService = () => ({
     },
     async update({ id, params }: UpdateParams): Promise<Template> {
         const { name, description, summary, tags, blogUrl, metadata, categories, flows, status } = params
-        const flow: FlowVersionTemplate | undefined = flows?.[0] ? sanitizeObjectForPostgresql(flows[0]) : undefined
+        // An empty `flows` is not a request to erase the packaged workflow: mirror
+        // templateService.update and replace it only when one is actually supplied.
+        const nextFlows = !isNil(flows) && flows.length > 0 ? flows : undefined
+        const flow: FlowVersionTemplate | undefined = nextFlows?.[0] ? sanitizeObjectForPostgresql(nextFlows[0]) : undefined
         const pieces = flow ? flowPieceUtil.getUsedPieces(flow.trigger) : undefined
         await templateRepo().update(id, {
             ...spreadIfDefined('name', name),
@@ -39,7 +42,7 @@ export const platformTemplateService = () => ({
             ...spreadIfDefined('blogUrl', blogUrl),
             ...spreadIfDefined('metadata', metadata),
             ...spreadIfDefined('categories', categories),
-            ...spreadIfDefined('flows', flows),
+            ...spreadIfDefined('flows', nextFlows),
             ...spreadIfDefined('pieces', pieces),
             ...spreadIfDefined('status', status),
         })

--- a/packages/server/api/src/app/template/template.controller.ts
+++ b/packages/server/api/src/app/template/template.controller.ts
@@ -85,8 +85,14 @@ export const templateController: FastifyPluginAsyncZod = async (app) => {
 
     app.post('/:id', { ...UpdateParams,
         preValidation: async (request) => {
-            const migratedFlows = await migrateFlowVersionTemplateList(request.body.flows ?? [])
-            request.body.flows = migratedFlows
+            // Only migrate flows the request actually carries. Coercing an absent
+            // `flows` to [] made it *defined*, and the CUSTOM update path then stored
+            // that empty array over the template's packaged workflow — a details-only
+            // edit (name, summary, categories, metadata) destroyed the flow export.
+            if (isNil(request.body.flows)) {
+                return
+            }
+            request.body.flows = await migrateFlowVersionTemplateList(request.body.flows)
         },
     }, async (request, reply) => {
         const template = await templateService(app.log).getOneOrThrow({ id: request.params.id })

--- a/packages/server/api/test/integration/cloud/flow-templates/flow-templates.test.ts
+++ b/packages/server/api/test/integration/cloud/flow-templates/flow-templates.test.ts
@@ -305,6 +305,35 @@ describe('Templates', () => {
             expect(response?.statusCode).toBe(StatusCodes.OK)
             expect(response?.json().name).toBe('updated-name')
         })
+
+        it('should keep the packaged flow when the update does not carry one', async () => {
+            // arrange
+            const { mockOwner, mockPlatform, mockPlatformTemplate } =
+                await createMockPlatformTemplate({ platformId: apId() })
+
+            const testToken = await generateMockToken({
+                type: PrincipalType.USER,
+                id: mockOwner.id,
+                platform: { id: mockPlatform.id },
+            })
+
+            const response = await app?.inject({
+                method: 'POST',
+                url: `/api/v1/templates/${mockPlatformTemplate.id}`,
+                headers: {
+                    authorization: `Bearer ${testToken}`,
+                },
+                body: {
+                    summary: 'updated-summary',
+                },
+            })
+
+            // assert: an edit that omits `flows` must not erase the export
+            expect(response?.statusCode).toBe(StatusCodes.OK)
+            expect(response?.json().summary).toBe('updated-summary')
+            expect(response?.json().flows).toHaveLength(mockPlatformTemplate.flows.length)
+            expect(response?.json().flows[0].displayName).toBe(mockPlatformTemplate.flows[0].displayName)
+        })
     })
 })
 


### PR DESCRIPTION
## Description

Updating a template's details wipes its packaged workflow. Change a template's name, summary, description, categories or metadata through `POST /v1/templates/:id`, and the stored flow export is replaced with an empty array — permanently. The template survives, but its flow is gone.

The update route's `preValidation` hook does:

```ts
const migratedFlows = await migrateFlowVersionTemplateList(request.body.flows ?? [])
request.body.flows = migratedFlows
```

`undefined ?? []` → `[]`, so an *absent* `flows` reaches the service **defined** as an empty array. `platformTemplateService.update` (the `CUSTOM` path) then does `spreadIfDefined('flows', flows)`, and an empty array is "defined", so it writes `flows: []` over the stored export.

`pieces` is left untouched — it is only recomputed when `flows[0]` exists — so a damaged template still lists its used pieces while its flow and preview are gone. That is what makes this easy to miss in a UI: the template still looks populated.

`templateService.update` (the `SHARED` / `OFFICIAL` path) already guards against exactly this with `if (!isNil(params.flows) && params.flows.length > 0)`. The `CUSTOM` path does not.

**Fix — two guards, mirroring the SHARED path:**

- `template.controller.ts` — the update hook migrates `flows` only when the request actually carries them, so an omitted `flows` stays omitted.
- `ee/template/platform-template.service.ts` — an empty `flows` array is treated as "not supplied" rather than "erase it". `pieces` is still recomputed whenever a flow *is* supplied.

Create is deliberately untouched: there, `flows ?? []` just turns a missing body field into `templateValidator`'s existing "Flows are required" validation error.

We hit this in a self-hosted deployment — every details-only edit through our own UI destroyed the template's workflow, and the templates could only be re-created from their source flows.

## How was this tested?

Added an integration case to `test/integration/cloud/flow-templates/flow-templates.test.ts`: *"should keep the packaged flow when the update does not carry one"* — updates only `summary` and asserts the flow export survives.

Run locally against this branch (PGLITE + in-memory queue, no docker needed):

- with the fix: `Tests 12 passed (12)`
- with the test but reverting only the two source files: that one case fails (`flows` comes back empty), so it is a real regression guard rather than a vacuous assertion
- `eslint` on the three touched files: 0 errors (3 pre-existing warnings, all on lines this PR does not touch)

Edition paths: the changed service is the `ee` CUSTOM template path, exercised by the `cloud` integration suite above. The SHARED/OFFICIAL path in `templateService.update` is unchanged and already had the equivalent guard.

Fixes # (issue)

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

An update that genuinely wants to replace the workflow still does, unchanged — it sends a non-empty `flows`. The only behaviour that changes is that an update which sends no flows (or an empty array) no longer erases the stored one.

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)

No auth, permission, secret, crypto, outbound-HTTP or file-handling surface is touched; the ownership and platform checks in the route run before this code and are unchanged.

Closes #15191
