### PR TITLE
fix(agents): agents ask before they send, post or delete

### DIFF
--- a/packages/core/execution/src/lib/engine/rpc.ts
+++ b/packages/core/execution/src/lib/engine/rpc.ts
@@ -97,8 +97,14 @@ export function apErrorOf(error: unknown): RpcApError | undefined {
     if (!isObject(source) || typeof source['code'] !== 'string') {
         return undefined
     }
-    const entityType = (isObject(source['params']) ? source['params'] : source)['entityType']
-    return { code: source['code'], ...spreadIfNotUndefined('entityType', typeof entityType === 'string' ? entityType : undefined) }
+    const params = isObject(source['params']) ? source['params'] : source
+    const entityType = params['entityType']
+    const message = params['message']
+    return {
+        code: source['code'],
+        ...spreadIfNotUndefined('entityType', typeof entityType === 'string' ? entityType : undefined),
+        ...spreadIfNotUndefined('message', typeof message === 'string' ? message : undefined),
+    }
 }
 
 function isRpcErrorEnvelope(value: unknown): value is { __rpcError: string, __rpcApError?: unknown } {
@@ -110,6 +116,7 @@ export type RpcTimeout = number | ((method: string) => number)
 export type RpcApError = {
     code: string
     entityType?: string
+    message?: string
 }
 
 type RpcLog = {

--- a/packages/core/execution/src/lib/workers/worker-contract.ts
+++ b/packages/core/execution/src/lib/workers/worker-contract.ts
@@ -94,6 +94,7 @@ export type WorkerToApiContract = {
     executeAgentTool(input: ExecuteAgentToolRequest): Promise<ExecuteAgentToolResponse>
     resumeFlowStep(input: ResumeFlowStepRequest): Promise<void>
     updateFlowStepProgress(input: UpdateFlowStepProgressRequest): Promise<void>
+    preparePieceTool(input: PreparePieceToolRequest): Promise<PreparePieceToolResponse>
     executePieceTool(input: ExecutePieceToolRequest): Promise<ExecutePieceToolResponse>
     executeKnowledgeBaseTool(input: ExecuteKnowledgeBaseToolRequest): Promise<ExecuteKnowledgeBaseToolResponse>
     executeFlowTool(input: ExecuteFlowToolRequest): Promise<ExecuteFlowToolResponse>
@@ -216,10 +217,25 @@ export type ExecuteAgentToolRequest = {
     conversationId?: string
 }
 
+export type PreparePieceToolRequest = {
+    conversationId: string
+    toolName: string
+    instruction: string
+    preparedId: string
+    provider?: AIProviderName
+    providerConfigId?: string
+    piece: AgentPieceToolMetadata
+}
+
+export type PreparePieceToolResponse = {
+    input: Record<string, unknown>
+}
+
 export type ExecutePieceToolRequest = {
     conversationId: string
     toolName: string
     instruction: string
+    preparedId?: string
     provider?: AIProviderName
     providerConfigId?: string
     piece: AgentPieceToolMetadata

--- a/packages/core/execution/src/lib/workers/worker-contract.ts
+++ b/packages/core/execution/src/lib/workers/worker-contract.ts
@@ -226,6 +226,7 @@ export type PreparePieceToolResponse = {
     input: Record<string, unknown>
     actionDisplayName: string
     needsApproval: boolean
+    connectionLabel?: string
 }
 
 export type ExecutePieceToolRequest = {

--- a/packages/core/execution/src/lib/workers/worker-contract.ts
+++ b/packages/core/execution/src/lib/workers/worker-contract.ts
@@ -217,18 +217,15 @@ export type ExecuteAgentToolRequest = {
     conversationId?: string
 }
 
-export type PreparePieceToolRequest = {
-    conversationId: string
-    toolName: string
-    instruction: string
+export type PreparePieceToolRequest = Omit<ExecutePieceToolRequest, 'preparedId'> & {
     preparedId: string
-    provider?: AIProviderName
-    providerConfigId?: string
-    piece: AgentPieceToolMetadata
+    tainted: boolean
 }
 
 export type PreparePieceToolResponse = {
     input: Record<string, unknown>
+    actionDisplayName: string
+    needsApproval: boolean
 }
 
 export type ExecutePieceToolRequest = {

--- a/packages/core/execution/src/lib/workers/worker-contract.ts
+++ b/packages/core/execution/src/lib/workers/worker-contract.ts
@@ -385,6 +385,7 @@ export type SendPersonalizationProgressRequest = {
 }
 
 export const LONG_RUNNING_RPC_METHODS: readonly string[] = [
+    'preparePieceTool',
     'executePieceTool',
     'executeFlowTool',
     'executeKnowledgeBaseTool',

--- a/packages/core/execution/test/workers/long-running-rpc.test.ts
+++ b/packages/core/execution/test/workers/long-running-rpc.test.ts
@@ -1,0 +1,8 @@
+import { describe, expect, it } from 'vitest'
+import { LONG_RUNNING_RPC_METHODS } from '../../src/lib/workers/worker-contract'
+
+describe('which RPC methods are given the long deadline', () => {
+    it.each(['preparePieceTool', 'executePieceTool', 'executeFlowTool', 'executeKnowledgeBaseTool', 'executeAgentTool'])('gives %s the long deadline', (method) => {
+        expect(LONG_RUNNING_RPC_METHODS).toContain(method)
+    })
+})

--- a/packages/core/shared/package.json
+++ b/packages/core/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/shared",
-  "version": "0.155.0",
+  "version": "0.156.0",
   "type": "commonjs",
   "sideEffects": false,
   "main": "./dist/src/index.js",

--- a/packages/core/shared/package.json
+++ b/packages/core/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/shared",
-  "version": "0.156.0",
+  "version": "0.157.0",
   "type": "commonjs",
   "sideEffects": false,
   "main": "./dist/src/index.js",

--- a/packages/core/shared/src/lib/ee/agent/tool-classification.ts
+++ b/packages/core/shared/src/lib/ee/agent/tool-classification.ts
@@ -57,23 +57,6 @@ function isReadOnlyActionCall({ actionName, input }: { actionName: string, input
     return false
 }
 
-// A tool the author configured on the agent is pre-authorised in the sense that someone chose it,
-// but choosing Gmail's send action is not the same as approving a particular email. Ask when the
-// action writes and somebody is there to answer; never ask on an unattended run, where nobody is.
-function configuredToolNeedsApproval({ actionName, attended, tainted }: {
-    actionName: string
-    attended: boolean
-    tainted?: boolean
-}): boolean {
-    if (!attended) {
-        return false
-    }
-    if (isWriteActionName(actionName)) {
-        return true
-    }
-    return tainted === true && !isReadActionName(actionName)
-}
-
 function isWriteActionName(actionName: string): boolean {
     return actionNameMatchesPatterns({ actionName, patterns: WRITE_ACTION_PATTERNS })
 }
@@ -90,7 +73,6 @@ export const agentToolClassification = {
     isReadActionName,
     isReadOnlyActionCall,
     isWriteActionName,
-    configuredToolNeedsApproval,
     readOnlyRejection,
     hasFailureTextPrefix,
 }

--- a/packages/core/shared/src/lib/ee/agent/tool-classification.ts
+++ b/packages/core/shared/src/lib/ee/agent/tool-classification.ts
@@ -57,6 +57,23 @@ function isReadOnlyActionCall({ actionName, input }: { actionName: string, input
     return false
 }
 
+// A tool the author configured on the agent is pre-authorised in the sense that someone chose it,
+// but choosing Gmail's send action is not the same as approving a particular email. Ask when the
+// action writes and somebody is there to answer; never ask on an unattended run, where nobody is.
+function configuredToolNeedsApproval({ actionName, attended, tainted }: {
+    actionName: string
+    attended: boolean
+    tainted?: boolean
+}): boolean {
+    if (!attended) {
+        return false
+    }
+    if (isWriteActionName(actionName)) {
+        return true
+    }
+    return tainted === true && !isReadActionName(actionName)
+}
+
 function isWriteActionName(actionName: string): boolean {
     return actionNameMatchesPatterns({ actionName, patterns: WRITE_ACTION_PATTERNS })
 }
@@ -73,6 +90,7 @@ export const agentToolClassification = {
     isReadActionName,
     isReadOnlyActionCall,
     isWriteActionName,
+    configuredToolNeedsApproval,
     readOnlyRejection,
     hasFailureTextPrefix,
 }

--- a/packages/core/shared/test/ee/agent-tool-classification.test.ts
+++ b/packages/core/shared/test/ee/agent-tool-classification.test.ts
@@ -101,22 +101,21 @@ describe('agentToolClassification.requiresActionPreview — taint (untrusted con
     })
 })
 
-describe('agentToolClassification.configuredToolNeedsApproval', () => {
-    it('asks before a write when someone is there to answer', () => {
-        expect(agentToolClassification.configuredToolNeedsApproval({ actionName: 'send_email', attended: true })).toBe(true)
-        expect(agentToolClassification.configuredToolNeedsApproval({ actionName: 'delete_email', attended: true })).toBe(true)
+describe('agentToolClassification.requiresActionPreview: an action whose name proves nothing', () => {
+    const UNMATCHED_WRITES = ['refund_payment', 'capture_payment_intent', 'cancel_subscription', 'add_row_to_sheet', 'upload_file', 'deactivate_user', 'archive_email', 'run_workflow']
+
+    it.each(UNMATCHED_WRITES)('asks before %s, which carries no write verb in its name', (actionName) => {
+        expect(agentToolClassification.requiresActionPreview({ actionName })).toBe(true)
     })
 
-    it('never asks on an unattended run, because nobody can answer', () => {
-        expect(agentToolClassification.configuredToolNeedsApproval({ actionName: 'send_email', attended: false })).toBe(false)
+    it('asks before a custom api call that is not a provably safe method', () => {
+        expect(agentToolClassification.requiresActionPreview({ actionName: 'custom_api_call', input: { method: 'DELETE' } })).toBe(true)
+        expect(agentToolClassification.requiresActionPreview({ actionName: 'custom_api_call', input: {} })).toBe(true)
     })
 
-    it('lets a read through without asking', () => {
-        expect(agentToolClassification.configuredToolNeedsApproval({ actionName: 'gmail_search_mail', attended: true })).toBe(false)
-    })
-
-    it('asks about anything unproven once the turn has read untrusted content', () => {
-        expect(agentToolClassification.configuredToolNeedsApproval({ actionName: 'run_report', attended: true, tainted: true })).toBe(true)
-        expect(agentToolClassification.configuredToolNeedsApproval({ actionName: 'gmail_search_mail', attended: true, tainted: true })).toBe(false)
+    it('still lets a read through, so the asking stays worth reading', () => {
+        expect(agentToolClassification.requiresActionPreview({ actionName: 'gmail_search_mail' })).toBe(false)
+        expect(agentToolClassification.requiresActionPreview({ actionName: 'get_row' })).toBe(false)
+        expect(agentToolClassification.requiresActionPreview({ actionName: 'custom_api_call', input: { method: 'GET' } })).toBe(false)
     })
 })

--- a/packages/core/shared/test/ee/agent-tool-classification.test.ts
+++ b/packages/core/shared/test/ee/agent-tool-classification.test.ts
@@ -100,3 +100,23 @@ describe('agentToolClassification.requiresActionPreview — taint (untrusted con
         expect(agentToolClassification.requiresActionPreview({ actionName: 'send_channel_message', tainted: true })).toBe(true)
     })
 })
+
+describe('agentToolClassification.configuredToolNeedsApproval', () => {
+    it('asks before a write when someone is there to answer', () => {
+        expect(agentToolClassification.configuredToolNeedsApproval({ actionName: 'send_email', attended: true })).toBe(true)
+        expect(agentToolClassification.configuredToolNeedsApproval({ actionName: 'delete_email', attended: true })).toBe(true)
+    })
+
+    it('never asks on an unattended run, because nobody can answer', () => {
+        expect(agentToolClassification.configuredToolNeedsApproval({ actionName: 'send_email', attended: false })).toBe(false)
+    })
+
+    it('lets a read through without asking', () => {
+        expect(agentToolClassification.configuredToolNeedsApproval({ actionName: 'gmail_search_mail', attended: true })).toBe(false)
+    })
+
+    it('asks about anything unproven once the turn has read untrusted content', () => {
+        expect(agentToolClassification.configuredToolNeedsApproval({ actionName: 'run_report', attended: true, tainted: true })).toBe(true)
+        expect(agentToolClassification.configuredToolNeedsApproval({ actionName: 'gmail_search_mail', attended: true, tainted: true })).toBe(false)
+    })
+})

--- a/packages/server/api/src/app/database/redis/distributed-store-factory.ts
+++ b/packages/server/api/src/app/database/redis/distributed-store-factory.ts
@@ -115,6 +115,11 @@ export const distributedStoreFactory = (getRedisClient: () => Promise<Redis>) =>
         }
     },
 
+    async removeField(key: string, field: string): Promise<void> {
+        const redisClient = await getRedisClient()
+        await redisClient.hdel(key, field)
+    },
+
     async deleteKeyIfFieldValueMatches(key: string, field: string, expectedValue: unknown): Promise<void> {
         const redisClient = await getRedisClient()
         const lua = `

--- a/packages/server/api/src/app/database/redis/distributed-store-factory.ts
+++ b/packages/server/api/src/app/database/redis/distributed-store-factory.ts
@@ -21,6 +21,14 @@ export const distributedStoreFactory = (getRedisClient: () => Promise<Redis>) =>
         return JSON.parse(value) as T
     },
 
+    async take<T>(key: string): Promise<T | null> {
+        const redisClient = await getRedisClient()
+        const value = await redisClient.getdel(key)
+        if (!value) return null
+
+        return JSON.parse(value) as T
+    },
+
     async putIfAbsent(key: string, value: unknown, ttlInSeconds: number): Promise<boolean> {
         const serializedValue = JSON.stringify(value)
         const redisClient = await getRedisClient()

--- a/packages/server/api/src/app/ee/agent/agent-approval-gate.ts
+++ b/packages/server/api/src/app/ee/agent/agent-approval-gate.ts
@@ -12,6 +12,7 @@ const CANCEL_KEY_PREFIX = 'chat-cancel:'
 const AVAILABLE_CONNECTIONS_PREFIX = 'chat-conn-avail:'
 const SELECTED_CONNECTION_PREFIX = 'chat-conn-sel:'
 const PENDING_GATE_PREFIX = 'chat-pending-gate:'
+const PREPARED_TOOL_PREFIX = 'agent-prepared-tool:'
 
 function decisionKey(gateId: string): string {
     return `${KEY_PREFIX}${gateId}`
@@ -133,6 +134,24 @@ async function getSelectedConnection({ conversationId, pieceName }: {
     return distributedStore.get<SelectedConnection>(`${SELECTED_CONNECTION_PREFIX}${conversationId}:${pieceName}`)
 }
 
+async function storePreparedToolInput({ conversationId, preparedId, input }: {
+    conversationId: string
+    preparedId: string
+    input: Record<string, unknown>
+}): Promise<void> {
+    await distributedStore.put(`${PREPARED_TOOL_PREFIX}${conversationId}:${preparedId}`, input, GATE_TTL_SECONDS)
+}
+
+async function takePreparedToolInput({ conversationId, preparedId }: {
+    conversationId: string
+    preparedId: string
+}): Promise<Record<string, unknown> | null> {
+    const key = `${PREPARED_TOOL_PREFIX}${conversationId}:${preparedId}`
+    const input = await distributedStore.get<Record<string, unknown>>(key)
+    await distributedStore.delete(key)
+    return input
+}
+
 async function storePendingGate({ conversationId, gate }: {
     conversationId: string
     gate: PendingGate
@@ -163,6 +182,8 @@ export const agentApprovalGate = {
     storeSelectedConnection,
     getSelectedConnection,
     storePendingGate,
+    storePreparedToolInput,
+    takePreparedToolInput,
     getPendingGate,
     clearPendingGate,
 }

--- a/packages/server/api/src/app/ee/agent/agent-approval-gate.ts
+++ b/packages/server/api/src/app/ee/agent/agent-approval-gate.ts
@@ -31,6 +31,9 @@ async function resolveGate({ gateId, approved, payload, log }: { gateId: string,
     const wasSet = await distributedStore.putIfAbsent(decisionKey(gateId), { approved, payload, approvedInput }, GATE_TTL_SECONDS)
     if (wasSet) {
         await pubsub.publish(channelName(gateId), JSON.stringify({ approved, payload }))
+        if (conversationId && !approved) {
+            await discardPreparedTool({ conversationId, preparedId: gateId })
+        }
         if (conversationId) {
             await distributedStore.delete(`${PENDING_GATE_PREFIX}${conversationId}`)
             await distributedStore.delete(`${PENDING_GATE_PREFIX}gate:${gateId}`)
@@ -134,22 +137,30 @@ async function getSelectedConnection({ conversationId, pieceName }: {
     return distributedStore.get<SelectedConnection>(`${SELECTED_CONNECTION_PREFIX}${conversationId}:${pieceName}`)
 }
 
-async function storePreparedToolInput({ conversationId, preparedId, input }: {
-    conversationId: string
-    preparedId: string
-    input: Record<string, unknown>
-}): Promise<void> {
-    await distributedStore.put(`${PREPARED_TOOL_PREFIX}${conversationId}:${preparedId}`, input, GATE_TTL_SECONDS)
+function preparedToolKey({ conversationId, preparedId }: { conversationId: string, preparedId: string }): string {
+    return `${PREPARED_TOOL_PREFIX}${conversationId}:${preparedId}`
 }
 
-async function takePreparedToolInput({ conversationId, preparedId }: {
+async function storePreparedTool({ conversationId, preparedId, prepared }: {
     conversationId: string
     preparedId: string
-}): Promise<Record<string, unknown> | null> {
-    const key = `${PREPARED_TOOL_PREFIX}${conversationId}:${preparedId}`
-    const input = await distributedStore.get<Record<string, unknown>>(key)
-    await distributedStore.delete(key)
-    return input
+    prepared: PreparedTool
+}): Promise<void> {
+    await distributedStore.put(preparedToolKey({ conversationId, preparedId }), prepared, GATE_TTL_SECONDS)
+}
+
+async function takePreparedTool({ conversationId, preparedId }: {
+    conversationId: string
+    preparedId: string
+}): Promise<PreparedTool | null> {
+    return distributedStore.take<PreparedTool>(preparedToolKey({ conversationId, preparedId }))
+}
+
+async function discardPreparedTool({ conversationId, preparedId }: {
+    conversationId: string
+    preparedId: string
+}): Promise<void> {
+    await distributedStore.delete(preparedToolKey({ conversationId, preparedId }))
 }
 
 async function storePendingGate({ conversationId, gate }: {
@@ -160,6 +171,10 @@ async function storePendingGate({ conversationId, gate }: {
         distributedStore.put(`${PENDING_GATE_PREFIX}${conversationId}`, gate, GATE_TTL_SECONDS),
         distributedStore.put(`${PENDING_GATE_PREFIX}gate:${gate.gateId}`, conversationId, GATE_TTL_SECONDS),
     ])
+}
+
+async function conversationIdForGate({ gateId }: { gateId: string }): Promise<string | null> {
+    return distributedStore.get<string>(`${PENDING_GATE_PREFIX}gate:${gateId}`)
 }
 
 async function getPendingGate({ conversationId }: { conversationId: string }): Promise<PendingGate | null> {
@@ -182,10 +197,18 @@ export const agentApprovalGate = {
     storeSelectedConnection,
     getSelectedConnection,
     storePendingGate,
-    storePreparedToolInput,
-    takePreparedToolInput,
+    conversationIdForGate,
+    storePreparedTool,
+    takePreparedTool,
+    discardPreparedTool,
     getPendingGate,
     clearPendingGate,
+}
+
+export type PreparedTool = {
+    input: Record<string, unknown>
+    piece: { pieceName: string, actionName: string, pieceVersion?: string }
+    needsApproval: boolean
 }
 
 type GateDecision = {

--- a/packages/server/api/src/app/ee/agent/agent-approval-gate.ts
+++ b/packages/server/api/src/app/ee/agent/agent-approval-gate.ts
@@ -11,7 +11,7 @@ const CHANNEL_PREFIX = 'tool-approval:'
 const CANCEL_KEY_PREFIX = 'chat-cancel:'
 const AVAILABLE_CONNECTIONS_PREFIX = 'chat-conn-avail:'
 const SELECTED_CONNECTION_PREFIX = 'chat-conn-sel:'
-const PENDING_GATE_PREFIX = 'chat-pending-gate:'
+const PENDING_GATE_PREFIX = 'chat-pending-gate:v2:'
 const PREPARED_TOOL_PREFIX = 'agent-prepared-tool:'
 
 function decisionKey(gateId: string): string {
@@ -26,8 +26,8 @@ async function resolveGate({ gateId, approved, payload, log }: { gateId: string,
     // Bind the decision to the exact inputs the user saw in the preview, so a consumer can verify
     // the action it's about to run matches what was approved (not a different payload reusing the id).
     const conversationId = await distributedStore.get<string>(`${PENDING_GATE_PREFIX}gate:${gateId}`)
-    const pendingGate = conversationId ? await distributedStore.get<PendingGate>(`${PENDING_GATE_PREFIX}${conversationId}`) : null
-    const approvedInput = pendingGate?.gateId === gateId ? pendingGate.toolInput : undefined
+    const pendingGate = conversationId ? (await readPendingGates({ conversationId }))[gateId] : undefined
+    const approvedInput = pendingGate?.toolInput
     const wasSet = await distributedStore.putIfAbsent(decisionKey(gateId), { approved, payload, approvedInput }, GATE_TTL_SECONDS)
     if (wasSet) {
         await pubsub.publish(channelName(gateId), JSON.stringify({ approved, payload }))
@@ -35,7 +35,7 @@ async function resolveGate({ gateId, approved, payload, log }: { gateId: string,
             await discardPreparedTool({ conversationId, preparedId: gateId })
         }
         if (conversationId) {
-            await distributedStore.delete(`${PENDING_GATE_PREFIX}${conversationId}`)
+            await distributedStore.removeField(`${PENDING_GATE_PREFIX}${conversationId}`, gateId)
             await distributedStore.delete(`${PENDING_GATE_PREFIX}gate:${gateId}`)
         }
         log?.info({ gate: { id: gateId }, decision: approved ? 'approved' : 'denied' }, '[agentApprovalGate] Gate decided')
@@ -168,17 +168,21 @@ async function storePendingGate({ conversationId, gate }: {
     gate: PendingGate
 }): Promise<void> {
     await Promise.all([
-        distributedStore.put(`${PENDING_GATE_PREFIX}${conversationId}`, gate, GATE_TTL_SECONDS),
+        distributedStore.merge(`${PENDING_GATE_PREFIX}${conversationId}`, { [gate.gateId]: gate }, GATE_TTL_SECONDS),
         distributedStore.put(`${PENDING_GATE_PREFIX}gate:${gate.gateId}`, conversationId, GATE_TTL_SECONDS),
     ])
 }
 
-async function conversationIdForGate({ gateId }: { gateId: string }): Promise<string | null> {
-    return distributedStore.get<string>(`${PENDING_GATE_PREFIX}gate:${gateId}`)
+async function readPendingGates({ conversationId }: { conversationId: string }): Promise<Record<string, PendingGate>> {
+    return await distributedStore.hgetJson<Record<string, PendingGate>>(`${PENDING_GATE_PREFIX}${conversationId}`) ?? {}
 }
 
-async function getPendingGate({ conversationId }: { conversationId: string }): Promise<PendingGate | null> {
-    return distributedStore.get<PendingGate>(`${PENDING_GATE_PREFIX}${conversationId}`)
+async function getPendingGates({ conversationId }: { conversationId: string }): Promise<PendingGate[]> {
+    return Object.values(await readPendingGates({ conversationId }))
+}
+
+async function conversationIdForGate({ gateId }: { gateId: string }): Promise<string | null> {
+    return distributedStore.get<string>(`${PENDING_GATE_PREFIX}gate:${gateId}`)
 }
 
 async function clearPendingGate({ conversationId }: { conversationId: string }): Promise<void> {
@@ -197,11 +201,11 @@ export const agentApprovalGate = {
     storeSelectedConnection,
     getSelectedConnection,
     storePendingGate,
+    getPendingGates,
     conversationIdForGate,
     storePreparedTool,
     takePreparedTool,
     discardPreparedTool,
-    getPendingGate,
     clearPendingGate,
 }
 

--- a/packages/server/api/src/app/ee/agent/agent-conversation-controller.ts
+++ b/packages/server/api/src/app/ee/agent/agent-conversation-controller.ts
@@ -277,13 +277,16 @@ export const agentConversationController: FastifyPluginAsyncZod = async (app) =>
         const userId = request.principal.id
         const conversation = await agentConversationService(request.log).getConversationOrThrow({ id: conversationId, platformId, userId })
         const pieceName = request.query.pieceName
-        const pinned = await pinnedAccounts({ conversation, pieceName, platformId, userId, log: request.log })
-        const cached = await agentApprovalGate.getAvailableConnections({ conversationId, pieceName })
-        if (cached.length > 0) {
+        const [pinned, allProjects] = await Promise.all([
+            pinnedAccounts({ conversation, pieceName, platformId, userId, log: request.log }),
+            agentHelpers.getUserProjects({ platformId, userId, log: request.log }),
+        ])
+        const projects = isNil(pinned) ? allProjects : allProjects.filter((project) => project.id === pinned.projectId)
+        const { data: result } = await tryCatch(() => findConnectionsForPiece({ pieceName, projects, platformId, log: request.log }))
+        if (isNil(result)) {
+            const cached = await agentApprovalGate.getAvailableConnections({ conversationId, pieceName })
             return reply.status(StatusCodes.OK).send(connectionOffer({ connections: cached, pinned }))
         }
-        const projects = await agentHelpers.getUserProjects({ platformId, userId, log: request.log })
-        const result = await findConnectionsForPiece({ pieceName, projects, platformId, log: request.log })
         if (!('pickConnection' in result)) {
             return reply.status(StatusCodes.OK).send(connectionOffer({ connections: [], pinned }))
         }

--- a/packages/server/api/src/app/ee/agent/agent-conversation-controller.ts
+++ b/packages/server/api/src/app/ee/agent/agent-conversation-controller.ts
@@ -263,12 +263,12 @@ export const agentConversationController: FastifyPluginAsyncZod = async (app) =>
         const platformId = request.principal.platform.id
         const userId = request.principal.id
         const conversation = await agentConversationService(request.log).getConversationOrThrow({ id: conversationId, platformId, userId })
-        const gate = await agentApprovalGate.getPendingGate({ conversationId })
-        // A preempted run can leave (or race in) a pending gate keyed by conversation; only surface
-        // the gate when it belongs to the run that currently owns the conversation.
-        const gateRunId = gate?.runId
-        const staleGate = !isNil(gateRunId) && !isNil(conversation.activeRunId) && gateRunId !== conversation.activeRunId
-        return reply.status(StatusCodes.OK).send(staleGate ? null : gate)
+        const gates = await agentApprovalGate.getPendingGates({ conversationId })
+        // A preempted run can leave (or race in) a pending gate; only surface one that belongs to
+        // the run that currently owns the conversation. A turn can open several at once, so the
+        // client is handed one at a time and asks again once it has been answered.
+        const ownedByThisRun = gates.filter((gate) => isNil(gate.runId) || isNil(conversation.activeRunId) || gate.runId === conversation.activeRunId)
+        return reply.status(StatusCodes.OK).send(ownedByThisRun[0] ?? null)
     })
 
     app.get('/conversations/:id/connections', GetPickerConnectionsRoute, async (request, reply) => {

--- a/packages/server/api/src/app/ee/agent/agent-conversation-controller.ts
+++ b/packages/server/api/src/app/ee/agent/agent-conversation-controller.ts
@@ -219,6 +219,14 @@ export const agentConversationController: FastifyPluginAsyncZod = async (app) =>
 
     app.post('/tool-approvals/:gateId', ToolApprovalRoute, async (request, reply) => {
         request.log.info({ gate: { id: request.params.gateId }, approved: request.body.approved }, '[agentConversationController] Tool approval received')
+        const gateConversationId = await agentApprovalGate.conversationIdForGate({ gateId: request.params.gateId })
+        if (!isNil(gateConversationId)) {
+            await agentConversationService(request.log).getConversationOrThrow({
+                id: gateConversationId,
+                platformId: request.principal.platform.id,
+                userId: request.principal.id,
+            })
+        }
         await agentApprovalGate.resolveGate({
             gateId: request.params.gateId,
             approved: request.body.approved,

--- a/packages/server/api/src/app/ee/agent/agent-rpc-handlers.ts
+++ b/packages/server/api/src/app/ee/agent/agent-rpc-handlers.ts
@@ -22,7 +22,7 @@ import { userService } from '../../user/user-service'
 import { resumeService } from '../../waitpoints/resume-service'
 import { smtpEmailSender } from '../helper/email/email-sender/smtp-email-sender'
 import { emailService } from '../helper/email/email-service'
-import { agentApprovalGate } from './agent-approval-gate'
+import { agentApprovalGate, PreparedTool } from './agent-approval-gate'
 import { agentCompaction } from './agent-compaction'
 import { buildAttachmentNote, buildUserContentWithFiles, persistAgentAttachments } from './agent-file-utils'
 import { agentHelpers } from './agent-helpers'
@@ -43,6 +43,7 @@ const CHAT_ONLY_TOOL_PREFIX = '__'
 const OWNER_SCOPED_TOOLS = ['ap_remember']
 const ATTENDED_STATE_TOOLS = ['__cancel_check', '__approval_wait', '__store_pending_gate', '__store_selected_connection']
 const CONFIGURED_TOOL_SOURCES: AgentRunSource[] = [AgentRunSource.FLOW_STEP, AgentRunSource.AGENT]
+const ATTENDED_SOURCES: AgentRunSource[] = [AgentRunSource.CHAT, AgentRunSource.AGENT]
 const AGENT_SURFACE_TOOLS = ['ap_list_agents', 'ap_create_agent', 'ap_update_agent', 'ap_add_agent_tool', 'ap_remove_agent_tool']
 const UNATTENDED_FORBIDDEN_TOOLS = ['ap_run_code', 'ap_execute_action', 'ap_explore_data', 'ap_list_across_projects', ...AGENT_SURFACE_TOOLS]
 const KNOWLEDGE_BASE_SEARCH_LIMIT = 5
@@ -479,42 +480,34 @@ export const agentRpcHandlers = (log: FastifyBaseLogger) => ({
     },
 
     async preparePieceTool(input: PreparePieceToolRequest): Promise<PreparePieceToolResponse> {
-        const { projectId, platformId } = await configuredToolConversationOrThrow({ conversationId: input.conversationId })
+        const { projectId, platformId, attended } = await configuredToolConversationOrThrow({ conversationId: input.conversationId })
         const model = await agentHelpers.resolveFastModel({ platformId, scope: { type: 'project', projectId }, log, ...spreadIfDefined('provider', input.provider), ...spreadIfDefined('providerConfigId', input.providerConfigId) })
-        const resolvedInput = await pieceToolRunner.resolveInput({
+        const piece = { pieceName: input.piece.pieceName, actionName: input.piece.actionName, ...spreadIfDefined('pieceVersion', input.piece.pieceVersion) }
+        const { resolvedInput, actionDisplayName } = await pieceToolRunner.resolveInput({
             model,
-            piece: { pieceName: input.piece.pieceName, actionName: input.piece.actionName, pieceVersion: input.piece.pieceVersion },
+            piece,
             instruction: input.instruction,
             projectId,
             platformId,
             log,
             ...spreadIfDefined('predefinedInput', input.piece.predefinedInput),
         })
-        await agentApprovalGate.storePreparedToolInput({ conversationId: input.conversationId, preparedId: input.preparedId, input: resolvedInput })
-        return { input: pieceToolRunner.withoutCredential(resolvedInput) }
+        const needsApproval = attended && agentToolClassification.requiresActionPreview({
+            actionName: input.piece.actionName,
+            input: resolvedInput,
+            tainted: input.tainted,
+        })
+        await agentApprovalGate.storePreparedTool({ conversationId: input.conversationId, preparedId: input.preparedId, prepared: { input: resolvedInput, piece, needsApproval } })
+        return { input: pieceToolRunner.withoutCredential(resolvedInput), actionDisplayName, needsApproval }
     },
 
     async executePieceTool(input: ExecutePieceToolRequest): Promise<ExecutePieceToolResponse> {
-        const { projectId, platformId } = await configuredToolConversationOrThrow({ conversationId: input.conversationId })
-        const prepared = isNil(input.preparedId)
+        const { projectId } = await configuredToolConversationOrThrow({ conversationId: input.conversationId })
+        const stored = isNil(input.preparedId)
             ? null
-            : await agentApprovalGate.takePreparedToolInput({ conversationId: input.conversationId, preparedId: input.preparedId })
-        if (!isNil(input.preparedId) && isNil(prepared)) {
-            throw new ActivepiecesError({ code: ErrorCode.VALIDATION, params: { message: 'The approved input for this action has expired. Ask the agent to try again.' } })
-        }
-        const model = await agentHelpers.resolveFastModel({ platformId, scope: { type: 'project', projectId }, log, ...spreadIfDefined('provider', input.provider), ...spreadIfDefined('providerConfigId', input.providerConfigId) })
-        const piece = { pieceName: input.piece.pieceName, actionName: input.piece.actionName, pieceVersion: input.piece.pieceVersion }
-        const { data: run, error: runError } = await tryCatch(() => isNil(prepared)
-            ? pieceToolRunner.runFromInstruction({
-                model,
-                piece,
-                instruction: input.instruction,
-                projectId,
-                platformId,
-                log,
-                ...spreadIfDefined('predefinedInput', input.piece.predefinedInput),
-            })
-            : pieceToolRunner.runResolved({ piece, resolvedInput: prepared, projectId, log }))
+            : await agentApprovalGate.takePreparedTool({ conversationId: input.conversationId, preparedId: input.preparedId })
+        const prepared = await approvedPreparedToolOrThrow({ prepared: stored, preparedId: input.preparedId, toolName: input.toolName, log })
+        const { data: run, error: runError } = await tryCatch(() => pieceToolRunner.runResolved({ piece: prepared.piece, resolvedInput: prepared.input, projectId, log }))
         if (!isNil(runError) || isNil(run)) {
             log.error({ error: runError, tool: { name: input.toolName }, piece: { name: input.piece.pieceName, version: input.piece.pieceVersion ?? null }, action: { name: input.piece.actionName } }, '[agentRpc#executePieceTool] Configured action could not run')
             throw runError
@@ -809,12 +802,28 @@ function emailApprovalMatches({ approvedInput, recipients, subject, body }: {
     return sameRecipients && approvedInput.subject === subject && approvedInput.body === body
 }
 
-async function configuredToolConversationOrThrow({ conversationId }: { conversationId: string }): Promise<{ projectId: string, platformId: string }> {
+async function configuredToolConversationOrThrow({ conversationId }: { conversationId: string }): Promise<{ projectId: string, platformId: string, attended: boolean }> {
     const conversation = await agentHelpers.conversationRepo().findOneBy({ id: conversationId })
     if (isNil(conversation) || !CONFIGURED_TOOL_SOURCES.includes(conversation.source) || isNil(conversation.projectId)) {
         throw new ActivepiecesError({ code: ErrorCode.AUTHORIZATION, params: { message: 'This run is not allowed to run a configured piece tool' } })
     }
-    return { projectId: conversation.projectId, platformId: conversation.platformId }
+    return { projectId: conversation.projectId, platformId: conversation.platformId, attended: ATTENDED_SOURCES.includes(conversation.source) }
+}
+
+async function approvedPreparedToolOrThrow({ prepared, preparedId, toolName, log }: { prepared: PreparedTool | null, preparedId?: string, toolName: string, log: FastifyBaseLogger }): Promise<PreparedTool> {
+    if (isNil(prepared)) {
+        log.warn({ tool: { name: toolName }, prepared: { id: preparedId ?? null } }, '[agentRpc#executePieceTool] Refused an action with no prepared input')
+        throw new ActivepiecesError({ code: ErrorCode.VALIDATION, params: { message: 'This action was not prepared for review, or the review expired. Ask the agent to try again.' } })
+    }
+    if (!prepared.needsApproval) {
+        return prepared
+    }
+    const decision = isNil(preparedId) ? 'pending' : await agentApprovalGate.checkDecision({ gateId: preparedId })
+    if (decision === 'pending' || !decision.approved) {
+        log.warn({ tool: { name: toolName }, prepared: { id: preparedId ?? null }, piece: { name: prepared.piece.pieceName }, action: { name: prepared.piece.actionName } }, '[agentRpc#executePieceTool] Blocked an action the user never approved')
+        throw new ActivepiecesError({ code: ErrorCode.AUTHORIZATION, params: { message: 'This action needs your approval before it can run.' } })
+    }
+    return prepared
 }
 
 async function loadOrStartConversation({ conversationId, platformId, userId, source, projectId, modelName }: {

--- a/packages/server/api/src/app/ee/agent/agent-rpc-handlers.ts
+++ b/packages/server/api/src/app/ee/agent/agent-rpc-handlers.ts
@@ -1,6 +1,6 @@
-import { ActivepiecesError, ErrorCode, isNil, Permission, sanitizeObjectForPostgresql, spreadIfDefined, tryCatch, unique } from '@activepieces/core-utils'
+import { ActivepiecesError, connectionTemplate, ErrorCode, isNil, Permission, sanitizeObjectForPostgresql, spreadIfDefined, tryCatch, unique } from '@activepieces/core-utils'
 import { agentAiUtils } from '@activepieces/server-utils'
-import { AgentConfigResponse, AgentConversation, AgentConversationStatus, AgentRunSource, agentToolClassification, ExecuteAgentToolRequest, ExecuteAgentToolResponse, ExecuteFlowToolRequest, ExecuteFlowToolResponse, ExecuteKnowledgeBaseToolRequest, ExecuteKnowledgeBaseToolResponse, ExecutePieceToolRequest, ExecutePieceToolResponse, FileCompression, FileType, FlowActionType, flowStructureUtil, GetAgentConfigRequest, GetEnabledAiToolsResponse, HeartbeatAgentConversationRequest, PersistedAgentMessage, PersistedAgentPartType, PersistedAgentRole, PreparePieceToolRequest, PreparePieceToolResponse, ResumeFlowStepRequest, SaveAgentFileRequest, SaveAgentFileResponse, SaveAgentMessagesRequest, SendAgentEmailRequest, SendAgentEmailResponse, UpdateAgentProgressRequest, UpdateFlowStepProgressRequest, UpdateProjectContextRequest } from '@activepieces/shared'
+import { AgentConfigResponse, AgentConversation, AgentConversationStatus, AgentPieceToolMetadata, AgentRunSource, agentToolClassification, ExecuteAgentToolRequest, ExecuteAgentToolResponse, ExecuteFlowToolRequest, ExecuteFlowToolResponse, ExecuteKnowledgeBaseToolRequest, ExecuteKnowledgeBaseToolResponse, ExecutePieceToolRequest, ExecutePieceToolResponse, FileCompression, FileType, FlowActionType, flowStructureUtil, GetAgentConfigRequest, GetEnabledAiToolsResponse, HeartbeatAgentConversationRequest, PersistedAgentMessage, PersistedAgentPartType, PersistedAgentRole, PreparePieceToolRequest, PreparePieceToolResponse, ResumeFlowStepRequest, SaveAgentFileRequest, SaveAgentFileResponse, SaveAgentMessagesRequest, SendAgentEmailRequest, SendAgentEmailResponse, UpdateAgentProgressRequest, UpdateFlowStepProgressRequest, UpdateProjectContextRequest } from '@activepieces/shared'
 import { embed, ModelMessage } from 'ai'
 import { FastifyBaseLogger } from 'fastify'
 import { aiToolConfigService } from '../../ai/ai-tool-config-service'
@@ -483,6 +483,7 @@ export const agentRpcHandlers = (log: FastifyBaseLogger) => ({
         const { projectId, platformId, attended } = await configuredToolConversationOrThrow({ conversationId: input.conversationId })
         const model = await agentHelpers.resolveFastModel({ platformId, scope: { type: 'project', projectId }, log, ...spreadIfDefined('provider', input.provider), ...spreadIfDefined('providerConfigId', input.providerConfigId) })
         const piece = { pieceName: input.piece.pieceName, actionName: input.piece.actionName, ...spreadIfDefined('pieceVersion', input.piece.pieceVersion) }
+        const connection = await connectionForConfiguredTool({ piece: input.piece, projectId, platformId, log })
         const { resolvedInput, actionDisplayName } = await pieceToolRunner.resolveInput({
             model,
             piece,
@@ -491,6 +492,7 @@ export const agentRpcHandlers = (log: FastifyBaseLogger) => ({
             platformId,
             log,
             ...spreadIfDefined('predefinedInput', input.piece.predefinedInput),
+            ...spreadIfDefined('connectionExternalId', connection.externalId),
         })
         const needsApproval = attended && agentToolClassification.requiresActionPreview({
             actionName: input.piece.actionName,
@@ -498,7 +500,7 @@ export const agentRpcHandlers = (log: FastifyBaseLogger) => ({
             tainted: input.tainted,
         })
         await agentApprovalGate.storePreparedTool({ conversationId: input.conversationId, preparedId: input.preparedId, prepared: { input: resolvedInput, piece, needsApproval } })
-        return { input: pieceToolRunner.withoutCredential(resolvedInput), actionDisplayName, needsApproval }
+        return { input: pieceToolRunner.withoutCredential(resolvedInput), actionDisplayName, needsApproval, ...spreadIfDefined('connectionLabel', connection.label) }
     },
 
     async executePieceTool(input: ExecutePieceToolRequest): Promise<ExecutePieceToolResponse> {
@@ -513,7 +515,7 @@ export const agentRpcHandlers = (log: FastifyBaseLogger) => ({
             throw runError
         }
         const { result, resolvedInput } = run
-        log.info({ conversation: { id: input.conversationId }, tool: { name: input.toolName, input: resolvedInput }, connection: { externalId: input.piece.predefinedInput?.auth }, piece: { name: input.piece.pieceName } }, '[agentRpc#executePieceTool] Ran a configured piece action')
+        log.info({ conversation: { id: input.conversationId }, tool: { name: input.toolName, input: resolvedInput }, connection: { externalId: connectionTemplate.unwrapExternalId(prepared.input.auth) }, piece: { name: prepared.piece.pieceName } }, '[agentRpc#executePieceTool] Ran a configured piece action')
         return { result }
     },
 
@@ -800,6 +802,20 @@ function emailApprovalMatches({ approvedInput, recipients, subject, body }: {
         : []
     const sameRecipients = approvedRecipients.length === recipients.length && approvedRecipients.every((email) => recipients.includes(email))
     return sameRecipients && approvedInput.subject === subject && approvedInput.body === body
+}
+
+async function connectionForConfiguredTool({ piece, projectId, platformId, log }: {
+    piece: AgentPieceToolMetadata
+    projectId: string
+    platformId: string
+    log: FastifyBaseLogger
+}): Promise<{ externalId?: string, label?: string }> {
+    const pinned = connectionTemplate.unwrapExternalId(piece.predefinedInput?.auth) ?? undefined
+    if (isNil(pinned)) {
+        return {}
+    }
+    const connection = await appConnectionService(log).getOneWithoutValue({ projectId, platformId, externalId: pinned })
+    return { externalId: pinned, ...spreadIfDefined('label', connection?.displayName) }
 }
 
 async function configuredToolConversationOrThrow({ conversationId }: { conversationId: string }): Promise<{ projectId: string, platformId: string, attended: boolean }> {

--- a/packages/server/api/src/app/ee/agent/agent-rpc-handlers.ts
+++ b/packages/server/api/src/app/ee/agent/agent-rpc-handlers.ts
@@ -1,6 +1,6 @@
 import { ActivepiecesError, ErrorCode, isNil, Permission, sanitizeObjectForPostgresql, spreadIfDefined, tryCatch, unique } from '@activepieces/core-utils'
 import { agentAiUtils } from '@activepieces/server-utils'
-import { AgentConfigResponse, AgentConversation, AgentConversationStatus, AgentRunSource, agentToolClassification, ExecuteAgentToolRequest, ExecuteAgentToolResponse, ExecuteFlowToolRequest, ExecuteFlowToolResponse, ExecuteKnowledgeBaseToolRequest, ExecuteKnowledgeBaseToolResponse, ExecutePieceToolRequest, ExecutePieceToolResponse, FileCompression, FileType, FlowActionType, flowStructureUtil, GetAgentConfigRequest, GetEnabledAiToolsResponse, HeartbeatAgentConversationRequest, PersistedAgentMessage, PersistedAgentPartType, PersistedAgentRole, ResumeFlowStepRequest, SaveAgentFileRequest, SaveAgentFileResponse, SaveAgentMessagesRequest, SendAgentEmailRequest, SendAgentEmailResponse, UpdateAgentProgressRequest, UpdateFlowStepProgressRequest, UpdateProjectContextRequest } from '@activepieces/shared'
+import { AgentConfigResponse, AgentConversation, AgentConversationStatus, AgentRunSource, agentToolClassification, ExecuteAgentToolRequest, ExecuteAgentToolResponse, ExecuteFlowToolRequest, ExecuteFlowToolResponse, ExecuteKnowledgeBaseToolRequest, ExecuteKnowledgeBaseToolResponse, ExecutePieceToolRequest, ExecutePieceToolResponse, FileCompression, FileType, FlowActionType, flowStructureUtil, GetAgentConfigRequest, GetEnabledAiToolsResponse, HeartbeatAgentConversationRequest, PersistedAgentMessage, PersistedAgentPartType, PersistedAgentRole, PreparePieceToolRequest, PreparePieceToolResponse, ResumeFlowStepRequest, SaveAgentFileRequest, SaveAgentFileResponse, SaveAgentMessagesRequest, SendAgentEmailRequest, SendAgentEmailResponse, UpdateAgentProgressRequest, UpdateFlowStepProgressRequest, UpdateProjectContextRequest } from '@activepieces/shared'
 import { embed, ModelMessage } from 'ai'
 import { FastifyBaseLogger } from 'fastify'
 import { aiToolConfigService } from '../../ai/ai-tool-config-service'
@@ -478,14 +478,10 @@ export const agentRpcHandlers = (log: FastifyBaseLogger) => ({
         log.info(resumeFields, '[agentRpc#resumeFlowStep] Handed the result back to the flow')
     },
 
-    async executePieceTool(input: ExecutePieceToolRequest): Promise<ExecutePieceToolResponse> {
-        const conversation = await agentHelpers.conversationRepo().findOneBy({ id: input.conversationId })
-        if (isNil(conversation) || !CONFIGURED_TOOL_SOURCES.includes(conversation.source) || isNil(conversation.projectId)) {
-            throw new ActivepiecesError({ code: ErrorCode.AUTHORIZATION, params: { message: 'This run is not allowed to run a configured piece tool' } })
-        }
-        const { projectId, platformId } = conversation
+    async preparePieceTool(input: PreparePieceToolRequest): Promise<PreparePieceToolResponse> {
+        const { projectId, platformId } = await configuredToolConversationOrThrow({ conversationId: input.conversationId })
         const model = await agentHelpers.resolveFastModel({ platformId, scope: { type: 'project', projectId }, log, ...spreadIfDefined('provider', input.provider), ...spreadIfDefined('providerConfigId', input.providerConfigId) })
-        const { data: run, error: runError } = await tryCatch(() => pieceToolRunner.runFromInstruction({
+        const resolvedInput = await pieceToolRunner.resolveInput({
             model,
             piece: { pieceName: input.piece.pieceName, actionName: input.piece.actionName, pieceVersion: input.piece.pieceVersion },
             instruction: input.instruction,
@@ -493,7 +489,32 @@ export const agentRpcHandlers = (log: FastifyBaseLogger) => ({
             platformId,
             log,
             ...spreadIfDefined('predefinedInput', input.piece.predefinedInput),
-        }))
+        })
+        await agentApprovalGate.storePreparedToolInput({ conversationId: input.conversationId, preparedId: input.preparedId, input: resolvedInput })
+        return { input: pieceToolRunner.withoutCredential(resolvedInput) }
+    },
+
+    async executePieceTool(input: ExecutePieceToolRequest): Promise<ExecutePieceToolResponse> {
+        const { projectId, platformId } = await configuredToolConversationOrThrow({ conversationId: input.conversationId })
+        const prepared = isNil(input.preparedId)
+            ? null
+            : await agentApprovalGate.takePreparedToolInput({ conversationId: input.conversationId, preparedId: input.preparedId })
+        if (!isNil(input.preparedId) && isNil(prepared)) {
+            throw new ActivepiecesError({ code: ErrorCode.VALIDATION, params: { message: 'The approved input for this action has expired. Ask the agent to try again.' } })
+        }
+        const model = await agentHelpers.resolveFastModel({ platformId, scope: { type: 'project', projectId }, log, ...spreadIfDefined('provider', input.provider), ...spreadIfDefined('providerConfigId', input.providerConfigId) })
+        const piece = { pieceName: input.piece.pieceName, actionName: input.piece.actionName, pieceVersion: input.piece.pieceVersion }
+        const { data: run, error: runError } = await tryCatch(() => isNil(prepared)
+            ? pieceToolRunner.runFromInstruction({
+                model,
+                piece,
+                instruction: input.instruction,
+                projectId,
+                platformId,
+                log,
+                ...spreadIfDefined('predefinedInput', input.piece.predefinedInput),
+            })
+            : pieceToolRunner.runResolved({ piece, resolvedInput: prepared, projectId, log }))
         if (!isNil(runError) || isNil(run)) {
             log.error({ error: runError, tool: { name: input.toolName }, piece: { name: input.piece.pieceName, version: input.piece.pieceVersion ?? null }, action: { name: input.piece.actionName } }, '[agentRpc#executePieceTool] Configured action could not run')
             throw runError
@@ -786,6 +807,14 @@ function emailApprovalMatches({ approvedInput, recipients, subject, body }: {
         : []
     const sameRecipients = approvedRecipients.length === recipients.length && approvedRecipients.every((email) => recipients.includes(email))
     return sameRecipients && approvedInput.subject === subject && approvedInput.body === body
+}
+
+async function configuredToolConversationOrThrow({ conversationId }: { conversationId: string }): Promise<{ projectId: string, platformId: string }> {
+    const conversation = await agentHelpers.conversationRepo().findOneBy({ id: conversationId })
+    if (isNil(conversation) || !CONFIGURED_TOOL_SOURCES.includes(conversation.source) || isNil(conversation.projectId)) {
+        throw new ActivepiecesError({ code: ErrorCode.AUTHORIZATION, params: { message: 'This run is not allowed to run a configured piece tool' } })
+    }
+    return { projectId: conversation.projectId, platformId: conversation.platformId }
 }
 
 async function loadOrStartConversation({ conversationId, platformId, userId, source, projectId, modelName }: {

--- a/packages/server/api/src/app/ee/agent/tools/piece-tool-runner.ts
+++ b/packages/server/api/src/app/ee/agent/tools/piece-tool-runner.ts
@@ -8,8 +8,8 @@ import { mcpUtils } from '../../../mcp/tools/mcp-utils'
 import { pieceMetadataService } from '../../../pieces/metadata/piece-metadata-service'
 import { pieceInputFiller, ResolveProperty } from './piece-input-filler'
 
-async function resolveInput({ piece, instruction, predefinedInput, model, projectId, platformId, connectionExternalId, log }: RunFromInstructionParams): Promise<Record<string, unknown>> {
-    const { properties, pieceVersion } = await resolveAction({ piece, platformId, log })
+async function resolveInput({ piece, instruction, predefinedInput, model, projectId, platformId, connectionExternalId, log }: ResolveInputParams): Promise<ResolvedPieceInput> {
+    const { properties, pieceVersion, actionDisplayName } = await resolveAction({ piece, platformId, log })
     const resolvedInput = await pieceInputFiller.fillInput({
         action: { name: piece.actionName, properties, ...(isNil(connectionExternalId) ? {} : { connectionExternalId }) },
         instruction,
@@ -22,7 +22,7 @@ async function resolveInput({ piece, instruction, predefinedInput, model, projec
 
     assertUrlStaysOnThePieceHost({ actionName: piece.actionName, input: resolvedInput })
 
-    return resolvedInput
+    return { resolvedInput, actionDisplayName }
 }
 
 function withoutCredential(input: Record<string, unknown>): Record<string, unknown> {
@@ -48,17 +48,6 @@ async function runResolved({ piece, resolvedInput, projectId, connectionExternal
     return { result, resolvedInput: withoutCredential(resolvedInput) }
 }
 
-async function runFromInstruction(params: RunFromInstructionParams): Promise<PieceToolRun> {
-    const resolvedInput = await resolveInput(params)
-    return runResolved({
-        piece: params.piece,
-        resolvedInput,
-        projectId: params.projectId,
-        log: params.log,
-        ...(isNil(params.connectionExternalId) ? {} : { connectionExternalId: params.connectionExternalId }),
-    })
-}
-
 async function resolveAction({ piece, platformId, log }: { piece: PieceActionRef, platformId: string, log: FastifyBaseLogger }) {
     const metadata = await pieceMetadataService(log).getOrThrow({
         platformId,
@@ -72,7 +61,7 @@ async function resolveAction({ piece, platformId, log }: { piece: PieceActionRef
             params: { entityType: 'PieceAction', entityId: `${piece.pieceName}:${piece.actionName}` },
         })
     }
-    return { properties: action.props, pieceVersion: metadata.version }
+    return { properties: action.props, pieceVersion: metadata.version, actionDisplayName: action.displayName }
 }
 
 function propertyResolverFor({ piece, pieceVersion, projectId, platformId, log }: {
@@ -117,7 +106,6 @@ const ABSOLUTE_URL = /^https?:\/\//i
 const REDACTED_AUTH = 'Redacted'
 
 export const pieceToolRunner = {
-    runFromInstruction,
     resolveInput,
     runResolved,
     withoutCredential,
@@ -129,7 +117,7 @@ export type PieceActionRef = {
     pieceVersion?: string
 }
 
-export type RunFromInstructionParams = {
+export type ResolveInputParams = {
     piece: PieceActionRef
     instruction: string
     predefinedInput?: PredefinedInputsStructure
@@ -138,6 +126,11 @@ export type RunFromInstructionParams = {
     platformId: string
     connectionExternalId?: string
     log: FastifyBaseLogger
+}
+
+export type ResolvedPieceInput = {
+    resolvedInput: Record<string, unknown>
+    actionDisplayName: string
 }
 
 export type PieceToolRun = {

--- a/packages/server/api/src/app/ee/agent/tools/piece-tool-runner.ts
+++ b/packages/server/api/src/app/ee/agent/tools/piece-tool-runner.ts
@@ -1,5 +1,5 @@
 import { PredefinedInputsStructure } from '@activepieces/core-piece-types'
-import { ActivepiecesError, ErrorCode, isNil } from '@activepieces/core-utils'
+import { ActivepiecesError, connectionTemplate, ErrorCode, isNil, spreadIfDefined } from '@activepieces/core-utils'
 import { McpToolResult } from '@activepieces/shared'
 import { LanguageModel } from 'ai'
 import { FastifyBaseLogger } from 'fastify'
@@ -10,10 +10,11 @@ import { pieceInputFiller, ResolveProperty } from './piece-input-filler'
 
 async function resolveInput({ piece, instruction, predefinedInput, model, projectId, platformId, connectionExternalId, log }: ResolveInputParams): Promise<ResolvedPieceInput> {
     const { properties, pieceVersion, actionDisplayName } = await resolveAction({ piece, platformId, log })
+    const account = connectionExternalId ?? connectionTemplate.unwrapExternalId(predefinedInput?.auth) ?? undefined
     const resolvedInput = await pieceInputFiller.fillInput({
-        action: { name: piece.actionName, properties, ...(isNil(connectionExternalId) ? {} : { connectionExternalId }) },
+        action: { name: piece.actionName, properties, ...spreadIfDefined('connectionExternalId', account) },
         instruction,
-        ...(isNil(predefinedInput) ? {} : { predefinedInput }),
+        ...(isNil(predefinedInput) && isNil(account) ? {} : { predefinedInput: { fields: predefinedInput?.fields ?? {}, ...spreadIfDefined('auth', account) } }),
         ports: {
             resolveProperty: propertyResolverFor({ piece, pieceVersion, projectId, platformId, log }),
             completeObject: pieceInputFiller.modelCompleter(model),

--- a/packages/server/api/src/app/ee/agent/tools/piece-tool-runner.ts
+++ b/packages/server/api/src/app/ee/agent/tools/piece-tool-runner.ts
@@ -8,7 +8,7 @@ import { mcpUtils } from '../../../mcp/tools/mcp-utils'
 import { pieceMetadataService } from '../../../pieces/metadata/piece-metadata-service'
 import { pieceInputFiller, ResolveProperty } from './piece-input-filler'
 
-async function runFromInstruction({ piece, instruction, predefinedInput, model, projectId, platformId, connectionExternalId, log }: RunFromInstructionParams): Promise<PieceToolRun> {
+async function resolveInput({ piece, instruction, predefinedInput, model, projectId, platformId, connectionExternalId, log }: RunFromInstructionParams): Promise<Record<string, unknown>> {
     const { properties, pieceVersion } = await resolveAction({ piece, platformId, log })
     const resolvedInput = await pieceInputFiller.fillInput({
         action: { name: piece.actionName, properties, ...(isNil(connectionExternalId) ? {} : { connectionExternalId }) },
@@ -22,6 +22,20 @@ async function runFromInstruction({ piece, instruction, predefinedInput, model, 
 
     assertUrlStaysOnThePieceHost({ actionName: piece.actionName, input: resolvedInput })
 
+    return resolvedInput
+}
+
+function withoutCredential(input: Record<string, unknown>): Record<string, unknown> {
+    return { ...input, ...(isNil(input.auth) ? {} : { auth: REDACTED_AUTH }) }
+}
+
+async function runResolved({ piece, resolvedInput, projectId, connectionExternalId, log }: {
+    piece: PieceActionRef
+    resolvedInput: Record<string, unknown>
+    projectId: string
+    connectionExternalId?: string
+    log: FastifyBaseLogger
+}): Promise<PieceToolRun> {
     const result = await executePieceActionRun({
         projectId,
         pieceName: piece.pieceName,
@@ -31,7 +45,18 @@ async function runFromInstruction({ piece, instruction, predefinedInput, model, 
         ...(isNil(connectionExternalId) ? {} : { connectionExternalId }),
     })
 
-    return { result, resolvedInput: { ...resolvedInput, ...(isNil(resolvedInput.auth) ? {} : { auth: REDACTED_AUTH }) } }
+    return { result, resolvedInput: withoutCredential(resolvedInput) }
+}
+
+async function runFromInstruction(params: RunFromInstructionParams): Promise<PieceToolRun> {
+    const resolvedInput = await resolveInput(params)
+    return runResolved({
+        piece: params.piece,
+        resolvedInput,
+        projectId: params.projectId,
+        log: params.log,
+        ...(isNil(params.connectionExternalId) ? {} : { connectionExternalId: params.connectionExternalId }),
+    })
 }
 
 async function resolveAction({ piece, platformId, log }: { piece: PieceActionRef, platformId: string, log: FastifyBaseLogger }) {
@@ -93,6 +118,9 @@ const REDACTED_AUTH = 'Redacted'
 
 export const pieceToolRunner = {
     runFromInstruction,
+    resolveInput,
+    runResolved,
+    withoutCredential,
 }
 
 export type PieceActionRef = {

--- a/packages/server/api/src/app/workers/rpc/worker-rpc-service.ts
+++ b/packages/server/api/src/app/workers/rpc/worker-rpc-service.ts
@@ -347,6 +347,9 @@ export function createHandlers(log: FastifyBaseLogger, assignment: WorkerGroupAs
             return agentRpcHandlers(agentRpcLog(log, { conversationId, runId, platformId: input.platformId, userId: input.userId })).executeAgentTool(input)
         },
 
+        async preparePieceTool(input) {
+            return agentRpcHandlers(agentRpcLog(log, { conversationId: input.conversationId })).preparePieceTool(input)
+        },
         async executePieceTool(input) {
             return agentRpcHandlers(agentRpcLog(log, { conversationId: input.conversationId })).executePieceTool(input)
         },

--- a/packages/server/api/test/integration/ee/agent/agent-tool-approval.test.ts
+++ b/packages/server/api/test/integration/ee/agent/agent-tool-approval.test.ts
@@ -18,7 +18,7 @@ afterAll(async () => {
     await teardownTestEnvironment()
 })
 
-async function conversationWithPendingGate(ctx: TestContext): Promise<string> {
+async function conversation(ctx: TestContext): Promise<string> {
     const conversationId = apId()
     await db.save('agent_conversation', {
         id: conversationId,
@@ -32,11 +32,20 @@ async function conversationWithPendingGate(ctx: TestContext): Promise<string> {
         messages: [],
         uiMessages: [],
     })
-    const gateId = `gate-${conversationId}`
+    return conversationId
+}
+
+async function openGate({ conversationId, gateId, actionName }: { conversationId: string, gateId: string, actionName: string }): Promise<void> {
     await agentApprovalGate.storePendingGate({
         conversationId,
-        gate: { gateId, toolName: 'gmail-send_email', displayName: 'Send email', toolInput: { pieceName: '@activepieces/piece-gmail', actionName: 'send_email', input: { to: 'jane@customer.com' } } },
+        gate: { gateId, toolName: `slack-${actionName}`, displayName: actionName, toolInput: { pieceName: '@activepieces/piece-slack', actionName, input: { to: 'jane@customer.com' } } },
     })
+}
+
+async function conversationWithPendingGate(ctx: TestContext): Promise<string> {
+    const conversationId = await conversation(ctx)
+    const gateId = `gate-${conversationId}`
+    await openGate({ conversationId, gateId, actionName: 'send_email' })
     return gateId
 }
 
@@ -59,5 +68,35 @@ describe('approving an agent action belongs to the person it was shown to', () =
 
         expect(response.statusCode).not.toBe(StatusCodes.OK)
         expect(await agentApprovalGate.checkDecision({ gateId })).toBe('pending')
+    })
+})
+
+describe('a turn that opens several actions at once keeps a card for each', () => {
+    it('hands over the second action once the first has been answered', async () => {
+        const ctx = await createTestContext(app, { plan: { agentsEnabled: true, chatEnabled: true } })
+        const conversationId = await conversation(ctx)
+        await openGate({ conversationId, gateId: 'gate-first', actionName: 'set_user_status' })
+        await openGate({ conversationId, gateId: 'gate-second', actionName: 'send_channel_message' })
+
+        const both = await agentApprovalGate.getPendingGates({ conversationId })
+        expect(both.map((gate) => gate.gateId).sort()).toEqual(['gate-first', 'gate-second'])
+
+        await agentApprovalGate.resolveGate({ gateId: 'gate-first', approved: true })
+
+        const left = await agentApprovalGate.getPendingGates({ conversationId })
+        expect(left.map((gate) => gate.gateId)).toEqual(['gate-second'])
+    })
+
+    it('binds each decision to the action it was shown for, not to the other one', async () => {
+        const ctx = await createTestContext(app, { plan: { agentsEnabled: true, chatEnabled: true } })
+        const conversationId = await conversation(ctx)
+        await openGate({ conversationId, gateId: 'gate-status', actionName: 'set_user_status' })
+        await openGate({ conversationId, gateId: 'gate-message', actionName: 'send_channel_message' })
+
+        await agentApprovalGate.resolveGate({ gateId: 'gate-status', approved: true })
+        const decision = await agentApprovalGate.checkDecision({ gateId: 'gate-status' })
+
+        expect(decision !== 'pending' && decision.approvedInput?.actionName).toBe('set_user_status')
+        expect(await agentApprovalGate.checkDecision({ gateId: 'gate-message' })).toBe('pending')
     })
 })

--- a/packages/server/api/test/integration/ee/agent/agent-tool-approval.test.ts
+++ b/packages/server/api/test/integration/ee/agent/agent-tool-approval.test.ts
@@ -1,0 +1,63 @@
+import { AgentRunSource, apId, DefaultProjectRole } from '@activepieces/shared'
+import { FastifyInstance } from 'fastify'
+import { StatusCodes } from 'http-status-codes'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { agentApprovalGate } from '../../../../src/app/ee/agent/agent-approval-gate'
+import { db } from '../../../helpers/db'
+import { createMemberContext, createTestContext, TestContext } from '../../../helpers/test-context'
+import { setupTestEnvironment, teardownTestEnvironment } from '../../../helpers/test-setup'
+
+let app: FastifyInstance
+
+beforeAll(async () => {
+    process.env.AP_AGENTS_ENABLED = 'true'
+    app = await setupTestEnvironment()
+})
+
+afterAll(async () => {
+    await teardownTestEnvironment()
+})
+
+async function conversationWithPendingGate(ctx: TestContext): Promise<string> {
+    const conversationId = apId()
+    await db.save('agent_conversation', {
+        id: conversationId,
+        created: new Date().toISOString(),
+        updated: new Date().toISOString(),
+        platformId: ctx.platform.id,
+        projectId: ctx.project.id,
+        userId: ctx.user.id,
+        source: AgentRunSource.AGENT,
+        status: 'STREAMING',
+        messages: [],
+        uiMessages: [],
+    })
+    const gateId = `gate-${conversationId}`
+    await agentApprovalGate.storePendingGate({
+        conversationId,
+        gate: { gateId, toolName: 'gmail-send_email', displayName: 'Send email', toolInput: { pieceName: '@activepieces/piece-gmail', actionName: 'send_email', input: { to: 'jane@customer.com' } } },
+    })
+    return gateId
+}
+
+describe('approving an agent action belongs to the person it was shown to', () => {
+    it('lets the conversation owner approve their own pending action', async () => {
+        const ctx = await createTestContext(app, { plan: { agentsEnabled: true, chatEnabled: true } })
+        const gateId = await conversationWithPendingGate(ctx)
+
+        const response = await ctx.post(`/v1/agents/tool-approvals/${gateId}`, { approved: true })
+
+        expect(response.statusCode).toBe(StatusCodes.OK)
+    })
+
+    it('refuses someone else in the platform approving an action they were never shown', async () => {
+        const ctx = await createTestContext(app, { plan: { agentsEnabled: true, chatEnabled: true } })
+        const gateId = await conversationWithPendingGate(ctx)
+        const other = await createMemberContext(app, ctx, { projectRole: DefaultProjectRole.ADMIN })
+
+        const response = await other.post(`/v1/agents/tool-approvals/${gateId}`, { approved: true })
+
+        expect(response.statusCode).not.toBe(StatusCodes.OK)
+        expect(await agentApprovalGate.checkDecision({ gateId })).toBe('pending')
+    })
+})

--- a/packages/server/api/test/unit/app/ee/agent/agent-rpc-handlers.test.ts
+++ b/packages/server/api/test/unit/app/ee/agent/agent-rpc-handlers.test.ts
@@ -47,17 +47,33 @@ vi.mock('ai', async (importOriginal) => ({
     embed: () => mockEmbed(),
 }))
 
-const { mockTakePreparedTool, mockCheckDecision } = vi.hoisted(() => ({
+const { mockTakePreparedTool, mockCheckDecision, mockGetSelectedConnection, mockStorePreparedTool } = vi.hoisted(() => ({
     mockTakePreparedTool: vi.fn(),
     mockCheckDecision: vi.fn(),
+    mockGetSelectedConnection: vi.fn().mockResolvedValue(null),
+    mockStorePreparedTool: vi.fn(),
 }))
 
 vi.mock('../../../../../src/app/ee/agent/agent-approval-gate', () => ({
-    agentApprovalGate: { takePreparedTool: mockTakePreparedTool, checkDecision: mockCheckDecision },
+    agentApprovalGate: {
+        takePreparedTool: mockTakePreparedTool,
+        checkDecision: mockCheckDecision,
+        getSelectedConnection: mockGetSelectedConnection,
+        storePreparedTool: mockStorePreparedTool,
+    },
 }))
 
-const { mockRunResolved, mockUpdateStepProgress } = vi.hoisted(() => ({
+const { mockGetOneWithoutValue } = vi.hoisted(() => ({
+    mockGetOneWithoutValue: vi.fn().mockResolvedValue(null),
+}))
+
+vi.mock('../../../../../src/app/app-connection/app-connection-service/app-connection-service', () => ({
+    appConnectionService: () => ({ getOneWithoutValue: mockGetOneWithoutValue }),
+}))
+
+const { mockRunResolved, mockResolveInput, mockUpdateStepProgress } = vi.hoisted(() => ({
     mockRunResolved: vi.fn().mockResolvedValue({ result: { ok: true }, resolvedInput: {} }),
+    mockResolveInput: vi.fn().mockResolvedValue({ resolvedInput: { to: 'jane@customer.com' }, actionDisplayName: 'Send Email' }),
     mockUpdateStepProgress: vi.fn(),
 }))
 
@@ -66,7 +82,7 @@ vi.mock('../../../../../src/app/flows/flow-run/engine-run-callback-service', () 
 }))
 
 vi.mock('../../../../../src/app/ee/agent/tools/piece-tool-runner', () => ({
-    pieceToolRunner: { runResolved: mockRunResolved },
+    pieceToolRunner: { runResolved: mockRunResolved, resolveInput: mockResolveInput, withoutCredential: (input: Record<string, unknown>) => input },
 }))
 
 const { mockGetOnePopulated } = vi.hoisted(() => ({
@@ -651,5 +667,57 @@ describe('agentRpcHandlers.executeKnowledgeBaseTool — an oversized embedding i
         })
 
         expect(mockKbSearch).toHaveBeenCalledWith(expect.objectContaining({ queryEmbedding: expect.objectContaining({ length: 768 }) }))
+    })
+})
+
+describe('agentRpcHandlers.preparePieceTool — which account a configured action runs as', () => {
+    const AGENT_CHAT = { id: 'conv-1', source: 'AGENT', projectId: 'proj-1', platformId: 'plat-1' }
+    const PINNED = 'conn-author-pinned'
+
+    async function prepare({ pinnedExists, pinnedAuth = PINNED }: { pinnedExists: boolean, pinnedAuth?: string }) {
+        mockResolveInput.mockClear()
+        mockFindOneBy.mockResolvedValue(AGENT_CHAT)
+        mockGetOneWithoutValue.mockResolvedValue(pinnedExists ? { id: 'ac-1', externalId: PINNED, displayName: 'Sales Inbox' } : null)
+        const { agentRpcHandlers } = await import('../../../../../src/app/ee/agent/agent-rpc-handlers')
+        const response = await agentRpcHandlers(noopLogger as never).preparePieceTool({
+            conversationId: 'conv-1',
+            toolName: 'gmail-send_email',
+            instruction: 'email the summary',
+            preparedId: 'call-1',
+            tainted: false,
+            piece: { pieceName: '@activepieces/piece-gmail', pieceVersion: '0.1.0', actionName: 'send_email', predefinedInput: { auth: pinnedAuth, fields: {} } },
+        })
+        return { call: mockResolveInput.mock.calls[0][0], response, lookup: mockGetOneWithoutValue.mock.calls[0]?.[0] }
+    }
+
+    it('runs as the account the author pinned, and hands it to dynamic property resolution', async () => {
+        const { call } = await prepare({ pinnedExists: true })
+
+        expect(call.connectionExternalId).toBe(PINNED)
+    })
+
+    it('names the account on the approval card, so approving says whose it is', async () => {
+        const { response } = await prepare({ pinnedExists: true })
+
+        expect(response.connectionLabel).toBe('Sales Inbox')
+    })
+
+    it('looks the account up inside the conversation project only', async () => {
+        const { lookup } = await prepare({ pinnedExists: true })
+
+        expect(lookup).toMatchObject({ projectId: 'proj-1', platformId: 'plat-1', externalId: PINNED })
+    })
+
+    it('still runs as the pinned account when it cannot be named, rather than picking another one', async () => {
+        const { call, response } = await prepare({ pinnedExists: false })
+
+        expect(call.connectionExternalId).toBe(PINNED)
+        expect(response.connectionLabel).toBeUndefined()
+    })
+
+    it('asks for no account when the author pinned none', async () => {
+        const { call } = await prepare({ pinnedExists: false, pinnedAuth: '' })
+
+        expect(call.connectionExternalId).toBeUndefined()
     })
 })

--- a/packages/server/api/test/unit/app/ee/agent/agent-rpc-handlers.test.ts
+++ b/packages/server/api/test/unit/app/ee/agent/agent-rpc-handlers.test.ts
@@ -47,12 +47,17 @@ vi.mock('ai', async (importOriginal) => ({
     embed: () => mockEmbed(),
 }))
 
-vi.mock('../../../../../src/app/ee/agent/agent-approval-gate', () => ({
-    agentApprovalGate: {},
+const { mockTakePreparedTool, mockCheckDecision } = vi.hoisted(() => ({
+    mockTakePreparedTool: vi.fn(),
+    mockCheckDecision: vi.fn(),
 }))
 
-const { mockRunFromInstruction, mockUpdateStepProgress } = vi.hoisted(() => ({
-    mockRunFromInstruction: vi.fn().mockResolvedValue({ result: { ok: true }, resolvedInput: {} }),
+vi.mock('../../../../../src/app/ee/agent/agent-approval-gate', () => ({
+    agentApprovalGate: { takePreparedTool: mockTakePreparedTool, checkDecision: mockCheckDecision },
+}))
+
+const { mockRunResolved, mockUpdateStepProgress } = vi.hoisted(() => ({
+    mockRunResolved: vi.fn().mockResolvedValue({ result: { ok: true }, resolvedInput: {} }),
     mockUpdateStepProgress: vi.fn(),
 }))
 
@@ -61,7 +66,7 @@ vi.mock('../../../../../src/app/flows/flow-run/engine-run-callback-service', () 
 }))
 
 vi.mock('../../../../../src/app/ee/agent/tools/piece-tool-runner', () => ({
-    pieceToolRunner: { runFromInstruction: mockRunFromInstruction },
+    pieceToolRunner: { runResolved: mockRunResolved },
 }))
 
 const { mockGetOnePopulated } = vi.hoisted(() => ({
@@ -385,38 +390,85 @@ describe('agentRpcHandlers.executeAgentTool — the owner\'s own memory is not a
     })
 })
 
-describe('agentRpcHandlers.executePieceTool — only a flow-step run may run a configured action', () => {
-    async function runPieceTool(conversation: unknown) {
-        mockRunFromInstruction.mockClear()
+describe('agentRpcHandlers.executePieceTool — a configured action runs only the input that was approved', () => {
+    const GMAIL_SEND = { pieceName: '@activepieces/piece-gmail', actionName: 'send_email', pieceVersion: '0.1.0' }
+
+    async function runPieceTool({ conversation, prepared, decision }: {
+        conversation: unknown
+        prepared?: unknown
+        decision?: unknown
+    }) {
+        mockRunResolved.mockClear()
         mockFindOneBy.mockResolvedValue(conversation)
+        mockTakePreparedTool.mockResolvedValue(prepared ?? null)
+        mockCheckDecision.mockResolvedValue(decision ?? 'pending')
         const { agentRpcHandlers } = await import('../../../../../src/app/ee/agent/agent-rpc-handlers')
         return agentRpcHandlers(noopLogger as never).executePieceTool({
             conversationId: 'conv-1',
             toolName: 'send_email',
             instruction: 'email the summary',
-            piece: { pieceName: '@activepieces/piece-gmail', pieceVersion: '0.1.0', actionName: 'send_email' },
+            preparedId: 'call-1',
+            piece: GMAIL_SEND,
         })
     }
 
-    it('runs the action in the conversation\'s own project', async () => {
-        await runPieceTool({ id: 'conv-1', source: 'FLOW_STEP', projectId: 'proj-1', platformId: 'plat-1' })
+    const agentChat = { id: 'conv-1', source: 'AGENT', projectId: 'proj-1', platformId: 'plat-1' }
+    const flowStep = { id: 'conv-1', source: 'FLOW_STEP', projectId: 'proj-1', platformId: 'plat-1' }
+    const approvedSend = { input: { to: 'jane@customer.com' }, piece: GMAIL_SEND, needsApproval: true }
 
-        expect(mockRunFromInstruction).toHaveBeenCalledTimes(1)
-        const call = mockRunFromInstruction.mock.calls[0][0]
+    it('runs the action in the conversation\'s own project, on the prepared input', async () => {
+        await runPieceTool({ conversation: flowStep, prepared: { input: { to: 'ops@acme.com' }, piece: GMAIL_SEND, needsApproval: false } })
+
+        expect(mockRunResolved).toHaveBeenCalledTimes(1)
+        const call = mockRunResolved.mock.calls[0][0]
         expect(call.projectId).toBe('proj-1')
-        expect(call.piece).toEqual({ pieceName: '@activepieces/piece-gmail', actionName: 'send_email', pieceVersion: '0.1.0' })
+        expect(call.resolvedInput).toEqual({ to: 'ops@acme.com' })
+    })
+
+    it('runs the piece and action the input was prepared for, not the one the caller asks for', async () => {
+        await runPieceTool({
+            conversation: agentChat,
+            prepared: { input: { url: '/messages' }, piece: { pieceName: '@activepieces/piece-slack', actionName: 'send_message' }, needsApproval: true },
+            decision: { approved: true },
+        })
+
+        expect(mockRunResolved.mock.calls[0][0].piece).toEqual({ pieceName: '@activepieces/piece-slack', actionName: 'send_message' })
+    })
+
+    it('refuses when nothing was prepared, so skipping the preview does not skip the gate', async () => {
+        await expect(runPieceTool({ conversation: agentChat })).rejects.toThrow()
+
+        expect(mockRunResolved).not.toHaveBeenCalled()
+    })
+
+    it('refuses an action awaiting approval that no one has answered yet', async () => {
+        await expect(runPieceTool({ conversation: agentChat, prepared: approvedSend, decision: 'pending' })).rejects.toThrow()
+
+        expect(mockRunResolved).not.toHaveBeenCalled()
+    })
+
+    it('refuses an action the person declined', async () => {
+        await expect(runPieceTool({ conversation: agentChat, prepared: approvedSend, decision: { approved: false } })).rejects.toThrow()
+
+        expect(mockRunResolved).not.toHaveBeenCalled()
+    })
+
+    it('runs an action the person approved', async () => {
+        await runPieceTool({ conversation: agentChat, prepared: approvedSend, decision: { approved: true } })
+
+        expect(mockRunResolved).toHaveBeenCalledTimes(1)
     })
 
     it('refuses when the conversation is a chat', async () => {
-        await expect(runPieceTool({ id: 'conv-1', source: 'CHAT', projectId: 'proj-1' })).rejects.toThrow()
+        await expect(runPieceTool({ conversation: { id: 'conv-1', source: 'CHAT', projectId: 'proj-1' } })).rejects.toThrow()
 
-        expect(mockRunFromInstruction).not.toHaveBeenCalled()
+        expect(mockRunResolved).not.toHaveBeenCalled()
     })
 
     it('refuses a flow-step run with no project, so the action is never run unscoped', async () => {
-        await expect(runPieceTool({ id: 'conv-1', source: 'FLOW_STEP', projectId: null })).rejects.toThrow()
+        await expect(runPieceTool({ conversation: { id: 'conv-1', source: 'FLOW_STEP', projectId: null } })).rejects.toThrow()
 
-        expect(mockRunFromInstruction).not.toHaveBeenCalled()
+        expect(mockRunResolved).not.toHaveBeenCalled()
     })
 })
 

--- a/packages/server/api/test/unit/app/ee/agent/piece-tool-runner.test.ts
+++ b/packages/server/api/test/unit/app/ee/agent/piece-tool-runner.test.ts
@@ -166,3 +166,38 @@ describe('pieceToolRunner: a custom API call stays on the connection\'s own host
         expect(mockExecutePieceActionRun).toHaveBeenCalledTimes(1)
     })
 })
+
+describe('pieceToolRunner.resolveInput: which account fills the input and lists the options', () => {
+    beforeEach(() => {
+        vi.clearAllMocks()
+        mockGetOrThrow.mockResolvedValue(metadataWith({ text: { displayName: 'Text', required: true, type: PropertyType.SHORT_TEXT } }))
+        mockCompleter.mockResolvedValue({ text: 'hello' })
+        mockExecutePieceActionRun.mockResolvedValue({ content: [{ type: 'text', text: 'sent' }] })
+    })
+
+    async function resolve(overrides: Record<string, unknown>) {
+        const { pieceToolRunner } = await import('../../../../../src/app/ee/agent/tools/piece-tool-runner')
+        const { resolvedInput } = await pieceToolRunner.resolveInput({
+            piece: { pieceName: '@activepieces/piece-slack', actionName: 'send_message' },
+            instruction: 'say hello in general',
+            model: {} as never,
+            projectId: 'proj-1',
+            platformId: 'plat-1',
+            log: log as never,
+            ...overrides,
+        } as never)
+        return resolvedInput
+    }
+
+    it('runs as the pinned account when nothing overrides it', async () => {
+        expect(await resolve({ predefinedInput: { auth: 'conn-pinned', fields: {} } })).toMatchObject({ auth: 'conn-pinned' })
+    })
+
+    it('runs as the overriding account, and the pin does not win it back', async () => {
+        expect(await resolve({ predefinedInput: { auth: 'conn-pinned', fields: {} }, connectionExternalId: 'conn-override' })).toMatchObject({ auth: 'conn-override' })
+    })
+
+    it('runs as the overriding account when the author pinned none', async () => {
+        expect(await resolve({ connectionExternalId: 'conn-override' })).toMatchObject({ auth: 'conn-override' })
+    })
+})

--- a/packages/server/api/test/unit/app/ee/agent/piece-tool-runner.test.ts
+++ b/packages/server/api/test/unit/app/ee/agent/piece-tool-runner.test.ts
@@ -32,9 +32,14 @@ function metadataWith(props: Record<string, unknown>) {
     return { version: '1.4.0', actions: { send_message: { props } } }
 }
 
-async function run(overrides: Record<string, unknown> = {}) {
+async function prepareAndRun(params: Record<string, unknown>) {
     const { pieceToolRunner } = await import('../../../../../src/app/ee/agent/tools/piece-tool-runner')
-    return pieceToolRunner.runFromInstruction({
+    const { resolvedInput } = await pieceToolRunner.resolveInput(params as never)
+    return pieceToolRunner.runResolved({ piece: params.piece as never, resolvedInput, projectId: params.projectId as string, log: log as never })
+}
+
+async function run(overrides: Record<string, unknown> = {}) {
+    return prepareAndRun({
         piece: { pieceName: '@activepieces/piece-slack', actionName: 'send_message' },
         instruction: 'say hello in general',
         model: {} as never,
@@ -45,7 +50,7 @@ async function run(overrides: Record<string, unknown> = {}) {
     } as never)
 }
 
-describe('pieceToolRunner.runFromInstruction', () => {
+describe('pieceToolRunner: preparing then running a configured action', () => {
     beforeEach(() => {
         vi.clearAllMocks()
         mockGetOrThrow.mockResolvedValue(metadataWith({ text: { displayName: 'Text', required: true, type: PropertyType.SHORT_TEXT } }))
@@ -124,7 +129,7 @@ describe('pieceToolRunner.runFromInstruction', () => {
     })
 })
 
-describe('pieceToolRunner.runFromInstruction — a custom API call stays on the connection\'s own host', () => {
+describe('pieceToolRunner: a custom API call stays on the connection\'s own host', () => {
     beforeEach(() => {
         vi.clearAllMocks()
         mockGetOrThrow.mockResolvedValue({ version: '1.4.0', actions: { custom_api_call: { props: { url: { displayName: 'URL', required: true, type: PropertyType.SHORT_TEXT } } } } })
@@ -133,8 +138,7 @@ describe('pieceToolRunner.runFromInstruction — a custom API call stays on the 
 
     async function callWithUrl(url: unknown) {
         mockCompleter.mockResolvedValue({ url })
-        const { pieceToolRunner } = await import('../../../../../src/app/ee/agent/tools/piece-tool-runner')
-        return pieceToolRunner.runFromInstruction({
+        return prepareAndRun({
             piece: { pieceName: '@activepieces/piece-slack', actionName: 'custom_api_call' },
             instruction: 'call the api',
             model: {} as never,

--- a/packages/server/worker/src/lib/execute/jobs/ee/agent/agent-worker-tools.ts
+++ b/packages/server/worker/src/lib/execute/jobs/ee/agent/agent-worker-tools.ts
@@ -1465,6 +1465,7 @@ function createConfiguredPieceTools({ tools, runPieceTool, preparePieceTool, tai
                         pieceName: configured.pieceMetadata.pieceName,
                         actionName: configured.pieceMetadata.actionName,
                         actionDisplayName: prepared.actionDisplayName,
+                        ...spreadIfDefined('connectionLabel', prepared.connectionLabel),
                         input: prepared.input,
                         isBatch: false,
                     })
@@ -1499,6 +1500,7 @@ function createConfiguredPieceTools({ tools, runPieceTool, preparePieceTool, tai
                         toolCallId: preparedId,
                         actionDisplayName: prepared.actionDisplayName,
                         pieceName: configured.pieceMetadata.pieceName,
+                        ...spreadIfDefined('connectionLabel', prepared.connectionLabel),
                         status: succeeded ? 'success' : 'failed',
                         output: data.result,
                         timestamp: new Date().toISOString(),

--- a/packages/server/worker/src/lib/execute/jobs/ee/agent/agent-worker-tools.ts
+++ b/packages/server/worker/src/lib/execute/jobs/ee/agent/agent-worker-tools.ts
@@ -155,21 +155,36 @@ function gateNoResponseMessage(step: string): string {
     return `⏳ The user hasn't responded to the ${step} yet (it timed out) — they did NOT decline, they're just away. Decide based on how essential this step is: if the task can continue without it, skip only this step, keep going, and briefly tell the user what you skipped and why. If it is required to proceed, stop here and tell the user this step needs their approval — ask them to approve it to continue. Never assume approval or perform the gated action on your own.`
 }
 
-function createDisplayTools({ waitForApproval, displayToolTimeoutMs, onConnectionSelected, onConnectorReconnected, onGateOpened }: {
+function createDisplayTools({ waitForApproval, displayToolTimeoutMs, onConnectionSelected, onConnectorReconnected, onGateOpened, accountAlreadyChosenFor }: {
     waitForApproval: (params: { gateId: string, timeoutMs?: number }) => Promise<GateDecision>
     displayToolTimeoutMs: number
     onConnectionSelected?: (params: { pieceName: string, connectionExternalId: string, label: string, projectId: string }) => Promise<void>
     onConnectorReconnected?: (connectorUuid: string) => void
     onGateOpened?: (params: { gateId: string, toolName: string, displayName: string, toolInput: Record<string, unknown> }) => Promise<void>
+    accountAlreadyChosenFor?: (pieceName: string) => boolean
 }): ToolSet {
-    function blockingExecute({ dismissMessage, successKey, toolName, getDisplayName, onApproved }: {
+    function refuseIfAccountAlreadyChosen(input: Record<string, unknown>): { content: { type: string, text: string }[] } | undefined {
+        const piece = typeof input['piece'] === 'string' ? input['piece'] : ''
+        if (isNil(accountAlreadyChosenFor) || !accountAlreadyChosenFor(normalizePieceName(piece))) {
+            return undefined
+        }
+        const displayName = typeof input['displayName'] === 'string' ? input['displayName'] : piece
+        return { content: [{ type: 'text', text: `This agent already runs on the ${displayName} account its author chose, so there is nothing to connect or reconnect here and this card was not shown. Use the ${displayName} tool. If it fails, say exactly what failed — do not describe it as a connection problem unless the failure says the credentials were rejected.` }] }
+    }
+
+    function blockingExecute({ dismissMessage, successKey, toolName, getDisplayName, onApproved, refuseWhen }: {
         dismissMessage: string | ((input: Record<string, unknown>) => string)
         successKey?: string
         toolName: string
         getDisplayName?: (input: Record<string, unknown>) => string
         onApproved?: (params: { input: Record<string, unknown>, payload?: Record<string, unknown> }) => Promise<Record<string, unknown>>
+        refuseWhen?: (input: Record<string, unknown>) => { content: { type: string, text: string }[] } | undefined
     }) {
         return async (input: Record<string, unknown>, options: ToolExecutionOptions<undefined>) => {
+            const refusal = refuseWhen?.(input)
+            if (!isNil(refusal)) {
+                return refusal
+            }
             if (onGateOpened) {
                 const fallbackName = typeof input['displayName'] === 'string' ? input['displayName'] : toolName
                 await tryCatch(() => onGateOpened({
@@ -203,6 +218,7 @@ function createDisplayTools({ waitForApproval, displayToolTimeoutMs, onConnectio
             }),
             execute: blockingExecute({
                 toolName: 'ap_show_connection_required',
+                refuseWhen: refuseIfAccountAlreadyChosen,
                 dismissMessage: 'The user chose not to connect this service. Stop and ask: "Would you like me to continue building with a placeholder you can connect later, or would you prefer to stop here?"',
                 onApproved: async ({ input, payload = {} }) => {
                     const connectionExternalId = payload['connectionExternalId']
@@ -252,6 +268,7 @@ function createDisplayTools({ waitForApproval, displayToolTimeoutMs, onConnectio
             }),
             execute: blockingExecute({
                 toolName: 'ap_show_connection_picker',
+                refuseWhen: refuseIfAccountAlreadyChosen,
                 dismissMessage: (input) => `The user chose not to select a ${typeof input['displayName'] === 'string' ? input['displayName'] : 'service'} account. Do not pick one on their behalf. Ask: "Would you like me to continue building with a placeholder you can connect later, or would you prefer to stop here?"`,
                 onApproved: async ({ input, payload = {} }) => {
                     const connectionExternalId = payload['connectionExternalId']
@@ -1476,6 +1493,7 @@ function createConfiguredPieceTools({ tools, runPieceTool, preparePieceTool, tai
                         toolInput: {
                             pieceName: configured.pieceMetadata.pieceName,
                             actionName: configured.pieceMetadata.actionName,
+                            ...spreadIfDefined('connectionLabel', prepared.connectionLabel),
                             input: prepared.input,
                         },
                     }))

--- a/packages/server/worker/src/lib/execute/jobs/ee/agent/agent-worker-tools.ts
+++ b/packages/server/worker/src/lib/execute/jobs/ee/agent/agent-worker-tools.ts
@@ -1428,9 +1428,15 @@ export type AgentEventEmitter = {
     emitBuildPlan(data: BuildPlanEvent): void
 }
 
-function createConfiguredPieceTools({ tools, runPieceTool, log }: {
+function createConfiguredPieceTools({ tools, runPieceTool, preparePieceTool, attended, taintState, eventEmitter, waitForApproval, onGateOpened, log }: {
     tools: AgentPieceTool[]
-    runPieceTool: (input: { toolName: string, instruction: string, piece: AgentPieceToolMetadata }) => Promise<{ result: unknown }>
+    runPieceTool: (input: { toolName: string, instruction: string, piece: AgentPieceToolMetadata, preparedId?: string }) => Promise<{ result: unknown }>
+    preparePieceTool: (input: { toolName: string, instruction: string, piece: AgentPieceToolMetadata, preparedId: string }) => Promise<{ input: Record<string, unknown> }>
+    attended: boolean
+    taintState: TaintState
+    eventEmitter: ReturnType<typeof createEventEmitter>
+    waitForApproval: (params: { gateId: string, timeoutMs?: number }) => Promise<GateDecision>
+    onGateOpened?: (params: { gateId: string, toolName: string, displayName: string, toolInput: Record<string, unknown> }) => Promise<void>
     log: FastifyBaseLogger
 }): ToolSet {
     let callsMade = 0
@@ -1441,13 +1447,49 @@ function createConfiguredPieceTools({ tools, runPieceTool, log }: {
             inputSchema: z.object({
                 instruction: z.string().describe('What this action should do, including any values it needs, in plain language'),
             }),
-            execute: async ({ instruction }) => {
+            execute: async ({ instruction }, options) => {
                 callsMade += 1
                 if (callsMade > MAX_CONFIGURED_TOOL_CALLS) {
                     log.warn({ tool: { name: configured.toolName }, callsMade }, '[configuredPieceTool] Refused, this run has already run enough actions')
                     return { content: [{ type: 'text', text: `This run has already performed ${MAX_CONFIGURED_TOOL_CALLS} actions, which is the limit. Do not try again; say what is left undone.` }] }
                 }
-                const { data, error } = await tryCatch(() => runPieceTool({ toolName: configured.toolName, instruction, piece: configured.pieceMetadata }))
+                const needsApproval = agentToolClassification.configuredToolNeedsApproval({
+                    actionName: configured.pieceMetadata.actionName,
+                    attended,
+                    tainted: taintState.tainted,
+                })
+                let preparedId: string | undefined = undefined
+                if (needsApproval) {
+                    const gateId = options.toolCallId
+                    const { data: prepared, error: prepareError } = await tryCatch(() => preparePieceTool({ toolName: configured.toolName, instruction, piece: configured.pieceMetadata, preparedId: gateId }))
+                    if (prepareError || isNil(prepared)) {
+                        log.warn({ error: prepareError, tool: { name: configured.toolName } }, '[configuredPieceTool] Could not work out what this action would do')
+                        return { content: [{ type: 'text', text: `That action could not be prepared for review, so nothing ran: ${String(prepareError)}` }] }
+                    }
+                    eventEmitter.emitActionPreview({
+                        toolCallId: gateId,
+                        pieceName: configured.pieceMetadata.pieceName,
+                        actionName: configured.pieceMetadata.actionName,
+                        actionDisplayName: configured.toolName,
+                        input: prepared.input,
+                        isBatch: false,
+                    })
+                    if (onGateOpened) {
+                        await tryCatch(() => onGateOpened({
+                            gateId,
+                            toolName: configured.toolName,
+                            displayName: configured.pieceMetadata.actionName,
+                            toolInput: prepared.input,
+                        }))
+                    }
+                    const decision = await waitForApproval({ gateId })
+                    if (decision.outcome !== 'approved') {
+                        const text = decision.outcome === 'timeout' ? gateNoResponseMessage('action approval') : 'Action cancelled by user.'
+                        return { content: [{ type: 'text', text }] }
+                    }
+                    preparedId = gateId
+                }
+                const { data, error } = await tryCatch(() => runPieceTool({ toolName: configured.toolName, instruction, piece: configured.pieceMetadata, ...(isNil(preparedId) ? {} : { preparedId }) }))
                 if (error) {
                     const reachedTheServer = String(error).includes('handler threw')
                     log.warn({ error, tool: { name: configured.toolName }, reachedTheServer }, '[configuredPieceTool] Action did not return a result')

--- a/packages/server/worker/src/lib/execute/jobs/ee/agent/agent-worker-tools.ts
+++ b/packages/server/worker/src/lib/execute/jobs/ee/agent/agent-worker-tools.ts
@@ -1,6 +1,6 @@
 import { chunk, isNil, isObject, spreadIfDefined, tryCatch, tryCatchSync } from '@activepieces/core-utils'
 import { largeResultUtils, MAX_TOOL_RESULT_BYTES, safeHttp } from '@activepieces/server-utils'
-import { ActionPreviewEvent, ActionReceiptEvent, AgentEventType, AgentKnowledgeBaseTool, AgentOutputField, AgentOutputFieldType, AgentPhase, AgentPieceTool, AgentPieceToolMetadata, agentToolClassification, apId, BatchItemResult, BuildPlanEvent, FileProducedEvent, ImageGeneratedEvent, KnowledgeBaseSourceType, PreparePieceToolResponse, ResolvedAgentFlowTool, SaveAgentFileResponse, SendAgentEmailResponse, SendAgentEventRequest, TASK_COMPLETION_TOOL_NAME, ToolProgressEvent } from '@activepieces/shared'
+import { ActionPreviewEvent, ActionReceiptEvent, AgentEventType, AgentKnowledgeBaseTool, AgentOutputField, AgentOutputFieldType, AgentPhase, AgentPieceTool, AgentPieceToolMetadata, agentToolClassification, apErrorOf, apId, BatchItemResult, BuildPlanEvent, FileProducedEvent, ImageGeneratedEvent, KnowledgeBaseSourceType, PreparePieceToolResponse, ResolvedAgentFlowTool, SaveAgentFileResponse, SendAgentEmailResponse, SendAgentEventRequest, TASK_COMPLETION_TOOL_NAME, ToolProgressEvent } from '@activepieces/shared'
 import { jsonSchema, JSONSchema7, tool, ToolExecutionOptions, ToolSet } from 'ai'
 import { FastifyBaseLogger } from 'fastify'
 import { stripHtml } from 'string-strip-html'
@@ -1455,8 +1455,9 @@ function createConfiguredPieceTools({ tools, runPieceTool, preparePieceTool, tai
                 const preparedId = options.toolCallId
                 const { data: prepared, error: prepareError } = await tryCatch(() => preparePieceTool({ toolName: configured.toolName, instruction, piece: configured.pieceMetadata, preparedId, tainted: taintState.tainted }))
                 if (prepareError || isNil(prepared)) {
+                    const reason = apErrorOf(prepareError)?.message ?? String(prepareError)
                     log.warn({ error: prepareError, tool: { name: configured.toolName } }, '[configuredPieceTool] Could not work out what this action would do')
-                    return { content: [{ type: 'text', text: `That action could not be prepared, so nothing ran: ${String(prepareError)}` }] }
+                    return { content: [{ type: 'text', text: `That action could not be prepared, so nothing ran, and this is not a connection problem: ${reason}` }] }
                 }
                 if (prepared.needsApproval) {
                     eventEmitter.emitActionPreview({
@@ -1488,7 +1489,7 @@ function createConfiguredPieceTools({ tools, runPieceTool, preparePieceTool, tai
                     const reachedTheServer = String(error).includes('handler threw')
                     log.warn({ error, tool: { name: configured.toolName }, reachedTheServer }, '[configuredPieceTool] Action did not return a result')
                     return { content: [{ type: 'text', text: reachedTheServer
-                        ? `That action failed: ${String(error)}`
+                        ? `That action failed, and this is not a connection problem: ${apErrorOf(error)?.message ?? String(error)}`
                         : `That action was sent but did not report back in time, so it may already have run. Do not call it again. Tell the user it needs checking. (${String(error)})` }] }
                 }
                 const succeeded = isSuccessResult(data.result)

--- a/packages/server/worker/src/lib/execute/jobs/ee/agent/agent-worker-tools.ts
+++ b/packages/server/worker/src/lib/execute/jobs/ee/agent/agent-worker-tools.ts
@@ -1,6 +1,6 @@
 import { chunk, isNil, isObject, spreadIfDefined, tryCatch, tryCatchSync } from '@activepieces/core-utils'
 import { largeResultUtils, MAX_TOOL_RESULT_BYTES, safeHttp } from '@activepieces/server-utils'
-import { ActionPreviewEvent, ActionReceiptEvent, AgentEventType, AgentKnowledgeBaseTool, AgentOutputField, AgentOutputFieldType, AgentPhase, AgentPieceTool, AgentPieceToolMetadata, agentToolClassification, apId, BatchItemResult, BuildPlanEvent, FileProducedEvent, ImageGeneratedEvent, KnowledgeBaseSourceType, ResolvedAgentFlowTool, SaveAgentFileResponse, SendAgentEmailResponse, SendAgentEventRequest, TASK_COMPLETION_TOOL_NAME, ToolProgressEvent } from '@activepieces/shared'
+import { ActionPreviewEvent, ActionReceiptEvent, AgentEventType, AgentKnowledgeBaseTool, AgentOutputField, AgentOutputFieldType, AgentPhase, AgentPieceTool, AgentPieceToolMetadata, agentToolClassification, apId, BatchItemResult, BuildPlanEvent, FileProducedEvent, ImageGeneratedEvent, KnowledgeBaseSourceType, PreparePieceToolResponse, ResolvedAgentFlowTool, SaveAgentFileResponse, SendAgentEmailResponse, SendAgentEventRequest, TASK_COMPLETION_TOOL_NAME, ToolProgressEvent } from '@activepieces/shared'
 import { jsonSchema, JSONSchema7, tool, ToolExecutionOptions, ToolSet } from 'ai'
 import { FastifyBaseLogger } from 'fastify'
 import { stripHtml } from 'string-strip-html'
@@ -1428,15 +1428,14 @@ export type AgentEventEmitter = {
     emitBuildPlan(data: BuildPlanEvent): void
 }
 
-function createConfiguredPieceTools({ tools, runPieceTool, preparePieceTool, attended, taintState, eventEmitter, waitForApproval, onGateOpened, log }: {
+function createConfiguredPieceTools({ tools, runPieceTool, preparePieceTool, taintState, eventEmitter, waitForApproval, onGateOpened, log }: {
     tools: AgentPieceTool[]
-    runPieceTool: (input: { toolName: string, instruction: string, piece: AgentPieceToolMetadata, preparedId?: string }) => Promise<{ result: unknown }>
-    preparePieceTool: (input: { toolName: string, instruction: string, piece: AgentPieceToolMetadata, preparedId: string }) => Promise<{ input: Record<string, unknown> }>
-    attended: boolean
+    runPieceTool: (input: { toolName: string, instruction: string, piece: AgentPieceToolMetadata, preparedId: string }) => Promise<{ result: unknown }>
+    preparePieceTool: (input: { toolName: string, instruction: string, piece: AgentPieceToolMetadata, preparedId: string, tainted: boolean }) => Promise<PreparePieceToolResponse>
     taintState: TaintState
-    eventEmitter: ReturnType<typeof createEventEmitter>
+    eventEmitter: AgentEventEmitter
     waitForApproval: (params: { gateId: string, timeoutMs?: number }) => Promise<GateDecision>
-    onGateOpened?: (params: { gateId: string, toolName: string, displayName: string, toolInput: Record<string, unknown> }) => Promise<void>
+    onGateOpened: (params: { gateId: string, toolName: string, displayName: string, toolInput: Record<string, unknown> }) => Promise<void>
     log: FastifyBaseLogger
 }): ToolSet {
     let callsMade = 0
@@ -1453,43 +1452,38 @@ function createConfiguredPieceTools({ tools, runPieceTool, preparePieceTool, att
                     log.warn({ tool: { name: configured.toolName }, callsMade }, '[configuredPieceTool] Refused, this run has already run enough actions')
                     return { content: [{ type: 'text', text: `This run has already performed ${MAX_CONFIGURED_TOOL_CALLS} actions, which is the limit. Do not try again; say what is left undone.` }] }
                 }
-                const needsApproval = agentToolClassification.configuredToolNeedsApproval({
-                    actionName: configured.pieceMetadata.actionName,
-                    attended,
-                    tainted: taintState.tainted,
-                })
-                let preparedId: string | undefined = undefined
-                if (needsApproval) {
-                    const gateId = options.toolCallId
-                    const { data: prepared, error: prepareError } = await tryCatch(() => preparePieceTool({ toolName: configured.toolName, instruction, piece: configured.pieceMetadata, preparedId: gateId }))
-                    if (prepareError || isNil(prepared)) {
-                        log.warn({ error: prepareError, tool: { name: configured.toolName } }, '[configuredPieceTool] Could not work out what this action would do')
-                        return { content: [{ type: 'text', text: `That action could not be prepared for review, so nothing ran: ${String(prepareError)}` }] }
-                    }
+                const preparedId = options.toolCallId
+                const { data: prepared, error: prepareError } = await tryCatch(() => preparePieceTool({ toolName: configured.toolName, instruction, piece: configured.pieceMetadata, preparedId, tainted: taintState.tainted }))
+                if (prepareError || isNil(prepared)) {
+                    log.warn({ error: prepareError, tool: { name: configured.toolName } }, '[configuredPieceTool] Could not work out what this action would do')
+                    return { content: [{ type: 'text', text: `That action could not be prepared, so nothing ran: ${String(prepareError)}` }] }
+                }
+                if (prepared.needsApproval) {
                     eventEmitter.emitActionPreview({
-                        toolCallId: gateId,
+                        toolCallId: preparedId,
                         pieceName: configured.pieceMetadata.pieceName,
                         actionName: configured.pieceMetadata.actionName,
-                        actionDisplayName: configured.toolName,
+                        actionDisplayName: prepared.actionDisplayName,
                         input: prepared.input,
                         isBatch: false,
                     })
-                    if (onGateOpened) {
-                        await tryCatch(() => onGateOpened({
-                            gateId,
-                            toolName: configured.toolName,
-                            displayName: configured.pieceMetadata.actionName,
-                            toolInput: prepared.input,
-                        }))
-                    }
-                    const decision = await waitForApproval({ gateId })
+                    await tryCatch(() => onGateOpened({
+                        gateId: preparedId,
+                        toolName: configured.toolName,
+                        displayName: prepared.actionDisplayName,
+                        toolInput: {
+                            pieceName: configured.pieceMetadata.pieceName,
+                            actionName: configured.pieceMetadata.actionName,
+                            input: prepared.input,
+                        },
+                    }))
+                    const decision = await waitForApproval({ gateId: preparedId })
                     if (decision.outcome !== 'approved') {
                         const text = decision.outcome === 'timeout' ? gateNoResponseMessage('action approval') : 'Action cancelled by user.'
                         return { content: [{ type: 'text', text }] }
                     }
-                    preparedId = gateId
                 }
-                const { data, error } = await tryCatch(() => runPieceTool({ toolName: configured.toolName, instruction, piece: configured.pieceMetadata, ...(isNil(preparedId) ? {} : { preparedId }) }))
+                const { data, error } = await tryCatch(() => runPieceTool({ toolName: configured.toolName, instruction, piece: configured.pieceMetadata, preparedId }))
                 if (error) {
                     const reachedTheServer = String(error).includes('handler threw')
                     log.warn({ error, tool: { name: configured.toolName }, reachedTheServer }, '[configuredPieceTool] Action did not return a result')
@@ -1497,7 +1491,19 @@ function createConfiguredPieceTools({ tools, runPieceTool, preparePieceTool, att
                         ? `That action failed: ${String(error)}`
                         : `That action was sent but did not report back in time, so it may already have run. Do not call it again. Tell the user it needs checking. (${String(error)})` }] }
                 }
-                if (!isSuccessResult(data.result)) {
+                const succeeded = isSuccessResult(data.result)
+                taintState.tainted = true
+                if (!agentToolClassification.isReadOnlyActionCall({ actionName: configured.pieceMetadata.actionName, input: prepared.input })) {
+                    eventEmitter.emitActionReceipt({
+                        toolCallId: preparedId,
+                        actionDisplayName: prepared.actionDisplayName,
+                        pieceName: configured.pieceMetadata.pieceName,
+                        status: succeeded ? 'success' : 'failed',
+                        output: data.result,
+                        timestamp: new Date().toISOString(),
+                    })
+                }
+                if (!succeeded) {
                     log.warn({ tool: { name: configured.toolName } }, '[configuredPieceTool] Action reported a failure')
                     return { content: [{ type: 'text', text: `That action failed: ${extractUserFacingError({ result: data.result })}` }] }
                 }

--- a/packages/server/worker/src/lib/execute/jobs/ee/agent/execute-agent-run.ts
+++ b/packages/server/worker/src/lib/execute/jobs/ee/agent/execute-agent-run.ts
@@ -647,9 +647,8 @@ function buildToolSet({ ctx, eventEmitter, log, phaseState, taintState, mcpToolS
     // answer, and an agent that asks an empty room reads the silence as a refusal and stops.
     const configuredTools = agentWorkerTools.createConfiguredPieceTools({
         tools: dryRun || discoveryOnly ? [] : configuredPieceTools,
-        runPieceTool: ({ toolName, instruction, piece, preparedId }) => ctx.apiClient.executePieceTool({ conversationId, toolName, instruction, piece, provider, providerConfigId, ...(isNil(preparedId) ? {} : { preparedId }) }),
-        preparePieceTool: ({ toolName, instruction, piece, preparedId }) => ctx.apiClient.preparePieceTool({ conversationId, toolName, instruction, piece, preparedId, provider, providerConfigId }),
-        attended: source !== AgentRunSource.FLOW_STEP,
+        runPieceTool: ({ toolName, instruction, piece, preparedId }) => ctx.apiClient.executePieceTool({ conversationId, toolName, instruction, piece, preparedId, provider, providerConfigId }),
+        preparePieceTool: ({ toolName, instruction, piece, preparedId, tainted }) => ctx.apiClient.preparePieceTool({ conversationId, toolName, instruction, piece, preparedId, tainted, provider, providerConfigId }),
         taintState,
         eventEmitter,
         waitForApproval,

--- a/packages/server/worker/src/lib/execute/jobs/ee/agent/execute-agent-run.ts
+++ b/packages/server/worker/src/lib/execute/jobs/ee/agent/execute-agent-run.ts
@@ -647,7 +647,13 @@ function buildToolSet({ ctx, eventEmitter, log, phaseState, taintState, mcpToolS
     // answer, and an agent that asks an empty room reads the silence as a refusal and stops.
     const configuredTools = agentWorkerTools.createConfiguredPieceTools({
         tools: dryRun || discoveryOnly ? [] : configuredPieceTools,
-        runPieceTool: ({ toolName, instruction, piece }) => ctx.apiClient.executePieceTool({ conversationId, toolName, instruction, piece, provider, providerConfigId }),
+        runPieceTool: ({ toolName, instruction, piece, preparedId }) => ctx.apiClient.executePieceTool({ conversationId, toolName, instruction, piece, provider, providerConfigId, ...(isNil(preparedId) ? {} : { preparedId }) }),
+        preparePieceTool: ({ toolName, instruction, piece, preparedId }) => ctx.apiClient.preparePieceTool({ conversationId, toolName, instruction, piece, preparedId, provider, providerConfigId }),
+        attended: source !== AgentRunSource.FLOW_STEP,
+        taintState,
+        eventEmitter,
+        waitForApproval,
+        onGateOpened: storePendingGate,
         log,
     })
     const configuredFlowToolSet = agentWorkerTools.createConfiguredFlowTools({

--- a/packages/server/worker/src/lib/execute/jobs/ee/agent/execute-agent-run.ts
+++ b/packages/server/worker/src/lib/execute/jobs/ee/agent/execute-agent-run.ts
@@ -585,9 +585,13 @@ function buildToolSet({ ctx, eventEmitter, log, phaseState, taintState, mcpToolS
         }))
     }
 
+    const piecesTheAuthorGaveAnAccount = new Set(source !== AgentRunSource.AGENT ? [] : configuredPieceTools
+        .filter((tool) => !isNil(tool.pieceMetadata.predefinedInput?.auth))
+        .map((tool) => tool.pieceMetadata.pieceName))
     const displayTools = agentWorkerTools.createDisplayTools({
         waitForApproval,
         displayToolTimeoutMs: DISPLAY_TOOL_TIMEOUT_MS,
+        accountAlreadyChosenFor: (pieceName) => piecesTheAuthorGaveAnAccount.has(pieceName),
         onConnectionSelected: async ({ pieceName, connectionExternalId, label, projectId: connProjectId }) => {
             selectedConnectionByPiece.set(pieceName, connectionExternalId)
             await tryCatch(() => ctx.apiClient.executeAgentTool({

--- a/packages/server/worker/test/lib/execute/jobs/ee/agent/agent-worker-tools.test.ts
+++ b/packages/server/worker/test/lib/execute/jobs/ee/agent/agent-worker-tools.test.ts
@@ -620,3 +620,41 @@ describe('agentWorkerTools', () => {
         })
     })
 })
+
+describe('an agent does not offer to connect an account its author already chose', () => {
+    function pickerTools({ accountAlreadyChosenFor }: { accountAlreadyChosenFor?: (pieceName: string) => boolean }) {
+        const gatesOpened: string[] = []
+        const tools = agentWorkerTools.createDisplayTools({
+            waitForApproval: async () => ({ outcome: 'approved' as const, payload: { connectionExternalId: 'conn-1', label: 'Sales Inbox', projectId: 'proj-1' } }),
+            displayToolTimeoutMs: 1000,
+            onGateOpened: async ({ toolName }) => { gatesOpened.push(toolName) },
+            ...(accountAlreadyChosenFor ? { accountAlreadyChosenFor } : {}),
+        })
+        return { tools, gatesOpened }
+    }
+
+    async function showPicker({ toolName, accountAlreadyChosenFor }: { toolName: string, accountAlreadyChosenFor?: (pieceName: string) => boolean }) {
+        const { tools, gatesOpened } = pickerTools({ accountAlreadyChosenFor })
+        const result = await tools[toolName].execute({ piece: 'google-sheets', displayName: 'Google Sheets' }, { toolCallId: 'call-1' })
+        return { result, gatesOpened }
+    }
+
+    it.each(['ap_show_connection_picker', 'ap_show_connection_required'])('refuses %s for a piece the author gave an account, without blocking the turn', async (toolName) => {
+        const { result, gatesOpened } = await showPicker({ toolName, accountAlreadyChosenFor: (pieceName) => pieceName === '@activepieces/piece-google-sheets' })
+
+        expect(JSON.stringify(result)).toContain('nothing to connect or reconnect')
+        expect(gatesOpened).toEqual([])
+    })
+
+    it('still shows the card for a piece with no account chosen for it', async () => {
+        const { gatesOpened } = await showPicker({ toolName: 'ap_show_connection_picker', accountAlreadyChosenFor: () => false })
+
+        expect(gatesOpened).toEqual(['ap_show_connection_picker'])
+    })
+
+    it('still shows the card where no agent chose accounts at all, which is ordinary chat', async () => {
+        const { gatesOpened } = await showPicker({ toolName: 'ap_show_connection_picker' })
+
+        expect(gatesOpened).toEqual(['ap_show_connection_picker'])
+    })
+})

--- a/packages/web/src/app/routes/chat-with-ai/components/action-preview-card.tsx
+++ b/packages/web/src/app/routes/chat-with-ai/components/action-preview-card.tsx
@@ -42,7 +42,7 @@ export function ActionPreviewCard({
           : preview.actionDisplayName
       }
     >
-      {preview.pieceName && preview.connectionLabel && (
+      {preview.pieceName && (
         <div className="flex items-center gap-2 pb-3">
           <PieceIconWithPieceName
             pieceName={pieceName}
@@ -50,11 +50,13 @@ export function ActionPreviewCard({
             border={false}
             showTooltip={false}
           />
-          <span className="text-xs text-muted-foreground">
-            {t('Using: {connectionLabel}', {
-              connectionLabel: preview.connectionLabel,
-            })}
-          </span>
+          {preview.connectionLabel && (
+            <span className="text-xs text-muted-foreground">
+              {t('Using: {connectionLabel}', {
+                connectionLabel: preview.connectionLabel,
+              })}
+            </span>
+          )}
         </div>
       )}
 

--- a/packages/web/src/features/chat/lib/use-chat.ts
+++ b/packages/web/src/features/chat/lib/use-chat.ts
@@ -108,6 +108,10 @@ function buildToolCallMetaFromGate(
       pieceName,
       actionName,
       actionDisplayName: gate.displayName,
+      connectionLabel:
+        typeof gateInput.connectionLabel === 'string'
+          ? gateInput.connectionLabel
+          : undefined,
       input:
         typeof gateInput.input === 'object' && gateInput.input !== null
           ? (gateInput.input as Record<string, unknown>)

--- a/packages/web/src/features/chat/lib/use-chat.ts
+++ b/packages/web/src/features/chat/lib/use-chat.ts
@@ -97,14 +97,16 @@ function buildToolCallMetaFromGate(
     return {};
   }
   const gateInput = gate.toolInput ?? {};
+  const pieceName =
+    typeof gateInput.pieceName === 'string' ? gateInput.pieceName : '';
+  const actionName =
+    typeof gateInput.actionName === 'string' ? gateInput.actionName : '';
   let actionPreview: ActionPreviewEvent | null = null;
-  if (gate.toolName === 'ap_execute_action') {
+  if (pieceName && actionName) {
     actionPreview = {
       toolCallId: gate.gateId,
-      pieceName:
-        typeof gateInput.pieceName === 'string' ? gateInput.pieceName : '',
-      actionName:
-        typeof gateInput.actionName === 'string' ? gateInput.actionName : '',
+      pieceName,
+      actionName,
       actionDisplayName: gate.displayName,
       input:
         typeof gateInput.input === 'object' && gateInput.input !== null


### PR DESCRIPTION
## Description

An agent's author picks its tools. Until now, picking Gmail's send action meant the agent sent email with nobody asked, while the very same action requested ad hoc in chat waited behind an approval card showing the exact payload. This closes that gap: on a conversation someone is watching, a configured action that is not provably read-only shows the resolved input and waits. An unattended flow-step run never asks, because nobody is there to answer.

Three things make it hold up rather than merely look right:

**The server decides, and it decides on the payload.** Classification was going to live in the worker, keyed on the action's name. 665 of the 2359 action names in `packages/pieces/community` match neither the read nor the write word list, so `refund_payment`, `cancel_subscription`, `add_row_to_sheet`, `capture_payment_intent` and `upload_file` would all have run unasked, while `get_post` would have interrupted to ask about reading a blog post. The decision now runs server-side through the same `requiresActionPreview` the ad-hoc path already uses, on the input after it is resolved, so an unrecognised verb asks and a `custom_api_call` is judged by its HTTP method.

**What runs is what was approved, once.** Prepare resolves the input, stores it with the piece and action it was previewed for, and returns a redacted copy for the card. Execute takes that record, requires a recorded user decision when the record says approval was needed, and runs the piece and action from the record rather than from the request. A caller that skips the card no longer skips the gate, an approved input cannot be spent twice, and a declined one is dropped rather than left to expire.

**A blocked run survives a page refresh.** A pending gate rebuilds its card on reload, so switching tabs no longer strands a run behind a button that vanished with the page. Approving a gate also now requires owning the conversation it was shown in.

Testing it harder turned up the same class of hole one level down: a model routinely fires several tool calls in one step, and the pending-gate store kept one gate per conversation, so the second overwrote the first. Live the cards queue and that was fine; after a reload only the survivor came back and the other action sat blocked until it timed out. Gates are kept per gate id now, the endpoint hands over one at a time, and the key is versioned because its shape changed.

**And the reported bug behind all of it.** An agent kept asking to reconnect Slack and Google Sheets accounts that were working. Two causes, neither a prompt problem. Preparing a configured action never passed the account to dynamic property resolution, so any dropdown needing auth to list its options had none: the model was asked to choose a spreadsheet from an empty list, failed, and the agent reported the only explanation that fits every failure. And it opened the connection card *before* calling the tool at all, because deciding whether an account needs attention was left entirely to the model. The pinned account now reaches property resolution, and a saved agent gets no connect-or-reconnect card for a piece whose account its author already chose — the model is told to run the tool and report what actually failed. Ordinary chat and the builder are untouched, since choosing accounts is what they are for. The approval card also now names the account an action will run as, on the card and the receipt and across a reload.

Two smaller things travel with it: a configured action leaves a receipt and taints the rest of the turn the way a web fetch does, and a failed action tells the agent what actually went wrong. That last one came out of live testing: the RPC boundary kept only the error code, so any failure reached the agent as `handler threw: VALIDATION` and it guessed the most common cause, telling the user to reconnect a connection that was working fine.

Deliberately not here, each worth its own PR: remembering a decision per agent and action, so a 200-email agent is not babysat; a declared `sideEffect` on the action definition, so classification stops resting on a word list; the connection label on the card, so it says whose account; and an audit event for a configured write. Two connection defects also surfaced while testing and are not mine to fix here: a configured agent tool ignores the connection picked through the reconnect card, since it only ever reads its pinned account, and the picker's option list is cached per conversation for 24 hours, so a newly created connection can be invisible to it.

## How was this tested?

Live, on a local EE stack, with a Slack `custom_api_call` tool configured on a saved agent — the case that used to skip the gate on all 474 pieces that expose it:

- a POST showed the card with the action's real title and the resolved body, and waited
- a full page reload with the card pending brought it back with Run and Cancel intact
- Cancel returned "Action cancelled by user", nothing ran, and the stored input was gone from Redis
- a GET ran straight through with no card, so the asking stays worth reading
- Run executed the approved input server-side
- asked for an absolute URL, the agent now reads the host guard's own explanation and retries with a path instead of prompting to reconnect

Verified by test rather than live: two concurrent gates both surviving a reload, and a second platform member being refused an approval. The live parallel repro was blocked by upstream provider overload on the input-fill model, which is also why that stage is not in the list above.

Automated: 8 new cases pinning the fail-closed default on the action names the word list misses, 8 on the execute contract (nothing prepared, awaiting approval, declined, approved, and the piece coming from the record rather than the request), and an integration test that a second platform member cannot approve someone else's pending action. Each security assertion was checked by breaking the guard and watching it fail.

Also verified live: the request that used to fail with "I can't find your spreadsheet" now resolves a real spreadsheet and sheet id through the dropdown and stops on an "Add Row · Using: Google Sheets" card, and the connection card is no longer offered for an account the agent already has.

Suites: shared 508, core-execution 140, worker 264, web 668, api unit 1042 (4 files failing on `main` too, all untouched by this branch), EE integration 314.

Editions: EE with `agentsEnabled`. CE and Cloud unaffected — the module is already gated.

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

- [ ] no — reviewed, no security impact
- [x] yes — security-sensitive (call out the risk and mitigation in the description above)
