### PR TITLE
chore(release): v0.90.0

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   app:
-    image: ghcr.io/activepieces/activepieces:0.89.0
+    image: ghcr.io/activepieces/activepieces:0.90.0
     container_name: activepieces-app
     restart: unless-stopped
     ports:
@@ -16,7 +16,7 @@ services:
     networks:
       - activepieces
   worker:
-    image: ghcr.io/activepieces/activepieces:0.89.0
+    image: ghcr.io/activepieces/activepieces:0.90.0
     restart: unless-stopped
     depends_on:
       - app

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activepieces",
-  "version": "0.89.0",
+  "version": "0.90.0",
   "packageManager": "bun@1.4.0",
   "trustedDependencies": [
     "sqlite3",


### PR DESCRIPTION
## Description

Version bump to cut the **0.90.0** release. Two files, three lines:

- `package.json` — `version` `0.89.0` → `0.90.0`
- `docker-compose.yml` — both `app` and `worker` image pins → `ghcr.io/activepieces/activepieces:0.90.0`

`package.json` is the single runtime source of truth for the release version (`apVersionUtil.getCurrentRelease` reads it, and it is baked into the image from source). Nothing in the pipeline bumps it — `continuous-delivery-release.yml` reads the version from `package.json` at the `release-candidate` ref, so this commit has to be on `main` before the RC is cut or the release republishes 0.89.0.

**This must merge before the Thursday 5 PM UTC RC cut.**

Same shape as the 0.89.0 bump, 6699a01ff36.

## How was this tested?

No code paths change — the diff is a version string and two image pins. CI covers it.

Verified the diff matches the 0.89.0 bump precedent exactly (`package.json` + both `docker-compose.yml` pins, nothing else), and that no lockfile sync is needed: the root package's own version is not recorded in `bun.lock`, and the 0.89.0 bump likewise touched only these two files.

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
