### PR TITLE
fix(agents): charge for an agent draft the model garbled

### DIFF
--- a/packages/server/api/src/app/ee/agent/agent-draft-ai.ts
+++ b/packages/server/api/src/app/ee/agent/agent-draft-ai.ts
@@ -62,6 +62,8 @@ export const agentDraftAi = (log: FastifyBaseLogger) => ({
             })
         }
 
+        await debitDraft({ platformId, projectId, log })
+
         const parsed = parseDraft(raw)
         if (isNil(parsed)) {
             log.error({ platform: { id: platformId }, reply: raw.slice(0, REPLY_LOG_LIMIT) }, '[agentDraftAi] The model replied with something that is not a draft')
@@ -70,7 +72,6 @@ export const agentDraftAi = (log: FastifyBaseLogger) => ({
                 params: { message: 'Could not draft an agent from that description, try rewording it' },
             })
         }
-        await debitDraft({ platformId, projectId, log })
         return {
             ...parsed,
             tools: resolveToolPicks({ picks: parsed.tools, candidates }),

--- a/packages/server/api/test/unit/app/ee/agent/agent-draft-billing.test.ts
+++ b/packages/server/api/test/unit/app/ee/agent/agent-draft-billing.test.ts
@@ -1,0 +1,101 @@
+import { AIProviderName } from '@activepieces/core-utils'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { mockGenerateText, mockTrackBilling, mockGetOrCreateForPlatform, mockResolveTierModel } = vi.hoisted(() => ({
+    mockGenerateText: vi.fn(),
+    mockTrackBilling: vi.fn().mockResolvedValue(undefined),
+    mockGetOrCreateForPlatform: vi.fn().mockResolvedValue({ plan: 'free', licenseKey: null }),
+    mockResolveTierModel: vi.fn().mockResolvedValue({ model: {}, modelId: 'fast-model', provider: 'activepieces' }),
+}))
+
+vi.mock('ai', async (importOriginal) => ({
+    ...(await importOriginal<Record<string, unknown>>()),
+    generateText: mockGenerateText,
+}))
+
+vi.mock('../../../../../src/app/platform/billing-and-telemetry', () => ({
+    trackBillingAndSendTelemetry: mockTrackBilling,
+}))
+
+vi.mock('../../../../../src/app/platform/billing-provider', () => ({
+    CreditUsageSource: { AGENT_DRAFT: 'agent_draft' },
+}))
+
+vi.mock('../../../../../src/app/ee/platform/platform-plan/platform-plan.service', () => ({
+    platformPlanService: () => ({ getOrCreateForPlatform: mockGetOrCreateForPlatform }),
+}))
+
+vi.mock('../../../../../src/app/app-connection/app-connection-service/app-connection-service', () => ({
+    appConnectionService: () => ({ listConnectedPieces: vi.fn().mockResolvedValue([]) }),
+}))
+
+vi.mock('../../../../../src/app/pieces/metadata/piece-metadata-service', () => ({
+    pieceMetadataService: () => ({ get: vi.fn().mockResolvedValue(null) }),
+}))
+
+vi.mock('../../../../../src/app/ee/agent/agent-helpers', () => ({
+    agentHelpers: {
+        resolveTierModel: mockResolveTierModel,
+        runScopeOrThrow: ({ projectId }: { projectId: string }) => ({ type: 'project', projectId }),
+        resolveChatProviderName: vi.fn().mockResolvedValue(AIProviderName.ACTIVEPIECES),
+        resolveTier: vi.fn().mockReturnValue({ id: 'fast', creditWeight: 3 }),
+        resolveModelIdForProvider: vi.fn().mockReturnValue('model-x'),
+    },
+}))
+
+const log = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() }
+
+async function draft() {
+    const { agentDraftAi } = await import('../../../../../src/app/ee/agent/agent-draft-ai')
+    return agentDraftAi(log as never).draft({ platformId: 'plat-1', projectId: 'proj-1', prompt: 'watch the deploys' })
+}
+
+const A_VALID_DRAFT = JSON.stringify({
+    displayName: 'Deploy watcher',
+    description: 'Watches deploys',
+    icon: 'bot',
+    color: 'PURPLE',
+    instructions: 'Watch the deploys and report failures.',
+    tools: [],
+})
+
+describe('drafting an agent charges for the model call the provider actually ran', () => {
+    beforeEach(() => {
+        vi.clearAllMocks()
+        mockGetOrCreateForPlatform.mockResolvedValue({ plan: 'free', licenseKey: null })
+        mockResolveTierModel.mockResolvedValue({ model: {}, modelId: 'fast-model', provider: 'activepieces' })
+    })
+
+    it('charges for a draft it could use', async () => {
+        mockGenerateText.mockResolvedValue({ text: A_VALID_DRAFT })
+
+        await draft()
+
+        expect(mockTrackBilling).toHaveBeenCalledTimes(1)
+    })
+
+    it('charges when the model replied with something that is not a draft', async () => {
+        mockGenerateText.mockResolvedValue({ text: 'I would love to help you build an agent!' })
+
+        await expect(draft()).rejects.toThrow()
+
+        expect(mockTrackBilling).toHaveBeenCalledTimes(1)
+    })
+
+    it('charges nothing when the model call itself failed, since nothing was served', async () => {
+        mockGenerateText.mockRejectedValue(new Error('provider is down'))
+
+        await expect(draft()).rejects.toThrow()
+
+        expect(mockTrackBilling).not.toHaveBeenCalled()
+    })
+
+    it('charges nothing when no provider could be resolved at all', async () => {
+        mockResolveTierModel.mockRejectedValue(new Error('no provider'))
+
+        await expect(draft()).rejects.toThrow()
+
+        expect(mockGenerateText).not.toHaveBeenCalled()
+        expect(mockTrackBilling).not.toHaveBeenCalled()
+    })
+})


### PR DESCRIPTION
## Description

Drafting an agent from a sentence debited credits only after the model's reply parsed into a draft. That let the one failure which definitely costs money go free: the provider ran, spent its tokens, and replied with prose instead of JSON. We told the user to reword it and charged nothing.

```
const parsed = parseDraft(raw)
if (isNil(parsed)) { throw ... }        // ← returned here, never debited
await debitDraft({ platformId, projectId, log })
```

The debit now happens once the model has actually replied, before we try to read it. A provider that never answered — a rejected key, a timeout, an outage — still costs nothing, which is the case where nothing was served.

`DRAFTS_PER_MINUTE` bounded how fast this could be repeated, not that it was free.

## How was this tested?

Four unit cases on which failures cost money:

- a usable draft charges once
- a reply that is not a draft charges once (this one fails against the old ordering, which is how I know it is load-bearing)
- a model call that threw charges nothing
- no resolvable provider never calls the model and charges nothing

Suites: api unit agent 166, EE integration agent 176. Lint and `tsc` clean.

Editions: EE and Cloud, wherever credits are enforced. No API, schema or permission changes.

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)
