### PR TITLE
feat(outseta): expose subscription quantity and expiration date, add found=false lookups

### DIFF
--- a/packages/pieces/community/outseta/package.json
+++ b/packages/pieces/community/outseta/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-outseta",
-  "version": "0.3.0",
+  "version": "1.0.0",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {

--- a/packages/pieces/community/outseta/package.json
+++ b/packages/pieces/community/outseta/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-outseta",
-  "version": "0.2.3",
+  "version": "0.3.0",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {

--- a/packages/pieces/community/outseta/src/action/create-account.ts
+++ b/packages/pieces/community/outseta/src/action/create-account.ts
@@ -2,6 +2,7 @@ import { createAction, Property } from '@activepieces/pieces-framework';
 import { outsetaAuth } from '../auth';
 import { OutsetaClient } from '../common/client';
 import { customPropertiesProp, mergeCustomProperties } from '../common/custom-properties';
+import { outsetaEnums } from '../common/enums';
 import { planUidDropdown } from '../common/dropdowns';
 
 export const createAccountAction = createAction({
@@ -25,15 +26,8 @@ export const createAccountAction = createAction({
       displayName: 'Account Stage',
       required: false,
       options: {
-        options: [
-          { label: 'Lead', value: 1 },
-          { label: 'Trialing', value: 2 },
-          { label: 'Subscribing', value: 3 },
-          { label: 'Delinquent', value: 4 },
-          { label: 'Cancelling', value: 5 },
-          { label: 'Expired', value: 6 },
-          { label: 'Demo', value: 7 },
-        ],
+        disabled: false,
+        options: outsetaEnums.accountStage.options,
       },
     }),
     clientIdentifier: Property.ShortText({

--- a/packages/pieces/community/outseta/src/action/get-account.ts
+++ b/packages/pieces/community/outseta/src/action/get-account.ts
@@ -1,50 +1,49 @@
-import { createAction, Property } from '@activepieces/pieces-framework';
+import {
+  createAction,
+  isNil,
+  Property,
+  tryCatch,
+} from '@activepieces/pieces-framework';
 import { outsetaAuth } from '../auth';
 import { OutsetaClient } from '../common/client';
+import { outsetaErrors } from '../common/errors';
+import { outsetaLookup } from '../common/lookup';
+import { outsetaMappers } from '../common/mappers';
+import { OutsetaAccount, OutsetaPerson } from '../common/outseta-types';
 
 export const getAccountAction = createAction({
   name: 'get_account',
   auth: outsetaAuth,
   displayName: 'Retrieve Account',
   description:
-    'Retrieve an account by its UID, or by the email of its primary contact. Returns plan, subscription, billing address, primary contact and add-on details. Can return found=false instead of failing when the account does not exist.',
+    'Retrieve an account by its UID, or by the email of its primary contact. Returns the account, its addresses, its primary contact and which plan it is on. Returns found=false when nothing matches.',
   audience: 'both',
+  classification: 'READ',
   aiMetadata: {
     description:
-      'Fetches a single Outseta CRM account by its UID or by its primary contact email, returning core fields plus billing address, primary contact, and current subscription/plan/add-on details. Use to read an account by either identifier. Disable "Fail if not found" to get found=false for a missing or deleted account instead of a failed step. Read-only and idempotent.',
+      'Fetches a single Outseta CRM account by its UID or by a contact email, returning account fields, billing and mailing address, primary contact, custom properties, and the current subscription UID plus plan UID and name. For subscription dates, rate, quantity or add-ons use Retrieve Subscription, which also accepts an account UID. Fill exactly one lookup field. Returns found=false instead of failing. Read-only and idempotent.',
     idempotent: true,
   },
+  propertyGroups: [
+    {
+      key: 'lookup',
+      display: 'tabs',
+      label: 'Find account by',
+      description: 'Fill one of the two — whichever tab you leave filled is the one used.',
+      props: ['accountUid', 'primaryContactEmail'],
+    },
+  ],
   props: {
-    lookupBy: Property.StaticDropdown({
-      displayName: 'Lookup by',
-      description: 'How to find the account to retrieve.',
-      required: true,
-      defaultValue: 'uid',
-      options: {
-        disabled: false,
-        options: [
-          { label: 'Account UID', value: 'uid' },
-          { label: 'Primary contact email', value: 'email' },
-        ],
-      },
-    }),
     accountUid: Property.ShortText({
       displayName: 'Account UID',
-      description: 'Used when "Lookup by" is set to Account UID.',
       required: false,
+      placeholder: '1QpnM0nW',
     }),
     primaryContactEmail: Property.ShortText({
-      displayName: 'Primary contact email',
-      description:
-        'Used when "Lookup by" is set to Primary contact email. The action will resolve the email to the linked account.',
+      displayName: 'Contact email',
+      description: 'Resolved to the account this person belongs to.',
       required: false,
-    }),
-    failIfNotFound: Property.Checkbox({
-      displayName: 'Fail if not found',
-      description:
-        'Enabled by default: the step fails when the account does not exist. Disable it to return found=false instead, so the flow can branch on a deleted or unknown account without failing.',
-      required: false,
-      defaultValue: true,
+      placeholder: 'jane@example.com',
     }),
   },
   async run(context) {
@@ -54,165 +53,72 @@ export const getAccountAction = createAction({
       apiSecret: context.auth.props.apiSecret,
     });
 
-    // Undefined for flows saved before this prop existed: keep failing, which
-    // is the behaviour those flows were built against.
-    const failIfNotFound = context.propsValue.failIfNotFound ?? true;
+    const lookup = outsetaLookup.single([
+      { key: 'accountUid', label: 'Account UID', value: context.propsValue.accountUid },
+      {
+        key: 'primaryContactEmail',
+        label: 'Contact email',
+        value: context.propsValue.primaryContactEmail,
+      },
+    ]);
 
-    let accountUid = context.propsValue.accountUid;
+    const accountUid =
+      lookup.key === 'accountUid'
+        ? lookup.value
+        : await accountUidByEmail({ client, email: lookup.value });
 
-    if (context.propsValue.lookupBy === 'email') {
-      const email = context.propsValue.primaryContactEmail;
-      if (!email) {
-        throw new Error('Primary contact email is required when looking up by email.');
-      }
-      const people = await client.getAllPages<any>(
-        `/api/v1/crm/people?Email=${encodeURIComponent(email)}&fields=*,PersonAccount.Account.Uid`
-      );
-      const person = people.find(
-        (p: any) => p.Email?.toLowerCase() === email.toLowerCase()
-      );
-      if (!person) {
-        if (failIfNotFound) {
-          throw new Error(`No person found with email "${email}".`);
-        }
-        return NOT_FOUND_RESULT;
-      }
-      const memberships: any[] = Array.isArray(person.PersonAccount)
-        ? person.PersonAccount
-        : (person.PersonAccount?.items ?? person.PersonAccount?.Items ?? []);
-      accountUid = memberships[0]?.Account?.Uid ?? null;
-      if (!accountUid) {
-        if (failIfNotFound) {
-          throw new Error(`Person "${email}" is not linked to any account.`);
-        }
-        return NOT_FOUND_RESULT;
-      }
+    const account = isNil(accountUid)
+      ? null
+      : await accountByUid({ client, uid: accountUid });
+
+    if (isNil(account)) {
+      return { found: false, ...outsetaMappers.account({}) };
     }
 
-    // A missing UID is a misconfigured step, not a missing record, so this
-    // always throws regardless of "Fail if not found".
-    if (!accountUid) {
-      throw new Error('Account UID is required.');
-    }
-
-    // The leading `*` is required: when ?fields= is provided, Outseta returns
-    // ONLY the listed fields. Without `*`, top-level scalar fields like Name,
-    // AccountStage, BillingAddress, etc. would all come back null.
-    const path = `/api/v1/crm/accounts/${accountUid}?fields=*,BillingAddress.*,MailingAddress.*,PrimaryContact.*,CurrentSubscription.*,CurrentSubscription.Plan.*,CurrentSubscription.Plan.PlanFamily.*,CurrentSubscription.SubscriptionAddOns.*,CurrentSubscription.SubscriptionAddOns.AddOn.*`;
-
-    let account: any;
-    try {
-      account = await client.get<any>(path);
-    } catch (e: any) {
-      // Outseta answers 404 for a UID it no longer knows, e.g. an account that
-      // has been deleted. That is a missing record, not a transport failure.
-      if (e?.response?.status === 404 && !failIfNotFound) {
-        return NOT_FOUND_RESULT;
-      }
-      throw e;
-    }
-
-    const sub = account.CurrentSubscription;
-    const rawAddOns = sub?.SubscriptionAddOns;
-    const addOns: any[] = Array.isArray(rawAddOns)
-      ? rawAddOns
-      : (rawAddOns?.items ?? rawAddOns?.Items ?? []);
-    const addOnNames = addOns
-      .map((a: any) => a.AddOn?.Name)
-      .filter(Boolean)
-      .join(', ');
-
-    return {
-      found: true,
-      uid: account.Uid ?? null,
-      name: account.Name ?? null,
-      account_stage: account.AccountStage ?? null,
-      account_stage_label: account.AccountStageLabel ?? null,
-      client_identifier: account.ClientIdentifier ?? null,
-      invoice_notes: account.InvoiceNotes ?? null,
-      has_logged_in: account.HasLoggedIn ?? null,
-      is_demo: account.IsDemo ?? null,
-      lifetime_revenue: account.LifetimeRevenue ?? null,
-      created: account.Created ?? null,
-      updated: account.Updated ?? null,
-      billing_address_line1: account.BillingAddress?.AddressLine1 ?? null,
-      billing_address_line2: account.BillingAddress?.AddressLine2 ?? null,
-      billing_address_city: account.BillingAddress?.City ?? null,
-      billing_address_state: account.BillingAddress?.State ?? null,
-      billing_address_postal_code: account.BillingAddress?.PostalCode ?? null,
-      billing_address_country: account.BillingAddress?.Country ?? null,
-      primary_contact_uid: account.PrimaryContact?.Uid ?? null,
-      primary_contact_email: account.PrimaryContact?.Email ?? null,
-      primary_contact_first_name: account.PrimaryContact?.FirstName ?? null,
-      primary_contact_last_name: account.PrimaryContact?.LastName ?? null,
-      current_subscription_uid: sub?.Uid ?? null,
-      subscription_status: sub?.SubscriptionStatus ?? null,
-      plan_uid: sub?.Plan?.Uid ?? null,
-      plan_name: sub?.Plan?.Name ?? null,
-      plan_family_name: sub?.Plan?.PlanFamily?.Name ?? null,
-      billing_renewal_term: sub?.BillingRenewalTerm ?? null,
-      // Seat/unit count billed on the subscription. Distinct from the per-add-on
-      // quantity nested in add_ons below.
-      quantity: sub?.Quantity ?? null,
-      renewal_date: sub?.RenewalDate ?? null,
-      start_date: sub?.StartDate ?? null,
-      end_date: sub?.EndDate ?? null,
-      // When an expiring subscription lapses. Outseta keeps this separate from
-      // both end_date and renewal_date, and they can differ.
-      expiration_date: sub?.ExpirationDate ?? null,
-      // Convenience field, unchanged for backwards compatibility: renewal_date
-      // when the subscription renews, end_date otherwise. It does NOT consider
-      // expiration_date — read expiration_date directly for that.
-      validity_date: sub?.RenewalDate ?? sub?.EndDate ?? null,
-      add_ons: addOns.map((a: any) => ({
-        uid: a.AddOn?.Uid ?? a.Uid ?? null,
-        name: a.AddOn?.Name ?? null,
-        quantity: a.Quantity ?? null,
-      })),
-      // Same names joined, so they can be written straight to a text field.
-      add_ons_names: addOnNames || null,
-    };
+    return { found: true, ...outsetaMappers.account(account) };
   },
 });
 
-// Every key of the success payload, emptied out. Returned instead of throwing
-// when "Fail if not found" is unchecked, so a flow can branch on `found`
-// rather than on a failed step.
-const NOT_FOUND_RESULT = {
-  found: false,
-  uid: null,
-  name: null,
-  account_stage: null,
-  account_stage_label: null,
-  client_identifier: null,
-  invoice_notes: null,
-  has_logged_in: null,
-  is_demo: null,
-  lifetime_revenue: null,
-  created: null,
-  updated: null,
-  billing_address_line1: null,
-  billing_address_line2: null,
-  billing_address_city: null,
-  billing_address_state: null,
-  billing_address_postal_code: null,
-  billing_address_country: null,
-  primary_contact_uid: null,
-  primary_contact_email: null,
-  primary_contact_first_name: null,
-  primary_contact_last_name: null,
-  current_subscription_uid: null,
-  subscription_status: null,
-  plan_uid: null,
-  plan_name: null,
-  plan_family_name: null,
-  billing_renewal_term: null,
-  quantity: null,
-  renewal_date: null,
-  start_date: null,
-  end_date: null,
-  expiration_date: null,
-  validity_date: null,
-  add_ons: [],
-  add_ons_names: null,
-};
+async function accountByUid({
+  client,
+  uid,
+}: {
+  client: OutsetaClient;
+  uid: string;
+}): Promise<OutsetaAccount | null> {
+  const { data, error } = await tryCatch(() =>
+    client.get<OutsetaAccount>(`/api/v1/crm/accounts/${uid}?${ACCOUNT_FIELDS}`)
+  );
+
+  if (error) {
+    if (outsetaErrors.isNotFound(error)) {
+      return null;
+    }
+    throw error;
+  }
+
+  return data;
+}
+
+async function accountUidByEmail({
+  client,
+  email,
+}: {
+  client: OutsetaClient;
+  email: string;
+}): Promise<string | null> {
+  const people = await client.getAllPages<OutsetaPerson>(
+    `/api/v1/crm/people?Email=${encodeURIComponent(
+      email
+    )}&fields=Uid,Email,PersonAccount.Account.Uid`
+  );
+
+  const person = people.find(
+    (candidate) => candidate.Email?.toLowerCase() === email.toLowerCase()
+  );
+
+  return outsetaMappers.toArray(person?.PersonAccount)[0]?.Account?.Uid ?? null;
+}
+
+const ACCOUNT_FIELDS =
+  'fields=*,BillingAddress.*,MailingAddress.*,PrimaryContact.Uid,PrimaryContact.Email,PrimaryContact.FirstName,PrimaryContact.LastName,CurrentSubscription.Uid,CurrentSubscription.Plan.Uid,CurrentSubscription.Plan.Name';

--- a/packages/pieces/community/outseta/src/action/get-account.ts
+++ b/packages/pieces/community/outseta/src/action/get-account.ts
@@ -2,16 +2,58 @@ import { createAction, Property } from '@activepieces/pieces-framework';
 import { outsetaAuth } from '../auth';
 import { OutsetaClient } from '../common/client';
 
+// Every key of the success payload, emptied out. Returned instead of throwing
+// when "Fail if not found" is unchecked, so a flow can branch on `found`
+// rather than on a failed step.
+const NOT_FOUND_RESULT = {
+  found: false,
+  uid: null,
+  name: null,
+  account_stage: null,
+  account_stage_label: null,
+  client_identifier: null,
+  invoice_notes: null,
+  has_logged_in: null,
+  is_demo: null,
+  lifetime_revenue: null,
+  created: null,
+  updated: null,
+  billing_address_line1: null,
+  billing_address_line2: null,
+  billing_address_city: null,
+  billing_address_state: null,
+  billing_address_postal_code: null,
+  billing_address_country: null,
+  primary_contact_uid: null,
+  primary_contact_email: null,
+  primary_contact_first_name: null,
+  primary_contact_last_name: null,
+  current_subscription_uid: null,
+  subscription_status: null,
+  plan_uid: null,
+  plan_name: null,
+  plan_family_name: null,
+  billing_renewal_term: null,
+  quantity: null,
+  renewal_date: null,
+  start_date: null,
+  end_date: null,
+  expiration_date: null,
+  validity_date: null,
+  add_ons: [],
+  add_ons_names: null,
+};
+
 export const getAccountAction = createAction({
   name: 'get_account',
   auth: outsetaAuth,
   displayName: 'Retrieve Account',
   description:
-    'Retrieve an account by its UID, or by the email of its primary contact. Returns plan, subscription, billing address, primary contact and add-on details.',
+    'Retrieve an account by its UID, or by the email of its primary contact. Returns plan, subscription, billing address, primary contact and add-on details. Can return found=false instead of failing when the account does not exist.',
   audience: 'both',
   aiMetadata: {
     description:
-      'Fetches a single Outseta CRM account by its UID or by its primary contact email, returning core fields plus billing address, primary contact, and current subscription/plan/add-on details. Use to read an account by either identifier. Read-only and idempotent.',
+      'Fetches a single Outseta CRM account by its UID or by its primary contact email, returning core fields plus billing address, primary contact, and current subscription/plan/add-on details. Use to read an account by either identifier. Disable "Fail if not found" to get found=false for a missing or deleted account instead of a failed step. Read-only and idempotent.',
     idempotent: true,
   },
   props: {
@@ -39,6 +81,13 @@ export const getAccountAction = createAction({
         'Used when "Lookup by" is set to Primary contact email. The action will resolve the email to the linked account.',
       required: false,
     }),
+    failIfNotFound: Property.Checkbox({
+      displayName: 'Fail if not found',
+      description:
+        'Enabled by default: the step fails when the account does not exist. Disable it to return found=false instead, so the flow can branch on a deleted or unknown account without failing.',
+      required: false,
+      defaultValue: true,
+    }),
   },
   async run(context) {
     const client = new OutsetaClient({
@@ -46,6 +95,10 @@ export const getAccountAction = createAction({
       apiKey: context.auth.props.apiKey,
       apiSecret: context.auth.props.apiSecret,
     });
+
+    // Undefined for flows saved before this prop existed: keep failing, which
+    // is the behaviour those flows were built against.
+    const failIfNotFound = context.propsValue.failIfNotFound ?? true;
 
     let accountUid = context.propsValue.accountUid;
 
@@ -61,17 +114,25 @@ export const getAccountAction = createAction({
         (p: any) => p.Email?.toLowerCase() === email.toLowerCase()
       );
       if (!person) {
-        throw new Error(`No person found with email "${email}".`);
+        if (failIfNotFound) {
+          throw new Error(`No person found with email "${email}".`);
+        }
+        return NOT_FOUND_RESULT;
       }
       const memberships: any[] = Array.isArray(person.PersonAccount)
         ? person.PersonAccount
         : (person.PersonAccount?.items ?? person.PersonAccount?.Items ?? []);
       accountUid = memberships[0]?.Account?.Uid ?? null;
       if (!accountUid) {
-        throw new Error(`Person "${email}" is not linked to any account.`);
+        if (failIfNotFound) {
+          throw new Error(`Person "${email}" is not linked to any account.`);
+        }
+        return NOT_FOUND_RESULT;
       }
     }
 
+    // A missing UID is a misconfigured step, not a missing record, so this
+    // always throws regardless of "Fail if not found".
     if (!accountUid) {
       throw new Error('Account UID is required.');
     }
@@ -79,17 +140,32 @@ export const getAccountAction = createAction({
     // The leading `*` is required: when ?fields= is provided, Outseta returns
     // ONLY the listed fields. Without `*`, top-level scalar fields like Name,
     // AccountStage, BillingAddress, etc. would all come back null.
-    const account = await client.get<any>(
-      `/api/v1/crm/accounts/${accountUid}?fields=*,BillingAddress.*,MailingAddress.*,PrimaryContact.*,CurrentSubscription.*,CurrentSubscription.Plan.*,CurrentSubscription.Plan.PlanFamily.*,CurrentSubscription.SubscriptionAddOns.*,CurrentSubscription.SubscriptionAddOns.AddOn.*`
-    );
+    const path = `/api/v1/crm/accounts/${accountUid}?fields=*,BillingAddress.*,MailingAddress.*,PrimaryContact.*,CurrentSubscription.*,CurrentSubscription.Plan.*,CurrentSubscription.Plan.PlanFamily.*,CurrentSubscription.SubscriptionAddOns.*,CurrentSubscription.SubscriptionAddOns.AddOn.*`;
+
+    let account: any;
+    try {
+      account = await client.get<any>(path);
+    } catch (e: any) {
+      // Outseta answers 404 for a UID it no longer knows, e.g. an account that
+      // has been deleted. That is a missing record, not a transport failure.
+      if (e?.response?.status === 404 && !failIfNotFound) {
+        return NOT_FOUND_RESULT;
+      }
+      throw e;
+    }
 
     const sub = account.CurrentSubscription;
     const rawAddOns = sub?.SubscriptionAddOns;
     const addOns: any[] = Array.isArray(rawAddOns)
       ? rawAddOns
       : (rawAddOns?.items ?? rawAddOns?.Items ?? []);
+    const addOnNames = addOns
+      .map((a: any) => a.AddOn?.Name)
+      .filter(Boolean)
+      .join(', ');
 
     return {
+      found: true,
       uid: account.Uid ?? null,
       name: account.Name ?? null,
       account_stage: account.AccountStage ?? null,
@@ -117,17 +193,26 @@ export const getAccountAction = createAction({
       plan_name: sub?.Plan?.Name ?? null,
       plan_family_name: sub?.Plan?.PlanFamily?.Name ?? null,
       billing_renewal_term: sub?.BillingRenewalTerm ?? null,
+      // Seat/unit count billed on the subscription. Distinct from the per-add-on
+      // quantity nested in add_ons below.
+      quantity: sub?.Quantity ?? null,
       renewal_date: sub?.RenewalDate ?? null,
       start_date: sub?.StartDate ?? null,
       end_date: sub?.EndDate ?? null,
-      // Unified validity date: renewal_date for recurring plans,
-      // end_date for one-time plans (which have no renewal).
+      // When an expiring subscription lapses. Outseta keeps this separate from
+      // both end_date and renewal_date, and they can differ.
+      expiration_date: sub?.ExpirationDate ?? null,
+      // Convenience field, unchanged for backwards compatibility: renewal_date
+      // when the subscription renews, end_date otherwise. It does NOT consider
+      // expiration_date — read expiration_date directly for that.
       validity_date: sub?.RenewalDate ?? sub?.EndDate ?? null,
       add_ons: addOns.map((a: any) => ({
         uid: a.AddOn?.Uid ?? a.Uid ?? null,
         name: a.AddOn?.Name ?? null,
         quantity: a.Quantity ?? null,
       })),
+      // Same names joined, so they can be written straight to a text field.
+      add_ons_names: addOnNames || null,
     };
   },
 });

--- a/packages/pieces/community/outseta/src/action/get-account.ts
+++ b/packages/pieces/community/outseta/src/action/get-account.ts
@@ -2,48 +2,6 @@ import { createAction, Property } from '@activepieces/pieces-framework';
 import { outsetaAuth } from '../auth';
 import { OutsetaClient } from '../common/client';
 
-// Every key of the success payload, emptied out. Returned instead of throwing
-// when "Fail if not found" is unchecked, so a flow can branch on `found`
-// rather than on a failed step.
-const NOT_FOUND_RESULT = {
-  found: false,
-  uid: null,
-  name: null,
-  account_stage: null,
-  account_stage_label: null,
-  client_identifier: null,
-  invoice_notes: null,
-  has_logged_in: null,
-  is_demo: null,
-  lifetime_revenue: null,
-  created: null,
-  updated: null,
-  billing_address_line1: null,
-  billing_address_line2: null,
-  billing_address_city: null,
-  billing_address_state: null,
-  billing_address_postal_code: null,
-  billing_address_country: null,
-  primary_contact_uid: null,
-  primary_contact_email: null,
-  primary_contact_first_name: null,
-  primary_contact_last_name: null,
-  current_subscription_uid: null,
-  subscription_status: null,
-  plan_uid: null,
-  plan_name: null,
-  plan_family_name: null,
-  billing_renewal_term: null,
-  quantity: null,
-  renewal_date: null,
-  start_date: null,
-  end_date: null,
-  expiration_date: null,
-  validity_date: null,
-  add_ons: [],
-  add_ons_names: null,
-};
-
 export const getAccountAction = createAction({
   name: 'get_account',
   auth: outsetaAuth,
@@ -216,3 +174,45 @@ export const getAccountAction = createAction({
     };
   },
 });
+
+// Every key of the success payload, emptied out. Returned instead of throwing
+// when "Fail if not found" is unchecked, so a flow can branch on `found`
+// rather than on a failed step.
+const NOT_FOUND_RESULT = {
+  found: false,
+  uid: null,
+  name: null,
+  account_stage: null,
+  account_stage_label: null,
+  client_identifier: null,
+  invoice_notes: null,
+  has_logged_in: null,
+  is_demo: null,
+  lifetime_revenue: null,
+  created: null,
+  updated: null,
+  billing_address_line1: null,
+  billing_address_line2: null,
+  billing_address_city: null,
+  billing_address_state: null,
+  billing_address_postal_code: null,
+  billing_address_country: null,
+  primary_contact_uid: null,
+  primary_contact_email: null,
+  primary_contact_first_name: null,
+  primary_contact_last_name: null,
+  current_subscription_uid: null,
+  subscription_status: null,
+  plan_uid: null,
+  plan_name: null,
+  plan_family_name: null,
+  billing_renewal_term: null,
+  quantity: null,
+  renewal_date: null,
+  start_date: null,
+  end_date: null,
+  expiration_date: null,
+  validity_date: null,
+  add_ons: [],
+  add_ons_names: null,
+};

--- a/packages/pieces/community/outseta/src/action/get-deal.ts
+++ b/packages/pieces/community/outseta/src/action/get-deal.ts
@@ -1,48 +1,79 @@
-import { createAction, Property } from '@activepieces/pieces-framework';
+import {
+  createAction,
+  InputPropertyMap,
+  isNil,
+  Property,
+  tryCatch,
+} from '@activepieces/pieces-framework';
 import { outsetaAuth } from '../auth';
 import { OutsetaClient } from '../common/client';
 import { pipelineDropdown } from '../common/dropdowns';
+import { outsetaErrors } from '../common/errors';
+import { outsetaMappers } from '../common/mappers';
+import { OutsetaDeal } from '../common/outseta-types';
 
 export const getDealAction = createAction({
   name: 'get_deal',
   auth: outsetaAuth,
   displayName: 'Retrieve Deal',
   description:
-    'Retrieve a deal by its UID, or by the email of the contact associated with the deal plus the pipeline.',
+    'Retrieve a deal by its UID, or by the email of an associated contact within a pipeline. Returns found=false when nothing matches.',
   audience: 'both',
+  classification: 'READ',
   aiMetadata: {
     description:
-      'Fetches a single Outseta CRM deal by its UID, or by the contact email plus pipeline, returning amount, due date, pipeline stage, and the associated account. Use to read a deal by either identifier. Read-only and idempotent.',
+      'Fetches a single Outseta CRM deal by its UID, or by a contact email within a chosen pipeline, returning amount, due date, pipeline and stage, the associated account, contact emails and custom properties. Pick the lookup mode first, then fill the fields it reveals. Returns found=false instead of failing. Read-only and idempotent.',
     idempotent: true,
   },
   props: {
     lookupBy: Property.StaticDropdown({
-      displayName: 'Lookup by',
-      description: 'How to find the deal to retrieve.',
+      displayName: 'Find deal by',
       required: true,
       defaultValue: 'uid',
+      display: 'cards',
       options: {
         disabled: false,
         options: [
-          { label: 'Deal UID', value: 'uid' },
-          { label: 'Contact email + pipeline', value: 'email' },
+          {
+            label: 'Deal UID',
+            value: 'uid',
+            description: 'You already have the identifier',
+            icon: 'tag',
+          },
+          {
+            label: 'Contact + pipeline',
+            value: 'contact',
+            description: 'Search a pipeline by contact email',
+            icon: 'users',
+          },
         ],
       },
     }),
-    dealUid: Property.ShortText({
-      displayName: 'Deal UID',
-      description: 'Used when "Lookup by" is set to Deal UID.',
-      required: false,
-    }),
-    contactEmail: Property.ShortText({
-      displayName: 'Contact Email',
-      description: 'Used when "Lookup by" is set to Contact email + pipeline.',
-      required: false,
-    }),
-    pipelineUid: pipelineDropdown({
-      required: false,
-      description:
-        'Used when "Lookup by" is set to Contact email + pipeline. Required in that mode.',
+    lookup: Property.DynamicProperties({
+      displayName: 'Deal',
+      required: true,
+      auth: outsetaAuth,
+      refreshers: ['lookupBy'],
+      props: async (propsValue): Promise<InputPropertyMap> => {
+        if (asText(propsValue['lookupBy']) === 'contact') {
+          return {
+            contactEmail: Property.ShortText({
+              displayName: 'Contact email',
+              description: 'An email attached to the deal.',
+              required: true,
+              placeholder: 'jane@example.com',
+            }),
+            pipelineUid: pipelineDropdown({ required: true }),
+          };
+        }
+        return {
+          dealUid: Property.ShortText({
+            displayName: 'Deal UID',
+            required: true,
+            placeholder: 'dQGeJZDW',
+          }),
+        };
+      },
     }),
   },
   async run(context) {
@@ -52,59 +83,100 @@ export const getDealAction = createAction({
       apiSecret: context.auth.props.apiSecret,
     });
 
-    let match: any;
+    const lookup = context.propsValue.lookup ?? {};
 
-    if (context.propsValue.lookupBy === 'uid') {
-      const uid = context.propsValue.dealUid;
-      if (!uid) {
-        throw new Error('Deal UID is required when looking up by UID.');
-      }
-      match = await client.get<any>(
-        `/api/v1/crm/deals/${uid}?fields=Uid,Name,Amount,DueDate,Created,Updated,AssignedToPersonClientIdentifier,DealPipelineStage.Uid,DealPipelineStage.Name,DealPipelineStage.DealPipeline.Uid,DealPeople.Person.Uid,DealPeople.Person.Email,Account.Uid,Account.Name`
-      );
-    } else {
-      const contactEmail = context.propsValue.contactEmail?.toLowerCase();
-      const pipelineUid = context.propsValue.pipelineUid;
-      if (!contactEmail || !pipelineUid) {
-        throw new Error(
-          'Contact email and pipeline are both required when looking up by email + pipeline.'
-        );
-      }
-      // Outseta supports server-side nested filters on /crm/deals — confirmed
-      // by Outseta support. A non-existent pipeline UID returns 400 "Invalid
-      // filter specification"; a real but unmatched UID returns an empty list.
-      const items = await client.getAllPages<any>(
-        `/api/v1/crm/deals?DealPipelineStage.DealPipeline.Uid=${encodeURIComponent(pipelineUid)}&fields=Uid,Name,Amount,DueDate,Created,Updated,AssignedToPersonClientIdentifier,DealPipelineStage.Uid,DealPipelineStage.Name,DealPipelineStage.DealPipeline.Uid,DealPeople.Person.Uid,DealPeople.Person.Email,Account.Uid,Account.Name`
-      );
-      match = items.find((deal: any) => {
-        const dealPeople: any[] =
-          deal.DealPeople?.items ?? deal.DealPeople?.Items ?? deal.DealPeople ?? [];
-        const hasContact = dealPeople.some(
-          (dp: any) => dp.Person?.Email?.toLowerCase() === contactEmail
-        );
-        const inPipeline =
-          deal.DealPipelineStage?.DealPipeline?.Uid === pipelineUid;
-        return hasContact && inPipeline;
-      });
-      if (!match) {
-        throw new Error(
-          `No deal found for contact "${context.propsValue.contactEmail}" in the selected pipeline.`
-        );
-      }
+    const deal =
+      context.propsValue.lookupBy === 'contact'
+        ? await dealByContact({
+            client,
+            contactEmail: requireText({
+              value: asText(lookup['contactEmail']),
+              label: 'Contact email',
+            }),
+            pipelineUid: requireText({
+              value: asText(lookup['pipelineUid']),
+              label: 'Pipeline',
+            }),
+          })
+        : await dealByUid({
+            client,
+            uid: requireText({
+              value: asText(lookup['dealUid']),
+              label: 'Deal UID',
+            }),
+          });
+
+    if (isNil(deal)) {
+      return { found: false, ...outsetaMappers.deal({}) };
     }
 
-    return {
-      uid: match.Uid ?? null,
-      name: match.Name ?? null,
-      amount: match.Amount ?? null,
-      due_date: match.DueDate ?? null,
-      pipeline_stage_uid: match.DealPipelineStage?.Uid ?? null,
-      pipeline_stage_name: match.DealPipelineStage?.Name ?? null,
-      account_uid: match.Account?.Uid ?? null,
-      account_name: match.Account?.Name ?? null,
-      assigned_to_client_identifier: match.AssignedToPersonClientIdentifier ?? null,
-      created: match.Created ?? null,
-      updated: match.Updated ?? null,
-    };
+    return { found: true, ...outsetaMappers.deal(deal) };
   },
 });
+
+function asText(value: unknown): string | undefined {
+  return typeof value === 'string' && value !== '' ? value : undefined;
+}
+
+function requireText({
+  value,
+  label,
+}: {
+  value: string | undefined;
+  label: string;
+}): string {
+  if (isNil(value)) {
+    throw new Error(`${label} is required for the selected lookup mode.`);
+  }
+  return value;
+}
+
+async function dealByUid({
+  client,
+  uid,
+}: {
+  client: OutsetaClient;
+  uid: string;
+}): Promise<OutsetaDeal | null> {
+  const { data, error } = await tryCatch(() =>
+    client.get<OutsetaDeal>(`/api/v1/crm/deals/${uid}?${DEAL_FIELDS}`)
+  );
+
+  if (error) {
+    if (outsetaErrors.isNotFound(error)) {
+      return null;
+    }
+    throw error;
+  }
+
+  return data;
+}
+
+async function dealByContact({
+  client,
+  contactEmail,
+  pipelineUid,
+}: {
+  client: OutsetaClient;
+  contactEmail: string;
+  pipelineUid: string;
+}): Promise<OutsetaDeal | null> {
+  const deals = await client.getAllPages<OutsetaDeal>(
+    `/api/v1/crm/deals?DealPipelineStage.DealPipeline.Uid=${encodeURIComponent(
+      pipelineUid
+    )}&${DEAL_FIELDS}`
+  );
+
+  const wanted = contactEmail.toLowerCase();
+
+  return (
+    deals.find((deal) =>
+      outsetaMappers
+        .toArray(deal.DealPeople)
+        .some((link) => link.Person?.Email?.toLowerCase() === wanted)
+    ) ?? null
+  );
+}
+
+const DEAL_FIELDS =
+  'fields=*,DealPipelineStage.Uid,DealPipelineStage.Name,DealPipelineStage.DealPipeline.Uid,DealPipelineStage.DealPipeline.Name,DealPeople.Person.Uid,DealPeople.Person.Email,Account.Uid,Account.Name';

--- a/packages/pieces/community/outseta/src/action/get-last-payment.ts
+++ b/packages/pieces/community/outseta/src/action/get-last-payment.ts
@@ -1,6 +1,8 @@
 import { createAction, Property } from '@activepieces/pieces-framework';
 import { outsetaAuth } from '../auth';
 import { OutsetaClient } from '../common/client';
+import { outsetaMappers } from '../common/mappers';
+import { OutsetaTransaction } from '../common/outseta-types';
 
 export const getLastPaymentAction = createAction({
   name: 'get_last_payment',
@@ -9,6 +11,7 @@ export const getLastPaymentAction = createAction({
   description:
     'Retrieve the most recent payment transaction for an account. Returns found=false if no payment has ever been recorded.',
   audience: 'both',
+  classification: 'READ',
   aiMetadata: {
     description:
       'Returns the single most recent payment transaction for an account, or found=false if none exists. Use for the latest payment only; for the full payment/refund/invoice history use List Account Transactions. Read-only and idempotent.',
@@ -19,6 +22,7 @@ export const getLastPaymentAction = createAction({
       displayName: 'Account UID',
       required: true,
       description: 'The UID of the account to retrieve the last payment for.',
+      placeholder: '1QpnM0nW',
     }),
   },
   async run(context) {
@@ -28,35 +32,17 @@ export const getLastPaymentAction = createAction({
       apiSecret: context.auth.props.apiSecret,
     });
 
-    // GET /api/v1/billing/transactions/{accountUid} returns transactions for the
-    // account. Filter to BillingTransactionType=2 (= Payment) and sort by
-    // Created DESC to get the most recent payment in a single request.
-    const res = await client.get<{ items?: Record<string, unknown>[]; Items?: Record<string, unknown>[] }>(
-      `/api/v1/billing/transactions/${context.propsValue.accountUid}?BillingTransactionType=${PAYMENT_TRANSACTION_TYPE}&limit=1&orderBy=Created%20DESC&fields=*,Invoice.*`
+    const page = await client.getPage<OutsetaTransaction>(
+      `/api/v1/billing/transactions/${context.propsValue.accountUid}?BillingTransactionType=${PAYMENT_TRANSACTION_TYPE}&limit=1&orderBy=Created%20DESC&fields=*,Invoice.Uid,Invoice.Number,Invoice.BillingInvoiceStatus`
     );
-    const items = res?.items ?? res?.Items ?? [];
-    if (items.length === 0) {
-      return {
-        found: false,
-        uid: null,
-        amount: null,
-        date: null,
-        invoice_uid: null,
-        invoice_number: null,
-        created: null,
-      };
+
+    const payment = page.items[0];
+
+    if (!payment) {
+      return { found: false, ...outsetaMappers.transaction({}) };
     }
 
-    const payment = items[0] as any;
-    return {
-      found: true,
-      uid: payment.Uid ?? null,
-      amount: payment.Amount ?? null,
-      date: payment.TransactionDate ?? payment.Created ?? null,
-      invoice_uid: payment.Invoice?.Uid ?? null,
-      invoice_number: payment.Invoice?.Number ?? null,
-      created: payment.Created ?? null,
-    };
+    return { found: true, ...outsetaMappers.transaction(payment) };
   },
 });
 

--- a/packages/pieces/community/outseta/src/action/get-person.ts
+++ b/packages/pieces/community/outseta/src/action/get-person.ts
@@ -1,42 +1,48 @@
-import { createAction, Property } from '@activepieces/pieces-framework';
+import {
+  createAction,
+  isNil,
+  Property,
+  tryCatch,
+} from '@activepieces/pieces-framework';
 import { outsetaAuth } from '../auth';
 import { OutsetaClient } from '../common/client';
+import { outsetaErrors } from '../common/errors';
+import { outsetaLookup } from '../common/lookup';
+import { outsetaMappers } from '../common/mappers';
+import { OutsetaPerson } from '../common/outseta-types';
 
 export const getPersonAction = createAction({
   name: 'get_person',
   auth: outsetaAuth,
   displayName: 'Retrieve Person',
   description:
-    'Retrieve a person by email or by UID, including the linked account.',
+    'Retrieve a person by email or by UID, with their linked account and custom properties. Returns found=false when nobody matches.',
   audience: 'both',
+  classification: 'READ',
   aiMetadata: {
     description:
-      'Fetches a single Outseta CRM person (contact) by email or by UID, returning identity, contact, and mailing-address fields plus the linked account. Use to read a person by either identifier. Read-only and idempotent.',
+      'Fetches a single Outseta CRM person by email or by UID, returning identity, contact and mailing-address fields plus the linked account and any custom properties. Fill exactly one of the two lookup fields. Returns found=false instead of failing when nobody matches. Read-only and idempotent.',
     idempotent: true,
   },
+  propertyGroups: [
+    {
+      key: 'lookup',
+      display: 'tabs',
+      label: 'Find person by',
+      description: 'Fill one of the two — whichever tab you leave filled is the one used.',
+      props: ['email', 'personUid'],
+    },
+  ],
   props: {
-    lookupBy: Property.StaticDropdown({
-      displayName: 'Lookup by',
-      description: 'How to find the person to retrieve.',
-      required: true,
-      defaultValue: 'email',
-      options: {
-        disabled: false,
-        options: [
-          { label: 'Email', value: 'email' },
-          { label: 'Person UID', value: 'uid' },
-        ],
-      },
-    }),
     email: Property.ShortText({
       displayName: 'Email',
-      description: 'Used when "Lookup by" is set to Email.',
       required: false,
+      placeholder: 'jane@example.com',
     }),
     personUid: Property.ShortText({
       displayName: 'Person UID',
-      description: 'Used when "Lookup by" is set to Person UID.',
       required: false,
+      placeholder: 'dQG7vBzQ',
     }),
   },
   async run(context) {
@@ -46,65 +52,62 @@ export const getPersonAction = createAction({
       apiSecret: context.auth.props.apiSecret,
     });
 
-    let person: any;
+    const lookup = outsetaLookup.single([
+      { key: 'email', label: 'Email', value: context.propsValue.email },
+      { key: 'personUid', label: 'Person UID', value: context.propsValue.personUid },
+    ]);
 
-    if (context.propsValue.lookupBy === 'uid') {
-      const uid = context.propsValue.personUid;
-      if (!uid) {
-        throw new Error('Person UID is required when looking up by UID.');
-      }
-      person = await client.get<any>(
-        `/api/v1/crm/people/${uid}?fields=*,MailingAddress.*,PersonAccount.Account.Uid,PersonAccount.Account.Name,PersonAccount.Account.AccountStage`
-      );
-    } else {
-      const email = context.propsValue.email;
-      if (!email) {
-        throw new Error('Email is required when looking up by Email.');
-      }
-      const items = await client.getAllPages<any>(
-        `/api/v1/crm/people?Email=${encodeURIComponent(email)}&fields=*,PersonAccount.Account.Uid,PersonAccount.Account.Name,PersonAccount.Account.AccountStage`
-      );
-      person = items.find(
-        (p: any) => p.Email?.toLowerCase() === email.toLowerCase()
-      );
-      if (!person) {
-        throw new Error(`No person found with email "${email}".`);
-      }
+    const person =
+      lookup.key === 'personUid'
+        ? await personByUid({ client, uid: lookup.value })
+        : await personByEmail({ client, email: lookup.value });
+
+    if (isNil(person)) {
+      return { found: false, ...outsetaMappers.person({}) };
     }
 
-    return {
-      uid: person.Uid ?? null,
-      email: person.Email ?? null,
-      first_name: person.FirstName ?? null,
-      last_name: person.LastName ?? null,
-      full_name: person.FullName ?? null,
-      phone_mobile: person.PhoneMobile ?? null,
-      phone_work: person.PhoneWork ?? null,
-      title: person.Title ?? null,
-      timezone: person.Timezone ?? null,
-      language: person.Language ?? null,
-      has_logged_in: person.HasLoggedIn ?? null,
-      created: person.Created ?? null,
-      updated: person.Updated ?? null,
-      mailing_address_line1: person.MailingAddress?.AddressLine1 ?? null,
-      mailing_address_line2: person.MailingAddress?.AddressLine2 ?? null,
-      mailing_address_city: person.MailingAddress?.City ?? null,
-      mailing_address_state: person.MailingAddress?.State ?? null,
-      mailing_address_postal_code: person.MailingAddress?.PostalCode ?? null,
-      mailing_address_country: person.MailingAddress?.Country ?? null,
-      account_uid: firstMembership(person)?.Account?.Uid ?? null,
-      account_name: firstMembership(person)?.Account?.Name ?? null,
-      account_stage: firstMembership(person)?.Account?.AccountStage ?? null,
-    };
+    return { found: true, ...outsetaMappers.person(person) };
   },
 });
 
-function firstMembership(person: any): any {
-  // PersonAccount comes back as a direct array on /crm/people, but be
-  // defensive in case the API ever wraps it in {items: [...]} like other
-  // collections do.
-  const list = Array.isArray(person?.PersonAccount)
-    ? person.PersonAccount
-    : (person?.PersonAccount?.items ?? person?.PersonAccount?.Items ?? []);
-  return list[0];
+async function personByUid({
+  client,
+  uid,
+}: {
+  client: OutsetaClient;
+  uid: string;
+}): Promise<OutsetaPerson | null> {
+  const { data, error } = await tryCatch(() =>
+    client.get<OutsetaPerson>(`/api/v1/crm/people/${uid}?${PERSON_FIELDS}`)
+  );
+
+  if (error) {
+    if (outsetaErrors.isNotFound(error)) {
+      return null;
+    }
+    throw error;
+  }
+
+  return data;
 }
+
+async function personByEmail({
+  client,
+  email,
+}: {
+  client: OutsetaClient;
+  email: string;
+}): Promise<OutsetaPerson | null> {
+  const people = await client.getAllPages<OutsetaPerson>(
+    `/api/v1/crm/people?Email=${encodeURIComponent(email)}&${PERSON_FIELDS}`
+  );
+
+  return (
+    people.find(
+      (candidate) => candidate.Email?.toLowerCase() === email.toLowerCase()
+    ) ?? null
+  );
+}
+
+const PERSON_FIELDS =
+  'fields=*,MailingAddress.*,PersonAccount.IsPrimary,PersonAccount.Role,PersonAccount.Account.Uid,PersonAccount.Account.Name,PersonAccount.Account.AccountStage';

--- a/packages/pieces/community/outseta/src/action/get-subscription.ts
+++ b/packages/pieces/community/outseta/src/action/get-subscription.ts
@@ -1,49 +1,49 @@
-import { createAction, Property } from '@activepieces/pieces-framework';
+import {
+  createAction,
+  isNil,
+  Property,
+  tryCatch,
+} from '@activepieces/pieces-framework';
 import { outsetaAuth } from '../auth';
 import { OutsetaClient } from '../common/client';
+import { outsetaErrors } from '../common/errors';
+import { outsetaLookup } from '../common/lookup';
+import { outsetaMappers } from '../common/mappers';
+import { OutsetaAccount, OutsetaSubscription } from '../common/outseta-types';
 
 export const getSubscriptionAction = createAction({
   name: 'get_subscription',
   auth: outsetaAuth,
   displayName: 'Retrieve Subscription',
   description:
-    "Retrieve a subscription by its UID, or fetch the current subscription of an account by Account UID. Returns plan, billing terms, quantity, renewal/expiration dates, discount, and add-on details. Can return found=false instead of failing when there is no such subscription.",
+    "Retrieve a subscription by its UID, or an account's current subscription by account UID. Returns plan, billing term, quantity, rate, all four dates, discount and add-ons. Returns found=false when nothing matches.",
   audience: 'both',
+  classification: 'READ',
   aiMetadata: {
     description:
-      'Fetches a subscription by its UID, or an account\'s current subscription by account UID, returning plan, billing term, quantity, renewal/expiration dates, discount, and add-ons. Use to read subscription/billing state; for account-level fields use Retrieve Account. Disable "Fail if not found" to get found=false when the account has no current subscription instead of a failed step. Read-only and idempotent.',
+      "Fetches a subscription by its UID, or an account's current subscription by account UID, returning plan, billing term, quantity, rate, discount, add-ons and the four distinct dates: start, end, expiration and renewal. Outseta has no subscription status field — use the dates to decide whether it is active. Fill exactly one lookup field. Returns found=false instead of failing. Read-only and idempotent.",
     idempotent: true,
   },
+  propertyGroups: [
+    {
+      key: 'lookup',
+      display: 'tabs',
+      label: 'Find subscription by',
+      description: 'Fill one of the two — whichever tab you leave filled is the one used.',
+      props: ['subscriptionUid', 'accountUid'],
+    },
+  ],
   props: {
-    lookupBy: Property.StaticDropdown({
-      displayName: 'Lookup by',
-      description: 'How to find the subscription to retrieve.',
-      required: true,
-      defaultValue: 'subscriptionUid',
-      options: {
-        disabled: false,
-        options: [
-          { label: 'Subscription UID', value: 'subscriptionUid' },
-          { label: "Account UID (current subscription)", value: 'accountUid' },
-        ],
-      },
-    }),
     subscriptionUid: Property.ShortText({
       displayName: 'Subscription UID',
       required: false,
-      description: 'Used when "Lookup by" is set to Subscription UID.',
+      placeholder: 'dQG7vBzQ',
     }),
     accountUid: Property.ShortText({
       displayName: 'Account UID',
+      description: "Resolved to that account's current subscription.",
       required: false,
-      description: 'Used when "Lookup by" is set to Account UID. Resolves to the account\'s current subscription.',
-    }),
-    failIfNotFound: Property.Checkbox({
-      displayName: 'Fail if not found',
-      description:
-        'Enabled by default: the step fails when the subscription does not exist, or when the account has no current subscription. Disable it to return found=false instead, so the flow can branch on an expired or cancelled account without failing.',
-      required: false,
-      defaultValue: true,
+      placeholder: '1QpnM0nW',
     }),
   },
   async run(context) {
@@ -53,131 +53,77 @@ export const getSubscriptionAction = createAction({
       apiSecret: context.auth.props.apiSecret,
     });
 
-    // Undefined for flows saved before this prop existed: keep failing, which
-    // is the behaviour those flows were built against.
-    const failIfNotFound = context.propsValue.failIfNotFound ?? true;
+    const lookup = outsetaLookup.single([
+      {
+        key: 'subscriptionUid',
+        label: 'Subscription UID',
+        value: context.propsValue.subscriptionUid,
+      },
+      { key: 'accountUid', label: 'Account UID', value: context.propsValue.accountUid },
+    ]);
 
-    let subscriptionUid = context.propsValue.subscriptionUid;
+    const subscriptionUid =
+      lookup.key === 'subscriptionUid'
+        ? lookup.value
+        : await currentSubscriptionUid({ client, accountUid: lookup.value });
 
-    if (context.propsValue.lookupBy === 'accountUid') {
-      const accountUid = context.propsValue.accountUid;
-      if (!accountUid) {
-        throw new Error('Account UID is required when looking up by Account UID.');
-      }
+    const subscription = isNil(subscriptionUid)
+      ? null
+      : await subscriptionByUid({ client, uid: subscriptionUid });
 
-      let account: any;
-      try {
-        account = await client.get<any>(
-          `/api/v1/crm/accounts/${accountUid}?fields=Uid,CurrentSubscription.Uid`
-        );
-      } catch (e: any) {
-        // Outseta answers 404 for a UID it no longer knows, e.g. an account
-        // that has been deleted.
-        if (e?.response?.status === 404 && !failIfNotFound) {
-          return NOT_FOUND_RESULT;
-        }
-        throw e;
-      }
-
-      // Outseta detaches CurrentSubscription once an account expires, so this
-      // is empty for every lapsed account, not only for unknown UIDs.
-      subscriptionUid = account?.CurrentSubscription?.Uid ?? null;
-      if (!subscriptionUid) {
-        if (failIfNotFound) {
-          throw new Error(`Account ${accountUid} does not have an active subscription.`);
-        }
-        return NOT_FOUND_RESULT;
-      }
+    if (isNil(subscription)) {
+      return { found: false, ...outsetaMappers.subscription({}) };
     }
 
-    // A missing UID is a misconfigured step, not a missing record, so this
-    // always throws regardless of "Fail if not found".
-    if (!subscriptionUid) {
-      throw new Error('Subscription UID is required.');
-    }
-
-    let sub: any;
-    try {
-      sub = await client.get<any>(
-        `/api/v1/billing/subscriptions/${subscriptionUid}?fields=*,Plan.*,Plan.PlanFamily.*,Account.*,SubscriptionAddOns.*,SubscriptionAddOns.AddOn.*`
-      );
-    } catch (e: any) {
-      if (e?.response?.status === 404 && !failIfNotFound) {
-        return NOT_FOUND_RESULT;
-      }
-      throw e;
-    }
-
-    const rawAddOns = sub?.SubscriptionAddOns;
-    const addOns: any[] = Array.isArray(rawAddOns)
-      ? rawAddOns
-      : (rawAddOns?.items ?? rawAddOns?.Items ?? []);
-    const addOnNames = addOns
-      .map((a: any) => a.AddOn?.Name)
-      .filter(Boolean)
-      .join(', ');
-
-    return {
-      found: true,
-      uid: sub.Uid ?? null,
-      account_uid: sub.Account?.Uid ?? null,
-      account_name: sub.Account?.Name ?? null,
-      subscription_status: sub.SubscriptionStatus ?? null,
-      plan_uid: sub.Plan?.Uid ?? null,
-      plan_name: sub.Plan?.Name ?? null,
-      plan_family_name: sub.Plan?.PlanFamily?.Name ?? null,
-      billing_renewal_term: sub.BillingRenewalTerm ?? null,
-      // Seat/unit count billed on the subscription. Distinct from the per-add-on
-      // quantity nested in add_ons below.
-      quantity: sub.Quantity ?? null,
-      rate: sub.Rate ?? null,
-      discount_code: sub.DiscountCode ?? null,
-      start_date: sub.StartDate ?? null,
-      end_date: sub.EndDate ?? null,
-      // When an expiring subscription lapses. Outseta keeps this separate from
-      // both end_date and renewal_date, and they can differ.
-      expiration_date: sub.ExpirationDate ?? null,
-      renewal_date: sub.RenewalDate ?? null,
-      // Convenience field, unchanged for backwards compatibility: renewal_date
-      // when the subscription renews, end_date otherwise. It does NOT consider
-      // expiration_date — read expiration_date directly for that.
-      validity_date: sub.RenewalDate ?? sub.EndDate ?? null,
-      created: sub.Created ?? null,
-      updated: sub.Updated ?? null,
-      add_ons: addOns.map((a: any) => ({
-        uid: a.AddOn?.Uid ?? a.Uid ?? null,
-        name: a.AddOn?.Name ?? null,
-        quantity: a.Quantity ?? null,
-      })),
-      // Same names joined, so they can be written straight to a text field.
-      add_ons_names: addOnNames || null,
-    };
+    return { found: true, ...outsetaMappers.subscription(subscription) };
   },
 });
 
-// Every key of the success payload, emptied out. Returned instead of throwing
-// when "Fail if not found" is unchecked, so a flow can branch on `found`
-// rather than on a failed step.
-const NOT_FOUND_RESULT = {
-  found: false,
-  uid: null,
-  account_uid: null,
-  account_name: null,
-  subscription_status: null,
-  plan_uid: null,
-  plan_name: null,
-  plan_family_name: null,
-  billing_renewal_term: null,
-  quantity: null,
-  rate: null,
-  discount_code: null,
-  start_date: null,
-  end_date: null,
-  expiration_date: null,
-  renewal_date: null,
-  validity_date: null,
-  created: null,
-  updated: null,
-  add_ons: [],
-  add_ons_names: null,
-};
+async function subscriptionByUid({
+  client,
+  uid,
+}: {
+  client: OutsetaClient;
+  uid: string;
+}): Promise<OutsetaSubscription | null> {
+  const { data, error } = await tryCatch(() =>
+    client.get<OutsetaSubscription>(
+      `/api/v1/billing/subscriptions/${uid}?${SUBSCRIPTION_FIELDS}`
+    )
+  );
+
+  if (error) {
+    if (outsetaErrors.isNotFound(error)) {
+      return null;
+    }
+    throw error;
+  }
+
+  return data;
+}
+
+async function currentSubscriptionUid({
+  client,
+  accountUid,
+}: {
+  client: OutsetaClient;
+  accountUid: string;
+}): Promise<string | null> {
+  const { data, error } = await tryCatch(() =>
+    client.get<OutsetaAccount>(
+      `/api/v1/crm/accounts/${accountUid}?fields=Uid,CurrentSubscription.Uid`
+    )
+  );
+
+  if (error) {
+    if (outsetaErrors.isNotFound(error)) {
+      return null;
+    }
+    throw error;
+  }
+
+  return data.CurrentSubscription?.Uid ?? null;
+}
+
+const SUBSCRIPTION_FIELDS =
+  'fields=*,Plan.Uid,Plan.Name,Plan.PlanFamily.Name,Account.Uid,Account.Name,LatestInvoice.Uid,LatestInvoice.Number,SubscriptionAddOns.Quantity,SubscriptionAddOns.Rate,SubscriptionAddOns.AddOn.Uid,SubscriptionAddOns.AddOn.Name';

--- a/packages/pieces/community/outseta/src/action/get-subscription.ts
+++ b/packages/pieces/community/outseta/src/action/get-subscription.ts
@@ -2,33 +2,6 @@ import { createAction, Property } from '@activepieces/pieces-framework';
 import { outsetaAuth } from '../auth';
 import { OutsetaClient } from '../common/client';
 
-// Every key of the success payload, emptied out. Returned instead of throwing
-// when "Fail if not found" is unchecked, so a flow can branch on `found`
-// rather than on a failed step.
-const NOT_FOUND_RESULT = {
-  found: false,
-  uid: null,
-  account_uid: null,
-  account_name: null,
-  subscription_status: null,
-  plan_uid: null,
-  plan_name: null,
-  plan_family_name: null,
-  billing_renewal_term: null,
-  quantity: null,
-  rate: null,
-  discount_code: null,
-  start_date: null,
-  end_date: null,
-  expiration_date: null,
-  renewal_date: null,
-  validity_date: null,
-  created: null,
-  updated: null,
-  add_ons: [],
-  add_ons_names: null,
-};
-
 export const getSubscriptionAction = createAction({
   name: 'get_subscription',
   auth: outsetaAuth,
@@ -181,3 +154,30 @@ export const getSubscriptionAction = createAction({
     };
   },
 });
+
+// Every key of the success payload, emptied out. Returned instead of throwing
+// when "Fail if not found" is unchecked, so a flow can branch on `found`
+// rather than on a failed step.
+const NOT_FOUND_RESULT = {
+  found: false,
+  uid: null,
+  account_uid: null,
+  account_name: null,
+  subscription_status: null,
+  plan_uid: null,
+  plan_name: null,
+  plan_family_name: null,
+  billing_renewal_term: null,
+  quantity: null,
+  rate: null,
+  discount_code: null,
+  start_date: null,
+  end_date: null,
+  expiration_date: null,
+  renewal_date: null,
+  validity_date: null,
+  created: null,
+  updated: null,
+  add_ons: [],
+  add_ons_names: null,
+};

--- a/packages/pieces/community/outseta/src/action/get-subscription.ts
+++ b/packages/pieces/community/outseta/src/action/get-subscription.ts
@@ -2,16 +2,43 @@ import { createAction, Property } from '@activepieces/pieces-framework';
 import { outsetaAuth } from '../auth';
 import { OutsetaClient } from '../common/client';
 
+// Every key of the success payload, emptied out. Returned instead of throwing
+// when "Fail if not found" is unchecked, so a flow can branch on `found`
+// rather than on a failed step.
+const NOT_FOUND_RESULT = {
+  found: false,
+  uid: null,
+  account_uid: null,
+  account_name: null,
+  subscription_status: null,
+  plan_uid: null,
+  plan_name: null,
+  plan_family_name: null,
+  billing_renewal_term: null,
+  quantity: null,
+  rate: null,
+  discount_code: null,
+  start_date: null,
+  end_date: null,
+  expiration_date: null,
+  renewal_date: null,
+  validity_date: null,
+  created: null,
+  updated: null,
+  add_ons: [],
+  add_ons_names: null,
+};
+
 export const getSubscriptionAction = createAction({
   name: 'get_subscription',
   auth: outsetaAuth,
   displayName: 'Retrieve Subscription',
   description:
-    "Retrieve a subscription by its UID, or fetch the current subscription of an account by Account UID. Returns plan, billing terms, renewal dates, discount, and add-on details.",
+    "Retrieve a subscription by its UID, or fetch the current subscription of an account by Account UID. Returns plan, billing terms, quantity, renewal/expiration dates, discount, and add-on details. Can return found=false instead of failing when there is no such subscription.",
   audience: 'both',
   aiMetadata: {
     description:
-      'Fetches a subscription by its UID, or an account\'s current subscription by account UID, returning plan, billing term, renewal dates, discount, and add-ons. Use to read subscription/billing state; for account-level fields use Retrieve Account. Read-only and idempotent.',
+      'Fetches a subscription by its UID, or an account\'s current subscription by account UID, returning plan, billing term, quantity, renewal/expiration dates, discount, and add-ons. Use to read subscription/billing state; for account-level fields use Retrieve Account. Disable "Fail if not found" to get found=false when the account has no current subscription instead of a failed step. Read-only and idempotent.',
     idempotent: true,
   },
   props: {
@@ -38,6 +65,13 @@ export const getSubscriptionAction = createAction({
       required: false,
       description: 'Used when "Lookup by" is set to Account UID. Resolves to the account\'s current subscription.',
     }),
+    failIfNotFound: Property.Checkbox({
+      displayName: 'Fail if not found',
+      description:
+        'Enabled by default: the step fails when the subscription does not exist, or when the account has no current subscription. Disable it to return found=false instead, so the flow can branch on an expired or cancelled account without failing.',
+      required: false,
+      defaultValue: true,
+    }),
   },
   async run(context) {
     const client = new OutsetaClient({
@@ -46,6 +80,10 @@ export const getSubscriptionAction = createAction({
       apiSecret: context.auth.props.apiSecret,
     });
 
+    // Undefined for flows saved before this prop existed: keep failing, which
+    // is the behaviour those flows were built against.
+    const failIfNotFound = context.propsValue.failIfNotFound ?? true;
+
     let subscriptionUid = context.propsValue.subscriptionUid;
 
     if (context.propsValue.lookupBy === 'accountUid') {
@@ -53,29 +91,61 @@ export const getSubscriptionAction = createAction({
       if (!accountUid) {
         throw new Error('Account UID is required when looking up by Account UID.');
       }
-      const account = await client.get<any>(
-        `/api/v1/crm/accounts/${accountUid}?fields=Uid,CurrentSubscription.Uid`
-      );
+
+      let account: any;
+      try {
+        account = await client.get<any>(
+          `/api/v1/crm/accounts/${accountUid}?fields=Uid,CurrentSubscription.Uid`
+        );
+      } catch (e: any) {
+        // Outseta answers 404 for a UID it no longer knows, e.g. an account
+        // that has been deleted.
+        if (e?.response?.status === 404 && !failIfNotFound) {
+          return NOT_FOUND_RESULT;
+        }
+        throw e;
+      }
+
+      // Outseta detaches CurrentSubscription once an account expires, so this
+      // is empty for every lapsed account, not only for unknown UIDs.
       subscriptionUid = account?.CurrentSubscription?.Uid ?? null;
       if (!subscriptionUid) {
-        throw new Error(`Account ${accountUid} does not have an active subscription.`);
+        if (failIfNotFound) {
+          throw new Error(`Account ${accountUid} does not have an active subscription.`);
+        }
+        return NOT_FOUND_RESULT;
       }
     }
 
+    // A missing UID is a misconfigured step, not a missing record, so this
+    // always throws regardless of "Fail if not found".
     if (!subscriptionUid) {
       throw new Error('Subscription UID is required.');
     }
 
-    const sub = await client.get<any>(
-      `/api/v1/billing/subscriptions/${subscriptionUid}?fields=*,Plan.*,Plan.PlanFamily.*,Account.*,SubscriptionAddOns.*,SubscriptionAddOns.AddOn.*`
-    );
+    let sub: any;
+    try {
+      sub = await client.get<any>(
+        `/api/v1/billing/subscriptions/${subscriptionUid}?fields=*,Plan.*,Plan.PlanFamily.*,Account.*,SubscriptionAddOns.*,SubscriptionAddOns.AddOn.*`
+      );
+    } catch (e: any) {
+      if (e?.response?.status === 404 && !failIfNotFound) {
+        return NOT_FOUND_RESULT;
+      }
+      throw e;
+    }
 
     const rawAddOns = sub?.SubscriptionAddOns;
     const addOns: any[] = Array.isArray(rawAddOns)
       ? rawAddOns
       : (rawAddOns?.items ?? rawAddOns?.Items ?? []);
+    const addOnNames = addOns
+      .map((a: any) => a.AddOn?.Name)
+      .filter(Boolean)
+      .join(', ');
 
     return {
+      found: true,
       uid: sub.Uid ?? null,
       account_uid: sub.Account?.Uid ?? null,
       account_name: sub.Account?.Name ?? null,
@@ -84,11 +154,20 @@ export const getSubscriptionAction = createAction({
       plan_name: sub.Plan?.Name ?? null,
       plan_family_name: sub.Plan?.PlanFamily?.Name ?? null,
       billing_renewal_term: sub.BillingRenewalTerm ?? null,
+      // Seat/unit count billed on the subscription. Distinct from the per-add-on
+      // quantity nested in add_ons below.
+      quantity: sub.Quantity ?? null,
       rate: sub.Rate ?? null,
       discount_code: sub.DiscountCode ?? null,
       start_date: sub.StartDate ?? null,
       end_date: sub.EndDate ?? null,
+      // When an expiring subscription lapses. Outseta keeps this separate from
+      // both end_date and renewal_date, and they can differ.
+      expiration_date: sub.ExpirationDate ?? null,
       renewal_date: sub.RenewalDate ?? null,
+      // Convenience field, unchanged for backwards compatibility: renewal_date
+      // when the subscription renews, end_date otherwise. It does NOT consider
+      // expiration_date — read expiration_date directly for that.
       validity_date: sub.RenewalDate ?? sub.EndDate ?? null,
       created: sub.Created ?? null,
       updated: sub.Updated ?? null,
@@ -97,6 +176,8 @@ export const getSubscriptionAction = createAction({
         name: a.AddOn?.Name ?? null,
         quantity: a.Quantity ?? null,
       })),
+      // Same names joined, so they can be written straight to a text field.
+      add_ons_names: addOnNames || null,
     };
   },
 });

--- a/packages/pieces/community/outseta/src/action/list-accounts.ts
+++ b/packages/pieces/community/outseta/src/action/list-accounts.ts
@@ -1,31 +1,99 @@
 import { createAction, Property } from '@activepieces/pieces-framework';
 import { outsetaAuth } from '../auth';
 import { OutsetaClient } from '../common/client';
+import { outsetaEnums } from '../common/enums';
+import { outsetaListProps } from '../common/list-props';
+import { outsetaMappers } from '../common/mappers';
+import { outsetaQuery } from '../common/list-query';
+import { OutsetaAccount } from '../common/outseta-types';
 
 export const listAccountsAction = createAction({
   name: 'list_accounts',
   auth: outsetaAuth,
   displayName: 'List Accounts',
-  description: 'Retrieve a paginated list of accounts from your Outseta CRM.',
+  description:
+    'List CRM accounts, optionally filtered and sorted. Each account comes back in the same shape as Retrieve Account.',
   audience: 'both',
+  classification: 'SEARCH',
   aiMetadata: {
     description:
-      'Returns a paginated list of CRM accounts. Use to browse or scan accounts; to fetch one known account use Retrieve Account. Read-only and idempotent.',
+      'Lists Outseta CRM accounts with optional filters (name, stage, client identifier, created or updated date range, free-text search) and sorting. Items have the same shape as Retrieve Account. Use for browsing or filtering many accounts; to fetch one known account use Retrieve Account. Read-only and idempotent.',
     idempotent: true,
   },
+  propertyGroups: [
+    {
+      key: 'account',
+      display: 'builder',
+      label: 'Account',
+      icon: 'user',
+      props: ['search', 'name', 'accountStage', 'clientIdentifier'],
+    },
+    {
+      key: 'dates',
+      display: 'builder',
+      label: 'Dates',
+      icon: 'calendar',
+      props: ['createdRange', 'updatedRange'],
+    },
+    {
+      key: 'sort',
+      display: 'builder',
+      label: 'Sort',
+      icon: 'sliders',
+      props: ['sortBy', 'direction'],
+    },
+    { key: 'paging', display: 'footer', props: ['limit', 'page'] },
+  ],
   props: {
-    limit: Property.Number({
-      displayName: 'Limit',
+    search: Property.ShortText({
+      displayName: 'Search',
+      description: 'Partial match on the account name, or an exact account UID.',
       required: false,
-      defaultValue: 100,
-      description: 'Maximum number of accounts to return (default 100).',
+      icon: 'text',
+      placeholder: 'Acme',
     }),
-    offset: Property.Number({
-      displayName: 'Page',
+    name: Property.ShortText({
+      displayName: 'Name contains',
       required: false,
-      defaultValue: 0,
-      description: 'Page number to fetch (0 = first page, 1 = second page, ...). Outseta uses page-based pagination, not record-based.',
+      icon: 'text',
+      placeholder: 'Acme',
     }),
+    accountStage: Property.StaticDropdown({
+      displayName: 'Stage is',
+      required: false,
+      icon: 'filter',
+      options: { disabled: false, options: outsetaEnums.accountStage.options },
+    }),
+    clientIdentifier: Property.ShortText({
+      displayName: 'Client identifier is',
+      required: false,
+      icon: 'tag',
+      placeholder: 'crm-1234',
+    }),
+    createdRange: Property.DateRange({
+      displayName: 'Created',
+      required: false,
+      display: 'dropdown',
+      icon: 'calendar',
+    }),
+    updatedRange: Property.DateRange({
+      displayName: 'Updated',
+      required: false,
+      display: 'dropdown',
+      icon: 'calendar',
+    }),
+    sortBy: outsetaListProps.sortBy({
+      options: [
+        { label: 'Created', value: 'Created' },
+        { label: 'Updated', value: 'Updated' },
+        { label: 'Name', value: 'Name' },
+        { label: 'Stage', value: 'AccountStage' },
+      ],
+      defaultValue: 'Created',
+    }),
+    direction: outsetaListProps.direction(),
+    limit: outsetaListProps.limit(),
+    page: outsetaListProps.page(),
   },
   async run(context) {
     const client = new OutsetaClient({
@@ -34,13 +102,38 @@ export const listAccountsAction = createAction({
       apiSecret: context.auth.props.apiSecret,
     });
 
-    const limit = context.propsValue.limit ?? 100;
-    const offset = context.propsValue.offset ?? 0;
+    const query = outsetaQuery.build({
+      filters: [
+        { field: 'q', value: context.propsValue.search },
+        { field: 'Name', operator: 'contains', value: context.propsValue.name },
+        { field: 'AccountStage', value: context.propsValue.accountStage },
+        { field: 'ClientIdentifier', value: context.propsValue.clientIdentifier },
+        ...outsetaQuery.dateRangeFilters({
+          field: 'Created',
+          range: context.propsValue.createdRange,
+        }),
+        ...outsetaQuery.dateRangeFilters({
+          field: 'Updated',
+          range: context.propsValue.updatedRange,
+        }),
+      ],
+      orderBy: context.propsValue.sortBy,
+      orderDirection: context.propsValue.direction,
+      limit: context.propsValue.limit,
+      page: context.propsValue.page,
+    });
 
-    const result = await client.get<any>(
-      `/api/v1/crm/accounts?limit=${limit}&offset=${offset}`
+    const result = await client.getPage<OutsetaAccount>(
+      `/api/v1/crm/accounts?${query}&${ACCOUNT_FIELDS}`
     );
 
-    return result;
+    return {
+      items: result.items.map(outsetaMappers.account),
+      ...outsetaQuery.pageInfo(result),
+    };
   },
 });
+
+
+const ACCOUNT_FIELDS =
+  'fields=*,BillingAddress.*,MailingAddress.*,PrimaryContact.Uid,PrimaryContact.Email,PrimaryContact.FirstName,PrimaryContact.LastName,CurrentSubscription.Uid,CurrentSubscription.Plan.Uid,CurrentSubscription.Plan.Name';

--- a/packages/pieces/community/outseta/src/action/list-addons.ts
+++ b/packages/pieces/community/outseta/src/action/list-addons.ts
@@ -1,33 +1,78 @@
 import { createAction, Property } from '@activepieces/pieces-framework';
 import { outsetaAuth } from '../auth';
 import { OutsetaClient } from '../common/client';
+import { outsetaEnums } from '../common/enums';
+import { outsetaListProps } from '../common/list-props';
+import { outsetaMappers } from '../common/mappers';
+import { outsetaQuery } from '../common/list-query';
+import { OutsetaAddOn } from '../common/outseta-types';
 
 export const listAddOnsAction = createAction({
   name: 'list_addons',
   auth: outsetaAuth,
-  displayName: 'List Add-Ons',
-  description:
-    'Retrieve a paginated list of add-ons from your Outseta billing catalog.',
+  displayName: 'List Add-ons',
+  description: 'List billing add-ons from the catalogue, optionally filtered and sorted.',
   audience: 'both',
+  classification: 'SEARCH',
   aiMetadata: {
     description:
-      'Returns a paginated list of add-ons from the billing catalog. Use to discover available add-on UIDs, e.g. before Add Add-on to Subscription. Read-only and idempotent.',
+      'Lists Outseta billing add-ons from the catalogue with optional filters (name, billing type, created date range) and sorting, returning rates for every billing term and quantity rules. These are catalogue add-ons, not the add-ons attached to a subscription — for those use Retrieve Subscription. Read-only and idempotent.',
     idempotent: true,
   },
+  propertyGroups: [
+    {
+      key: 'addon',
+      display: 'builder',
+      label: 'Add-on',
+      icon: 'tag',
+      props: ['name', 'billingAddOnType'],
+    },
+    {
+      key: 'dates',
+      display: 'builder',
+      label: 'Dates',
+      icon: 'calendar',
+      props: ['createdRange'],
+    },
+    {
+      key: 'sort',
+      display: 'builder',
+      label: 'Sort',
+      icon: 'sliders',
+      props: ['sortBy', 'direction'],
+    },
+    { key: 'paging', display: 'footer', props: ['limit', 'page'] },
+  ],
   props: {
-    limit: Property.Number({
-      displayName: 'Limit',
+    name: Property.ShortText({
+      displayName: 'Name contains',
       required: false,
-      defaultValue: 100,
-      description: 'Maximum number of add-ons to return (default 100).',
+      icon: 'text',
+      placeholder: 'Extra seat',
     }),
-    offset: Property.Number({
-      displayName: 'Page',
+    billingAddOnType: Property.StaticDropdown({
+      displayName: 'Billing type is',
       required: false,
-      defaultValue: 0,
-      description:
-        'Page number to fetch (0 = first page, 1 = second page, ...). Outseta uses page-based pagination, not record-based.',
+      icon: 'filter',
+      options: { disabled: false, options: outsetaEnums.billingAddOnType.options },
     }),
+    createdRange: Property.DateRange({
+      displayName: 'Created',
+      required: false,
+      display: 'dropdown',
+      icon: 'calendar',
+    }),
+    sortBy: outsetaListProps.sortBy({
+      options: [
+        { label: 'Created', value: 'Created' },
+        { label: 'Updated', value: 'Updated' },
+        { label: 'Name', value: 'Name' },
+      ],
+      defaultValue: 'Name',
+    }),
+    direction: outsetaListProps.direction(),
+    limit: outsetaListProps.limit(),
+    page: outsetaListProps.page(),
   },
   async run(context) {
     const client = new OutsetaClient({
@@ -36,11 +81,28 @@ export const listAddOnsAction = createAction({
       apiSecret: context.auth.props.apiSecret,
     });
 
-    const limit = context.propsValue.limit ?? 100;
-    const offset = context.propsValue.offset ?? 0;
+    const query = outsetaQuery.build({
+      filters: [
+        { field: 'Name', operator: 'contains', value: context.propsValue.name },
+        { field: 'BillingAddOnType', value: context.propsValue.billingAddOnType },
+        ...outsetaQuery.dateRangeFilters({
+          field: 'Created',
+          range: context.propsValue.createdRange,
+        }),
+      ],
+      orderBy: context.propsValue.sortBy,
+      orderDirection: context.propsValue.direction,
+      limit: context.propsValue.limit,
+      page: context.propsValue.page,
+    });
 
-    return client.get<unknown>(
-      `/api/v1/billing/addons?limit=${limit}&offset=${offset}`
+    const result = await client.getPage<OutsetaAddOn>(
+      `/api/v1/billing/addons?${query}&fields=*`
     );
+
+    return {
+      items: result.items.map(outsetaMappers.addOn),
+      ...outsetaQuery.pageInfo(result),
+    };
   },
 });

--- a/packages/pieces/community/outseta/src/action/list-cases.ts
+++ b/packages/pieces/community/outseta/src/action/list-cases.ts
@@ -25,7 +25,7 @@ export const listCasesAction = createAction({
       display: 'builder',
       label: 'Ticket',
       icon: 'inbox',
-      props: ['search', 'subject', 'source'],
+      props: ['search', 'subject', 'status', 'source'],
     },
     {
       key: 'submitter',
@@ -62,6 +62,12 @@ export const listCasesAction = createAction({
       required: false,
       icon: 'text',
       placeholder: 'invoice',
+    }),
+    status: Property.StaticDropdown({
+      displayName: 'Status is',
+      required: false,
+      icon: 'filter',
+      options: { disabled: false, options: outsetaEnums.supportCaseStatus.options },
     }),
     source: Property.StaticDropdown({
       displayName: 'Source is',
@@ -117,6 +123,7 @@ export const listCasesAction = createAction({
       filters: [
         { field: 'q', value: context.propsValue.search },
         { field: 'Subject', operator: 'contains', value: context.propsValue.subject },
+        { field: 'Status', value: context.propsValue.status },
         { field: 'Source', value: context.propsValue.source },
         { field: 'FromPerson.Uid', value: context.propsValue.fromPersonUid },
         { field: 'FromPerson.Email', value: context.propsValue.fromPersonEmail },

--- a/packages/pieces/community/outseta/src/action/list-cases.ts
+++ b/packages/pieces/community/outseta/src/action/list-cases.ts
@@ -1,45 +1,110 @@
 import { createAction, Property } from '@activepieces/pieces-framework';
 import { outsetaAuth } from '../auth';
 import { OutsetaClient } from '../common/client';
+import { outsetaEnums } from '../common/enums';
+import { outsetaListProps } from '../common/list-props';
+import { outsetaMappers } from '../common/mappers';
+import { outsetaQuery } from '../common/list-query';
+import { OutsetaCase } from '../common/outseta-types';
 
 export const listCasesAction = createAction({
   name: 'list_cases',
   auth: outsetaAuth,
-  displayName: 'List Cases',
-  description:
-    'Retrieve a paginated list of support tickets (cases) from Outseta. Optionally filter by the person who submitted them.',
+  displayName: 'List Tickets',
+  description: 'List support tickets, optionally filtered and sorted.',
   audience: 'both',
+  classification: 'SEARCH',
   aiMetadata: {
     description:
-      'Returns a paginated list of support tickets, optionally filtered by the submitting person\'s UID or email. Use to scan or find tickets; to open one use Create Ticket. Read-only and idempotent.',
+      'Lists Outseta support tickets with optional filters (free-text search, submitter UID or email, source, subject, submitted or created date range) and sorting, returning subject, body, source, submitter and assignment. Read-only and idempotent.',
     idempotent: true,
   },
+  propertyGroups: [
+    {
+      key: 'ticket',
+      display: 'builder',
+      label: 'Ticket',
+      icon: 'inbox',
+      props: ['search', 'subject', 'source'],
+    },
+    {
+      key: 'submitter',
+      display: 'builder',
+      label: 'Submitted by',
+      icon: 'user',
+      props: ['fromPersonUid', 'fromPersonEmail'],
+    },
+    {
+      key: 'dates',
+      display: 'builder',
+      label: 'Dates',
+      icon: 'calendar',
+      props: ['submittedRange', 'createdRange'],
+    },
+    {
+      key: 'sort',
+      display: 'builder',
+      label: 'Sort',
+      icon: 'sliders',
+      props: ['sortBy', 'direction'],
+    },
+    { key: 'paging', display: 'footer', props: ['limit', 'page'] },
+  ],
   props: {
-    fromPersonUid: Property.ShortText({
-      displayName: 'From Person UID',
+    search: Property.ShortText({
+      displayName: 'Search',
       required: false,
-      description:
-        'Optional. Only return cases submitted by this person.',
+      icon: 'text',
+      placeholder: 'refund',
+    }),
+    subject: Property.ShortText({
+      displayName: 'Subject contains',
+      required: false,
+      icon: 'text',
+      placeholder: 'invoice',
+    }),
+    source: Property.StaticDropdown({
+      displayName: 'Source is',
+      required: false,
+      icon: 'filter',
+      options: { disabled: false, options: outsetaEnums.supportCaseSource.options },
+    }),
+    fromPersonUid: Property.ShortText({
+      displayName: 'Submitter UID is',
+      required: false,
+      icon: 'user',
+      placeholder: 'dQG7vBzQ',
     }),
     fromPersonEmail: Property.ShortText({
-      displayName: 'From Person Email',
+      displayName: 'Submitter email is',
       required: false,
-      description:
-        'Optional. Only return cases submitted by the person with this email.',
+      icon: 'user',
+      placeholder: 'jane@example.com',
     }),
-    limit: Property.Number({
-      displayName: 'Limit',
+    submittedRange: Property.DateRange({
+      displayName: 'Submitted',
       required: false,
-      defaultValue: 100,
-      description: 'Maximum number of cases to return (default 100).',
+      display: 'dropdown',
+      icon: 'calendar',
     }),
-    offset: Property.Number({
-      displayName: 'Page',
+    createdRange: Property.DateRange({
+      displayName: 'Created',
       required: false,
-      defaultValue: 0,
-      description:
-        'Page number to fetch (0 = first page, 1 = second page, ...). Outseta uses page-based pagination, not record-based.',
+      display: 'dropdown',
+      icon: 'calendar',
     }),
+    sortBy: outsetaListProps.sortBy({
+      options: [
+        { label: 'Created', value: 'Created' },
+        { label: 'Updated', value: 'Updated' },
+        { label: 'Submitted', value: 'SubmittedDateTime' },
+        { label: 'Last activity', value: 'LastActivity' },
+      ],
+      defaultValue: 'Created',
+    }),
+    direction: outsetaListProps.direction(),
+    limit: outsetaListProps.limit(),
+    page: outsetaListProps.page(),
   },
   async run(context) {
     const client = new OutsetaClient({
@@ -48,19 +113,35 @@ export const listCasesAction = createAction({
       apiSecret: context.auth.props.apiSecret,
     });
 
-    const params: string[] = [
-      `limit=${context.propsValue.limit ?? 100}`,
-      `offset=${context.propsValue.offset ?? 0}`,
-    ];
-    if (context.propsValue.fromPersonUid) {
-      params.push(`FromPerson.Uid=${encodeURIComponent(context.propsValue.fromPersonUid)}`);
-    }
-    if (context.propsValue.fromPersonEmail) {
-      params.push(
-        `FromPerson.Email=${encodeURIComponent(context.propsValue.fromPersonEmail)}`
-      );
-    }
+    const query = outsetaQuery.build({
+      filters: [
+        { field: 'q', value: context.propsValue.search },
+        { field: 'Subject', operator: 'contains', value: context.propsValue.subject },
+        { field: 'Source', value: context.propsValue.source },
+        { field: 'FromPerson.Uid', value: context.propsValue.fromPersonUid },
+        { field: 'FromPerson.Email', value: context.propsValue.fromPersonEmail },
+        ...outsetaQuery.dateRangeFilters({
+          field: 'SubmittedDateTime',
+          range: context.propsValue.submittedRange,
+        }),
+        ...outsetaQuery.dateRangeFilters({
+          field: 'Created',
+          range: context.propsValue.createdRange,
+        }),
+      ],
+      orderBy: context.propsValue.sortBy,
+      orderDirection: context.propsValue.direction,
+      limit: context.propsValue.limit,
+      page: context.propsValue.page,
+    });
 
-    return client.get<unknown>(`/api/v1/support/cases?${params.join('&')}`);
+    const result = await client.getPage<OutsetaCase>(
+      `/api/v1/support/cases?${query}&fields=*,FromPerson.Uid,FromPerson.Email,FromPerson.FullName`
+    );
+
+    return {
+      items: result.items.map(outsetaMappers.supportCase),
+      ...outsetaQuery.pageInfo(result),
+    };
   },
 });

--- a/packages/pieces/community/outseta/src/action/list-deals.ts
+++ b/packages/pieces/community/outseta/src/action/list-deals.ts
@@ -1,31 +1,118 @@
 import { createAction, Property } from '@activepieces/pieces-framework';
 import { outsetaAuth } from '../auth';
 import { OutsetaClient } from '../common/client';
+import { pipelineDropdown, pipelineStageDropdown } from '../common/dropdowns';
+import { outsetaListProps } from '../common/list-props';
+import { outsetaMappers } from '../common/mappers';
+import { outsetaQuery } from '../common/list-query';
+import { OutsetaDeal } from '../common/outseta-types';
 
 export const listDealsAction = createAction({
   name: 'list_deals',
   auth: outsetaAuth,
   displayName: 'List Deals',
-  description: 'Retrieve a paginated list of deals from your Outseta CRM.',
+  description:
+    'List CRM deals, optionally filtered and sorted. Each deal comes back in the same shape as Retrieve Deal.',
   audience: 'both',
+  classification: 'SEARCH',
   aiMetadata: {
     description:
-      'Returns a paginated list of CRM deals. Use to browse or scan deals; to fetch one known deal use Retrieve Deal. Read-only and idempotent.',
+      'Lists Outseta CRM deals with optional filters (free-text search, pipeline, pipeline stage, name, amount range, due date range, created or updated date range) and sorting. Items have the same shape as Retrieve Deal. Use for browsing or filtering many deals; to fetch one known deal use Retrieve Deal. Read-only and idempotent.',
     idempotent: true,
   },
+  propertyGroups: [
+    {
+      key: 'deal',
+      display: 'builder',
+      label: 'Deal',
+      icon: 'tag',
+      props: ['search', 'name', 'minAmount', 'maxAmount'],
+    },
+    {
+      key: 'pipeline',
+      display: 'builder',
+      label: 'Pipeline',
+      icon: 'filter',
+      props: ['pipelineUid', 'pipelineStageUid'],
+    },
+    {
+      key: 'dates',
+      display: 'builder',
+      label: 'Dates',
+      icon: 'calendar',
+      props: ['dueDateRange', 'createdRange', 'updatedRange'],
+    },
+    {
+      key: 'sort',
+      display: 'builder',
+      label: 'Sort',
+      icon: 'sliders',
+      props: ['sortBy', 'direction'],
+    },
+    { key: 'paging', display: 'footer', props: ['limit', 'page'] },
+  ],
   props: {
-    limit: Property.Number({
-      displayName: 'Limit',
+    search: Property.ShortText({
+      displayName: 'Search',
       required: false,
-      defaultValue: 100,
-      description: 'Maximum number of deals to return (default 100).',
+      icon: 'text',
+      placeholder: 'renewal',
     }),
-    offset: Property.Number({
-      displayName: 'Page',
+    name: Property.ShortText({
+      displayName: 'Name contains',
       required: false,
-      defaultValue: 0,
-      description: 'Page number to fetch (0 = first page, 1 = second page, ...). Outseta uses page-based pagination, not record-based.',
+      icon: 'text',
+      placeholder: 'renewal',
     }),
+    minAmount: Property.Number({
+      displayName: 'Amount at least',
+      required: false,
+      icon: 'sliders',
+    }),
+    maxAmount: Property.Number({
+      displayName: 'Amount at most',
+      required: false,
+      icon: 'sliders',
+    }),
+    pipelineUid: pipelineDropdown({
+      required: false,
+      description: 'Only return deals in this pipeline.',
+    }),
+    pipelineStageUid: pipelineStageDropdown({
+      required: false,
+      description: 'Only return deals at this stage. Pick a pipeline first.',
+    }),
+    dueDateRange: Property.DateRange({
+      displayName: 'Due date',
+      required: false,
+      display: 'dropdown',
+      icon: 'calendar',
+    }),
+    createdRange: Property.DateRange({
+      displayName: 'Created',
+      required: false,
+      display: 'dropdown',
+      icon: 'calendar',
+    }),
+    updatedRange: Property.DateRange({
+      displayName: 'Updated',
+      required: false,
+      display: 'dropdown',
+      icon: 'calendar',
+    }),
+    sortBy: outsetaListProps.sortBy({
+      options: [
+        { label: 'Created', value: 'Created' },
+        { label: 'Updated', value: 'Updated' },
+        { label: 'Name', value: 'Name' },
+        { label: 'Amount', value: 'Amount' },
+        { label: 'Due date', value: 'DueDate' },
+      ],
+      defaultValue: 'Created',
+    }),
+    direction: outsetaListProps.direction(),
+    limit: outsetaListProps.limit(),
+    page: outsetaListProps.page(),
   },
   async run(context) {
     const client = new OutsetaClient({
@@ -34,9 +121,46 @@ export const listDealsAction = createAction({
       apiSecret: context.auth.props.apiSecret,
     });
 
-    const limit = context.propsValue.limit ?? 100;
-    const offset = context.propsValue.offset ?? 0;
+    const query = outsetaQuery.build({
+      filters: [
+        { field: 'q', value: context.propsValue.search },
+        { field: 'Name', operator: 'contains', value: context.propsValue.name },
+        { field: 'Amount', operator: 'gte', value: context.propsValue.minAmount },
+        { field: 'Amount', operator: 'lte', value: context.propsValue.maxAmount },
+        {
+          field: 'DealPipelineStage.DealPipeline.Uid',
+          value: context.propsValue.pipelineUid,
+        },
+        { field: 'DealPipelineStage.Uid', value: context.propsValue.pipelineStageUid },
+        ...outsetaQuery.dateRangeFilters({
+          field: 'DueDate',
+          range: context.propsValue.dueDateRange,
+        }),
+        ...outsetaQuery.dateRangeFilters({
+          field: 'Created',
+          range: context.propsValue.createdRange,
+        }),
+        ...outsetaQuery.dateRangeFilters({
+          field: 'Updated',
+          range: context.propsValue.updatedRange,
+        }),
+      ],
+      orderBy: context.propsValue.sortBy,
+      orderDirection: context.propsValue.direction,
+      limit: context.propsValue.limit,
+      page: context.propsValue.page,
+    });
 
-    return client.get<unknown>(`/api/v1/crm/deals?limit=${limit}&offset=${offset}`);
+    const result = await client.getPage<OutsetaDeal>(
+      `/api/v1/crm/deals?${query}&${DEAL_FIELDS}`
+    );
+
+    return {
+      items: result.items.map(outsetaMappers.deal),
+      ...outsetaQuery.pageInfo(result),
+    };
   },
 });
+
+const DEAL_FIELDS =
+  'fields=*,DealPipelineStage.Uid,DealPipelineStage.Name,DealPipelineStage.DealPipeline.Uid,DealPipelineStage.DealPipeline.Name,DealPeople.Person.Uid,DealPeople.Person.Email,Account.Uid,Account.Name';

--- a/packages/pieces/community/outseta/src/action/list-discounts.ts
+++ b/packages/pieces/community/outseta/src/action/list-discounts.ts
@@ -1,33 +1,93 @@
 import { createAction, Property } from '@activepieces/pieces-framework';
 import { outsetaAuth } from '../auth';
 import { OutsetaClient } from '../common/client';
+import { outsetaListProps } from '../common/list-props';
+import { outsetaMappers } from '../common/mappers';
+import { outsetaQuery } from '../common/list-query';
+import { OutsetaDiscountCoupon } from '../common/outseta-types';
 
 export const listDiscountsAction = createAction({
   name: 'list_discounts',
   auth: outsetaAuth,
   displayName: 'List Discounts',
-  description:
-    'Retrieve a paginated list of discount coupons from your Outseta billing catalog.',
+  description: 'List discount coupons, optionally filtered and sorted.',
   audience: 'both',
+  classification: 'SEARCH',
   aiMetadata: {
     description:
-      'Returns a paginated list of discount coupons from the billing catalog. Use to discover existing coupon UIDs, e.g. before Apply Discount to Account. Read-only and idempotent.',
+      'Lists Outseta discount coupons with optional filters (search by name or code, still-redeemable only, active or inactive, created date range) and sorting, returning the amount or percentage off, duration and redemption counts. Read-only and idempotent.',
     idempotent: true,
   },
+  propertyGroups: [
+    {
+      key: 'discount',
+      display: 'builder',
+      label: 'Discount',
+      icon: 'tag',
+      props: ['search', 'canRedeem', 'isActive'],
+    },
+    {
+      key: 'dates',
+      display: 'builder',
+      label: 'Dates',
+      icon: 'calendar',
+      props: ['createdRange'],
+    },
+    {
+      key: 'sort',
+      display: 'builder',
+      label: 'Sort',
+      icon: 'sliders',
+      props: ['sortBy', 'direction'],
+    },
+    { key: 'paging', display: 'footer', props: ['limit', 'page'] },
+  ],
   props: {
-    limit: Property.Number({
-      displayName: 'Limit',
+    search: Property.ShortText({
+      displayName: 'Search',
+      description: 'Matches the coupon name or code.',
       required: false,
-      defaultValue: 100,
-      description: 'Maximum number of discounts to return (default 100).',
+      icon: 'text',
+      placeholder: 'WELCOME',
     }),
-    offset: Property.Number({
-      displayName: 'Page',
+    canRedeem: Property.StaticDropdown({
+      displayName: 'Redeemable',
       required: false,
-      defaultValue: 0,
-      description:
-        'Page number to fetch (0 = first page, 1 = second page, ...). Outseta uses page-based pagination, not record-based.',
+      icon: 'filter',
+      options: {
+        disabled: false,
+        options: [{ label: 'Still redeemable only', value: 'true' }],
+      },
     }),
+    isActive: Property.StaticDropdown({
+      displayName: 'Active',
+      required: false,
+      icon: 'filter',
+      options: {
+        disabled: false,
+        options: [
+          { label: 'Active only', value: 'true' },
+          { label: 'Inactive only', value: 'false' },
+        ],
+      },
+    }),
+    createdRange: Property.DateRange({
+      displayName: 'Created',
+      required: false,
+      display: 'dropdown',
+      icon: 'calendar',
+    }),
+    sortBy: outsetaListProps.sortBy({
+      options: [
+        { label: 'Created', value: 'Created' },
+        { label: 'Updated', value: 'Updated' },
+        { label: 'Name', value: 'Name' },
+      ],
+      defaultValue: 'Created',
+    }),
+    direction: outsetaListProps.direction(),
+    limit: outsetaListProps.limit(),
+    page: outsetaListProps.page(),
   },
   async run(context) {
     const client = new OutsetaClient({
@@ -36,11 +96,29 @@ export const listDiscountsAction = createAction({
       apiSecret: context.auth.props.apiSecret,
     });
 
-    const limit = context.propsValue.limit ?? 100;
-    const offset = context.propsValue.offset ?? 0;
+    const query = outsetaQuery.build({
+      filters: [
+        { field: 'q', value: context.propsValue.search },
+        { field: 'canRedeem', value: context.propsValue.canRedeem },
+        { field: 'IsActive', value: context.propsValue.isActive },
+        ...outsetaQuery.dateRangeFilters({
+          field: 'Created',
+          range: context.propsValue.createdRange,
+        }),
+      ],
+      orderBy: context.propsValue.sortBy,
+      orderDirection: context.propsValue.direction,
+      limit: context.propsValue.limit,
+      page: context.propsValue.page,
+    });
 
-    return client.get<unknown>(
-      `/api/v1/billing/discountcoupons?limit=${limit}&offset=${offset}`
+    const result = await client.getPage<OutsetaDiscountCoupon>(
+      `/api/v1/billing/discountcoupons?${query}&fields=*`
     );
+
+    return {
+      items: result.items.map(outsetaMappers.discount),
+      ...outsetaQuery.pageInfo(result),
+    };
   },
 });

--- a/packages/pieces/community/outseta/src/action/list-persons.ts
+++ b/packages/pieces/community/outseta/src/action/list-persons.ts
@@ -1,31 +1,105 @@
 import { createAction, Property } from '@activepieces/pieces-framework';
 import { outsetaAuth } from '../auth';
 import { OutsetaClient } from '../common/client';
+import { outsetaListProps } from '../common/list-props';
+import { outsetaMappers } from '../common/mappers';
+import { outsetaQuery } from '../common/list-query';
+import { OutsetaPerson } from '../common/outseta-types';
 
 export const listPersonsAction = createAction({
   name: 'list_persons',
   auth: outsetaAuth,
   displayName: 'List Persons',
-  description: 'Retrieve a paginated list of persons from your Outseta CRM.',
+  description:
+    'List CRM people, optionally filtered and sorted. Each person comes back in the same shape as Retrieve Person.',
   audience: 'both',
+  classification: 'SEARCH',
   aiMetadata: {
     description:
-      'Returns a paginated list of CRM persons (contacts). Use to browse or scan contacts; to fetch one known person use Retrieve Person. Read-only and idempotent.',
+      'Lists Outseta CRM people with optional filters (free-text search, email, first or last name, job title, created or updated date range) and sorting. Items have the same shape as Retrieve Person. Use for browsing or filtering many people; to fetch one known person use Retrieve Person. Read-only and idempotent.',
     idempotent: true,
   },
+  propertyGroups: [
+    {
+      key: 'person',
+      display: 'builder',
+      label: 'Person',
+      icon: 'user',
+      props: ['search', 'email', 'firstName', 'lastName', 'title'],
+    },
+    {
+      key: 'dates',
+      display: 'builder',
+      label: 'Dates',
+      icon: 'calendar',
+      props: ['createdRange', 'updatedRange'],
+    },
+    {
+      key: 'sort',
+      display: 'builder',
+      label: 'Sort',
+      icon: 'sliders',
+      props: ['sortBy', 'direction'],
+    },
+    { key: 'paging', display: 'footer', props: ['limit', 'page'] },
+  ],
   props: {
-    limit: Property.Number({
-      displayName: 'Limit',
+    search: Property.ShortText({
+      displayName: 'Search',
+      description: 'Matches the first name, last name or email address.',
       required: false,
-      defaultValue: 100,
-      description: 'Maximum number of persons to return (default 100).',
+      icon: 'text',
+      placeholder: 'jane',
     }),
-    offset: Property.Number({
-      displayName: 'Page',
+    email: Property.ShortText({
+      displayName: 'Email contains',
       required: false,
-      defaultValue: 0,
-      description: 'Page number to fetch (0 = first page, 1 = second page, ...). Outseta uses page-based pagination, not record-based.',
+      icon: 'user',
+      placeholder: '@example.com',
     }),
+    firstName: Property.ShortText({
+      displayName: 'First name contains',
+      required: false,
+      icon: 'text',
+      placeholder: 'Jane',
+    }),
+    lastName: Property.ShortText({
+      displayName: 'Last name contains',
+      required: false,
+      icon: 'text',
+      placeholder: 'Doe',
+    }),
+    title: Property.ShortText({
+      displayName: 'Job title contains',
+      required: false,
+      icon: 'tag',
+      placeholder: 'Head of',
+    }),
+    createdRange: Property.DateRange({
+      displayName: 'Created',
+      required: false,
+      display: 'dropdown',
+      icon: 'calendar',
+    }),
+    updatedRange: Property.DateRange({
+      displayName: 'Updated',
+      required: false,
+      display: 'dropdown',
+      icon: 'calendar',
+    }),
+    sortBy: outsetaListProps.sortBy({
+      options: [
+        { label: 'Created', value: 'Created' },
+        { label: 'Updated', value: 'Updated' },
+        { label: 'Email', value: 'Email' },
+        { label: 'First name', value: 'FirstName' },
+        { label: 'Last name', value: 'LastName' },
+      ],
+      defaultValue: 'Created',
+    }),
+    direction: outsetaListProps.direction(),
+    limit: outsetaListProps.limit(),
+    page: outsetaListProps.page(),
   },
   async run(context) {
     const client = new OutsetaClient({
@@ -34,13 +108,38 @@ export const listPersonsAction = createAction({
       apiSecret: context.auth.props.apiSecret,
     });
 
-    const limit = context.propsValue.limit ?? 100;
-    const offset = context.propsValue.offset ?? 0;
+    const query = outsetaQuery.build({
+      filters: [
+        { field: 'q', value: context.propsValue.search },
+        { field: 'Email', operator: 'contains', value: context.propsValue.email },
+        { field: 'FirstName', operator: 'contains', value: context.propsValue.firstName },
+        { field: 'LastName', operator: 'contains', value: context.propsValue.lastName },
+        { field: 'Title', operator: 'contains', value: context.propsValue.title },
+        ...outsetaQuery.dateRangeFilters({
+          field: 'Created',
+          range: context.propsValue.createdRange,
+        }),
+        ...outsetaQuery.dateRangeFilters({
+          field: 'Updated',
+          range: context.propsValue.updatedRange,
+        }),
+      ],
+      orderBy: context.propsValue.sortBy,
+      orderDirection: context.propsValue.direction,
+      limit: context.propsValue.limit,
+      page: context.propsValue.page,
+    });
 
-    const result = await client.get<any>(
-      `/api/v1/crm/people?limit=${limit}&offset=${offset}`
+    const result = await client.getPage<OutsetaPerson>(
+      `/api/v1/crm/people?${query}&${PERSON_FIELDS}`
     );
 
-    return result;
+    return {
+      items: result.items.map(outsetaMappers.person),
+      ...outsetaQuery.pageInfo(result),
+    };
   },
 });
+
+const PERSON_FIELDS =
+  'fields=*,MailingAddress.*,PersonAccount.IsPrimary,PersonAccount.Role,PersonAccount.Account.Uid,PersonAccount.Account.Name,PersonAccount.Account.AccountStage';

--- a/packages/pieces/community/outseta/src/action/list-plans.ts
+++ b/packages/pieces/community/outseta/src/action/list-plans.ts
@@ -1,33 +1,97 @@
 import { createAction, Property } from '@activepieces/pieces-framework';
 import { outsetaAuth } from '../auth';
 import { OutsetaClient } from '../common/client';
+import { outsetaListProps } from '../common/list-props';
+import { outsetaMappers } from '../common/mappers';
+import { outsetaQuery } from '../common/list-query';
+import { OutsetaPlan } from '../common/outseta-types';
 
 export const listPlansAction = createAction({
   name: 'list_plans',
   auth: outsetaAuth,
   displayName: 'List Plans',
-  description:
-    'Retrieve a paginated list of subscription plans from your Outseta billing catalog.',
+  description: 'List billing plans, optionally filtered and sorted.',
   audience: 'both',
+  classification: 'SEARCH',
   aiMetadata: {
     description:
-      'Returns a paginated list of subscription plans from the billing catalog. Use to discover available plan UIDs, e.g. before Change Account Plan or Create Account. Read-only and idempotent.',
+      'Lists Outseta billing plans with optional filters (name, active or inactive, per-user, created date range) and sorting, returning rates for every billing term, trial length and quantity rules. Read-only and idempotent.',
     idempotent: true,
   },
+  propertyGroups: [
+    {
+      key: 'plan',
+      display: 'builder',
+      label: 'Plan',
+      icon: 'tag',
+      props: ['name', 'isActive', 'isPerUser'],
+    },
+    {
+      key: 'dates',
+      display: 'builder',
+      label: 'Dates',
+      icon: 'calendar',
+      props: ['createdRange'],
+    },
+    {
+      key: 'sort',
+      display: 'builder',
+      label: 'Sort',
+      icon: 'sliders',
+      props: ['sortBy', 'direction'],
+    },
+    { key: 'paging', display: 'footer', props: ['limit', 'page'] },
+  ],
   props: {
-    limit: Property.Number({
-      displayName: 'Limit',
+    name: Property.ShortText({
+      displayName: 'Name contains',
       required: false,
-      defaultValue: 100,
-      description: 'Maximum number of plans to return (default 100).',
+      icon: 'text',
+      placeholder: 'Pro',
     }),
-    offset: Property.Number({
-      displayName: 'Page',
+    isActive: Property.StaticDropdown({
+      displayName: 'Active',
       required: false,
-      defaultValue: 0,
-      description:
-        'Page number to fetch (0 = first page, 1 = second page, ...). Outseta uses page-based pagination, not record-based.',
+      icon: 'filter',
+      options: {
+        disabled: false,
+        options: [
+          { label: 'Active only', value: 'true' },
+          { label: 'Inactive only', value: 'false' },
+        ],
+      },
     }),
+    isPerUser: Property.StaticDropdown({
+      displayName: 'Per-user pricing',
+      required: false,
+      icon: 'users',
+      options: {
+        disabled: false,
+        options: [
+          { label: 'Per-user only', value: 'true' },
+          { label: 'Flat-rate only', value: 'false' },
+        ],
+      },
+    }),
+    createdRange: Property.DateRange({
+      displayName: 'Created',
+      required: false,
+      display: 'dropdown',
+      icon: 'calendar',
+    }),
+    sortBy: outsetaListProps.sortBy({
+      options: [
+        { label: 'Created', value: 'Created' },
+        { label: 'Updated', value: 'Updated' },
+        { label: 'Name', value: 'Name' },
+        { label: 'Monthly rate', value: 'MonthlyRate' },
+        { label: 'Annual rate', value: 'AnnualRate' },
+      ],
+      defaultValue: 'Name',
+    }),
+    direction: outsetaListProps.direction(),
+    limit: outsetaListProps.limit(),
+    page: outsetaListProps.page(),
   },
   async run(context) {
     const client = new OutsetaClient({
@@ -36,11 +100,29 @@ export const listPlansAction = createAction({
       apiSecret: context.auth.props.apiSecret,
     });
 
-    const limit = context.propsValue.limit ?? 100;
-    const offset = context.propsValue.offset ?? 0;
+    const query = outsetaQuery.build({
+      filters: [
+        { field: 'Name', operator: 'contains', value: context.propsValue.name },
+        { field: 'IsActive', value: context.propsValue.isActive },
+        { field: 'IsPerUser', value: context.propsValue.isPerUser },
+        ...outsetaQuery.dateRangeFilters({
+          field: 'Created',
+          range: context.propsValue.createdRange,
+        }),
+      ],
+      orderBy: context.propsValue.sortBy,
+      orderDirection: context.propsValue.direction,
+      limit: context.propsValue.limit,
+      page: context.propsValue.page,
+    });
 
-    return client.get<unknown>(
-      `/api/v1/billing/plans?limit=${limit}&offset=${offset}`
+    const result = await client.getPage<OutsetaPlan>(
+      `/api/v1/billing/plans?${query}&fields=*,PlanFamily.Uid,PlanFamily.Name`
     );
+
+    return {
+      items: result.items.map(outsetaMappers.plan),
+      ...outsetaQuery.pageInfo(result),
+    };
   },
 });

--- a/packages/pieces/community/outseta/src/action/list-transactions.ts
+++ b/packages/pieces/community/outseta/src/action/list-transactions.ts
@@ -1,38 +1,92 @@
 import { createAction, Property } from '@activepieces/pieces-framework';
 import { outsetaAuth } from '../auth';
 import { OutsetaClient } from '../common/client';
+import { outsetaEnums } from '../common/enums';
+import { outsetaListProps } from '../common/list-props';
+import { outsetaMappers } from '../common/mappers';
+import { outsetaQuery } from '../common/list-query';
+import { OutsetaTransaction } from '../common/outseta-types';
 
 export const listTransactionsAction = createAction({
   name: 'list_transactions',
   auth: outsetaAuth,
   displayName: 'List Account Transactions',
   description:
-    'Retrieve all billing transactions (payments, refunds, invoices) for a given account.',
+    "List an account's billing transactions — invoices, payments, refunds and credits — optionally filtered and sorted.",
   audience: 'both',
+  classification: 'SEARCH',
   aiMetadata: {
     description:
-      'Returns a paginated list of all billing transactions (payments, refunds, invoices) for an account, by account UID. Use for full history; for just the latest payment use Get Last Payment for Account. Read-only and idempotent.',
+      "Lists one account's billing transactions (invoices, payments, credits, refunds, chargebacks, tax refunds) with optional filters (type, amount range, transaction date range) and sorting. Use for the full history; for the single latest payment use Get Last Payment for Account. Read-only and idempotent.",
     idempotent: true,
   },
+  propertyGroups: [
+    {
+      key: 'transaction',
+      display: 'builder',
+      label: 'Transaction',
+      icon: 'filter',
+      props: ['transactionType', 'minAmount', 'maxAmount'],
+    },
+    {
+      key: 'dates',
+      display: 'builder',
+      label: 'Dates',
+      icon: 'calendar',
+      props: ['transactionDateRange'],
+    },
+    {
+      key: 'sort',
+      display: 'builder',
+      label: 'Sort',
+      icon: 'sliders',
+      props: ['sortBy', 'direction'],
+    },
+    { key: 'paging', display: 'footer', props: ['limit', 'page'] },
+  ],
   props: {
     accountUid: Property.ShortText({
       displayName: 'Account UID',
-      description: 'The UID of the account to retrieve transactions for.',
+      description: 'The account whose transactions you want.',
       required: true,
+      placeholder: '1QpnM0nW',
     }),
-    limit: Property.Number({
-      displayName: 'Limit',
+    transactionType: Property.StaticDropdown({
+      displayName: 'Type is',
       required: false,
-      defaultValue: 100,
-      description: 'Maximum number of transactions to return (default 100).',
+      icon: 'filter',
+      options: {
+        disabled: false,
+        options: outsetaEnums.billingTransactionType.options,
+      },
     }),
-    offset: Property.Number({
-      displayName: 'Page',
+    minAmount: Property.Number({
+      displayName: 'Amount at least',
       required: false,
-      defaultValue: 0,
-      description:
-        'Page number to fetch (0 = first page, 1 = second page, ...). Outseta uses page-based pagination, not record-based.',
+      icon: 'sliders',
     }),
+    maxAmount: Property.Number({
+      displayName: 'Amount at most',
+      required: false,
+      icon: 'sliders',
+    }),
+    transactionDateRange: Property.DateRange({
+      displayName: 'Transaction date',
+      required: false,
+      display: 'dropdown',
+      icon: 'calendar',
+    }),
+    sortBy: outsetaListProps.sortBy({
+      options: [
+        { label: 'Created', value: 'Created' },
+        { label: 'Transaction date', value: 'TransactionDate' },
+        { label: 'Amount', value: 'Amount' },
+      ],
+      defaultValue: 'Created',
+    }),
+    direction: outsetaListProps.direction(),
+    limit: outsetaListProps.limit(),
+    page: outsetaListProps.page(),
   },
   async run(context) {
     const client = new OutsetaClient({
@@ -41,11 +95,32 @@ export const listTransactionsAction = createAction({
       apiSecret: context.auth.props.apiSecret,
     });
 
-    const limit = context.propsValue.limit ?? 100;
-    const offset = context.propsValue.offset ?? 0;
+    const query = outsetaQuery.build({
+      filters: [
+        {
+          field: 'BillingTransactionType',
+          value: context.propsValue.transactionType,
+        },
+        { field: 'Amount', operator: 'gte', value: context.propsValue.minAmount },
+        { field: 'Amount', operator: 'lte', value: context.propsValue.maxAmount },
+        ...outsetaQuery.dateRangeFilters({
+          field: 'TransactionDate',
+          range: context.propsValue.transactionDateRange,
+        }),
+      ],
+      orderBy: context.propsValue.sortBy,
+      orderDirection: context.propsValue.direction,
+      limit: context.propsValue.limit,
+      page: context.propsValue.page,
+    });
 
-    return client.get<unknown>(
-      `/api/v1/billing/transactions/${context.propsValue.accountUid}?limit=${limit}&offset=${offset}&orderBy=Created%20DESC`
+    const result = await client.getPage<OutsetaTransaction>(
+      `/api/v1/billing/transactions/${context.propsValue.accountUid}?${query}&fields=*,Invoice.Uid,Invoice.Number,Invoice.BillingInvoiceStatus`
     );
+
+    return {
+      items: result.items.map(outsetaMappers.transaction),
+      ...outsetaQuery.pageInfo(result),
+    };
   },
 });

--- a/packages/pieces/community/outseta/src/action/update-account.ts
+++ b/packages/pieces/community/outseta/src/action/update-account.ts
@@ -1,6 +1,7 @@
 import { createAction, Property } from '@activepieces/pieces-framework';
 import { outsetaAuth } from '../auth';
 import { OutsetaClient } from '../common/client';
+import { outsetaEnums } from '../common/enums';
 import { customPropertiesProp, mergeCustomProperties } from '../common/custom-properties';
 
 export const updateAccountAction = createAction({
@@ -28,15 +29,8 @@ export const updateAccountAction = createAction({
       displayName: 'Account Stage',
       required: false,
       options: {
-        options: [
-          { label: 'Lead', value: 1 },
-          { label: 'Trialing', value: 2 },
-          { label: 'Subscribing', value: 3 },
-          { label: 'Delinquent', value: 4 },
-          { label: 'Cancelling', value: 5 },
-          { label: 'Expired', value: 6 },
-          { label: 'Demo', value: 7 },
-        ],
+        disabled: false,
+        options: outsetaEnums.accountStage.options,
       },
     }),
     clientIdentifier: Property.ShortText({

--- a/packages/pieces/community/outseta/src/common/client.ts
+++ b/packages/pieces/community/outseta/src/common/client.ts
@@ -1,8 +1,9 @@
+import { isNil } from '@activepieces/pieces-framework';
 import {
-  HttpMessageBody,
   HttpMethod,
   httpClient,
 } from '@activepieces/pieces-common';
+import { OutsetaPage } from './outseta-types';
 
 export class OutsetaClient {
   private readonly baseUrl: string;
@@ -29,31 +30,46 @@ export class OutsetaClient {
     return this.request<T>(HttpMethod.DELETE, path);
   }
 
-  async getAllPages<T>(basePath: string, pageSize = 100): Promise<T[]> {
-    const allItems: T[] = [];
-    // Outseta's `offset` is PAGE-BASED, not item-based.
-    // Verified against the live API on /crm/people (total=182):
-    //   limit=100 offset=0 → 100 items (items 0-99)
-    //   limit=100 offset=1 → 82 items  (items 100-181)
-    //   limit=100 offset=2 → 0 items   (past end)
-    //   limit=50  offset=3 → 32 items  (items 150-181)
-    //   limit=25  offset=7 → 7 items   (items 175-181)
-    // Increment by 1 per iteration, not by pageSize.
+  async getPage<T>(path: string): Promise<PagedResult<T>> {
+    const response = await this.get<OutsetaPage<T>>(path);
+    return {
+      items: response?.items ?? response?.Items ?? [],
+      total: response?.metadata?.total ?? null,
+      limit: response?.metadata?.limit ?? null,
+      offset: response?.metadata?.offset ?? null,
+    };
+  }
+
+  async getAllPages<T>(basePath: string, requestedPageSize = 100): Promise<T[]> {
+    const collected: T[] = [];
     let page = 0;
+    let appliedPageSize = requestedPageSize;
 
-    while (true) {
+    for (;;) {
       const separator = basePath.includes('?') ? '&' : '?';
-      const res = await this.get<PaginatedResponse<T>>(
-        `${basePath}${separator}limit=${pageSize}&offset=${page}`
+      const result = await this.getPage<T>(
+        `${basePath}${separator}limit=${requestedPageSize}&offset=${page}`
       );
-      const items: T[] = res?.items ?? res?.Items ?? [];
-      allItems.push(...items);
+      collected.push(...result.items);
 
-      if (items.length < pageSize) break;
+      if (!isNil(result.limit) && result.limit > 0) {
+        appliedPageSize = result.limit;
+      }
+
+      const reachedTotal =
+        !isNil(result.total) && collected.length >= result.total;
+
+      if (
+        result.items.length === 0 ||
+        result.items.length < appliedPageSize ||
+        reachedTotal
+      ) {
+        break;
+      }
       page += 1;
     }
 
-    return allItems;
+    return collected;
   }
 
   private async request<T>(
@@ -68,7 +84,7 @@ export class OutsetaClient {
         Authorization: this.authHeader,
         'Content-Type': 'application/json',
       },
-      body: body as HttpMessageBody,
+      body,
     });
 
     if (response.status < 200 || response.status >= 300) {
@@ -77,7 +93,7 @@ export class OutsetaClient {
       );
     }
 
-    return response.body as T;
+    return response.body;
   }
 }
 
@@ -87,7 +103,9 @@ type OutsetaAuth = {
   apiSecret: string;
 };
 
-type PaginatedResponse<T> = {
-  items?: T[];
-  Items?: T[];
+type PagedResult<T> = {
+  items: T[];
+  total: number | null;
+  limit: number | null;
+  offset: number | null;
 };

--- a/packages/pieces/community/outseta/src/common/enums.ts
+++ b/packages/pieces/community/outseta/src/common/enums.ts
@@ -1,0 +1,93 @@
+import { isNil } from '@activepieces/pieces-framework';
+
+const ACCOUNT_STAGE: EnumLabels = {
+  2: 'Trialing',
+  3: 'Subscribing',
+  4: 'Cancelling',
+  5: 'Expired',
+  6: 'Trial Expired',
+  7: 'Past Due',
+  8: 'Cancelling Trial',
+  9: 'Paused',
+  10: 'Created',
+};
+
+const BILLING_RENEWAL_TERM: EnumLabels = {
+  1: 'Monthly',
+  2: 'Annual',
+  3: 'Quarterly',
+  4: 'One-time',
+};
+
+const BILLING_ADD_ON_TYPE: EnumLabels = {
+  1: 'Recurring',
+  2: 'Usage',
+  3: 'One-time',
+};
+
+const DISCOUNT_DURATION: EnumLabels = {
+  1: 'Forever',
+  2: 'Once',
+  3: 'Repeating',
+};
+
+const SUPPORT_CASE_SOURCE: EnumLabels = {
+  1: 'Website',
+  2: 'Email',
+  3: 'Facebook',
+  4: 'Twitter',
+  5: 'Chat',
+};
+
+const BILLING_TRANSACTION_TYPE: EnumLabels = {
+  1: 'Invoice',
+  2: 'Payment',
+  3: 'Credit',
+  4: 'Refund',
+  5: 'Chargeback',
+  6: 'Tax Refund',
+};
+
+const BILLING_INVOICE_STATUS: EnumLabels = {
+  1: 'Unpaid',
+  2: 'Paid',
+  3: 'Partial',
+  4: 'Uncollected',
+  5: 'Refunded',
+  6: 'Uncollectible',
+  7: 'Processing',
+};
+
+const ACCOUNT_ROLE: EnumLabels = {
+  1: 'Admin',
+  2: 'Member',
+  3: 'Operator',
+};
+
+function describe(labels: EnumLabels): OutsetaEnum {
+  return {
+    options: Object.entries(labels).map(([value, label]) => ({
+      label,
+      value: Number(value),
+    })),
+    label: (value) => (isNil(value) ? null : (labels[value] ?? null)),
+  };
+}
+
+export const outsetaEnums = {
+  accountStage: describe(ACCOUNT_STAGE),
+  billingRenewalTerm: describe(BILLING_RENEWAL_TERM),
+  billingAddOnType: describe(BILLING_ADD_ON_TYPE),
+  discountDuration: describe(DISCOUNT_DURATION),
+  supportCaseSource: describe(SUPPORT_CASE_SOURCE),
+  billingTransactionType: describe(BILLING_TRANSACTION_TYPE),
+  billingInvoiceStatus: describe(BILLING_INVOICE_STATUS),
+  accountRole: describe(ACCOUNT_ROLE),
+};
+
+type EnumLabels = Record<number, string>;
+
+type OutsetaEnum = {
+  options: { label: string; value: number }[];
+  label: (value: number | null | undefined) => string | null;
+};

--- a/packages/pieces/community/outseta/src/common/enums.ts
+++ b/packages/pieces/community/outseta/src/common/enums.ts
@@ -31,6 +31,12 @@ const DISCOUNT_DURATION: EnumLabels = {
   3: 'Repeating',
 };
 
+const SUPPORT_CASE_STATUS: EnumLabels = {
+  1: 'Open',
+  2: 'Closed',
+  3: 'Spam',
+};
+
 const SUPPORT_CASE_SOURCE: EnumLabels = {
   1: 'Website',
   2: 'Email',
@@ -79,6 +85,7 @@ export const outsetaEnums = {
   billingRenewalTerm: describe(BILLING_RENEWAL_TERM),
   billingAddOnType: describe(BILLING_ADD_ON_TYPE),
   discountDuration: describe(DISCOUNT_DURATION),
+  supportCaseStatus: describe(SUPPORT_CASE_STATUS),
   supportCaseSource: describe(SUPPORT_CASE_SOURCE),
   billingTransactionType: describe(BILLING_TRANSACTION_TYPE),
   billingInvoiceStatus: describe(BILLING_INVOICE_STATUS),

--- a/packages/pieces/community/outseta/src/common/errors.ts
+++ b/packages/pieces/community/outseta/src/common/errors.ts
@@ -1,0 +1,9 @@
+function isNotFound(error: unknown): boolean {
+  if (typeof error !== 'object' || error === null) {
+    return false;
+  }
+  const response = (error as { response?: { status?: number } }).response;
+  return response?.status === 404;
+}
+
+export const outsetaErrors = { isNotFound };

--- a/packages/pieces/community/outseta/src/common/list-props.ts
+++ b/packages/pieces/community/outseta/src/common/list-props.ts
@@ -1,0 +1,59 @@
+import { Property } from '@activepieces/pieces-framework';
+
+function direction() {
+  return Property.StaticDropdown({
+    displayName: 'Direction',
+    required: false,
+    defaultValue: 'desc',
+    icon: 'sliders',
+    options: {
+      disabled: false,
+      options: [
+        { label: 'Descending', value: 'desc' },
+        { label: 'Ascending', value: 'asc' },
+      ],
+    },
+  });
+}
+
+function limit() {
+  return Property.Number({
+    displayName: 'Limit',
+    description:
+      'Results per page. Outseta caps this at 100, and at 25 when related records are included.',
+    required: false,
+    defaultValue: 100,
+    display: 'stepper',
+    min: 1,
+    max: 100,
+  });
+}
+
+function page() {
+  return Property.Number({
+    displayName: 'Page',
+    description: 'Page number, starting at 0. Outseta pages by page number, not by record.',
+    required: false,
+    defaultValue: 0,
+    display: 'stepper',
+    min: 0,
+    max: 10000,
+  });
+}
+
+function sortBy({ options, defaultValue }: SortByParams) {
+  return Property.StaticDropdown({
+    displayName: 'Sort by',
+    required: false,
+    defaultValue,
+    icon: 'sliders',
+    options: { disabled: false, options },
+  });
+}
+
+export const outsetaListProps = { sortBy, direction, limit, page };
+
+type SortByParams = {
+  options: { label: string; value: string }[];
+  defaultValue: string;
+};

--- a/packages/pieces/community/outseta/src/common/list-query.ts
+++ b/packages/pieces/community/outseta/src/common/list-query.ts
@@ -1,0 +1,125 @@
+import { dateRangeUtils, DateRangeValue, isNil } from '@activepieces/pieces-framework';
+
+const WILDCARD_PATTERNS: Record<string, (value: string) => string> = {
+  contains: (value) => `*${value}*`,
+  starts_with: (value) => `${value}*`,
+  ends_with: (value) => `*${value}`,
+};
+
+const COMPARISON_SUFFIXES: Record<string, string> = {
+  gt: '__gt',
+  gte: '__gte',
+  lt: '__lt',
+  lte: '__lte',
+  ne: '__ne',
+  is_null: '__isnull',
+};
+
+function isBlank(value: unknown): boolean {
+  return isNil(value) || value === '';
+}
+
+function paramFor(filter: OutsetaFilter): [string, string] | null {
+  if (isBlank(filter.value)) {
+    return null;
+  }
+  const value = String(filter.value);
+  const operator = filter.operator ?? 'eq';
+
+  const wildcard = WILDCARD_PATTERNS[operator];
+  if (wildcard) {
+    return [filter.field, wildcard(value)];
+  }
+
+  const suffix = COMPARISON_SUFFIXES[operator];
+  if (suffix) {
+    return [`${filter.field}${suffix}`, value];
+  }
+
+  return [filter.field, value];
+}
+
+function build({ filters = [], orderBy, orderDirection, limit, page }: BuildQueryParams): string {
+  const params = new URLSearchParams();
+
+  for (const filter of filters) {
+    const param = paramFor(filter);
+    if (param) {
+      params.append(param[0], param[1]);
+    }
+  }
+
+  if (!isBlank(orderBy)) {
+    params.append('orderBy', `${orderBy} ${orderDirection === 'desc' ? 'DESC' : 'ASC'}`);
+  }
+  if (!isNil(limit)) {
+    params.append('limit', String(limit));
+  }
+  if (!isNil(page)) {
+    params.append('offset', String(page));
+  }
+
+  return params.toString();
+}
+
+function dateRangeFilters({ field, range }: DateRangeFilterParams): OutsetaFilter[] {
+  const { after, before } = dateRangeUtils.resolve(range);
+  return [
+    { field, operator: 'gte', value: after },
+    { field, operator: 'lte', value: before },
+  ];
+}
+
+function pageInfo({ total, limit, offset }: PageInfoParams): PageInfo {
+  const hasMore =
+    !isNil(total) && !isNil(limit) && !isNil(offset) && limit > 0
+      ? (offset + 1) * limit < total
+      : false;
+
+  return { total: total ?? null, page: offset ?? null, has_more: hasMore };
+}
+
+export const outsetaQuery = { build, dateRangeFilters, pageInfo };
+
+export type OutsetaFilterOperator =
+  | 'eq'
+  | 'ne'
+  | 'contains'
+  | 'starts_with'
+  | 'ends_with'
+  | 'gt'
+  | 'gte'
+  | 'lt'
+  | 'lte'
+  | 'is_null';
+
+export type OutsetaFilter = {
+  field: string;
+  operator?: OutsetaFilterOperator;
+  value: unknown;
+};
+
+type BuildQueryParams = {
+  filters?: OutsetaFilter[];
+  orderBy?: string | null;
+  orderDirection?: string | null;
+  limit?: number | null;
+  page?: number | null;
+};
+
+type PageInfoParams = {
+  total: number | null;
+  limit: number | null;
+  offset: number | null;
+};
+
+type PageInfo = {
+  total: number | null;
+  page: number | null;
+  has_more: boolean;
+};
+
+type DateRangeFilterParams = {
+  field: string;
+  range: DateRangeValue | null | undefined;
+};

--- a/packages/pieces/community/outseta/src/common/lookup.ts
+++ b/packages/pieces/community/outseta/src/common/lookup.ts
@@ -1,0 +1,36 @@
+import { isNil } from '@activepieces/pieces-framework';
+
+function single(candidates: LookupCandidate[]): ResolvedLookup {
+  const filled = candidates.filter(
+    (candidate): candidate is ResolvedLookup =>
+      !isNil(candidate.value) && candidate.value !== ''
+  );
+
+  if (filled.length === 0) {
+    throw new Error(
+      `Nothing to look up. Fill one of: ${candidates
+        .map((candidate) => candidate.label)
+        .join(', ')}.`
+    );
+  }
+
+  if (filled.length > 1) {
+    throw new Error(
+      `Two lookup values are filled (${filled
+        .map((candidate) => candidate.label)
+        .join(', ')}). Clear the one you are not using — switch tabs to find it.`
+    );
+  }
+
+  return filled[0];
+}
+
+export const outsetaLookup = { single };
+
+export type LookupCandidate = {
+  key: string;
+  label: string;
+  value: string | undefined | null;
+};
+
+type ResolvedLookup = LookupCandidate & { value: string };

--- a/packages/pieces/community/outseta/src/common/mappers.ts
+++ b/packages/pieces/community/outseta/src/common/mappers.ts
@@ -297,6 +297,7 @@ function supportCase(raw: OutsetaCase) {
     subject: raw.Subject ?? null,
     body: raw.Body ?? null,
     status: raw.Status ?? null,
+    status_label: outsetaEnums.supportCaseStatus.label(raw.Status),
     source: raw.Source ?? null,
     source_label: outsetaEnums.supportCaseSource.label(raw.Source),
     submitted_date: raw.SubmittedDateTime ?? null,

--- a/packages/pieces/community/outseta/src/common/mappers.ts
+++ b/packages/pieces/community/outseta/src/common/mappers.ts
@@ -1,0 +1,346 @@
+import { isNil } from '@activepieces/pieces-framework';
+import { outsetaEnums } from './enums';
+import {
+  OutsetaAccount,
+  OutsetaAddOn,
+  OutsetaAddress,
+  OutsetaCase,
+  OutsetaCollection,
+  OutsetaDeal,
+  OutsetaDiscountCoupon,
+  OutsetaPerson,
+  OutsetaPersonAccount,
+  OutsetaPlan,
+  OutsetaSubscription,
+  OutsetaSubscriptionAddOn,
+  OutsetaTransaction,
+} from './outseta-types';
+
+const ACCOUNT_NATIVE_KEYS = new Set([
+  '_objectType', 'ActivityEventData', 'Uid', 'Created', 'Updated',
+  'SchemaLessData', 'SchemaLessDataLoaded', 'LastEventCreated', 'ProcessedStripeEventIds',
+  'Name', 'ClientIdentifier', 'Currency', 'InvoiceNotes', 'IsDemo',
+  'BillingAddress', 'MailingAddress', 'AccountStage', 'AccountStageLabel',
+  'PaymentInformation', 'PersonAccount', 'Subscriptions', 'Deals',
+  'CurrentSubscription', 'LatestSubscription', 'PrimarySubscription',
+  'PrimaryContact', 'DomainName', 'HasLoggedIn', 'LifetimeRevenue',
+  'LastLoginDateTime', 'Nonce', 'RecaptchaToken', 'WebflowSlug',
+  'RewardFulReferralId', 'ToltReferralId', 'TaxIds', 'TaxStatus',
+  'TaxId', 'TaxIdIsInvalid', 'TaxIdType',
+  'StripeId', 'IsLivemode', 'StripeDefaultPaymentMethodId', 'StripeInvoices',
+  'StripePaymentMethods', 'StripeSubscriptions', 'PrimaryStripeSubscription',
+  'CurrentStripeProducts', 'NextStripeInvoiceDate', 'StripeNextInvoiceSequence',
+  'StripePrice', 'StripePriceIds', 'StripePromotionCode',
+  'AccountSpecificPageUrl1', 'AccountSpecificPageUrl2', 'AccountSpecificPageUrl3',
+  'AccountSpecificPageUrl4', 'AccountSpecificPageUrl5', 'AccountSpecificPageUrl6',
+  'AccountSpecificPageUrl7', 'AccountSpecificPageUrl8', 'AccountSpecificPageUrl9',
+  'AccountSpecificPageUrl10',
+]);
+
+const PERSON_NATIVE_KEYS = new Set([
+  '_objectType', 'ActivityEventData', 'Uid', 'Created', 'Updated',
+  'SchemaLessData', 'SchemaLessDataLoaded',
+  'Email', 'FirstName', 'LastName', 'FullName', 'Title',
+  'PhoneMobile', 'PhoneWork', 'MailingAddress', 'ProfileImageS3Url',
+  'Timezone', 'Language', 'IPAddress', 'Referer', 'UserAgent',
+  'UserAgentPlatformBrowser', 'LastLoginDateTime', 'HasLoggedIn',
+  'Password', 'PasswordLastUpdated', 'PasswordMustChange',
+  'PersonAccount', 'Account', 'AccountUids', 'DealPeople',
+  'LeadFormSubmissions', 'EmailListPerson', 'OptInToEmailList', 'HasUnsubscribed',
+  'OAuthGoogleProfileId', 'OAuthIntegrationStatus',
+  'DiscordUser', 'IsConnectedToDiscord', 'RecaptchaToken',
+]);
+
+const DEAL_NATIVE_KEYS = new Set([
+  '_objectType', 'ActivityEventData', 'Uid', 'Created', 'Updated',
+  'SchemaLessData', 'SchemaLessDataLoaded',
+  'Name', 'Amount', 'DueDate', 'Weight', 'AssignedToPersonClientIdentifier',
+  'DealPipelineStage', 'PipelineUid', 'DealPeople', 'Contacts',
+  'Account', 'AccountId', 'Owner',
+]);
+
+function toArray<T>(collection: OutsetaCollection<T>): T[] {
+  if (Array.isArray(collection)) {
+    return collection;
+  }
+  return collection?.items ?? collection?.Items ?? [];
+}
+
+function customPropertiesOf(
+  entity: Record<string, unknown>,
+  nativeKeys: Set<string>
+): Record<string, unknown> {
+  return Object.fromEntries(
+    Object.entries(entity).filter(([key]) => !nativeKeys.has(key))
+  );
+}
+
+function address(prefix: string, value: OutsetaAddress | null | undefined) {
+  return {
+    [`${prefix}_line1`]: value?.AddressLine1 ?? null,
+    [`${prefix}_line2`]: value?.AddressLine2 ?? null,
+    [`${prefix}_city`]: value?.City ?? null,
+    [`${prefix}_state`]: value?.State ?? null,
+    [`${prefix}_postal_code`]: value?.PostalCode ?? null,
+    [`${prefix}_country`]: value?.Country ?? null,
+  };
+}
+
+function firstMembership(
+  person: OutsetaPerson | null | undefined
+): OutsetaPersonAccount | undefined {
+  return toArray(person?.PersonAccount)[0];
+}
+
+function subscriptionAddOns(subscription: OutsetaSubscription | null | undefined) {
+  return toArray(subscription?.SubscriptionAddOns).map(
+    (item: OutsetaSubscriptionAddOn) => ({
+      uid: item.AddOn?.Uid ?? item.Uid ?? null,
+      name: item.AddOn?.Name ?? null,
+      quantity: item.Quantity ?? null,
+      rate: item.Rate ?? null,
+    })
+  );
+}
+
+function account(raw: OutsetaAccount) {
+  return {
+    uid: raw.Uid ?? null,
+    name: raw.Name ?? null,
+    account_stage: raw.AccountStage ?? null,
+    account_stage_label:
+      raw.AccountStageLabel ?? outsetaEnums.accountStage.label(raw.AccountStage),
+    client_identifier: raw.ClientIdentifier ?? null,
+    currency: raw.Currency ?? null,
+    invoice_notes: raw.InvoiceNotes ?? null,
+    domain_name: raw.DomainName ?? null,
+    is_demo: raw.IsDemo ?? null,
+    has_logged_in: raw.HasLoggedIn ?? null,
+    lifetime_revenue: raw.LifetimeRevenue ?? null,
+    last_login: raw.LastLoginDateTime ?? null,
+    created: raw.Created ?? null,
+    updated: raw.Updated ?? null,
+    ...address('billing_address', raw.BillingAddress),
+    ...address('mailing_address', raw.MailingAddress),
+    primary_contact_uid: raw.PrimaryContact?.Uid ?? null,
+    primary_contact_email: raw.PrimaryContact?.Email ?? null,
+    primary_contact_first_name: raw.PrimaryContact?.FirstName ?? null,
+    primary_contact_last_name: raw.PrimaryContact?.LastName ?? null,
+    current_subscription_uid: raw.CurrentSubscription?.Uid ?? null,
+    plan_uid: raw.CurrentSubscription?.Plan?.Uid ?? null,
+    plan_name: raw.CurrentSubscription?.Plan?.Name ?? null,
+    custom_properties: customPropertiesOf(raw, ACCOUNT_NATIVE_KEYS),
+  };
+}
+
+function person(raw: OutsetaPerson) {
+  const membership = firstMembership(raw);
+  return {
+    uid: raw.Uid ?? null,
+    email: raw.Email ?? null,
+    first_name: raw.FirstName ?? null,
+    last_name: raw.LastName ?? null,
+    full_name: raw.FullName ?? null,
+    phone_mobile: raw.PhoneMobile ?? null,
+    phone_work: raw.PhoneWork ?? null,
+    title: raw.Title ?? null,
+    timezone: raw.Timezone ?? null,
+    language: raw.Language ?? null,
+    has_logged_in: raw.HasLoggedIn ?? null,
+    has_unsubscribed: raw.HasUnsubscribed ?? null,
+    last_login: raw.LastLoginDateTime ?? null,
+    created: raw.Created ?? null,
+    updated: raw.Updated ?? null,
+    ...address('mailing_address', raw.MailingAddress),
+    account_uid: membership?.Account?.Uid ?? raw.Account?.Uid ?? null,
+    account_name: membership?.Account?.Name ?? raw.Account?.Name ?? null,
+    account_stage:
+      membership?.Account?.AccountStage ?? raw.Account?.AccountStage ?? null,
+    account_role: outsetaEnums.accountRole.label(membership?.Role),
+    is_primary_contact: membership?.IsPrimary ?? null,
+    custom_properties: customPropertiesOf(raw, PERSON_NATIVE_KEYS),
+  };
+}
+
+function deal(raw: OutsetaDeal) {
+  return {
+    uid: raw.Uid ?? null,
+    name: raw.Name ?? null,
+    amount: raw.Amount ?? null,
+    due_date: raw.DueDate ?? null,
+    pipeline_uid: raw.DealPipelineStage?.DealPipeline?.Uid ?? null,
+    pipeline_name: raw.DealPipelineStage?.DealPipeline?.Name ?? null,
+    pipeline_stage_uid: raw.DealPipelineStage?.Uid ?? null,
+    pipeline_stage_name: raw.DealPipelineStage?.Name ?? null,
+    account_uid: raw.Account?.Uid ?? null,
+    account_name: raw.Account?.Name ?? null,
+    assigned_to_client_identifier: raw.AssignedToPersonClientIdentifier ?? null,
+    contacts: toArray(raw.DealPeople)
+      .map((item) => item.Person?.Email)
+      .filter((email): email is string => !isNil(email)),
+    created: raw.Created ?? null,
+    updated: raw.Updated ?? null,
+    custom_properties: customPropertiesOf(raw, DEAL_NATIVE_KEYS),
+  };
+}
+
+function subscription(raw: OutsetaSubscription) {
+  const addOns = subscriptionAddOns(raw);
+  return {
+    uid: raw.Uid ?? null,
+    account_uid: raw.Account?.Uid ?? null,
+    account_name: raw.Account?.Name ?? null,
+    plan_uid: raw.Plan?.Uid ?? null,
+    plan_name: raw.Plan?.Name ?? null,
+    plan_family_name: raw.Plan?.PlanFamily?.Name ?? null,
+    billing_renewal_term: raw.BillingRenewalTerm ?? null,
+    billing_renewal_term_label: outsetaEnums.billingRenewalTerm.label(
+      raw.BillingRenewalTerm
+    ),
+    quantity: raw.Quantity ?? null,
+    rate: raw.Rate ?? null,
+    discount_code: raw.DiscountCode ?? null,
+    discount_expiration_date: raw.DiscountCouponExpirationDate ?? null,
+    start_date: raw.StartDate ?? null,
+    end_date: raw.EndDate ?? null,
+    expiration_date: raw.ExpirationDate ?? null,
+    renewal_date: raw.RenewalDate ?? null,
+    is_plan_upgrade_required: raw.IsPlanUpgradeRequired ?? null,
+    new_required_quantity: raw.NewRequiredQuantity ?? null,
+    latest_invoice_uid: raw.LatestInvoice?.Uid ?? null,
+    latest_invoice_number: raw.LatestInvoice?.Number ?? null,
+    created: raw.Created ?? null,
+    updated: raw.Updated ?? null,
+    add_ons: addOns,
+    add_ons_names: addOns
+      .map((item) => item.name)
+      .filter((name): name is string => !isNil(name))
+      .join(', '),
+  };
+}
+
+function plan(raw: OutsetaPlan) {
+  return {
+    uid: raw.Uid ?? null,
+    name: raw.Name ?? null,
+    description: raw.Description ?? null,
+    plan_family_uid: raw.PlanFamily?.Uid ?? null,
+    plan_family_name: raw.PlanFamily?.Name ?? null,
+    monthly_rate: raw.MonthlyRate ?? null,
+    annual_rate: raw.AnnualRate ?? null,
+    quarterly_rate: raw.QuarterlyRate ?? null,
+    one_time_rate: raw.OneTimeRate ?? null,
+    setup_fee: raw.SetupFee ?? null,
+    unit_of_measure: raw.UnitOfMeasure ?? null,
+    is_active: raw.IsActive ?? null,
+    is_taxable: raw.IsTaxable ?? null,
+    is_per_user: raw.IsPerUser ?? null,
+    is_quantity_editable: raw.IsQuantityEditable ?? null,
+    minimum_quantity: raw.MinimumQuantity ?? null,
+    maximum_people: raw.MaximumPeople ?? null,
+    trial_period_days: raw.TrialPeriodDays ?? null,
+    expires_after_months: raw.ExpiresAfterMonths ?? null,
+    expiration_date: raw.ExpirationDate ?? null,
+    created: raw.Created ?? null,
+    updated: raw.Updated ?? null,
+  };
+}
+
+function addOn(raw: OutsetaAddOn) {
+  return {
+    uid: raw.Uid ?? null,
+    name: raw.Name ?? null,
+    billing_add_on_type: raw.BillingAddOnType ?? null,
+    billing_add_on_type_label: outsetaEnums.billingAddOnType.label(
+      raw.BillingAddOnType
+    ),
+    monthly_rate: raw.MonthlyRate ?? null,
+    annual_rate: raw.AnnualRate ?? null,
+    quarterly_rate: raw.QuarterlyRate ?? null,
+    one_time_rate: raw.OneTimeRate ?? null,
+    setup_fee: raw.SetupFee ?? null,
+    unit_of_measure: raw.UnitOfMeasure ?? null,
+    is_quantity_editable: raw.IsQuantityEditable ?? null,
+    minimum_quantity: raw.MinimumQuantity ?? null,
+    is_taxable: raw.IsTaxable ?? null,
+    is_billed_during_trial: raw.IsBilledDuringTrial ?? null,
+    expires_after_months: raw.ExpiresAfterMonths ?? null,
+    expiration_date: raw.ExpirationDate ?? null,
+    created: raw.Created ?? null,
+    updated: raw.Updated ?? null,
+  };
+}
+
+function discount(raw: OutsetaDiscountCoupon) {
+  return {
+    uid: raw.Uid ?? null,
+    name: raw.Name ?? null,
+    coupon_code: raw.UniqueIdentifier ?? null,
+    is_active: raw.IsActive ?? null,
+    amount_off: raw.AmountOff ?? null,
+    percent_off: raw.PercentOff ?? null,
+    redeem_by: raw.RedeemBy ?? null,
+    duration: raw.Duration ?? null,
+    duration_label: outsetaEnums.discountDuration.label(raw.Duration),
+    duration_in_months: raw.DurationInMonths ?? null,
+    times_redeemed: raw.TimesRedeemed ?? null,
+    max_redemptions: raw.MaxRedemptions ?? null,
+    apply_to_add_ons: raw.ApplyToAddOns ?? null,
+    created: raw.Created ?? null,
+    updated: raw.Updated ?? null,
+  };
+}
+
+function supportCase(raw: OutsetaCase) {
+  return {
+    uid: raw.Uid ?? null,
+    subject: raw.Subject ?? null,
+    body: raw.Body ?? null,
+    status: raw.Status ?? null,
+    source: raw.Source ?? null,
+    source_label: outsetaEnums.supportCaseSource.label(raw.Source),
+    submitted_date: raw.SubmittedDateTime ?? null,
+    last_activity: raw.LastActivity ?? null,
+    assigned_to_client_identifier: raw.AssignedToPersonClientIdentifier ?? null,
+    from_person_uid: raw.FromPerson?.Uid ?? null,
+    from_person_email: raw.FromPerson?.Email ?? null,
+    from_person_full_name: raw.FromPerson?.FullName ?? null,
+    created: raw.Created ?? null,
+    updated: raw.Updated ?? null,
+  };
+}
+
+function transaction(raw: OutsetaTransaction) {
+  return {
+    uid: raw.Uid ?? null,
+    amount: raw.Amount ?? null,
+    date: raw.TransactionDate ?? raw.Created ?? null,
+    transaction_type: raw.BillingTransactionType ?? null,
+    transaction_type_label: outsetaEnums.billingTransactionType.label(
+      raw.BillingTransactionType
+    ),
+    is_captured: raw.IsCaptured ?? null,
+    is_electronic: raw.IsElectronicTransaction ?? null,
+    account_uid: raw.Account?.Uid ?? null,
+    invoice_uid: raw.Invoice?.Uid ?? null,
+    invoice_number: raw.Invoice?.Number ?? null,
+    invoice_status_label: outsetaEnums.billingInvoiceStatus.label(
+      raw.Invoice?.BillingInvoiceStatus
+    ),
+    created: raw.Created ?? null,
+    updated: raw.Updated ?? null,
+  };
+}
+
+export const outsetaMappers = {
+  account,
+  person,
+  deal,
+  subscription,
+  plan,
+  addOn,
+  discount,
+  supportCase,
+  transaction,
+  toArray,
+};

--- a/packages/pieces/community/outseta/src/common/outseta-types.ts
+++ b/packages/pieces/community/outseta/src/common/outseta-types.ts
@@ -1,0 +1,240 @@
+export type OutsetaCollection<T> =
+  | T[]
+  | { items?: T[]; Items?: T[] }
+  | null
+  | undefined;
+
+export type OutsetaPage<T> = {
+  metadata?: { limit?: number; offset?: number; total?: number };
+  items?: T[];
+  Items?: T[];
+};
+
+export type OutsetaAddress = {
+  AddressLine1?: string | null;
+  AddressLine2?: string | null;
+  AddressLine3?: string | null;
+  City?: string | null;
+  State?: string | null;
+  PostalCode?: string | null;
+  Country?: string | null;
+};
+
+export type OutsetaPlanFamily = {
+  Uid?: string | null;
+  Name?: string | null;
+};
+
+export type OutsetaPlan = {
+  Uid?: string | null;
+  Name?: string | null;
+  Description?: string | null;
+  PlanFamily?: OutsetaPlanFamily | null;
+  MonthlyRate?: number | null;
+  AnnualRate?: number | null;
+  QuarterlyRate?: number | null;
+  OneTimeRate?: number | null;
+  SetupFee?: number | null;
+  IsActive?: boolean | null;
+  IsTaxable?: boolean | null;
+  IsPerUser?: boolean | null;
+  IsQuantityEditable?: boolean | null;
+  MinimumQuantity?: number | null;
+  MaximumPeople?: number | null;
+  TrialPeriodDays?: number | null;
+  UnitOfMeasure?: string | null;
+  ExpiresAfterMonths?: number | null;
+  ExpirationDate?: string | null;
+  Created?: string | null;
+  Updated?: string | null;
+};
+
+export type OutsetaAddOn = {
+  Uid?: string | null;
+  Name?: string | null;
+  BillingAddOnType?: number | null;
+  IsQuantityEditable?: boolean | null;
+  MinimumQuantity?: number | null;
+  MonthlyRate?: number | null;
+  AnnualRate?: number | null;
+  QuarterlyRate?: number | null;
+  OneTimeRate?: number | null;
+  SetupFee?: number | null;
+  UnitOfMeasure?: string | null;
+  IsTaxable?: boolean | null;
+  IsBilledDuringTrial?: boolean | null;
+  ExpiresAfterMonths?: number | null;
+  ExpirationDate?: string | null;
+  Created?: string | null;
+  Updated?: string | null;
+};
+
+export type OutsetaSubscriptionAddOn = {
+  Uid?: string | null;
+  AddOn?: OutsetaAddOn | null;
+  Quantity?: number | null;
+  Rate?: number | null;
+  StartDate?: string | null;
+  EndDate?: string | null;
+  ExpirationDate?: string | null;
+  RenewalDate?: string | null;
+};
+
+export type OutsetaInvoice = {
+  Uid?: string | null;
+  Number?: number | null;
+  InvoiceDate?: string | null;
+  BillingInvoiceStatus?: number | null;
+  Amount?: number | null;
+  AmountOutstanding?: number | null;
+  AmountPaid?: number | null;
+};
+
+export type OutsetaSubscription = {
+  Uid?: string | null;
+  Account?: OutsetaAccount | null;
+  Plan?: OutsetaPlan | null;
+  BillingRenewalTerm?: number | null;
+  Quantity?: number | null;
+  Rate?: number | null;
+  DiscountCode?: string | null;
+  DiscountCouponExpirationDate?: string | null;
+  StartDate?: string | null;
+  EndDate?: string | null;
+  ExpirationDate?: string | null;
+  RenewalDate?: string | null;
+  NewRequiredQuantity?: number | null;
+  IsPlanUpgradeRequired?: boolean | null;
+  PlanUpgradeRequiredMessage?: string | null;
+  LatestInvoice?: OutsetaInvoice | null;
+  SubscriptionAddOns?: OutsetaCollection<OutsetaSubscriptionAddOn>;
+  Created?: string | null;
+  Updated?: string | null;
+};
+
+export type OutsetaPersonAccount = {
+  Uid?: string | null;
+  Account?: OutsetaAccount | null;
+  Person?: OutsetaPerson | null;
+  IsPrimary?: boolean | null;
+  ReceiveInvoices?: boolean | null;
+  Role?: number | null;
+};
+
+export type OutsetaPerson = {
+  Uid?: string | null;
+  Email?: string | null;
+  FirstName?: string | null;
+  LastName?: string | null;
+  FullName?: string | null;
+  PhoneMobile?: string | null;
+  PhoneWork?: string | null;
+  Title?: string | null;
+  Timezone?: string | null;
+  Language?: string | null;
+  HasLoggedIn?: boolean | null;
+  HasUnsubscribed?: boolean | null;
+  LastLoginDateTime?: string | null;
+  MailingAddress?: OutsetaAddress | null;
+  PersonAccount?: OutsetaCollection<OutsetaPersonAccount>;
+  Account?: OutsetaAccount | null;
+  Created?: string | null;
+  Updated?: string | null;
+  [key: string]: unknown;
+};
+
+export type OutsetaAccount = {
+  Uid?: string | null;
+  Name?: string | null;
+  AccountStage?: number | null;
+  AccountStageLabel?: string | null;
+  ClientIdentifier?: string | null;
+  Currency?: string | null;
+  InvoiceNotes?: string | null;
+  IsDemo?: boolean | null;
+  HasLoggedIn?: boolean | null;
+  LifetimeRevenue?: number | null;
+  DomainName?: string | null;
+  LastLoginDateTime?: string | null;
+  BillingAddress?: OutsetaAddress | null;
+  MailingAddress?: OutsetaAddress | null;
+  PrimaryContact?: OutsetaPerson | null;
+  CurrentSubscription?: OutsetaSubscription | null;
+  Created?: string | null;
+  Updated?: string | null;
+  [key: string]: unknown;
+};
+
+export type OutsetaDealPipeline = {
+  Uid?: string | null;
+  Name?: string | null;
+};
+
+export type OutsetaDealPipelineStage = {
+  Uid?: string | null;
+  Name?: string | null;
+  DealPipeline?: OutsetaDealPipeline | null;
+};
+
+export type OutsetaDealPerson = {
+  Uid?: string | null;
+  Person?: OutsetaPerson | null;
+};
+
+export type OutsetaDeal = {
+  Uid?: string | null;
+  Name?: string | null;
+  Amount?: number | null;
+  DueDate?: string | null;
+  AssignedToPersonClientIdentifier?: string | null;
+  DealPipelineStage?: OutsetaDealPipelineStage | null;
+  DealPeople?: OutsetaCollection<OutsetaDealPerson>;
+  Account?: OutsetaAccount | null;
+  Created?: string | null;
+  Updated?: string | null;
+  [key: string]: unknown;
+};
+
+export type OutsetaDiscountCoupon = {
+  Uid?: string | null;
+  Name?: string | null;
+  UniqueIdentifier?: string | null;
+  IsActive?: boolean | null;
+  AmountOff?: number | null;
+  PercentOff?: number | null;
+  RedeemBy?: string | null;
+  Duration?: number | null;
+  DurationInMonths?: number | null;
+  TimesRedeemed?: number | null;
+  MaxRedemptions?: number | null;
+  ApplyToAddOns?: boolean | null;
+  Created?: string | null;
+  Updated?: string | null;
+};
+
+export type OutsetaCase = {
+  Uid?: string | null;
+  Subject?: string | null;
+  Body?: string | null;
+  Status?: number | null;
+  Source?: number | null;
+  SubmittedDateTime?: string | null;
+  LastActivity?: string | null;
+  AssignedToPersonClientIdentifier?: string | null;
+  FromPerson?: OutsetaPerson | null;
+  Created?: string | null;
+  Updated?: string | null;
+};
+
+export type OutsetaTransaction = {
+  Uid?: string | null;
+  TransactionDate?: string | null;
+  BillingTransactionType?: number | null;
+  Amount?: number | null;
+  IsCaptured?: boolean | null;
+  IsElectronicTransaction?: boolean | null;
+  Account?: OutsetaAccount | null;
+  Invoice?: OutsetaInvoice | null;
+  Created?: string | null;
+  Updated?: string | null;
+};


### PR DESCRIPTION
## Problem

`Retrieve Account` and `Retrieve Subscription` both drop two fields that the Outseta API already returns **in the same response** — the queries use `CurrentSubscription.*` / `*`, so the data arrives and is discarded at the mapping step. No extra request is needed to expose them.

**1. `Quantity`** — the seat/unit count billed on the subscription. The only `quantity` in the output today is the per-add-on one nested inside `add_ons`, which is a different value. A flow that needs the billed quantity has to fall back to a code step and call the API directly.

**2. `ExpirationDate`** — the date an expiring subscription lapses. The string `ExpirationDate` appears nowhere in the piece today.

**3. `validity_date` is misleading.** It looks like it covers the second point, but it is `RenewalDate ?? EndDate` — and `EndDate` is a *third*, distinct date, not a synonym for expiration. The Subscription schema carries `StartDate`, `EndDate`, `ExpirationDate` and `RenewalDate` as four separate nullable fields.

On a real subscription with no renewal date, `EndDate` in May and `ExpirationDate` in August, `validity_date` reports **May**. The two dates coincide often enough that the gap is easy to miss, and nothing in the output signals which one is being read.

**4. Both actions fail hard when the record does not exist.** `Retrieve Account` throws on a 404, so a flow cannot branch on a deleted account, and `Retrieve Subscription` by Account UID throws for every lapsed account — Outseta detaches `CurrentSubscription` once an account expires, so this is a routine state, not an edge case.

## Changes

All additive:

- Add **`quantity`** and **`expiration_date`** to both actions.
- Add **`add_ons_names`** — the add-on names joined — so they can be written straight to a text field without a code step.
- Add an optional **"Fail if not found"** checkbox, enabled by default. When disabled, a missing record returns `found: false` with the payload emptied out, matching the shape `Get Last Payment for Account` already uses in this piece. The value is `undefined` for flows saved before this prop existed, and is read as `true`, so those flows keep failing exactly as they did.
- Add **`found: true`** to the success payload of both actions.
- Leave **`validity_date` untouched** for backwards compatibility, and correct the comment above it, which described the behaviour wrongly. Now that `expiration_date` and `end_date` are both exposed, nobody has to rely on the merged field.

A misconfigured step (no UID supplied) still throws regardless of the checkbox — that is a configuration error, not a missing record.

## Versioning

`0.2.3` → `0.3.0` (minor).

No output attribute is removed, no prop is removed, no required prop is added, and no existing behaviour changes — per the piece-versioning checklist that is a minor bump, not a major one.

## Testing

Verified against a live Outseta account, comparing the piece output to a direct API call on the same records:

- A subscription returning `Quantity: 3` from the API produced no quantity anywhere in either action's output.
- A subscription with `RenewalDate: null`, `EndDate: 2025-05-31`, `ExpirationDate: 2025-08-29` returned `validity_date: 2025-05-31` — three months off the expiration, with no way to tell from the output.
- An expired account returned `CurrentSubscription: null`, confirming the lookup-by-account path throws for lapsed accounts.

Both files type-check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)