### PR TITLE
fix(fillout-forms): don't double-parse the webhook body in new-form-response

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -3154,7 +3154,7 @@
     },
     "packages/pieces/community/fillout-forms": {
       "name": "@activepieces/piece-fillout-forms",
-      "version": "0.1.8",
+      "version": "0.1.9",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -3163,6 +3163,7 @@
       },
       "devDependencies": {
         "tslib": "2.6.2",
+        "vitest": "3.2.6",
       },
     },
     "packages/pieces/community/fireberry": {

--- a/packages/pieces/community/fillout-forms/package.json
+++ b/packages/pieces/community/fillout-forms/package.json
@@ -1,12 +1,13 @@
 {
   "name": "@activepieces/piece-fillout-forms",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",
     "bundle": "node ../../../../dist/packages/cli/src/index.js pieces bundle",
-    "lint": "eslint 'src/**/*.ts'"
+    "lint": "eslint 'src/**/*.ts'",
+    "test": "vitest run"
   },
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
@@ -15,6 +16,7 @@
     "@activepieces/core-utils": "workspace:*"
   },
   "devDependencies": {
-    "tslib": "2.6.2"
+    "tslib": "2.6.2",
+    "vitest": "3.2.6"
   }
 }

--- a/packages/pieces/community/fillout-forms/src/lib/triggers/new-form-response.test.ts
+++ b/packages/pieces/community/fillout-forms/src/lib/triggers/new-form-response.test.ts
@@ -1,0 +1,69 @@
+/// <reference types="vitest/globals" />
+
+import { newFormResponse } from './new-form-response';
+
+const SUBMISSION = {
+  submissionId: 'abc123',
+  submissionTime: '2026-08-31T10:00:00.000Z',
+  questions: [
+    {
+      id: '5AtgG35AAZVcrSVfRubvp1',
+      name: 'What is your name?',
+      type: 'ShortAnswer',
+      value: 'John Doe',
+    },
+  ],
+  calculations: [],
+  urlParameters: [],
+};
+
+const WEBHOOK_BODY = {
+  formId: 'vs1PXaHmRfus',
+  formName: 'Contact form',
+  submission: SUBMISSION,
+};
+
+const buildContext = (body: unknown) =>
+  ({
+    payload: {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body,
+      queryParams: {},
+    },
+  } as never);
+
+describe('fillout new-form-response run()', () => {
+  test('returns the submission when the body is an already-parsed object', async () => {
+    const output = await newFormResponse.run(buildContext(WEBHOOK_BODY));
+
+    expect(output).toEqual([SUBMISSION]);
+  });
+
+  test('still returns the submission when the body is a raw JSON string', async () => {
+    const output = await newFormResponse.run(
+      buildContext(JSON.stringify(WEBHOOK_BODY))
+    );
+
+    expect(output).toEqual([SUBMISSION]);
+  });
+
+  test('returns an array holding exactly one item', async () => {
+    const output = await newFormResponse.run(buildContext(WEBHOOK_BODY));
+
+    expect(Array.isArray(output)).toBe(true);
+    expect(output).toHaveLength(1);
+  });
+
+  test('a parsed body without a submission yields one undefined item', async () => {
+    const output = await newFormResponse.run(buildContext({}));
+
+    expect(output).toEqual([undefined]);
+  });
+
+  test('a string body that is not JSON still raises', async () => {
+    await expect(
+      newFormResponse.run(buildContext('not json'))
+    ).rejects.toThrow(SyntaxError);
+  });
+});

--- a/packages/pieces/community/fillout-forms/src/lib/triggers/new-form-response.ts
+++ b/packages/pieces/community/fillout-forms/src/lib/triggers/new-form-response.ts
@@ -68,7 +68,8 @@ export const newFormResponse = createTrigger({
     return submissions.responses;
   },
   async run(context) {
-    const payload = JSON.parse(context.payload.body as string) as {
+    const body = context.payload.body;
+    const payload = (typeof body === 'string' ? JSON.parse(body) : body) as {
       submission: Record<string, any>;
     };
     return [payload.submission];

--- a/packages/pieces/community/fillout-forms/vitest.config.ts
+++ b/packages/pieces/community/fillout-forms/vitest.config.ts
@@ -1,0 +1,17 @@
+import path from 'path'
+import { defineConfig } from 'vitest/config'
+
+const repoRoot = path.resolve(__dirname, '../../../..')
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+  },
+  resolve: {
+    alias: {
+      '@activepieces/pieces-framework': path.resolve(repoRoot, 'packages/pieces/framework/src/index.ts'),
+      '@activepieces/pieces-common': path.resolve(repoRoot, 'packages/pieces/common/src/index.ts'),
+    },
+  },
+})

--- a/packages/pieces/community/fillout-forms/vitest.config.ts
+++ b/packages/pieces/community/fillout-forms/vitest.config.ts
@@ -12,6 +12,8 @@ export default defineConfig({
     alias: {
       '@activepieces/pieces-framework': path.resolve(repoRoot, 'packages/pieces/framework/src/index.ts'),
       '@activepieces/pieces-common': path.resolve(repoRoot, 'packages/pieces/common/src/index.ts'),
+      '@activepieces/core-piece-types': path.resolve(repoRoot, 'packages/core/piece-types/src/index.ts'),
+      '@activepieces/core-utils': path.resolve(repoRoot, 'packages/core/utils/src/index.ts'),
     },
   },
 })


### PR DESCRIPTION
## Description

The Fillout **New Form Response** trigger has never fired on a real webhook delivery. It silently dropped 100% of live submissions in every release since `0.65.0`.

```ts
async run(context) {
  const payload = JSON.parse(context.payload.body as string) as { submission: Record<string, any> };
  return [payload.submission];
}
```

Fillout posts with `Content-Type: application/json`, so `convertBody()` in `webhook-request-converter.ts` hands the trigger a body Fastify has **already parsed** — an object, not a string. `JSON.parse(object)` stringifies it to `"[object Object]"` and throws `SyntaxError`. The `as string` cast hid the mismatch from the compiler.

The failure is silent end to end: the engine wraps the throw as `INTERNAL_ERROR`, `execute-webhook.ts` only submits payloads on `EngineResponseStatus.OK`, so no run row, no issue, no alert — and the job still reports `OK`. The trigger looked healthy in the builder the whole time because `test()` polls `GET /forms/:id/submissions` instead of using the webhook body.

The fix is to parse only when the body actually is a string, which handles both shapes:

```ts
const body = context.payload.body;
const payload = (typeof body === 'string' ? JSON.parse(body) : body) as {
  submission: Record<string, any>;
};
```

**Scope is Fillout only.** The one other `payload.body as string` in `packages/pieces` is `salesforce/new-outbound-message`, which is `text/xml` — Fastify does not parse that, so its cast is genuine. `respaid` already guards with `typeof`.

Bumps `@activepieces/piece-fillout-forms` to `0.1.9`.

**Credit:** reported and diagnosed by Laurent Meyer (@laurentmmeyer), who proposed the same fix in #15131. That PR could not be merged (CLA unsigned), so it is re-landed here with his diagnosis intact.

## How was this tested?

- **Reproduced live on a local CE instance with the unpatched build** — webhook delivered, `HTTP 200` returned, no run created and no error surfaced anywhere in the UI or logs. With the fix, the run is created and the trigger output is the `submission` object.
- **Regression test added** — `new-form-response.test.ts`, 5 cases: already-parsed object, raw JSON string, single-item array shape, `{}` with no submission, and a non-JSON string.
- **Mutation-proven** — reverting the source fix fails the object cases with `SyntaxError: "[object Object]" is not valid JSON` while the raw-string case keeps passing, which is exactly why this went unnoticed for a year.
- `tsc --noEmit -p packages/pieces/community/fillout-forms/tsconfig.lib.json` clean; `turbo run lint --filter=@activepieces/piece-fillout-forms` 0 errors (15 pre-existing `no-explicit-any` warnings, untouched).
- Edition paths: piece-level change with no edition-specific code path — the webhook body arrives identically on CE, EE and Cloud.

Fixes #15149

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)
