### PR TITLE
ci(pieces): fail PR when a piece's heap usage regresses

### DIFF
--- a/.github/workflows/validate-publishable-packages.yml
+++ b/.github/workflows/validate-publishable-packages.yml
@@ -39,3 +39,32 @@ jobs:
 
       - name: validate publishable packages
         run: npx ts-node -r tsconfig-paths/register -P packages/server/engine/tsconfig.lib.json tools/scripts/validate-publishable-packages.ts
+
+      - name: find changed pieces
+        id: changed
+        run: |
+          OUTPUT=$(npx ts-node -r tsconfig-paths/register -P packages/server/engine/tsconfig.lib.json tools/scripts/pieces/find-changed-pieces.ts)
+          TURBO_FILTER=$(echo "$OUTPUT" | grep '^TURBO_FILTER:' | sed 's/^TURBO_FILTER://')
+          CHANGED_DIRS=$(echo "$OUTPUT" | sed -n '/^CHANGED_DIRS:$/,/^TURBO_FILTER:/{ /^CHANGED_DIRS:$/d; /^TURBO_FILTER:/d; p; }')
+          if [ -z "$TURBO_FILTER" ]; then
+            echo "No changed pieces found"
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
+            echo "turbo_filter=$TURBO_FILTER" >> "$GITHUB_OUTPUT"
+            {
+              echo "changed_dirs<<PIECES_EOF"
+              echo "$CHANGED_DIRS"
+              echo "PIECES_EOF"
+            } >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: build changed pieces
+        if: steps.changed.outputs.has_changes == 'true'
+        run: npx turbo run build ${{ steps.changed.outputs.turbo_filter }}
+
+      - name: check piece heap usage
+        if: steps.changed.outputs.has_changes == 'true' && !contains(github.event.pull_request.labels.*.name, 'skip-heap-check')
+        env:
+          CHANGED_PIECES: ${{ steps.changed.outputs.changed_dirs }}
+        run: npx ts-node -r tsconfig-paths/register -P packages/server/engine/tsconfig.lib.json tools/scripts/pieces/check-pieces-heap.ts

--- a/tools/scripts/pieces/check-pieces-heap.ts
+++ b/tools/scripts/pieces/check-pieces-heap.ts
@@ -107,17 +107,22 @@ async function checkOne(piecePath: string): Promise<PieceHeapResult> {
 function verdict(r: PieceHeapResult): { failed: boolean; reasons: string[] } {
     const reasons: string[] = []
     if (!r.ok) {
-        reasons.push(r.error ?? 'unknown-error')
-        return { failed: false, reasons }
+        reasons.push(`could not measure current build: ${r.error ?? 'unknown error'}`)
+        return { failed: true, reasons }
     }
-    if (r.previousHeapMB !== undefined) {
-        const delta = r.heapMB! - r.previousHeapMB
-        if (delta > DELTA_LIMIT_MB) {
-            reasons.push(`heap grew +${delta.toFixed(2)} MB vs ${r.previousVersion} (${r.previousHeapMB.toFixed(2)} → ${r.heapMB!.toFixed(2)} MB); allowed +${DELTA_LIMIT_MB} MB`)
+    if (r.previousError !== undefined) {
+        reasons.push(`could not measure previously-published version to verify delta: ${r.previousError}`)
+        return { failed: true, reasons }
+    }
+    if (r.previousMissing === true) {
+        if (r.heapMB! > ABSOLUTE_LIMIT_MB) {
+            reasons.push(`heap ${r.heapMB!.toFixed(2)} MB > absolute limit ${ABSOLUTE_LIMIT_MB} MB (new piece)`)
         }
-    } else if (r.heapMB! > ABSOLUTE_LIMIT_MB) {
-        const scope = r.previousMissing ? 'new piece' : 'no previous measurement available'
-        reasons.push(`heap ${r.heapMB!.toFixed(2)} MB > absolute limit ${ABSOLUTE_LIMIT_MB} MB (${scope})`)
+        return { failed: reasons.length > 0, reasons }
+    }
+    const delta = r.heapMB! - r.previousHeapMB!
+    if (delta > DELTA_LIMIT_MB) {
+        reasons.push(`heap grew +${delta.toFixed(2)} MB vs ${r.previousVersion} (${r.previousHeapMB!.toFixed(2)} → ${r.heapMB!.toFixed(2)} MB); allowed +${DELTA_LIMIT_MB} MB`)
     }
     return { failed: reasons.length > 0, reasons }
 }
@@ -136,31 +141,24 @@ async function main(): Promise<void> {
     }
 
     let failed = 0
-    let errored = 0
     for (const r of results) {
         const v = verdict(r)
-        if (!r.ok) errored++
-        else if (v.failed) failed++
-        const tag = !r.ok ? 'ERR ' : v.failed ? 'FAIL' : 'ok  '
+        if (v.failed) failed++
+        const tag = v.failed ? 'FAIL' : 'ok  '
         const heap = r.ok ? `${r.heapMB!.toFixed(2)} MB` : '—'
         const prev = r.previousHeapMB !== undefined
             ? `  (prev ${r.previousVersion}: ${r.previousHeapMB.toFixed(2)} MB)`
             : r.previousMissing
                 ? '  (new piece, never published)'
-                : r.previousError
-                    ? `  (prev unavailable: ${r.previousError})`
-                    : ''
+                : ''
         console.info(`  [${tag}] ${r.name.padEnd(46)} ${heap.padStart(10)}${prev}`)
-        if (!r.ok) {
-            console.info(`         └─ ${r.error}`)
-        }
         for (const reason of v.reasons) {
-            if (r.ok) console.info(`         └─ ${reason}`)
+            console.info(`         └─ ${reason}`)
         }
     }
 
     console.info('')
-    console.info(`[checkPiecesHeap] measured=${results.length - errored}  failed=${failed}  errors=${errored}`)
+    console.info(`[checkPiecesHeap] checked=${results.length}  failed=${failed}`)
 
     if (failed > 0) {
         console.info(`\nTo bypass this check on a PR, apply the "${SKIP_LABEL}" label. Only use it when you understand the cost.`)

--- a/tools/scripts/pieces/check-pieces-heap.ts
+++ b/tools/scripts/pieces/check-pieces-heap.ts
@@ -1,0 +1,189 @@
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+import { spawnSync } from 'node:child_process'
+import { chunk } from '@activepieces/core-utils'
+import { findAllPiecesDirectoryInSource } from '../utils/piece-script-utils'
+import { preparePieceDistForPublish } from '../../../packages/cli/src/lib/utils/prepare-piece-utils'
+import { readPackageJson } from '../utils/files'
+
+async function bundleIfNeeded(piecePath: string): Promise<void> {
+    const bundleEntry = join(piecePath, 'dist', 'index.bundle.js')
+    if (existsSync(bundleEntry)) {
+        return
+    }
+    await preparePieceDistForPublish(piecePath)
+}
+
+function runNode(args: string[], cwd: string, timeoutMs: number): { status: number | null; stdout: string; stderr: string } {
+    const r = spawnSync('node', args, { cwd, timeout: timeoutMs, encoding: 'utf-8' })
+    return { status: r.status, stdout: r.stdout, stderr: r.stderr }
+}
+
+function installIntoScratch(spec: string, scratch: string, timeoutMs: number): { ok: boolean; error?: string } {
+    writeFileSync(join(scratch, 'package.json'), JSON.stringify({ name: 'ap-heap-probe', version: '0.0.0', private: true }))
+    const install = spawnSync('npm', [
+        'install', spec,
+        '--no-audit', '--no-fund', '--no-save',
+        '--prefer-offline', '--production', '--force',
+        '--loglevel=error',
+    ], { cwd: scratch, timeout: timeoutMs, encoding: 'utf-8' })
+    if (install.status !== 0) {
+        return { ok: false, error: 'install-failed: ' + (install.stderr || install.stdout || '').slice(0, 240) }
+    }
+    return { ok: true }
+}
+
+function measureFromNodeModules(scratch: string, pkgName: string): { ok: boolean; heapMB?: number; error?: string } {
+    const distFolder = join(scratch, 'node_modules', pkgName)
+    if (!existsSync(distFolder)) {
+        return { ok: false, error: `piece dir missing from scratch node_modules: ${distFolder}` }
+    }
+    const measure = runNode(['--expose-gc', resolve(__dirname, 'heap-check-child.mjs'), distFolder], scratch, 90_000)
+    if (measure.status !== 0) {
+        return { ok: false, error: 'child-crashed: ' + (measure.stderr || '').slice(0, 240) }
+    }
+    const line = measure.stdout.trim().split('\n').pop() ?? ''
+    const parsed = JSON.parse(line) as { heapDeltaBytes?: number; error?: string }
+    if (parsed.error) return { ok: false, error: parsed.error }
+    return { ok: true, heapMB: parsed.heapDeltaBytes! / 1e6 }
+}
+
+function measurePreviousPublished(pkgName: string): { ok: boolean; heapMB?: number; version?: string; error?: string; missing?: boolean } {
+    const view = spawnSync('npm', ['view', pkgName, 'version', '--json'], { timeout: 60_000, encoding: 'utf-8' })
+    if (view.status !== 0) {
+        const stderr = (view.stderr || '').toString()
+        if (stderr.includes('E404')) {
+            return { ok: true, missing: true }
+        }
+        return { ok: false, error: 'npm-view-failed: ' + stderr.slice(0, 240) }
+    }
+    const version = JSON.parse(view.stdout.trim()) as string
+
+    const scratch = mkdtempSync(join(tmpdir(), 'ap-heap-prev-'))
+    try {
+        const install = installIntoScratch(`${pkgName}@${version}`, scratch, 5 * 60_000)
+        if (!install.ok) return { ok: false, error: install.error, version }
+        const m = measureFromNodeModules(scratch, pkgName)
+        return { ...m, version }
+    } finally {
+        rmSync(scratch, { recursive: true, force: true })
+    }
+}
+
+async function measureCurrent(piecePath: string, pkgName: string): Promise<{ ok: boolean; heapMB?: number; error?: string }> {
+    await bundleIfNeeded(piecePath)
+    const distPath = resolve(piecePath, 'dist')
+    const scratch = mkdtempSync(join(tmpdir(), 'ap-heap-cur-'))
+    try {
+        const install = installIntoScratch(`file:${distPath}`, scratch, 5 * 60_000)
+        if (!install.ok) return { ok: false, error: install.error }
+        return measureFromNodeModules(scratch, pkgName)
+    } finally {
+        rmSync(scratch, { recursive: true, force: true })
+    }
+}
+
+async function checkOne(piecePath: string): Promise<PieceHeapResult> {
+    const pkg = await readPackageJson(piecePath)
+    const [current, prev] = await Promise.all([
+        measureCurrent(piecePath, pkg.name),
+        Promise.resolve(measurePreviousPublished(pkg.name)),
+    ])
+    if (!current.ok) {
+        return { name: pkg.name, ok: false, error: `current: ${current.error}` }
+    }
+    return {
+        name: pkg.name,
+        ok: true,
+        heapMB: current.heapMB!,
+        previousHeapMB: prev.ok && !prev.missing ? prev.heapMB : undefined,
+        previousVersion: prev.version,
+        previousMissing: prev.missing === true,
+        previousError: !prev.ok ? prev.error : undefined,
+    }
+}
+
+function verdict(r: PieceHeapResult): { failed: boolean; reasons: string[] } {
+    const reasons: string[] = []
+    if (!r.ok) {
+        reasons.push(r.error ?? 'unknown-error')
+        return { failed: false, reasons }
+    }
+    if (r.previousHeapMB !== undefined) {
+        const delta = r.heapMB! - r.previousHeapMB
+        if (delta > DELTA_LIMIT_MB) {
+            reasons.push(`heap grew +${delta.toFixed(2)} MB vs ${r.previousVersion} (${r.previousHeapMB.toFixed(2)} → ${r.heapMB!.toFixed(2)} MB); allowed +${DELTA_LIMIT_MB} MB`)
+        }
+    } else if (r.heapMB! > ABSOLUTE_LIMIT_MB) {
+        const scope = r.previousMissing ? 'new piece' : 'no previous measurement available'
+        reasons.push(`heap ${r.heapMB!.toFixed(2)} MB > absolute limit ${ABSOLUTE_LIMIT_MB} MB (${scope})`)
+    }
+    return { failed: reasons.length > 0, reasons }
+}
+
+async function main(): Promise<void> {
+    const changed = process.env['CHANGED_PIECES']
+    const piecePaths = changed
+        ? changed.split('\n').filter(Boolean)
+        : await findAllPiecesDirectoryInSource()
+
+    console.info(`[checkPiecesHeap] checking ${piecePaths.length} piece(s)${changed ? ' (scoped to changed)' : ' (all)'}  new pieces: heap <= ${ABSOLUTE_LIMIT_MB} MB  existing pieces: delta <= +${DELTA_LIMIT_MB} MB vs latest published`)
+
+    const results: PieceHeapResult[] = []
+    for (const batch of chunk(piecePaths, 3)) {
+        results.push(...await Promise.all(batch.map(checkOne)))
+    }
+
+    let failed = 0
+    let errored = 0
+    for (const r of results) {
+        const v = verdict(r)
+        if (!r.ok) errored++
+        else if (v.failed) failed++
+        const tag = !r.ok ? 'ERR ' : v.failed ? 'FAIL' : 'ok  '
+        const heap = r.ok ? `${r.heapMB!.toFixed(2)} MB` : '—'
+        const prev = r.previousHeapMB !== undefined
+            ? `  (prev ${r.previousVersion}: ${r.previousHeapMB.toFixed(2)} MB)`
+            : r.previousMissing
+                ? '  (new piece, never published)'
+                : r.previousError
+                    ? `  (prev unavailable: ${r.previousError})`
+                    : ''
+        console.info(`  [${tag}] ${r.name.padEnd(46)} ${heap.padStart(10)}${prev}`)
+        if (!r.ok) {
+            console.info(`         └─ ${r.error}`)
+        }
+        for (const reason of v.reasons) {
+            if (r.ok) console.info(`         └─ ${reason}`)
+        }
+    }
+
+    console.info('')
+    console.info(`[checkPiecesHeap] measured=${results.length - errored}  failed=${failed}  errors=${errored}`)
+
+    if (failed > 0) {
+        console.info(`\nTo bypass this check on a PR, apply the "${SKIP_LABEL}" label. Only use it when you understand the cost.`)
+        process.exit(1)
+    }
+}
+
+const ABSOLUTE_LIMIT_MB = Number(process.env['PIECE_HEAP_ABSOLUTE_MB'] ?? '10')
+const DELTA_LIMIT_MB = Number(process.env['PIECE_HEAP_DELTA_MB'] ?? '2')
+const SKIP_LABEL = 'skip-heap-check'
+
+type PieceHeapResult = {
+    name: string
+    ok: boolean
+    heapMB?: number
+    previousHeapMB?: number
+    previousVersion?: string
+    previousMissing?: boolean
+    previousError?: string
+    error?: string
+}
+
+main().catch(err => {
+    console.error(err)
+    process.exit(2)
+})

--- a/tools/scripts/pieces/heap-check-child.mjs
+++ b/tools/scripts/pieces/heap-check-child.mjs
@@ -1,0 +1,40 @@
+import { createRequire } from 'node:module'
+import { resolve } from 'node:path'
+
+const distFolder = process.argv[2]
+if (!distFolder) {
+    console.error('[heap-check-child] missing dist folder argv')
+    process.exit(2)
+}
+
+if (typeof global.gc !== 'function') {
+    console.error('[heap-check-child] run with --expose-gc')
+    process.exit(2)
+}
+
+const pkg = createRequire(import.meta.url)(resolve(distFolder, 'package.json'))
+const entryRel = pkg.main ?? 'index.js'
+const entry = resolve(distFolder, entryRel)
+
+const require = createRequire(import.meta.url)
+
+global.gc()
+const before = process.memoryUsage()
+const t0 = process.hrtime.bigint()
+try {
+    require(entry)
+} catch (e) {
+    console.log(JSON.stringify({ error: String(e).split('\n')[0].slice(0, 240) }))
+    process.exit(0)
+}
+const t1 = process.hrtime.bigint()
+global.gc()
+const after = process.memoryUsage()
+
+console.log(JSON.stringify({
+    heapDeltaBytes: after.heapUsed - before.heapUsed,
+    heapAfterBytes: after.heapUsed,
+    rssDeltaBytes: after.rss - before.rss,
+    externalDeltaBytes: after.external - before.external,
+    requireMs: Number(t1 - t0) / 1e6,
+}))


### PR DESCRIPTION
## Summary

Adds a CI heap-usage check for pieces that runs on PRs modifying \`packages/pieces/**\`, gating merges on heap-on-require of the built piece bundle.

**Rules:**
- **New piece** (no npm history) — fail if heap-on-require > **10 MB**.
- **Existing piece** — fail if \`new_heap − previously_published_heap > +2 MB\`. Absolute cap does not apply — pieces that are already heavy can stay heavy, they just cannot grow.
- **Bypass** — apply the \`skip-heap-check\` label to the PR.
- **Measurement error** (current build install/require fails, or baseline of an existing piece cannot be measured) — fails with \"cannot verify\", since neither the delta nor absolute policy is safe without both numbers.

Thresholds overridable via \`PIECE_HEAP_ABSOLUTE_MB\` and \`PIECE_HEAP_DELTA_MB\` env.

## Why

The 2026-06 regression: a shared workspace-package bump inflated every piece's heap-on-require from ~60 MB to ~175 MB. Five pre-fix Google pieces loaded together OOM'd a 512 MB sandbox process (reproduced locally — google-sheets alone crossed 217 MB, the process died on the 4th piece with \`Ineffective mark-compacts near heap limit\`). A delta check against the previously-published version catches this class of regression at PR time without needing a maintained allow-list.

## How

- \`tools/scripts/pieces/check-pieces-heap.ts\` — parent, iterates changed pieces from the existing \`find-changed-pieces.ts\`, spawns one plain-Node child per piece for isolation.
- \`tools/scripts/pieces/heap-check-child.mjs\` — child: cold \`require()\` the bundle in a fresh \`node --expose-gc\` process, reports heap delta post-GC. Fresh process because ts-node loader in the parent would pollute measurement.
- \`.github/workflows/validate-publishable-packages.yml\` — three new steps: find changed → \`turbo run build\` → run the check. Check step is gated on \`!contains(github.event.pull_request.labels.*.name, 'skip-heap-check')\`.

## Test plan

Verified locally by pointing \`CHANGED_PIECES\` at real piece dirs:

| Piece | Prev on npm | Current build | Delta | Rule | Verdict |
|---|---|---|---|---|---|
| piece-qrcode | 0.0.18 · 1.88 MB | 3.17 MB | +1.29 | existing → delta | ok (under +2 MB) |
| piece-hubspot | 0.9.0 · 15.92 MB | 14.55 MB | -1.37 | existing → delta | ok |
| piece-hubspot (earlier 3 MB flat cap variant) | — | 14.55 MB | — | flat cap | fail, exit 1 |

This PR itself doesn't modify any piece, so the new CI step will report \"No changed pieces found\" here. First real exercise happens on the next PR that touches \`packages/pieces/**\`.

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)