### PR TITLE
feat(clay): send rows to a table and trigger on rows Clay sends back

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1891,7 +1891,6 @@
       "dependencies": {
         "@activepieces/pieces-common": "workspace:*",
         "@activepieces/pieces-framework": "workspace:*",
-        "@activepieces/shared": "workspace:*",
         "tslib": "2.6.2",
       },
       "devDependencies": {

--- a/bun.lock
+++ b/bun.lock
@@ -1887,12 +1887,15 @@
     },
     "packages/pieces/community/clay": {
       "name": "@activepieces/piece-clay",
-      "version": "0.0.1",
+      "version": "0.1.0",
       "dependencies": {
         "@activepieces/pieces-common": "workspace:*",
         "@activepieces/pieces-framework": "workspace:*",
         "@activepieces/shared": "workspace:*",
         "tslib": "2.6.2",
+      },
+      "devDependencies": {
+        "vitest": "3.2.6",
       },
     },
     "packages/pieces/community/clearout": {

--- a/packages/pieces/community/clay/.eslintrc.json
+++ b/packages/pieces/community/clay/.eslintrc.json
@@ -3,7 +3,24 @@
     "ignorePatterns": ["!**/*"],
     "overrides": [
         { "files": ["*.ts", "*.tsx", "*.js", "*.jsx"], "rules": {} },
-        { "files": ["*.ts", "*.tsx"], "rules": {} },
+        {
+            "files": ["*.ts", "*.tsx"],
+            "rules": {
+                "no-restricted-imports": [
+                    "error",
+                    {
+                        "patterns": [
+                            "lodash",
+                            "lodash/*",
+                            "@activepieces/core-*",
+                            "@activepieces/server*",
+                            "@activepieces/engine",
+                            "@activepieces/shared"
+                        ]
+                    }
+                ]
+            }
+        },
         { "files": ["*.js", "*.jsx"], "rules": {} }
     ]
 }

--- a/packages/pieces/community/clay/package.json
+++ b/packages/pieces/community/clay/package.json
@@ -1,16 +1,20 @@
 {
     "name": "@activepieces/piece-clay",
-    "version": "0.0.1",
+    "version": "0.1.0",
     "main": "./dist/src/index.js",
     "types": "./dist/src/index.d.ts",
     "scripts": {
         "build": "tsc -p tsconfig.lib.json && cp package.json dist/",
-        "lint": "eslint 'src/**/*.ts'"
+        "lint": "eslint 'src/**/*.ts'",
+        "test": "vitest run"
     },
     "dependencies": {
         "@activepieces/pieces-common": "workspace:*",
         "@activepieces/pieces-framework": "workspace:*",
         "@activepieces/shared": "workspace:*",
         "tslib": "2.6.2"
+    },
+    "devDependencies": {
+        "vitest": "3.2.6"
     }
 }

--- a/packages/pieces/community/clay/package.json
+++ b/packages/pieces/community/clay/package.json
@@ -11,7 +11,6 @@
     "dependencies": {
         "@activepieces/pieces-common": "workspace:*",
         "@activepieces/pieces-framework": "workspace:*",
-        "@activepieces/shared": "workspace:*",
         "tslib": "2.6.2"
     },
     "devDependencies": {

--- a/packages/pieces/community/clay/src/index.ts
+++ b/packages/pieces/community/clay/src/index.ts
@@ -4,18 +4,21 @@ import { PieceCategory } from '@activepieces/shared';
 import { clayAuth } from './lib/auth';
 import { searchCompaniesAction } from './lib/actions/search-companies';
 import { searchPeopleAction } from './lib/actions/search-people';
+import { sendRowToTableAction } from './lib/actions/send-row-to-table';
+import { rowReceivedTrigger } from './lib/triggers/row-received';
 
 export const clay = createPiece({
     displayName: 'Clay',
-    description: 'Search Clay\'s GTM database for people and companies.',
+    description: 'Search Clay\'s GTM database, and move table rows in and out of Clay.',
     minimumSupportedRelease: '0.36.1',
     logoUrl: 'https://cdn.activepieces.com/pieces/clay.png',
     categories: [PieceCategory.SALES_AND_CRM],
     auth: clayAuth,
-    authors: ['kishanprmr'],
+    authors: ['kishanprmr', 'odaithalji'],
     actions: [
         searchCompaniesAction,
         searchPeopleAction,
+        sendRowToTableAction,
         createCustomApiCallAction({
             baseUrl: () => 'https://api.clay.com/public/v0',
             auth: clayAuth,
@@ -24,5 +27,5 @@ export const clay = createPiece({
             }),
         }),
     ],
-    triggers: [],
+    triggers: [rowReceivedTrigger],
 });

--- a/packages/pieces/community/clay/src/index.ts
+++ b/packages/pieces/community/clay/src/index.ts
@@ -1,6 +1,5 @@
-import { createPiece } from '@activepieces/pieces-framework';
+import { createPiece, PieceCategory } from '@activepieces/pieces-framework';
 import { createCustomApiCallAction } from '@activepieces/pieces-common';
-import { PieceCategory } from '@activepieces/shared';
 import { clayAuth } from './lib/auth';
 import { searchCompaniesAction } from './lib/actions/search-companies';
 import { searchPeopleAction } from './lib/actions/search-people';
@@ -14,7 +13,7 @@ export const clay = createPiece({
     logoUrl: 'https://cdn.activepieces.com/pieces/clay.png',
     categories: [PieceCategory.SALES_AND_CRM],
     auth: clayAuth,
-    authors: ['kishanprmr', 'odaithalji'],
+    authors: ['kishanprmr', 'OdaiAhmed99'],
     actions: [
         searchCompaniesAction,
         searchPeopleAction,

--- a/packages/pieces/community/clay/src/lib/actions/send-row-to-table.ts
+++ b/packages/pieces/community/clay/src/lib/actions/send-row-to-table.ts
@@ -19,19 +19,19 @@ export const sendRowToTableAction = createAction({
         webhookUrl: Property.ShortText({
             displayName: 'Webhook URL',
             description:
-                'The webhook URL Clay generated for the table source. In Clay, open the table\'s webhook source and copy the value from the Webhook URL panel.\n\nOnly https addresses on clay.com are accepted. The row and the source token are both sent to this address, so anywhere else is refused rather than trusted.',
+                'From the table\'s webhook source in Clay, the value in its Webhook URL panel. Only https addresses on clay.com are accepted.',
             required: true,
         }),
         authToken: Property.ShortText({
             displayName: 'Authentication Token',
             description:
-                'The token Clay showed when the webhook source was created, sent as the x-clay-webhook-auth header. Leave empty only if the source has no token - if it has one, Clay rejects rows sent without it. Clay displays the token once, so use Refresh auth token on the source if it was not saved.',
+                'The token Clay showed when the source was created. Leave empty only if the source has none. Clay shows it once, so use Refresh auth token on the source if it was not saved.',
             required: false,
         }),
         row: Property.Object({
             displayName: 'Row',
             description:
-                'The fields to send, as key-value pairs. Keys should match what the Clay source expects, which its Setup mapping panel controls.',
+                'The fields to send, as key-value pairs. Keys should match the source\'s Setup mapping panel.',
             required: true,
         }),
     },

--- a/packages/pieces/community/clay/src/lib/actions/send-row-to-table.ts
+++ b/packages/pieces/community/clay/src/lib/actions/send-row-to-table.ts
@@ -12,7 +12,7 @@ export const sendRowToTableAction = createAction({
     audience: 'both',
     aiMetadata: {
         description:
-            'Sends one row of data into a Clay table through that table\'s webhook source, where it runs the table\'s enrichment columns. Requires the table\'s webhook URL, which is generated in Clay on the table itself, plus that source\'s authentication token when it has one. Clay only acknowledges receipt, so a successful call means the row was accepted, not that enrichment has finished. Whether re-sending the same data updates the existing row or appends another one depends on the table\'s own configuration, so treat a retry as capable of adding a duplicate row.',
+            'Sends one row of data into a Clay table through that table\'s webhook source, where it runs the table\'s enrichment columns. Requires the table\'s webhook URL, which is generated in Clay on the table itself and must be an https address on clay.com, plus that source\'s authentication token when it has one. Clay only acknowledges receipt, so a successful call means the row was accepted, not that enrichment has finished. Whether re-sending the same data updates the existing row or appends another one depends on the table\'s own configuration, so treat a retry as capable of adding a duplicate row.',
         idempotent: false,
     },
     outputSchema: sendRowOutputSchema,
@@ -20,7 +20,7 @@ export const sendRowToTableAction = createAction({
         webhookUrl: Property.ShortText({
             displayName: 'Webhook URL',
             description:
-                'The webhook URL Clay generated for the table source. In Clay, open the table\'s webhook source and copy the value from the Webhook URL panel.',
+                'The webhook URL Clay generated for the table source. In Clay, open the table\'s webhook source and copy the value from the Webhook URL panel.\n\nOnly https addresses on clay.com are accepted. The row and the source token are both sent to this address, so anywhere else is refused rather than trusted.',
             required: true,
         }),
         authToken: Property.ShortText({

--- a/packages/pieces/community/clay/src/lib/actions/send-row-to-table.ts
+++ b/packages/pieces/community/clay/src/lib/actions/send-row-to-table.ts
@@ -1,0 +1,46 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { clayAuth } from '../auth';
+import { clayWebhook } from '../common/webhook';
+import { sendRowOutputSchema } from '../common/output-schemas';
+
+export const sendRowToTableAction = createAction({
+    auth: clayAuth,
+    name: 'send_row_to_table',
+    displayName: 'Send Row to Clay Table',
+    description: 'Sends a row to a Clay table through its webhook source.',
+    classification: 'WRITE',
+    audience: 'both',
+    aiMetadata: {
+        description:
+            'Sends one row of data into a Clay table through that table\'s webhook source, where it runs the table\'s enrichment columns. Requires the table\'s webhook URL, which is generated in Clay on the table itself, plus that source\'s authentication token when it has one. Clay only acknowledges receipt, so a successful call means the row was accepted, not that enrichment has finished. Whether re-sending the same data updates the existing row or appends another one depends on the table\'s own configuration, so treat a retry as capable of adding a duplicate row.',
+        idempotent: false,
+    },
+    outputSchema: sendRowOutputSchema,
+    props: {
+        webhookUrl: Property.ShortText({
+            displayName: 'Webhook URL',
+            description:
+                'The webhook URL Clay generated for the table source. In Clay, open the table\'s webhook source and copy the value from the Webhook URL panel.',
+            required: true,
+        }),
+        authToken: Property.ShortText({
+            displayName: 'Authentication Token',
+            description:
+                'The token Clay showed when the webhook source was created, sent as the x-clay-webhook-auth header. Leave empty only if the source has no token - if it has one, Clay rejects rows sent without it. Clay displays the token once, so use Refresh auth token on the source if it was not saved.',
+            required: false,
+        }),
+        row: Property.Object({
+            displayName: 'Row',
+            description:
+                'The fields to send, as key-value pairs. Keys should match what the Clay source expects, which its Setup mapping panel controls.',
+            required: true,
+        }),
+    },
+    async run({ propsValue }) {
+        return await clayWebhook.sendRow({
+            webhookUrl: propsValue.webhookUrl,
+            authToken: propsValue.authToken,
+            row: propsValue.row,
+        });
+    },
+});

--- a/packages/pieces/community/clay/src/lib/actions/send-row-to-table.ts
+++ b/packages/pieces/community/clay/src/lib/actions/send-row-to-table.ts
@@ -1,10 +1,8 @@
 import { createAction, Property } from '@activepieces/pieces-framework';
-import { clayAuth } from '../auth';
 import { clayWebhook } from '../common/webhook';
 import { sendRowOutputSchema } from '../common/output-schemas';
 
 export const sendRowToTableAction = createAction({
-    auth: clayAuth,
     name: 'send_row_to_table',
     displayName: 'Send Row to Clay Table',
     description: 'Sends a row to a Clay table through its webhook source.',
@@ -16,6 +14,7 @@ export const sendRowToTableAction = createAction({
         idempotent: false,
     },
     outputSchema: sendRowOutputSchema,
+    requireAuth: false,
     props: {
         webhookUrl: Property.ShortText({
             displayName: 'Webhook URL',

--- a/packages/pieces/community/clay/src/lib/common/output-schemas.ts
+++ b/packages/pieces/community/clay/src/lib/common/output-schemas.ts
@@ -1,0 +1,19 @@
+import { OutputSchema } from '@activepieces/pieces-framework';
+
+export const sendRowOutputSchema: OutputSchema = {
+    fields: [
+        {
+            key: 'success',
+            label: 'Accepted',
+            format: 'boolean',
+            description:
+                'True when Clay accepted the row. Clay acknowledges receipt only, and the table\'s enrichment columns run afterwards, so this does not mean enrichment has finished.',
+        },
+        {
+            key: 'response',
+            label: 'Clay Response',
+            description:
+                'Clay\'s own acknowledgement, passed through unchanged. Its shape follows the Send response as setting on the webhook source: an object such as {"success": true} for JSON, or the text OK for Plaintext.',
+        },
+    ],
+};

--- a/packages/pieces/community/clay/src/lib/common/webhook.ts
+++ b/packages/pieces/community/clay/src/lib/common/webhook.ts
@@ -1,0 +1,159 @@
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+import { isNil, tryCatch } from '@activepieces/pieces-framework';
+import crypto from 'crypto';
+
+async function sendRow({
+    webhookUrl,
+    authToken,
+    row,
+}: {
+    webhookUrl: string;
+    authToken?: string;
+    row: Record<string, unknown>;
+}): Promise<ClayWebhookResult> {
+    const url = normalizeSourceUrl(webhookUrl);
+    const result = await tryCatch(() =>
+        httpClient.sendRequest<unknown>({
+            method: HttpMethod.POST,
+            url,
+            headers: isNil(authToken)
+                ? undefined
+                : { [WEBHOOK_AUTH_HEADER]: authToken },
+            body: row,
+        }),
+    );
+
+    if (result.error !== null) {
+        throw new Error(sendFailureMessage({ error: result.error, authToken }));
+    }
+
+    return { success: true, response: result.data.body };
+}
+
+function verifySignature({
+    signingSecret,
+    rawBody,
+    signatureHeader,
+}: {
+    signingSecret: string;
+    rawBody: unknown;
+    signatureHeader: string | undefined;
+}): boolean {
+    const signedBytes = signedPayloadOf(rawBody);
+    if (isNil(signatureHeader) || isNil(signedBytes)) {
+        return false;
+    }
+
+    const provided = signatureHeader.startsWith(SIGNATURE_PREFIX)
+        ? signatureHeader.slice(SIGNATURE_PREFIX.length)
+        : signatureHeader;
+    const expected = crypto
+        .createHmac('sha256', signingSecret)
+        .update(signedBytes)
+        .digest('hex');
+
+    const providedBytes = Buffer.from(provided, 'hex');
+    const expectedBytes = Buffer.from(expected, 'hex');
+    if (
+        providedBytes.length === 0 ||
+        providedBytes.length !== expectedBytes.length
+    ) {
+        return false;
+    }
+
+    return crypto.timingSafeEqual(providedBytes, expectedBytes);
+}
+
+function signatureHeaderOf(headers: Record<string, string> | undefined): string | undefined {
+    if (isNil(headers)) {
+        return undefined;
+    }
+    const match = Object.keys(headers).find(
+        (name) => name.toLowerCase() === SIGNATURE_HEADER,
+    );
+    return isNil(match) ? undefined : headers[match];
+}
+
+function isVerificationPing(body: unknown): boolean {
+    if (typeof body !== 'object' || isNil(body)) {
+        return false;
+    }
+    if (isNil(Reflect.get(body, 'webhookId'))) {
+        return false;
+    }
+    const row = Reflect.get(body, 'data');
+    if (isNil(row)) {
+        return true;
+    }
+    return typeof row === 'object' && Object.keys(row).length === 0;
+}
+
+function signedPayloadOf(rawBody: unknown): string | Buffer | undefined {
+    if (typeof rawBody === 'string' || Buffer.isBuffer(rawBody)) {
+        return rawBody;
+    }
+    return undefined;
+}
+
+function normalizeSourceUrl(webhookUrl: string): string {
+    const trimmed = webhookUrl.trim();
+    if (trimmed.length === 0) {
+        throw new Error('Webhook URL is required');
+    }
+    if (!/^https?:\/\//i.test(trimmed)) {
+        throw new Error(
+            'Webhook URL must start with http:// or https://. Copy it from the Webhook URL panel on your Clay table source.',
+        );
+    }
+    return trimmed;
+}
+
+function sendFailureMessage({
+    error,
+    authToken,
+}: {
+    error: Error;
+    authToken?: string;
+}): string {
+    const status = statusOf(error);
+
+    if (status === 401) {
+        return isNil(authToken)
+            ? 'Clay rejected the row with 401 Unauthorized. This webhook source has an authentication token, so fill in Authentication Token with the value Clay showed when the source was created.'
+            : 'Clay rejected the row with 401 Unauthorized. The authentication token does not match the one on this Clay webhook source. Note that a newly refreshed token can take up to a minute to become active.';
+    }
+    if (status === 404) {
+        return 'Clay returned 404 for this webhook URL. Check the URL against the Webhook URL panel on the table source, and that the source has not been deleted.';
+    }
+
+    return `Clay rejected the row${isNil(status) ? '' : ` with ${status}`}: ${error.message}`;
+}
+
+function statusOf(error: unknown): number | undefined {
+    if (typeof error !== 'object' || isNil(error)) {
+        return undefined;
+    }
+    const response = Reflect.get(error, 'response');
+    if (typeof response !== 'object' || isNil(response)) {
+        return undefined;
+    }
+    const status = Reflect.get(response, 'status');
+    return typeof status === 'number' ? status : undefined;
+}
+
+export const clayWebhook = {
+    sendRow,
+    verifySignature,
+    signatureHeaderOf,
+    isVerificationPing,
+    normalizeSourceUrl,
+};
+
+export const WEBHOOK_AUTH_HEADER = 'x-clay-webhook-auth';
+export const SIGNATURE_HEADER = 'x-clay-signature';
+export const SIGNATURE_PREFIX = 'sha256=';
+
+export type ClayWebhookResult = {
+    success: boolean;
+    response: unknown;
+};

--- a/packages/pieces/community/clay/src/lib/common/webhook.ts
+++ b/packages/pieces/community/clay/src/lib/common/webhook.ts
@@ -12,19 +12,20 @@ async function sendRow({
     row: Record<string, unknown>;
 }): Promise<ClayWebhookResult> {
     const url = normalizeSourceUrl(webhookUrl);
+    const token = trimmedSecretOf(authToken);
     const result = await tryCatch(() =>
         httpClient.sendRequest<unknown>({
             method: HttpMethod.POST,
             url,
-            headers: isNil(authToken)
+            headers: isNil(token)
                 ? undefined
-                : { [WEBHOOK_AUTH_HEADER]: authToken },
+                : { [WEBHOOK_AUTH_HEADER]: token },
             body: row,
         }),
     );
 
     if (result.error !== null) {
-        throw new Error(sendFailureMessage({ error: result.error, authToken }));
+        throw new Error(sendFailureMessage({ error: result.error, authToken: token }));
     }
 
     return { success: true, response: result.data.body };
@@ -121,6 +122,11 @@ function normalizeSourceUrl(webhookUrl: string): string {
     return trimmed;
 }
 
+function trimmedSecretOf(secret: string | undefined): string | undefined {
+    const trimmed = secret?.trim();
+    return isNil(trimmed) || trimmed.length === 0 ? undefined : trimmed;
+}
+
 function parsedUrlOf(value: string): URL | undefined {
     try {
         return new URL(value);
@@ -174,6 +180,7 @@ export const clayWebhook = {
     signatureHeaderOf,
     isVerificationPing,
     normalizeSourceUrl,
+    trimmedSecretOf,
 };
 
 export const WEBHOOK_AUTH_HEADER = 'x-clay-webhook-auth';

--- a/packages/pieces/community/clay/src/lib/common/webhook.ts
+++ b/packages/pieces/community/clay/src/lib/common/webhook.ts
@@ -100,12 +100,39 @@ function normalizeSourceUrl(webhookUrl: string): string {
     if (trimmed.length === 0) {
         throw new Error('Webhook URL is required');
     }
-    if (!/^https?:\/\//i.test(trimmed)) {
+
+    const parsed = parsedUrlOf(trimmed);
+    if (isNil(parsed)) {
         throw new Error(
-            'Webhook URL must start with http:// or https://. Copy it from the Webhook URL panel on your Clay table source.',
+            `Webhook URL is not a valid URL. ${COPY_FROM_CLAY}`,
         );
     }
+    if (parsed.protocol !== 'https:') {
+        throw new Error(
+            `Webhook URL must use https, because the row and the source token are sent to it. ${COPY_FROM_CLAY}`,
+        );
+    }
+    if (!isClayHost(parsed.hostname)) {
+        throw new Error(
+            `Webhook URL must point at Clay, but this one points at ${parsed.hostname}. The row and the source token are sent to this address, so anywhere else is refused. ${COPY_FROM_CLAY}`,
+        );
+    }
+
     return trimmed;
+}
+
+function parsedUrlOf(value: string): URL | undefined {
+    try {
+        return new URL(value);
+    }
+    catch {
+        return undefined;
+    }
+}
+
+function isClayHost(hostname: string): boolean {
+    const host = hostname.toLowerCase();
+    return host === CLAY_DOMAIN || host.endsWith(`.${CLAY_DOMAIN}`);
 }
 
 function sendFailureMessage({
@@ -152,6 +179,9 @@ export const clayWebhook = {
 export const WEBHOOK_AUTH_HEADER = 'x-clay-webhook-auth';
 export const SIGNATURE_HEADER = 'x-clay-signature';
 export const SIGNATURE_PREFIX = 'sha256=';
+export const CLAY_DOMAIN = 'clay.com';
+export const COPY_FROM_CLAY =
+    'Copy it from the Webhook URL panel on your Clay table source.';
 
 export type ClayWebhookResult = {
     success: boolean;

--- a/packages/pieces/community/clay/src/lib/triggers/row-received.ts
+++ b/packages/pieces/community/clay/src/lib/triggers/row-received.ts
@@ -1,0 +1,89 @@
+import {
+    createTrigger,
+    Property,
+    TriggerStrategy,
+} from '@activepieces/pieces-framework';
+import { clayAuth } from '../auth';
+import { clayWebhook } from '../common/webhook';
+
+export const rowReceivedTrigger = createTrigger({
+    auth: clayAuth,
+    name: 'row_received',
+    displayName: 'Row Received from Clay',
+    description: 'Triggers when Clay sends a row to this flow.',
+    aiMetadata: {
+        description:
+            'Fires when Clay posts a row to this flow, carrying whatever fields the Clay side was configured to send. Clay has no API for registering webhooks, so somebody has to point a Clay webhook or an HTTP API enrichment column at this trigger\'s URL by hand before it receives anything.',
+    },
+    type: TriggerStrategy.WEBHOOK,
+    props: {
+        setupInstructions: Property.MarkDown({
+            value: `
+Clay has no API for registering webhooks, so point Clay at this flow yourself. Copy this URL:
+
+\`\`\`text
+{{webhookUrl}}
+\`\`\`
+
+Then use whichever route suits you. They behave differently, so the choice matters.
+
+**To send rows from a table - add an HTTP API column.** This is the usual choice.
+
+- Set the method to \`POST\` and paste the URL into **Endpoint**. Put nothing else in that field: typing \`/\` there opens Clay's column picker, and an inserted column silently corrupts the URL.
+- Set the **Body** to the columns you want, for example \`{"Domain": "/Domain"}\`. With an empty body nothing useful arrives.
+- Leave **Signing Secret** below **empty**. Clay's HTTP API column cannot sign a request, so a secret there rejects every delivery.
+
+**To receive workspace events - create a webhook in Clay's settings.**
+
+- Paste the URL into Clay's **Webhook URL** field.
+- Clay immediately sends a signed verification request carrying an empty row. This trigger ignores it, so it will not start a run.
+- Optionally paste that webhook's \`whsec_...\` secret into **Signing Secret** below, and every delivery's signature is then checked.
+
+The fields you receive are whatever Clay sends, so they follow your own table's columns rather than a fixed shape.
+            `,
+        }),
+        signingSecret: Property.ShortText({
+            displayName: 'Signing Secret',
+            description:
+                'Only for a webhook created in Clay\'s settings, which signs each delivery with an x-clay-signature header. Paste that webhook\'s whsec_... secret to have every delivery verified and anything unsigned rejected.\n\nLeave this empty when Clay reaches this flow through a table\'s HTTP API column. That column is a general-purpose HTTP request builder and cannot compute a signature, so a secret here would reject every delivery it sends.',
+            required: false,
+        }),
+    },
+    sampleData: {
+        Domain: 'activepieces.com',
+        Company: 'Activepieces',
+    },
+
+    async onEnable() {
+        return;
+    },
+
+    async onDisable() {
+        return;
+    },
+
+    async run(context) {
+        const { signingSecret } = context.propsValue;
+
+        if (signingSecret) {
+            const verified = clayWebhook.verifySignature({
+                signingSecret,
+                rawBody: context.payload.rawBody,
+                signatureHeader: clayWebhook.signatureHeaderOf(
+                    context.payload.headers,
+                ),
+            });
+            if (!verified) {
+                throw new Error(
+                    'The x-clay-signature header did not match the signing secret, so this request was not accepted. Check that Signing Secret matches the secret Clay showed for this webhook, including its whsec_ prefix.',
+                );
+            }
+        }
+
+        if (clayWebhook.isVerificationPing(context.payload.body)) {
+            return [];
+        }
+
+        return [context.payload.body];
+    },
+});

--- a/packages/pieces/community/clay/src/lib/triggers/row-received.ts
+++ b/packages/pieces/community/clay/src/lib/triggers/row-received.ts
@@ -3,11 +3,9 @@ import {
     Property,
     TriggerStrategy,
 } from '@activepieces/pieces-framework';
-import { clayAuth } from '../auth';
 import { clayWebhook } from '../common/webhook';
 
 export const rowReceivedTrigger = createTrigger({
-    auth: clayAuth,
     name: 'row_received',
     displayName: 'Row Received from Clay',
     description: 'Triggers when Clay sends a row to this flow.',
@@ -16,6 +14,7 @@ export const rowReceivedTrigger = createTrigger({
             'Fires when Clay posts a row to this flow, carrying whatever fields the Clay side was configured to send. Clay has no API for registering webhooks, so somebody has to point a Clay webhook or an HTTP API enrichment column at this trigger\'s URL by hand before it receives anything.',
     },
     type: TriggerStrategy.WEBHOOK,
+    requireAuth: false,
     props: {
         setupInstructions: Property.MarkDown({
             value: `
@@ -63,7 +62,9 @@ The fields you receive are whatever Clay sends, so they follow your own table's 
     },
 
     async run(context) {
-        const { signingSecret } = context.propsValue;
+        const signingSecret = clayWebhook.trimmedSecretOf(
+            context.propsValue.signingSecret,
+        );
 
         if (signingSecret) {
             const verified = clayWebhook.verifySignature({

--- a/packages/pieces/community/clay/src/lib/triggers/row-received.ts
+++ b/packages/pieces/community/clay/src/lib/triggers/row-received.ts
@@ -18,33 +18,25 @@ export const rowReceivedTrigger = createTrigger({
     props: {
         setupInstructions: Property.MarkDown({
             value: `
-Clay has no API for registering webhooks, so point Clay at this flow yourself. Copy this URL:
+Clay cannot register a webhook for you, so paste this URL into Clay yourself:
 
 \`\`\`text
 {{webhookUrl}}
 \`\`\`
 
-Then use whichever route suits you. They behave differently, so the choice matters.
+**Sending rows from a table** is the usual route. Add an **HTTP API** column, then:
 
-**To send rows from a table - add an HTTP API column.** This is the usual choice.
+1. Set the method to \`POST\` and paste the URL into **Endpoint**. Paste only the URL - typing \`/\` there opens Clay's column picker and corrupts it.
+2. Set the **Body** to the columns you want, for example \`{"Domain": "/Domain"}\`.
+3. Leave **Signing Secret** below empty. An HTTP API column cannot sign a request, so a secret there rejects every delivery.
 
-- Set the method to \`POST\` and paste the URL into **Endpoint**. Put nothing else in that field: typing \`/\` there opens Clay's column picker, and an inserted column silently corrupts the URL.
-- Set the **Body** to the columns you want, for example \`{"Domain": "/Domain"}\`. With an empty body nothing useful arrives.
-- Leave **Signing Secret** below **empty**. Clay's HTTP API column cannot sign a request, so a secret there rejects every delivery.
-
-**To receive workspace events - create a webhook in Clay's settings.**
-
-- Paste the URL into Clay's **Webhook URL** field.
-- Clay immediately sends a signed verification request carrying an empty row. This trigger ignores it, so it will not start a run.
-- Optionally paste that webhook's \`whsec_...\` secret into **Signing Secret** below, and every delivery's signature is then checked.
-
-The fields you receive are whatever Clay sends, so they follow your own table's columns rather than a fixed shape.
+**For workspace events**, create a webhook in Clay's settings and paste the URL into its **Webhook URL** field. Its first verification request carries an empty row and is ignored. Optionally put that webhook's \`whsec_...\` secret in **Signing Secret** below.
             `,
         }),
         signingSecret: Property.ShortText({
             displayName: 'Signing Secret',
             description:
-                'Only for a webhook created in Clay\'s settings, which signs each delivery with an x-clay-signature header. Paste that webhook\'s whsec_... secret to have every delivery verified and anything unsigned rejected.\n\nLeave this empty when Clay reaches this flow through a table\'s HTTP API column. That column is a general-purpose HTTP request builder and cannot compute a signature, so a secret here would reject every delivery it sends.',
+                'The whsec_... secret of a webhook created in Clay\'s settings, used to verify every delivery. Leave empty for an HTTP API column, which cannot sign requests.',
             required: false,
         }),
     },

--- a/packages/pieces/community/clay/test/webhook.test.ts
+++ b/packages/pieces/community/clay/test/webhook.test.ts
@@ -1,14 +1,11 @@
 /// <reference types="vitest/globals" />
 
-const sendRequest = vi.fn();
-
-vi.mock('@activepieces/pieces-common', () => ({
-    HttpMethod: { GET: 'GET', POST: 'POST', PUT: 'PUT', DELETE: 'DELETE' },
-    httpClient: {
-        sendRequest: (...args: unknown[]) => sendRequest(...args),
-    },
-}));
-
+import {
+    HttpMethod,
+    HttpRequest,
+    HttpResponse,
+    httpClient,
+} from '@activepieces/pieces-common';
 import { clayWebhook } from '../src/lib/common/webhook';
 
 const FIXTURE_SECRET =
@@ -18,7 +15,24 @@ const FIXTURE_BODY =
 const FIXTURE_SIGNATURE =
     'sha256=f787d8f6ca1d5ea61ac6ae74dceb201cafc5b41ccd1593522c1344837d102c19';
 
-const lastRequest = () => sendRequest.mock.calls.at(-1)?.[0];
+let sendRequest: ReturnType<typeof vi.spyOn>;
+let lastRequest: HttpRequest | undefined;
+
+beforeEach(() => {
+    lastRequest = undefined;
+    sendRequest = vi.spyOn(httpClient, 'sendRequest');
+});
+
+afterEach(() => {
+    vi.restoreAllMocks();
+});
+
+function acknowledgeWith(body: unknown) {
+    sendRequest.mockImplementation(async (request: HttpRequest): Promise<HttpResponse> => {
+        lastRequest = request;
+        return { status: 200, headers: {}, body };
+    });
+}
 
 function httpError(status: number) {
     return Object.assign(new Error(`Request failed with status ${status}`), {
@@ -154,6 +168,25 @@ describe('the verification ping Clay sends when a webhook is created', () => {
     });
 });
 
+describe('a secret pasted into a field, whitespace and all', () => {
+    test('surrounding whitespace is trimmed, so a pasted secret still verifies', () => {
+        expect(
+            clayWebhook.verifySignature({
+                signingSecret:
+                    clayWebhook.trimmedSecretOf(` ${FIXTURE_SECRET}\n`) ?? '',
+                rawBody: FIXTURE_BODY,
+                signatureHeader: FIXTURE_SIGNATURE,
+            }),
+        ).toBe(true);
+    });
+
+    test('whitespace alone counts as empty, so it never enables verification', () => {
+        expect(clayWebhook.trimmedSecretOf('   ')).toBeUndefined();
+        expect(clayWebhook.trimmedSecretOf('')).toBeUndefined();
+        expect(clayWebhook.trimmedSecretOf(undefined)).toBeUndefined();
+    });
+});
+
 describe('webhook URL handling', () => {
     test('surrounding whitespace is trimmed', () => {
         expect(
@@ -216,8 +249,6 @@ describe('the destination is constrained to Clay, because the token travels with
     });
 
     test('no request is attempted when the destination is refused', async () => {
-        sendRequest.mockReset();
-
         await expect(
             clayWebhook.sendRow({
                 webhookUrl: 'https://evil.example.com/collect',
@@ -231,45 +262,43 @@ describe('the destination is constrained to Clay, because the token travels with
 });
 
 describe('sending a row', () => {
-    beforeEach(() => sendRequest.mockReset());
-
     test('the token travels in the x-clay-webhook-auth header', async () => {
-        sendRequest.mockResolvedValueOnce({ body: { success: true } });
+        acknowledgeWith({ success: true });
         await clayWebhook.sendRow({
             webhookUrl: 'https://api.clay.com/v3/sources/webhook/x',
             authToken: 'a-token',
             row: { Domain: 'activepieces.com' },
         });
 
-        expect(lastRequest().headers).toEqual({ 'x-clay-webhook-auth': 'a-token' });
+        expect(lastRequest?.headers).toEqual({ 'x-clay-webhook-auth': 'a-token' });
     });
 
     test('no header is sent when the source has no token', async () => {
-        sendRequest.mockResolvedValueOnce({ body: { success: true } });
+        acknowledgeWith({ success: true });
         await clayWebhook.sendRow({
             webhookUrl: 'https://api.clay.com/v3/sources/webhook/x',
             row: { Domain: 'activepieces.com' },
         });
 
-        expect(lastRequest().headers).toBeUndefined();
+        expect(lastRequest?.headers).toBeUndefined();
     });
 
     test('the row is sent as the request body, flat', async () => {
-        sendRequest.mockResolvedValueOnce({ body: { success: true } });
+        acknowledgeWith({ success: true });
         await clayWebhook.sendRow({
             webhookUrl: 'https://api.clay.com/v3/sources/webhook/x',
             row: { Domain: 'activepieces.com', Company: 'Activepieces' },
         });
 
-        expect(lastRequest().method).toBe('POST');
-        expect(lastRequest().body).toEqual({
+        expect(lastRequest?.method).toBe(HttpMethod.POST);
+        expect(lastRequest?.body).toEqual({
             Domain: 'activepieces.com',
             Company: 'Activepieces',
         });
     });
 
     test('a JSON acknowledgement is reported alongside a stable success flag', async () => {
-        sendRequest.mockResolvedValueOnce({ body: { success: true } });
+        acknowledgeWith({ success: true });
 
         await expect(
             clayWebhook.sendRow({
@@ -280,7 +309,7 @@ describe('sending a row', () => {
     });
 
     test('a plaintext acknowledgement keeps the same success flag', async () => {
-        sendRequest.mockResolvedValueOnce({ body: 'OK' });
+        acknowledgeWith('OK');
 
         await expect(
             clayWebhook.sendRow({
@@ -333,5 +362,30 @@ describe('sending a row', () => {
                 row: {},
             }),
         ).rejects.toThrow(/500/);
+    });
+});
+
+describe('a token pasted into a field, whitespace and all', () => {
+    test('surrounding whitespace is trimmed before the token reaches Clay', async () => {
+        acknowledgeWith({ success: true });
+        await clayWebhook.sendRow({
+            webhookUrl: 'https://api.clay.com/v3/sources/webhook/x',
+            authToken: '  a-token\n',
+            row: { Domain: 'activepieces.com' },
+        });
+
+        expect(lastRequest?.headers).toEqual({ 'x-clay-webhook-auth': 'a-token' });
+    });
+
+    test('a whitespace-only token is treated as absent, so the 401 names the field to fill in', async () => {
+        sendRequest.mockRejectedValueOnce(httpError(401));
+
+        await expect(
+            clayWebhook.sendRow({
+                webhookUrl: 'https://api.clay.com/v3/sources/webhook/x',
+                authToken: '   ',
+                row: {},
+            }),
+        ).rejects.toThrow(/Authentication Token/);
     });
 });

--- a/packages/pieces/community/clay/test/webhook.test.ts
+++ b/packages/pieces/community/clay/test/webhook.test.ts
@@ -164,17 +164,69 @@ describe('webhook URL handling', () => {
     test('a URL without a scheme is refused rather than guessed at', () => {
         expect(() =>
             clayWebhook.normalizeSourceUrl('api.clay.com/v3/sources/webhook/x'),
-        ).toThrow(/http/i);
+        ).toThrow(/not a valid URL/i);
     });
 
     test('a blank URL is refused', () => {
         expect(() => clayWebhook.normalizeSourceUrl('   ')).toThrow(/required/i);
     });
 
-    test('http is accepted, since a source may be proxied', () => {
-        expect(clayWebhook.normalizeSourceUrl('http://localhost:3001/hook')).toBe(
-            'http://localhost:3001/hook',
-        );
+    test('a Clay subdomain is accepted, so their infrastructure can move', () => {
+        expect(
+            clayWebhook.normalizeSourceUrl('https://eu.api.clay.com/v3/sources/webhook/x'),
+        ).toBe('https://eu.api.clay.com/v3/sources/webhook/x');
+    });
+});
+
+describe('the destination is constrained to Clay, because the token travels with the row', () => {
+    test('a non-Clay host is refused and named in the error', () => {
+        expect(() =>
+            clayWebhook.normalizeSourceUrl('https://evil.example.com/collect'),
+        ).toThrow(/evil\.example\.com/);
+    });
+
+    test('a lookalike domain is refused', () => {
+        expect(() =>
+            clayWebhook.normalizeSourceUrl('https://notclay.com/v3/sources/webhook/x'),
+        ).toThrow(/must point at Clay/i);
+    });
+
+    test('a domain that merely ends in the brand name is refused', () => {
+        expect(() =>
+            clayWebhook.normalizeSourceUrl('https://evil-clay.com/v3/sources/webhook/x'),
+        ).toThrow(/must point at Clay/i);
+    });
+
+    test('Clay as a prefix of another domain is refused', () => {
+        expect(() =>
+            clayWebhook.normalizeSourceUrl('https://clay.com.evil.example/collect'),
+        ).toThrow(/must point at Clay/i);
+    });
+
+    test('plain http is refused even on a Clay host', () => {
+        expect(() =>
+            clayWebhook.normalizeSourceUrl('http://api.clay.com/v3/sources/webhook/x'),
+        ).toThrow(/https/i);
+    });
+
+    test('a loopback address is refused, so the token cannot be pointed inward', () => {
+        expect(() =>
+            clayWebhook.normalizeSourceUrl('https://127.0.0.1/collect'),
+        ).toThrow(/must point at Clay/i);
+    });
+
+    test('no request is attempted when the destination is refused', async () => {
+        sendRequest.mockReset();
+
+        await expect(
+            clayWebhook.sendRow({
+                webhookUrl: 'https://evil.example.com/collect',
+                authToken: 'a-token',
+                row: { Domain: 'activepieces.com' },
+            }),
+        ).rejects.toThrow(/must point at Clay/i);
+
+        expect(sendRequest).not.toHaveBeenCalled();
     });
 });
 

--- a/packages/pieces/community/clay/test/webhook.test.ts
+++ b/packages/pieces/community/clay/test/webhook.test.ts
@@ -1,0 +1,285 @@
+/// <reference types="vitest/globals" />
+
+const sendRequest = vi.fn();
+
+vi.mock('@activepieces/pieces-common', () => ({
+    HttpMethod: { GET: 'GET', POST: 'POST', PUT: 'PUT', DELETE: 'DELETE' },
+    httpClient: {
+        sendRequest: (...args: unknown[]) => sendRequest(...args),
+    },
+}));
+
+import { clayWebhook } from '../src/lib/common/webhook';
+
+const FIXTURE_SECRET =
+    'whsec_testonlyfixture000000000000000000000000000000000000000000000';
+const FIXTURE_BODY =
+    '{"webhookId":"wh_fixture","createdAt":"2026-09-02T13:25:15.924Z","data":{"Domain":"activepieces.com"}}';
+const FIXTURE_SIGNATURE =
+    'sha256=f787d8f6ca1d5ea61ac6ae74dceb201cafc5b41ccd1593522c1344837d102c19';
+
+const lastRequest = () => sendRequest.mock.calls.at(-1)?.[0];
+
+function httpError(status: number) {
+    return Object.assign(new Error(`Request failed with status ${status}`), {
+        response: { status, body: { message: 'nope' } },
+    });
+}
+
+describe('signature verification', () => {
+    test('a signature Clay would send is accepted', () => {
+        expect(
+            clayWebhook.verifySignature({
+                signingSecret: FIXTURE_SECRET,
+                rawBody: FIXTURE_BODY,
+                signatureHeader: FIXTURE_SIGNATURE,
+            }),
+        ).toBe(true);
+    });
+
+    test('the whsec_ prefix is part of the key, not stripped like Standard Webhooks does', () => {
+        const standardWebhooksSignature =
+            'sha256=b0169390732d1cb7ae61f1927bd7c5ac181d1c6262331cabf5a28545d0719efa';
+
+        expect(
+            clayWebhook.verifySignature({
+                signingSecret: FIXTURE_SECRET,
+                rawBody: FIXTURE_BODY,
+                signatureHeader: standardWebhooksSignature,
+            }),
+        ).toBe(false);
+    });
+
+    test('a tampered body is rejected', () => {
+        expect(
+            clayWebhook.verifySignature({
+                signingSecret: FIXTURE_SECRET,
+                rawBody: FIXTURE_BODY.replace('activepieces.com', 'evil.com'),
+                signatureHeader: FIXTURE_SIGNATURE,
+            }),
+        ).toBe(false);
+    });
+
+    test('a different secret is rejected', () => {
+        expect(
+            clayWebhook.verifySignature({
+                signingSecret: 'whsec_someoneelsessecret',
+                rawBody: FIXTURE_BODY,
+                signatureHeader: FIXTURE_SIGNATURE,
+            }),
+        ).toBe(false);
+    });
+
+    test('a signature without the sha256= prefix still verifies', () => {
+        expect(
+            clayWebhook.verifySignature({
+                signingSecret: FIXTURE_SECRET,
+                rawBody: FIXTURE_BODY,
+                signatureHeader: FIXTURE_SIGNATURE.replace('sha256=', ''),
+            }),
+        ).toBe(true);
+    });
+
+    test('a parsed body is rejected, since re-serialising changes the bytes', () => {
+        expect(
+            clayWebhook.verifySignature({
+                signingSecret: FIXTURE_SECRET,
+                rawBody: JSON.parse(FIXTURE_BODY),
+                signatureHeader: FIXTURE_SIGNATURE,
+            }),
+        ).toBe(false);
+    });
+
+    test('a missing signature header is rejected', () => {
+        expect(
+            clayWebhook.verifySignature({
+                signingSecret: FIXTURE_SECRET,
+                rawBody: FIXTURE_BODY,
+                signatureHeader: undefined,
+            }),
+        ).toBe(false);
+    });
+
+    test('an empty signature is rejected rather than throwing', () => {
+        expect(
+            clayWebhook.verifySignature({
+                signingSecret: FIXTURE_SECRET,
+                rawBody: FIXTURE_BODY,
+                signatureHeader: 'sha256=',
+            }),
+        ).toBe(false);
+    });
+
+    test('the header is found whatever its casing', () => {
+        expect(
+            clayWebhook.signatureHeaderOf({ 'X-Clay-Signature': 'sha256=abc' }),
+        ).toBe('sha256=abc');
+        expect(
+            clayWebhook.signatureHeaderOf({ 'x-clay-signature': 'sha256=abc' }),
+        ).toBe('sha256=abc');
+        expect(clayWebhook.signatureHeaderOf({ other: 'x' })).toBeUndefined();
+        expect(clayWebhook.signatureHeaderOf(undefined)).toBeUndefined();
+    });
+});
+
+describe('the verification ping Clay sends when a webhook is created', () => {
+    test('an enveloped delivery with an empty row is a ping', () => {
+        expect(
+            clayWebhook.isVerificationPing({
+                webhookId: 'wh_x',
+                createdAt: '2026-09-02',
+                data: {},
+            }),
+        ).toBe(true);
+    });
+
+    test('an enveloped delivery carrying a row is not a ping', () => {
+        expect(
+            clayWebhook.isVerificationPing({
+                webhookId: 'wh_x',
+                createdAt: '2026-09-02',
+                data: { Domain: 'activepieces.com' },
+            }),
+        ).toBe(false);
+    });
+
+    test('a flat payload from an HTTP API column is never a ping', () => {
+        expect(
+            clayWebhook.isVerificationPing({ Domain: 'activepieces.com' }),
+        ).toBe(false);
+        expect(
+            clayWebhook.isVerificationPing({ Domain: 'stripe.com', Company: 'Stripe' }),
+        ).toBe(false);
+        expect(clayWebhook.isVerificationPing({})).toBe(false);
+    });
+});
+
+describe('webhook URL handling', () => {
+    test('surrounding whitespace is trimmed', () => {
+        expect(
+            clayWebhook.normalizeSourceUrl('  https://api.clay.com/v3/sources/webhook/x  '),
+        ).toBe('https://api.clay.com/v3/sources/webhook/x');
+    });
+
+    test('a URL without a scheme is refused rather than guessed at', () => {
+        expect(() =>
+            clayWebhook.normalizeSourceUrl('api.clay.com/v3/sources/webhook/x'),
+        ).toThrow(/http/i);
+    });
+
+    test('a blank URL is refused', () => {
+        expect(() => clayWebhook.normalizeSourceUrl('   ')).toThrow(/required/i);
+    });
+
+    test('http is accepted, since a source may be proxied', () => {
+        expect(clayWebhook.normalizeSourceUrl('http://localhost:3001/hook')).toBe(
+            'http://localhost:3001/hook',
+        );
+    });
+});
+
+describe('sending a row', () => {
+    beforeEach(() => sendRequest.mockReset());
+
+    test('the token travels in the x-clay-webhook-auth header', async () => {
+        sendRequest.mockResolvedValueOnce({ body: { success: true } });
+        await clayWebhook.sendRow({
+            webhookUrl: 'https://api.clay.com/v3/sources/webhook/x',
+            authToken: 'a-token',
+            row: { Domain: 'activepieces.com' },
+        });
+
+        expect(lastRequest().headers).toEqual({ 'x-clay-webhook-auth': 'a-token' });
+    });
+
+    test('no header is sent when the source has no token', async () => {
+        sendRequest.mockResolvedValueOnce({ body: { success: true } });
+        await clayWebhook.sendRow({
+            webhookUrl: 'https://api.clay.com/v3/sources/webhook/x',
+            row: { Domain: 'activepieces.com' },
+        });
+
+        expect(lastRequest().headers).toBeUndefined();
+    });
+
+    test('the row is sent as the request body, flat', async () => {
+        sendRequest.mockResolvedValueOnce({ body: { success: true } });
+        await clayWebhook.sendRow({
+            webhookUrl: 'https://api.clay.com/v3/sources/webhook/x',
+            row: { Domain: 'activepieces.com', Company: 'Activepieces' },
+        });
+
+        expect(lastRequest().method).toBe('POST');
+        expect(lastRequest().body).toEqual({
+            Domain: 'activepieces.com',
+            Company: 'Activepieces',
+        });
+    });
+
+    test('a JSON acknowledgement is reported alongside a stable success flag', async () => {
+        sendRequest.mockResolvedValueOnce({ body: { success: true } });
+
+        await expect(
+            clayWebhook.sendRow({
+                webhookUrl: 'https://api.clay.com/v3/sources/webhook/x',
+                row: {},
+            }),
+        ).resolves.toEqual({ success: true, response: { success: true } });
+    });
+
+    test('a plaintext acknowledgement keeps the same success flag', async () => {
+        sendRequest.mockResolvedValueOnce({ body: 'OK' });
+
+        await expect(
+            clayWebhook.sendRow({
+                webhookUrl: 'https://api.clay.com/v3/sources/webhook/x',
+                row: {},
+            }),
+        ).resolves.toEqual({ success: true, response: 'OK' });
+    });
+
+    test('a 401 with no token names the field to fill in', async () => {
+        sendRequest.mockRejectedValueOnce(httpError(401));
+
+        await expect(
+            clayWebhook.sendRow({
+                webhookUrl: 'https://api.clay.com/v3/sources/webhook/x',
+                row: {},
+            }),
+        ).rejects.toThrow(/Authentication Token/);
+    });
+
+    test('a 401 with a token says the token does not match', async () => {
+        sendRequest.mockRejectedValueOnce(httpError(401));
+
+        await expect(
+            clayWebhook.sendRow({
+                webhookUrl: 'https://api.clay.com/v3/sources/webhook/x',
+                authToken: 'wrong',
+                row: {},
+            }),
+        ).rejects.toThrow(/does not match/);
+    });
+
+    test('a 404 points at the source rather than the token', async () => {
+        sendRequest.mockRejectedValueOnce(httpError(404));
+
+        await expect(
+            clayWebhook.sendRow({
+                webhookUrl: 'https://api.clay.com/v3/sources/webhook/x',
+                row: {},
+            }),
+        ).rejects.toThrow(/404/);
+    });
+
+    test('an unrecognised failure still surfaces Clay\'s own message', async () => {
+        sendRequest.mockRejectedValueOnce(httpError(500));
+
+        await expect(
+            clayWebhook.sendRow({
+                webhookUrl: 'https://api.clay.com/v3/sources/webhook/x',
+                row: {},
+            }),
+        ).rejects.toThrow(/500/);
+    });
+});

--- a/packages/pieces/community/clay/vitest.config.ts
+++ b/packages/pieces/community/clay/vitest.config.ts
@@ -1,0 +1,18 @@
+import path from 'path'
+import { defineConfig } from 'vitest/config'
+
+const repoRoot = path.resolve(__dirname, '../../../..')
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+  },
+  resolve: {
+    alias: {
+      '@activepieces/shared': path.resolve(repoRoot, 'packages/core/shared/src/index.ts'),
+      '@activepieces/pieces-framework': path.resolve(repoRoot, 'packages/pieces/framework/src/index.ts'),
+      '@activepieces/pieces-common': path.resolve(repoRoot, 'packages/pieces/common/src/index.ts'),
+    },
+  },
+})

--- a/packages/pieces/community/clay/vitest.config.ts
+++ b/packages/pieces/community/clay/vitest.config.ts
@@ -10,7 +10,6 @@ export default defineConfig({
   },
   resolve: {
     alias: {
-      '@activepieces/shared': path.resolve(repoRoot, 'packages/core/shared/src/index.ts'),
       '@activepieces/pieces-framework': path.resolve(repoRoot, 'packages/pieces/framework/src/index.ts'),
       '@activepieces/pieces-common': path.resolve(repoRoot, 'packages/pieces/common/src/index.ts'),
     },


### PR DESCRIPTION
## Description

GIT-1369

Adds a **Send Row to Clay Table** action and a **Row Received from Clay** trigger, closing the GTM loop the ticket describes: push a lead into Clay, let Clay enrich it, receive the enriched row back.

**Two corrections to the ticket, since it would otherwise mislead a reviewer.**

It is filed as "New piece — Clay", but `@activepieces/piece-clay` already exists: @kishanprmr shipped it in #15176 on the same day this was picked up, with Search People, Search Companies and a custom API call, and no triggers. So this extends an existing piece rather than creating one, and bumps it `0.0.1 → 0.1.0`.

It also states Clay has "no public REST API". Clay launched one on 9 July 2026 at `api.clay.com/public/v0`, authenticated with a `clay-api-key` header, and this repo's own piece already calls it. The ticket's conclusion still holds, but for a better reason: Clay's docs say plainly *"Can I build or write to Clay tables via CLI or API? No"*, and the `Tables` primitive is read-only and Enterprise-only. A table's webhook source really is the only way to write a row on any plan.

**Send Row to Clay Table** posts the row to that source with the token in `x-clay-webhook-auth`. The token is optional, because a source can exist without one, but Clay answers `401` when a source *has* a token and the request omits it, so the two cases get separate messages naming what to fix — one points at the field to fill in, the other mentions that a refreshed token takes up to a minute to become active.

**Row Received from Clay** is a manual-setup webhook trigger, because Clay exposes no endpoint for registering webhooks: thirteen candidate paths all `404` against a live API key, while `POST /search/query-mode` and `POST /tables/query` answer `400` with field-level validation on the same probe, so the negative result is trustworthy rather than a naming guess.

### The signature, and why a conventional implementation would break

Clay signs deliveries with `x-clay-signature: sha256=<hex>`, an HMAC-SHA256 over the raw body. **The key is the entire secret string including the `whsec_` prefix.** That prefix is the Standard Webhooks / Stripe convention, where implementations strip it and base64-decode the remainder — do the conventional thing here and every genuine Clay request is rejected, which would read as Clay's fault. This was settled by capturing a real signed request and computing all eight plausible key-and-encoding combinations against it; exactly one reproduced the signature. A test pins it with a synthetic secret and a precomputed expected value, and reverting to the conventional derivation fails three tests.

Verification is opt-in for a real reason, not as a nicety: Clay reaches a flow by two routes, and only one of them can sign. A webhook created in Clay's settings signs every delivery; a table's **HTTP API column** is a general-purpose request builder that cannot compute an HMAC at all. A required secret would make that second route — the one that actually sends table rows — impossible to use. The trigger's setup instructions and the field's own description both say so.

Clay also sends a signed verification request the moment a webhook is created, carrying an empty row. That ping starts no run, otherwise enabling the trigger would fire the flow on empty data and, on a flow that writes to a CRM, create an empty record. The check requires the enveloped shape, so a flat payload from an HTTP API column is never mistaken for a ping — an earlier version keyed only on an empty `data`, which silently discarded every delivery from the most common route.

### outputSchema on the action only, deliberately

The action's output is normalised to `{ success, response }` so it is stable, which is what lets it have a schema at all: a source set to "Send response as: Plaintext" replies with the bare string `OK` rather than `{"success": true}`, so `response` passes Clay's own acknowledgement through untouched while `success` stays dependable.

The trigger has none, and adding one would be a mistake. It receives the enveloped `{webhookId, createdAt, data}` from a settings webhook or a flat body from an HTTP API column, and either way the field names are the user's own table columns. Any fixed schema describes somebody's payload wrongly, and the visible symptom is a "friendly view" full of empty values — observed during testing before the schema was removed. With no schema the builder shows the payload that actually arrived. `sampleData` is a flat row, matching the common route.

## How was this tested?

Against a live Clay workspace, not mocks.

- **Action, on two real tables**: correct token accepted; missing token and wrong token each refused with their own message; a scheme-less URL and a blank URL refused; a whitespace-padded URL trimmed and accepted. Rows confirmed present in the table by the account owner, and the rejected ones confirmed absent.
- **Trigger, end-to-end through an ngrok tunnel into a published flow**: signed deliveries produced runs with the row available to later steps; a tampered body and an unsigned request were refused; the creation ping produced no run. The flat HTTP-API-column route was driven from a real Clay table and confirmed by the account owner.
- **36 unit tests**, mutation-checked five ways: switching the HMAC key to the Standard Webhooks derivation fails four, removing the trim on a pasted secret fails four, removing the destination check fails six, loosening it to a substring match fails three, and reverting the flat-payload ping fix fails one.
- **Neither component needs a Clay connection.** Raised by review: neither reads `context.auth`, yet both forced the user to create an API-key connection — a key that is still beta in Clay — before Clay could be pointed at the flow. Both are now `requireAuth: false`, following `discord`'s `send-message-webhook` (a webhook URL as a step prop) and `kallabot-ai`'s `call-events` (a manual-setup webhook trigger on an authed piece). The piece's two existing search actions still require it, since they call the API.

Edition paths: piece-local only, with no server, database, EE or appearance surface, so behaviour is identical on CE, EE and Cloud.

**Left unproven rather than guessed:** `aiMetadata.idempotent` is `false`. Whether Clay upserts a repeated identical row or appends another one could not be established from the API — the acknowledgement is the same either way — so the conservative value stands. It matters because an agent told a write is idempotent will retry it, and a wrong `true` would quietly duplicate rows in somebody's GTM data.

Fixes GIT-1369

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

Two additive steps on an existing piece. The existing actions, its auth and any existing connection are untouched, and no env var or migration is involved.

### Security impact?  (required — CI fails if this is left unedited)

- [ ] no — reviewed, no security impact
- [x] yes — security-sensitive (call out the risk and mitigation in the description above)

Ticked deliberately, since three things here deserve a reviewer's attention:

- **Webhook signature verification** is implemented here, with the non-obvious key derivation described above. Comparison is `timingSafeEqual` over equal-length buffers, and a signature that is absent, empty, wrong-length or unparseable is refused rather than throwing. Verifying against `payload.rawBody` is load-bearing: a re-serialised body changes the bytes and fails verification, so a test asserts that a parsed body is rejected.
- **It proves origin, not freshness.** Clay sends no timestamp and signs the body alone, so a captured request stays valid indefinitely and can be replayed. Worth knowing rather than assuming otherwise.
- **The send destination is constrained to Clay.** The row and the source token both travel to whatever URL the step carries, so validating only the scheme would have let a mistyped host, or one resolved from an upstream expression, receive them. An https address on `clay.com` or a subdomain of it is required, and anything else is rejected before a request is attempted. Raised by review; the permissive version had a test asserting it, on the reasoning that Clay might change its URL shape later, which is the wrong trade against a silent credential leak.
- **The source's auth token is a step property, so it lives in the flow's settings rather than an encrypted connection.** The framework has no masked step property, and the piece's existing auth holds a workspace API key while this token is per-table, so folding it into the connection would mean one connection per table. Reviewed and agreed to merge as is, since step-prop webhook URLs are how the Slack and Discord webhook actions work too. Note also that the webhook URL alone is *not* sufficient to write to a source, since a token-bearing source refuses an unauthenticated POST. **Correcting an earlier claim in this description:** it said both routes were "recorded in the ticket for a follow-up decision". @ibrahim-abuznaid checked, and neither GIT-1369 nor the synced GitHub issue carries that note — so the follow-up needs a PIE ticket rather than being already captured. It should cover the connection-based route (the framework accepts an array of auth types, so a "Table webhook source" `CustomAuth` variant could sit beside the API-key auth without a breaking change), plus the two existing search actions' missing `outputSchema` and their 25 optional filters with no `advanced: true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

