### PR TITLE
feat(firecrawl): capture browser action outputs & add storeInCache toggle

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -3167,15 +3167,17 @@
     },
     "packages/pieces/community/firecrawl": {
       "name": "@activepieces/piece-firecrawl",
-      "version": "0.3.14",
+      "version": "0.3.15",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
         "@activepieces/pieces-common": "workspace:*",
         "@activepieces/pieces-framework": "workspace:*",
         "ajv": "8.18.0",
+        "mime-types": "2.1.35",
       },
       "devDependencies": {
+        "@types/mime-types": "2.1.1",
         "tslib": "2.6.2",
       },
     },

--- a/packages/pieces/community/firecrawl/package.json
+++ b/packages/pieces/community/firecrawl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-firecrawl",
-  "version": "0.3.14",
+  "version": "0.3.15",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {

--- a/packages/pieces/community/firecrawl/package.json
+++ b/packages/pieces/community/firecrawl/package.json
@@ -12,10 +12,12 @@
     "@activepieces/pieces-common": "workspace:*",
     "@activepieces/pieces-framework": "workspace:*",
     "ajv": "8.18.0",
+    "mime-types": "2.1.35",
     "@activepieces/core-piece-types": "workspace:*",
     "@activepieces/core-utils": "workspace:*"
   },
   "devDependencies": {
+    "@types/mime-types": "2.1.1",
     "tslib": "2.6.2"
   }
 }

--- a/packages/pieces/community/firecrawl/src/lib/actions/crawl.ts
+++ b/packages/pieces/community/firecrawl/src/lib/actions/crawl.ts
@@ -315,7 +315,7 @@ export const crawl = createAction({
     const result = await polling(jobId, auth.secret_text, timeoutSeconds, 'crawl');
 
     if (propsValue.formats === 'screenshot') {
-      await downloadAndSaveCrawlScreenshots(result, context);
+      result.data = await downloadAndSaveCrawlScreenshots(result, context);
     }
 
     return result;

--- a/packages/pieces/community/firecrawl/src/lib/actions/crawl.ts
+++ b/packages/pieces/community/firecrawl/src/lib/actions/crawl.ts
@@ -1,7 +1,7 @@
 import { createAction, Property, InputPropertyMap } from '@activepieces/pieces-framework';
 import { httpClient, HttpMethod } from '@activepieces/pieces-common';
 import { firecrawlAuth } from '../auth';
-import { forScreenshotOutputFormat, forSimpleOutputFormat, forJsonOutputFormat, polling, downloadAndSaveCrawlScreenshots, FIRECRAWL_API_BASE_URL } from '../common/common';
+import { forScreenshotOutputFormat, forSimpleOutputFormat, forJsonOutputFormat, polling, saveFirecrawlFile, FIRECRAWL_API_BASE_URL } from '../common/common';
 import { crawlWebsiteActionOutputSchema } from '../output-schemas';
 
 function webhookConfig(useWebhook: boolean, webhookProperties: any): any {
@@ -314,8 +314,14 @@ export const crawl = createAction({
     const timeoutSeconds = propsValue.timeout || 300;
     const result = await polling(jobId, auth.secret_text, timeoutSeconds, 'crawl');
 
-    if (propsValue.formats === 'screenshot') {
-      result.data = await downloadAndSaveCrawlScreenshots(result, context);
+    if (propsValue.formats === 'screenshot' && Array.isArray(result.data)) {
+      result.data = await Promise.all(
+        result.data.map(async (page: any) =>
+          page.screenshot
+            ? { ...page, screenshot: await saveFirecrawlFile(context, page.screenshot) }
+            : page
+        )
+      );
     }
 
     return result;

--- a/packages/pieces/community/firecrawl/src/lib/actions/scrape-url.ts
+++ b/packages/pieces/community/firecrawl/src/lib/actions/scrape-url.ts
@@ -86,7 +86,7 @@ export const scrapeUrl = createAction({
 
       const result = response.body;
       if (format === 'screenshot' && result?.data?.screenshot) {
-        await downloadAndSaveScreenshot(result.data, context);
+        result.data.screenshot = await downloadAndSaveScreenshot(result.data, context);
       }
       return result;
     } catch (error: any) {

--- a/packages/pieces/community/firecrawl/src/lib/actions/scrape-url.ts
+++ b/packages/pieces/community/firecrawl/src/lib/actions/scrape-url.ts
@@ -1,7 +1,7 @@
 import { createAction, Property } from '@activepieces/pieces-framework';
 import { httpClient, HttpMethod } from '@activepieces/pieces-common';
 import { firecrawlAuth } from '../auth';
-import { downloadAndSaveScreenshot, FIRECRAWL_API_BASE_URL } from '../common/common';
+import { saveFirecrawlFile, FIRECRAWL_API_BASE_URL } from '../common/common';
 import { scrapeUrlActionOutputSchema } from '../output-schemas';
 
 export const scrapeUrl = createAction({
@@ -86,7 +86,7 @@ export const scrapeUrl = createAction({
 
       const result = response.body;
       if (format === 'screenshot' && result?.data?.screenshot) {
-        result.data.screenshot = await downloadAndSaveScreenshot(result.data, context);
+        result.data.screenshot = await saveFirecrawlFile(context, result.data.screenshot);
       }
       return result;
     } catch (error: any) {

--- a/packages/pieces/community/firecrawl/src/lib/actions/scrape.ts
+++ b/packages/pieces/community/firecrawl/src/lib/actions/scrape.ts
@@ -308,6 +308,7 @@ export const scrape = createAction({
       )
     );
     const javascriptReturns = result.data.actions?.javascriptReturns ?? [];
+    const scrapes = result.data.actions?.scrapes ?? [];
 
     result.data = {
       screenshot: savedScreenshot,
@@ -316,6 +317,7 @@ export const scrape = createAction({
         pdfs: savedPdfs,
         screenshots: savedActionScreenshots,
         javascriptReturns,
+        scrapes,
       },
       metadata: result.data.metadata
     };

--- a/packages/pieces/community/firecrawl/src/lib/actions/scrape.ts
+++ b/packages/pieces/community/firecrawl/src/lib/actions/scrape.ts
@@ -1,7 +1,7 @@
 import { createAction, Property, InputPropertyMap } from '@activepieces/pieces-framework';
 import { httpClient, HttpMethod } from '@activepieces/pieces-common';
 import { firecrawlAuth } from '../auth';
-import { forScreenshotOutputFormat, forSimpleOutputFormat, downloadAndSaveScreenshot, forJsonOutputFormat, FIRECRAWL_API_BASE_URL } from '../common/common';
+import { forScreenshotOutputFormat, forSimpleOutputFormat, downloadAndSaveScreenshot, downloadAndSavePdfs,forJsonOutputFormat, FIRECRAWL_API_BASE_URL } from '../common/common';
 import { scrapeUrlActionOutputSchema } from '../output-schemas';
 
 function forDefaultScreenshot(): any {
@@ -101,7 +101,8 @@ export const scrape = createAction({
             { label: 'Links', value: 'links' },
             { label: 'Images', value: 'images' },
             { label: 'Screenshot', value: 'screenshot' },
-            { label: 'JSON', value: 'json' }
+            { label: 'JSON', value: 'json' },
+            { label: 'PDF', value: 'pdf' }
           ]
         };
       },
@@ -274,6 +275,8 @@ export const scrape = createAction({
         prompt: jsonFormat.prompt,
         schema: jsonFormat.schema
       });
+    } else if (format === 'pdf') {
+      body['actions'] = [...(body['actions'] || []), { type: 'pdf', format: 'A4' }];
     } else {
       const simpleFormat = forSimpleOutputFormat(format);
       formatsArray.push(simpleFormat);
@@ -297,11 +300,13 @@ export const scrape = createAction({
 
     const result = response.body;
     await downloadAndSaveScreenshot(result.data, context);
+    const savedPdfs = await downloadAndSavePdfs(result.data, context);
 
     // reorder the data object to put screenshot first, then user's selected format only
     result.data = {
       screenshot: result.data.screenshot,
       [format]: result.data[format],
+      pdfs: savedPdfs,
       metadata: result.data.metadata
     };
 

--- a/packages/pieces/community/firecrawl/src/lib/actions/scrape.ts
+++ b/packages/pieces/community/firecrawl/src/lib/actions/scrape.ts
@@ -299,13 +299,13 @@ export const scrape = createAction({
     });
 
     const result = response.body;
-    await downloadAndSaveScreenshot(result.data, context);
+    const savedScreenshot = await downloadAndSaveScreenshot(result.data, context);
     const savedPdfs = await downloadAndSavePdfs(result.data, context);
 
     // reorder the data object to put screenshot first, then user's selected format only
     result.data = {
-      screenshot: result.data.screenshot,
-      [format]: result.data[format],
+      screenshot: savedScreenshot,
+      ...(format !== 'screenshot' && { [format]: result.data[format] }),
       pdfs: savedPdfs,
       metadata: result.data.metadata
     };

--- a/packages/pieces/community/firecrawl/src/lib/actions/scrape.ts
+++ b/packages/pieces/community/firecrawl/src/lib/actions/scrape.ts
@@ -307,6 +307,7 @@ export const scrape = createAction({
         downloadAndSaveScreenshot({ screenshot: url }, context)
       )
     );
+    const javascriptReturns = result.data.actions?.javascriptReturns ?? [];
 
     result.data = {
       screenshot: savedScreenshot,
@@ -314,6 +315,7 @@ export const scrape = createAction({
       actions: {
         pdfs: savedPdfs,
         screenshots: savedActionScreenshots,
+        javascriptReturns,
       },
       metadata: result.data.metadata
     };

--- a/packages/pieces/community/firecrawl/src/lib/actions/scrape.ts
+++ b/packages/pieces/community/firecrawl/src/lib/actions/scrape.ts
@@ -310,18 +310,24 @@ export const scrape = createAction({
     const javascriptReturns = result.data.actions?.javascriptReturns ?? [];
     const scrapes = result.data.actions?.scrapes ?? [];
 
-    result.data = {
-      screenshot: savedScreenshot,
-      ...(format !== 'screenshot' && { [format]: result.data[format] }),
-      actions: {
-        pdfs: savedPdfs,
-        screenshots: savedActionScreenshots,
-        javascriptReturns,
-        scrapes,
+    const output: { success: boolean; data: Record<string, unknown> } = {
+      success: result.success,
+      data: {
+        screenshot: savedScreenshot,
+        actions: {
+          pdfs: savedPdfs,
+          screenshots: savedActionScreenshots,
+          javascriptReturns,
+          scrapes,
+        },
+        metadata: result.data.metadata,
       },
-      metadata: result.data.metadata
     };
 
-    return result;
+    if (format !== 'screenshot') {
+      output.data[format] = result.data[format];
+    }
+
+    return output;
   },
 }); 

--- a/packages/pieces/community/firecrawl/src/lib/actions/scrape.ts
+++ b/packages/pieces/community/firecrawl/src/lib/actions/scrape.ts
@@ -32,6 +32,12 @@ export const scrape = createAction({
       required: false,
       defaultValue: 60000,
     }),
+    storeInCache: Property.Checkbox({
+      displayName: 'Store In Cache',
+      description: 'If enabled, the page will be stored in the Firecrawl index and cache. Disabling this is useful if your scraping activity may have data protection concerns.',
+      required: false,
+      defaultValue: false,
+    }),
     useActions: Property.Checkbox({
       displayName: 'Perform Actions Before Scraping',
       description: 'Enable to perform a sequence of actions on the page before scraping (like clicking buttons, filling forms, etc.). See [Firecrawl Actions Documentation](https://docs.firecrawl.dev/api-reference/endpoint/scrape#body-actions) for details on available actions and their parameters.',
@@ -238,8 +244,13 @@ export const scrape = createAction({
     const body: Record<string, any> = {
       url: propsValue.url,
       timeout: propsValue.timeout,
+      storeInCache: propsValue.storeInCache,
     };
-    
+
+    if (!propsValue.storeInCache){
+      body['maxAge'] = 0;
+    }
+
     if (propsValue.useActions && propsValue.actionProperties && propsValue.actionProperties['actions']) {
       body['actions'] = propsValue.actionProperties['actions'] || [];
     }

--- a/packages/pieces/community/firecrawl/src/lib/actions/scrape.ts
+++ b/packages/pieces/community/firecrawl/src/lib/actions/scrape.ts
@@ -305,7 +305,7 @@ export const scrape = createAction({
     // reorder the data object to put screenshot first, then user's selected format only
     result.data = {
       screenshot: savedScreenshot,
-      ...(format !== 'screenshot' && { [format]: result.data[format] }),
+      ...(format !== 'pdf' && format !== 'screenshot' && { [format]: result.data[format] }),
       pdfs: savedPdfs,
       metadata: result.data.metadata
     };

--- a/packages/pieces/community/firecrawl/src/lib/actions/scrape.ts
+++ b/packages/pieces/community/firecrawl/src/lib/actions/scrape.ts
@@ -301,12 +301,20 @@ export const scrape = createAction({
     const result = response.body;
     const savedScreenshot = await downloadAndSaveScreenshot(result.data, context);
     const savedPdfs = await downloadAndSavePdfs(result.data, context);
+    const savedActionScreenshots = await Promise.all(
+      (result.data.actions?.screenshots ?? []).map((url: string) =>
+        downloadAndSaveScreenshot({ screenshot: url }, context)
+      )
+    );
 
     // reorder the data object to put screenshot first, then user's selected format only
     result.data = {
       screenshot: savedScreenshot,
       ...(format !== 'pdf' && format !== 'screenshot' && { [format]: result.data[format] }),
-      pdfs: savedPdfs,
+      actions: {
+        pdfs: savedPdfs,
+        screenshots: savedActionScreenshots,
+      },
       metadata: result.data.metadata
     };
 

--- a/packages/pieces/community/firecrawl/src/lib/actions/scrape.ts
+++ b/packages/pieces/community/firecrawl/src/lib/actions/scrape.ts
@@ -79,6 +79,10 @@ export const scrape = createAction({
               {
                 type: 'screenshot',
               },
+              {
+                type: 'pdf',
+                format: 'A4',
+              },
             ],
           }),
         };
@@ -102,7 +106,6 @@ export const scrape = createAction({
             { label: 'Images', value: 'images' },
             { label: 'Screenshot', value: 'screenshot' },
             { label: 'JSON', value: 'json' },
-            { label: 'PDF', value: 'pdf' }
           ]
         };
       },
@@ -255,9 +258,9 @@ export const scrape = createAction({
     if (propsValue.useActions && propsValue.actionProperties && propsValue.actionProperties['actions']) {
       body['actions'] = propsValue.actionProperties['actions'] || [];
     }
-    
+
     const format = propsValue.formats as string;
-    const formatsArray: any[] = []; 
+    const formatsArray: any[] = [];
 
     // user selection
     if (format === 'screenshot') {
@@ -275,8 +278,6 @@ export const scrape = createAction({
         prompt: jsonFormat.prompt,
         schema: jsonFormat.schema
       });
-    } else if (format === 'pdf') {
-      body['actions'] = [...(body['actions'] || []), { type: 'pdf', format: 'A4' }];
     } else {
       const simpleFormat = forSimpleOutputFormat(format);
       formatsArray.push(simpleFormat);
@@ -307,10 +308,9 @@ export const scrape = createAction({
       )
     );
 
-    // reorder the data object to put screenshot first, then user's selected format only
     result.data = {
       screenshot: savedScreenshot,
-      ...(format !== 'pdf' && format !== 'screenshot' && { [format]: result.data[format] }),
+      ...(format !== 'screenshot' && { [format]: result.data[format] }),
       actions: {
         pdfs: savedPdfs,
         screenshots: savedActionScreenshots,

--- a/packages/pieces/community/firecrawl/src/lib/actions/scrape.ts
+++ b/packages/pieces/community/firecrawl/src/lib/actions/scrape.ts
@@ -245,13 +245,14 @@ export const scrape = createAction({
   },
   async run(context) {
     const { auth, propsValue } = context;
+    const shouldStoreInCache = propsValue.storeInCache ?? false;
     const body: Record<string, any> = {
       url: propsValue.url,
       timeout: propsValue.timeout,
-      storeInCache: propsValue.storeInCache,
+      storeInCache: shouldStoreInCache,
     };
 
-    if (!propsValue.storeInCache){
+    if (!shouldStoreInCache) {
       body['maxAge'] = 0;
     }
 

--- a/packages/pieces/community/firecrawl/src/lib/actions/scrape.ts
+++ b/packages/pieces/community/firecrawl/src/lib/actions/scrape.ts
@@ -1,7 +1,7 @@
 import { createAction, Property, InputPropertyMap } from '@activepieces/pieces-framework';
 import { httpClient, HttpMethod } from '@activepieces/pieces-common';
 import { firecrawlAuth } from '../auth';
-import { forScreenshotOutputFormat, forSimpleOutputFormat, downloadAndSaveScreenshot, downloadAndSavePdfs,forJsonOutputFormat, FIRECRAWL_API_BASE_URL } from '../common/common';
+import { forScreenshotOutputFormat, forSimpleOutputFormat, saveFirecrawlFile, forJsonOutputFormat, FIRECRAWL_API_BASE_URL } from '../common/common';
 import { scrapeUrlActionOutputSchema } from '../output-schemas';
 
 function forDefaultScreenshot(): any {
@@ -302,12 +302,16 @@ export const scrape = createAction({
 
     const result = response.body;
     const savedScreenshot = result.data.screenshot
-      ? await downloadAndSaveScreenshot(result.data, context)
+      ? await saveFirecrawlFile(context, result.data.screenshot)
       : undefined;
-    const savedPdfs = await downloadAndSavePdfs(result.data, context);
+    const savedPdfs = await Promise.all(
+      (result.data.actions?.pdfs ?? []).map((pdfUrl: string) =>
+        saveFirecrawlFile(context, pdfUrl)
+      )
+    );
     const savedActionScreenshots = await Promise.all(
-      (result.data.actions?.screenshots ?? []).map((url: string) =>
-        downloadAndSaveScreenshot({ screenshot: url }, context)
+      (result.data.actions?.screenshots ?? []).map((screenshotUrl: string) =>
+        saveFirecrawlFile(context, screenshotUrl)
       )
     );
     const javascriptReturns = result.data.actions?.javascriptReturns ?? [];

--- a/packages/pieces/community/firecrawl/src/lib/actions/scrape.ts
+++ b/packages/pieces/community/firecrawl/src/lib/actions/scrape.ts
@@ -301,7 +301,9 @@ export const scrape = createAction({
     });
 
     const result = response.body;
-    const savedScreenshot = await downloadAndSaveScreenshot(result.data, context);
+    const savedScreenshot = result.data.screenshot
+      ? await downloadAndSaveScreenshot(result.data, context)
+      : undefined;
     const savedPdfs = await downloadAndSavePdfs(result.data, context);
     const savedActionScreenshots = await Promise.all(
       (result.data.actions?.screenshots ?? []).map((url: string) =>

--- a/packages/pieces/community/firecrawl/src/lib/actions/scrape.ts
+++ b/packages/pieces/community/firecrawl/src/lib/actions/scrape.ts
@@ -328,6 +328,7 @@ export const scrape = createAction({
           scrapes,
         },
         metadata: result.data.metadata,
+        warning: result.data.warning,
       },
     };
 

--- a/packages/pieces/community/firecrawl/src/lib/actions/scrape.ts
+++ b/packages/pieces/community/firecrawl/src/lib/actions/scrape.ts
@@ -2,7 +2,7 @@ import { createAction, Property, InputPropertyMap } from '@activepieces/pieces-f
 import { httpClient, HttpMethod } from '@activepieces/pieces-common';
 import { firecrawlAuth } from '../auth';
 import { forScreenshotOutputFormat, forSimpleOutputFormat, saveFirecrawlFile, forJsonOutputFormat, FIRECRAWL_API_BASE_URL } from '../common/common';
-import { scrapeUrlActionOutputSchema } from '../output-schemas';
+import { scrapeActionOutputSchema } from '../output-schemas';
 
 function forDefaultScreenshot(): any {
   return {
@@ -18,7 +18,7 @@ export const scrape = createAction({
   displayName: 'Scrape Website',
   description: 'Scrape a website by performing a series of actions like clicking, typing, taking screenshots, and extracting data.',
   audience: 'human',
-  outputSchema: scrapeUrlActionOutputSchema,
+  outputSchema: scrapeActionOutputSchema,
   aiMetadata: { description: 'Fetches the content of a single web page and returns it in a chosen format (markdown, HTML, links, summary, screenshot, or AI-extracted JSON). Choose this to read one specific URL; for many pages use Crawl, and for a structured data pull across several known URLs use Extract Structured Data. Optionally runs browser actions (click, type, wait, screenshot) before scraping. Read-only against the target, so repeating the same call is safe.', idempotent: true },
   props: {
     url: Property.ShortText({

--- a/packages/pieces/community/firecrawl/src/lib/common/common.ts
+++ b/packages/pieces/community/firecrawl/src/lib/common/common.ts
@@ -40,6 +40,32 @@ export async function downloadAndSaveScreenshot(screenshotTarget: any, context: 
   };
 }
 
+export async function downloadAndSavePdfs(
+  dataTarget: any,
+  context: any,
+): Promise<Array<{ fileName: string; fileUrl: string }>> {
+  const pdfUrls: string[] = dataTarget.actions?.pdfs || [];
+  const savedPdfs: { fileName: string; fileUrl: string }[] = [];
+
+  for (const pdfUrl of pdfUrls) {
+    const response = await httpClient.sendRequest({
+      method: HttpMethod.GET,
+      url: pdfUrl,
+      responseType: 'arraybuffer'
+    });
+
+    const fileName = `pdf-${randomUUID()}.pdf`;
+    const fileUrl = await context.files.write({
+      fileName: fileName,
+      data: Buffer.from(response.body),
+    });
+
+    savedPdfs.push({ fileName, fileUrl });
+  }
+
+  return savedPdfs;
+}
+
 export async function downloadAndSaveCrawlScreenshots(crawlResult: any, context: any): Promise<void> {
 
   if (!crawlResult.data || !Array.isArray(crawlResult.data)) {

--- a/packages/pieces/community/firecrawl/src/lib/common/common.ts
+++ b/packages/pieces/community/firecrawl/src/lib/common/common.ts
@@ -20,7 +20,10 @@ export const forSimpleOutputFormat = (format: string): string => {
 }
 
 // Download and save screenshot(s) - works for both single scrape and crawl results
-export async function downloadAndSaveScreenshot(screenshotTarget: any, context: any): Promise<void> {
+export async function downloadAndSaveScreenshot(
+  screenshotTarget: any,
+  context: any,
+): Promise<{ fileName: string; fileUrl: string }> {
   const screenshotUrl = screenshotTarget.screenshot;
   const response = await httpClient.sendRequest({
     method: HttpMethod.GET,
@@ -34,10 +37,7 @@ export async function downloadAndSaveScreenshot(screenshotTarget: any, context: 
     data: Buffer.from(response.body),
   });
 
-  screenshotTarget.screenshot = {
-    fileName: fileName,
-    fileUrl: fileUrl,
-  };
+  return { fileName, fileUrl };
 }
 
 export async function downloadAndSavePdfs(
@@ -66,21 +66,27 @@ export async function downloadAndSavePdfs(
   return savedPdfs;
 }
 
-export async function downloadAndSaveCrawlScreenshots(crawlResult: any, context: any): Promise<void> {
+export async function downloadAndSaveCrawlScreenshots(crawlResult: any, context: any): Promise<any[]> {
 
   if (!crawlResult.data || !Array.isArray(crawlResult.data)) {
-    return;
+    return crawlResult.data;
   }
 
-  for (const data of crawlResult.data) {
-    if (data.screenshot) {
+  return Promise.all(
+    crawlResult.data.map(async (data: any) => {
+      if (!data.screenshot) {
+        return data;
+      }
+
       try {
-        await downloadAndSaveScreenshot(data, context);
+        const savedScreenshot = await downloadAndSaveScreenshot(data, context);
+        return { ...data, screenshot: savedScreenshot };
       } catch (error) {
         console.error(`Failed to download screenshot for page: ${error}`);
+        return data;
       }
-    }
-  }
+    }),
+  );
 }
 
 // scrape, extract and crawl uses this function

--- a/packages/pieces/community/firecrawl/src/lib/common/common.ts
+++ b/packages/pieces/community/firecrawl/src/lib/common/common.ts
@@ -4,6 +4,7 @@ import {
 } from '@activepieces/pieces-common';
 import Ajv from 'ajv';
 import { randomUUID } from 'crypto';
+import mime from 'mime-types';
 
 export const FIRECRAWL_API_BASE_URL = 'https://api.firecrawl.dev/v2';
 export const POLLING_INTERVAL = 5000;
@@ -19,51 +20,33 @@ export const forSimpleOutputFormat = (format: string): string => {
   return format;
 }
 
-// Download and save screenshot(s) - works for both single scrape and crawl results
-export async function downloadAndSaveScreenshot(
-  screenshotTarget: any,
+export async function saveFirecrawlFile(
   context: any,
+  firecrawlFileUrl: string,
 ): Promise<{ fileName: string; fileUrl: string }> {
-  const screenshotUrl = screenshotTarget.screenshot;
   const response = await httpClient.sendRequest({
     method: HttpMethod.GET,
-    url: screenshotUrl,
+    url: firecrawlFileUrl,
     responseType: 'arraybuffer'
   });
 
-  const fileName = `screenshot-${randomUUID()}.png`;
+  const contentTypeHeader = response.headers?.['content-type'];
+  const contentType = Array.isArray(contentTypeHeader) ? contentTypeHeader[0] : contentTypeHeader;
+  const extension = contentType ? mime.extension(contentType) : false;
+
+  if (!extension || extension === 'bin') {
+    throw new Error(
+      `Firecrawl returned a file with an unusable content type (${contentType ?? 'none'}), so its extension could not be determined: ${firecrawlFileUrl}`,
+    );
+  }
+
+  const fileName = `firecrawl-${randomUUID()}.${extension}`;
   const fileUrl = await context.files.write({
     fileName: fileName,
     data: Buffer.from(response.body),
   });
 
   return { fileName, fileUrl };
-}
-
-export async function downloadAndSavePdfs(
-  dataTarget: any,
-  context: any,
-): Promise<Array<{ fileName: string; fileUrl: string }>> {
-  const pdfUrls: string[] = dataTarget.actions?.pdfs || [];
-  const savedPdfs: { fileName: string; fileUrl: string }[] = [];
-
-  for (const pdfUrl of pdfUrls) {
-    const response = await httpClient.sendRequest({
-      method: HttpMethod.GET,
-      url: pdfUrl,
-      responseType: 'arraybuffer'
-    });
-
-    const fileName = `pdf-${randomUUID()}.pdf`;
-    const fileUrl = await context.files.write({
-      fileName: fileName,
-      data: Buffer.from(response.body),
-    });
-
-    savedPdfs.push({ fileName, fileUrl });
-  }
-
-  return savedPdfs;
 }
 
 export async function downloadAndSaveCrawlScreenshots(crawlResult: any, context: any): Promise<any[]> {
@@ -79,7 +62,7 @@ export async function downloadAndSaveCrawlScreenshots(crawlResult: any, context:
       }
 
       try {
-        const savedScreenshot = await downloadAndSaveScreenshot(data, context);
+        const savedScreenshot = await saveFirecrawlFile(context, data.screenshot);
         return { ...data, screenshot: savedScreenshot };
       } catch (error) {
         console.error(`Failed to download screenshot for page: ${error}`);

--- a/packages/pieces/community/firecrawl/src/lib/common/common.ts
+++ b/packages/pieces/community/firecrawl/src/lib/common/common.ts
@@ -31,16 +31,8 @@ export async function saveFirecrawlFile(
   });
 
   const contentTypeHeader = response.headers?.['content-type'];
-  const contentType = Array.isArray(contentTypeHeader) ? contentTypeHeader[0] : contentTypeHeader;
-  const extension = contentType ? mime.extension(contentType) : false;
-
-  if (!extension || extension === 'bin') {
-    throw new Error(
-      `Firecrawl returned a file with an unusable content type (${contentType ?? 'none'}), so its extension could not be determined: ${firecrawlFileUrl}`,
-    );
-  }
-
-  const fileName = `firecrawl-${randomUUID()}.${extension}`;
+  const fileMimetype = typeof contentTypeHeader === 'string' ? contentTypeHeader : 'application/octet-stream';
+  const fileName = `firecrawl-${randomUUID()}.${mime.extension(fileMimetype) || 'bin'}`;
   const fileUrl = await context.files.write({
     fileName: fileName,
     data: Buffer.from(response.body),

--- a/packages/pieces/community/firecrawl/src/lib/common/common.ts
+++ b/packages/pieces/community/firecrawl/src/lib/common/common.ts
@@ -61,13 +61,8 @@ export async function downloadAndSaveCrawlScreenshots(crawlResult: any, context:
         return data;
       }
 
-      try {
-        const savedScreenshot = await saveFirecrawlFile(context, data.screenshot);
-        return { ...data, screenshot: savedScreenshot };
-      } catch (error) {
-        console.error(`Failed to download screenshot for page: ${error}`);
-        return data;
-      }
+      const savedScreenshot = await saveFirecrawlFile(context, data.screenshot);
+      return { ...data, screenshot: savedScreenshot };
     }),
   );
 }

--- a/packages/pieces/community/firecrawl/src/lib/common/common.ts
+++ b/packages/pieces/community/firecrawl/src/lib/common/common.ts
@@ -41,24 +41,6 @@ export async function saveFirecrawlFile(
   return { fileName, fileUrl };
 }
 
-export async function downloadAndSaveCrawlScreenshots(crawlResult: any, context: any): Promise<any[]> {
-
-  if (!crawlResult.data || !Array.isArray(crawlResult.data)) {
-    return crawlResult.data;
-  }
-
-  return Promise.all(
-    crawlResult.data.map(async (data: any) => {
-      if (!data.screenshot) {
-        return data;
-      }
-
-      const savedScreenshot = await saveFirecrawlFile(context, data.screenshot);
-      return { ...data, screenshot: savedScreenshot };
-    }),
-  );
-}
-
 // scrape, extract and crawl uses this function
 export function forJsonOutputFormat(jsonExtractionConfig: any): any {
 

--- a/packages/pieces/community/firecrawl/src/lib/output-schemas.ts
+++ b/packages/pieces/community/firecrawl/src/lib/output-schemas.ts
@@ -15,7 +15,7 @@ const scrapeResultFields: OutputSchema['fields'] = [
     ],
   },
   {
-    key: 'pdf',
+    key: 'pdfs',
     label: 'PDF',
     listItems: [
       { key: 'fileName', label: 'File Name' },

--- a/packages/pieces/community/firecrawl/src/lib/output-schemas.ts
+++ b/packages/pieces/community/firecrawl/src/lib/output-schemas.ts
@@ -34,6 +34,14 @@ const scrapeResultFields: OutputSchema['fields'] = [
           { key: 'fileUrl', label: 'File URL', format: 'url' },
         ],
       },
+      {
+        key: 'javascriptReturns',
+        label: 'JavaScript Returns',
+        listItems: [
+          { key: 'type', label: 'Type' },
+          { key: 'value', label: 'Value' },
+        ],
+      },
     ],
   },
   {

--- a/packages/pieces/community/firecrawl/src/lib/output-schemas.ts
+++ b/packages/pieces/community/firecrawl/src/lib/output-schemas.ts
@@ -15,6 +15,14 @@ const scrapeResultFields: OutputSchema['fields'] = [
     ],
   },
   {
+    key: 'pdf',
+    label: 'PDF',
+    listItems: [
+      { key: 'fileName', label: 'File Name' },
+      { key: 'fileUrl', label: 'File URL', format: 'url' },
+    ],
+  },
+  {
     key: 'metadata',
     label: 'Metadata',
     children: [

--- a/packages/pieces/community/firecrawl/src/lib/output-schemas.ts
+++ b/packages/pieces/community/firecrawl/src/lib/output-schemas.ts
@@ -15,11 +15,25 @@ const scrapeResultFields: OutputSchema['fields'] = [
     ],
   },
   {
-    key: 'pdfs',
-    label: 'PDF',
-    listItems: [
-      { key: 'fileName', label: 'File Name' },
-      { key: 'fileUrl', label: 'File URL', format: 'url' },
+    key: 'actions',
+    label: 'Actions',
+    children: [
+      {
+        key: 'pdfs',
+        label: 'PDF',
+        listItems: [
+          { key: 'fileName', label: 'File Name' },
+          { key: 'fileUrl', label: 'File URL', format: 'url' },
+        ],
+      },
+      {
+        key: 'screenshots',
+        label: 'Screenshots',
+        listItems: [
+          { key: 'fileName', label: 'File Name' },
+          { key: 'fileUrl', label: 'File URL', format: 'url' },
+        ],
+      },
     ],
   },
   {

--- a/packages/pieces/community/firecrawl/src/lib/output-schemas.ts
+++ b/packages/pieces/community/firecrawl/src/lib/output-schemas.ts
@@ -42,6 +42,15 @@ const scrapeResultFields: OutputSchema['fields'] = [
           { key: 'value', label: 'Value' },
         ],
       },
+      {
+        key: 'scrapes',
+        label: 'Scrapes',
+        labelKey: 'url',
+        listItems: [
+          { key: 'url', label: 'URL', format: 'url' },
+          { key: 'html', label: 'HTML', format: 'html' },
+        ],
+      },
     ],
   },
   {

--- a/packages/pieces/community/firecrawl/src/lib/output-schemas.ts
+++ b/packages/pieces/community/firecrawl/src/lib/output-schemas.ts
@@ -1,6 +1,6 @@
 import { OutputSchema } from '@activepieces/pieces-framework';
 
-const scrapeResultFields: OutputSchema['fields'] = [
+const pageContentFields: OutputSchema['fields'] = [
   { key: 'markdown', label: 'Markdown' },
   { key: 'html', label: 'HTML', format: 'html' },
   { key: 'rawHtml', label: 'Raw HTML', format: 'html' },
@@ -14,64 +14,84 @@ const scrapeResultFields: OutputSchema['fields'] = [
       { key: 'fileUrl', label: 'File URL', format: 'url' },
     ],
   },
-  {
-    key: 'actions',
-    label: 'Actions',
-    children: [
-      {
-        key: 'pdfs',
-        label: 'PDF',
-        listItems: [
-          { key: 'fileName', label: 'File Name' },
-          { key: 'fileUrl', label: 'File URL', format: 'url' },
-        ],
-      },
-      {
-        key: 'screenshots',
-        label: 'Screenshots',
-        listItems: [
-          { key: 'fileName', label: 'File Name' },
-          { key: 'fileUrl', label: 'File URL', format: 'url' },
-        ],
-      },
-      {
-        key: 'javascriptReturns',
-        label: 'JavaScript Returns',
-        listItems: [
-          { key: 'type', label: 'Type' },
-          { key: 'value', label: 'Value' },
-        ],
-      },
-      {
-        key: 'scrapes',
-        label: 'Scrapes',
-        labelKey: 'url',
-        listItems: [
-          { key: 'url', label: 'URL', format: 'url' },
-          { key: 'html', label: 'HTML', format: 'html' },
-        ],
-      },
-    ],
-  },
-  {
-    key: 'metadata',
-    label: 'Metadata',
-    children: [
-      { key: 'title', label: 'Title' },
-      { key: 'language', label: 'Language' },
-      { key: 'sourceURL', label: 'Source URL', format: 'url' },
-      { key: 'url', label: 'Final URL', format: 'url' },
-      { key: 'statusCode', label: 'Status Code', format: 'number' },
-      { key: 'favicon', label: 'Favicon', format: 'image' },
-      { key: 'creditsUsed', label: 'Credits Used', format: 'number' },
-    ],
-  },
 ];
+
+const pageMetadataField: OutputSchema['fields'][number] = {
+  key: 'metadata',
+  label: 'Metadata',
+  children: [
+    { key: 'title', label: 'Title' },
+    { key: 'language', label: 'Language' },
+    { key: 'sourceURL', label: 'Source URL', format: 'url' },
+    { key: 'url', label: 'Final URL', format: 'url' },
+    { key: 'statusCode', label: 'Status Code', format: 'number' },
+    { key: 'favicon', label: 'Favicon', format: 'image' },
+    { key: 'creditsUsed', label: 'Credits Used', format: 'number' },
+  ],
+};
+
+const scrapeActionsField: OutputSchema['fields'][number] = {
+  key: 'actions',
+  label: 'Actions',
+  children: [
+    {
+      key: 'pdfs',
+      label: 'PDF',
+      listItems: [
+        { key: 'fileName', label: 'File Name' },
+        { key: 'fileUrl', label: 'File URL', format: 'url' },
+      ],
+    },
+    {
+      key: 'screenshots',
+      label: 'Screenshots',
+      listItems: [
+        { key: 'fileName', label: 'File Name' },
+        { key: 'fileUrl', label: 'File URL', format: 'url' },
+      ],
+    },
+    {
+      key: 'javascriptReturns',
+      label: 'JavaScript Returns',
+      listItems: [
+        { key: 'type', label: 'Type' },
+        { key: 'value', label: 'Value' },
+      ],
+    },
+    {
+      key: 'scrapes',
+      label: 'Scrapes',
+      labelKey: 'url',
+      listItems: [
+        { key: 'url', label: 'URL', format: 'url' },
+        { key: 'html', label: 'HTML', format: 'html' },
+      ],
+    },
+  ],
+};
+
+const pageResultFields: OutputSchema['fields'] = [
+  ...pageContentFields,
+  pageMetadataField,
+];
+
+const scrapeResultFields: OutputSchema['fields'] = [
+  ...pageContentFields,
+  scrapeActionsField,
+  pageMetadataField,
+];
+
+export const scrapeActionOutputSchema: OutputSchema = {
+  fields: [
+    { key: 'success', label: 'Success', format: 'boolean' },
+    { key: 'data', label: 'Data', children: scrapeResultFields },
+  ],
+};
 
 export const scrapeUrlActionOutputSchema: OutputSchema = {
   fields: [
     { key: 'success', label: 'Success', format: 'boolean' },
-    { key: 'data', label: 'Data', children: scrapeResultFields },
+    { key: 'data', label: 'Data', children: pageResultFields },
   ],
 };
 
@@ -83,7 +103,7 @@ const jobResultFields: OutputSchema['fields'] = [
   { key: 'creditsUsed', label: 'Credits Used', format: 'number' },
   { key: 'expiresAt', label: 'Expires At', format: 'datetime' },
   { key: 'next', label: 'Next Page URL', format: 'url' },
-  { key: 'data', label: 'Pages', listItems: scrapeResultFields },
+  { key: 'data', label: 'Pages', listItems: pageResultFields },
 ];
 
 export const crawlWebsiteActionOutputSchema: OutputSchema = {

--- a/packages/pieces/community/firecrawl/src/lib/output-schemas.ts
+++ b/packages/pieces/community/firecrawl/src/lib/output-schemas.ts
@@ -70,14 +70,18 @@ const scrapeActionsField: OutputSchema['fields'][number] = {
   ],
 };
 
+const pageWarningField: OutputSchema['fields'][number] = { key: 'warning', label: 'Warning' };
+
 const pageResultFields: OutputSchema['fields'] = [
   ...pageContentFields,
+  pageWarningField,
   pageMetadataField,
 ];
 
 const scrapeResultFields: OutputSchema['fields'] = [
   ...pageContentFields,
   scrapeActionsField,
+  pageWarningField,
   pageMetadataField,
 ];
 


### PR DESCRIPTION
## Description

Scrape Website can run browser actions before it reads the page: click, scroll, screenshot, run Javascript. It was throwing away everything these actions produced. This PR returns all of it and adds a **Store In Cache** toggle for scrapes that shouldn't leave a copy on Firecrawl's side.

### 1. Store In Cache
Firecrawl keeps a copy of every page it scrapes and by default serves that copy back for up to two days rather than re-fetching. However, it is the wrong default when the pages being scraped contain personal
or sensitive data, or when the flow specifically needs the page as it is right now. [(docs)](https://docs.firecrawl.dev/api-reference/endpoint/scrape)

A new **Store In Cache** checkbox on Scrape Website controls this. It is off by default. 

<img width="516" height="87" alt="Screenshot 2026-09-04 at 2 34 53 PM" src="https://github.com/user-attachments/assets/0e70fd44-8d76-4c42-8bdc-2ddc1bcadfe8" />

Turning it off sends two parameters, not one:

- `storeInCache: false` — stops the scraped page entering Firecrawl's index
- `maxAge: 0` — stops a copy cached by an *earlier* run being served back

Both are needed. `storeInCache` only governs what goes in; without `maxAge: 0`, a page cached before the toggle was switched off would still be returned, and the user would believe they had opted out while still reading a stored copy. Both now reads from `propsValue.storeInCache ?? false` rather than straight off `propsValue`. A step saved before `0.3.15` has no `storeInCache` key at all — `defaultValue: false` is only a builder affordance, and a patch upgrade keeps the stored input as-is — so without the coalesce `JSON.stringify` would drop `storeInCache` from the body while `!undefined` still sent `maxAge: 0`. That would mean no cache benefits and Firecrawl stores the page anyways with the checkbox showing unchecked. Thank you to @OdaiAhmed99 for catching this. 

**Trade-off:** with the default off, scrapes no longer benefit from Firecrawl's cache, so they are slower than before and every run costs a fresh scrape. That includes the full-page screenshot `forDefaultScreenshot()` requests on every run regardless of the chosen format, and, for anyone who keeps the default Actions JSON, an A4 PDF render on top of it. Users who scrape the same stable pages repeatedly should turn the toggle on. 

### 2. Action Outputs

The Scrape Website Piece can run a list of browser actions before it reads the page: click a button, scroll to load more, dismiss a pop up, take a screenshot etc. Some of these actions produces an output. A `screenshot` action produces an image. A `pdf`action produces a file. An `executeJavascript` action produces a value. Firecrawl returns all of them under `data.actions`. 

The previous piece was deleting all these information collected as it built a fresh output object with only a few keys in it and actions​ was not one of them, so everything the actions produced was lost. 

Every action output is now returned:
| Action you add | What you get back |
|---|---|
| `screenshot` | `data.actions.screenshots` — images taken partway through, not just of the finished page |
| `pdf` | `data.actions.pdfs` — PDFs of the page |
| `scrape` | `data.actions.scrapes` — the page's HTML at that point in the sequence |
| `executeJavascript` | `data.actions.javascriptReturns` — whatever your script returned |

<img width="463" height="182" alt="Screenshot 2026-09-04 at 2 42 41 PM" src="https://github.com/user-attachments/assets/c901d64e-d781-4bdd-a197-052430846611" />

Grouping them under `data.actions` mirrors Firecrawl's own response shape, so their docs map directly onto the step output. It also keeps `screenshot` — the final page, a single file — clearly apart from `actions.screenshots`, which is a list of mid-sequence captures.

Two UI notes:
- `{ "type": "pdf", "format": "A4" }` was added to the default Actions JSON. Generating a PDF is a common thing to want and nothing else in the UI hinted that a `pdf` action existed.
- `pdf` is deliberately **not** an Output Format option. Firecrawl only produces PDFs through a page action, and not through an actual API call. 

<img width="544" height="398" alt="Screenshot 2026-09-04 at 3 02 01 PM" src="https://github.com/user-attachments/assets/fa20aed4-bf9f-4ef5-b13c-d75e548adb86" />

### 3. One helper for saving Firecrawl files 
`downloadAndSaveScreenshot(target, context)` wrote its result into the caller's object at a fixed key (`target.screenshot`), and `downloadAndSaveCrawlScreenshots` looped over a crawl result doing the same. Action screenshots and PDFs need to end up in lists, and there can be several of each, so there was nothing to reuse.

Both are replaced by one `saveFirecrawlFile` that takes a URL and returns `{ fileName, fileUrl }`, letting each caller decide where the value goes:

```ts
const savedPdfs = await Promise.all(
  (result.data.actions?.pdfs ?? []).map((pdfUrl: string) =>
    saveFirecrawlFile(context, pdfUrl)
  )
);
```

Since the same helper now saves PDFs as well as PNGs, the filename comes from the response's `content-type` (`firecrawl-<uuid>.<ext>`, falling back to `.bin` when the type is unrecognised) instead of a hardcoded `.png`. This adds `mime-types` to the piece's dependencies.

All four call sites:`scrape.ts` (page screenshot, action screenshots, action PDFs), `scrape-url.ts` and `crawl.ts`, now take the returned value, which also matches the repo's preference for immutable data flow. `crawl.ts` maps its pages into a new array rather than mutating each page in place.

### 4. Behaviour changes for existing steps

1. **Existing Scrape Website steps stop using the cache.** Per the coalesce above, a step saved before `0.3.15` now scrapes fresh on every run — slower, and one scrape's worth of credits per run. Ticking the new checkbox restores the old behaviour.
2. **A failed asset download now fails the step, in crawl too.** `downloadAndSaveCrawlScreenshots` used to catch a failed page screenshot, log it to the server console and carry on, which left the user with fewer screenshots than pages and nothing in the step output explaining why — a piece's `console.error` never reaches the step output. All four download paths now behave the same way: a failed asset fails the step rather than returning a silently incomplete result.
3. **Saved screenshot filenames change shape**, from `screenshot-<uuid>.png` to `firecrawl-<uuid>.png`. The `fileName` and `fileUrl` keys are unchanged; only a flow that pattern-matches on the filename itself would notice.

## How was this tested?

Manually in the flow builder (CE), scraping https://www.wikipedia.org/:

- Actions with `screenshot`, `pdf`, `scrape` and `executeJavascript` in one sequence — all four
  surfaced under `data.actions`, each populated
- The action screenshot saves as a separate file from the page screenshot (different file IDs),
  confirming the two are kept distinct rather than merged
- `executeJavascript` returning `document.title` — surfaced as `{ type: "string", value: "Wikipedia" }`
- Output format set to Markdown — `data.markdown` present alongside all four action outputs
- Output format set to Screenshot — no colliding format key added, and `data.screenshot` is still a single `{ fileName, fileUrl }` object rather than the raw Firecrawl URL
- Perform Actions Before Scraping turned off — four empty arrays under `data.actions`, no error
- Store In Cache on and off — request body logged; `storeInCache: false` and `maxAge: 0` both sent when unchecked, neither sent when checked
- **Upgrade path:** a step saved on `0.3.14` and then run on `0.3.15` — body logged, `storeInCache: false` present rather than dropped
- Firecrawl returning no screenshot — `data.screenshot` is `undefined` instead of `TypeError: Invalid URL`
- A bad URL in `data.actions.pdfs` — the step fails rather than returning a partial output
- Saved `fileUrl`s all resolve: both PNGs and the PDF open correctly, with `.png` / `.pdf` derived from the content type

### Breaking change? (required)
- [x] no — reviewed, not breaking

### Security impact? (required)
- [x] no — reviewed, no security impact



---

Tracked in Linear: GIT-1859 (https://linear.app/activepieces/issue/GIT-1859)
Closes #15334
