### PR TITLE
fix(bettermode): bump piece version

### DIFF
--- a/packages/pieces/community/bettermode/package.json
+++ b/packages/pieces/community/bettermode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-bettermode",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {


### PR DESCRIPTION
## Description

Bump bettermode piece version to 0.1.9.

## How was this tested?

npm run lint-dev

Fixes # (issue)

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact