### PR TITLE
refactor(telemetry): remove event names nothing emits

### DIFF
--- a/packages/core/shared/src/lib/core/common/telemetry.ts
+++ b/packages/core/shared/src/lib/core/common/telemetry.ts
@@ -2,31 +2,6 @@ import type { RunEnvironment } from '@activepieces/core-execution'
 import type { FlowId, ProjectId, UserId } from '@activepieces/core-utils'
 import type { McpId } from '../../automation/mcp/mcp'
 
-type FlowCreated = {
-    flowId: FlowId
-}
-type PiecesSearch = {
-    target: 'steps' | 'triggers'
-    search: string
-}
-
-type TemplateSearch = {
-    search: string
-    tags: string[]
-    pieces: string[]
-}
-
-type RunCreated = {
-    projectId: ProjectId
-    flowId: FlowId
-    environment: RunEnvironment
-    count: number
-}
-
-type FlowPublished = {
-    flowId: FlowId
-}
-
 type SignedUp = {
     userId: UserId
     email?: string
@@ -35,138 +10,9 @@ type SignedUp = {
     projectId: ProjectId
 }
 
-type EmailCodeRequested = {
-    isNewIdentity: boolean
-}
-
-type EmailCodeVerified = {
-    needsNameStep: boolean
-}
-
-type EmailCodeRejected = {
-    errorCode: string
-}
-
-type EmailCodeResendRequested = Record<string, never>
-
-type CaptchaUnavailable = {
-    surface: string
-}
-
-type QuotaAlert = {
-    percentageUsed: number
-}
-type FlowImported = {
-    id: string
-    name: string
-    location:
-    | 'import flow view'
-    | 'inside the builder'
-    | 'import flow by uri encoded query param'
-    tab?: string
-}
-type FlowImportedUsingFile = {
-    location: 'inside dashboard' | 'inside the builder'
-    multiple: boolean
-}
-
-type FlowIssueClicked = {
-    flowId: string
-}
-
-type FlowIssueResolved = {
-    flowId: string
-}
-
-type RequestTrialSubmitted = {
-    fullName: string
-    email: string
-    numberOfEmployees: string
-    companyName: string
-    goal: string
-}
-
-type RequestTrialClicked = {
-    location: string
-}
-
-type KeyActivated = {
-    date: string
-    key: string
-}
-
-type UpgradeClicked = {
-    limitType?: 'team'
-}
-
-type UpgradePopup = {
-    limitType?: 'team'
-}
-
-type ReferralLinkCopied = {
+type SignedIn = {
     userId: UserId
-}
-
-type RewardButtonClicked = {
-    source: 'note' | 'rewards-button'
-}
-
-type RewardInstructionsClicked = {
-    type: 'share-template' | 'linkedin' | 'referral' | 'contribute-piece'
-}
-
-type Referral = {
-    referredUserId: UserId
-}
-
-type FlowShared = {
-    flowId: FlowId
-    projectId: ProjectId
-}
-
-type OpenedFromDashboard = {
-    location: 'sidenav' | 'tasks-progress'
-}
-
-type FormsViewed = {
-    flowId: string
-    projectId: string
-    formProps: Record<string, unknown>
-}
-
-type UserInvited = {
     platformId: string
-    projectId?: string
-    email: string
-}
-
-type TriggerFailuresExceeded = {
-    projectId: string
-    flowId: string
-    pieceName: string
-    pieceVersion: string
-}
-type AiProviderConfiguredOrUsed = {
-    provider: string
-    projectId: string
-    platformId: string
-}
-
-type McpToolCalled = {
-    mcpId: McpId
-    toolName: string
-}
-
-type McpServerConnected = {
-    userId: string
-    projectId?: string
-    platformId?: string
-}
-
-type PieceSelectorSearch = {
-    search: string
-    isTrigger: boolean
-    selectedActionOrTriggerName: string | null
 }
 
 type SignUpSubmitted = {
@@ -186,8 +32,6 @@ type SignUpFailed = {
     errorCode: string
 }
 
-type EmailVerificationCompleted = Record<string, never>
-
 type SignInSubmitted = {
     method: 'email'
 }
@@ -200,59 +44,61 @@ type FederatedLoginStarted = {
     provider: 'google' | 'saml'
 }
 
-type SignedIn = {
-    userId: UserId
-    platformId: string
+type EmailVerificationCompleted = Record<string, never>
+
+type CaptchaUnavailable = {
+    surface: string
 }
-export enum TelemetryEventName {
-    SIGNED_UP = 'signed.up',
-    EMAIL_CODE_REQUESTED = 'email.code.requested',
-    EMAIL_CODE_VERIFIED = 'email.code.verified',
-    EMAIL_CODE_REJECTED = 'email.code.rejected',
-    EMAIL_CODE_RESEND_REQUESTED = 'email.code.resend.requested',
-    CAPTCHA_UNAVAILABLE = 'captcha.unavailable',
-    QUOTA_ALERT = 'quota.alert',
-    REQUEST_TRIAL_CLICKED = 'request.trial.clicked',
-    REQUEST_TRIAL_SUBMITTED = 'request.trial.submitted',
-    KEY_ACTIVATED = 'key.activated',
-    FLOW_ISSUE_CLICKED = 'flow.issue.clicked',
-    FLOW_ISSUE_RESOLVED = 'flow.issue.resolved',
-    USER_INVITED = 'user.invited',
-    UPGRADE_POPUP = 'upgrade.popup',
-    CREATED_FLOW = 'flow.created',
-    DEMO_IMPORTED = 'demo.imported',
-    FLOW_RUN_CREATED = 'run.created',
-    FLOW_PUBLISHED = 'flow.published',
-    /**used with templates dialog + import flow component + flows imported by uri query param*/
-    FLOW_IMPORTED = 'flow.imported',
-    /**used only with import flow dialog*/
-    FLOW_IMPORTED_USING_FILE = 'flow.imported.using.file',
-    PIECES_SEARCH = 'pieces.search',
-    REFERRAL = 'referral',
-    REFERRAL_LINK_COPIED = 'referral.link.copied',
-    FLOW_SHARED = 'flow.shared',
-    TEMPLATE_SEARCH = 'template.search',
-    FORMS_VIEWED = 'forms.viewed',
-    FORMS_SUBMITTED = 'forms.submitted',
-    REWARDS_OPENED = 'rewards.opened',
-    REWARDS_INSTRUCTION_CLICKED = 'rewards.instructions.clicked',
-    TRIGGER_FAILURES_EXCEEDED = 'trigger.failures.exceeded',
-    AI_PROVIDER_USED = 'ai.provider.used',
-    AI_PROVIDER_CONFIGURED = 'ai.provider.configured',
-    MCP_TOOL_CALLED = 'mcp.tool.called',
-    MCP_SERVER_CONNECTED = 'mcp.server.connected',
-    UPGRADE_POPUP_OPENED = 'upgrade.popup.opened',
-    UPGRADE_CLICKED = 'upgrade.clicked',
-    OPENED_PRICING_FROM_DASHBOARD = 'opened.pricing.from.dashboard',
-    PIECE_SELECTOR_SEARCH = 'piece.selector.search',
-    SIGN_UP_SUBMITTED = 'signup.submitted',
-    SIGN_UP_FAILED = 'signup.failed',
-    EMAIL_VERIFICATION_COMPLETED = 'email.verification.completed',
-    SIGN_IN_SUBMITTED = 'signin.submitted',
-    SIGN_IN_FAILED = 'signin.failed',
-    FEDERATED_LOGIN_STARTED = 'federated.login.started',
-    SIGNED_IN = 'signed.in',
-    CHAT_PAGE_VIEWED = 'chat.page.viewed',
+
+type EmailCodeRequested = {
+    isNewIdentity: boolean
+}
+
+type EmailCodeVerified = {
+    needsNameStep: boolean
+}
+
+type EmailCodeRejected = {
+    errorCode: string
+}
+
+type EmailCodeResendRequested = Record<string, never>
+
+type FlowCreated = {
+    flowId: FlowId
+}
+
+type RunCreated = {
+    projectId: ProjectId
+    flowId: FlowId
+    environment: RunEnvironment
+    count: number
+}
+
+type FlowPublished = {
+    flowId: FlowId
+}
+
+type FlowImportedUsingFile = {
+    location: 'inside dashboard' | 'inside the builder'
+    multiple: boolean
+}
+
+type PieceSelectorSearch = {
+    search: string
+    isTrigger: boolean
+    selectedActionOrTriggerName: string | null
+}
+
+type McpToolCalled = {
+    mcpId: McpId
+    toolName: string
+}
+
+type McpServerConnected = {
+    userId: string
+    projectId?: string
+    platformId?: string
 }
 
 type BaseTelemetryEvent<T, P> = {
@@ -260,100 +106,47 @@ type BaseTelemetryEvent<T, P> = {
     payload: P
 }
 
+export enum TelemetryEventName {
+    SIGNED_UP = 'signed.up',
+    SIGNED_IN = 'signed.in',
+    SIGN_UP_SUBMITTED = 'signup.submitted',
+    SIGN_UP_FAILED = 'signup.failed',
+    SIGN_IN_SUBMITTED = 'signin.submitted',
+    SIGN_IN_FAILED = 'signin.failed',
+    FEDERATED_LOGIN_STARTED = 'federated.login.started',
+    EMAIL_VERIFICATION_COMPLETED = 'email.verification.completed',
+    CAPTCHA_UNAVAILABLE = 'captcha.unavailable',
+    EMAIL_CODE_REQUESTED = 'email.code.requested',
+    EMAIL_CODE_VERIFIED = 'email.code.verified',
+    EMAIL_CODE_REJECTED = 'email.code.rejected',
+    EMAIL_CODE_RESEND_REQUESTED = 'email.code.resend.requested',
+    CREATED_FLOW = 'flow.created',
+    FLOW_RUN_CREATED = 'run.created',
+    FLOW_PUBLISHED = 'flow.published',
+    FLOW_IMPORTED_USING_FILE = 'flow.imported.using.file',
+    PIECE_SELECTOR_SEARCH = 'piece.selector.search',
+    MCP_TOOL_CALLED = 'mcp.tool.called',
+    MCP_SERVER_CONNECTED = 'mcp.server.connected',
+}
+
 export type TelemetryEvent =
-  | BaseTelemetryEvent<TelemetryEventName.SIGNED_UP, SignedUp>
-  | BaseTelemetryEvent<
-  TelemetryEventName.EMAIL_CODE_REQUESTED,
-  EmailCodeRequested
-  >
-  | BaseTelemetryEvent<
-  TelemetryEventName.EMAIL_CODE_VERIFIED,
-  EmailCodeVerified
-  >
-  | BaseTelemetryEvent<
-  TelemetryEventName.EMAIL_CODE_REJECTED,
-  EmailCodeRejected
-  >
-  | BaseTelemetryEvent<
-  TelemetryEventName.EMAIL_CODE_RESEND_REQUESTED,
-  EmailCodeResendRequested
-  >
-  | BaseTelemetryEvent<
-  TelemetryEventName.CAPTCHA_UNAVAILABLE,
-  CaptchaUnavailable
-  >
-  | BaseTelemetryEvent<TelemetryEventName.REFERRAL, Referral>
-  | BaseTelemetryEvent<
-  TelemetryEventName.REQUEST_TRIAL_CLICKED,
-  RequestTrialClicked
-  >
-  | BaseTelemetryEvent<TelemetryEventName.KEY_ACTIVATED, KeyActivated>
-  | BaseTelemetryEvent<
-  TelemetryEventName.REQUEST_TRIAL_SUBMITTED,
-  RequestTrialSubmitted
-  >
-  | BaseTelemetryEvent<TelemetryEventName.FLOW_ISSUE_CLICKED, FlowIssueClicked>
-  | BaseTelemetryEvent<
-  TelemetryEventName.FLOW_ISSUE_RESOLVED,
-  FlowIssueResolved
-  >
-  | BaseTelemetryEvent<TelemetryEventName.UPGRADE_CLICKED, UpgradeClicked>
-  | BaseTelemetryEvent<TelemetryEventName.UPGRADE_POPUP, UpgradePopup>
-  | BaseTelemetryEvent<TelemetryEventName.FLOW_RUN_CREATED, RunCreated>
-  | BaseTelemetryEvent<TelemetryEventName.FLOW_PUBLISHED, FlowPublished>
-  | BaseTelemetryEvent<TelemetryEventName.QUOTA_ALERT, QuotaAlert>
-  | BaseTelemetryEvent<TelemetryEventName.CREATED_FLOW, FlowCreated>
-  | BaseTelemetryEvent<TelemetryEventName.TEMPLATE_SEARCH, TemplateSearch>
-  | BaseTelemetryEvent<TelemetryEventName.PIECES_SEARCH, PiecesSearch>
-  | BaseTelemetryEvent<TelemetryEventName.FLOW_IMPORTED, FlowImported>
-  | BaseTelemetryEvent<
-  TelemetryEventName.FLOW_IMPORTED_USING_FILE,
-  FlowImportedUsingFile
-  >
-  | BaseTelemetryEvent<
-  TelemetryEventName.REFERRAL_LINK_COPIED,
-  ReferralLinkCopied
-  >
-  | BaseTelemetryEvent<TelemetryEventName.FLOW_SHARED, FlowShared>
-  | BaseTelemetryEvent<TelemetryEventName.DEMO_IMPORTED, Record<string, never>>
-  | BaseTelemetryEvent<
-  TelemetryEventName.OPENED_PRICING_FROM_DASHBOARD,
-  OpenedFromDashboard
-  >
-  | BaseTelemetryEvent<TelemetryEventName.FORMS_VIEWED, FormsViewed>
-  | BaseTelemetryEvent<TelemetryEventName.USER_INVITED, UserInvited>
-  | BaseTelemetryEvent<TelemetryEventName.FORMS_SUBMITTED, FormsViewed>
-  | BaseTelemetryEvent<TelemetryEventName.REWARDS_OPENED, RewardButtonClicked>
-  | BaseTelemetryEvent<
-  TelemetryEventName.REWARDS_INSTRUCTION_CLICKED,
-  RewardInstructionsClicked
-  >
-  | BaseTelemetryEvent<
-  TelemetryEventName.TRIGGER_FAILURES_EXCEEDED,
-  TriggerFailuresExceeded
-  >
-  | BaseTelemetryEvent<
-  TelemetryEventName.AI_PROVIDER_USED,
-  AiProviderConfiguredOrUsed
-  >
-  | BaseTelemetryEvent<
-  TelemetryEventName.AI_PROVIDER_CONFIGURED,
-  AiProviderConfiguredOrUsed
-  >
-  | BaseTelemetryEvent<TelemetryEventName.MCP_TOOL_CALLED, McpToolCalled>
-  | BaseTelemetryEvent<TelemetryEventName.MCP_SERVER_CONNECTED, McpServerConnected>
-  | BaseTelemetryEvent<TelemetryEventName.PIECE_SELECTOR_SEARCH, PieceSelectorSearch>
-  | BaseTelemetryEvent<TelemetryEventName.SIGN_UP_SUBMITTED, SignUpSubmitted>
-  | BaseTelemetryEvent<TelemetryEventName.SIGN_UP_FAILED, SignUpFailed>
-  | BaseTelemetryEvent<
-  TelemetryEventName.EMAIL_VERIFICATION_COMPLETED,
-  EmailVerificationCompleted
-  >
-  | BaseTelemetryEvent<TelemetryEventName.SIGN_IN_SUBMITTED, SignInSubmitted>
-  | BaseTelemetryEvent<TelemetryEventName.SIGN_IN_FAILED, SignInFailed>
-  | BaseTelemetryEvent<
-  TelemetryEventName.FEDERATED_LOGIN_STARTED,
-  FederatedLoginStarted
-  >
-  | BaseTelemetryEvent<TelemetryEventName.SIGNED_IN, SignedIn>
-  | BaseTelemetryEvent<TelemetryEventName.CHAT_PAGE_VIEWED, Record<string, never>>
+    | BaseTelemetryEvent<TelemetryEventName.SIGNED_UP, SignedUp>
+    | BaseTelemetryEvent<TelemetryEventName.SIGNED_IN, SignedIn>
+    | BaseTelemetryEvent<TelemetryEventName.SIGN_UP_SUBMITTED, SignUpSubmitted>
+    | BaseTelemetryEvent<TelemetryEventName.SIGN_UP_FAILED, SignUpFailed>
+    | BaseTelemetryEvent<TelemetryEventName.SIGN_IN_SUBMITTED, SignInSubmitted>
+    | BaseTelemetryEvent<TelemetryEventName.SIGN_IN_FAILED, SignInFailed>
+    | BaseTelemetryEvent<TelemetryEventName.FEDERATED_LOGIN_STARTED, FederatedLoginStarted>
+    | BaseTelemetryEvent<TelemetryEventName.EMAIL_VERIFICATION_COMPLETED, EmailVerificationCompleted>
+    | BaseTelemetryEvent<TelemetryEventName.CAPTCHA_UNAVAILABLE, CaptchaUnavailable>
+    | BaseTelemetryEvent<TelemetryEventName.EMAIL_CODE_REQUESTED, EmailCodeRequested>
+    | BaseTelemetryEvent<TelemetryEventName.EMAIL_CODE_VERIFIED, EmailCodeVerified>
+    | BaseTelemetryEvent<TelemetryEventName.EMAIL_CODE_REJECTED, EmailCodeRejected>
+    | BaseTelemetryEvent<TelemetryEventName.EMAIL_CODE_RESEND_REQUESTED, EmailCodeResendRequested>
+    | BaseTelemetryEvent<TelemetryEventName.CREATED_FLOW, FlowCreated>
+    | BaseTelemetryEvent<TelemetryEventName.FLOW_RUN_CREATED, RunCreated>
+    | BaseTelemetryEvent<TelemetryEventName.FLOW_PUBLISHED, FlowPublished>
+    | BaseTelemetryEvent<TelemetryEventName.FLOW_IMPORTED_USING_FILE, FlowImportedUsingFile>
+    | BaseTelemetryEvent<TelemetryEventName.PIECE_SELECTOR_SEARCH, PieceSelectorSearch>
+    | BaseTelemetryEvent<TelemetryEventName.MCP_TOOL_CALLED, McpToolCalled>
+    | BaseTelemetryEvent<TelemetryEventName.MCP_SERVER_CONNECTED, McpServerConnected>


### PR DESCRIPTION
> **Stacked.** Base is `feat/add-setup-observability`. One PR sits above this one and depends on the enum this leaves behind.

## Description

`TelemetryEventName` had 46 members. 26 of them have no emit site anywhere in the tree — nothing constructs the event, and nothing has for a long time. This deletes those 26 along with their payload types and union members, leaving the 20 that are actually captured.

**Why they looked alive.** `packages/core/shared/dist` carries a generated `.d.ts` copy of the whole union, so a plain `grep -rn 'TelemetryEventName.FOO' packages` returns a hit for every name, and a per-symbol hit *count* reads like real usage. Excluding `dist` (and checking that the surviving hits are emit sites rather than the type declaration) is what separates the two sets. I also grepped the raw event strings — `quota.alert`, `key.activated`, `flow.shared`, … — in case anything captured by literal; nothing does.

What went: the referral programme and rewards drawer, the trial-request form, forms analytics, quota and upgrade prompts, flow issues, AI provider configured/used, `user.invited`, `template.search`, `demo.imported`, `chat.page.viewed`, and two superseded search/import names — `pieces.search` (superseded by `piece.selector.search`) and `flow.imported` (the templates dialog fires `flow.imported.using.file`).

**No PostHog impact.** Nothing is renamed and nothing is added — I diffed the name→value pairs, not the lines: 46 → 20 members, zero added, zero value changes on survivors. Deleting a name that is never emitted splits no series and touches no historical data.

`@activepieces/shared` goes to `0.156.0`.

### On the PR size check

`core/shared` is budgeted at 250 meaningful lines and the gate counts deletions, so a 285-line removal trips it at 365. Hence `large-pr-ok` — the diff is a deletion of dead code and reviews far faster than its line count suggests.

## How was this tested?

- Every removed name verified unreferenced outside `packages/core/shared/dist`, by symbol and by raw string.
- `tsc --noEmit` clean on `packages/web`; `packages/server/api` shows only its 3 pre-existing `ee/agent` errors, unchanged by this branch; nothing in `packages/server/worker` references telemetry.
- `turbo run lint --filter=web --filter=@activepieces/shared` — 0 errors.
- `turbo run test --filter=web --filter=@activepieces/shared` — all green.
- Edition-neutral: shared types only, no gating, no runtime behaviour.

### Breaking change?  (required — CI fails if this is left unedited)

- [ ] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [x] yes — functional (default/limit/behaviour change, new self-hosted setup step)

`TelemetryEventName` is an internal enum. It is not an API field, a column, or an env var, and no self-hoster or API consumer imports it — the only consumers are this repo's own capture call sites.

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)
