### PR TITLE
fix(webhooks): register sync listener before starting run

### DIFF
--- a/packages/server/api/src/app/webhooks/webhook.service.ts
+++ b/packages/server/api/src/app/webhooks/webhook.service.ts
@@ -297,6 +297,15 @@ async function handleSync(params: SyncWebhookParams): Promise<EngineHttpResponse
         }
     }
 
+    // Register before making the job runnable. A fast worker can otherwise publish
+    // the response before the in-memory listener exists, losing it and producing
+    // a false timeout for an execution that already completed successfully.
+    const listenerResult = engineResponseWatcher(logger).oneTimeListener<EngineHttpResponse>(webhookRequestId, true, timeoutMs ?? WEBHOOK_TIMEOUT_MS, {
+        status: StatusCodes.REQUEST_TIMEOUT,
+        body: {},
+        headers: {},
+    })
+
     const createdRun = await flowRunService(logger).start({
         platformId,
         environment: runEnvironment,
@@ -316,11 +325,6 @@ async function handleSync(params: SyncWebhookParams): Promise<EngineHttpResponse
     wideEvent.set({ flowRun: { id: createdRun.id } })
     params.onRunCreated?.(createdRun)
 
-    const listenerResult = await engineResponseWatcher(logger).oneTimeListener<EngineHttpResponse>(webhookRequestId, true, timeoutMs ?? WEBHOOK_TIMEOUT_MS, {
-        status: StatusCodes.REQUEST_TIMEOUT,
-        body: {},
-        headers: {},
-    })
     return listenerResult
 }
 

--- a/packages/server/api/test/unit/app/webhooks/webhook-credit-gate.test.ts
+++ b/packages/server/api/test/unit/app/webhooks/webhook-credit-gate.test.ts
@@ -148,6 +148,9 @@ describe('sync webhook credit gate', () => {
 
         expect(mockStart).toHaveBeenCalledTimes(1)
         expect(mockCreateQuotaExceededRun).not.toHaveBeenCalled()
+        expect(mockOneTimeListener.mock.invocationCallOrder[0]).toBeLessThan(
+            mockStart.mock.invocationCallOrder[0],
+        )
         expect(response.status).toBe(StatusCodes.OK)
         expect(response.body).toEqual({ ok: true })
     })


### PR DESCRIPTION
## What changed

Register the sync webhook response listener before `flowRunService.start()` makes the worker job runnable. A sufficiently fast worker could previously publish its response while the in-memory listener map had no matching entry; the message was dropped and the API returned the default timeout even though the run completed.

The unit test now locks in the ordering invariant: **subscribe before start**.

## Why

This matches the narrow reproduction in #13334: imported minimal flows complete in under 100 ms, while the API watcher times out at `AP_WEBHOOK_TIMEOUT_SECONDS`. Slower/UI-built flows can hide the race.

## Validation

- TypeScript syntax checked locally with Node's parser.
- Added an ordering assertion to the existing sync-webhook unit test.

I could not run the monorepo test command in the available container because npm/corepack were not installed.

Fixes the lost-response portion of #13334. The separately reported missing `flow_run` row may still need independent instrumentation.