### PR TITLE
feat(worker): log flow run terminal failures at error level

### DIFF
--- a/packages/server/worker/src/lib/execute/jobs/execute-flow.ts
+++ b/packages/server/worker/src/lib/execute/jobs/execute-flow.ts
@@ -181,17 +181,19 @@ async function reportFlowStatus({ ctx, data, status, internalError, failedStep }
     // MEMORY_LIMIT_EXCEEDED / LOG_SIZE_EXCEEDED). Emit one structured error log so failed runs are
     // observable in log-based monitoring: the per-job wide event otherwise records FIRE_AND_FORGET
     // business failures as outcome:'success' (worker.ts), leaving them invisible at anything but debug.
-    // Carry the status under `flowRunStatus`, not `outcome` — worker.ts overwrites `outcome` back to
-    // 'success' after this handler returns.
+    // The status/environment/step sit under the canonical flowRun.*/step.* paths (not `outcome`, which
+    // worker.ts overwrites back to 'success' after this handler returns).
     ctx.log.error({
-        flowRun: { id: data.runId },
+        flowRun: {
+            id: data.runId,
+            status,
+            environment: data.environment,
+        },
         flow: { id: data.flowId },
         flowVersion: { id: data.flowVersionId },
         project: { id: data.projectId },
         platform: { id: data.platformId },
-        environment: data.environment,
-        flowRunStatus: status,
-        failedStep: failedStep?.name,
+        step: { name: failedStep?.name },
         errorMessage: internalError?.message,
     }, 'Flow run terminal failure')
 

--- a/packages/server/worker/src/lib/execute/jobs/execute-flow.ts
+++ b/packages/server/worker/src/lib/execute/jobs/execute-flow.ts
@@ -177,6 +177,24 @@ async function reportFlowStatus({ ctx, data, status, internalError, failedStep }
         failedStep,
     })
 
+    // Every call to reportFlowStatus reports a terminal FAILURE (FAILED / INTERNAL_ERROR / TIMEOUT /
+    // MEMORY_LIMIT_EXCEEDED / LOG_SIZE_EXCEEDED). Emit one structured error log so failed runs are
+    // observable in log-based monitoring: the per-job wide event otherwise records FIRE_AND_FORGET
+    // business failures as outcome:'success' (worker.ts), leaving them invisible at anything but debug.
+    // Carry the status under `flowRunStatus`, not `outcome` — worker.ts overwrites `outcome` back to
+    // 'success' after this handler returns.
+    ctx.log.error({
+        flowRun: { id: data.runId },
+        flow: { id: data.flowId },
+        flowVersion: { id: data.flowVersionId },
+        project: { id: data.projectId },
+        platform: { id: data.platformId },
+        environment: data.environment,
+        flowRunStatus: status,
+        failedStep: failedStep?.name,
+        errorMessage: internalError?.message,
+    }, 'Flow run terminal failure')
+
     if (status === FlowRunStatus.INTERNAL_ERROR && isDedicatedWorker()) {
         onCallService(ctx.log, workerSettings.getSettings().PAGE_ONCALL_WEBHOOK).page({
             code: ErrorCode.ENGINE_OPERATION_FAILURE,


### PR DESCRIPTION
## Why

Business flow-run failures are effectively **invisible in the logs** today. A run that ends `FAILED` / `TIMEOUT` / `MEMORY_LIMIT_EXCEEDED` / `LOG_SIZE_EXCEEDED` returns normally from the worker job handler (`FIRE_AND_FORGET`), so the per-job wide event in `worker.ts` records it as `outcome:'success'` and the terminal `FlowRunStatus` is never written to any log field. Only `INTERNAL_ERROR` (which throws) surfaces, via `outcome:'failed'`.

That means log-based monitoring / alerting can't see ordinary flow failures at all. We want to build failure alerting off the logs (e.g. shipped to Datadog), so failed runs need to be observable.

## What

Emit **one structured error-level log** in `reportFlowStatus` — the single choke point every terminal-failure path funnels through (`FAILED`, `INTERNAL_ERROR`, `TIMEOUT`, `MEMORY_LIMIT_EXCEEDED`, `LOG_SIZE_EXCEEDED`).

```ts
ctx.log.error({
    flowRun: { id: data.runId },
    flow: { id: data.flowId },
    flowVersion: { id: data.flowVersionId },
    project: { id: data.projectId },
    platform: { id: data.platformId },
    environment: data.environment,
    flowRunStatus: status,
    failedStep: failedStep?.name,
    errorMessage: internalError?.message,
}, 'Flow run terminal failure')
```

## Design notes

- **Status carried as `flowRunStatus`, not `outcome`.** `worker.ts` unconditionally sets `outcome:'success'` *after* the handler returns, so anything named `outcome` here would be clobbered. More importantly, `outcome` is the **job-handler health** axis (it drives job retry + on-call paging); a user's flow failing is not a worker failure, so it must stay `outcome:'success'`. `flowRunStatus` is the distinct **flow-result** axis.
- **Error level is intentional** — it raises the per-job wide event to `error`, which is never sampled out, so the failure log is always retained.
- No change to retry / on-call / `outcome` semantics; purely additive observability. All fields come from `ExecuteFlowJobData` with no extra DB lookup.
