### PR TITLE
fix(project-releases): a release records who actually made it

### DIFF
--- a/packages/server/api/src/app/ee/projects/project-release/project-release.controller.ts
+++ b/packages/server/api/src/app/ee/projects/project-release/project-release.controller.ts
@@ -1,4 +1,4 @@
-import { ApId, SeekPage } from '@activepieces/core-utils'
+import { ApId, assertNotNullOrUndefined, SeekPage } from '@activepieces/core-utils'
 import { ApplicationEventName, CreateProjectReleaseRequestBody, DiffReleaseRequest, ListProjectReleasesRequest, PrincipalType, ProjectRelease, SERVICE_KEY_SECURITY_OPENAPI } from '@activepieces/shared'
 import { FastifyPluginAsyncZod } from 'fastify-type-provider-zod'
 import { StatusCodes } from 'http-status-codes'
@@ -6,7 +6,7 @@ import { z } from 'zod'
 import { ProjectResourceType } from '../../../core/security/authorization/common'
 import { securityAccess } from '../../../core/security/authorization/fastify-security'
 import { applicationEvents } from '../../../helper/application-events'
-import { platformService } from '../../../platform/platform.service'
+import { securityHelper } from '../../../helper/security-helper'
 import { ProjectReleaseEntity } from './project-release.entity'
 import { projectReleaseService } from './project-release.service'
 
@@ -29,12 +29,12 @@ export const projectReleaseController: FastifyPluginAsyncZod = async (app) => {
     })
 
     app.post('/', CreateProjectReleaseRequest, async (req) => {
-        const platform = await platformService(req.log).getOneOrThrow(req.principal.platform.id)
-        const ownerId = platform.ownerId
+        const userId = await securityHelper.getUserIdFromRequest(req)
+        assertNotNullOrUndefined(userId, 'userId')
         const release = await projectReleaseService.create({
             platformId: req.principal.platform.id,
             projectId: req.projectId,
-            ownerId,
+            userId,
             params: req.body,
             log: req.log,
         })
@@ -49,11 +49,11 @@ export const projectReleaseController: FastifyPluginAsyncZod = async (app) => {
     })
 
     app.post('/diff', DiffProjectReleaseRequest, async (req) => {
-        const platform = await platformService(req.log).getOneOrThrow(req.principal.platform.id)
-        const ownerId = platform.ownerId
+        const userId = await securityHelper.getUserIdFromRequest(req)
+        assertNotNullOrUndefined(userId, 'userId')
         return projectReleaseService.releasePlan({
             projectId: req.projectId,
-            userId: ownerId,
+            userId,
             platformId: req.principal.platform.id,
             params: req.body,
             log: req.log,

--- a/packages/server/api/src/app/ee/projects/project-release/project-release.service.ts
+++ b/packages/server/api/src/app/ee/projects/project-release/project-release.service.ts
@@ -15,11 +15,11 @@ const projectReleaseRepo = repoFactory(ProjectReleaseEntity)
 
 export const projectReleaseService = {
     async create(request: CreateProjectReleaseParams): Promise<ProjectRelease> {
-        const { platformId, projectId, ownerId, params, log } = request
+        const { platformId, projectId, userId, params, log } = request
         const lockKey = `project-release:${params.projectId}`
         const lock = await memoryLock.acquire(lockKey)
         try {
-            const diffs = await findDiffStates({ projectId, userId: ownerId, platformId, params, log })
+            const diffs = await findDiffStates({ projectId, userId, platformId, params, log })
             const flowIdsToApply = params.selectedFlowsIds ?? diffs.flows.map((flow) => flow.flowState.id)
             const filteredDiffs = await projectDiffService.filterFlows(flowIdsToApply, diffs)
             await projectStateService(log).apply({
@@ -34,7 +34,7 @@ export const projectReleaseService = {
                 created: new Date().toISOString(),
                 updated: new Date().toISOString(),
                 projectId,
-                importedBy: ownerId,
+                importedBy: userId,
                 fileId,
                 name: params.name,
                 description: params.description,
@@ -188,7 +188,7 @@ async function assertTargetProjectOwnedByPlatform({ targetProjectId, platformId,
 type CreateProjectReleaseParams = {
     platformId: PlatformId
     projectId: ProjectId
-    ownerId: ApId
+    userId: ApId
     params: CreateProjectReleaseRequestBody
     log: FastifyBaseLogger
 }

--- a/packages/server/api/test/integration/cloud/project-release/project-release.test.ts
+++ b/packages/server/api/test/integration/cloud/project-release/project-release.test.ts
@@ -1,5 +1,5 @@
 import { apId } from '@activepieces/core-utils'
-import { CreateProjectReleaseRequestBody, ProjectReleaseType } from '@activepieces/shared'
+import { CreateProjectReleaseRequestBody, DefaultProjectRole, ProjectReleaseType } from '@activepieces/shared'
 import { faker } from '@faker-js/faker'
 import { FastifyInstance } from 'fastify'
 import { StatusCodes } from 'http-status-codes'
@@ -11,7 +11,7 @@ import {
     createMockProjectRelease,
     mockAndSaveBasicSetup,
 } from '../../../helpers/mocks'
-import { createTestContext } from '../../../helpers/test-context'
+import { createMemberContext, createServiceContext, createTestContext } from '../../../helpers/test-context'
 import { setupTestEnvironment, teardownTestEnvironment } from '../../../helpers/test-setup'
 
 let app: FastifyInstance | null = null
@@ -84,6 +84,63 @@ describe('Project Release API', () => {
             })
 
             expect(response?.statusCode).toBe(StatusCodes.OK)
+        })
+
+        it('should record the acting user in importedBy, not the platform owner', async () => {
+            const ownerCtx = await createTestContext(app!, {
+                project: { releasesEnabled: true },
+                plan: { environmentsEnabled: true },
+            })
+            const memberCtx = await createMemberContext(app!, ownerCtx, {
+                projectRole: DefaultProjectRole.ADMIN,
+            })
+
+            const mockSourceProject = createMockProject({
+                platformId: ownerCtx.platform.id,
+                ownerId: ownerCtx.user.id,
+                releasesEnabled: true,
+            })
+            await db.save('project', mockSourceProject)
+
+            const response = await memberCtx.post('/v1/project-releases', {
+                name: 'Member Release',
+                description: 'Released by a project member',
+                selectedFlowsIds: null,
+                projectId: memberCtx.project.id,
+                type: ProjectReleaseType.PROJECT,
+                targetProjectId: mockSourceProject.id,
+            })
+
+            expect(response?.statusCode).toBe(StatusCodes.OK)
+            expect(memberCtx.user.id).not.toBe(ownerCtx.platform.ownerId)
+            expect(response?.json().importedBy).toBe(memberCtx.user.id)
+        })
+
+        it('should fall back to the platform owner for SERVICE principals', async () => {
+            const ownerCtx = await createTestContext(app!, {
+                project: { releasesEnabled: true },
+                plan: { environmentsEnabled: true },
+            })
+            const serviceCtx = await createServiceContext(app!, ownerCtx)
+
+            const mockSourceProject = createMockProject({
+                platformId: ownerCtx.platform.id,
+                ownerId: ownerCtx.user.id,
+                releasesEnabled: true,
+            })
+            await db.save('project', mockSourceProject)
+
+            const response = await serviceCtx.post('/v1/project-releases', {
+                name: 'Service Release',
+                description: 'Released by an api key',
+                selectedFlowsIds: null,
+                projectId: ownerCtx.project.id,
+                type: ProjectReleaseType.PROJECT,
+                targetProjectId: mockSourceProject.id,
+            })
+
+            expect(response?.statusCode).toBe(StatusCodes.OK)
+            expect(response?.json().importedBy).toBe(ownerCtx.platform.ownerId)
         })
     })
 


### PR DESCRIPTION
## Description

A project release is always recorded as having been made by the platform owner, whoever actually made it.

`project-release.controller.ts` resolves `platform.ownerId` and hands it to the service, which writes it to `importedBy` on the release row and uses the same id as the git actor. So the "Imported By" column in the releases list, and the release detail panel, name the platform owner for every release in every project. On an embedded platform, where many end users share a project, that makes the release history unable to answer the one question it exists for: who promoted this change?

Both `POST /v1/project-releases` and `POST /v1/project-releases/diff` now use the existing `securityHelper.getUserIdFromRequest(req)`:

- `PrincipalType.USER` -> `principal.id`, the acting user
- `PrincipalType.SERVICE` -> `platform.ownerId`, unchanged, because an API key has no human behind it

That helper already backs app connections, global connections and variables, so release attribution stops being a special case.

`projectReleaseService.create`'s `ownerId` param is renamed to `userId`, since the value is no longer an owner id.

No frontend change is needed: `projectReleaseService.enrich` already resolves `importedBy` into `importedByUser`, and both `routes/project-release/index.tsx` and `view-release.tsx` already render it.

Two notes for reviewers:

1. **`PROJECT_RELEASE_CREATED` was already correct.** It goes through `applicationEvents.sendUserEvent`, which uses `authenticationUtils.extractUserIdFromRequest` and has always returned `principal.id` for USER principals. This change makes the release row agree with the audit event it was already disagreeing with.
2. **The git actor id changes too, and I believe harmlessly.** For `ProjectReleaseType.GIT`, the id reaches `gitHelper.createGitRepoAndReturnPaths`, which sets `user.email` / `user.name` on the temporary clone. The release path (`gitRepoService.getState`) only clones and reads files, it never commits or pushes, so nothing is authored with that identity. `gitRepoService.push` is untouched and still uses its own `userId`. Worth a second pair of eyes since you know the git-sync path better than I do.

New releases will therefore record a different user than before, which is the point of the fix. Existing rows are untouched, there is no API shape change, and no migration.

## How was this tested?

Added two cases to `packages/server/api/test/integration/cloud/project-release/project-release.test.ts`:

- a non-owner project member creates a PROJECT release, and `importedBy` comes back as that member. The test also asserts the member is not the platform owner, so it cannot pass by coincidence.
- a SERVICE principal creates a PROJECT release, and `importedBy` comes back as the platform owner.

Verified locally on this branch:

- `turbo run build --filter=api` clean
- `eslint` on the touched files: 0 errors
- `AP_EDITION=cloud vitest run test/integration/cloud/project-release`: 14/14 passing
- the new acting-user test fails on unmodified `main`, so it does test the fix

Cloud/EE path only, the controller lives under `ee/`.

Fixes # (issue)

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

- [ ] no — reviewed, no security impact
- [x] yes — security-sensitive (call out the risk and mitigation in the description above)

Flagged as security-sensitive because it changes how a principal is resolved into a user id. No authorization boundary moves: the `securityAccess.project(...)` configs on both routes are untouched, the set of allowed principal types is unchanged, and the SERVICE path resolves exactly as before. The change is to which user id gets recorded and used as the git identity, not to who may call the endpoint.

Closes #15192
