### PR TITLE
fix(fillout-forms): new-form-response trigger silently drops all webhooks (double JSON.parse)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -3141,7 +3141,7 @@
     },
     "packages/pieces/community/fillout-forms": {
       "name": "@activepieces/piece-fillout-forms",
-      "version": "0.1.8",
+      "version": "0.1.9",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -3150,6 +3150,7 @@
       },
       "devDependencies": {
         "tslib": "2.6.2",
+        "vitest": "3.2.6",
       },
     },
     "packages/pieces/community/fireberry": {

--- a/packages/pieces/community/fillout-forms/package.json
+++ b/packages/pieces/community/fillout-forms/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",
     "bundle": "node ../../../../dist/packages/cli/src/index.js pieces bundle",
-    "lint": "eslint 'src/**/*.ts'"
+    "lint": "eslint 'src/**/*.ts'",
+    "test": "vitest run"
   },
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
@@ -15,6 +16,7 @@
     "@activepieces/core-utils": "workspace:*"
   },
   "devDependencies": {
-    "tslib": "2.6.2"
+    "tslib": "2.6.2",
+    "vitest": "3.2.6"
   }
 }

--- a/packages/pieces/community/fillout-forms/package.json
+++ b/packages/pieces/community/fillout-forms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-fillout-forms",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {

--- a/packages/pieces/community/fillout-forms/src/lib/triggers/new-form-response.test.ts
+++ b/packages/pieces/community/fillout-forms/src/lib/triggers/new-form-response.test.ts
@@ -1,0 +1,69 @@
+/// <reference types="vitest/globals" />
+
+import { newFormResponse } from './new-form-response';
+
+const SUBMISSION = {
+  submissionId: 'abc123',
+  submissionTime: '2026-08-31T10:00:00.000Z',
+  questions: [
+    {
+      id: '5AtgG35AAZVcrSVfRubvp1',
+      name: 'What is your name?',
+      type: 'ShortAnswer',
+      value: 'John Doe',
+    },
+  ],
+  calculations: [],
+  urlParameters: [],
+};
+
+const WEBHOOK_BODY = {
+  formId: 'vs1PXaHmRfus',
+  formName: 'Contact form',
+  submission: SUBMISSION,
+};
+
+const buildContext = (body: unknown) =>
+  ({
+    payload: {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body,
+      queryParams: {},
+    },
+  } as never);
+
+describe('fillout new-form-response run()', () => {
+  test('returns the submission when the body is an already-parsed object', async () => {
+    const output = await newFormResponse.run(buildContext(WEBHOOK_BODY));
+
+    expect(output).toEqual([SUBMISSION]);
+  });
+
+  test('still returns the submission when the body is a raw JSON string', async () => {
+    const output = await newFormResponse.run(
+      buildContext(JSON.stringify(WEBHOOK_BODY))
+    );
+
+    expect(output).toEqual([SUBMISSION]);
+  });
+
+  test('returns an array holding exactly one item', async () => {
+    const output = await newFormResponse.run(buildContext(WEBHOOK_BODY));
+
+    expect(Array.isArray(output)).toBe(true);
+    expect(output).toHaveLength(1);
+  });
+
+  test('a parsed body without a submission yields one undefined item', async () => {
+    const output = await newFormResponse.run(buildContext({}));
+
+    expect(output).toEqual([undefined]);
+  });
+
+  test('a string body that is not JSON still raises', async () => {
+    await expect(
+      newFormResponse.run(buildContext('not json'))
+    ).rejects.toThrow(SyntaxError);
+  });
+});

--- a/packages/pieces/community/fillout-forms/src/lib/triggers/new-form-response.ts
+++ b/packages/pieces/community/fillout-forms/src/lib/triggers/new-form-response.ts
@@ -68,7 +68,8 @@ export const newFormResponse = createTrigger({
     return submissions.responses;
   },
   async run(context) {
-    const payload = JSON.parse(context.payload.body as string) as {
+    const body = context.payload.body;
+    const payload = (typeof body === 'string' ? JSON.parse(body) : body) as {
       submission: Record<string, any>;
     };
     return [payload.submission];

--- a/packages/pieces/community/fillout-forms/vitest.config.ts
+++ b/packages/pieces/community/fillout-forms/vitest.config.ts
@@ -1,0 +1,17 @@
+import path from 'path'
+import { defineConfig } from 'vitest/config'
+
+const repoRoot = path.resolve(__dirname, '../../../..')
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+  },
+  resolve: {
+    alias: {
+      '@activepieces/pieces-framework': path.resolve(repoRoot, 'packages/pieces/framework/src/index.ts'),
+      '@activepieces/pieces-common': path.resolve(repoRoot, 'packages/pieces/common/src/index.ts'),
+    },
+  },
+})


### PR DESCRIPTION
## The bug

The `new-form-response` trigger never fires on real webhook deliveries:

```ts
async run(context) {
  const payload = JSON.parse(context.payload.body as string) as { ... };
  return [payload.submission];
}
```

Fillout sends its webhooks with `Content-Type: application/json`, so by the time the engine hands the payload to the trigger, `context.payload.body` is already a **parsed object**, not a raw string. `JSON.parse(object)` stringifies it to `"[object Object]"` and throws `SyntaxError: Unexpected token 'o'`. The engine swallows the error as "payload filtered out", so the job reports `outcome: success` and **no run is ever created — silently**. The `as string` cast hides the mismatch from the compiler.

The `test()` function is unaffected (it polls `GET /forms/:id/submissions`), which is why the trigger looks healthy in the builder while dropping every live submission.

## Repro

1. Create a flow with the Fillout **New Form Response** trigger, publish + enable (webhook is registered correctly at Fillout).
2. Submit the form.
3. Webhook is delivered, `EXECUTE_WEBHOOK` job succeeds in the worker logs — but no flow run appears.

Observed on self-hosted 0.88.1; the parsed-body behavior comes from the shared webhook controller, so this should affect Cloud identically.

## The fix

Accept both shapes — parse only when the body is actually a string:

```ts
const body = context.payload.body;
const payload = (typeof body === 'string' ? JSON.parse(body) : body) as {
  submission: Record<string, any>;
};
```

Verified on our instance (patched bundle of 0.1.8): the same webhook payloads that were silently dropped now create runs with the submission as trigger output.
