### PR TITLE
fix(auth): sign-in now says why it failed instead of a generic error

### DIFF
--- a/packages/core/utils/src/lib/activepieces-error.ts
+++ b/packages/core/utils/src/lib/activepieces-error.ts
@@ -51,6 +51,7 @@ export type ApErrorParams =
     | ValidationErrorParams
     | InvitationOnlySignUpParams
     | UserIsInActiveErrorParams
+    | UserNotFoundOnPlatformErrorParams
     | DomainIsNotAllowedErrorParams
     | EmailAuthIsDisabledParams
     | ExistingAlertChannelErrorParams
@@ -209,6 +210,13 @@ ErrorCode.EMAIL_IS_NOT_VERIFIED,
 
 export type UserIsInActiveErrorParams = BaseErrorParams<
 ErrorCode.USER_IS_INACTIVE,
+{
+    email: string
+}
+>
+
+export type UserNotFoundOnPlatformErrorParams = BaseErrorParams<
+ErrorCode.USER_NOT_FOUND_ON_PLATFORM,
 {
     email: string
 }
@@ -551,6 +559,7 @@ export enum ErrorCode {
     TRIGGER_UPDATE_STATUS = 'TRIGGER_UPDATE_STATUS',
     TRIGGER_FAILED = 'TRIGGER_FAILED',
     USER_IS_INACTIVE = 'USER_IS_INACTIVE',
+    USER_NOT_FOUND_ON_PLATFORM = 'USER_NOT_FOUND_ON_PLATFORM',
     VALIDATION = 'VALIDATION',
     INVALID_LICENSE_KEY = 'INVALID_LICENSE_KEY',
     EMAIL_ALREADY_HAS_ACTIVATION_KEY = 'EMAIL_ALREADY_HAS_ACTIVATION_KEY',

--- a/packages/server/api/src/app/authentication/authentication.service.ts
+++ b/packages/server/api/src/app/authentication/authentication.service.ts
@@ -112,7 +112,14 @@ export const authenticationService = (log: FastifyBaseLogger) => ({
             identityId: identity.id,
             platformId,
         })
-        assertNotNullOrUndefined(user, 'User not found')
+        if (isNil(user)) {
+            throw new ActivepiecesError({
+                code: ErrorCode.USER_NOT_FOUND_ON_PLATFORM,
+                params: {
+                    email: identity.email,
+                },
+            })
+        }
         log.info({ email: params.email, platform: { id: platformId } }, 'User signed in with password')
         return authenticationUtils(log).getProjectAndToken({
             userId: user.id,

--- a/packages/server/api/src/app/helper/error-handler.ts
+++ b/packages/server/api/src/app/helper/error-handler.ts
@@ -95,6 +95,7 @@ const statusCodeMap: Partial<Record<ErrorCode, StatusCodes>> = {
     [ErrorCode.SESSION_EXPIRED]: StatusCodes.FORBIDDEN,
     [ErrorCode.EMAIL_IS_NOT_VERIFIED]: StatusCodes.FORBIDDEN,
     [ErrorCode.USER_IS_INACTIVE]: StatusCodes.FORBIDDEN,
+    [ErrorCode.USER_NOT_FOUND_ON_PLATFORM]: StatusCodes.FORBIDDEN,
     [ErrorCode.DOMAIN_NOT_ALLOWED]: StatusCodes.FORBIDDEN,
     [ErrorCode.EMAIL_AUTH_DISABLED]: StatusCodes.FORBIDDEN,
     [ErrorCode.INVALID_SMTP_CREDENTIALS]: StatusCodes.BAD_REQUEST,

--- a/packages/server/api/test/integration/ce/authentication/authentication.test.ts
+++ b/packages/server/api/test/integration/ce/authentication/authentication.test.ts
@@ -174,6 +174,38 @@ describe('Authentication API', () => {
             expect(await databaseConnection().getRepository('platform').count()).toBe(0)
         })
 
+        it('Tells an identity with no user on the resolved platform why it cannot sign in', async () => {
+            // arrange
+            await app?.inject({
+                method: 'POST',
+                url: '/api/v1/authentication/sign-up',
+                body: createMockSignUpRequest({ email: 'ahmad.tash@activepieces.com' }),
+            })
+
+            const password = 'password-that-verifies'
+            await userIdentityService(app!.log).create({
+                email: 'orphan.identity@activepieces.com',
+                password,
+                firstName: 'Orphan',
+                lastName: 'Identity',
+                trackEvents: false,
+                newsLetter: false,
+                provider: UserIdentityProvider.EMAIL,
+                verified: true,
+            })
+
+            // act
+            const response = await app?.inject({
+                method: 'POST',
+                url: '/api/v1/authentication/sign-in',
+                body: createMockSignInRequest({ email: 'orphan.identity@activepieces.com', password }),
+            })
+
+            // assert
+            expect(response?.statusCode).toBe(StatusCodes.FORBIDDEN)
+            expect(response?.json()?.code).toBe('USER_NOT_FOUND_ON_PLATFORM')
+        })
+
         it('Fails if password doesn\'t match', async () => {
             // arrange
             const mockSignUpRequest = createMockSignUpRequest()

--- a/packages/web/public/locales/en/translation.json
+++ b/packages/web/public/locales/en/translation.json
@@ -1843,6 +1843,7 @@
   "User has been deactivated": "User has been deactivated",
   "Email domain is disallowed": "Email domain is disallowed",
   "Email authentication has been disabled": "Email authentication has been disabled",
+  "Your account is not set up on this platform, please contact your administrator": "Your account is not set up on this platform, please contact your administrator",
   "Forgot your password?": "Forgot your password?",
   "Sign up is restricted. You need an invitation to join. Please contact the administrator.": "Sign up is restricted. You need an invitation to join. Please contact the administrator.",
   "Email is already used": "Email is already used",

--- a/packages/web/src/features/authentication/components/sign-in-form.tsx
+++ b/packages/web/src/features/authentication/components/sign-in-form.tsx
@@ -114,6 +114,14 @@ const SignInForm = ({ onForgotPassword }: SignInFormProps) => {
             });
             break;
           }
+          case ErrorCode.USER_NOT_FOUND_ON_PLATFORM: {
+            form.setError('root.serverError', {
+              message: t(
+                'Your account is not set up on this platform, please contact your administrator',
+              ),
+            });
+            break;
+          }
           default: {
             form.setError('root.serverError', {
               message: t('Something went wrong, please try again later'),


### PR DESCRIPTION
Fixes [GIT-1830](https://linear.app/activepieces/issue/GIT-1830)
Closes #15158

## Problem

An identity whose `user` row is missing on the platform sign-in resolves for it (a self-hosted admin deleting a member, GIT-1094; or the same shape behind Pylon 4599, 3296, 3076):

1. `signInWithPassword` hit `assertNotNullOrUndefined(user, 'User not found')`, a plain `Error` that `errorHandler` cannot map, so the reply was `500 {"statusCode":500,"error":"Internal Server Error","message":"User not found is null or undefined"}` with **no `code`**.
2. `sign-in-form.tsx` therefore took its `isNil(errorCode)` branch and printed "Something went wrong, please try again later" — indistinguishable from a network block or an outage, with no way forward for the customer.
3. Password reset succeeds and signup correctly reports the email as already in use, so the three flows disagree about whether the account works.

## Fix

- `packages/core/utils/src/lib/activepieces-error.ts` — new `ErrorCode.USER_NOT_FOUND_ON_PLATFORM` + params type.
- `packages/server/api/src/app/helper/error-handler.ts` — mapped to `403`, alongside `USER_IS_INACTIVE`.
- `packages/server/api/src/app/authentication/authentication.service.ts` — throws it in place of the bare assert. Same shape `getUserForPlatform` already uses two functions down.
- `packages/web/src/features/authentication/components/sign-in-form.tsx` + `en/translation.json` — one case in the existing switch, so the message is specific instead of generic.

Scope is ticket fix #1 only. Fix #2 (mirror `federatedAuthn`'s `getOrCreateWithProject` in the password path) and fix #3 (`provisionOrOnboard` minting a fresh platform) are deliberately not in this PR.

## Verification

- Regression test `packages/server/api/test/integration/ce/authentication/authentication.test.ts`. **Red-first proven**: against the pre-fix code it fails with `AssertionError: expected 500 to be 403`; it passes with the fix.
- `npm run lint-dev` — 0 errors (71 pre-existing warnings, none in touched files).
- CE `test/integration/ce/authentication` — 61/61 pass. Cloud `test/integration/cloud/authn` — 20/20 pass.
- Driven end to end on a local CE instance (api + web + worker + engine, Postgres): orphan identity → `403 {"code":"USER_NOT_FOUND_ON_PLATFORM"}`; healthy account → `200` + token; wrong password → `401 INVALID_CREDENTIALS` (unchanged).
- `Visual:` sign-in form, error state — before (generic) / after (specific) / wrong-password (unchanged). Light theme; the change reuses the existing `FormMessage` destructive token and is not theme-sensitive.
- `Other affected paths:` checked — all 10 `getOneByIdentityAndPlatform` call sites. `getUserForPlatform` (same file, `switchPlatform`) already throws a coded `AUTHORIZATION` error; the other 8 handle null explicitly. Line 115 was the only bare-assert site, and it is fixed.
- `Repro:` second `user_identity` sharing a known password hash with no `user` row on the platform; pre-fix 500 with no code, post-fix 403 with one — full steps in the Reproduction block.
- `Product decision embedded:` surface the broken state with a coded 403 rather than auto-repairing the missing user row; alternative considered: mirror `federatedAuthn`'s `getOrCreateWithProject` (ticket fix #2, out of scope here).

<details>
<summary>Plan &amp; reasoning</summary>

## Plan

- Smallest change that makes the response specific: one new `ErrorCode`, one status-map entry, one throw, one frontend case, one `en` key.
- Rejected: reuse `ErrorCode.AUTHORIZATION` (2 lines, no new enum). The frontend switch has no case for it, so the customer would keep seeing the exact generic string this ticket is about, and it would conflate a genuine authz denial in `switchPlatform` with a broken account.
- Rejected: `ErrorCode.ENTITY_NOT_FOUND` — maps to 404 and also falls through to the frontend `default:` branch.
- 403 not 401: the credentials are correct (`verifyIdentityPassword` runs first), so prompting for a retry would be wrong. Matches `USER_IS_INACTIVE`.
- Footprint estimated at 5 files / ~30 lines of product code; actual is 5 files / 27 lines product + 32 lines test.
- No `@activepieces/shared` change, so no version bump. `packages/core/utils` is not covered by that rule and its last two `activepieces-error.ts` commits did not bump it.

## Non-happy scenarios considered

- **Account enumeration.** The new code is only reachable *after* `verifyIdentityPassword` succeeds, so an attacker must already hold valid credentials to distinguish it from `INVALID_CREDENTIALS`. No oracle is created — and the pre-fix 500 was already distinguishable from the 401.
- **Params leak.** `params` carries only the normalized email the caller just submitted. Platform id is deliberately not included.
- **Exhaustive `ErrorCode` consumers.** Only one map exists (`statusCodeMap`) and it is `Partial<Record<...>>`, so the new member breaks nothing.
- **Other locales.** Only `en` gets the key; the other 10 fall back to the key text, same as every other untranslated string in this file.
- **Wide events.** The failure now records as a 403 without a stack instead of a 500 with one — correct, it is no longer an unexpected error.
- **Pieces.** `@activepieces/core-utils` is consumed by pieces; adding an enum member is additive.

## Alternatives rejected

- Repair the row on sign-in (`getOrCreateWithProject`) — that is ticket fix #2, a separate product call about silently provisioning access, out of scope here.
- Change `provisionOrOnboard` — ticket fix #3, out of scope.

</details>

<details>
<summary>Reproduction</summary>

## Environment

Local CE instance from this branch: `AP_EDITION=ce`, `AP_DB_TYPE=POSTGRES` against `postgres:14.4` (throwaway database `ap_git1830`), `AP_QUEUE_MODE=MEMORY`, api on `:3000`, vite web on `:4210`, worker and engine running. No cloud, no shared data.

## Harness

`repro.sh` — needs a running api and psql access to its database:

```bash
#!/usr/bin/env bash
set -euo pipefail
API=${API:-http://127.0.0.1:3000}
PSQL=${PSQL:-"docker exec activepieces-db-1 psql -U postgres -d ap_git1830"}
PASSWORD='Password123!'

# 1. First account: creates the platform, the user row and the personal project.
curl -sf -X POST "$API/api/v1/authentication/sign-up" -H 'Content-Type: application/json' \
  -d "{\"email\":\"admin@ap.com\",\"password\":\"$PASSWORD\",\"firstName\":\"Admin\",\"lastName\":\"User\",\"trackEvents\":false,\"newsLetter\":false}" >/dev/null

# 2. Second identity sharing that password hash, with NO user row on the platform.
$PSQL -c "INSERT INTO user_identity (id, created, updated, email, password, \"trackEvents\", \"newsLetter\", verified, \"firstName\", \"lastName\", \"tokenVersion\", provider)
          SELECT 'orphan1830aaaaaaaaaaa', now(), now(), 'orphan@ap.com', password, \"trackEvents\", \"newsLetter\", true, 'Orphan', 'Identity', \"tokenVersion\", provider
          FROM user_identity WHERE email = 'admin@ap.com';"

# 3. Sign in.
curl -s -w '\nstatus=%{http_code}\n' -X POST "$API/api/v1/authentication/sign-in" \
  -H 'Content-Type: application/json' -d "{\"email\":\"orphan@ap.com\",\"password\":\"$PASSWORD\"}"
curl -s -o /dev/null -w 'healthy=%{http_code}\n' -X POST "$API/api/v1/authentication/sign-in" \
  -H 'Content-Type: application/json' -d "{\"email\":\"admin@ap.com\",\"password\":\"$PASSWORD\"}"
curl -s -w '\nwrongpw=%{http_code}\n' -X POST "$API/api/v1/authentication/sign-in" \
  -H 'Content-Type: application/json' -d '{"email":"admin@ap.com","password":"WrongPassword1!"}'
```

## Trigger

Step 2 is what matters: an identity that exists and verifies its password, with zero `user` rows on the platform `platformUtils.getPlatformIdForRequest` resolves (on self-hosted that is `getOldestPlatform()`, so it is always non-nil once one platform exists). This is the same end state a self-hosted admin reaches by deleting a member whose identity survives (GIT-1094) — copying the row reproduces it without depending on the delete path's cascade behaviour.

## Results

| input | pre-fix | post-fix |
|---|---|---|
| orphan identity, correct password | `500`, body has **no `code`** | `403 USER_NOT_FOUND_ON_PLATFORM` |
| healthy account, correct password | `200` + token | `200` + token |
| healthy account, wrong password | `401 INVALID_CREDENTIALS` | `401 INVALID_CREDENTIALS` |

The pre-fix column was produced on this same instance by reverting only the three server files and letting `tsx watch` reload, so both columns come from one running stack.

</details>

## How was this tested?

Automated: new CE integration test (red-first proven), plus the full CE authentication suite (61) and the Cloud authn suite (20). Manual: local CE instance driven through the real sign-in form for all three cases above. EE not exercised — the touched code path is CE and shared by every edition.

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

Additive enum member; a path that answered 500 now answers 403 with a code. No self-hoster or API consumer action required.

### Security impact?  (required — CI fails if this is left unedited)

- [ ] no — reviewed, no security impact
- [x] yes — security-sensitive (call out the risk and mitigation in the description above)

Touches the password sign-in path. Risk considered: turning an anonymous 500 into a named 403 could in principle help enumerate accounts. It does not — the branch sits *after* `verifyIdentityPassword`, so it is unreachable without valid credentials, and the pre-fix 500 was already distinguishable from the 401. The error params carry only the caller's own normalized email, never the platform id.
