### PR TITLE
docs(agents): match the docs to the agents screen that shipped

### DIFF
--- a/docs/about/changelog.mdx
+++ b/docs/about/changelog.mdx
@@ -21,7 +21,7 @@ name, brief, talk to, and reuse.
   and adds one that sends, posts or files only when the sentence asks for it.
 - **Edit with AI**: describe a change in the editor — *"only reply to paying customers"* —
   and the instructions and tools are rewritten for you. Edits stay a draft until you press
-  **Save and go live**, and going live updates every flow already using the agent on its
+  **Publish**, and publishing updates every flow already using the agent on its
   next run, with nothing to republish.
 
 **Where an agent lives**

--- a/docs/agents/create.mdx
+++ b/docs/agents/create.mdx
@@ -24,9 +24,15 @@ Drafting needs an [AI provider connected](/admin-guide/guides/setup-ai-providers
 Ask for what you want done, not for the tools. The draft only picks an action that reads your data unless the sentence asks for something to be sent, posted or filed, so *"tell me when something changes"* gets an agent that reports, not one that emails.
 </Tip>
 
+## Start from a blank one
+
+**New agent**, beside the view toggles on the list, skips the drafting and opens an empty agent for you to write yourself. It goes to your personal project, since an agent you have not deliberately placed belongs to you; where a platform does not create personal projects, the button asks which project to use. Either way you can [move it later](/agents/manage).
+
+A blank agent has no model yet, so it opens straight into its editor with that still to pick.
+
 ## Choose where it lives
 
-Under the prompt box, **New agents go to** names the project the agent will belong to, and lets you change it before you create it. That matters because the project is the boundary: an agent reaches only its own project's connections, flows, tables and knowledge.
+Start typing in the prompt box and **New agents go to** appears beneath it, naming the project the agent will belong to and letting you change it before you create it. That matters because the project is the boundary: an agent reaches only its own project's connections, flows, tables and knowledge.
 
 If you have one project, there is nothing to choose and the control stays out of the way. See [managing an agent](/agents/manage) for moving one later.
 
@@ -68,7 +74,7 @@ The editor has two tabs beside the Configure panel.
   </Card>
 </CardGroup>
 
-Edits are a draft until you press **Save and go live**. The header says which state you are in: *Changes not live yet* while you are editing, *Live* once saved, and *Needs a model to run* if no model is picked. Going live updates every flow already using the agent on its next run, with nothing to republish.
+Edits are a draft until you press **Publish**. The header says which state you are in: *Changes not live yet* while you are editing, *Live* once published, and *Needs a model to run* if no model is picked. Publishing updates every flow already using the agent on its next run, with nothing to republish.
 
 <Tip>
 Brief it like a capable new colleague. Say the goal and the edges, not every keystroke. The two people forget most: what "done" looks like, and which calls it should hand back to a human.

--- a/docs/agents/manage.mdx
+++ b/docs/agents/manage.mdx
@@ -9,11 +9,11 @@ icon: "folder-tree"
 
 An agent belongs to one project, and that decides what it can reach: the connections it authenticates with, the flows it can call, the tables and files it looks things up in. Two projects with the same Gmail connection name are two different mailboxes.
 
-The **Agents** page spans every project you can see, so the card tells you which project each agent belongs to. The project filter beside the search box narrows the list, and it also moves the destination under the prompt box to that project. Whatever you pick in **New agents go to** wins, so check that line before you create anything.
+The **Agents** page spans every project you can see, so each agent's row tells you which project it belongs to. The project filter beside the search box narrows the list, and it also sets where a described agent will be created. Start typing in the prompt box and **New agents go to** appears beneath it, naming that destination; whatever you pick there wins, so check it before you create anything.
 
 ## Move it to another project
 
-From the `...` menu on a card, or from **Project** in the agent's own Advanced section, pick **Move to another project**.
+From the `...` menu beside the agent, or from **Project** in the agent's own Advanced section, pick **Move to another project**.
 
 The agent takes its instructions, tools and conversations with it. Before you confirm, the dialog says what the move costs:
 


### PR DESCRIPTION
## Description

The agents docs describe a screen that changed underneath them, in #15223 and #15231. Four corrections, each checked against the running app rather than against my memory of what I built.

- **Save and go live is Publish**, on the Create page and in the September changelog entry. The changelog is hand-written, so it drifted too.
- **The destination line is no longer always there.** Both Create and Manage said "under the prompt box, New agents go to names the project", which read as a thing you could go and look at. It appears once you start typing, so both pages now say when you will see it.
- **The `...` menu is not only on a card**, now that the list view is a table. Reworded to name the agent rather than the card.
- **The New agent button was documented nowhere.** It skips drafting, opens an empty agent in your personal project, asks which project on a platform that creates none, and lands in the editor with the model still to pick.

## How was this tested?

Read against the app rather than asserted: the New agent button is present, the destination line is absent at rest and appears once the prompt box has text, and both view toggles are there. Docs-only otherwise — no code paths touched.

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)
