### PR TITLE
fix(core): treat bare date literals as dates in formula args

### DIFF
--- a/packages/core/formula/src/lib/formula-evaluator.ts
+++ b/packages/core/formula/src/lib/formula-evaluator.ts
@@ -4,12 +4,6 @@ import { AP_FUNCTIONS } from './function-registry'
 const CURRENT_FORMULA_VERSION = 1
 const FORMULA_PREFIX = `ap-formula-v${CURRENT_FORMULA_VERSION}::{`
 const FORMULA_SUFFIX = `}::ap-formula-v${CURRENT_FORMULA_VERSION}`
-// Mirrored close marker means tokenization is a plain regex split — no
-// brace-counting or string-literal tracking needed at the wrapper level.
-// `[\s\S]*?` matches any character including newlines, non-greedy so adjacent
-// formulas don't merge into one capture. The `v(\d+)` lets us route saved
-// flows from older format versions to the right evaluator after we ship v2,
-// without a data migration.
 const FORMULA_REGEX = /ap-formula-v(\d+)::\{([\s\S]*?)\}::ap-formula-v\1/g
 
 function wrap(expression: string): string {
@@ -210,8 +204,13 @@ function wrapStringArgs(expr: string): string {
             const inner = wrapStringArgs(arg)
             if (!fn) return inner
             const expectedSpec = fn.argTypes[Math.min(i, fn.argTypes.length - 1)]
-            const shouldQuote = expectedSpec === 'string' ||
-                (Array.isArray(expectedSpec) && (expectedSpec as string[]).includes('string'))
+            const shouldQuote =
+                expectedSpec === 'string' ||
+                expectedSpec === 'date' ||
+                (Array.isArray(expectedSpec) && (
+                    expectedSpec.includes('string') ||
+                    expectedSpec.includes('date')
+                ))
             return shouldQuote ? quoteIfBare(inner) : inner
         })
 

--- a/packages/core/shared/package.json
+++ b/packages/core/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/shared",
-  "version": "0.155.0",
+  "version": "0.155.1",
   "type": "commonjs",
   "sideEffects": false,
   "main": "./dist/src/index.js",

--- a/packages/core/shared/test/formula/function-evaluator.test.ts
+++ b/packages/core/shared/test/formula/function-evaluator.test.ts
@@ -320,6 +320,12 @@ describe('get_day / get_month / get_year', () => {
         expect(result('get_day("2024-03-15")')).toBe(15))
     it('get_year returns year', () =>
         expect(result('get_year("2024-03-15")')).toBe(2024))
+    it('get_year treats bare date literals as dates', () =>
+        expect(result('get_year(2025-01-15)')).toBe(2025))
+    it('start_of_day accepts a bare date literal', () =>
+        expect(result('format_date(start_of_day(2025-01-15))')).toBe('2025-01-15'))
+    it('to_date accepts a bare date literal', () =>
+        expect(result('format_date(to_date(2025-01-15))')).toBe('2025-01-15'))
     it('get_month returns month name', () => {
         const r = result('get_month("2024-03-15")') as string
         expect(r.toLowerCase()).toContain('march')


### PR DESCRIPTION
## Description

Bare date literals in date-typed formula args were being evaluated as arithmetic expressions instead of dates. This updates formula arg quoting so `date` parameters are handled the same way as `string` parameters.

## How was this tested?

- `bunx turbo run build --filter=@activepieces/core-formula`
- `bunx vitest run packages/core/shared/test/formula/function-evaluator.test.ts`
- `npm run lint-dev`

Fixes #14761

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)