### PR TITLE
chore(release): v0.89.0

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   app:
-    image: ghcr.io/activepieces/activepieces:0.88.3
+    image: ghcr.io/activepieces/activepieces:0.89.0
     container_name: activepieces-app
     restart: unless-stopped
     ports:
@@ -16,7 +16,7 @@ services:
     networks:
       - activepieces
   worker:
-    image: ghcr.io/activepieces/activepieces:0.88.3
+    image: ghcr.io/activepieces/activepieces:0.89.0
     restart: unless-stopped
     depends_on:
       - app

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activepieces",
-  "version": "0.88.3",
+  "version": "0.89.0",
   "packageManager": "bun@1.4.0",
   "trustedDependencies": [
     "sqlite3",


### PR DESCRIPTION
## Description

Bumps the platform version to `0.89.0` for the weekly release and pins the `docker-compose.yml` app and worker images to the same tag. Only the two version-carrying files are touched, matching previous cuts (#14766, #14930).

Notes for the release owner:

- `main` still said `0.88.3` even though `0.88.4` and `0.88.4-hotfix.1` tags exist — those cuts were never synced back to main. `0.89.0` supersedes both.
- No migration added since `0.88.4` is tagged `release = '0.89.0'` — the 13 new migrations carry tags from `0.86.4` to `0.88.4`. Three of them (`DropChatbot`, `AddAiProviderScopes`, `WidenMcpOAuthState`) are `breaking = true`, which is the migration rollback-safety flag, not a customer-facing breaking change.

## How was this tested?

- `node --print "require('./package.json').version"` → `0.89.0`.
- Grepped the repo — no remaining `0.88.3` image pins; only `package.json` and the two `docker-compose.yml` images carry the version.

Fixes # (no GitHub issue)

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)