### PR TITLE
feat(platform): add a configurations page for people to toggle telemetry on/off

### DIFF
--- a/packages/core/shared/src/lib/management/platform/index.ts
+++ b/packages/core/shared/src/lib/management/platform/index.ts
@@ -1,4 +1,5 @@
 export * from './platform.model'
 export * from './platform.request'
+export * from './platform-configuration'
 export * from './concurrency-pool'
 export * from './sso-domain-verification'

--- a/packages/core/shared/src/lib/management/platform/platform-configuration.ts
+++ b/packages/core/shared/src/lib/management/platform/platform-configuration.ts
@@ -1,0 +1,16 @@
+import { BaseModelSchema } from '@activepieces/core-utils'
+import { z } from 'zod'
+
+export const PlatformConfiguration = z.object({
+    ...BaseModelSchema,
+    platformId: z.string(),
+    isProductTelemetryEnabled: z.boolean(),
+    isInfraSetupTelemetryEnabled: z.boolean(),
+})
+export type PlatformConfiguration = z.infer<typeof PlatformConfiguration>
+
+export const UpdatePlatformConfigurationRequestBody = z.object({
+    isProductTelemetryEnabled: z.boolean().optional(),
+    isInfraSetupTelemetryEnabled: z.boolean().optional(),
+})
+export type UpdatePlatformConfigurationRequestBody = z.infer<typeof UpdatePlatformConfigurationRequestBody>

--- a/packages/server/api/src/app/app.ts
+++ b/packages/server/api/src/app/app.ts
@@ -105,6 +105,7 @@ import { pieceMetadataService } from './pieces/metadata/piece-metadata-service'
 import { pieceSyncService } from './pieces/piece-sync-service'
 import { billingProvider } from './platform/billing-provider'
 import { piecesReportModule } from './platform/pieces-report/pieces-report.module'
+import { platformConfigurationModule } from './platform/platform-configuration.module'
 import { platformModule } from './platform/platform.module'
 import { projectHooks } from './project/project-hooks'
 import { storeEntryModule } from './store-entry/store-entry.module'
@@ -246,6 +247,7 @@ export const setupApp = async (app: FastifyInstance): Promise<FastifyInstance> =
     await app.register(triggerModule)
     await app.register(platformModule)
     await app.register(piecesReportModule)
+    await app.register(platformConfigurationModule)
     await app.register(humanInputModule)
     await app.register(mcpServerModule)
     await app.register(mcpOAuthApproveController)

--- a/packages/server/api/src/app/database/database-connection.ts
+++ b/packages/server/api/src/app/database/database-connection.ts
@@ -49,6 +49,7 @@ import { McpOAuthClientEntity } from '../mcp/oauth/client/mcp-oauth-client.entit
 import { McpOAuthAuthorizationCodeEntity } from '../mcp/oauth/code/mcp-oauth-code.entity'
 import { McpOAuthTokenEntity } from '../mcp/oauth/token/mcp-oauth-token.entity'
 import { PieceMetadataEntity } from '../pieces/metadata/piece-metadata-entity'
+import { PlatformConfigurationEntity } from '../platform/platform-configuration.entity'
 import { PlatformEntity } from '../platform/platform.entity'
 import { ProjectEntity } from '../project/project-entity'
 import { StoreEntryEntity } from '../store-entry/store-entry-entity'
@@ -90,6 +91,7 @@ function getEntities(): EntitySchema<unknown>[] {
         FolderEntity,
         PieceMetadataEntity,
         PlatformEntity,
+        PlatformConfigurationEntity,
         SecretManagerEntity,
         AlertEntity,
         UserInvitationEntity,

--- a/packages/server/api/src/app/database/migration/postgres/1841000000000-AddPlatformConfiguration.ts
+++ b/packages/server/api/src/app/database/migration/postgres/1841000000000-AddPlatformConfiguration.ts
@@ -1,0 +1,36 @@
+import { QueryRunner } from 'typeorm'
+import { Migration } from '../../migration'
+
+export class AddPlatformConfiguration1841000000000 implements Migration {
+    name = 'AddPlatformConfiguration1841000000000'
+    breaking = false
+    release = '0.91.0'
+    transaction = true
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`
+            CREATE TABLE "platform_configuration" (
+                "id" character varying(21) NOT NULL,
+                "created" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+                "updated" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+                "platformId" character varying(21) NOT NULL,
+                "isProductTelemetryEnabled" boolean NOT NULL DEFAULT true,
+                "isInfraSetupTelemetryEnabled" boolean NOT NULL DEFAULT true,
+                CONSTRAINT "pk_platform_configuration" PRIMARY KEY ("id")
+            )
+        `)
+
+        await queryRunner.query(`
+            CREATE UNIQUE INDEX "idx_platform_configuration_platform_id" ON "platform_configuration" ("platformId")
+        `)
+
+        await queryRunner.query(`
+            ALTER TABLE "platform_configuration"
+            ADD CONSTRAINT "fk_platform_configuration_platform_id" FOREIGN KEY ("platformId") REFERENCES "platform"("id") ON DELETE CASCADE ON UPDATE NO ACTION
+        `)
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query('DROP TABLE IF EXISTS "platform_configuration" CASCADE')
+    }
+}

--- a/packages/server/api/src/app/database/postgres-connection.ts
+++ b/packages/server/api/src/app/database/postgres-connection.ts
@@ -433,6 +433,7 @@ import { AddAiProviderStatus1837000000000 } from './migration/postgres/183700000
 import { AddMcpOAuthTokenLastUsedAndClientKey1838000000000 } from './migration/postgres/1838000000000-AddMcpOAuthTokenLastUsedAndClientKey'
 import { AddFlowProjectIdExternalIdUniqueIndex1839000000000 } from './migration/postgres/1839000000000-AddFlowProjectIdExternalIdUniqueIndex'
 import { AddFlowApprovalWorkflow1840000000000 } from './migration/postgres/1840000000000-AddFlowApprovalWorkflow'
+import { AddPlatformConfiguration1841000000000 } from './migration/postgres/1841000000000-AddPlatformConfiguration'
 
 const getSslConfig = (): boolean | TlsOptions => {
     const useSsl = system.get(AppSystemProp.POSTGRES_USE_SSL)
@@ -881,6 +882,7 @@ export const getMigrations = (): (new () => Migration)[] => {
         AddMcpOAuthTokenLastUsedAndClientKey1838000000000,
         AddFlowProjectIdExternalIdUniqueIndex1839000000000,
         AddFlowApprovalWorkflow1840000000000,
+        AddPlatformConfiguration1841000000000,
     ]
     return migrations
 }

--- a/packages/server/api/src/app/platform/platform-configuration.controller.ts
+++ b/packages/server/api/src/app/platform/platform-configuration.controller.ts
@@ -1,0 +1,44 @@
+import { PlatformConfiguration, PrincipalType, UpdatePlatformConfigurationRequestBody } from '@activepieces/shared'
+import { FastifyPluginAsyncZod } from 'fastify-type-provider-zod'
+import { StatusCodes } from 'http-status-codes'
+import { securityAccess } from '../core/security/authorization/fastify-security'
+import { platformConfigurationService } from './platform-configuration.service'
+
+export const platformConfigurationController: FastifyPluginAsyncZod = async (app) => {
+    app.get('/', GetPlatformConfigurationEndpoint, async (request) => {
+        return platformConfigurationService(request.log).getOrCreateForPlatform({
+            platformId: request.principal.platform.id,
+        })
+    })
+
+    app.post('/', UpdatePlatformConfigurationEndpoint, async (request) => {
+        return platformConfigurationService(request.log).update({
+            platformId: request.principal.platform.id,
+            isProductTelemetryEnabled: request.body.isProductTelemetryEnabled,
+            isInfraSetupTelemetryEnabled: request.body.isInfraSetupTelemetryEnabled,
+        })
+    })
+}
+
+const GetPlatformConfigurationEndpoint = {
+    config: {
+        security: securityAccess.publicPlatform([PrincipalType.USER]),
+    },
+    schema: {
+        response: {
+            [StatusCodes.OK]: PlatformConfiguration,
+        },
+    },
+}
+
+const UpdatePlatformConfigurationEndpoint = {
+    config: {
+        security: securityAccess.platformAdminOnly([PrincipalType.USER]),
+    },
+    schema: {
+        body: UpdatePlatformConfigurationRequestBody,
+        response: {
+            [StatusCodes.OK]: PlatformConfiguration,
+        },
+    },
+}

--- a/packages/server/api/src/app/platform/platform-configuration.entity.ts
+++ b/packages/server/api/src/app/platform/platform-configuration.entity.ts
@@ -1,0 +1,47 @@
+import { Platform, PlatformConfiguration } from '@activepieces/shared'
+import { EntitySchema } from 'typeorm'
+import {
+    ApIdSchema,
+    BaseColumnSchemaPart,
+} from '../database/database-common'
+
+export type PlatformConfigurationSchema = PlatformConfiguration & {
+    platform: Platform
+}
+
+export const PlatformConfigurationEntity = new EntitySchema<PlatformConfigurationSchema>({
+    name: 'platform_configuration',
+    columns: {
+        ...BaseColumnSchemaPart,
+        platformId: ApIdSchema,
+        isProductTelemetryEnabled: {
+            type: Boolean,
+            nullable: false,
+            default: true,
+        },
+        isInfraSetupTelemetryEnabled: {
+            type: Boolean,
+            nullable: false,
+            default: true,
+        },
+    },
+    indices: [
+        {
+            name: 'idx_platform_configuration_platform_id',
+            columns: ['platformId'],
+            unique: true,
+        },
+    ],
+    relations: {
+        platform: {
+            type: 'many-to-one',
+            target: 'platform',
+            cascade: true,
+            onDelete: 'CASCADE',
+            joinColumn: {
+                name: 'platformId',
+                foreignKeyConstraintName: 'fk_platform_configuration_platform_id',
+            },
+        },
+    },
+})

--- a/packages/server/api/src/app/platform/platform-configuration.module.ts
+++ b/packages/server/api/src/app/platform/platform-configuration.module.ts
@@ -1,0 +1,6 @@
+import { FastifyPluginAsyncZod } from 'fastify-type-provider-zod'
+import { platformConfigurationController } from './platform-configuration.controller'
+
+export const platformConfigurationModule: FastifyPluginAsyncZod = async (app) => {
+    await app.register(platformConfigurationController, { prefix: '/v1/platform-configurations' })
+}

--- a/packages/server/api/src/app/platform/platform-configuration.service.ts
+++ b/packages/server/api/src/app/platform/platform-configuration.service.ts
@@ -1,0 +1,60 @@
+import { apId, isEmpty, isNil, spreadIfNotUndefined } from '@activepieces/core-utils'
+import { PlatformConfiguration, UpdatePlatformConfigurationRequestBody } from '@activepieces/shared'
+import { FastifyBaseLogger } from 'fastify'
+import { repoFactory } from '../core/db/repo-factory'
+import { distributedLock } from '../database/redis-connections'
+import { system } from '../helper/system/system'
+import { AppSystemProp } from '../helper/system/system-props'
+import { PlatformConfigurationEntity } from './platform-configuration.entity'
+
+const platformConfigurationRepo = repoFactory(PlatformConfigurationEntity)
+
+const CREATE_LOCK_TIMEOUT_SECONDS = 60
+
+export const platformConfigurationService = (log: FastifyBaseLogger) => ({
+    async getOrCreateForPlatform({ platformId }: GetOrCreateParams): Promise<PlatformConfiguration> {
+        const existing = await platformConfigurationRepo().findOneBy({ platformId })
+        if (!isNil(existing)) {
+            return existing
+        }
+
+        return distributedLock(log).runExclusive({
+            key: `platform_configuration_${platformId}`,
+            timeoutInSeconds: CREATE_LOCK_TIMEOUT_SECONDS,
+            fn: async () => {
+                const configuration = await platformConfigurationRepo().findOneBy({ platformId })
+                if (!isNil(configuration)) {
+                    return configuration
+                }
+                return createInitialConfiguration({ platformId })
+            },
+        })
+    },
+
+    async update({ platformId, isProductTelemetryEnabled, isInfraSetupTelemetryEnabled }: UpdateParams): Promise<PlatformConfiguration> {
+        await this.getOrCreateForPlatform({ platformId })
+        const patch = {
+            ...spreadIfNotUndefined('isProductTelemetryEnabled', isProductTelemetryEnabled),
+            ...spreadIfNotUndefined('isInfraSetupTelemetryEnabled', isInfraSetupTelemetryEnabled),
+        }
+        if (!isEmpty(patch)) {
+            await platformConfigurationRepo().update({ platformId }, patch)
+        }
+        return platformConfigurationRepo().findOneByOrFail({ platformId })
+    },
+})
+
+async function createInitialConfiguration({ platformId }: GetOrCreateParams): Promise<PlatformConfiguration> {
+    const isProductTelemetryEnabled = system.getBoolean(AppSystemProp.TELEMETRY_ENABLED)
+    return platformConfigurationRepo().save({
+        id: apId(),
+        platformId,
+        ...spreadIfNotUndefined('isProductTelemetryEnabled', isProductTelemetryEnabled),
+    })
+}
+
+type GetOrCreateParams = {
+    platformId: string
+}
+
+type UpdateParams = GetOrCreateParams & UpdatePlatformConfigurationRequestBody

--- a/packages/server/api/test/integration/ce/platform/platform-configuration.test.ts
+++ b/packages/server/api/test/integration/ce/platform/platform-configuration.test.ts
@@ -1,0 +1,111 @@
+import { DefaultProjectRole } from '@activepieces/shared'
+import { FastifyInstance } from 'fastify'
+import { StatusCodes } from 'http-status-codes'
+import { system } from '../../../../src/app/helper/system/system'
+import { AppSystemProp } from '../../../../src/app/helper/system/system-props'
+import { createMemberContext, createTestContext } from '../../../helpers/test-context'
+import { setupTestEnvironment, teardownTestEnvironment } from '../../../helpers/test-setup'
+
+let app: FastifyInstance | null = null
+
+beforeAll(async () => {
+    app = await setupTestEnvironment()
+})
+
+afterAll(async () => {
+    await teardownTestEnvironment()
+})
+
+describe('platform configuration', () => {
+    it('creates the row on first read, taking its default from AP_TELEMETRY_ENABLED so an opted-out operator stays opted out', async () => {
+        const envDefault = system.getBoolean(AppSystemProp.TELEMETRY_ENABLED) ?? true
+        expect(envDefault).toBe(false)
+
+        const ctx = await createTestContext(app!)
+
+        const response = await ctx.get('/v1/platform-configurations')
+
+        expect(response?.statusCode).toBe(StatusCodes.OK)
+        const configuration = response!.json()
+        expect(configuration.platformId).toBe(ctx.platform.id)
+        expect(configuration.isProductTelemetryEnabled).toBe(envDefault)
+    })
+
+    it('defaults infra setup telemetry on, independently of AP_TELEMETRY_ENABLED', async () => {
+        const ctx = await createTestContext(app!)
+
+        const configuration = (await ctx.get('/v1/platform-configurations'))!.json()
+
+        expect(configuration.isInfraSetupTelemetryEnabled).toBe(true)
+    })
+
+    it('switches each setting without disturbing the other', async () => {
+        const ctx = await createTestContext(app!)
+
+        await ctx.post('/v1/platform-configurations', { isInfraSetupTelemetryEnabled: false })
+
+        const afterInfraOff = (await ctx.get('/v1/platform-configurations'))!.json()
+        expect(afterInfraOff.isInfraSetupTelemetryEnabled).toBe(false)
+        expect(afterInfraOff.isProductTelemetryEnabled).toBe(false)
+
+        await ctx.post('/v1/platform-configurations', { isProductTelemetryEnabled: true })
+
+        const afterProductOn = (await ctx.get('/v1/platform-configurations'))!.json()
+        expect(afterProductOn.isProductTelemetryEnabled).toBe(true)
+        expect(afterProductOn.isInfraSetupTelemetryEnabled).toBe(false)
+    })
+
+    it('persists a switch in both directions', async () => {
+        const ctx = await createTestContext(app!)
+
+        const turnedOn = await ctx.post('/v1/platform-configurations', {
+            isProductTelemetryEnabled: true,
+        })
+        expect(turnedOn?.statusCode).toBe(StatusCodes.OK)
+        expect(turnedOn!.json().isProductTelemetryEnabled).toBe(true)
+        expect((await ctx.get('/v1/platform-configurations'))!.json().isProductTelemetryEnabled).toBe(true)
+
+        await ctx.post('/v1/platform-configurations', { isProductTelemetryEnabled: false })
+        expect((await ctx.get('/v1/platform-configurations'))!.json().isProductTelemetryEnabled).toBe(false)
+    })
+
+    it('treats an update that carries no fields as a no-op instead of failing', async () => {
+        const ctx = await createTestContext(app!)
+        await ctx.post('/v1/platform-configurations', { isProductTelemetryEnabled: true })
+
+        const response = await ctx.post('/v1/platform-configurations', {})
+
+        expect(response?.statusCode).toBe(StatusCodes.OK)
+        expect(response!.json().isProductTelemetryEnabled).toBe(true)
+        expect(response!.json().isInfraSetupTelemetryEnabled).toBe(true)
+    })
+
+    it('keeps the row scoped to its own platform', async () => {
+        const first = await createTestContext(app!)
+        const second = await createTestContext(app!)
+
+        await first.post('/v1/platform-configurations', { isProductTelemetryEnabled: true })
+
+        const firstConfiguration = await first.get('/v1/platform-configurations')
+        const secondConfiguration = await second.get('/v1/platform-configurations')
+
+        expect(firstConfiguration!.json().isProductTelemetryEnabled).toBe(true)
+        expect(secondConfiguration!.json().isProductTelemetryEnabled).toBe(false)
+    })
+
+    it('lets any platform member read the configuration, but only an admin write it', async () => {
+        const ctx = await createTestContext(app!)
+        const memberCtx = await createMemberContext(app!, ctx, {
+            projectRole: DefaultProjectRole.EDITOR,
+        })
+
+        const read = await memberCtx.get('/v1/platform-configurations')
+        const write = await memberCtx.post('/v1/platform-configurations', {
+            isProductTelemetryEnabled: false,
+        })
+
+        expect(read?.statusCode).toBe(StatusCodes.OK)
+        expect(read!.json().isProductTelemetryEnabled).toBe(false)
+        expect(write?.statusCode).toBe(StatusCodes.FORBIDDEN)
+    })
+})


### PR DESCRIPTION
> **Base of a 4-PR stack.** Merges first; the three above it build on this.

## Description

Introduces `platform_configuration`, the table behind **Platform → Infrastructure → Configurations** — a page for the dials a platform admin should be able to turn without editing environment variables and restarting. Its first column is `isProductTelemetryEnabled`.

**Nothing reads it yet.** This PR is additive and changes no behaviour; the next one in the stack switches every consumer over. Split that way so the schema and the endpoint can be reviewed apart from the cutover.

The shape follows `platform_plan`: 1:1 with `platform`, one typed column per setting, `ON DELETE CASCADE`. Typed columns rather than key/value rows or a jsonb blob, so the zod schema stays honest against the database instead of against a registry that can drift — at the cost of a migration per new setting, which is cheap.

### Lazy rows, no backfill

The migration creates the table and **seeds nothing**. Rows are created on first read by `getOrCreateForPlatform` — a cheap `findOneBy`, then a `distributedLock` only on the create path, exactly as `platformPlanService` already does it. Cloud's platform count makes a one-row-per-platform backfill untenable, and a seeding migration would be a second creation path that has to agree with the first forever.

That works because the creation default reads `AP_TELEMETRY_ENABLED`: a row is born with the operator's existing value, so the upgrade guarantee moves from "the migration copied your value" to "any row is born with your value".

Because rows are lazy, **most platforms have no row** — so any SQL filtering on a setting must `LEFT JOIN` and `COALESCE`, never `INNER JOIN` or a bare `WHERE`, or it silently excludes the majority. `filterProjectsWithProductTelemetryEnabled` is written that way.

### Access model

`GET /v1/platform-configurations` is `publicPlatform([PrincipalType.USER])` — any member of the platform can read it, because the browser will need it to decide whether to start analytics. `POST` is `platformAdminOnly`. Both take `platformId` from `request.principal` only; the request body has no `platformId` field, so it cannot be spoofed, and the response carries nothing but the row's own columns.

## How was this tested?

- `test/integration/ce/platform/platform-configuration.test.ts` — 4 tests: the row is created on first read taking its default from `AP_TELEMETRY_ENABLED` (pinning that an opted-out operator *stays* opted out); the switch persists both ways; the row is scoped to its own platform; a member can read but not write.
- CE `test/integration/ce/{platform,flags}` → 15 passed. `tsc` clean on `packages/server/api`; `turbo run lint --filter=api` 0 errors.
- Migration reviewed against the entity column by column (types, nullability, defaults, index and FK names) and registered in both `getEntities()` and `getMigrations()`. Pure DDL on a new empty table, so `breaking = false` — the rollback-safety flag — is correct.

### Breaking change?  (required — CI fails if this is left unedited)

- [ ] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [x] yes — functional (default/limit/behaviour change, new self-hosted setup step)

Purely additive: a new table, a new endpoint, no existing behaviour touched. The functional break lands in the next PR of the stack, where consumers switch over.

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)

Adds an endpoint whose read access is deliberately wider than its write access — see **Access model**. No secrets, no cryptography, no outbound HTTP.
