### PR TITLE
fix(dev): make the piece dev loop work on Windows

### DIFF
--- a/packages/server/api/src/app/pieces/dev-piece-watcher.ts
+++ b/packages/server/api/src/app/pieces/dev-piece-watcher.ts
@@ -145,7 +145,7 @@ function spawnAndWait(cmd: string, args: string[]): Promise<void> {
         const child = spawn(cmd, args, {
             cwd: process.cwd(),
             stdio: 'inherit',
-            shell: false,
+            shell: process.platform === 'win32',
         })
         child.on('close', (code) => {
             if (code === 0) {

--- a/packages/server/engine/src/lib/core/piece/piece-child.ts
+++ b/packages/server/engine/src/lib/core/piece/piece-child.ts
@@ -1,3 +1,4 @@
+import { pathToFileURL } from 'node:url'
 import { isNil, isObject } from '@activepieces/core-utils'
 import { Piece } from '@activepieces/pieces-framework'
 import { extractPieceFromModule } from '@activepieces/shared'
@@ -37,7 +38,7 @@ async function handleParentMessage(message: ParentMessage): Promise<void> {
 }
 
 async function loadPiece({ piecePath, pieceName, pieceVersion }: { piecePath: string, pieceName: string, pieceVersion: string }): Promise<Piece> {
-    const pieceModule = await import(piecePath)
+    const pieceModule = await import(pathToFileURL(piecePath).href)
     return extractPieceFromModule<Piece>({ module: pieceModule, pieceName, pieceVersion })
 }
 

--- a/packages/server/sandbox/src/lib/cache/engine/engine-installer.ts
+++ b/packages/server/sandbox/src/lib/cache/engine/engine-installer.ts
@@ -11,6 +11,8 @@ import { SandboxSettings } from '../../types'
 const engineDistPath = 'dist/packages/engine'
 const engineBundles = ['main.js', 'piece-child.js']
 const installedPaths = new Map<string, Promise<void>>()
+const renameRetryDelaysMs = [25, 50, 100, 200, 400]
+const contendedRenameCodes = ['EPERM', 'EACCES', 'EBUSY']
 
 export const engineInstaller = (_log: ApLogger, getSettings: () => SandboxSettings) => ({
     async install({ path }: InstallParams): Promise<EngineInstallResult> {
@@ -33,21 +35,61 @@ export const engineInstaller = (_log: ApLogger, getSettings: () => SandboxSettin
 
 async function copyEngine({ path }: CopyEngineParams): Promise<void> {
     for (const bundle of engineBundles) {
-        await atomicCopy(`${engineDistPath}/${bundle}`, `${path}/${bundle}`)
-        await atomicCopy(`${engineDistPath}/${bundle}.map`, `${path}/${bundle}.map`)
+        await atomicCopy({ src: `${engineDistPath}/${bundle}`, dest: `${path}/${bundle}` })
+        await atomicCopy({ src: `${engineDistPath}/${bundle}.map`, dest: `${path}/${bundle}.map` })
     }
 }
 
-async function atomicCopy(src: PathLike, dest: PathLike): Promise<void> {
+async function atomicCopy({ src, dest }: AtomicCopyParams): Promise<void> {
     const destDir = dirname(dest.toString())
     const tempPath = join(destDir, `engine.temp.${nanoid()}.js`)
     await fileSystemUtils.threadSafeMkdir(destDir)
     await copyFile(src, tempPath)
+    const { error } = await tryCatch(() => renameWithRetry({ tempPath, dest }))
+    if (isNil(error)) {
+        return
+    }
+    await tryCatch(() => fileSystemUtils.deleteFile(tempPath))
+    const destAlreadyInstalled = isContendedRenameError(error) && await fileSystemUtils.fileExists(dest.toString())
+    if (!destAlreadyInstalled) {
+        throw error
+    }
+}
+
+async function renameWithRetry({ tempPath, dest }: RenameWithRetryParams): Promise<void> {
+    for (const delayMs of renameRetryDelaysMs) {
+        const { error } = await tryCatch(() => rename(tempPath, dest))
+        if (isNil(error)) {
+            return
+        }
+        if (!isContendedRenameError(error)) {
+            throw error
+        }
+        await delay(delayMs)
+    }
     await rename(tempPath, dest)
+}
+
+function isContendedRenameError(error: Error): boolean {
+    return 'code' in error && contendedRenameCodes.includes(String(error.code))
+}
+
+function delay(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms))
 }
 
 type CopyEngineParams = {
     path: string
+}
+
+type AtomicCopyParams = {
+    src: PathLike
+    dest: PathLike
+}
+
+type RenameWithRetryParams = {
+    tempPath: string
+    dest: PathLike
 }
 
 type InstallParams = {

--- a/packages/server/sandbox/src/lib/cache/engine/engine-installer.ts
+++ b/packages/server/sandbox/src/lib/cache/engine/engine-installer.ts
@@ -1,5 +1,5 @@
 import { PathLike } from 'fs'
-import { copyFile, rename } from 'node:fs/promises'
+import { copyFile, readFile, rename } from 'node:fs/promises'
 import { dirname, join } from 'node:path'
 import { isNil, tryCatch } from '@activepieces/core-utils'
 import { fileSystemUtils } from '@activepieces/server-utils'
@@ -50,10 +50,19 @@ async function atomicCopy({ src, dest }: AtomicCopyParams): Promise<void> {
         return
     }
     await tryCatch(() => fileSystemUtils.deleteFile(tempPath))
-    const destAlreadyInstalled = isContendedRenameError(error) && await fileSystemUtils.fileExists(dest.toString())
-    if (!destAlreadyInstalled) {
+    const destMatchesSource = isContendedRenameError(error) && await hasSameContent({ src, dest })
+    if (!destMatchesSource) {
         throw error
     }
+}
+
+async function hasSameContent({ src, dest }: HasSameContentParams): Promise<boolean> {
+    const { data, error } = await tryCatch(() => Promise.all([readFile(src), readFile(dest)]))
+    if (!isNil(error) || isNil(data)) {
+        return false
+    }
+    const [srcContent, destContent] = data
+    return srcContent.equals(destContent)
 }
 
 async function renameWithRetry({ tempPath, dest }: RenameWithRetryParams): Promise<void> {
@@ -89,6 +98,11 @@ type AtomicCopyParams = {
 
 type RenameWithRetryParams = {
     tempPath: string
+    dest: PathLike
+}
+
+type HasSameContentParams = {
+    src: PathLike
     dest: PathLike
 }
 


### PR DESCRIPTION
## Description

Three POSIX-only assumptions made local piece development unusable on Windows. Each fix is platform-neutral and changes nothing on Linux or macOS.

**Engine installer — `EPERM` on `rename`.** The installer copied engine bundles into place with `rename()`. POSIX replaces an open file atomically; Windows throws `EPERM` when the destination is held by a running sandbox. Two property lookups firing at once raced each other, so one sandbox install died and its dropdown crashed while the other succeeded — producing an inconsistent "Unexpected error, please retry" on one field and a correct empty state on its identical sibling. The rename now retries a contended destination with backoff, and treats a destination another installer has already written as success.

**Piece loader — `ERR_UNSUPPORTED_ESM_URL_SCHEME`.** `loadPiece` passed a raw absolute path to a dynamic `import()`. Windows rejects this because `C:` parses as a protocol, so *every* dynamic-property evaluation failed. It now converts through `pathToFileURL`, which is correct on all platforms.

**Dev piece watcher — `spawn npx ENOENT`.** The watcher spawned `npx` with `shell: false`. On Windows `npx` is `npx.cmd`, which `spawn` cannot resolve without a shell, so every rebuild failed. Because `invalidateDevPieceCache()` runs *after* the build inside the same `try` block, the failure meant the cache was never invalidated — so piece edits silently never reached the builder. Piece hot-reload has therefore never worked on Windows; it fails quietly and serves stale metadata indefinitely.

## How was this tested?

Manually, on Windows 11 with `AP_DEV_PIECES` set, against a dev server running CE.

All three failures were reproduced from logs before the fix and confirmed resolved after:
- `EPERM: operation not permitted, rename '...engine.temp.*.js' -> '...piece-child.js'` at `engine-installer.ts:46` — 28 occurrences in a single session, all on `EXECUTE_PROPERTY` jobs. Zero after.
- `Building 1 piece(s): google-sheets... / Failed to run build process...` looping on `spawn npx ENOENT`. After the fix the watcher completes and logs `Changes are ready!`, and edited piece metadata reaches the builder without an API restart.
- Dynamic-property evaluation now succeeds instead of failing on the import scheme.

`@activepieces/sandbox`, `@activepieces/engine` and `@activepieces/server-api` all compile.

**Not tested on Linux or macOS.** All three changes are no-ops there by construction — `shell: process.platform === 'win32'` is false, `pathToFileURL` is the documented correct form for dynamic import on every platform, and the rename retry only engages on `EPERM`/`EACCES`/`EBUSY`, which POSIX does not raise for this operation. Worth a reviewer's eye on that reasoning rather than my word.

Only the CE path was exercised; this code is edition-independent.

Fixes # (issue)

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)
