### PR TITLE
fix(agents): a blank agent lands in the same place whichever way you start it

### DIFF
--- a/packages/web/src/app/routes/agents/index.tsx
+++ b/packages/web/src/app/routes/agents/index.tsx
@@ -5,7 +5,6 @@ import {
   ColorName,
   MAX_DRAFT_PROMPT_LENGTH,
   PROJECT_COLOR_PALETTE,
-  ProjectType,
 } from '@activepieces/shared';
 import { t } from 'i18next';
 import {
@@ -37,8 +36,6 @@ import { Button } from '@/components/ui/button';
 import {
   DropdownMenu,
   DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuLabel,
   DropdownMenuRadioGroup,
   DropdownMenuRadioItem,
   DropdownMenuTrigger,
@@ -54,6 +51,7 @@ import {
   useAgentsAvailable,
 } from '@/features/agents/hooks/agents-hooks';
 import { createAgentUtils } from '@/features/agents/lib/create-agent-utils';
+import { NewBlankAgentButton } from '@/features/agents/new-blank-agent-button';
 import { aiProviderQueries } from '@/features/platform-admin/hooks/ai-provider-hooks';
 import { getProjectName, projectCollectionUtils } from '@/features/projects';
 import { useIsPlatformAdmin } from '@/hooks/authorization-hooks';
@@ -221,10 +219,6 @@ const AgentsPageContent = () => {
     );
   };
 
-  const personalProject = (allProjects ?? []).find(
-    (entry) => entry.type === ProjectType.PERSONAL,
-  );
-
   const createBlankAgent = (projectId: string) => {
     if (createAgent.isPending) {
       return;
@@ -345,15 +339,14 @@ const AgentsPageContent = () => {
             </p>
           ))}
         {chatIsOffOnEveryProvider && (
-          <Button
-            variant="outline"
+          <NewBlankAgentButton
+            projects={allProjects ?? []}
+            pending={createAgent.isPending}
+            onCreate={createBlankAgent}
             className="mt-4 gap-2"
-            loading={createAgent.isPending}
-            onClick={() => createBlankAgent(createInProjectId)}
-          >
-            <Pencil size={16} />
-            {t('Write one by hand instead')}
-          </Button>
+            icon={<Pencil size={16} />}
+            label={t('Write one by hand instead')}
+          />
         )}
         <div
           className={cn(
@@ -582,45 +575,15 @@ const AgentsPageContent = () => {
                   />
                 </button>
               </div>
-              {personalProject === undefined ? (
-                <DropdownMenu>
-                  <DropdownMenuTrigger asChild>
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      className="px-3.5 text-neutral-700"
-                      loading={createAgent.isPending}
-                    >
-                      <Plus size={15} />
-                      {t('New agent')}
-                    </Button>
-                  </DropdownMenuTrigger>
-                  <DropdownMenuContent align="end" className="w-[220px]">
-                    <DropdownMenuLabel className="text-xs font-normal text-muted-foreground">
-                      {t('Create it in')}
-                    </DropdownMenuLabel>
-                    {projectOptions.map((option) => (
-                      <DropdownMenuItem
-                        key={option.value}
-                        onSelect={() => createBlankAgent(option.value)}
-                      >
-                        {option.label}
-                      </DropdownMenuItem>
-                    ))}
-                  </DropdownMenuContent>
-                </DropdownMenu>
-              ) : (
-                <Button
-                  variant="outline"
-                  size="sm"
-                  className="px-3.5 text-neutral-700"
-                  loading={createAgent.isPending}
-                  onClick={() => createBlankAgent(personalProject.id)}
-                >
-                  <Plus size={15} />
-                  {t('New agent')}
-                </Button>
-              )}
+              <NewBlankAgentButton
+                projects={allProjects ?? []}
+                pending={createAgent.isPending}
+                onCreate={createBlankAgent}
+                size="sm"
+                className="px-3.5 text-neutral-700"
+                icon={<Plus size={15} />}
+                label={t('New agent')}
+              />
             </div>
           </div>
 

--- a/packages/web/src/features/agents/new-blank-agent-button.tsx
+++ b/packages/web/src/features/agents/new-blank-agent-button.tsx
@@ -1,0 +1,83 @@
+import { Project, ProjectType } from '@activepieces/shared';
+import { t } from 'i18next';
+import { ReactNode } from 'react';
+
+import { Button } from '@/components/ui/button';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { getProjectName } from '@/features/projects';
+
+export const NewBlankAgentButton = ({
+  projects,
+  pending,
+  onCreate,
+  variant = 'outline',
+  size,
+  className,
+  icon,
+  label,
+}: NewBlankAgentButtonProps) => {
+  const personalProject = projects.find(
+    (project) => project.type === ProjectType.PERSONAL,
+  );
+
+  if (personalProject !== undefined) {
+    return (
+      <Button
+        variant={variant}
+        size={size}
+        className={className}
+        loading={pending}
+        onClick={() => onCreate(personalProject.id)}
+      >
+        {icon}
+        {label}
+      </Button>
+    );
+  }
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          variant={variant}
+          size={size}
+          className={className}
+          loading={pending}
+        >
+          {icon}
+          {label}
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="w-[220px]">
+        <DropdownMenuLabel className="text-xs font-normal text-muted-foreground">
+          {t('Create it in')}
+        </DropdownMenuLabel>
+        {projects.map((project) => (
+          <DropdownMenuItem
+            key={project.id}
+            onSelect={() => onCreate(project.id)}
+          >
+            {getProjectName(project)}
+          </DropdownMenuItem>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+};
+
+type NewBlankAgentButtonProps = {
+  projects: Project[];
+  pending: boolean;
+  onCreate: (projectId: string) => void;
+  variant?: 'outline';
+  size?: 'sm';
+  className?: string;
+  icon: ReactNode;
+  label: string;
+};


### PR DESCRIPTION
## Description

#15231 gave the **New agent** button a rule for where a blank agent goes — your personal project, or a short list to pick from where a platform creates none. It left the other by-hand route alone.

**Write one by hand instead**, offered when no AI provider is turned on for chat, still created the agent in whatever project happened to be selected. Worse there than on the toolbar button, because that route appears with the prompt box empty, and the destination line is hidden until you type — so nothing on screen said where the agent was about to land.

That is the same silent placement Greptile flagged on the first button, surviving in the path nobody looked at. Fixing one and not the other is worse than fixing neither, because it reads as settled.

One `NewBlankAgentButton` now owns the decision and both routes render it, so there is one answer to where a blank agent goes instead of two that drifted apart.

While I was here: the roadmap's step 12, **AD5 · create from scratch**, needed no work. It was listed because *"or build it yourself"* was said to be waiting on it rather than shipping as a dead link — but both by-hand routes exist and work today, so there is no dangling promise for that screen to fill.

## How was this tested?

Live, both branches of the rule:

- with a personal project: a plain button, no popup, 6px radius, normal weight
- without one (forced by breaking the predicate, then reverted): the button becomes a menu (`aria-haspopup="menu"`) listing every reachable project under "Create it in"

Automated: `packages/web` 678 tests pass. Lint and `tsc` clean, and the temporary predicate used for the second case is gone from the tree.

Editions: EE with `agentsEnabled`. Presentation and destination only — no API, schema or permission changes.

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)
