### PR TITLE
fix(engine): user-caused run-callback failures no longer show as internal errors

### DIFF
--- a/packages/core/utils/src/lib/activepieces-error.ts
+++ b/packages/core/utils/src/lib/activepieces-error.ts
@@ -49,6 +49,7 @@ export type ApErrorParams =
     | TriggerUpdateStatusErrorParams
     | TriggerFailedErrorParams
     | ValidationErrorParams
+    | FileTooLargeErrorParams
     | InvitationOnlySignUpParams
     | UserIsInActiveErrorParams
     | UserNotFoundOnPlatformErrorParams
@@ -316,6 +317,14 @@ ErrorCode.VALIDATION,
 }
 >
 
+export type FileTooLargeErrorParams = BaseErrorParams<
+ErrorCode.FILE_TOO_LARGE,
+{
+    message: string
+    maxBytes: number
+}
+>
+
 export type TriggerUpdateStatusErrorParams = BaseErrorParams<
 ErrorCode.TRIGGER_UPDATE_STATUS,
 {
@@ -567,6 +576,7 @@ export enum ErrorCode {
     USER_IS_INACTIVE = 'USER_IS_INACTIVE',
     USER_NOT_FOUND_ON_PLATFORM = 'USER_NOT_FOUND_ON_PLATFORM',
     VALIDATION = 'VALIDATION',
+    FILE_TOO_LARGE = 'FILE_TOO_LARGE',
     INVALID_LICENSE_KEY = 'INVALID_LICENSE_KEY',
     EMAIL_ALREADY_HAS_ACTIVATION_KEY = 'EMAIL_ALREADY_HAS_ACTIVATION_KEY',
     INVALID_SMTP_CREDENTIALS = 'INVALID_SMTP_CREDENTIALS',

--- a/packages/server/api/src/app/file/files-service.ts
+++ b/packages/server/api/src/app/file/files-service.ts
@@ -37,8 +37,11 @@ export const filesService = {
 
 export function fileTooLargeError(maxBytes: number): ActivepiecesError {
     return new ActivepiecesError({
-        code: ErrorCode.VALIDATION,
-        params: { message: `File exceeds the maximum allowed size of ${maxBytes} bytes` },
+        code: ErrorCode.FILE_TOO_LARGE,
+        params: {
+            message: `File exceeds the maximum allowed size of ${maxBytes} bytes`,
+            maxBytes,
+        },
     })
 }
 

--- a/packages/server/api/src/app/helper/error-handler.ts
+++ b/packages/server/api/src/app/helper/error-handler.ts
@@ -103,6 +103,7 @@ const statusCodeMap: Partial<Record<ErrorCode, StatusCodes>> = {
     [ErrorCode.INVALID_GIT_CREDENTIALS]: StatusCodes.BAD_REQUEST,
     [ErrorCode.INVALID_OTP]: StatusCodes.GONE,
     [ErrorCode.VALIDATION]: StatusCodes.CONFLICT,
+    [ErrorCode.FILE_TOO_LARGE]: StatusCodes.REQUEST_TOO_LONG,
     [ErrorCode.INVITATION_ONLY_SIGN_UP]: StatusCodes.FORBIDDEN,
     [ErrorCode.AUTHENTICATION]: StatusCodes.UNAUTHORIZED,
     [ErrorCode.INVALID_LICENSE_KEY]: StatusCodes.BAD_REQUEST,

--- a/packages/server/engine/src/lib/api/engine-file-api.ts
+++ b/packages/server/engine/src/lib/api/engine-file-api.ts
@@ -1,6 +1,6 @@
 import { promisify } from 'node:util'
 import { zstdDecompress as zstdDecompressCallback } from 'node:zlib'
-import { EngineFileNotFoundError, EngineGenericError, FileCompression, FileType, isZstdCompressed } from '@activepieces/shared'
+import { EngineFileNotFoundError, EngineGenericError, ExecutionError, ExecutionErrorType, FileCompression, FileType, isZstdCompressed } from '@activepieces/shared'
 import { retryFetch } from './retry-fetch'
 
 const zstdDecompress = promisify(zstdDecompressCallback)
@@ -83,6 +83,14 @@ export const engineFileApi = {
 
 async function resolveUploadReadUrl(fileId: string, response: Response): Promise<UploadResult> {
     if (!response.ok) {
+        if (response.status === 413) {
+            const serverMessage = await readErrorMessage(response)
+            throw new ExecutionError(
+                'EngineFileTooLarge',
+                JSON.stringify({ message: serverMessage ?? `File ${fileId} exceeds the server's size limit` }),
+                ExecutionErrorType.USER,
+            )
+        }
         throw new EngineGenericError(
             'EngineFileUploadError',
             `Failed to upload engine file ${fileId}: ${response.status} ${response.statusText}`,
@@ -101,6 +109,16 @@ async function resolveUploadReadUrl(fileId: string, response: Response): Promise
 
 function toRequestBody(data: Uint8Array): BodyInit {
     return data.buffer instanceof ArrayBuffer ? new Uint8Array(data.buffer, data.byteOffset, data.byteLength) : new Uint8Array(data)
+}
+
+async function readErrorMessage(response: Response): Promise<string | undefined> {
+    try {
+        const body = await response.json() as { params?: { message?: unknown } }
+        return typeof body?.params?.message === 'string' ? body.params.message : undefined
+    }
+    catch {
+        return undefined
+    }
 }
 
 function buildPutHeaders({ type, fileName, compression, contentLength }: BuildHeadersParams): Record<string, string> {

--- a/packages/server/engine/src/lib/handler/base-executor.ts
+++ b/packages/server/engine/src/lib/handler/base-executor.ts
@@ -12,7 +12,7 @@ export async function failStep({ action, executionState, stepOutput, error, dura
         status: FlowRunStatus.FAILED,
         failedStep: {
             name: action.name,
-            displayName: action.displayName,
+            displayName: action.displayName ?? action.name,
             message,
         },
     })

--- a/packages/server/engine/src/lib/handler/flow-executor.ts
+++ b/packages/server/engine/src/lib/handler/flow-executor.ts
@@ -181,7 +181,7 @@ const applyLogSizeLimitIfExceeded = async (
         status: FlowRunStatus.LOG_SIZE_EXCEEDED,
         failedStep: {
             name: action.name,
-            displayName: action.displayName,
+            displayName: action.displayName ?? action.name,
             message: 'Flow run logs size exceeded',
         },
     })

--- a/packages/server/engine/src/lib/handler/piece-executor.ts
+++ b/packages/server/engine/src/lib/handler/piece-executor.ts
@@ -1,4 +1,4 @@
-import { ActivepiecesError, ErrorCode, isNil } from '@activepieces/core-utils'
+import { ActivepiecesError, ErrorCode, isNil, isObject } from '@activepieces/core-utils'
 import { PiecePropertyMap, StaticPropsValue } from '@activepieces/pieces-framework'
 import { EngineGenericError, ExecutionType, FlowActionType, FlowRunStatus, GenericStepOutput, PieceAction, RespondResponse, StepOutputStatus } from '@activepieces/shared'
 import { engineRunApi } from '../api/engine-run-api'
@@ -100,7 +100,7 @@ const executeAction: ActionHandler<PieceAction> = async ({ action, executionStat
                     runResponse: {
                         status: webhookResponse.status ?? 200,
                         body: webhookResponse.body ?? {},
-                        headers: webhookResponse.headers ?? {},
+                        headers: isObject(webhookResponse.headers) ? webhookResponse.headers : {},
                     },
                 },
             })

--- a/packages/server/engine/src/lib/operations/flow.operation.ts
+++ b/packages/server/engine/src/lib/operations/flow.operation.ts
@@ -150,7 +150,7 @@ async function buildFailedTriggerContext({ input, baseContext, error }: BuildFai
         status: FlowRunStatus.FAILED,
         failedStep: {
             name: trigger.name,
-            displayName: trigger.displayName,
+            displayName: trigger.displayName ?? trigger.name,
             message,
         },
     })


### PR DESCRIPTION
## Summary

Three deterministic bad payloads to `/v1/engine/{run-logs, flow-response}` and one to `PUT /v1/files` were all wrapping into `EngineGenericError → INTERNAL_ERROR → failed queue job → 3× BullMQ retry` — even though every retry hit the same 400/409, and each shape traced to user data, not an engine bug. Diagnosed via a categorization pass over `workerJobs` failed set + ClickHouse response bodies for the actual 400s.

### Bug 1 — run-logs 400: `body/failedStep/displayName Invalid input: expected string, received undefined`

14 identical 400s from ClickHouse today, all on one flow. Cause: a legacy flow_version with a step or trigger whose `displayName` predates the field being required. The engine writes `failedStep.displayName = action.displayName` verbatim at three sites; when it's undefined, the server's Zod schema rejects.

**Fix**: coerce `displayName ?? name` at `base-executor.ts:15`, `flow-executor.ts:184`, `flow.operation.ts:161`. `name` is always present (STEP_NAME_REGEX enforced), so it's a lossless fallback.

### Bug 2 — flow-response 400: `body/runResponse/headers Invalid input: expected record, received string`

3 identical 400s, all one flow. A `return_response` piece produced `headers` as a stringified JSON blob instead of an object; the engine forwarded it verbatim. Server's Zod (`z.record(z.string(), z.coerce.string())`) rejects.

**Fix**: at `piece-executor.ts:103`, drop non-object headers before forwarding: `isObject(webhookResponse.headers) ? webhookResponse.headers : {}`. The webhook still returns a valid response — just without the piece's malformed headers.

### Bug 3 — file upload 409 (was really "too large")

The 19 file-upload failures from the earlier snapshot (now aged out) all had shape `EngineFileUploadError: 409 Conflict`. Traced in code, not data: `fileTooLargeError` throws `ErrorCode.VALIDATION` which `error-handler.ts` maps to 409, so an oversized run log surfaces to the engine as a generic 409 with no way to distinguish it from other validation cases — and no way to know it's user-caused.

**Fix**: split fileTooLarge off from VALIDATION.

- New `ErrorCode.FILE_TOO_LARGE` with `{ message, maxBytes }` params
- `error-handler.ts`: `FILE_TOO_LARGE → 413 Payload Too Large`
- Engine's `resolveUploadReadUrl` on 413: read `params.message` from the server's response and throw a USER-typed `ExecutionError` with it. The existing engine machinery routes USER errors to FAILED runs (not INTERNAL_ERROR), so the flow_run shows the actual limit in the UI and the queue job completes instead of being retried three times.

Every other non-2xx path stays ENGINE-typed. This is deliberately not a blanket "4xx → USER" rewrite — that would launder real engine bugs (like Bug 1 and Bug 2 were).

## Test plan

- [ ] Local: run a flow with a step whose `displayName` is undefined; confirm run fails cleanly with `name` shown as the label, no queue-job failure.
- [ ] Local: a `return_response` piece that stringifies its headers; confirm the webhook returns with empty headers and the run succeeds.
- [ ] Local: upload a run log exceeding `AP_MAX_FILE_SIZE_MB`; confirm 413 body carries `code: FILE_TOO_LARGE` + `maxBytes`, and the flow_run status is `FAILED` (not `INTERNAL_ERROR`) with the size message.
- [ ] Post-merge on cloud: check the `workerJobs` failed set stops growing on the three shapes tracked in ClickHouse (`run-logs 400 displayName`, `flow-response 400 headers`, `PUT files 413`).

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

`FILE_TOO_LARGE` is a new ErrorCode (additive), and the status code change (409 → 413) is on an engine-only endpoint whose only consumer is the engine itself, updated atomically here.

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)