### PR TITLE
fix(builder): don't crash when a non-array value is stored on an ARRAY property

### DIFF
--- a/packages/web/src/app/builder/piece-properties/array-property.tsx
+++ b/packages/web/src/app/builder/piece-properties/array-property.tsx
@@ -73,15 +73,7 @@ const ArrayPieceProperty = React.memo(
     const form = useFormContext();
 
     const [fields, setFields] = useState<ArrayField[]>(() => {
-      const formValues = form.getValues(inputName);
-      if (formValues) {
-        return formValues.map((value: string | Record<string, unknown>) => ({
-          id: nanoid(),
-          value,
-        }));
-      } else {
-        return [];
-      }
+      return toArrayFields(form.getValues(inputName));
     });
 
     const updateFormValue = (newFields: ArrayField[]) => {
@@ -97,12 +89,8 @@ const ArrayPieceProperty = React.memo(
       const value = arrayProperty.properties
         ? getDefaultValuesForInputs(arrayProperty.properties)
         : '';
-      const formValues = form.getValues(inputName) || [];
       const newFields = [
-        ...formValues.map((value: string | Record<string, unknown>) => ({
-          id: nanoid(),
-          value,
-        })),
+        ...toArrayFields(form.getValues(inputName)),
         { id: nanoid(), value },
       ];
 
@@ -111,12 +99,7 @@ const ArrayPieceProperty = React.memo(
     };
 
     const remove = (index: number) => {
-      const currentFields: ArrayField[] = form
-        .getValues(inputName)
-        .map((value: string | Record<string, unknown>) => ({
-          id: nanoid(),
-          value,
-        }));
+      const currentFields = toArrayFields(form.getValues(inputName));
       const newFields = currentFields.filter((_, i) => i !== index);
       setFields(newFields);
       updateFormValue(newFields);
@@ -216,4 +199,15 @@ const ArrayPieceProperty = React.memo(
 );
 
 ArrayPieceProperty.displayName = 'ArrayPieceProperty';
+
+function toArrayFields(value: unknown): ArrayField[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value.map((item: string | Record<string, unknown>) => ({
+    id: nanoid(),
+    value: item,
+  }));
+}
+
 export { ArrayPieceProperty };


### PR DESCRIPTION
Switching the HTTP piece's Body Type from Raw to Form Data leaves {} stored against an ARRAY property, and ArrayPieceProperty crashed on it, replacing the entire step settings panel with "input value is invalid, please contact support". {} is truthy, so neither if (formValues) nor formValues || [] caught it.

How was this tested?
Reproduced in the builder, then verified the form renders an empty array editor and Add Item works. Targeted eslint clean.
### Breaking change?
- [x] no
- [ ] yes-technical
- [ ] yes-functional

### Security impact?
- [x] no
- [ ] yes-security-sensitive