### PR TITLE
fix(slack): make Message optional on Update / Send-Direct-Message actions (allow blocks-only)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "activepieces",
@@ -8343,7 +8344,7 @@
     },
     "packages/pieces/community/slack": {
       "name": "@activepieces/piece-slack",
-      "version": "0.17.9",
+      "version": "0.17.10",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -8355,6 +8356,7 @@
       },
       "devDependencies": {
         "tslib": "2.6.2",
+        "vitest": "3.2.6",
       },
     },
     "packages/pieces/community/slashed": {

--- a/packages/pieces/community/slack/package.json
+++ b/packages/pieces/community/slack/package.json
@@ -13,11 +13,13 @@
     "@activepieces/core-utils": "workspace:*"
   },
   "devDependencies": {
-    "tslib": "2.6.2"
+    "tslib": "2.6.2",
+    "vitest": "3.2.6"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",
     "bundle": "node ../../../../dist/packages/cli/src/index.js pieces bundle",
-    "lint": "eslint 'src/**/*.ts'"
+    "lint": "eslint 'src/**/*.ts'",
+    "test": "vitest run"
   }
 }

--- a/packages/pieces/community/slack/package.json
+++ b/packages/pieces/community/slack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-slack",
-  "version": "0.17.9",
+  "version": "0.17.10",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "dependencies": {

--- a/packages/pieces/community/slack/src/lib/actions/send-direct-message-action.ts
+++ b/packages/pieces/community/slack/src/lib/actions/send-direct-message-action.ts
@@ -26,12 +26,10 @@ export const slackSendDirectMessageAction = createAction({
   outputSchema: chatPostMessageOutputSchema,
   props: {
     userId: userId(true),
-    // Inline (optional) instead of the shared `text` prop, which is required:true
-    // and reused by the approval/action actions — keep those unchanged.
     text: Property.LongText({
       displayName: 'Message',
       description:
-        'The text of the message. Optional — leave it empty to send a blocks-only DM. When provided alongside Block Kit blocks it renders as a section above them (consistent with Post Message), and is also used as the notification fallback text.',
+        'The text of your message. Renders as a section above any Block Kit blocks, and is used as the notification fallback. Leave empty to send blocks only.',
       required: false,
     }),
     username,
@@ -57,8 +55,6 @@ export const slackSendDirectMessageAction = createAction({
     }
 
     const blockList: (KnownBlock | Block)[] = [];
-    // Build a section from `text` only when provided, so a blocks-only DM is possible.
-    // `text` is also passed as the notification fallback. Consistent with Post Message.
     if (text) {
       blockList.push(...textToSectionBlocks(text));
     }

--- a/packages/pieces/community/slack/src/lib/actions/send-direct-message-action.ts
+++ b/packages/pieces/community/slack/src/lib/actions/send-direct-message-action.ts
@@ -4,7 +4,6 @@ import { slackAuth } from '../auth';
 import { assertNotNullOrUndefined } from '@activepieces/pieces-framework';
 import {
   profilePicture,
-  text,
   userId,
   username,
   blocks,
@@ -27,7 +26,14 @@ export const slackSendDirectMessageAction = createAction({
   outputSchema: chatPostMessageOutputSchema,
   props: {
     userId: userId(true),
-    text,
+    // Inline (optional) instead of the shared `text` prop, which is required:true
+    // and reused by the approval/action actions — keep those unchanged.
+    text: Property.LongText({
+      displayName: 'Message',
+      description:
+        'The text of the message. When Block Kit blocks are provided, this is used only as the notification fallback and is NOT rendered as a section (so it never duplicates your blocks).',
+      required: false,
+    }),
     username,
     profilePicture,
     iconEmoji,
@@ -45,10 +51,17 @@ export const slackSendDirectMessageAction = createAction({
     const { text, userId, blocks, unfurlLinks, mentionOriginFlow } = context.propsValue;
 
     assertNotNullOrUndefined(token, 'token');
-    assertNotNullOrUndefined(text, 'text');
     assertNotNullOrUndefined(userId, 'userId');
+    if (!text && (!blocks || !Array.isArray(blocks) || blocks.length === 0)) {
+      throw new Error('Either Message or Block Kit blocks must be provided');
+    }
 
-    const blockList: (KnownBlock | Block)[] = [...textToSectionBlocks(text)]
+    const blockList: (KnownBlock | Block)[] = [];
+    // Render `text` as a section only when provided; with blocks it's the
+    // notification fallback (no duplicate section) — matching Post/Send Message.
+    if (text) {
+      blockList.push(...textToSectionBlocks(text));
+    }
 
     if(blocks && Array.isArray(blocks)) {
       blockList.push(...(blocks as unknown as (KnownBlock | Block)[]))
@@ -60,7 +73,7 @@ export const slackSendDirectMessageAction = createAction({
 
     return slackSendMessage({
       token,
-      text,
+      text: text || undefined,
       username: context.propsValue.username,
       profilePicture: context.propsValue.profilePicture,
       iconEmoji: context.propsValue.iconEmoji,

--- a/packages/pieces/community/slack/src/lib/actions/send-direct-message-action.ts
+++ b/packages/pieces/community/slack/src/lib/actions/send-direct-message-action.ts
@@ -31,7 +31,7 @@ export const slackSendDirectMessageAction = createAction({
     text: Property.LongText({
       displayName: 'Message',
       description:
-        'The text of the message. When Block Kit blocks are provided, this is used only as the notification fallback and is NOT rendered as a section (so it never duplicates your blocks).',
+        'The text of the message. Optional — leave it empty to send a blocks-only DM. When provided alongside Block Kit blocks it renders as a section above them (consistent with Post Message), and is also used as the notification fallback text.',
       required: false,
     }),
     username,
@@ -57,8 +57,8 @@ export const slackSendDirectMessageAction = createAction({
     }
 
     const blockList: (KnownBlock | Block)[] = [];
-    // Render `text` as a section only when provided; with blocks it's the
-    // notification fallback (no duplicate section) — matching Post/Send Message.
+    // Build a section from `text` only when provided, so a blocks-only DM is possible.
+    // `text` is also passed as the notification fallback. Consistent with Post Message.
     if (text) {
       blockList.push(...textToSectionBlocks(text));
     }

--- a/packages/pieces/community/slack/src/lib/actions/send-direct-message.action.ts
+++ b/packages/pieces/community/slack/src/lib/actions/send-direct-message.action.ts
@@ -29,7 +29,7 @@ export const slackSendDirectMessageAiAction = createAction({
     text: Property.LongText({
       displayName: 'Message',
       description:
-        'The text of the direct message. Optional — leave it empty to send a blocks-only DM. When provided alongside blocks it renders as a section above them (consistent with Post Message), and is also used as the notification fallback text.',
+        'The text of the direct message. Renders as a section above any blocks, and is used as the notification fallback. Leave empty to send blocks only.',
       required: false,
     }),
     unfurlLinks: Property.Checkbox({
@@ -56,8 +56,6 @@ export const slackSendDirectMessageAiAction = createAction({
     }
 
     const blockList: (KnownBlock | Block)[] = [];
-    // Build a section from `text` only when provided, so a blocks-only DM is possible.
-    // `text` is also passed as the notification fallback. Consistent with Post Message.
     if (text) {
       blockList.push(...textToSectionBlocks(text));
     }

--- a/packages/pieces/community/slack/src/lib/actions/send-direct-message.action.ts
+++ b/packages/pieces/community/slack/src/lib/actions/send-direct-message.action.ts
@@ -28,8 +28,9 @@ export const slackSendDirectMessageAiAction = createAction({
     }),
     text: Property.LongText({
       displayName: 'Message',
-      description: 'The text of the direct message.',
-      required: true,
+      description:
+        'The text of the direct message. When blocks are provided, this is used only as the notification fallback and is NOT rendered as a section (so it never duplicates your blocks).',
+      required: false,
     }),
     unfurlLinks: Property.Checkbox({
       displayName: 'Unfurl Links',
@@ -49,17 +50,24 @@ export const slackSendDirectMessageAiAction = createAction({
     const { text, userId, blocks, unfurlLinks } = context.propsValue;
 
     assertNotNullOrUndefined(token, 'token');
-    assertNotNullOrUndefined(text, 'text');
     assertNotNullOrUndefined(userId, 'userId');
+    if (!text && (!blocks || !Array.isArray(blocks) || blocks.length === 0)) {
+      throw new Error('Either Message or Block Kit blocks must be provided');
+    }
 
-    const blockList: (KnownBlock | Block)[] = [...textToSectionBlocks(text)];
+    const blockList: (KnownBlock | Block)[] = [];
+    // Render `text` as a section only when provided; with blocks it's the
+    // notification fallback (no duplicate section) — matching Post/Send Message.
+    if (text) {
+      blockList.push(...textToSectionBlocks(text));
+    }
     if (blocks && Array.isArray(blocks)) {
       blockList.push(...(blocks as unknown as (KnownBlock | Block)[]));
     }
 
     return slackSendMessage({
       token,
-      text,
+      text: text || undefined,
       conversationId: userId,
       blocks: blockList,
       unfurlLinks,

--- a/packages/pieces/community/slack/src/lib/actions/send-direct-message.action.ts
+++ b/packages/pieces/community/slack/src/lib/actions/send-direct-message.action.ts
@@ -29,7 +29,7 @@ export const slackSendDirectMessageAiAction = createAction({
     text: Property.LongText({
       displayName: 'Message',
       description:
-        'The text of the direct message. When blocks are provided, this is used only as the notification fallback and is NOT rendered as a section (so it never duplicates your blocks).',
+        'The text of the direct message. Optional — leave it empty to send a blocks-only DM. When provided alongside blocks it renders as a section above them (consistent with Post Message), and is also used as the notification fallback text.',
       required: false,
     }),
     unfurlLinks: Property.Checkbox({
@@ -56,8 +56,8 @@ export const slackSendDirectMessageAiAction = createAction({
     }
 
     const blockList: (KnownBlock | Block)[] = [];
-    // Render `text` as a section only when provided; with blocks it's the
-    // notification fallback (no duplicate section) — matching Post/Send Message.
+    // Build a section from `text` only when provided, so a blocks-only DM is possible.
+    // `text` is also passed as the notification fallback. Consistent with Post Message.
     if (text) {
       blockList.push(...textToSectionBlocks(text));
     }

--- a/packages/pieces/community/slack/src/lib/actions/update-message.action.ts
+++ b/packages/pieces/community/slack/src/lib/actions/update-message.action.ts
@@ -34,7 +34,7 @@ export const slackUpdateMessageAiAction = createAction({
     text: Property.LongText({
       displayName: 'Message',
       description:
-        'The new text of the message. Optional — leave it empty to send a blocks-only update. When provided alongside blocks it renders as a section above them (consistent with Post Message), and is also used as the notification fallback text.',
+        'The new text of the message. Renders as a section above any blocks, and is used as the notification fallback. Leave empty for a blocks-only update.',
       required: false,
     }),
     blocks: Property.Json({
@@ -54,9 +54,6 @@ export const slackUpdateMessageAiAction = createAction({
 
     const blockList: (KnownBlock | Block)[] = [];
 
-    // Build a section from `text` only when provided, so a blocks-only update is
-    // possible. `text` is also passed as the notification fallback. Consistent with
-    // the Post/Send Message action.
     if (propsValue.text) {
       blockList.push(...textToSectionBlocks(propsValue.text));
     }
@@ -65,7 +62,7 @@ export const slackUpdateMessageAiAction = createAction({
     }
 
     if (blockList.length === 0) {
-      throw new Error('Provide a Message and/or Block Kit blocks to update.');
+      throw new Error('Either Message or Block Kit blocks must be provided');
     }
 
     return await client.chat.update({

--- a/packages/pieces/community/slack/src/lib/actions/update-message.action.ts
+++ b/packages/pieces/community/slack/src/lib/actions/update-message.action.ts
@@ -33,8 +33,9 @@ export const slackUpdateMessageAiAction = createAction({
     }),
     text: Property.LongText({
       displayName: 'Message',
-      description: 'The new text of the message.',
-      required: true,
+      description:
+        'The new text of the message. When blocks are provided, this is used only as the notification fallback and is NOT rendered as a section (so it never duplicates your blocks).',
+      required: false,
     }),
     blocks: Property.Json({
       displayName: 'Block Kit Blocks',
@@ -51,15 +52,26 @@ export const slackUpdateMessageAiAction = createAction({
     }
     const client = new WebClient(getBotToken(auth as SlackAuthValue));
 
-    const blockList: (KnownBlock | Block)[] = [...textToSectionBlocks(propsValue.text)];
+    const blockList: (KnownBlock | Block)[] = [];
+
+    // Render `text` as a section only when provided; when blocks are supplied, `text`
+    // is the notification fallback (not a duplicated section) — consistent with the
+    // Send/Post Message action.
+    if (propsValue.text) {
+      blockList.push(...textToSectionBlocks(propsValue.text));
+    }
     if (propsValue.blocks && Array.isArray(propsValue.blocks) && propsValue.blocks.length > 0) {
       blockList.push(...(propsValue.blocks as unknown as (KnownBlock | Block)[]));
+    }
+
+    if (blockList.length === 0) {
+      throw new Error('Provide a Message and/or Block Kit blocks to update.');
     }
 
     return await client.chat.update({
       channel: propsValue.channel,
       ts: messageTimestamp,
-      text: propsValue.text,
+      text: propsValue.text || undefined,
       blocks: blockList,
     });
   },

--- a/packages/pieces/community/slack/src/lib/actions/update-message.action.ts
+++ b/packages/pieces/community/slack/src/lib/actions/update-message.action.ts
@@ -34,7 +34,7 @@ export const slackUpdateMessageAiAction = createAction({
     text: Property.LongText({
       displayName: 'Message',
       description:
-        'The new text of the message. When blocks are provided, this is used only as the notification fallback and is NOT rendered as a section (so it never duplicates your blocks).',
+        'The new text of the message. Optional — leave it empty to send a blocks-only update. When provided alongside blocks it renders as a section above them (consistent with Post Message), and is also used as the notification fallback text.',
       required: false,
     }),
     blocks: Property.Json({
@@ -54,9 +54,9 @@ export const slackUpdateMessageAiAction = createAction({
 
     const blockList: (KnownBlock | Block)[] = [];
 
-    // Render `text` as a section only when provided; when blocks are supplied, `text`
-    // is the notification fallback (not a duplicated section) — consistent with the
-    // Send/Post Message action.
+    // Build a section from `text` only when provided, so a blocks-only update is
+    // possible. `text` is also passed as the notification fallback. Consistent with
+    // the Post/Send Message action.
     if (propsValue.text) {
       blockList.push(...textToSectionBlocks(propsValue.text));
     }

--- a/packages/pieces/community/slack/src/lib/actions/update-message.ts
+++ b/packages/pieces/community/slack/src/lib/actions/update-message.ts
@@ -32,7 +32,7 @@ export const updateMessage = createAction({
     text: Property.LongText({
       displayName: 'Message',
       description:
-        'The updated text of the message. Optional — leave it empty to send a blocks-only update. When provided alongside Block Kit blocks it renders as a section above them (consistent with Send/Post Message), and is also used as the notification fallback text.',
+        'The updated text of your message. Renders as a section above any Block Kit blocks, and is used as the notification fallback. Leave empty for a blocks-only update.',
       required: false,
     }),
     mentionOriginFlow,
@@ -48,10 +48,6 @@ export const updateMessage = createAction({
 
     const blockList: (KnownBlock | Block)[] = [];
 
-    // Build a section from `text` only when it's provided, so a blocks-only update is
-    // possible (previously `text` was required and always rendered). `text` is also
-    // passed as the notification fallback below. Consistent with the Send/Post Message
-    // action, which likewise render `text` as a section when present.
     if (propsValue.text) {
       blockList.push(...textToSectionBlocks(propsValue.text));
     }
@@ -60,10 +56,8 @@ export const updateMessage = createAction({
       blockList.push(...(propsValue.blocks as unknown as (KnownBlock | Block)[]));
     }
 
-    // Require actual user content (text or blocks) — checked BEFORE the optional
-    // origin-flow footer so that footer alone can't satisfy the requirement.
     if (blockList.length === 0) {
-      throw new Error('Provide a Message and/or Block Kit blocks to update.');
+      throw new Error('Either Message or Block Kit blocks must be provided');
     }
 
     if (propsValue.mentionOriginFlow) {

--- a/packages/pieces/community/slack/src/lib/actions/update-message.ts
+++ b/packages/pieces/community/slack/src/lib/actions/update-message.ts
@@ -31,8 +31,9 @@ export const updateMessage = createAction({
     }),
     text: Property.LongText({
       displayName: 'Message',
-      description: 'The updated text of your message',
-      required: true,
+      description:
+        'The updated text of the message. When Block Kit blocks are provided, this is used only as the notification fallback and is NOT rendered as a section (so it never duplicates your blocks).',
+      required: false,
     }),
     mentionOriginFlow,
     blocks,
@@ -45,7 +46,15 @@ export const updateMessage = createAction({
     }
     const client = new WebClient(getBotToken(auth as SlackAuthValue));
 
-    const blockList: (KnownBlock | Block)[] = [...textToSectionBlocks(propsValue.text)];
+    const blockList: (KnownBlock | Block)[] = [];
+
+    // Only render `text` as a section when it's actually provided. When the caller
+    // supplies `blocks`, `text` is used solely as the notification fallback (standard
+    // Slack semantics) instead of being duplicated as a section on top of the blocks —
+    // matching the Send/Post Message action.
+    if (propsValue.text) {
+      blockList.push(...textToSectionBlocks(propsValue.text));
+    }
 
     if (propsValue.blocks && Array.isArray(propsValue.blocks) && propsValue.blocks.length > 0) {
       blockList.push(...(propsValue.blocks as unknown as (KnownBlock | Block)[]));
@@ -55,10 +64,14 @@ export const updateMessage = createAction({
       blockList.push(buildFlowOriginContextBlock(context));
     }
 
+    if (blockList.length === 0) {
+      throw new Error('Provide a Message and/or Block Kit blocks to update.');
+    }
+
     return await client.chat.update({
       channel: propsValue.channel,
       ts: messageTimestamp,
-      text: propsValue.text,
+      text: propsValue.text || undefined,
       blocks: blockList,
     });
   },

--- a/packages/pieces/community/slack/src/lib/actions/update-message.ts
+++ b/packages/pieces/community/slack/src/lib/actions/update-message.ts
@@ -32,7 +32,7 @@ export const updateMessage = createAction({
     text: Property.LongText({
       displayName: 'Message',
       description:
-        'The updated text of the message. When Block Kit blocks are provided, this is used only as the notification fallback and is NOT rendered as a section (so it never duplicates your blocks).',
+        'The updated text of the message. Optional — leave it empty to send a blocks-only update. When provided alongside Block Kit blocks it renders as a section above them (consistent with Send/Post Message), and is also used as the notification fallback text.',
       required: false,
     }),
     mentionOriginFlow,
@@ -48,10 +48,10 @@ export const updateMessage = createAction({
 
     const blockList: (KnownBlock | Block)[] = [];
 
-    // Only render `text` as a section when it's actually provided. When the caller
-    // supplies `blocks`, `text` is used solely as the notification fallback (standard
-    // Slack semantics) instead of being duplicated as a section on top of the blocks —
-    // matching the Send/Post Message action.
+    // Build a section from `text` only when it's provided, so a blocks-only update is
+    // possible (previously `text` was required and always rendered). `text` is also
+    // passed as the notification fallback below. Consistent with the Send/Post Message
+    // action, which likewise render `text` as a section when present.
     if (propsValue.text) {
       blockList.push(...textToSectionBlocks(propsValue.text));
     }
@@ -60,12 +60,14 @@ export const updateMessage = createAction({
       blockList.push(...(propsValue.blocks as unknown as (KnownBlock | Block)[]));
     }
 
-    if (propsValue.mentionOriginFlow) {
-      blockList.push(buildFlowOriginContextBlock(context));
-    }
-
+    // Require actual user content (text or blocks) — checked BEFORE the optional
+    // origin-flow footer so that footer alone can't satisfy the requirement.
     if (blockList.length === 0) {
       throw new Error('Provide a Message and/or Block Kit blocks to update.');
+    }
+
+    if (propsValue.mentionOriginFlow) {
+      blockList.push(buildFlowOriginContextBlock(context));
     }
 
     return await client.chat.update({

--- a/packages/pieces/community/slack/test/blocks-only.test.ts
+++ b/packages/pieces/community/slack/test/blocks-only.test.ts
@@ -1,0 +1,177 @@
+import { AppConnectionType } from '@activepieces/pieces-framework';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const sent: Record<string, unknown>[] = [];
+
+vi.mock('@slack/web-api', () => ({
+  WebClient: class {
+    chat = {
+      postMessage: async (args: Record<string, unknown>) => {
+        sent.push(args);
+        return { ok: true };
+      },
+      update: async (args: Record<string, unknown>) => {
+        sent.push(args);
+        return { ok: true };
+      },
+    };
+    conversations = {
+      open: async () => ({ ok: true, channel: { id: 'D0123ABCD' } }),
+    };
+    files = {
+      uploadV2: async (args: Record<string, unknown>) => {
+        sent.push(args);
+        return { ok: true };
+      },
+    };
+  },
+}));
+
+const { updateMessage } = await import('../src/lib/actions/update-message');
+const { slackUpdateMessageAiAction } = await import(
+  '../src/lib/actions/update-message.action'
+);
+const { slackSendDirectMessageAction } = await import(
+  '../src/lib/actions/send-direct-message-action'
+);
+const { slackSendDirectMessageAiAction } = await import(
+  '../src/lib/actions/send-direct-message.action'
+);
+
+const CONTEXT_BLOCK = {
+  type: 'context',
+  elements: [{ type: 'mrkdwn', text: 'build 42 passed' }],
+};
+
+const auth = {
+  type: AppConnectionType.CUSTOM_AUTH,
+  props: { botToken: 'xoxb-test' },
+};
+
+function ctx(propsValue: Record<string, unknown>) {
+  return {
+    auth,
+    propsValue,
+    server: { publicUrl: 'https://cloud.activepieces.com/api/' },
+    project: { id: 'proj_1' },
+    flows: { current: { id: 'flow_1' } },
+  };
+}
+
+const lastCall = () => sent[sent.length - 1];
+
+beforeEach(() => {
+  sent.length = 0;
+});
+
+const updateBase = { channel: 'C0123ABCD', ts: '1710304378.475129' };
+
+describe.each([
+  {
+    name: 'Update message (updateMessage)',
+    run: (props: Record<string, unknown>) =>
+      updateMessage.run(ctx({ ...updateBase, ...props })),
+    guard: /Either Message or Block Kit blocks must be provided/,
+  },
+  {
+    name: 'Update Message AI (slack_update_message)',
+    run: (props: Record<string, unknown>) =>
+      slackUpdateMessageAiAction.run(ctx({ ...updateBase, ...props })),
+    guard: /Either Message or Block Kit blocks must be provided/,
+  },
+  {
+    name: 'Send Message To A User (send_direct_message)',
+    run: (props: Record<string, unknown>) =>
+      slackSendDirectMessageAction.run(ctx({ userId: 'U0123ABCD', ...props })),
+    guard: /Either Message or Block Kit blocks must be provided/,
+  },
+  {
+    name: 'Send Direct Message AI (slack_send_direct_message)',
+    run: (props: Record<string, unknown>) =>
+      slackSendDirectMessageAiAction.run(ctx({ userId: 'U0123ABCD', ...props })),
+    guard: /Either Message or Block Kit blocks must be provided/,
+  },
+])('$name', ({ run, guard }) => {
+  it('sends blocks only, with no section pushed above them', async () => {
+    await run({ blocks: [CONTEXT_BLOCK] });
+
+    expect(lastCall().blocks).toEqual([CONTEXT_BLOCK]);
+    expect(lastCall().text).toBeUndefined();
+  });
+
+  it('treats an empty Message the same as an absent one', async () => {
+    await run({ text: '', blocks: [CONTEXT_BLOCK] });
+
+    expect(lastCall().blocks).toEqual([CONTEXT_BLOCK]);
+    expect(lastCall().text).toBeUndefined();
+  });
+
+  it('still renders Message as a section above the blocks when provided', async () => {
+    await run({ text: 'deploy finished', blocks: [CONTEXT_BLOCK] });
+
+    expect(lastCall().blocks).toEqual([
+      { type: 'section', text: { type: 'mrkdwn', text: 'deploy finished' } },
+      CONTEXT_BLOCK,
+    ]);
+    expect(lastCall().text).toBe('deploy finished');
+  });
+
+  it('sends Message alone as a section when no blocks are given', async () => {
+    await run({ text: 'deploy finished' });
+
+    expect(lastCall().blocks).toEqual([
+      { type: 'section', text: { type: 'mrkdwn', text: 'deploy finished' } },
+    ]);
+    expect(lastCall().text).toBe('deploy finished');
+  });
+
+  it('rejects when neither Message nor blocks are provided', async () => {
+    await expect(run({})).rejects.toThrow(guard);
+    expect(sent).toHaveLength(0);
+  });
+
+  it('rejects when Message is empty and blocks is an empty array', async () => {
+    await expect(run({ text: '', blocks: [] })).rejects.toThrow(guard);
+    expect(sent).toHaveLength(0);
+  });
+});
+
+describe('mentionOriginFlow footer', () => {
+  it('appends the footer below a blocks-only update', async () => {
+    await updateMessage.run(
+      ctx({ ...updateBase, blocks: [CONTEXT_BLOCK], mentionOriginFlow: true })
+    );
+
+    const blocks = lastCall().blocks as { type: string }[];
+    expect(blocks).toHaveLength(2);
+    expect(blocks[0]).toEqual(CONTEXT_BLOCK);
+    expect(blocks[1].type).toBe('context');
+  });
+
+  it('cannot satisfy the content requirement on its own', async () => {
+    await expect(
+      updateMessage.run(ctx({ ...updateBase, mentionOriginFlow: true }))
+    ).rejects.toThrow(/Either Message or Block Kit blocks must be provided/);
+    expect(sent).toHaveLength(0);
+  });
+
+  it('appends the footer below a blocks-only DM', async () => {
+    await slackSendDirectMessageAction.run(
+      ctx({ userId: 'U0123ABCD', blocks: [CONTEXT_BLOCK], mentionOriginFlow: true })
+    );
+
+    const blocks = lastCall().blocks as { type: string }[];
+    expect(blocks).toHaveLength(2);
+    expect(blocks[0]).toEqual(CONTEXT_BLOCK);
+    expect(blocks[1].type).toBe('context');
+  });
+
+  it('cannot satisfy the content requirement on its own for a DM', async () => {
+    await expect(
+      slackSendDirectMessageAction.run(
+        ctx({ userId: 'U0123ABCD', mentionOriginFlow: true })
+      )
+    ).rejects.toThrow(/Either Message or Block Kit blocks must be provided/);
+    expect(sent).toHaveLength(0);
+  });
+});

--- a/packages/pieces/community/slack/vitest.config.ts
+++ b/packages/pieces/community/slack/vitest.config.ts
@@ -1,0 +1,17 @@
+import path from 'path'
+import { defineConfig } from 'vitest/config'
+
+const repoRoot = path.resolve(__dirname, '../../../..')
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+  },
+  resolve: {
+    alias: {
+      '@activepieces/pieces-framework': path.resolve(repoRoot, 'packages/pieces/framework/src/index.ts'),
+      '@activepieces/pieces-common': path.resolve(repoRoot, 'packages/pieces/common/src/index.ts'),
+    },
+  },
+})


### PR DESCRIPTION
## Problem

**Update Message** (`updateMessage`, AI `slack_update_message`) and **Send Message To A User** (`send_direct_message`, AI `slack_send_direct_message`) mark **Message** (`text`) as **required** and always render it as a section block. So you can't send a **blocks-only** message (e.g. a single context block), and a required text field forces a section even when your content is already in `blocks`.

`Post Message` / `Send Message To A Channel` already handle this: `text` is optional and only rendered as a section when present (also serving as the notification fallback). This PR brings the Update / Direct-Message actions in line.

## Change

- Make **Message** optional on the four actions above.
- Build a section from `text` **only when it's provided** (so blocks-only works); `text` is still passed as the notification fallback.
- Require **text or blocks** (can't update/send truly empty).
- `piece-slack` patch bump 0.17.9 → 0.17.10.

Behavior is otherwise unchanged and consistent with Post/Send Message: if you provide **both** `text` and `blocks`, `text` renders as a section above the blocks (that's opt-in, same as the channel actions). To send blocks-only, leave **Message** empty.

Out of scope: `request_action_*` / `request_approval_*` (they build their own buttons and take no user `blocks`).

### Breaking change?
- [ ] Yes
- [x] No

### Security impact?
- [ ] Yes
- [x] No
