### PR TITLE
fix(e2e): give the sign-in fixture a budget it can finish in

### DIFF
--- a/packages/tests-e2e/checkly.config.ts
+++ b/packages/tests-e2e/checkly.config.ts
@@ -32,6 +32,9 @@ const config = defineConfig({
     alertEscalationPolicy: AlertEscalationBuilder.runBasedEscalation(1),
     /* Global configuration option for Playwright-powered checks. See https://www.checklyhq.com/docs/browser-checks/playwright-test/#global-configuration */
     playwrightConfig: {
+      /* Checkly does not read playwright.config.ts, so the per-test budget has to be repeated here.
+       * Signing in happens in a fixture, so the 30s default leaves nothing for the test's own assertions. */
+      timeout: 120000,
       use: {
         baseURL: 'https://cloud.activepieces.com',
         viewport: { width: 1280, height: 720 },

--- a/packages/tests-e2e/pages/authentication.page.ts
+++ b/packages/tests-e2e/pages/authentication.page.ts
@@ -1,6 +1,8 @@
 import { BasePage } from './base';
 import { faker } from '@faker-js/faker';
 
+const AUTH_STEP_TIMEOUT = 20000;
+
 export class AuthenticationPage extends BasePage {
   url = `/sign-in`;
   signUpUrl = `/sign-up`;
@@ -60,13 +62,13 @@ export class AuthenticationPage extends BasePage {
     const nameField = this.page.getByTestId('auth-full-name');
 
     const nameStepShown = nameField
-      .waitFor({ timeout: 30000 })
+      .waitFor({ timeout: AUTH_STEP_TIMEOUT })
       .catch(() => undefined);
     const leftOnboarding = this.page
       .waitForURL(
         (url) =>
           !ONBOARDING_PATHS.some((path) => url.pathname.startsWith(path)),
-        { timeout: 30000 },
+        { timeout: AUTH_STEP_TIMEOUT },
       )
       .catch(() => undefined);
     await Promise.race([nameStepShown, leftOnboarding]);
@@ -92,7 +94,7 @@ export class AuthenticationPage extends BasePage {
     await this.passwordFormField()
       .or(usePasswordLink)
       .first()
-      .waitFor({ timeout: 30000 });
+      .waitFor({ timeout: AUTH_STEP_TIMEOUT });
 
     if (await usePasswordLink.count()) {
       await usePasswordLink.first().click();

--- a/packages/tests-e2e/playwright.config.ts
+++ b/packages/tests-e2e/playwright.config.ts
@@ -24,6 +24,8 @@ const editionConfig = editionConfigs[AP_EDITION as keyof typeof editionConfigs];
 const config: PlaywrightTestConfig = {
   testDir: editionConfig.testDir,
   testMatch: '**/*.spec.ts',
+  /* Signing in happens in a fixture, so a test needs more than the 30s default to reach its own assertions */
+  timeout: 120000,
   /* Run tests in files in parallel */
   fullyParallel: true,
   /* Fail the build on CI if you accidentally left test.only in the source code. */


### PR DESCRIPTION
## Description

The e2e sign-in fixture was given waits equal to the whole test budget, so it could never finish one if it was actually needed.

Neither `playwright.config.ts` nor `checkly.config.ts` set a per-test `timeout`, so Playwright's 30s default applied — and `pages/authentication.page.ts` waited `30000ms` on the login screen. Signing in happens in the `page` fixture, so when the login screen changed and a wait was genuinely exercised, the fixture consumed the test's entire time in `Before Hooks`, the spec's own assertions never ran, and the reported error was whichever locator the clock stopped on rather than the step that stalled. That is why the Checkly failure read as `waiting for getByTestId('sign-in-email')` — a locator one click deeper than the screen the run was actually stuck on.

- both configs now set a 120s per-test timeout. Checkly does not read `playwright.config.ts`, so the value is repeated in `checkly.config.ts`, where `timeout` is a supported `playwrightConfig` key (verified against `checkly@6.9.10`'s own types).
- the auth steps wait 20s via a named `AUTH_STEP_TIMEOUT`, comfortably inside the budget, so a slow login screen fails as the step that stalled with the test's assertions still ahead of it.

**No locator changes.** `openPasswordForm()` already drives the current card correctly (#14868), and it deliberately clicks `auth-use-password` *only when that button exists*: Cloud opens on the email step with the password form one click deeper, while the SMTP-less instance CI boots renders the password form immediately and has no such button. An unconditional click passes on Cloud and hangs the full timeout in CI.

Worth knowing separately from this PR: the Checkly monitors run a hand-made check in a project called `E2E (undefined)` that reports *Never deployed* / `Drifted`, so nothing merged to `main` has ever reached them. That needs a `checkly deploy` and a deploy-on-merge workflow; this PR only makes the suite itself sound.

## How was this tested?

- `tsc --noEmit` on both changed TypeScript files — clean.
- `eslint` on both — clean, no new warnings.
- Confirmed `timeout` is a valid `playwrightConfig` key by reading `checkly/dist/constructs/playwright-config.d.ts` in the pinned `checkly@6.9.10`, rather than assuming it from the docs.
- Not run against Cloud: `npx checkly test` needs `CHECKLY_API_KEY` / `CHECKLY_ACCOUNT_ID` / `E2E_EMAIL` / `E2E_PASSWORD`, which I do not have. **Reviewer should run it before merging**, since that is also the first real signal about whether the webhook assertion itself passes on Cloud — it has not executed in over two weeks.

Fixes # (issue)

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)
