### PR TITLE
docs: clean up heading formatting in structure-projects guide

### DIFF
--- a/docs/admin-guide/guides/structure-projects.mdx
+++ b/docs/admin-guide/guides/structure-projects.mdx
@@ -11,13 +11,13 @@ Projects help you organize automations and resources for different teams or area
 
 Being invited to the platform does not automatically give a user access to every project. Users only see the projects they have access to, while **platform admins can access all projects**.
 
-### **Why you need projects: **
+### **Why you need projects:**
 
 For example, each department can have its own project, so other departments can’t access its connections or credentials.
 
 In the following parts under this project section, we will explore everything that you do within a project.
 
-### **Personal and Team Projects: **
+### **Personal and Team Projects:**
 
 In Activepieces, you have two types of projects:
 
@@ -59,7 +59,7 @@ New users get a personal project on signup by default. Platform admins can turn 
 
 **Global Connection:** You can also add or remove a global connection from a project. However, note that removing a global connection from a project that has a flow using it will break that flow.
 
-- **Inviting & Removing People From Projects: **
+- **Inviting & Removing People From Projects:**
 
 **How to invite someone to a project:**
 
@@ -134,7 +134,7 @@ Platform Admin → Pieces = Where platform admin controls pieces that are availa
 
 The Environment settings let you connect a project to a Git repository and manage [project releases](https://app.mintlify.com/activepieces/activepieces/editor/ginika%2Fdraft-aug-31/~/75eedf3e-853e-40f7-9be3-e4e61b448d4d). This is useful for teams that want a more controlled way to manage and track changes to their automations.
 
-The page contains two main options**: Git and Releases.** The page contains two main options: **Git and Releases.**
+The page contains two main options: **Git and Releases.**
 
 ### **Navigating Projects Via API**
 


### PR DESCRIPTION
## Description

Small formatting cleanup in the "Structure Projects" admin guide:

- Removed stray trailing spaces that sat *inside* the bold markers on four headings (`### **Why you need projects: **` → `### **Why you need projects:**`), which rendered a visible gap before the closing bold.
- Removed a duplicated sentence on the Environment section — the line about the page's two main options appeared twice, once with a misplaced colon.

No content changes, only markup.

## How was this tested?

Docs-only change; reviewed the rendered MDX diff. No code paths touched, so no edition testing applies.

Fixes # (issue)

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)