### PR TITLE
fix(agents): leaving the agent editor without editing no longer asks to discard changes

### DIFF
--- a/packages/web/src/app/routes/agents/id/index.tsx
+++ b/packages/web/src/app/routes/agents/id/index.tsx
@@ -724,12 +724,22 @@ const AgentEditScreen = ({
   const writeSeq = useRef(0);
   const writeLock = useRef(agentEditState.createWriteLock());
 
+  const lastFromServer = useRef(formValuesOf(agent));
+
   useEffect(() => {
-    if (unsavedTyping) return;
     const fromServer = formValuesOf(agent);
-    if (agentEditState.sameConfig({ left: fromServer, right: values })) return;
+    if (
+      agentEditState.sameConfig({
+        left: fromServer,
+        right: lastFromServer.current,
+      })
+    ) {
+      return;
+    }
+    if (unsavedTyping) return;
+    lastFromServer.current = fromServer;
     form.reset(fromServer);
-  }, [agent, values, unsavedTyping, form]);
+  }, [agent, unsavedTyping, form]);
 
   const setServerError = (error: Error, fallback: string) =>
     form.setError('root.serverError', {

--- a/packages/web/src/app/routes/agents/id/index.tsx
+++ b/packages/web/src/app/routes/agents/id/index.tsx
@@ -485,13 +485,26 @@ const ConfigureFields = ({
           defaultModel={form.watch('draft.modelName') ?? undefined}
           defaultConfigId={form.watch('draft.providerConfigId') ?? undefined}
           onChange={({ provider, model, configId }) => {
-            form.setValue('draft.provider', parseProvider(provider), {
+            const picked = {
+              provider: parseProvider(provider) ?? null,
+              modelName: model ?? null,
+              providerConfigId: configId ?? null,
+            };
+            if (
+              !agentEditState.modelPickChanged({
+                picked,
+                current: form.getValues('draft'),
+              })
+            ) {
+              return;
+            }
+            form.setValue('draft.provider', picked.provider, {
               shouldDirty: true,
             });
-            form.setValue('draft.modelName', model ?? null, {
+            form.setValue('draft.modelName', picked.modelName, {
               shouldDirty: true,
             });
-            form.setValue('draft.providerConfigId', configId ?? null, {
+            form.setValue('draft.providerConfigId', picked.providerConfigId, {
               shouldDirty: true,
             });
           }}
@@ -675,12 +688,9 @@ const AgentEditScreen = ({
   onEdited: () => void;
 }) => {
   const [mode, setMode] = useState('edit');
-  const [syncedDraft, setSyncedDraft] = useState<ConfigureAgentInput>(() =>
-    formValuesOf(agent),
-  );
   const form = useForm<ConfigureAgentInput, unknown, ConfigureAgentValues>({
     resolver: zodResolver(ConfigureAgentSchema),
-    defaultValues: syncedDraft,
+    defaultValues: formValuesOf(agent),
     mode: 'onChange',
   });
   const updateAgent = agentsMutations.useUpdateAgent({ id: agent.id });
@@ -702,10 +712,7 @@ const AgentEditScreen = ({
   const live = liveValuesOf(agent);
   const hasChanges =
     isNil(live) || !agentEditState.sameConfig({ left: values, right: live });
-  const unsavedTyping = !agentEditState.sameConfig({
-    left: values,
-    right: syncedDraft,
-  });
+  const unsavedTyping = form.formState.isDirty;
   const deletedRef = useRef(false);
   const leaveBlocker = useWarnBeforeLosingChanges({
     hasChanges: unsavedTyping,
@@ -721,21 +728,11 @@ const AgentEditScreen = ({
   const writeLock = useRef(agentEditState.createWriteLock());
 
   useEffect(() => {
-    const fromServer = formValuesOf(agent);
-    if (agentEditState.sameConfig({ left: fromServer, right: syncedDraft }))
-      return;
     if (unsavedTyping) return;
+    const fromServer = formValuesOf(agent);
+    if (agentEditState.sameConfig({ left: fromServer, right: values })) return;
     form.reset(fromServer);
-    setSyncedDraft(fromServer);
-  }, [agent, syncedDraft, unsavedTyping, form]);
-
-  // The model selector picks a default the moment it mounts, so a screen nobody has touched would
-  // otherwise arm the leave guard. Adopting that pick as the baseline keeps Save armed, since that
-  // compares against what is live, while the guard only speaks for changes a person made.
-  useEffect(() => {
-    if (!agentEditState.adoptsPickedModel({ values, syncedDraft })) return;
-    setSyncedDraft(values);
-  }, [values, syncedDraft]);
+  }, [agent, values, unsavedTyping, form]);
 
   const setServerError = (error: Error, fallback: string) =>
     form.setError('root.serverError', {
@@ -753,7 +750,7 @@ const AgentEditScreen = ({
       {
         onSuccess: () => {
           if (seq !== writeSeq.current) return;
-          setSyncedDraft(values);
+          form.reset(values);
           if (testRequested.current) setMode('test');
         },
         onError: (error) =>
@@ -787,7 +784,7 @@ const AgentEditScreen = ({
     updateAgent.mutate(toUpdateRequest(values), {
       onSuccess: () => {
         if (seq !== writeSeq.current) return;
-        setSyncedDraft(values);
+        form.reset(values);
         setJustLaunched(true);
         window.setTimeout(() => setJustLaunched(false), 1600);
         toast(t('Live — every flow using this agent just got the update'));

--- a/packages/web/src/app/routes/agents/id/index.tsx
+++ b/packages/web/src/app/routes/agents/id/index.tsx
@@ -484,7 +484,7 @@ const ConfigureFields = ({
           defaultProvider={form.watch('draft.provider') ?? undefined}
           defaultModel={form.watch('draft.modelName') ?? undefined}
           defaultConfigId={form.watch('draft.providerConfigId') ?? undefined}
-          onChange={({ provider, model, configId }) => {
+          onChange={({ provider, model, configId, picked: pickedBy }) => {
             const picked = {
               provider: parseProvider(provider) ?? null,
               modelName: model ?? null,
@@ -498,14 +498,11 @@ const ConfigureFields = ({
             ) {
               return;
             }
-            form.setValue('draft.provider', picked.provider, {
-              shouldDirty: true,
-            });
-            form.setValue('draft.modelName', picked.modelName, {
-              shouldDirty: true,
-            });
+            const shouldDirty = pickedBy !== 'default';
+            form.setValue('draft.provider', picked.provider, { shouldDirty });
+            form.setValue('draft.modelName', picked.modelName, { shouldDirty });
             form.setValue('draft.providerConfigId', picked.providerConfigId, {
-              shouldDirty: true,
+              shouldDirty,
             });
           }}
         />
@@ -740,6 +737,15 @@ const AgentEditScreen = ({
       message: api.extractServerErrorMessage(error, fallback),
     });
 
+  const markSavedUnlessEditedSince = (written: ConfigureAgentInput) => {
+    if (
+      !agentEditState.sameConfig({ left: form.getValues(), right: written })
+    ) {
+      return;
+    }
+    form.reset(written);
+  };
+
   const releaseWrite = () => writeLock.current.release();
   const claimWrite = () => writeLock.current.claim();
 
@@ -750,7 +756,7 @@ const AgentEditScreen = ({
       {
         onSuccess: () => {
           if (seq !== writeSeq.current) return;
-          form.reset(values);
+          markSavedUnlessEditedSince(values);
           if (testRequested.current) setMode('test');
         },
         onError: (error) =>
@@ -784,7 +790,7 @@ const AgentEditScreen = ({
     updateAgent.mutate(toUpdateRequest(values), {
       onSuccess: () => {
         if (seq !== writeSeq.current) return;
-        form.reset(values);
+        markSavedUnlessEditedSince(values);
         setJustLaunched(true);
         window.setTimeout(() => setJustLaunched(false), 1600);
         toast(t('Live — every flow using this agent just got the update'));

--- a/packages/web/src/app/routes/agents/lib/agent-edit-state.ts
+++ b/packages/web/src/app/routes/agents/lib/agent-edit-state.ts
@@ -10,32 +10,19 @@ function sameConfig({
   return JSON.stringify(left) === JSON.stringify(right);
 }
 
-function adoptsPickedModel({
-  values,
-  syncedDraft,
+function modelPickChanged({
+  picked,
+  current,
 }: {
-  values: AgentDraftShape;
-  syncedDraft: AgentDraftShape;
+  picked: ModelPick;
+  current: ModelPick;
 }): boolean {
-  const hadNoModel =
-    syncedDraft.draft.modelName === null ||
-    syncedDraft.draft.modelName === undefined ||
-    syncedDraft.draft.modelName === '';
-  if (!hadNoModel) {
-    return false;
-  }
-  const withoutModel = (shape: AgentDraftShape) => ({
-    ...shape,
-    draft: {
-      ...shape.draft,
-      provider: null,
-      modelName: null,
-      providerConfigId: null,
-    },
-  });
-  return (
-    values.draft.modelName !== syncedDraft.draft.modelName &&
-    sameConfig({ left: withoutModel(values), right: withoutModel(syncedDraft) })
+  const same = (left?: string | null, right?: string | null) =>
+    (left ?? null) === (right ?? null);
+  return !(
+    same(picked.provider, current.provider) &&
+    same(picked.modelName, current.modelName) &&
+    same(picked.providerConfigId, current.providerConfigId)
   );
 }
 
@@ -107,22 +94,18 @@ function createWriteLock(): WriteLock {
 
 export const agentEditState = {
   sameConfig,
-  adoptsPickedModel,
+  modelPickChanged,
   headerStatus,
   modeIntent,
   leaveGuard,
   createWriteLock,
 };
 
-export type AgentDraftShape = {
-  draft: {
-    provider?: unknown;
-    modelName?: string | null;
-    providerConfigId?: unknown;
-    [key: string]: unknown;
-  };
+export type ModelPick = {
+  provider?: string | null;
+  modelName?: string | null;
+  providerConfigId?: string | null;
 };
-
 export type HeaderStatus = 'needs-model' | 'live' | 'pending';
 export type ModeIntent = 'switch' | 'stage';
 export type LeaveGuard = {

--- a/packages/web/src/features/agents/ai-model/index.tsx
+++ b/packages/web/src/features/agents/ai-model/index.tsx
@@ -42,6 +42,7 @@ type AIModelSelectorProps = {
     provider?: string;
     model?: string;
     configId?: string;
+    picked?: 'user' | 'default';
   }) => void;
 };
 
@@ -131,6 +132,7 @@ export function AIModelSelector({
         provider: selectedProvider,
         model: firstModel,
         configId: selectedConfigId,
+        picked: 'default',
       });
     }
   }, [
@@ -155,6 +157,7 @@ export function AIModelSelector({
         provider: selectedProvider,
         model: fallback,
         configId: selectedConfigId,
+        picked: 'default',
       });
     }
   }, [
@@ -170,7 +173,7 @@ export function AIModelSelector({
     setSelectedProvider(provider);
     setSelectedConfigId(configId);
     setSelectedModel(undefined);
-    onChange({ provider, model: undefined, configId });
+    onChange({ provider, model: undefined, configId, picked: 'user' });
     setProviderOpen(false);
   };
 
@@ -180,6 +183,7 @@ export function AIModelSelector({
       provider: selectedProvider,
       model: modelId,
       configId: selectedConfigId,
+      picked: 'user',
     });
     setModelOpen(false);
   };

--- a/packages/web/test/app/routes/agents/id/leave-guard-arming.test.tsx
+++ b/packages/web/test/app/routes/agents/id/leave-guard-arming.test.tsx
@@ -52,6 +52,17 @@ vi.mock('@/features/agents', () => ({
           })
         }
       />
+      <button
+        data-testid="model-filled-by-default"
+        onClick={() =>
+          onChange({
+            provider: 'openai',
+            model: 'gpt-5',
+            configId: undefined,
+            picked: 'default',
+          })
+        }
+      />
     </>
   ),
   AgentStructuredOutput: () => <div data-testid="structured" />,
@@ -152,6 +163,19 @@ describe('the leave guard only speaks for edits a person made', () => {
 
     expect(screen.queryByText('Leave without saving?')).toBeNull();
     expect(onExit).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps a model the selector filled in for a blank agent', async () => {
+    renderScreen({ onExit: vi.fn() });
+    await settle();
+    expect(
+      screen.queryByText('Pick a model so this agent can answer.'),
+    ).toBeTruthy();
+
+    screen.getByTestId('model-filled-by-default').click();
+    await settle();
+
+    expect(screen.queryByText('Pick a model so this agent can answer.')).toBeNull();
   });
 
   it('still stops you when the model was picked by hand', async () => {

--- a/packages/web/test/app/routes/agents/id/leave-guard-arming.test.tsx
+++ b/packages/web/test/app/routes/agents/id/leave-guard-arming.test.tsx
@@ -1,0 +1,193 @@
+// @vitest-environment jsdom
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { cleanup, render, screen } from '@testing-library/react';
+import { createMemoryRouter, RouterProvider } from 'react-router-dom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+type ModelPick = {
+  provider?: string;
+  model?: string;
+  configId?: string;
+  picked?: 'user' | 'default';
+};
+
+const pendingSaves: { onSuccess?: () => void }[] = [];
+
+vi.mock('i18next', () => ({ t: (key: string) => key }));
+vi.mock('sonner', () => ({ toast: vi.fn() }));
+vi.mock('@/app/routes/chat-with-ai/ai-chat-box', () => ({
+  AIChatBox: () => <div data-testid="chat" />,
+}));
+vi.mock('@/app/builder/step-settings/agent-settings/agent-tools', () => ({
+  AgentTools: () => <div data-testid="tools" />,
+}));
+vi.mock('@/hooks/flags-hooks', () => ({
+  flagsHooks: { useFlag: () => ({ data: true }) },
+}));
+vi.mock('@/hooks/authorization-hooks', () => ({
+  useAuthorization: () => ({ checkAccess: () => true }),
+}));
+vi.mock('@/features/agents', () => ({
+  AIModelSelector: ({ onChange }: { onChange: (value: ModelPick) => void }) => (
+    <>
+      <button
+        data-testid="model"
+        onClick={() =>
+          onChange({
+            provider: 'openai',
+            model: 'gpt-5',
+            configId: undefined,
+            picked: 'user',
+          })
+        }
+      />
+      <button
+        data-testid="model-replaced-by-default"
+        onClick={() =>
+          onChange({
+            provider: 'openai',
+            model: 'gpt-5-mini',
+            configId: undefined,
+            picked: 'default',
+          })
+        }
+      />
+    </>
+  ),
+  AgentStructuredOutput: () => <div data-testid="structured" />,
+  KnowledgeBaseSection: () => <div data-testid="knowledge" />,
+  useAgentsAvailable: () => true,
+}));
+vi.mock('@/features/agents/hooks/agents-hooks', () => ({
+  agentsMutations: {
+    useUpdateAgent: () => ({
+      isPending: false,
+      mutate: (_request: unknown, options?: { onSuccess?: () => void }) => {
+        pendingSaves.push({ onSuccess: options?.onSuccess });
+      },
+    }),
+  },
+  agentsQueries: { useAgent: () => ({ data: undefined, isLoading: false }) },
+}));
+
+import { AgentEditScreen } from '@/app/routes/agents/id';
+
+const agentWithoutModel = {
+  id: 'agent_1',
+  displayName: 'Inbox agent',
+  description: null,
+  icon: 'bot',
+  color: 'PURPLE',
+  projectId: 'proj_1',
+  visibility: 'PROJECT',
+  sharedWithUserIds: [],
+  published: null,
+  draft: {
+    instructions: 'Sort the inbox.',
+    provider: null,
+    providerConfigId: null,
+    modelName: null,
+    maxSteps: 10,
+    tools: [],
+    structuredOutput: [],
+  },
+} as never;
+
+const renderScreen = ({ onExit }: { onExit: () => void }) => {
+  const router = createMemoryRouter(
+    [
+      {
+        path: '/',
+        element: (
+          <AgentEditScreen
+            agent={agentWithoutModel}
+            onExit={onExit}
+            onEdited={vi.fn()}
+          />
+        ),
+      },
+    ],
+    { initialEntries: ['/'] },
+  );
+  return render(
+    <QueryClientProvider client={new QueryClient()}>
+      <RouterProvider router={router} />
+    </QueryClientProvider>,
+  );
+};
+
+const clickBack = () => {
+  const back = screen.getByLabelText('Back to the agent');
+  back.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+};
+
+const typeInInstructions = (value: string) => {
+  const box = document.querySelector('textarea');
+  if (!box) throw new Error('instructions textarea not rendered');
+  const setter = Object.getOwnPropertyDescriptor(
+    HTMLTextAreaElement.prototype,
+    'value',
+  )?.set;
+  setter?.call(box, value);
+  box.dispatchEvent(new Event('input', { bubbles: true }));
+};
+
+const settle = () => new Promise((resolve) => setTimeout(resolve, 60));
+
+beforeEach(() => {
+  pendingSaves.length = 0;
+});
+afterEach(cleanup);
+
+describe('the leave guard only speaks for edits a person made', () => {
+  it('lets you leave after the selector swapped in a model by itself', async () => {
+    const onExit = vi.fn();
+    renderScreen({ onExit });
+    await settle();
+
+    screen.getByTestId('model-replaced-by-default').click();
+    await settle();
+    clickBack();
+    await settle();
+
+    expect(screen.queryByText('Leave without saving?')).toBeNull();
+    expect(onExit).toHaveBeenCalledTimes(1);
+  });
+
+  it('still stops you when the model was picked by hand', async () => {
+    const onExit = vi.fn();
+    renderScreen({ onExit });
+    await settle();
+
+    screen.getByTestId('model').click();
+    await settle();
+    clickBack();
+    await settle();
+
+    expect(screen.getByText('Leave without saving?')).toBeTruthy();
+    expect(onExit).not.toHaveBeenCalled();
+  });
+
+  it('keeps an edit typed while a save was in flight', async () => {
+    const onExit = vi.fn();
+    renderScreen({ onExit });
+    typeInInstructions('First edit.');
+    await settle();
+
+    document.querySelector('form')?.requestSubmit();
+    await settle();
+    expect(pendingSaves).toHaveLength(1);
+
+    typeInInstructions('Second edit, typed while saving.');
+    await settle();
+    pendingSaves[0]?.onSuccess?.();
+    await settle();
+
+    expect(document.querySelector('textarea')?.value).toBe(
+      'Second edit, typed while saving.',
+    );
+    clickBack();
+    await settle();
+    expect(screen.getByText('Leave without saving?')).toBeTruthy();
+  });
+});

--- a/packages/web/test/app/routes/agents/lib/agent-edit-state.test.ts
+++ b/packages/web/test/app/routes/agents/lib/agent-edit-state.test.ts
@@ -270,47 +270,47 @@ describe('leaveGuard', () => {
   );
 });
 
-describe('agentEditState.adoptsPickedModel', () => {
-  const withModel = (modelName: string | null) => ({
-    draft: { provider: 'openai', modelName, providerConfigId: 'cfg' },
+describe('agentEditState.modelPickChanged', () => {
+  const pick = {
+    provider: 'openrouter',
+    modelName: 'anthropic/claude-sonnet-4.6',
+    providerConfigId: null,
+  };
+
+  it('is false when the selector reports the model the form already holds', () => {
+    expect(
+      agentEditState.modelPickChanged({ picked: pick, current: pick }),
+    ).toBe(false);
   });
 
-  it('adopts the model the selector picked for an agent that had none', () => {
+  it('is true when the model differs', () => {
     expect(
-      agentEditState.adoptsPickedModel({
-        values: withModel('gpt-5'),
-        syncedDraft: {
-          draft: { provider: null, modelName: null, providerConfigId: null },
-        },
+      agentEditState.modelPickChanged({
+        picked: { ...pick, modelName: 'openai/gpt-5' },
+        current: pick,
       }),
     ).toBe(true);
   });
 
-  it('leaves a model the person chose themselves alone, so Save still warns on exit', () => {
+  it('treats a missing field and an explicit null as the same pick', () => {
     expect(
-      agentEditState.adoptsPickedModel({
-        values: withModel('gpt-5'),
-        syncedDraft: withModel('claude-sonnet-4-5'),
+      agentEditState.modelPickChanged({
+        picked: { provider: 'openrouter', modelName: 'x' },
+        current: {
+          provider: 'openrouter',
+          modelName: 'x',
+          providerConfigId: null,
+        },
       }),
     ).toBe(false);
   });
 
-  it("refuses when anything else changed too, since that edit is the person's", () => {
+  it('is true when only the provider config differs', () => {
     expect(
-      agentEditState.adoptsPickedModel({
-        values: {
-          ...withModel('gpt-5'),
-          draft: { ...withModel('gpt-5').draft, instructions: 'new' },
-        },
-        syncedDraft: {
-          draft: {
-            provider: null,
-            modelName: null,
-            providerConfigId: null,
-            instructions: 'old',
-          },
-        },
+      agentEditState.modelPickChanged({
+        picked: { ...pick, providerConfigId: 'cfg_1' },
+        current: pick,
       }),
-    ).toBe(false);
+    ).toBe(true);
   });
 });


### PR DESCRIPTION
## Description

Opening an agent, changing nothing, and pressing back could still ask you to discard changes. Now it only asks when you actually changed something.

The leave guard decided whether you had edited by comparing the form against a shadow copy of the last synced draft, as JSON strings. Anything the page wrote for you armed it: a key added in a different order, a normalising re-render, or the model selector reporting the model that was already on screen. There was already a workaround for that last case, but it only covered agents with no model saved yet, so it did nothing for an agent that already had one.

The form already tracks this. React Hook Form marks itself dirty for edits a person makes and for the explicit `shouldDirty` writes this editor performs, and for nothing else, so the guard now reads `formState.isDirty` and the shadow copy is deleted along with its workaround. Saving or staging resets the form rather than copying values sideways, which also means undoing an edit by hand disarms the guard, as it should. The model selector fires `onChange` when it mounts, so that handler returns early when the pick matches what the form holds.

Continues the Agents work after #15169. Not stacked on anything.

## How was this tested?

- `packages/web` unit suite, 648 tests, plus three new cases for the unchanged-pick rule (including a missing field being the same pick as an explicit `null`)
- Live on EE with agents enabled: open an agent, press back, no dialog. Same after expanding a tool row, focusing the instructions, and switching panels
- Type an edit, press back, dialog appears; Discard restores the saved instructions
- Edit, Save and go live, press back, no dialog (the reset-after-save path)

Fixes # (issue)

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)
