### PR TITLE
docs(agents): creating, placing and moving an agent

### DIFF
--- a/docs/about/changelog.mdx
+++ b/docs/about/changelog.mdx
@@ -4,6 +4,45 @@ description: "A log of all notable changes to Activepieces"
 icon: "code-commit"
 ---
 
+<Update label="September 2026" description="Agents: Reusable, Chattable, and Yours to Place">
+
+### Agents you can keep, talk to, and put where they belong
+
+An agent used to be a bag of settings inside one flow step. Now it is something you
+name, brief, talk to, and reuse.
+
+**Build one from a sentence**
+
+- **Describe the job**: the Agents page opens with a prompt box. Write *"summarise my
+  unread emails every morning"* and you get a drafted agent — a name, instructions, and
+  the tools it needs from the apps you have already connected. See
+  [Create an agent](/agents/create).
+- **It only reaches for what you asked for**: the draft picks actions that read your data,
+  and adds one that sends, posts or files only when the sentence asks for it.
+- **Edit with AI**: describe a change in the editor — *"only reply to paying customers"* —
+  and the instructions and tools are rewritten for you. Edits stay a draft until you press
+  **Save and go live**, and going live updates every flow already using the agent on its
+  next run, with nothing to republish.
+
+**Where an agent lives**
+
+- **Choose the project up front**: new agents no longer land wherever you happened to be.
+  The prompt box names the project and lets you change it, because the project decides
+  which connections, flows and files the agent can reach.
+- **Move one later**: with a preview of what it costs first — the apps that have no
+  connection in the new project, the people who lose a share, and the fact that tools which
+  keep working now use the new project's accounts. See
+  [Manage an agent](/agents/manage).
+- **Deleting is honest about consequences**: an agent still running inside a published flow
+  cannot be deleted or moved, and the flows are named so you know where to look.
+
+**Finding them**
+
+- The Agents page spans every project you can read, with search, sorting and a project
+  filter answered by the server, so a long list stays complete and fast.
+
+</Update>
+
 <Update label="August 2026" description="AI-Ready Pieces: Tool Search, AI Metadata & Audience">
 
 ### AI-ready pieces: tool search, AI metadata, and audience

--- a/docs/agents/create.mdx
+++ b/docs/agents/create.mdx
@@ -5,25 +5,34 @@ description: "The three routes in, and what each setting is for"
 icon: "pen"
 ---
 
-## Pick a starting point
+## Describe the job
 
-<CardGroup cols={3}>
+The **Agents** page opens with a prompt box. Write the job in a sentence and the agent is written for you: a name, instructions, and the tools it needs from the apps you have already connected.
+
+<CardGroup cols={2}>
   <Card title="Describe it" icon="wand-magic-sparkles" color="#8143E3">
-    Say what you need in a sentence.
+    *"Summarise my unread emails every morning."* You get a drafted agent to review.
   </Card>
-  <Card title="Use a template" icon="copy" color="#F59E0B">
-    Start from one already written.
-  </Card>
-  <Card title="Start blank" icon="file" color="#0EA5E9">
-    Write the instructions yourself.
+  <Card title="Start from a suggestion" icon="copy" color="#F59E0B">
+    The chips under the box — triage support tickets, research a company, enrich a lead — are the same route with the sentence written.
   </Card>
 </CardGroup>
 
-The prompt box sits at the top of the Agents page. Templates and blank are behind **New agent**. All three land in the same editor, and all three need an [AI provider connected](/admin-guide/guides/setup-ai-providers).
+Drafting needs an [AI provider connected](/admin-guide/guides/setup-ai-providers) and turned on for chat. Without one the page says so and offers to write the agent by hand instead.
+
+<Tip>
+Ask for what you want done, not for the tools. The draft only picks an action that reads your data unless the sentence asks for something to be sent, posted or filed, so *"tell me when something changes"* gets an agent that reports, not one that emails.
+</Tip>
+
+## Choose where it lives
+
+Under the prompt box, **New agents go to** names the project the agent will belong to, and lets you change it before you create it. That matters because the project is the boundary: an agent reaches only its own project's connections, flows, tables and knowledge.
+
+If you have one project, there is nothing to choose and the control stays out of the way. See [managing an agent](/agents/manage) for moving one later.
 
 ## Set it up
 
-The **Configure** tab holds everything that changes what the agent does.
+The **Configure** panel beside the conversation holds everything that changes what the agent does.
 
 <CardGroup cols={1}>
   <Card title="Instructions" icon="pen-line" color="#8143E3" horizontal>
@@ -46,9 +55,20 @@ The **Configure** tab holds everything that changes what the agent does.
   </Card>
 </CardGroup>
 
-## Try it
+## Try it, then put it live
 
-The editor has a conversation panel beside the configuration. Talk to the agent there, watch which tools it reaches for, and adjust the instructions until it behaves. Changes take effect as soon as you save.
+The editor has two tabs beside the Configure panel.
+
+<CardGroup cols={2}>
+  <Card title="Edit with AI" icon="wand-magic-sparkles" color="#8143E3">
+    Describe a change — *"only reply to paying customers"* — and it rewrites the instructions and tools for you.
+  </Card>
+  <Card title="Test" icon="flask" color="#0EA5E9">
+    Talk to the agent as it is now, and watch which tools it reaches for.
+  </Card>
+</CardGroup>
+
+Edits are a draft until you press **Save and go live**. The header says which state you are in: *Changes not live yet* while you are editing, *Live* once saved, and *Needs a model to run* if no model is picked. Going live updates every flow already using the agent on its next run, with nothing to republish.
 
 <Tip>
 Brief it like a capable new colleague. Say the goal and the edges, not every keystroke. The two people forget most: what "done" looks like, and which calls it should hand back to a human.

--- a/docs/agents/manage.mdx
+++ b/docs/agents/manage.mdx
@@ -1,0 +1,48 @@
+---
+title: "Manage an agent"
+sidebarTitle: "Manage an agent"
+description: "Where an agent lives, how to move it, and how to delete it safely"
+icon: "folder-tree"
+---
+
+## The project is the boundary
+
+An agent belongs to one project, and that decides what it can reach: the connections it authenticates with, the flows it can call, the tables and files it looks things up in. Two projects with the same Gmail connection name are two different mailboxes.
+
+The **Agents** page spans every project you can see, so the card tells you which project each agent belongs to. Use the project filter beside the search box to narrow the list, and new agents then go to that project.
+
+## Move it to another project
+
+From the `...` menu on a card, or from **Project** in the agent's own Advanced section, pick **Move to another project**.
+
+The agent takes its instructions, tools and conversations with it. Before you confirm, the dialog says what the move costs:
+
+<CardGroup cols={1}>
+  <Card title="Tools that stop working" icon="plug-circle-xmark" color="#F59E0B" horizontal>
+    A pinned connection is matched by name in the new project. Anything without a counterpart there stops working until you connect it, and the same is true for a flow or a file the new project does not have.
+  </Card>
+  <Card title="Accounts change under it" icon="right-left" color="#0EA5E9" horizontal>
+    Tools that keep working now use the new project's accounts. Moving an agent between two clients points it at the second client's data.
+  </Card>
+  <Card title="People who lose access" icon="user-minus" color="#EC4899" horizontal>
+    An agent shared with someone who is not in the new project loses that share, and moving it back does not restore it.
+  </Card>
+</CardGroup>
+
+Two things refuse the move outright: a **published flow still running the agent**, because the reference is live and that flow would break, and a project you cannot create agents in.
+
+<Note>
+Only the person who created the agent, or a project admin, can move or delete it. Everyone else in the project can use and edit it.
+</Note>
+
+## Delete it
+
+**Delete** sits in the same `...` menu, and in a danger zone at the bottom of the agent's Advanced section.
+
+Deleting is permanent: the instructions, the tools and every conversation held with the agent go with it. A draft flow step pointing at the agent will break, and the dialog says so.
+
+If a **published flow** still runs the agent, deleting is refused and the flows are named. Take the agent out of those flows first.
+
+## Who can see it
+
+An agent is visible to everyone in its project by default. Restrict it to yourself and named colleagues from the pencil beside its icon; a restricted agent shows a lock next to its name in the list.

--- a/docs/agents/manage.mdx
+++ b/docs/agents/manage.mdx
@@ -9,7 +9,7 @@ icon: "folder-tree"
 
 An agent belongs to one project, and that decides what it can reach: the connections it authenticates with, the flows it can call, the tables and files it looks things up in. Two projects with the same Gmail connection name are two different mailboxes.
 
-The **Agents** page spans every project you can see, so the card tells you which project each agent belongs to. Use the project filter beside the search box to narrow the list, and new agents then go to that project.
+The **Agents** page spans every project you can see, so the card tells you which project each agent belongs to. The project filter beside the search box narrows the list, and it also moves the destination under the prompt box to that project. Whatever you pick in **New agents go to** wins, so check that line before you create anything.
 
 ## Move it to another project
 
@@ -45,4 +45,8 @@ If a **published flow** still runs the agent, deleting is refused and the flows 
 
 ## Who can see it
 
-An agent is visible to everyone in its project by default. Restrict it to yourself and named colleagues from the pencil beside its icon; a restricted agent shows a lock next to its name in the list.
+An agent is visible to everyone in its project. A restricted agent, shared with you and named colleagues instead, shows a lock beside its name in the list.
+
+<Note>
+There is no screen for restricting an agent yet. Visibility is set through the API, with `visibility` and `sharedWithUserIds` on the agent create and update calls, and only the creator or a project admin can change who can see one. Everyone you share it with has to be a member of its project already, and a [move](#move-it-to-another-project) drops the shares that do not hold in the new project.
+</Note>

--- a/docs/agents/overview.mdx
+++ b/docs/agents/overview.mdx
@@ -41,3 +41,7 @@ Each time it runs, it reads the situation, decides which tools to use, and keeps
     Say what you need and the agent gets written for you.
   </Card>
 </CardGroup>
+
+## Where an agent lives
+
+An agent belongs to one project, and that decides which connections, flows and files it can reach. You choose the project when you create it, and you can [move it later](/agents/manage) — the dialog tells you what a move would break before you confirm.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -109,6 +109,7 @@
                   "pages": [
                      "agents/overview",
                      "agents/create",
+                     "agents/manage",
                      "agents/tools",
                      "agents/knowledge",
                      "agents/in-flows"


### PR DESCRIPTION
## Description

The Agents documentation described a surface that has changed twice since it was written, and it was missing the half people are most likely to get wrong. This corrects it and adds that half.

**`create.mdx` was stale.** It described templates and a blank agent behind a **New agent** button, and a **Configure** tab. There is no such button — the page opens with a prompt box and suggestion chips — and Configure is a panel beside two tabs, Edit with AI and Test. It also said "changes take effect as soon as you save" without saying that edits are a draft until **Save and go live**, which is the thing people actually need to know, along with what the header states mean.

**`manage.mdx` is new**, covering what nothing documented:

- the project is the boundary that decides which connections, flows, tables and files an agent can reach
- choosing that project when you create the agent, and the project filter on the list
- moving an agent later, and what the preview warns about first: tools that stop working, accounts changing under it, and people who lose a share and do not get it back
- deleting one, and why a published flow refuses both deleting and moving
- who may do it — creator or project admin

**A September changelog entry** for the whole arc: drafting from a sentence, Edit with AI, the draft-then-go-live model, choosing and changing the project, and the server-side list.

No product code changes.

## How was this tested?

- `docs.json` parses and the new page is in the Agents group, in reading order after Create
- Every claim checked against the shipped UI rather than the plan: the composer and its project chip, the two editor tabs, the header's *Live* / *Changes not live yet* / *Needs a model to run* states, the move dialog's three warnings and its two refusals, the delete danger zone, and the lock on a restricted agent's name
- Grepped the sibling pages for the same stale references (`New agent`, `Configure tab`, "conversation panel") and found none left

Fixes # (issue)

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)
