### PR TITLE
fix(deps): bump deepmerge-ts to 8.0.2 in the workspace that imports it

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -162,14 +162,13 @@
     },
     "packages/core/shared": {
       "name": "@activepieces/shared",
-      "version": "0.153.0",
+      "version": "0.155.1",
       "dependencies": {
         "@activepieces/core-execution": "workspace:*",
         "@activepieces/core-formula": "workspace:*",
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
         "dayjs": "1.11.9",
-        "deepmerge-ts": "7.1.0",
         "expr-eval": "2.0.2",
         "ipaddr.js": "2.3.0",
         "nanoid": "3.3.17",
@@ -189,7 +188,7 @@
       "name": "@activepieces/core-utils",
       "version": "0.6.1",
       "dependencies": {
-        "deepmerge-ts": "7.1.0",
+        "deepmerge-ts": "8.0.2",
         "ipaddr.js": "2.3.0",
         "nanoid": "3.3.17",
         "tslib": "2.6.2",
@@ -2316,7 +2315,7 @@
     },
     "packages/pieces/community/cryptolens": {
       "name": "@activepieces/piece-cryptolens",
-      "version": "0.0.8",
+      "version": "0.1.0",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -4323,7 +4322,7 @@
     },
     "packages/pieces/community/hugging-face": {
       "name": "@activepieces/piece-hugging-face",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -10228,7 +10227,7 @@
     },
     "packages/pieces/core/crypto": {
       "name": "@activepieces/piece-crypto",
-      "version": "0.0.27",
+      "version": "0.0.28",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -15204,7 +15203,7 @@
 
     "deepmerge": ["deepmerge@4.3.1", "", {}, "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A=="],
 
-    "deepmerge-ts": ["deepmerge-ts@7.1.0", "", {}, "sha512-q6bNsfNBtgr8ZOQqmZbl94MmYWm+QcDNIkqCxVWiw1vKvf+y/N2dZQKdnDXn4c5Ygt/y63tDof6OCN+2YwWVEg=="],
+    "deepmerge-ts": ["deepmerge-ts@8.0.2", "", {}, "sha512-uqbvqLUMrc6p0MO+WBRtTxY55hmyh94WRwI5a++PZe54X+bfVh59FSN7uWCBCW1CCVjzjnrwzfI8zidE2obMMw=="],
 
     "default-browser": ["default-browser@5.5.0", "", { "dependencies": { "bundle-name": "^4.1.0", "default-browser-id": "^5.0.0" } }, "sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw=="],
 

--- a/packages/core/shared/package.json
+++ b/packages/core/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/shared",
-  "version": "0.155.0",
+  "version": "0.155.1",
   "type": "commonjs",
   "sideEffects": false,
   "main": "./dist/src/index.js",
@@ -11,7 +11,6 @@
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*",
     "dayjs": "1.11.9",
-    "deepmerge-ts": "7.1.0",
     "expr-eval": "2.0.2",
     "ipaddr.js": "2.3.0",
     "nanoid": "3.3.17",

--- a/packages/core/utils/package.json
+++ b/packages/core/utils/package.json
@@ -9,7 +9,7 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "deepmerge-ts": "7.1.0",
+    "deepmerge-ts": "8.0.2",
     "ipaddr.js": "2.3.0",
     "nanoid": "3.3.17",
     "tslib": "2.6.2",


### PR DESCRIPTION
## Description

Resolves [GHSA-ggr8-5vv4-36mx](https://github.com/advisories/GHSA-ggr8-5vv4-36mx) (high) — `deepmerge-ts < 8.0.0` exhausts the call stack when merging deeply recursive or circular object graphs. Two Dependabot alerts were open for it, #1116 (`packages/core/utils`) and #1117 (`packages/core/shared`).

Supersedes #14907, which bumped only `packages/core/shared` and left the lockfile untouched.

**Bumps the workspace that actually imports the library.** The vulnerable call is `deepMergeAndCast` in `packages/core/utils/src/lib/utils.ts`, so `packages/core/utils` goes `7.1.0` → `8.0.2`.

**Drops the declaration from `packages/core/shared` rather than bumping it.** Nothing under `packages/core/shared/src` imports `deepmerge-ts` — it was a phantom dependency. Removing it closes alert #1117 without carrying a dependency the package does not use. `@activepieces/shared` gets a patch bump (`0.155.0` → `0.155.1`) per the repo convention.

**Takes 8.0.2, not 8.0.0.** `8.0.1` adds TypeScript 7 support and `8.0.2` corrects the `engines.node` declaration to `>=16.9.0`.

**Regenerates `bun.lock` in the same commit.** `bun install --frozen-lockfile` fails on a dependency-spec change the lockfile has not seen, which would have broken the Docker build (`Dockerfile`, `Dockerfile.worker`) and both the canary and release pipelines. `ci.yml` uses a plain `bun install`, so CI alone would not have caught it. The lockfile diff also picks up four version drifts already present on `main` (`@activepieces/shared` recorded as `0.153.0`, plus `piece-cryptolens`, `piece-hugging-face`, `piece-crypto`); these are left as `bun install` generated them rather than hand-edited. They are inert — `main` passes `--frozen-lockfile` despite them, because bun's frozen check enforces dependency specs but not workspace `version` fields.

### Why v8 is safe here

Diffing `7.1.0` against `8.0.2` across 14 merge scenarios shaped like this repo's call sites, exactly one behavioural difference shows up: **Map values are now deep-merged instead of replaced.** It cannot reach us — every `deepMergeAndCast` call site passes plain object literals or `JSON.parse` output, with no Maps, Sets or circular references. Array concatenation, `undefined`/`null` handling, and scalar-vs-object precedence are all unchanged.

The other v8 breaking changes are inapplicable: `deepmergeInto` is unused, and the `DeepMergeMetaMetaData` / `DeepMergeIntoFunctionUtils` / `MM`→`MI` type renames are unused. Module format is unchanged (`type: module` with dual `import`/`require` exports in both versions), so there is no CJS break.

## How was this tested?

| Check | Result |
| --- | --- |
| `bun install --frozen-lockfile` | pass — the gate #14907 fails |
| `turbo run build` (`core-utils`, `shared` + 3 dependents) | 5/5 |
| `tsc --noEmit` on `web` | clean |
| `turbo run lint` (`core-utils`, `shared`, `web`) | 0 errors |
| `npm run test-unit` | `shared` 498, `core-utils` 28, `core-execution` 135, `server-utils` 169, `pieces-framework` 15, `web` — all pass |

Confirmed the fix takes effect at runtime rather than just on paper: `packages/core/utils/node_modules/deepmerge-ts` resolves `8.0.2`, and the advisory repro (merging two 20,000-deep graphs, and merging circular objects) run through `core-utils`' own resolution succeeds where `7.1.0` threw `RangeError: Maximum call stack size exceeded`. `packages/core/shared` no longer links the package at all.

Still to do before merge — a manual smoke of the only two code paths that reach `deepMergeAndCast`, since both are frontend-only and not covered by tests:

- [ ] Builder → add a step of each type (Code, Loop, Router, piece action, piece trigger) — defaults populate, step is valid (`piece-selector-utils.ts`)
- [ ] Code step → Dependencies → add a package — merges into `packageJson` rather than replacing `dependencies` (`code-editor.tsx`)

No migration, no env var, no edition-gated surface, so CE / EE / Cloud behave identically here.

Fixes GHSA-ggr8-5vv4-36mx (Dependabot alerts #1116 and #1117)

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

- [ ] no — reviewed, no security impact
- [x] yes — security-sensitive (call out the risk and mitigation in the description above)

<!-- Risk: unbounded recursion in a merge helper (DoS / stack exhaustion). Mitigation: upgrade to a version with circular-reference handling and a maxDepth bound. Reachability is low — both call sites are in the web frontend, so the worst case is a self-inflicted browser tab crash, not a server outage. -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
