### PR TITLE
Assessment/talaljaber

### DIFF
--- a/packages/pieces/community/jira-cloud/src/index.ts
+++ b/packages/pieces/community/jira-cloud/src/index.ts
@@ -22,6 +22,7 @@ import { getIssueAttachmentAction } from './lib/actions/get-issue-attachment';
 import { markdownToJiraFormat } from './lib/actions/markdown-to-jira-format';
 import { getIssueAction } from './lib/actions/get-issue';
 import { transitionIssueAction } from './lib/actions/transition-issue';
+import { listIssueTransitionsAction } from './lib/actions/list-issue-transitions';
 import { newComment } from './lib/triggers/new-comment';
 import { issueAssigned } from './lib/triggers/issue-assigned';
 import { newAttachment } from './lib/triggers/new-attachment';
@@ -55,6 +56,7 @@ export const jiraCloud = createPiece({
 		markdownToJiraFormat,
 		getIssueAction,
 		transitionIssueAction,
+		listIssueTransitionsAction,
 		createCustomApiCallAction({
 			baseUrl: (auth) => {
 				return auth ? `${(auth).props.instanceUrl}/rest/api/3` : '';

--- a/packages/pieces/community/jira-cloud/src/lib/actions/add-attachment-to-issue.ts
+++ b/packages/pieces/community/jira-cloud/src/lib/actions/add-attachment-to-issue.ts
@@ -8,6 +8,7 @@ import { getProjectIdDropdown, getIssueIdDropdown } from '../common/props';
 export const addAttachmentToIssueAction = createAction({
 	auth: jiraCloudAuth,
 	name: 'add_issue_attachment',
+	classification: 'WRITE',
 	displayName: 'Add Attachment to Issue',
 	description: 'Adds an attachment to an issue.',
 	audience: 'both',

--- a/packages/pieces/community/jira-cloud/src/lib/actions/add-comment-to-issue.ts
+++ b/packages/pieces/community/jira-cloud/src/lib/actions/add-comment-to-issue.ts
@@ -7,6 +7,7 @@ import { getIssueIdDropdown, getProjectIdDropdown } from '../common/props';
 export const addCommentToIssueAction = createAction({
 	auth: jiraCloudAuth,
 	name: 'add_issue_comment',
+	classification: 'WRITE',
 	displayName: 'Add Issue Comment',
 	description: 'Adds a comment to an issue.',
 	audience: 'both',

--- a/packages/pieces/community/jira-cloud/src/lib/actions/add-watcher-to-issue.ts
+++ b/packages/pieces/community/jira-cloud/src/lib/actions/add-watcher-to-issue.ts
@@ -8,6 +8,7 @@ import { HttpError, HttpMethod } from '@activepieces/pieces-common';
 export const addWatcherToIssueAction = createAction({
 	auth: jiraCloudAuth,
 	name: 'add-watcher-to-issue',
+	classification: 'WRITE',
 	displayName: 'Add Watcher to Issue',
 	description: 'Adds a new watcher to an issue.',
 	audience: 'both',

--- a/packages/pieces/community/jira-cloud/src/lib/actions/assign-issue.ts
+++ b/packages/pieces/community/jira-cloud/src/lib/actions/assign-issue.ts
@@ -7,6 +7,7 @@ import { getIssueIdDropdown, getProjectIdDropdown, getUsersDropdown } from '../c
 export const assignIssueAction = createAction({
 	auth: jiraCloudAuth,
 	name: 'assign_issue',
+	classification: 'WRITE',
 	displayName: 'Assign Issue',
 	description: 'Assigns an issue to a user.',
 	audience: 'both',

--- a/packages/pieces/community/jira-cloud/src/lib/actions/create-issue.ts
+++ b/packages/pieces/community/jira-cloud/src/lib/actions/create-issue.ts
@@ -30,6 +30,7 @@ async function getFields(auth: JiraAuth, projectId: string, issueTypeId: string)
 
 export const createIssueAction = createAction({
 	name: 'create_issue',
+	classification: 'WRITE',
 	displayName: 'Create Issue',
 	description: 'Creates a new issue in a project.',
 	audience: 'both',

--- a/packages/pieces/community/jira-cloud/src/lib/actions/delete-issue-comment.ts
+++ b/packages/pieces/community/jira-cloud/src/lib/actions/delete-issue-comment.ts
@@ -7,6 +7,7 @@ import { getIssueIdDropdown, getProjectIdDropdown } from '../common/props';
 export const deleteIssueCommentAction = createAction({
 	auth: jiraCloudAuth,
 	name: 'delete_issue_comment',
+	classification: 'DESTRUCTIVE',
 	displayName: 'Delete Issue Comment',
 	description: 'Deletes a comment on a specific issue.',
 	audience: 'both',

--- a/packages/pieces/community/jira-cloud/src/lib/actions/find-user.ts
+++ b/packages/pieces/community/jira-cloud/src/lib/actions/find-user.ts
@@ -6,6 +6,7 @@ import { HttpMethod } from "@activepieces/pieces-common";
 export const findUserAction = createAction({
     auth:jiraCloudAuth,
     name:'find-user',
+    classification: 'SEARCH',
     displayName:'Find User',
     description:'Finds an existing user.',
     audience: 'both',

--- a/packages/pieces/community/jira-cloud/src/lib/actions/get-issue-attachment.ts
+++ b/packages/pieces/community/jira-cloud/src/lib/actions/get-issue-attachment.ts
@@ -6,6 +6,7 @@ import { AuthenticationType, httpClient, HttpMethod } from "@activepieces/pieces
 export const getIssueAttachmentAction = createAction({
     auth: jiraCloudAuth,
     name: 'get-issue-attachment',
+    classification: 'READ',
     displayName: 'Get Issue Attachment',
     description: 'Retrieves an attachment from an issue.',
     audience: 'both',

--- a/packages/pieces/community/jira-cloud/src/lib/actions/get-issue.ts
+++ b/packages/pieces/community/jira-cloud/src/lib/actions/get-issue.ts
@@ -7,6 +7,7 @@ import { getIssueIdDropdown, getProjectIdDropdown } from '../common/props';
 export const getIssueAction = createAction({
   auth: jiraCloudAuth,
   name: 'get_issue',
+  classification: 'READ',
   displayName: 'Get Issue',
   description: 'Get issue data.',
   audience: 'both',

--- a/packages/pieces/community/jira-cloud/src/lib/actions/link-issues.ts
+++ b/packages/pieces/community/jira-cloud/src/lib/actions/link-issues.ts
@@ -8,6 +8,7 @@ import { jiraApiCall } from '../common';
 export const linkIssuesAction = createAction({
   auth: jiraCloudAuth,
   name: 'link-issues',
+  classification: 'WRITE',
   displayName: 'Link Issues',
   description: 'Creates a link between two issues.',
   audience: 'both',

--- a/packages/pieces/community/jira-cloud/src/lib/actions/list-issue-comments.ts
+++ b/packages/pieces/community/jira-cloud/src/lib/actions/list-issue-comments.ts
@@ -7,6 +7,7 @@ import { getProjectIdDropdown, getIssueIdDropdown } from '../common/props';
 export const listIssueCommentsAction = createAction({
 	auth: jiraCloudAuth,
 	name: 'list_issue_comments',
+	classification: 'READ',
 	displayName: 'List Issue Comments',
 	description: 'Returns all comments for an issue.',
 	audience: 'both',

--- a/packages/pieces/community/jira-cloud/src/lib/actions/list-issue-transitions.ts
+++ b/packages/pieces/community/jira-cloud/src/lib/actions/list-issue-transitions.ts
@@ -1,0 +1,99 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { jiraCloudAuth } from '../../auth';
+import { jiraApiCall } from '../common';
+import { listIssueTransitionsOutputSchema } from '../output-schemas';
+
+/** One transition as returned by `GET /issue/{issueIdOrKey}/transitions`. */
+type JiraTransition = {
+  id: string;
+  name: string;
+  isAvailable?: boolean;
+  hasScreen?: boolean;
+  to?: {
+    id?: string;
+    name?: string;
+    statusCategory?: { key?: string };
+  };
+};
+
+/** Jira wraps the array in an envelope — this action never returns it raw. */
+type JiraTransitionsResponse = {
+  expand?: string;
+  transitions?: JiraTransition[];
+};
+
+/**
+ * Agent atomic: the id-resolution step that Transition Issue is missing.
+ *
+ * Transition Issue takes `transitionId` from `issueStatusIdProp`, a
+ * `Property.Dropdown` whose options resolver is the only code path in this piece
+ * that calls the transitions endpoint. Dropdown resolvers run in the flow builder,
+ * so an agent driving the piece over MCP has no way to obtain a transition id —
+ * and unlike a project or account id, it cannot be looked up anywhere else either,
+ * because transition ids are per-issue AND per-workflow-state.
+ */
+export const listIssueTransitionsAction = createAction({
+  auth: jiraCloudAuth,
+  name: 'list_issue_transitions',
+  // READ, not SEARCH. The split is how data is addressed (by id vs by query), and
+  // the shipped gmail atomics draw exactly that line: gmail_get_thread is READ with
+  // a required id even though it returns a collection, while gmail_list_drafts is
+  // SEARCH because it takes no required id. This takes a required issueIdOrKey.
+  classification: 'READ',
+  displayName: 'List Issue Transitions',
+  description:
+    'Lists the workflow transitions currently available for a specific issue.',
+  audience: 'ai',
+  aiMetadata: {
+    description:
+      'Resolves the workflow moves a specific Jira issue can make from its current status, together with the transition id each one requires; by default only transitions the caller may execute are returned, with an option to include blocked ones for diagnosis. Call it before Transition Issue, whose transition id is per-issue and workflow-state-dependent and so cannot be guessed, looked up elsewhere, or reused across issues. Read-only and idempotent.',
+    idempotent: true,
+  },
+  outputSchema: listIssueTransitionsOutputSchema,
+  props: {
+    issueIdOrKey: Property.ShortText({
+      displayName: 'Issue ID or Key',
+      description:
+        'The issue to list transitions for (e.g. "PROJ-123"). Obtain from Search Issues or Get Issue.',
+      required: true,
+    }),
+    includeUnavailableTransitions: Property.Checkbox({
+      displayName: 'Include Unavailable Transitions',
+      description:
+        'When enabled, also returns transitions the current user cannot execute (e.g. blocked by a workflow condition or permission). Useful for diagnosing why an expected status is unreachable.',
+      required: false,
+      defaultValue: false,
+    }),
+  },
+  async run(context) {
+    const { issueIdOrKey, includeUnavailableTransitions } = context.propsValue;
+
+    const response = await jiraApiCall<JiraTransitionsResponse>({
+      auth: context.auth,
+      method: HttpMethod.GET,
+      resourceUri: `/issue/${issueIdOrKey}/transitions`,
+      query: includeUnavailableTransitions
+        ? { includeUnavailableTransitions: 'true' }
+        : undefined,
+    });
+
+    // Flatten each transition's nested `to.statusCategory` so the output is
+    // table-ready, and never return Jira's { expand, transitions } envelope.
+    const transitions = (response.transitions ?? []).map((transition) => ({
+      id: transition.id,
+      name: transition.name,
+      toStatusId: transition.to?.id ?? null,
+      toStatusName: transition.to?.name ?? null,
+      toStatusCategory: transition.to?.statusCategory?.key ?? null,
+      isAvailable: transition.isAvailable ?? true,
+      hasScreen: transition.hasScreen ?? false,
+    }));
+
+    return {
+      issueIdOrKey,
+      count: transitions.length,
+      transitions,
+    };
+  },
+});

--- a/packages/pieces/community/jira-cloud/src/lib/actions/markdown-to-jira-format.ts
+++ b/packages/pieces/community/jira-cloud/src/lib/actions/markdown-to-jira-format.ts
@@ -5,6 +5,7 @@ import { MarkdownTransformer } from '@atlaskit/editor-markdown-transformer';
 
 export const markdownToJiraFormat = createAction({
   name: 'markdownToJiraFormat',
+  classification: 'READ',
   displayName: 'Markdown to Jira format',
   description:
     "Convert Markdown-formatted text to Jira's ADF syntax for use in comments and descriptions etc",

--- a/packages/pieces/community/jira-cloud/src/lib/actions/search-issues.ts
+++ b/packages/pieces/community/jira-cloud/src/lib/actions/search-issues.ts
@@ -7,6 +7,7 @@ import { propsValidation } from '@activepieces/pieces-common';
 
 export const searchIssues = createAction({
   name: 'search_issues',
+  classification: 'SEARCH',
   displayName: 'Search Issues',
   description: 'Search for issues with JQL',
   audience: 'both',

--- a/packages/pieces/community/jira-cloud/src/lib/actions/transition-issue.ts
+++ b/packages/pieces/community/jira-cloud/src/lib/actions/transition-issue.ts
@@ -12,6 +12,7 @@ import {
 export const transitionIssueAction = createAction({
   auth: jiraCloudAuth,
   name: 'transition_issue',
+  classification: 'WRITE',
   displayName: 'Transition Issue',
   description:
     'Moves an issue to a new status by executing a workflow transition.',

--- a/packages/pieces/community/jira-cloud/src/lib/actions/update-issue-comment.ts
+++ b/packages/pieces/community/jira-cloud/src/lib/actions/update-issue-comment.ts
@@ -7,6 +7,7 @@ import { getIssueIdDropdown, getProjectIdDropdown } from '../common/props';
 export const updateIssueCommentAction = createAction({
 	auth: jiraCloudAuth,
 	name: 'update_issue_comment',
+	classification: 'WRITE',
 	displayName: 'Update Issue Comment',
 	description: 'Updates a comment to a specific issue.',
 	audience: 'both',

--- a/packages/pieces/community/jira-cloud/src/lib/actions/update-issue.ts
+++ b/packages/pieces/community/jira-cloud/src/lib/actions/update-issue.ts
@@ -34,6 +34,7 @@ async function getFields(auth: JiraAuth, issueId: string): Promise<IssueFieldMet
 
 export const updateIssueAction = createAction({
 	name: 'update_issue',
+	classification: 'WRITE',
 	displayName: 'Update Issue',
 	description: 'Updates an existing issue.',
 	audience: 'both',

--- a/packages/pieces/community/jira-cloud/src/lib/output-schemas.ts
+++ b/packages/pieces/community/jira-cloud/src/lib/output-schemas.ts
@@ -1,0 +1,63 @@
+import type { OutputSchema } from '@activepieces/pieces-framework';
+
+/**
+ * Output schemas for the Jira Cloud piece.
+ *
+ * Authored from a real captured run against a live Jira Cloud site, per the
+ * output-schema skill's rule that a schema comes from captured output and never from
+ * a guessed shape.
+ *
+ * The paths describe what `run()` RETURNS — the flattened
+ * `{ issueIdOrKey, count, transitions[] }` object — not Jira's raw
+ * `{ expand, transitions[] }` envelope, which the action deliberately discards.
+ */
+export const listIssueTransitionsOutputSchema: OutputSchema = {
+  fields: [
+    {
+      key: 'issueIdOrKey',
+      label: 'Issue ID or Key',
+      description:
+        'Echoed back so a downstream step can pair transitions with their issue.',
+    },
+    { key: 'count', label: 'Transition Count', format: 'number' },
+    {
+      // listItems paths are RELATIVE to one transition — `id`, never
+      // `transitions.id`. The schema reference calls the absolute form the #1
+      // correctness bug in hand-written schemas.
+      key: 'transitions',
+      label: 'Transitions',
+      labelKey: 'name',
+      listItems: [
+        {
+          key: 'id',
+          label: 'Transition ID',
+          description:
+            'Pass this to Transition Issue. Valid only for this issue at its current status.',
+        },
+        { key: 'name', label: 'Transition Name' },
+        { key: 'toStatusId', label: 'Destination Status ID' },
+        { key: 'toStatusName', label: 'Destination Status' },
+        {
+          key: 'toStatusCategory',
+          label: 'Destination Status Category',
+          description:
+            'One of `new`, `indeterminate`, or `done` — the coarse bucket the destination status belongs to.',
+        },
+        {
+          key: 'isAvailable',
+          label: 'Available',
+          format: 'boolean',
+          description:
+            'False only when unavailable transitions were explicitly requested.',
+        },
+        {
+          key: 'hasScreen',
+          label: 'Requires Screen',
+          format: 'boolean',
+          description:
+            'True when Jira would prompt for extra fields, which the transition may require.',
+        },
+      ],
+    },
+  ],
+};

--- a/packages/pieces/community/youtube/src/lib/actions/search.ts
+++ b/packages/pieces/community/youtube/src/lib/actions/search.ts
@@ -11,18 +11,54 @@ export const youtubeSearchAction = createAction({
     'Search YouTube videos, channels, and playlists using the YouTube Data API search.list endpoint.',
   audience: 'both',
   aiMetadata: { description: 'Runs a YouTube search.list query across videos, channels, and playlists at once or restricted to a single resource type, and can instead be scoped to uploads owned by the authenticated account (For Mine), a CMS content owner, or the developer project. Use it to turn a free-text query, channel, date range, region, or topic into video, channel, or playlist IDs for later steps; prefer List Playlist Items when the playlist ID is already known. Video-only filters such as duration, definition, caption, event type, and location require Type to be Video, and Location must be paired with Location Radius. Read-only and idempotent.', idempotent: true },
+  // The groups hold the ESSENTIAL form and nothing else, deliberately.
+  // property-ui-selection.md section 4: "Only ungrouped props honour
+  // `advanced: true` - members of `tabs` and `section` groups are always
+  // essential; the flag is ignored on them." So a prop cannot be both grouped
+  // and advanced: putting an advanced prop in a section would silently promote
+  // it back into the first-run form. `section` is also the only display that
+  // keeps an Advanced section at all - one `builder` or `footer` group would
+  // disable it form-wide and neutralise every flag.
+  propertyGroups: [
+    {
+      key: 'search',
+      display: 'section',
+      label: 'Search',
+      icon: 'text',
+      description: 'What to look for, and what kind of result to return.',
+      props: ['query', 'type', 'order'],
+    },
+    {
+      key: 'results',
+      display: 'section',
+      label: 'Results',
+      icon: 'sliders',
+      description: 'How many results to return and how strictly to filter them.',
+      props: ['maxResults', 'safeSearch'],
+    },
+    {
+      key: 'published',
+      display: 'section',
+      label: 'Published',
+      icon: 'calendar',
+      description: 'Restrict results to a publication time window.',
+      props: ['publishedAfter', 'publishedBefore'],
+    },
+  ],
   props: {
     query: Property.ShortText({
       displayName: 'Query',
       description:
         'Search term. Supports operators like OR (`|`) and NOT (`-`) as supported by YouTube search.',
       required: false,
+      placeholder: 'activepieces tutorial | automation -shorts',
     }),
     type: Property.StaticDropdown({
       displayName: 'Type',
       description:
         'Restrict results to a resource type. Use "Any" to search videos, channels, and playlists.',
       required: false,
+      width: 'half',
       defaultValue: 'any',
       options: {
         options: [
@@ -38,34 +74,42 @@ export const youtubeSearchAction = createAction({
       description:
         'Restrict results to videos owned by the content owner set in On Behalf Of Content Owner.',
       required: false,
+      advanced: true,
     }),
     forDeveloper: Property.Checkbox({
       displayName: 'For Developer',
       description:
         'Restrict results to videos uploaded via your developer project.',
       required: false,
+      advanced: true,
     }),
     forMine: Property.Checkbox({
       displayName: 'For Mine',
       description:
         'Restrict results to videos owned by the authenticated user.',
       required: false,
+      advanced: true,
     }),
     onBehalfOfContentOwner: Property.ShortText({
       displayName: 'On Behalf Of Content Owner',
       description:
         'Required when For Content Owner is enabled. Intended for YouTube CMS content partners.',
       required: false,
+      advanced: true,
+      placeholder: 'YouTube CMS content owner ID',
     }),
     channelId: Property.ShortText({
       displayName: 'Channel ID',
       description: 'Only return resources from this channel.',
       required: false,
+      advanced: true,
+      placeholder: 'UC_x5XG1OV2P6uZZ5FSM9Ttw',
     }),
     channelType: Property.StaticDropdown({
       displayName: 'Channel Type',
       description: 'Restrict channel searches to a specific channel type.',
       required: false,
+      advanced: true,
       options: {
         options: [
           { label: 'Any', value: 'any' },
@@ -75,7 +119,10 @@ export const youtubeSearchAction = createAction({
     }),
     order: Property.StaticDropdown({
       displayName: 'Order',
+      description:
+        'How to sort results. Relevance is the YouTube ranking; Date returns newest first, which is what most latest-video automations want.',
       required: false,
+      width: 'half',
       defaultValue: 'relevance',
       options: {
         options: [
@@ -90,7 +137,10 @@ export const youtubeSearchAction = createAction({
     }),
     safeSearch: Property.StaticDropdown({
       displayName: 'Safe Search',
+      description:
+        'Whether to exclude restricted content. Moderate follows local community standards, Strict removes all restricted results, None applies no filter.',
       required: false,
+      width: 'half',
       defaultValue: 'moderate',
       options: {
         options: [
@@ -105,43 +155,59 @@ export const youtubeSearchAction = createAction({
       description:
         'Only include resources created at or after this datetime (RFC 3339).',
       required: false,
+      width: 'half',
     }),
     publishedBefore: Property.DateTime({
       displayName: 'Published Before',
       description:
         'Only include resources created before or at this datetime (RFC 3339).',
       required: false,
+      width: 'half',
     }),
     maxResults: Property.Number({
       displayName: 'Max Results',
       description: 'Acceptable values are 0 to 50. Defaults to 25.',
       required: false,
+      width: 'half',
       defaultValue: 25,
     }),
     pageToken: Property.ShortText({
       displayName: 'Page Token',
+      description:
+        'Fetch a specific page of results using the nextPageToken from a previous run.',
       required: false,
+      advanced: true,
+      placeholder: 'CAUQAA',
     }),
     regionCode: Property.ShortText({
       displayName: 'Region Code',
       description: 'ISO 3166-1 alpha-2 country code (for example: US, DE, JP).',
       required: false,
+      advanced: true,
+      placeholder: 'US',
     }),
     relevanceLanguage: Property.ShortText({
       displayName: 'Relevance Language',
       description:
         'ISO 639-1 language code (for example: en, es, ja, zh-Hans).',
       required: false,
+      advanced: true,
+      placeholder: 'en',
     }),
     topicId: Property.ShortText({
       displayName: 'Topic ID',
       description:
         'Curated Freebase topic ID to restrict results by topic (for example: /m/04rlf for Music).',
       required: false,
+      advanced: true,
+      placeholder: '/m/04rlf',
     }),
     eventType: Property.StaticDropdown({
       displayName: 'Event Type (video only)',
+      description:
+        'Restrict results to live broadcasts by state: Completed (already ended), Live (in progress), or Upcoming (scheduled).',
       required: false,
+      advanced: true,
       options: {
         options: [
           { label: 'Completed', value: 'completed' },
@@ -155,20 +221,31 @@ export const youtubeSearchAction = createAction({
       description:
         'Latitude,longitude center point (for example: 37.42307,-122.08427). Requires Location Radius.',
       required: false,
+      advanced: true,
+      placeholder: '37.42307,-122.08427',
     }),
     locationRadius: Property.ShortText({
       displayName: 'Location Radius (video only)',
       description:
         'Distance from Location with unit (m, km, ft, mi), for example: 5km. Requires Location.',
       required: false,
+      advanced: true,
+      placeholder: '5km',
     }),
     videoCategoryId: Property.ShortText({
       displayName: 'Video Category ID (video only)',
+      description:
+        'Restrict results to a single video category, by its numeric ID.',
       required: false,
+      advanced: true,
+      placeholder: '10',
     }),
     videoDuration: Property.StaticDropdown({
       displayName: 'Video Duration (video only)',
+      description:
+        'Restrict results by length: Short is under 4 minutes, Medium 4-20 minutes, Long over 20 minutes.',
       required: false,
+      advanced: true,
       options: {
         options: [
           { label: 'Any', value: 'any' },
@@ -180,7 +257,10 @@ export const youtubeSearchAction = createAction({
     }),
     videoDefinition: Property.StaticDropdown({
       displayName: 'Video Definition (video only)',
+      description:
+        'Restrict results to high-definition (720p or better) or standard-definition videos.',
       required: false,
+      advanced: true,
       options: {
         options: [
           { label: 'Any', value: 'any' },
@@ -191,7 +271,9 @@ export const youtubeSearchAction = createAction({
     }),
     videoDimension: Property.StaticDropdown({
       displayName: 'Video Dimension (video only)',
+      description: 'Restrict results to 2D or 3D videos.',
       required: false,
+      advanced: true,
       options: {
         options: [
           { label: 'Any', value: 'any' },
@@ -202,7 +284,10 @@ export const youtubeSearchAction = createAction({
     }),
     videoEmbeddable: Property.StaticDropdown({
       displayName: 'Video Embeddable (video only)',
+      description:
+        'Set to True to return only videos that can be embedded in a web page.',
       required: false,
+      advanced: true,
       options: {
         options: [
           { label: 'Any', value: 'any' },
@@ -212,7 +297,10 @@ export const youtubeSearchAction = createAction({
     }),
     videoLicense: Property.StaticDropdown({
       displayName: 'Video License (video only)',
+      description:
+        'Restrict results by licence. Creative Commons videos may be reused with attribution; YouTube is the standard licence.',
       required: false,
+      advanced: true,
       options: {
         options: [
           { label: 'Any', value: 'any' },
@@ -223,7 +311,10 @@ export const youtubeSearchAction = createAction({
     }),
     videoPaidProductPlacement: Property.StaticDropdown({
       displayName: 'Video Paid Product Placement (video only)',
+      description:
+        'Set to True to return only videos whose creator declared a paid promotion.',
       required: false,
+      advanced: true,
       options: {
         options: [
           { label: 'Any', value: 'any' },
@@ -233,7 +324,10 @@ export const youtubeSearchAction = createAction({
     }),
     videoSyndicated: Property.StaticDropdown({
       displayName: 'Video Syndicated (video only)',
+      description:
+        'Set to True to return only videos that can be played outside youtube.com.',
       required: false,
+      advanced: true,
       options: {
         options: [
           { label: 'Any', value: 'any' },
@@ -243,7 +337,9 @@ export const youtubeSearchAction = createAction({
     }),
     videoType: Property.StaticDropdown({
       displayName: 'Video Type (video only)',
+      description: 'Restrict results to episodes of a show or to full movies.',
       required: false,
+      advanced: true,
       options: {
         options: [
           { label: 'Any', value: 'any' },
@@ -254,7 +350,10 @@ export const youtubeSearchAction = createAction({
     }),
     videoCaption: Property.StaticDropdown({
       displayName: 'Video Caption (video only)',
+      description:
+        'Restrict results by caption availability. Closed Caption returns only captioned videos; None returns only uncaptioned ones.',
       required: false,
+      advanced: true,
       options: {
         options: [
           { label: 'Any', value: 'any' },

--- a/packages/pieces/community/zoom/src/lib/actions/create-meeting.ts
+++ b/packages/pieces/community/zoom/src/lib/actions/create-meeting.ts
@@ -7,6 +7,7 @@ import {
 } from '@activepieces/pieces-common';
 import { MeetingMessageBody, MeetingResponseBody } from '../common/models';
 import { zoomAuth } from '../..';
+import { zoomCreateMeetingOutputSchema } from '../output-schemas';
 
 const defaults = {
   agenda: 'My Meeting',
@@ -49,6 +50,7 @@ const action = () => {
     description: 'Create a new Zoom Meeting',
     audience: 'both',
     aiMetadata: { description: 'Schedules a new Zoom meeting on the authenticated user\'s account, returning the meeting ID and join URL. Use to set up a video call; only the topic is required, with optional start time, duration, password, and audio/recording settings. Each call creates a distinct meeting, so it is not idempotent.', idempotent: false },
+    outputSchema: zoomCreateMeetingOutputSchema,
     props: {
       topic: Property.ShortText({
         displayName: "Meeting's topic",

--- a/packages/pieces/community/zoom/src/lib/actions/find-meeting.ts
+++ b/packages/pieces/community/zoom/src/lib/actions/find-meeting.ts
@@ -7,6 +7,7 @@ import {
 import { MeetingResponseBody } from '../common/models';
 import { zoomMeetingDropdown } from '../common/props';
 import { zoomAuth } from '../..';
+import { zoomFindMeetingOutputSchema } from '../output-schemas';
 
 export const zoomFindMeeting = createAction({
   auth: zoomAuth,
@@ -16,6 +17,7 @@ export const zoomFindMeeting = createAction({
   description: 'Retrieve the details of an existing meeting.',
   audience: 'both',
   aiMetadata: { description: 'Fetches the full details of an existing Zoom meeting by its meeting ID. Use to look up a meeting before acting on it; optionally target a specific occurrence of a recurring meeting or include all previous occurrences. Read-only and idempotent.', idempotent: true },
+  outputSchema: zoomFindMeetingOutputSchema,
   props: {
     meeting_id: zoomMeetingDropdown,
     occurrence_id: Property.ShortText({

--- a/packages/pieces/community/zoom/src/lib/actions/update-meeting.ts
+++ b/packages/pieces/community/zoom/src/lib/actions/update-meeting.ts
@@ -7,6 +7,7 @@ import {
 import { MeetingMessageBody } from '../common/models';
 import { zoomMeetingDropdown } from '../common/props';
 import { zoomAuth } from '../..';
+import { zoomUpdateMeetingOutputSchema } from '../output-schemas';
 
 export const zoomUpdateMeeting = createAction({
   auth: zoomAuth,
@@ -16,6 +17,7 @@ export const zoomUpdateMeeting = createAction({
   description: 'Update the details of an existing meeting.',
   audience: 'both',
   aiMetadata: { description: 'Modifies an existing Zoom meeting identified by its meeting ID, applying only the fields you supply (topic, start time, duration, timezone, password, and audio/video/recording/waiting-room settings). Use to reschedule or reconfigure a meeting. Repeating the call with the same values produces the same end state, so it is idempotent.', idempotent: true },
+  outputSchema: zoomUpdateMeetingOutputSchema,
   props: {
     meeting_id: zoomMeetingDropdown,
     topic: Property.ShortText({

--- a/packages/pieces/community/zoom/src/lib/output-schemas.ts
+++ b/packages/pieces/community/zoom/src/lib/output-schemas.ts
@@ -1,0 +1,176 @@
+import type { OutputSchema } from '@activepieces/pieces-framework';
+
+/**
+ * Output schemas for the Zoom piece.
+ *
+ * Shape source: a live `POST /v2/users/me/meetings` 201 body and the
+ * `GET /v2/meetings/{meetingId}` 200 body for the same meeting, captured through a
+ * Server-to-Server OAuth app and diffed against each other. Not authored from docs.
+ *
+ * `find-meeting` and `create-meeting` return the same meeting resource, so the field
+ * set lives in one shared const and each action exports its own schema over it. The
+ * captured diff was: the create body adds `authentication_option`,
+ * `authentication_name` and `authentication_domains` under `settings`, and the find
+ * body adds `assistant_id` — all four are fields this curation drops anyway, so no
+ * described path is absent from either response.
+ *
+ * Curation policy: an outputSchema is a curated tree, so an omitted field is a hidden
+ * field. Kept is what a downstream step would branch on, template into a message, or
+ * pass to another action. Dropped is transport noise and duplicated credential
+ * material. Every `children` path is relative to its parent, never dotted from root.
+ *
+ * Deliberately not described, because they were not in the captured payloads and the
+ * schema skill forbids guessing a shape: `registration_url` (registration-enabled
+ * meetings only) and `occurrences` (recurring meetings only). Both are declared
+ * optional on `MeetingResponseBody` and can be added from a capture of those cases.
+ */
+
+/**
+ * The meeting resource, shared by Find and Create.
+ *
+ * Deliberately NOT included: `h323_password`, `pstn_password` and
+ * `encrypted_password` — encoded restatements of `password` for dial-in and URL
+ * embedding. Three near-duplicate secrets in the data selector is noise; the one
+ * canonical passcode is kept.
+ */
+const meetingFields: OutputSchema['fields'] = [
+  // --- Identity ---
+  {
+    key: 'id',
+    label: 'Meeting ID',
+    format: 'number',
+    description: 'Numeric meeting ID. Use this to look up, update, or delete the meeting.',
+  },
+  {
+    key: 'uuid',
+    label: 'Meeting UUID',
+    description:
+      'Unique identifier for this meeting *instance*. A recurring meeting keeps one ID but gets a new UUID per occurrence.',
+  },
+
+  // --- Content ---
+  { key: 'topic', label: 'Topic' },
+  { key: 'agenda', label: 'Agenda' },
+
+  // --- Schedule ---
+  {
+    key: 'type',
+    label: 'Meeting Type',
+    format: 'number',
+    description: '1 = instant, 2 = scheduled, 3 = recurring (no fixed time), 8 = recurring (fixed time).',
+  },
+  {
+    key: 'status',
+    label: 'Status',
+    description: 'Either `waiting` (not yet started) or `started`.',
+  },
+  { key: 'start_time', label: 'Start Time', format: 'datetime' },
+  {
+    key: 'duration',
+    label: 'Duration (Minutes)',
+    // Zoom returns whole minutes. The `duration` format renders elapsed time and would
+    // mis-scale an integer minute count, so this stays a labelled number.
+    format: 'number',
+  },
+  {
+    key: 'timezone',
+    label: 'Timezone',
+    description: 'IANA timezone the start time is expressed in, e.g. `Asia/Amman`.',
+  },
+  { key: 'created_at', label: 'Created At', format: 'datetime' },
+  {
+    key: 'pre_schedule',
+    label: 'Pre-Scheduled',
+    format: 'boolean',
+    description: 'True when the meeting was created as a pre-scheduled placeholder with no fixed time yet.',
+  },
+
+  // --- Access ---
+  {
+    key: 'join_url',
+    label: 'Join URL',
+    format: 'url',
+    description: 'Participant join link. This is the one to send to attendees.',
+  },
+  {
+    key: 'start_url',
+    label: 'Start URL',
+    format: 'url',
+    description:
+      'Host start link. Embeds a ZAK token that grants host rights and expires — treat it as a secret and never send it to participants.',
+  },
+  {
+    key: 'password',
+    label: 'Passcode',
+    description: 'Meeting passcode required to join when a passcode is enabled.',
+  },
+
+  // --- Host ---
+  { key: 'host_id', label: 'Host ID' },
+  { key: 'host_email', label: 'Host Email', format: 'email' },
+
+  // --- Settings ---
+  {
+    // `settings` carries 21 keys. Naming it without `children` would make the renderer
+    // drill all 21 generically — worse than omitting it. So it is described explicitly
+    // and narrowed to the 10 settings a flow would realistically read back.
+    key: 'settings',
+    label: 'Settings',
+    children: [
+      { key: 'host_video', label: 'Host Video On Join', format: 'boolean' },
+      { key: 'participant_video', label: 'Participant Video On Join', format: 'boolean' },
+      { key: 'join_before_host', label: 'Join Before Host', format: 'boolean' },
+      { key: 'waiting_room', label: 'Waiting Room Enabled', format: 'boolean' },
+      { key: 'mute_upon_entry', label: 'Mute On Entry', format: 'boolean' },
+      {
+        key: 'approval_type',
+        label: 'Registration Approval',
+        format: 'number',
+        description: '0 = automatically approve, 1 = manually approve, 2 = no registration required.',
+      },
+      {
+        key: 'audio',
+        label: 'Audio Options',
+        description: 'One of `both`, `telephony`, `voip`, or `thirdParty`.',
+      },
+      {
+        key: 'auto_recording',
+        label: 'Auto Recording',
+        description: 'One of `local`, `cloud`, or `none`.',
+      },
+      {
+        key: 'meeting_authentication',
+        label: 'Authentication Required',
+        format: 'boolean',
+        description: 'True when only authenticated users may join.',
+      },
+      {
+        key: 'encryption_type',
+        label: 'Encryption Type',
+        description: 'Either `enhanced_encryption` or `e2ee`.',
+      },
+    ],
+  },
+];
+
+/** `GET /v2/meetings/{meetingId}` — the meeting resource as returned by Find Meeting. */
+export const zoomFindMeetingOutputSchema: OutputSchema = {
+  fields: meetingFields,
+};
+
+/** `POST /v2/users/me/meetings` — the 201 body, the same meeting resource. */
+export const zoomCreateMeetingOutputSchema: OutputSchema = {
+  fields: meetingFields,
+};
+
+/**
+ * `PATCH /v2/meetings/{meetingId}` returns 204 with no body, so this action does not
+ * pass the Zoom response through — it returns a fixed acknowledgement object it builds
+ * itself. The schema describes that object, not a meeting.
+ */
+export const zoomUpdateMeetingOutputSchema: OutputSchema = {
+  fields: [
+    { key: 'success', label: 'Success', format: 'boolean' },
+    { key: 'message', label: 'Message' },
+  ],
+};


### PR DESCRIPTION
## Description

Pieces Team take-home submission. Three pieces, metadata only — no `run()` body, prop name, or prop type is changed, and nothing outside the three pieces is touched. **24 files, 461 insertions, 0 deletions.**

**Zoom — `outputSchema` for the meeting actions.** Find, Create and Update Meeting returned a rich meeting object with no schema, so the data selector and any MCP consumer saw untyped JSON. Find and Create return the same meeting resource, so one shared field set backs both; Update builds its own acknowledgement object and gets a schema describing that instead. Curated rather than exhaustive: the three encoded password variants are dropped as restatements of the canonical passcode, and `settings` is described with explicit children so the renderer does not drill all 21 of its keys generically.

**Jira Cloud — classification pass and one agent atomic.** No action in the piece carried a `classification`, so all sixteen are now classified from the API each `run()` actually calls. Adds `list_issue_transitions`, an `audience: 'ai'` atomic that fills a real gap: Transition Issue takes `transitionId` from `issueStatusIdProp`, a `Property.Dropdown` whose options resolver is the only code path in the piece that calls the transitions endpoint. Dropdown resolvers run in the flow builder, so an agent driving the piece over MCP cannot obtain a transition id — and unlike a project or account id it cannot be looked up elsewhere either, because transition ids are per-issue *and* per-workflow-state. All three of Transition Issue's props are dropdowns, so the action is effectively uncallable by an agent today.

**YouTube — step-settings UI on Search.** 30 props rendered as one flat wall of fields. Seven are now essential inside three `section` groups; the other 23 are `advanced`. The two are mutually exclusive by design: `advanced: true` is ignored on `section` members, so the groups hold exactly the essential form and everything advanced stays ungrouped. Adds `placeholder` to the ten text inputs where an example helps, `width: 'half'` only inside sections (the only place it takes effect), and descriptions to the fourteen props that shipped without one.

**Two things deliberately not done**, per the assessment brief: no `package.json` version bumps, and no change to `minimumSupportedRelease`. Flagging the second for maintainers rather than silently fixing it — `jira-cloud` currently declares `0.30.0`, and this PR adds the piece's first `audience: 'ai'` action. On engines predating the canvas filter, `ai` actions surface in the human step picker, so the floor is worth a look before release. Raising it is a release decision, not mine to make here.

## How was this tested?

Each part had one claim its structure could not prove, so all three were verified against the live vendor APIs:

- **Zoom** — created a real meeting through Create Meeting and read it back through Find Meeting, then diffed the payloads to confirm they return the same resource. The create body adds three `authentication_*` settings, the find body adds `assistant_id`; all four are fields this curation already drops, so no described path is absent from either response. Test meeting deleted afterwards.
- **Jira** — ran the atomic against a live Jira Cloud site. Also verified `includeUnavailableTransitions` genuinely changes behaviour by adding a *"Restrict who can move a work item"* workflow rule: the default returns 3 transitions, the flag returns 4 with `isAvailable: false`. All five endpoints considered during the audit were swept for a 2xx and the fields they were expected to carry.
- **YouTube** — ran real `search.list` calls. `query` alone returns results, all seven essentials together return results, and an advanced prop refines rather than enables — so the essential form is sufficient and nothing in Advanced is secretly required. `videoDuration` with `type=channel` returns HTTP 400 from YouTube itself, which is why Type is essential rather than tucked away.

Static checks beyond the above: every `outputSchema` path resolved against its captured payload at the correct scope (top-level against the root, `children` against the parent object, `listItems` against one array item), and the YouTube metadata checked for the failures that are silent at runtime — a prop both grouped and `advanced`, `width: 'half'` outside a section, or an `icon` outside the allow-list.

Editions: no edition-specific paths touched. Not run: the monorepo build — per the brief, CI typechecks the PR.

## How I worked

**Approach.** Read each part's guide before touching its code; small commits; treated the tests as the floor, not the target. Each part had one claim its own tests could not reach, so I closed all three live, as above.

**Tools.** Claude Code for exploration, drafting and review; throwaway verification scripts kept outside the repo; shipped Activepieces source as precedent wherever a rule was ambiguous. I can explain every line.

**Part 2 — coverage map.** One rule, not a wishlist: for each action list the opaque IDs it needs, then ask what produces them. Five have no producer anywhere — `projectId`, `issueTypeId`, `assigneeId`, `transitionId`, `commentId` — so five candidate atomics; `get_issue` needs a key `search_issues` already returns, so no hole. I built `list_issue_transitions` because its ID cannot be looked up anywhere, per the description above. The piece already ships `find-user` and `list-issue-comments`, two of the other four, which is good corroboration that the method finds holes maintainers also chose to fill.

**Part 3 — essential props.** The seven that answer what the action exists to answer: `query`, `type`, `order`, `maxResults`, `safeSearch`, `publishedAfter`/`publishedBefore`. Everything else refines a search that already works. `channelId` is Advanced despite being useful, since it needs an opaque ID the form cannot supply.

**One call I reversed after reading the real code.** The exercise describes `markdownToJiraFormat` as converting to Jira wiki markup, which would make it a generic transform an agent does natively and a candidate to demote to `audience: 'human'`. The shipped action instead emits ADF JSON via `@atlaskit` transformers, and an LLM hand-writing a structured schema is exactly the case where a deterministic converter earns its place — so it stays `both`.

N/A — assessment submission, no linked issue.

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

Purely additive: 0 deletions, no renames, no `run()` change, no default moved, no env var or setup step. The one required prop added belongs to a brand-new action, not an existing one.

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)

Credential-bearing fields were reviewed while curating the Zoom schema, and the net effect is a reduction in what the data selector surfaces: `h323_password`, `pstn_password` and `encrypted_password` are dropped, and `start_url` — which embeds a ZAK host token — is kept, since the action already returns it, but its description now warns that it grants host rights and must not be sent to participants. No `run()` behaviour changed, so no field is newly exposed.
