### PR TITLE
feat(pieces-common): improve the Custom API Call step form

### DIFF
--- a/packages/pieces/common/package.json
+++ b/packages/pieces/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/pieces-common",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "type": "commonjs",
   "sideEffects": false,
   "main": "./dist/src/index.js",

--- a/packages/pieces/common/src/lib/helpers/index.ts
+++ b/packages/pieces/common/src/lib/helpers/index.ts
@@ -169,8 +169,10 @@ export function createCustomApiCallAction<
     headers?: Partial<ReturnType<typeof Property.Object>>;
     queryParams?: Partial<ReturnType<typeof Property.Object>>;
     body?: Partial<ReturnType<typeof Property.Json>>;
+    response_is_binary?: Partial<ReturnType<typeof Property.Checkbox>>;
     failsafe?: Partial<ReturnType<typeof Property.Checkbox>>;
     timeout?: Partial<ReturnType<typeof Property.Number>>;
+    followRedirects?: Partial<ReturnType<typeof Property.Checkbox>>;
   };
   extraProps?: InputPropertyMap;
   authLocation?: 'headers' | 'queryParams';
@@ -328,6 +330,7 @@ export function createCustomApiCallAction<
         required: false,
         defaultValue: false,
         advanced: true,
+        ...(props?.response_is_binary ?? {}),
       }),
       failsafe: Property.Checkbox({
         displayName: 'Return Error as Output',
@@ -351,6 +354,7 @@ export function createCustomApiCallAction<
         required: false,
         defaultValue: false,
         advanced: true,
+        ...(props?.followRedirects ?? {}),
       }),
       ...extraProps,
     },

--- a/packages/pieces/common/src/lib/helpers/index.ts
+++ b/packages/pieces/common/src/lib/helpers/index.ts
@@ -197,9 +197,9 @@ export function createCustomApiCallAction<
           return {
             url: Property.ShortText({
               displayName: 'URL',
-              description: `You can either use the full URL or the relative path to the base URL
-i.e ${getBaseUrlForDescription(baseUrl, auth)}/resource or /resource`,
+              description: `Full URL, or a path relative to ${getBaseUrlForDescription(baseUrl, auth)}`,
               required: true,
+              placeholder: '/resource',
               defaultValue: auth ? baseUrl(auth) : '',
               ...(props?.url ?? {}),
             }),
@@ -209,6 +209,7 @@ i.e ${getBaseUrlForDescription(baseUrl, auth)}/resource or /resource`,
       method: Property.StaticDropdown({
         displayName: 'Method',
         required: true,
+        defaultValue: HttpMethod.GET,
         options: {
           options: Object.values(HttpMethod).map((v) => {
             return {
@@ -223,12 +224,13 @@ i.e ${getBaseUrlForDescription(baseUrl, auth)}/resource or /resource`,
         displayName: 'Headers',
         description:
           'Authorization headers are injected automatically from your connection.',
-        required: true,
+        required: false,
         ...(props?.headers ?? {}),
       }),
       queryParams: Property.Object({
         displayName: 'Query Parameters',
-        required: true,
+        description: 'Appended to the URL as ?key=value.',
+        required: false,
         ...(props?.queryParams ?? {}),
       }),
       body_type: Property.StaticDropdown({
@@ -321,25 +323,34 @@ i.e ${getBaseUrlForDescription(baseUrl, auth)}/resource or /resource`,
         },
       }),
       response_is_binary: Property.Checkbox({
-        displayName: 'Response is Binary ?',
+        displayName: 'Binary Response',
         description: 'Enable for files like PDFs, images, etc.',
         required: false,
         defaultValue: false,
+        advanced: true,
       }),
       failsafe: Property.Checkbox({
-        displayName: 'No Error on Failure',
+        displayName: 'Return Error as Output',
+        description:
+          'On a failed request, output the error instead of failing the step.',
         required: false,
+        advanced: true,
         ...(props?.failsafe ?? {}),
       }),
       timeout: Property.Number({
-        displayName: 'Timeout (in seconds)',
+        displayName: 'Timeout',
+        description: 'Seconds to wait before giving up. Leave empty for no limit.',
         required: false,
+        advanced: true,
         ...(props?.timeout ?? {}),
       }),
       followRedirects: Property.Checkbox({
-        displayName: 'Follow redirects',
+        displayName: 'Follow Redirects',
+        description:
+          'Follow 3xx redirects instead of returning them as the response.',
         required: false,
         defaultValue: false,
+        advanced: true,
       }),
       ...extraProps,
     },

--- a/packages/pieces/common/src/lib/helpers/index.ts
+++ b/packages/pieces/common/src/lib/helpers/index.ts
@@ -325,7 +325,7 @@ export function createCustomApiCallAction<
         },
       }),
       response_is_binary: Property.Checkbox({
-        displayName: 'Binary Response',
+        displayName: 'Response is Binary',
         description: 'Enable for files like PDFs, images, etc.',
         required: false,
         defaultValue: false,
@@ -342,13 +342,13 @@ export function createCustomApiCallAction<
       }),
       timeout: Property.Number({
         displayName: 'Timeout',
-        description: 'Seconds to wait before giving up. Leave empty for no limit.',
+        description: 'Seconds to wait for a response. Empty: up to the flow limit (10 min).',
         required: false,
         advanced: true,
         ...(props?.timeout ?? {}),
       }),
       followRedirects: Property.Checkbox({
-        displayName: 'Follow Redirects',
+        displayName: 'Follow redirects',
         description:
           'Follow 3xx redirects instead of returning them as the response.',
         required: false,


### PR DESCRIPTION
## Description

Tidies up the **Custom API Call** step form — the action produced by
`createCustomApiCallAction`, which for many pieces is the only action a human sees in the
builder. Metadata and copy only; `run()` is untouched.

This started as a Google Forms UI pass. Google Forms' own three actions are
`audience: 'ai'`, so the only action a human can pick there is Custom API Call — which
lives in `pieces-common` and is shared by **464 pieces**. Fixing it there rather than in
one piece is why the diff is a single shared file.

**Defect fixes**

- **`Headers` and `Query Parameters` were `required: true`** and rendered with red
  asterisks, but the OBJECT schema accepts `{}`, so the flag never actually blocked
  anything — it only told users two optional dictionaries were mandatory.
- **`Method` had no default**, so every new step opened on "Select an option" and was
  invalid until touched. Now defaults to `GET`.
- **`Response is Binary ?`** carried a stray space before a question mark that does not
  belong on a toggle label. Now `Response is Binary` — same wording as the HTTP piece.
- **`Timeout (in seconds)`** carried its unit in the label. Now `Timeout`, with the unit in
  the description: "Seconds to wait for a response. Empty: up to the flow limit (10 min)."
  An empty timeout does not mean "no limit" — the run still stops at the flow limit — so
  that is stated rather than implied.
- **`No Error on Failure`** was negatively phrased with no description, and read as a near
  duplicate of the step-level "Continue on Failure" toggle sitting a few rows below it. Now
  `Return Error as Output`, with a description saying what it actually does.
- **The `URL` description was ~100 characters with a hard line break**, so it truncated
  mid-sentence behind "read more". Rewritten to fit, plus a `/resource` placeholder.
- **`Follow redirects` had no description**, so the label alone had to carry what a 3xx
  does. Label unchanged; description added.

**Judgment call, easy to drop**

`Response is Binary`, `Return Error as Output`, `Timeout` and `Follow redirects` are now
`advanced: true`, which collapses them into the Advanced section and roughly halves the
form's height. All four are `required: false` with defaults, so nothing mandatory is hidden
behind a collapsed section.

Worth flagging honestly: `advanced` is currently used by exactly one community piece in the
repo, so this takes the pattern to 464 pieces at once. Every prop keeps its
`...(props?.x ?? {})` override spread, so any consumer can set `advanced: false`, and it is
a one-line revert if we would rather not. **Happy to drop just this part and keep the rest.**

**This does not ship on its own**

`find-changed-pieces.ts` republishes a piece only when `name@version` is missing from the
cloud registry, and pieces inline `pieces-common` at build time. So each consumer picks
this up on its next version bump. `npm run bump-all-pieces-patch-version` exists for that
(note: it covers `community/*` and skips `core/*`), but running it is a release decision, so
I have not — happy to if you want it out sooner. `pieces-common` itself is bumped
`0.13.0` → `0.13.1` per convention, though it is in `NON_PIECES_PACKAGES` and never
published on its own.

Some of the rollout will also happen by itself: the nightly `generate-translations.yml` run
touches the i18n files of every affected piece (see below), and `bump-translated-pieces`
bumps the pieces it touches.

**i18n**: three labels are renamed, and all three are Crowdin source keys —
`"Timeout (in seconds)"` and `"No Error on Failure"` each appear in 471 `translation.json`
files, `"Response is Binary ?"` in 469. Renaming orphans those keys, so non-English users
see English for those three labels and the new descriptions until the nightly regeneration
and Crowdin catch up. Standard consequence of any `displayName` rename, flagged here so it
does not read as an oversight. `"Follow redirects"` keeps its existing key — only its
description is new. No locale files were hand-edited.

**Unrelated bug you will hit while testing this — blocked on #15189**

Setting **Body Type = Form Data** throws *"input value is invalid, please contact support"*.
That is **not** caused by this PR. A non-array value (`{}`) ends up stored on the ARRAY
child, and `array-property.tsx` guards it with a truthy check — which `{}` passes — so
`.map()` runs on an object and crashes into the error boundary.

**#15189 already fixes this** — one web file, `toArrayFields()`, global for all pieces. It is
still open. Nothing to do in this PR; the two are complementary, and merging #15189 first
makes the Form Data path usable.

## How was this tested?

Manually on a local dev server (`AP_DEV_PIECES=google-forms`) on **CE**. The factory is
edition-agnostic — no EE hooks, no platform flags, no `platform.plan` gating — so the form
is identical on EE and Cloud.

- Confirmed off `/v1/pieces` that the served metadata has `method` defaulting to `GET`,
  `headers`/`queryParams` at `required: false`, the four advanced flags set, and every
  description under the 70-character "read more" threshold (34/40/63/66/69; `headers` left
  at exactly 70 so its existing translations survive).
- Walked the form in the builder at v0.5.8 and v0.5.9 — before/after screenshots below.
- `turbo run build --filter=@activepieces/pieces-common` clean; lint 0 errors.
- `packages/core/shared/test/ee/agent-tool-classification.test.ts` — 53 passed. Checked
  specifically that `requiresActionPreview` reads the tool call's `input.method` and not
  prop metadata, so `defaultValue: GET` cannot weaken the confirmation gate that stops chat
  silently issuing mutating requests via `custom_api_call`.

Note for reviewers: touching `packages/pieces/common` makes CI lint and build every piece
package, so this PR's checks are slower than the diff suggests.

Fixes # (issue)

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

No prop was renamed or removed and `run()` is untouched, so stored step values keep
working. The two `required` flags were relaxed, never tightened. The new `Method` default
applies only to steps created after this ships. Renamed `displayName`s are labels, not
input keys.

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)

`custom_api_call` is gated by `requiresActionPreview`, which requires confirmation for any
method that is not provably read-only. That gate reads the tool call's `input`, not prop
metadata, and an absent method still requires confirmation — so adding a `GET` default does
not change it. No change to auth handling, `authLocation`, or the request path.
<img width="495" height="827" alt="Screenshot 2026-09-03 165907" src="https://github.com/user-attachments/assets/cccba8cb-e385-4cef-bd52-534b10059fdb" />
<img width="497" height="826" alt="Screenshot 2026-09-03 165916" src="https://github.com/user-attachments/assets/1954f5be-3421-46e2-a857-347d57fb3756" />
<img width="487" height="832" alt="Screenshot 2026-09-03 165935" src="https://github.com/user-attachments/assets/40631a6d-1b2e-4cf3-8ff9-e7f7b629c7c5" />
<img width="505" height="827" alt="Screenshot 2026-09-03 170008" src="https://github.com/user-attachments/assets/f6a04eee-4b3c-4007-944a-e0d8ac6f0250" />
