### PR TITLE
fix: dedupe flow bundle publish to stop file PK race and S3 503 storms

### DIFF
--- a/packages/server/api/src/app/file/file.service.ts
+++ b/packages/server/api/src/app/file/file.service.ts
@@ -69,6 +69,9 @@ export const fileService = (log: FastifyBaseLogger) => ({
                     return await fileRepo().save({ ...baseFile, location: FileLocation.S3, s3Key })
                 }
                 catch (error) {
+                    if (isNil(params.data)) {
+                        throw error
+                    }
                     exceptionHandler.handle(error, log)
                     return saveFileToDb(baseFile, params.data)
                 }

--- a/packages/server/api/src/app/workers/rpc/worker-rpc-service.ts
+++ b/packages/server/api/src/app/workers/rpc/worker-rpc-service.ts
@@ -3,7 +3,7 @@ import { apVersionUtil, onCallService, UNKNOWN_VERSION } from '@activepieces/ser
 import { ExecutionType, FileCompression, FileLocation, FileType, FlowOperationType, FlowStatus, WebsocketClientEvent, WorkerGroupScope, WorkerToApiContract } from '@activepieces/shared'
 import { FastifyBaseLogger } from 'fastify'
 import { websocketService } from '../../core/websockets.service'
-import { redisConnections } from '../../database/redis-connections'
+import { distributedStore, redisConnections } from '../../database/redis-connections'
 import { agentRpcHandlers } from '../../ee/agent/agent-rpc-handlers'
 import { chatPersonalizationService } from '../../ee/agent/personalization/chat-personalization-service'
 import { fileService, getLocationForFile } from '../../file/file.service'
@@ -28,6 +28,10 @@ import { triggerSourceService } from '../../trigger/trigger-source/trigger-sourc
 import { getPlatformGroupQueueName, getProjectGroupQueueName, QueueName, WorkerGroupAssignment } from '../job'
 import { jobBroker } from '../job-queue/job-broker'
 import { machineService } from '../machine/machine-service'
+
+const FLOW_BUNDLE_PUBLISH_CLAIM_TTL_SECONDS = 60
+
+const getFlowBundlePublishClaimKey = (flowVersionId: string): string => `flow_bundle_publish_claim:${flowVersionId}`
 
 const getPollQueueName = (assignment: WorkerGroupAssignment | null): string => {
     if (isNil(assignment)) {
@@ -235,6 +239,16 @@ export function createHandlers(log: FastifyBaseLogger, assignment: WorkerGroupAs
             // bundle would just bloat the database (and a null-data pre-save would throw),
             // so tell the worker to skip publishing and always build inline.
             if (getLocationForFile(FileType.FLOW_BUNDLE) !== FileLocation.S3) {
+                return { kind: 'skip' }
+            }
+            // The bundle for a flowVersionId is immutable, and a burst of workers can
+            // finish provisioning the same version at once. Only the first claimer
+            // publishes; losing the claim is a normal outcome, not an error. Without
+            // this, concurrent callers race the deterministic file PK (duplicate key
+            // on the file table) and hammer the same S3 key (503 Slow Down). The
+            // claim expires so a publish that died mid-upload gets retried.
+            const claimed = await distributedStore.putIfAbsent(getFlowBundlePublishClaimKey(input.flowVersionId), 1, FLOW_BUNDLE_PUBLISH_CLAIM_TTL_SECONDS)
+            if (!claimed) {
                 return { kind: 'skip' }
             }
             // S3 without signed URLs: the worker streams the bytes back via uploadFlowBundle.


### PR DESCRIPTION
## Description

When a burst of workers finishes provisioning the same `flowVersionId` at once, they each call the `prepareFlowBundleUpload` RPC, which writes the `file` row with a deterministic primary key equal to the flow version id. TypeORM's `save()` does a SELECT-then-INSERT, so all concurrent callers see "row missing" and INSERT — one wins, the rest fail with `duplicate key value violates unique constraint "PK_36b46d232307066b3a2c9ea3a1d"`, logged at `error` level as `Unhandled exception` (plus a Sentry event). The same burst also has every worker PUT the same S3 key, which large deployments see as `503 Slow Down` storms (~400/hour reported). At scale this single race accounted for 15–25% of a self-hoster's API error volume.

The bundle for a flow version is immutable, so losing the publish race is a normal outcome, not an error.

### How it works

- `prepareFlowBundleUpload` now claims a short-lived Redis key (`flow_bundle_publish_claim:<flowVersionId>`, via the existing `distributedStore.putIfAbsent`, 60s TTL) before touching the DB or S3. Only the first claimer publishes; everyone else gets `{ kind: 'skip' }`, which the worker already handles as "don't publish". This removes both the duplicate-key race and the concurrent PUTs against the same S3 key. The TTL lets a publish that died mid-upload be retried by a later worker.
- The S3-error `catch` in `fileService.save` no longer falls back to `saveFileToDb` when `data` is null — that fallback is guaranteed to throw `data is required` (the FLOW_BUNDLE pre-save intentionally has no data), which buried the real error under a misleading `Unhandled exception`. The original error now propagates and surfaces as the worker's existing best-effort `warn`.

## How was this tested?

- `npm run lint-dev` — 0 errors.
- Code-path review: the claim gates both the signed-PUT (`kind: 'url'`) and stream-back (`kind: 'inline'`) transports; the DB-storage `skip` branch is unchanged; the worker treats `skip` as a no-op and already logs publish failures as best-effort warnings, so a skipped publish never affects a run.
- Edition-agnostic backend change (CE path, no EE code touched); only reachable on S3-backed bundle storage.

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)