### PR TITLE
feat: human input UI

### DIFF
--- a/packages/pieces/core/forms/package.json
+++ b/packages/pieces/core/forms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-forms",
-  "version": "0.4.21",
+  "version": "0.4.22",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {

--- a/packages/pieces/core/forms/src/lib/actions/return-response.ts
+++ b/packages/pieces/core/forms/src/lib/actions/return-response.ts
@@ -9,12 +9,13 @@ export const returnResponse = createAction({
   name: 'return_response',
   classification: 'WRITE',
   displayName: 'Respond on UI',
-  description: 'Return a file or text (markdown) as a response.',
+  description: 'Send text or a file back to the person waiting.',
   aiMetadata: { description: 'Sends markdown text and/or one file attachment back to the person waiting on the Web Form or Chat UI trigger that started the flow. Pick it as the replying step when that trigger has "Wait for Response" enabled; it produces nothing visible in flows started any other way. Not idempotent: each call emits a response to the waiting caller and stores a new file for any attachment.', idempotent: false },
   props: {
     markdown: Property.LongText({
       displayName: 'Text',
       description: 'Shown to the person waiting. Markdown is supported.',
+      placeholder: 'Thanks, we received your request.',
       required: false,
     }),
     file: Property.File({

--- a/packages/pieces/core/forms/src/lib/actions/return-response.ts
+++ b/packages/pieces/core/forms/src/lib/actions/return-response.ts
@@ -13,11 +13,13 @@ export const returnResponse = createAction({
   aiMetadata: { description: 'Sends markdown text and/or one file attachment back to the person waiting on the Web Form or Chat UI trigger that started the flow. Pick it as the replying step when that trigger has "Wait for Response" enabled; it produces nothing visible in flows started any other way. Not idempotent: each call emits a response to the waiting caller and stores a new file for any attachment.', idempotent: false },
   props: {
     markdown: Property.LongText({
-      displayName: 'Text (Markdown)',
+      displayName: 'Text',
+      description: 'Shown to the person waiting. Markdown is supported.',
       required: false,
     }),
     file: Property.File({
       displayName: 'Attachment',
+      description: 'A file the person can download with the response.',
       required: false,
     }),
   },

--- a/packages/pieces/core/forms/src/lib/actions/return-response.ts
+++ b/packages/pieces/core/forms/src/lib/actions/return-response.ts
@@ -9,7 +9,7 @@ export const returnResponse = createAction({
   name: 'return_response',
   classification: 'WRITE',
   displayName: 'Respond on UI',
-  description: 'Send text or a file back to the person waiting.',
+  description: 'Return a file or text (markdown) as a response.',
   aiMetadata: { description: 'Sends markdown text and/or one file attachment back to the person waiting on the Web Form or Chat UI trigger that started the flow. Pick it as the replying step when that trigger has "Wait for Response" enabled; it produces nothing visible in flows started any other way. Not idempotent: each call emits a response to the waiting caller and stores a new file for any attachment.', idempotent: false },
   props: {
     markdown: Property.LongText({

--- a/packages/pieces/core/forms/src/lib/triggers/chat-trigger.ts
+++ b/packages/pieces/core/forms/src/lib/triggers/chat-trigger.ts
@@ -10,7 +10,8 @@ import {
 } from '@activepieces/pieces-framework';
 import { chatSubmissionTriggerOutputSchema } from '../output-schemas';
 
-const responseMarkdown = `The sender waits for a **Respond on UI** step in this flow.`;
+const responseMarkdown = `The sender waits for a **Respond on UI** step in this flow.
+Without one, they see an error after {{webhookTimeoutSeconds}} seconds.`;
 
 const markdown = `**Published Chat URL:**
 \`\`\`text

--- a/packages/pieces/core/forms/src/lib/triggers/chat-trigger.ts
+++ b/packages/pieces/core/forms/src/lib/triggers/chat-trigger.ts
@@ -10,17 +10,19 @@ import {
 } from '@activepieces/pieces-framework';
 import { chatSubmissionTriggerOutputSchema } from '../output-schemas';
 
-const responseMarkdown = `
-This trigger sets up a chat interface. Ensure that **Respond on UI** is used in your flow`;
+const responseMarkdown = `Add a **Respond on UI** step to your flow to reply to the chat. Without it, the sender gets no answer.`;
 
-const markdown = `
-**Published Chat URL:**
+const markdown = `**Published Chat URL:**
 \`\`\`text
 {{chatUrl}}
 \`\`\`
 Use this for production, views the published version of the chat flow.
-<br>
-<br>
+
+**Draft Chat URL:**
+\`\`\`text
+{{chatUrl}}?${USE_DRAFT_QUERY_PARAM_NAME}=true
+\`\`\`
+Use this to try the chat before publishing, views the draft version (the one you are editing now). You can also press **Test Flow** in the builder to chat with the draft in a side panel.
 `;
 
 export const onChatSubmission = createTrigger({
@@ -42,7 +44,7 @@ export const onChatSubmission = createTrigger({
     }),
     botName: Property.ShortText({
       displayName: 'Bot Name',
-      description: 'The name of the chatbot',
+      description: 'Shown in the greeting above the chat box.',
       required: true,
       defaultValue: 'AI Bot',
     }),

--- a/packages/pieces/core/forms/src/lib/triggers/chat-trigger.ts
+++ b/packages/pieces/core/forms/src/lib/triggers/chat-trigger.ts
@@ -10,7 +10,7 @@ import {
 } from '@activepieces/pieces-framework';
 import { chatSubmissionTriggerOutputSchema } from '../output-schemas';
 
-const responseMarkdown = `Needs a **Respond on UI** step to reply to the sender.`;
+const responseMarkdown = `The sender waits for a **Respond on UI** step in this flow.`;
 
 const markdown = `**Published Chat URL:**
 \`\`\`text
@@ -41,7 +41,7 @@ export const onChatSubmission = createTrigger({
     }),
     responseMarkdown: Property.MarkDown({
       value: responseMarkdown,
-      variant: MarkdownVariant.WARNING,
+      variant: MarkdownVariant.INFO,
     }),
     botName: Property.ShortText({
       displayName: 'Bot Name',

--- a/packages/pieces/core/forms/src/lib/triggers/chat-trigger.ts
+++ b/packages/pieces/core/forms/src/lib/triggers/chat-trigger.ts
@@ -10,19 +10,20 @@ import {
 } from '@activepieces/pieces-framework';
 import { chatSubmissionTriggerOutputSchema } from '../output-schemas';
 
-const responseMarkdown = `Add a **Respond on UI** step to your flow to reply to the chat. Without it, the sender sees an error once the request times out.`;
+const responseMarkdown = `Needs a **Respond on UI** step to reply to the sender.`;
 
 const markdown = `**Published Chat URL:**
 \`\`\`text
 {{chatUrl}}
 \`\`\`
-Use this for production, views the published version of the chat flow.
+Production link. Serves the published version of the chat.
 
 **Draft Chat URL:**
 \`\`\`text
 {{chatUrl}}?${USE_DRAFT_QUERY_PARAM_NAME}=true
 \`\`\`
-Opens the draft (the version you are editing now) so you can try the chat before publishing. You can also press **Open Chat** in the builder to chat with the draft in a side panel.
+Testing link. Serves the draft you are editing now.
+Or press **Open Chat** in the builder to try it in a side panel.
 `;
 
 export const onChatSubmission = createTrigger({

--- a/packages/pieces/core/forms/src/lib/triggers/chat-trigger.ts
+++ b/packages/pieces/core/forms/src/lib/triggers/chat-trigger.ts
@@ -22,7 +22,7 @@ Use this for production, views the published version of the chat flow.
 \`\`\`text
 {{chatUrl}}?${USE_DRAFT_QUERY_PARAM_NAME}=true
 \`\`\`
-Opens the draft (the version you are editing now) so you can try the chat before publishing. Same link with \`?${USE_DRAFT_QUERY_PARAM_NAME}=true\` on the end. You can also press **Open Chat** in the builder to chat with the draft in a side panel.
+Opens the draft (the version you are editing now) so you can try the chat before publishing. You can also press **Open Chat** in the builder to chat with the draft in a side panel.
 `;
 
 export const onChatSubmission = createTrigger({

--- a/packages/pieces/core/forms/src/lib/triggers/chat-trigger.ts
+++ b/packages/pieces/core/forms/src/lib/triggers/chat-trigger.ts
@@ -22,7 +22,7 @@ Use this for production, views the published version of the chat flow.
 \`\`\`text
 {{chatUrl}}?${USE_DRAFT_QUERY_PARAM_NAME}=true
 \`\`\`
-Use this to try the chat before publishing, views the draft version (the one you are editing now). You can also press **Test Flow** in the builder to chat with the draft in a side panel.
+Opens the draft (the version you are editing now) so you can try the chat before publishing. Same link with \`?${USE_DRAFT_QUERY_PARAM_NAME}=true\` on the end. You can also press **Test Flow** in the builder to chat with the draft in a side panel.
 `;
 
 export const onChatSubmission = createTrigger({

--- a/packages/pieces/core/forms/src/lib/triggers/chat-trigger.ts
+++ b/packages/pieces/core/forms/src/lib/triggers/chat-trigger.ts
@@ -10,7 +10,7 @@ import {
 } from '@activepieces/pieces-framework';
 import { chatSubmissionTriggerOutputSchema } from '../output-schemas';
 
-const responseMarkdown = `Add a **Respond on UI** step to your flow to reply to the chat. Without it, the sender gets no answer.`;
+const responseMarkdown = `Add a **Respond on UI** step to your flow to reply to the chat. Without it, the sender sees an error once the request times out.`;
 
 const markdown = `**Published Chat URL:**
 \`\`\`text
@@ -22,7 +22,7 @@ Use this for production, views the published version of the chat flow.
 \`\`\`text
 {{chatUrl}}?${USE_DRAFT_QUERY_PARAM_NAME}=true
 \`\`\`
-Opens the draft (the version you are editing now) so you can try the chat before publishing. Same link with \`?${USE_DRAFT_QUERY_PARAM_NAME}=true\` on the end. You can also press **Test Flow** in the builder to chat with the draft in a side panel.
+Opens the draft (the version you are editing now) so you can try the chat before publishing. Same link with \`?${USE_DRAFT_QUERY_PARAM_NAME}=true\` on the end. You can also press **Open Chat** in the builder to chat with the draft in a side panel.
 `;
 
 export const onChatSubmission = createTrigger({

--- a/packages/pieces/core/forms/src/lib/triggers/form-trigger.ts
+++ b/packages/pieces/core/forms/src/lib/triggers/form-trigger.ts
@@ -20,9 +20,9 @@ Use this for production, views the published version of the form.
 \`\`\`text
 {{formUrl}}?${USE_DRAFT_QUERY_PARAM_NAME}=true
 \`\`\`
-Use this to generate sample data, views the draft version of the form (the one you are editing now).
+Use this to generate sample data, views the draft version of the form (the one you are editing now). Same link with \`?${USE_DRAFT_QUERY_PARAM_NAME}=true\` on the end.
 `;
-const responseMarkdown = `Add a **Respond on UI** step to your flow to send a response back to the form. Without it, the submitter waits until the flow finishes and sees nothing.`;
+const responseMarkdown = `When **Wait for Response** is on, add a **Respond on UI** step to reply to the submitter. Without one they wait until the flow ends and see nothing.`;
 
 type FormInput = {
   displayName: string;
@@ -59,7 +59,7 @@ export const onFormSubmission = createTrigger({
     }),
     waitForResponse: Property.Checkbox({
       displayName: 'Wait for Response',
-      description: 'Hold the submitter on the form until the flow replies.',
+      description: 'Keeps the submitter on the form until the flow replies.',
       defaultValue: false,
       required: false,
     }),
@@ -69,10 +69,12 @@ export const onFormSubmission = createTrigger({
     }),
     inputs: Property.Array({
       displayName: 'Inputs',
+      description: 'One row per field shown on the form.',
       required: true,
       properties: {
         displayName: Property.ShortText({
           displayName: 'Field Name',
+          placeholder: 'e.g. Email address',
           required: true,
         }),
         type: Property.StaticDropdown({
@@ -89,11 +91,13 @@ export const onFormSubmission = createTrigger({
         }),
         description: Property.ShortText({
           displayName: 'Field Description',
+          placeholder: 'Shown under the field',
           required: false,
         }),
         required: Property.Checkbox({
           displayName: 'Required',
-          required: true,
+          defaultValue: false,
+          required: false,
         }),
       },
     }),

--- a/packages/pieces/core/forms/src/lib/triggers/form-trigger.ts
+++ b/packages/pieces/core/forms/src/lib/triggers/form-trigger.ts
@@ -22,7 +22,8 @@ Production link. Serves the published version of the form.
 \`\`\`
 Testing link. Serves the draft you are editing now.
 `;
-const responseMarkdown = `With **Wait for Response** on, the form waits for a **Respond on UI** step.`;
+const responseMarkdown = `With **Wait for Response** on, the form waits for a **Respond on UI** step.
+Without one, it errors after {{webhookTimeoutSeconds}} seconds.`;
 
 type FormInput = {
   displayName: string;

--- a/packages/pieces/core/forms/src/lib/triggers/form-trigger.ts
+++ b/packages/pieces/core/forms/src/lib/triggers/form-trigger.ts
@@ -15,17 +15,14 @@ const markdown = `**Published Form URL:**
 {{formUrl}}
 \`\`\`
 Use this for production, views the published version of the form.
-<br>
-<br>
+
 **Draft Form URL:**
 \`\`\`text
 {{formUrl}}?${USE_DRAFT_QUERY_PARAM_NAME}=true
 \`\`\`
 Use this to generate sample data, views the draft version of the form (the one you are editing now).
 `;
-const responseMarkdown = `
-If **Wait for Response** is enabled, use **Respond on UI** in your flow to provide a response back to the form.
-`;
+const responseMarkdown = `Add a **Respond on UI** step to your flow to send a response back to the form. Without it, the submitter waits until the flow finishes and sees nothing.`;
 
 type FormInput = {
   displayName: string;
@@ -60,14 +57,15 @@ export const onFormSubmission = createTrigger({
       value: markdown,
       variant: MarkdownVariant.BORDERLESS,
     }),
+    waitForResponse: Property.Checkbox({
+      displayName: 'Wait for Response',
+      description: 'Hold the submitter on the form until the flow replies.',
+      defaultValue: false,
+      required: false,
+    }),
     response: Property.MarkDown({
       value: responseMarkdown,
       variant: MarkdownVariant.WARNING,
-    }),
-    waitForResponse: Property.Checkbox({
-      displayName: 'Wait for Response',
-      defaultValue: false,
-      required: true,
     }),
     inputs: Property.Array({
       displayName: 'Inputs',

--- a/packages/pieces/core/forms/src/lib/triggers/form-trigger.ts
+++ b/packages/pieces/core/forms/src/lib/triggers/form-trigger.ts
@@ -22,7 +22,7 @@ Use this for production, views the published version of the form.
 \`\`\`
 Use this to generate sample data, views the draft version of the form (the one you are editing now). Same link with \`?${USE_DRAFT_QUERY_PARAM_NAME}=true\` on the end.
 `;
-const responseMarkdown = `When **Wait for Response** is on, add a **Respond on UI** step to reply to the submitter. Without one they wait until the flow ends and see nothing.`;
+const responseMarkdown = `When **Wait for Response** is on, add a **Respond on UI** step to reply to the submitter. Without one, the form waits until the request times out and then shows an error.`;
 
 type FormInput = {
   displayName: string;

--- a/packages/pieces/core/forms/src/lib/triggers/form-trigger.ts
+++ b/packages/pieces/core/forms/src/lib/triggers/form-trigger.ts
@@ -22,7 +22,7 @@ Production link. Serves the published version of the form.
 \`\`\`
 Testing link. Serves the draft you are editing now.
 `;
-const responseMarkdown = `Needs a **Respond on UI** step when **Wait for Response** is on.`;
+const responseMarkdown = `With **Wait for Response** on, the form waits for a **Respond on UI** step.`;
 
 type FormInput = {
   displayName: string;
@@ -65,7 +65,7 @@ export const onFormSubmission = createTrigger({
     }),
     response: Property.MarkDown({
       value: responseMarkdown,
-      variant: MarkdownVariant.WARNING,
+      variant: MarkdownVariant.INFO,
     }),
     inputs: Property.Array({
       displayName: 'Inputs',

--- a/packages/pieces/core/forms/src/lib/triggers/form-trigger.ts
+++ b/packages/pieces/core/forms/src/lib/triggers/form-trigger.ts
@@ -14,15 +14,15 @@ const markdown = `**Published Form URL:**
 \`\`\`text
 {{formUrl}}
 \`\`\`
-Use this for production, views the published version of the form.
+Production link. Serves the published version of the form.
 
 **Draft Form URL:**
 \`\`\`text
 {{formUrl}}?${USE_DRAFT_QUERY_PARAM_NAME}=true
 \`\`\`
-Use this to generate sample data, views the draft version of the form (the one you are editing now).
+Testing link. Serves the draft you are editing now.
 `;
-const responseMarkdown = `When **Wait for Response** is on, add a **Respond on UI** step to reply to the submitter. Without one, the form waits until the request times out and then shows an error.`;
+const responseMarkdown = `Needs a **Respond on UI** step when **Wait for Response** is on.`;
 
 type FormInput = {
   displayName: string;

--- a/packages/pieces/core/forms/src/lib/triggers/form-trigger.ts
+++ b/packages/pieces/core/forms/src/lib/triggers/form-trigger.ts
@@ -20,7 +20,7 @@ Use this for production, views the published version of the form.
 \`\`\`text
 {{formUrl}}?${USE_DRAFT_QUERY_PARAM_NAME}=true
 \`\`\`
-Use this to generate sample data, views the draft version of the form (the one you are editing now). Same link with \`?${USE_DRAFT_QUERY_PARAM_NAME}=true\` on the end.
+Use this to generate sample data, views the draft version of the form (the one you are editing now).
 `;
 const responseMarkdown = `When **Wait for Response** is on, add a **Respond on UI** step to reply to the submitter. Without one, the form waits until the request times out and then shows an error.`;
 

--- a/packages/web/src/app/routes/chat/flow-chat.tsx
+++ b/packages/web/src/app/routes/chat/flow-chat.tsx
@@ -5,6 +5,7 @@ import {
 } from '@activepieces/shared';
 import { useMutation, useQuery } from '@tanstack/react-query';
 import { AxiosError } from 'axios';
+import { t } from 'i18next';
 import { nanoid } from 'nanoid';
 import { useEffect, useRef, useState } from 'react';
 
@@ -227,8 +228,7 @@ export function FlowChat({
   return (
     <main
       className={cn(
-        'flex w-full flex-col items-center justify-center pb-6',
-        messages.length > 0 ? 'h-screen' : 'h-screen',
+        'flex h-screen w-full flex-col items-center justify-center pb-6',
         className,
       )}
     >
@@ -249,7 +249,7 @@ export function FlowChat({
               ref={chatInputRef}
               onSendMessage={handleSendMessage}
               disabled={isSending}
-              placeholder="Type your message here..."
+              placeholder={t('Type your message here...')}
             />
           </div>
         </>
@@ -263,7 +263,7 @@ export function FlowChat({
               ref={chatInputRef}
               onSendMessage={handleSendMessage}
               disabled={isSending}
-              placeholder="Type your message here..."
+              placeholder={t('Type your message here...')}
             />
           </div>
         </>

--- a/packages/web/src/app/routes/chat/flow-chat.tsx
+++ b/packages/web/src/app/routes/chat/flow-chat.tsx
@@ -54,20 +54,16 @@ export function FlowChat({
   const messagesRef = useRef<HTMLDivElement>(null);
   const chatInputRef = useRef<HTMLTextAreaElement>(null);
 
+  const useDraft =
+    mode === ChatDrawerSource.TEST_FLOW || mode === ChatDrawerSource.TEST_STEP;
+
   const {
     data: chatUI,
     isLoading,
     isError: isLoadingError,
   } = useQuery<ChatUIResponse | null, Error>({
-    queryKey: ['chat', flowId],
-    queryFn: () =>
-      humanInputApi.getChatUI(
-        flowId,
-        mode === ChatDrawerSource.TEST_FLOW ||
-          mode === ChatDrawerSource.TEST_STEP
-          ? true
-          : false,
-      ),
+    queryKey: ['chat', flowId, useDraft],
+    queryFn: () => humanInputApi.getChatUI(flowId, useDraft),
     enabled: !isNil(flowId),
     staleTime: Infinity,
     retry: false,

--- a/packages/web/src/components/custom/markdown.tsx
+++ b/packages/web/src/components/custom/markdown.tsx
@@ -114,8 +114,8 @@ const ApMarkdown = React.memo(
               const codeContent = String(props.children).trim();
               const isCopying = codeContent === copiedText;
               return (
-                <div className="relative flex w-full items-center gap-1 rounded border border-solid bg-background p-1.5 text-sm">
-                  <code className="grow min-w-0 break-all select-all px-1 py-1.5 font-mono text-sm">
+                <div className="relative flex w-full max-w-full items-center gap-1 rounded border border-solid bg-background p-1.5 text-sm">
+                  <code className="grow min-w-0 whitespace-pre-wrap break-all select-all px-1 py-1.5 font-mono text-sm">
                     {codeContent}
                   </code>
                   <Button

--- a/packages/web/src/components/custom/markdown.tsx
+++ b/packages/web/src/components/custom/markdown.tsx
@@ -114,13 +114,10 @@ const ApMarkdown = React.memo(
               const codeContent = String(props.children).trim();
               const isCopying = codeContent === copiedText;
               return (
-                <div className="relative w-full items-center flex bg-background border border-solid text-sm rounded block w-full gap-1 p-1.5">
-                  <input
-                    type="text"
-                    className="grow bg-background"
-                    value={codeContent}
-                    disabled
-                  />
+                <div className="relative flex w-full items-center gap-1 rounded border border-solid bg-background p-1.5 text-sm">
+                  <code className="grow min-w-0 break-all select-all px-1 py-1.5 font-mono text-sm">
+                    {codeContent}
+                  </code>
                   <Button
                     variant="ghost"
                     className="bg-background rounded p-2 inline-flex items-center justify-center h-8"

--- a/packages/web/src/features/chat/chat-input/index.tsx
+++ b/packages/web/src/features/chat/chat-input/index.tsx
@@ -1,4 +1,5 @@
 import { isNil } from '@activepieces/core-utils';
+import { t } from 'i18next';
 import { ArrowUpIcon, Paperclip } from 'lucide-react';
 import * as React from 'react';
 import { useRef, useState } from 'react';
@@ -27,7 +28,7 @@ const ChatInput = React.forwardRef<HTMLTextAreaElement, ChatInputProps>(
       className,
       onSendMessage,
       disabled = false,
-      placeholder = 'Type your message here...',
+      placeholder = t('Type your message here...'),
       ...props
     },
     ref,

--- a/packages/web/src/features/forms/components/ap-form.tsx
+++ b/packages/web/src/features/forms/components/ap-form.tsx
@@ -138,7 +138,10 @@ const ApForm = ({ form, useDraft }: ApFormProps) => {
   inputs.current.forEach((input) => {
     const queryValue = queryParamsLowerCase[input.name.toLowerCase()];
     if (queryValue !== undefined) {
-      defaultValues[input.name] = queryValue;
+      defaultValues[input.name] =
+        input.type === FormInputType.TOGGLE
+          ? queryValue === 'true'
+          : queryValue;
     }
   });
 

--- a/packages/web/src/features/forms/components/ap-form.tsx
+++ b/packages/web/src/features/forms/components/ap-form.tsx
@@ -31,7 +31,6 @@ import {
   FormMessage,
 } from '@/components/ui/form';
 import { Input } from '@/components/ui/input';
-import { RequiredFieldAsterisk } from '@/components/ui/label';
 import { Separator } from '@/components/ui/separator';
 import { Textarea } from '@/components/ui/textarea';
 import { flagsHooks } from '@/hooks/flags-hooks';
@@ -227,17 +226,15 @@ const ApForm = ({ form, useDraft }: ApFormProps) => {
                                     <Checkbox
                                       id={input.name}
                                       onCheckedChange={(e) => field.onChange(e)}
-                                      checked={field.value as boolean}
+                                      checked={field.value === true}
                                     ></Checkbox>
                                   </FormControl>
                                   <FormLabel
                                     htmlFor={input.name}
                                     className="flex items-center gap-1"
+                                    showRequiredIndicator={input.required}
                                   >
                                     {input.displayName}
-                                    {input.required && (
-                                      <RequiredFieldAsterisk />
-                                    )}
                                   </FormLabel>
                                 </div>
                                 {input.description && (
@@ -253,50 +250,48 @@ const ApForm = ({ form, useDraft }: ApFormProps) => {
                                 <FormLabel
                                   htmlFor={input.name}
                                   className="flex items-center gap-1"
+                                  showRequiredIndicator={input.required}
                                 >
                                   {input.displayName}
-                                  {input.required && <RequiredFieldAsterisk />}
                                 </FormLabel>
-                                <FormControl className="flex flex-col gap-1">
-                                  <>
-                                    {input.type === FormInputType.TEXT_AREA && (
-                                      <Textarea
-                                        {...field}
-                                        name={input.name}
-                                        id={input.name}
-                                        onChange={field.onChange}
-                                        value={
-                                          field.value as string | undefined
+                                {input.type === FormInputType.TEXT_AREA && (
+                                  <FormControl>
+                                    <Textarea
+                                      {...field}
+                                      name={input.name}
+                                      id={input.name}
+                                      onChange={field.onChange}
+                                      value={String(field.value ?? '')}
+                                    />
+                                  </FormControl>
+                                )}
+                                {input.type === FormInputType.TEXT && (
+                                  <FormControl>
+                                    <Input
+                                      {...field}
+                                      onChange={field.onChange}
+                                      id={input.name}
+                                      name={input.name}
+                                      value={String(field.value ?? '')}
+                                    />
+                                  </FormControl>
+                                )}
+                                {input.type === FormInputType.FILE && (
+                                  <FormControl>
+                                    <Input
+                                      name={input.name}
+                                      id={input.name}
+                                      onChange={(e) => {
+                                        const file = e.target.files?.[0];
+                                        if (file) {
+                                          field.onChange(file);
                                         }
-                                      />
-                                    )}
-                                    {input.type === FormInputType.TEXT && (
-                                      <Input
-                                        {...field}
-                                        onChange={field.onChange}
-                                        id={input.name}
-                                        name={input.name}
-                                        value={
-                                          field.value as string | undefined
-                                        }
-                                      />
-                                    )}
-                                    {input.type === FormInputType.FILE && (
-                                      <Input
-                                        name={input.name}
-                                        id={input.name}
-                                        onChange={(e) => {
-                                          const file = e.target.files?.[0];
-                                          if (file) {
-                                            field.onChange(file);
-                                          }
-                                        }}
-                                        placeholder={input.displayName}
-                                        type="file"
-                                      />
-                                    )}
-                                  </>
-                                </FormControl>
+                                      }}
+                                      placeholder={input.displayName}
+                                      type="file"
+                                    />
+                                  </FormControl>
+                                )}
                                 {input.description && (
                                   <ReadMoreDescription
                                     text={input.description}

--- a/packages/web/src/features/forms/components/ap-form.tsx
+++ b/packages/web/src/features/forms/components/ap-form.tsx
@@ -28,8 +28,10 @@ import {
   FormField,
   FormLabel,
   FormItem,
+  FormMessage,
 } from '@/components/ui/form';
 import { Input } from '@/components/ui/input';
+import { RequiredFieldAsterisk } from '@/components/ui/label';
 import { Separator } from '@/components/ui/separator';
 import { Textarea } from '@/components/ui/textarea';
 import { flagsHooks } from '@/hooks/flags-hooks';
@@ -68,7 +70,14 @@ const createPropertySchema = (input: FormInputWithName): ZodType => {
         ? z.string().min(1, t('This field is required'))
         : z.string();
     case FormInputType.FILE:
-      return z.unknown();
+      return input.required
+        ? z
+            .unknown()
+            .refine(
+              (value) => value instanceof File,
+              t('This field is required'),
+            )
+        : z.unknown();
   }
 };
 
@@ -197,7 +206,7 @@ const ApForm = ({ form, useDraft }: ApFormProps) => {
       <div className="container py-20">
         <Form {...reactForm}>
           <form onSubmit={(e) => reactForm.handleSubmit(() => mutate())(e)}>
-            <Card className="w-[500px] mx-auto">
+            <Card className="w-full max-w-[500px] mx-auto">
               <CardHeader>
                 <CardTitle className="text-center">{form?.title}</CardTitle>
               </CardHeader>
@@ -212,33 +221,41 @@ const ApForm = ({ form, useDraft }: ApFormProps) => {
                         render={({ field }) => (
                           <>
                             {input.type === FormInputType.TOGGLE && (
-                              <>
-                                <FormItem className="flex items-center gap-2 h-full">
+                              <FormItem className="flex flex-col gap-1">
+                                <div className="flex items-center gap-2">
                                   <FormControl>
                                     <Checkbox
+                                      id={input.name}
                                       onCheckedChange={(e) => field.onChange(e)}
                                       checked={field.value as boolean}
                                     ></Checkbox>
                                   </FormControl>
                                   <FormLabel
                                     htmlFor={input.name}
-                                    className="flex items-center"
+                                    className="flex items-center gap-1"
                                   >
                                     {input.displayName}
+                                    {input.required && (
+                                      <RequiredFieldAsterisk />
+                                    )}
                                   </FormLabel>
-                                </FormItem>
-                                <ReadMoreDescription
-                                  text={input.description ?? ''}
-                                />
-                              </>
+                                </div>
+                                {input.description && (
+                                  <ReadMoreDescription
+                                    text={input.description}
+                                  />
+                                )}
+                                <FormMessage />
+                              </FormItem>
                             )}
                             {input.type !== FormInputType.TOGGLE && (
                               <FormItem className="flex flex-col gap-1">
                                 <FormLabel
                                   htmlFor={input.name}
-                                  className="flex items-center justify-between"
+                                  className="flex items-center gap-1"
                                 >
-                                  {input.displayName} {input.required && '*'}
+                                  {input.displayName}
+                                  {input.required && <RequiredFieldAsterisk />}
                                 </FormLabel>
                                 <FormControl className="flex flex-col gap-1">
                                   <>
@@ -278,11 +295,14 @@ const ApForm = ({ form, useDraft }: ApFormProps) => {
                                         type="file"
                                       />
                                     )}
-                                    <ReadMoreDescription
-                                      text={input.description ?? ''}
-                                    />
                                   </>
                                 </FormControl>
+                                {input.description && (
+                                  <ReadMoreDescription
+                                    text={input.description}
+                                  />
+                                )}
+                                <FormMessage />
                               </FormItem>
                             )}
                           </>

--- a/packages/web/src/features/forms/components/ap-form.tsx
+++ b/packages/web/src/features/forms/components/ap-form.tsx
@@ -293,7 +293,6 @@ const ApForm = ({ form, useDraft }: ApFormProps) => {
                                           field.onChange(file);
                                         }
                                       }}
-                                      placeholder={input.displayName}
                                       type="file"
                                     />
                                   </FormControl>

--- a/packages/web/src/features/forms/components/ap-form.tsx
+++ b/packages/web/src/features/forms/components/ap-form.tsx
@@ -97,6 +97,9 @@ function buildSchema(inputs: FormInputWithName[]) {
     ),
   };
 }
+const isTruthyQueryValue = (value: string) =>
+  ['true', '1', 'yes', 'on'].includes(value.toLowerCase());
+
 const handleDownloadFile = (fileBase: FileResponseInterface) => {
   const link = document.createElement('a');
   if ('url' in fileBase) {
@@ -140,7 +143,7 @@ const ApForm = ({ form, useDraft }: ApFormProps) => {
     if (queryValue !== undefined) {
       defaultValues[input.name] =
         input.type === FormInputType.TOGGLE
-          ? queryValue === 'true'
+          ? isTruthyQueryValue(queryValue)
           : queryValue;
     }
   });

--- a/packages/web/src/features/forms/hooks/forms-hooks.ts
+++ b/packages/web/src/features/forms/hooks/forms-hooks.ts
@@ -4,13 +4,14 @@ import { useMutation, useQuery } from '@tanstack/react-query';
 import { humanInputApi } from '../api/human-input-api';
 
 export const formsKeys = {
-  form: (flowId: string) => ['form', flowId] as const,
+  form: (flowId: string, useDraft: boolean) =>
+    ['form', flowId, useDraft] as const,
 };
 
 export const formsQueries = {
   useForm: (flowId: string, useDraft: boolean, enabled: boolean) =>
     useQuery<FormResponse | null, Error>({
-      queryKey: formsKeys.form(flowId),
+      queryKey: formsKeys.form(flowId, useDraft),
       queryFn: () => humanInputApi.getForm(flowId, useDraft),
       enabled,
       retry: false,


### PR DESCRIPTION
## Description

UI pass over the **Human Input** piece (`packages/pieces/core/forms`, shown as "Human Input"), the two public pages it generates, and one shared renderer bug the piece made visible.

### Hosted form (`/forms/:flowId`)

`ap-form.tsx` never rendered `FormMessage`, so no zod error ever reached the visitor: pressing **Submit** with an empty required field did nothing at all. It is now rendered under every field, and `FormControl` wraps exactly one input per branch (it used to wrap a Fragment, which meant Radix `Slot` dropped the `aria-describedby` / `aria-invalid` it injects, so the message would have been visual-only).

Also on that page:

- **A required File input was not validated** — `createPropertySchema` returned a bare `z.unknown()` and an empty upload submitted as `""`. It now requires a `File` when the author marked the field required.
- **Clicking a toggle's label did nothing** — no `id` on the `Checkbox` to match `htmlFor`. Added.
- **A toggle prefilled from the query string** arrived as the string `'true'`; it is now coerced (`true`, `1`, `yes`, `on`, any case).
- **Fixed `w-[500px]` card** → `w-full max-w-[500px]` for phones.
- Required marker via `showRequiredIndicator` instead of a literal `'*'`; the toggle branch now shows one too.
- `ReadMoreDescription` is only rendered when a description exists (it emitted an empty `<p>` before). Dead `placeholder` on the `type="file"` input removed.
- **Draft/published cache key**: `formsKeys.form` and the chat `useQuery` keyed on `flowId` alone with `staleTime: Infinity`, so opening the published URL then the draft URL in one session served the published version from cache. Both keys now include the draft flag.

### Shared renderer: ```` ```text ```` blocks in `ApMarkdown`

The block rendered a single-line `<input disabled>`, which clipped anything wider than the step panel and could not be selected. **122 piece files** show a URL this way. Human Input showed two URLs that differ only in a query string past the clipping point, so both boxes read as identical. The value now wraps (`whitespace-pre-wrap`, needed because react-markdown places it inside a `<pre>`) and is selectable; the copy button is unchanged. This is the one product-wide visual change in the PR.

### Config panels

- **Chat UI trigger** documented only the published URL, although the chat page has accepted `?useDraft=true` all along and the builder has an **Open Chat** drawer. The panel now shows the Draft URL and points at the drawer, mirroring the Web Form trigger.
- **Web Form trigger**: the note about Respond on UI sat *above* the `Wait for Response` toggle it describes; it now sits directly under it.
- Both notes were **WARNING** variants phrased as instructions ("use **Respond on UI** in your flow…" / "Ensure that **Respond on UI** is used in your flow"), which read as an error even when the step was already in the flow. They are now **INFO** notes that state what the trigger waits for, plus the consequence with the configured timeout via `{{webhookTimeoutSeconds}}` — the same pattern as the core Webhook trigger. Every line of panel copy is under 70 characters.
- `waitForResponse` and the nested `Required` checkbox were `required: true` with a boolean default — an asterisk on a field that is always answered. Now `required: false, defaultValue: false`. Stored value is unchanged: the builder writes `defaultValue ?? false` for every checkbox regardless of `required`.
- Descriptions and placeholders added where missing: `Inputs`, `Field Name`, `Field Description`, `Bot Name` (replacing "The name of the chatbot"), Respond on UI `Text` and `Attachment`. `Text (Markdown)` → `Text` with the format in the description. All under the 70-character `ReadMoreDescription` fold.
- Raw `<br>` spacing in markdown replaced with blank lines.

### Scope

UI Improvement lane only. No `aiMetadata`, `outputSchema`, `run()`, `classification`, `audience`, or action-level `description` was changed.

### i18n

- Renaming `Text (Markdown)` → `Text` and rewriting the panel copy orphans those Crowdin keys in `packages/pieces/core/forms/src/i18n/*.json` until the nightly `generate-translations.yml` regenerates. Fallback is English. **Locale files are intentionally not edited** — running `i18n:extract` locally produced ~4.5k lines of unrelated drift and was reverted.
- `t('Type your message here...')` (chat input placeholder, previously hardcoded) has no `en` entry yet; same workflow picks it up.
- Required-field message uses `t('This field is required')` to match the existing TEXT branch rather than `formErrors.required`, whose bare key `required` would render worse until translated.

### Deliberately not changed

- `required` for **TOGGLE** is still not enforced — an unticked toggle is a legitimate "no"; enforcing would reject submissions valid today. Product call.
- The `Inputs` label rendering red when empty is correct behaviour (`data-[error=true]`), not a bug.
- `putBackQuotesForInputNames` / payload shape — back-compat, out of scope.
- `waitForResponse` is now `required: false` in the piece while `FormProps` in `core-execution` still says `z.boolean()`; behaviour is identical because the builder always writes a boolean. Tightening the schema belongs to a different lane.
- Hardcoded English in `ChatNotFound`, `ChatIntro`, `ErrorBubble`, and the form's 404 — separate i18n pass.

## How was this tested?

- `npx turbo run build lint --filter=@activepieces/piece-forms --force` — passes, zero lint errors. Piece bumped `0.4.21` → `0.4.22`.
- `bun run typecheck` in `packages/web` — clean.
- ESLint on every changed web file — no new errors. The package-wide run is dominated by pre-existing `linebreak-style` errors from `core.autocrlf=true` on this Windows checkout; root `lint-dev` was not run because `--fix` would rewrite line endings repo-wide.
- Served metadata verified over `/api/v1/pieces/@activepieces/piece-forms` after an API restart: version, labels, descriptions, placeholders, both INFO variants, Draft Chat URL, no `<br>`.
- Manually in the builder: all three panels at 0.4.22; URL boxes wrap and show `?useDraft=true`.


- Reviewed three times by a separate model pass (verify → fix → re-verify); final verdict SHIP.
- Editions: all changes are edition-agnostic — piece metadata, public-page rendering, and one shared component. No `platform.plan` flags, no `ee/` imports.

Fixes # (issue)

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

Reviewer note: the required-File validation is the one behaviour change on already-published forms. It only rejects a submission that leaves a field the author explicitly marked **Required** empty — which every other field type already enforces — so it is treated as a bug fix.

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)