### PR TITLE
fix(agents): agent steps on Bedrock no longer fail with "provided model identifier is invalid"

### DIFF
--- a/packages/server/api/src/app/ee/agent/agent-helpers.ts
+++ b/packages/server/api/src/app/ee/agent/agent-helpers.ts
@@ -176,7 +176,7 @@ function pickAllowedModel({ provider, selectedModel, candidates, modelScope, mod
     return selectedModel && allowed.includes(selectedModel) ? selectedModel : allowed[0]
 }
 
-function resolveModelIdForProvider({ provider, selectedModel, config, modelScope, modelIds }: { provider: AIProviderName, selectedModel: string | null, config?: AIProviderConfig, modelScope?: AiProviderModelScope, modelIds?: string[] }): string {
+function resolveModelIdForProvider({ provider, selectedModel, config, modelScope, modelIds, fallbackModelId }: { provider: AIProviderName, selectedModel: string | null, config?: AIProviderConfig, modelScope?: AiProviderModelScope, modelIds?: string[], fallbackModelId?: string }): string {
     const catalog = manualTextModelCatalog({ config })
     if (!isNil(catalog)) {
         return pickAllowedModel({ provider, selectedModel, candidates: catalog, modelScope, modelIds })
@@ -185,6 +185,9 @@ function resolveModelIdForProvider({ provider, selectedModel, config, modelScope
     const tierModelId = resolveTier({ tierId: selectedModel }).modelId
     if (provider === AIProviderName.ACTIVEPIECES || provider === AIProviderName.OPENROUTER) {
         return tierModelId
+    }
+    if (isNil(curatedModels) && !isNil(fallbackModelId) && fallbackModelId.length > 0 && isNil(findTier({ tierId: fallbackModelId }))) {
+        return pickAllowedModel({ provider, selectedModel: fallbackModelId, candidates: [fallbackModelId], modelScope, modelIds })
     }
     const nativeModelId = tierModelId.replace(/^[^/]+\//, '').replace(/\./g, '-')
     const candidates = isNil(curatedModels) ? [nativeModelId] : curatedModels.map((model) => model.id)
@@ -218,9 +221,9 @@ function reportKeyOutcome({ platformId, providerId, log }: { platformId: string,
     }
 }
 
-async function resolveTierModel({ platformId, tierId, provider, providerConfigId, scope, log }: { platformId: string, tierId: string, provider?: AIProviderName, providerConfigId?: string, scope: ProviderScope, log: FastifyBaseLogger }): Promise<{ model: LanguageModel, modelId: string, provider: AIProviderName }> {
+async function resolveTierModel({ platformId, tierId, provider, providerConfigId, scope, log, fallbackModelId }: { platformId: string, tierId: string, provider?: AIProviderName, providerConfigId?: string, scope: ProviderScope, log: FastifyBaseLogger, fallbackModelId?: string }): Promise<{ model: LanguageModel, modelId: string, provider: AIProviderName }> {
     const providerConfig = await resolveRunProvider({ platformId, scope, log, ...spreadIfDefined('provider', provider), ...spreadIfDefined('providerConfigId', providerConfigId) })
-    const modelId = resolveModelIdForProvider({ provider: providerConfig.provider, selectedModel: tierId, config: providerConfig.config, modelScope: providerConfig.modelScope, modelIds: providerConfig.modelIds })
+    const modelId = resolveModelIdForProvider({ provider: providerConfig.provider, selectedModel: tierId, config: providerConfig.config, modelScope: providerConfig.modelScope, modelIds: providerConfig.modelIds, ...spreadIfDefined('fallbackModelId', fallbackModelId) })
     return {
         model: agentAiUtils.createChatModel({
             provider: providerConfig.provider,
@@ -234,12 +237,12 @@ async function resolveTierModel({ platformId, tierId, provider, providerConfigId
     }
 }
 
-async function resolveFastModel({ platformId, provider, providerConfigId, scope, log }: { platformId: string, provider?: AIProviderName, providerConfigId?: string, scope: ProviderScope, log: FastifyBaseLogger }): Promise<LanguageModel> {
-    return (await resolveTierModel({ platformId, tierId: FAST_TIER_ID, scope, log, ...spreadIfDefined('provider', provider), ...spreadIfDefined('providerConfigId', providerConfigId) })).model
+async function resolveFastModel({ platformId, provider, providerConfigId, scope, log, fallbackModelId }: { platformId: string, provider?: AIProviderName, providerConfigId?: string, scope: ProviderScope, log: FastifyBaseLogger, fallbackModelId?: string }): Promise<LanguageModel> {
+    return (await resolveTierModel({ platformId, tierId: FAST_TIER_ID, scope, log, ...spreadIfDefined('provider', provider), ...spreadIfDefined('providerConfigId', providerConfigId), ...spreadIfDefined('fallbackModelId', fallbackModelId) })).model
 }
 
-function resolveFastModelId({ provider, config, modelScope, modelIds }: { provider: AIProviderName, config?: AIProviderConfig, modelScope?: AiProviderModelScope, modelIds?: string[] }): string {
-    return resolveModelIdForProvider({ provider, selectedModel: FAST_TIER_ID, config, modelScope, modelIds })
+function resolveFastModelId({ provider, config, modelScope, modelIds, fallbackModelId }: { provider: AIProviderName, config?: AIProviderConfig, modelScope?: AiProviderModelScope, modelIds?: string[], fallbackModelId: string }): string {
+    return resolveModelIdForProvider({ provider, selectedModel: FAST_TIER_ID, config, modelScope, modelIds, fallbackModelId })
 }
 
 async function resolveEmbeddingModel({ platformId, provider, providerConfigId, scope, log }: { platformId: string, provider?: AIProviderName, providerConfigId?: string, scope: ProviderScope, log: FastifyBaseLogger }): Promise<{ model: EmbeddingModel, providerOptions: SharedV3ProviderOptions }> {

--- a/packages/server/api/src/app/ee/agent/agent-rpc-handlers.ts
+++ b/packages/server/api/src/app/ee/agent/agent-rpc-handlers.ts
@@ -299,7 +299,7 @@ export const agentRpcHandlers = (log: FastifyBaseLogger) => ({
             auth: providerConfig.auth as Record<string, unknown>,
             providerConfig: providerConfig.config as Record<string, unknown>,
             modelId: resolvedModelId,
-            fastModelId: agentHelpers.resolveFastModelId({ provider: providerConfig.provider, config: providerConfig.config, modelScope: providerConfig.modelScope, modelIds: providerConfig.modelIds }),
+            fastModelId: agentHelpers.resolveFastModelId({ provider: providerConfig.provider, config: providerConfig.config, modelScope: providerConfig.modelScope, modelIds: providerConfig.modelIds, fallbackModelId: resolvedModelId }),
             systemPrompt: systemPromptText,
             messages: messagesForLlm,
             allMessages,
@@ -479,8 +479,8 @@ export const agentRpcHandlers = (log: FastifyBaseLogger) => ({
     },
 
     async executePieceTool(input: ExecutePieceToolRequest): Promise<ExecutePieceToolResponse> {
-        const { projectId, platformId } = await configuredToolConversationOrThrow({ conversationId: input.conversationId })
-        const model = await agentHelpers.resolveFastModel({ platformId, scope: { type: 'project', projectId }, log, ...spreadIfDefined('provider', input.provider), ...spreadIfDefined('providerConfigId', input.providerConfigId) })
+        const { projectId, platformId, modelName } = await configuredToolConversationOrThrow({ conversationId: input.conversationId })
+        const model = await agentHelpers.resolveFastModel({ platformId, scope: { type: 'project', projectId }, log, ...spreadIfDefined('provider', input.provider), ...spreadIfDefined('providerConfigId', input.providerConfigId), ...spreadIfDefined('fallbackModelId', modelName) })
         const piece = { pieceName: input.piece.pieceName, actionName: input.piece.actionName, ...spreadIfDefined('pieceVersion', input.piece.pieceVersion) }
         const connection = await connectionForConfiguredTool({ piece: input.piece, projectId, platformId, log })
         const { data: run, error: runError } = await tryCatch(async () => {
@@ -809,12 +809,12 @@ async function connectionForConfiguredTool({ piece, projectId, platformId, log }
     return { externalId: pinned, ...spreadIfDefined('label', connection?.displayName) }
 }
 
-async function configuredToolConversationOrThrow({ conversationId }: { conversationId: string }): Promise<{ projectId: string, platformId: string }> {
-    const conversation = await agentHelpers.conversationRepo().findOneBy({ id: conversationId })
+async function configuredToolConversationOrThrow({ conversationId }: { conversationId: string }): Promise<{ projectId: string, platformId: string, modelName: string | null }> {
+    const conversation = await agentHelpers.conversationRepo().findOne({ where: { id: conversationId }, select: ['source', 'projectId', 'platformId', 'modelName'] })
     if (isNil(conversation) || !CONFIGURED_TOOL_SOURCES.includes(conversation.source) || isNil(conversation.projectId)) {
         throw new ActivepiecesError({ code: ErrorCode.AUTHORIZATION, params: { message: 'This run is not allowed to run a configured piece tool' } })
     }
-    return { projectId: conversation.projectId, platformId: conversation.platformId }
+    return { projectId: conversation.projectId, platformId: conversation.platformId, modelName: conversation.modelName ?? null }
 }
 
 async function loadOrStartConversation({ conversationId, platformId, userId, source, projectId, modelName }: {

--- a/packages/server/api/src/app/ee/agent/personalization/chat-personalization-service.ts
+++ b/packages/server/api/src/app/ee/agent/personalization/chat-personalization-service.ts
@@ -274,13 +274,14 @@ export const chatPersonalizationService = (log: FastifyBaseLogger) => ({
         ])
         const providerName = provider.provider
         const webSearch = enabledTools.data?.webSearch ?? null
+        const modelId = agentHelpers.resolveModelIdForProvider({ provider: providerName, selectedModel: null, config: provider.config, modelScope: provider.modelScope, modelIds: provider.modelIds })
         return {
             claimed: true,
             provider: provider.provider,
             auth: provider.auth,
             providerConfig: provider.config ?? {},
-            modelId: agentHelpers.resolveModelIdForProvider({ provider: providerName, selectedModel: null, config: provider.config, modelScope: provider.modelScope, modelIds: provider.modelIds }),
-            fastModelId: agentHelpers.resolveFastModelId({ provider: providerName, config: provider.config, modelScope: provider.modelScope, modelIds: provider.modelIds }),
+            modelId,
+            fastModelId: agentHelpers.resolveFastModelId({ provider: providerName, config: provider.config, modelScope: provider.modelScope, modelIds: provider.modelIds, fallbackModelId: modelId }),
             user: { firstName: user.firstName, lastName: user.lastName, email: user.email },
             platformName: platform.name,
             website: companyRow?.domain ?? null,

--- a/packages/server/api/test/unit/app/ee/agent/agent-model-resolution.test.ts
+++ b/packages/server/api/test/unit/app/ee/agent/agent-model-resolution.test.ts
@@ -12,13 +12,13 @@ vi.mock('../../../../../src/app/ai/ai-provider-service', () => ({
 const resolve = ({ provider, selectedModel }: { provider: AIProviderName, selectedModel: string | null }) =>
     agentHelpers.resolveModelIdForProvider({ provider, selectedModel })
 
-describe('resolveModelIdForProvider', () => {
-    const vertexConfig = (models: { modelId: string, modelType: AIProviderModelType }[]) => ({
-        project: 'gcp-project',
-        region: 'europe-west4',
-        models: models.map((model) => ({ ...model, modelName: model.modelId })),
-    })
+const vertexConfig = (models: { modelId: string, modelType: AIProviderModelType }[]) => ({
+    project: 'gcp-project',
+    region: 'europe-west4',
+    models: models.map((model) => ({ ...model, modelName: model.modelId })),
+})
 
+describe('resolveModelIdForProvider', () => {
     it('picks from the models an admin listed on the key, not the curated list', () => {
         const config = vertexConfig([
             { modelId: 'claude-3-5-sonnet@20241022', modelType: AIProviderModelType.TEXT },
@@ -92,12 +92,6 @@ describe('resolveModelIdForProvider', () => {
     it('strips the tier vendor prefix for providers that declare no curated models', () => {
         expect(resolve({ provider: AIProviderName.BEDROCK, selectedModel: 'smart' })).toBe('claude-sonnet-4-6')
     })
-
-    it('resolves the fast round to a model the provider offers', () => {
-        expect(agentHelpers.resolveFastModelId({ provider: AIProviderName.ANTHROPIC })).toBe('claude-haiku-4-5')
-        expect(agentHelpers.resolveFastModelId({ provider: AIProviderName.OPENAI })).toBe('gpt-5.5')
-        expect(agentHelpers.resolveFastModelId({ provider: AIProviderName.ACTIVEPIECES })).toBe('anthropic/claude-haiku-4.5')
-    })
 })
 
 describe('resolveModelIdForAnalytics', () => {
@@ -165,5 +159,38 @@ describe('resolveChatProviderName', () => {
         await agentHelpers.resolveChatProviderName({ platformId: 'plat-1', projectId: 'proj-1', log })
 
         expect(getChatProviderName).toHaveBeenCalledWith({ platformId: 'plat-1', scope: { type: 'project', projectId: 'proj-1' } })
+    })
+})
+
+describe('resolveFastModelId', () => {
+    it('falls back to the configured model when the provider has no curated list and no catalog', () => {
+        expect(agentHelpers.resolveFastModelId({ provider: AIProviderName.BEDROCK, config: { region: 'us-east-1' }, fallbackModelId: 'us.anthropic.claude-sonnet-5' })).toBe('us.anthropic.claude-sonnet-5')
+        expect(agentHelpers.resolveFastModelId({ provider: AIProviderName.AZURE, fallbackModelId: 'my-azure-deployment' })).toBe('my-azure-deployment')
+        expect(agentHelpers.resolveFastModelId({ provider: AIProviderName.MISTRAL, fallbackModelId: 'mistral-large-latest' })).toBe('mistral-large-latest')
+    })
+
+    it('keeps the fast tier where the provider ships a real fast model', () => {
+        expect(agentHelpers.resolveFastModelId({ provider: AIProviderName.ANTHROPIC, fallbackModelId: 'claude-sonnet-4-6' })).toBe('claude-haiku-4-5')
+        expect(agentHelpers.resolveFastModelId({ provider: AIProviderName.ACTIVEPIECES, fallbackModelId: 'unused' })).toBe('anthropic/claude-haiku-4.5')
+        expect(agentHelpers.resolveFastModelId({ provider: AIProviderName.OPENROUTER, fallbackModelId: 'unused' })).toBe('anthropic/claude-haiku-4.5')
+        expect(agentHelpers.resolveFastModelId({ provider: AIProviderName.OPENAI, fallbackModelId: 'unused' })).toBe('gpt-5.5')
+    })
+
+    it('picks the fast model from an admin-listed catalog instead of the fallback', () => {
+        const config = vertexConfig([{ modelId: 'gemini-2.5-flash', modelType: AIProviderModelType.TEXT }])
+
+        expect(agentHelpers.resolveFastModelId({ provider: AIProviderName.VERTEX, config, fallbackModelId: 'unused' })).toBe('gemini-2.5-flash')
+    })
+
+    it('holds the fallback against the key model allow-list', () => {
+        const scoped = { provider: AIProviderName.BEDROCK, config: { region: 'us-east-1' }, modelScope: 'selected' as const }
+
+        expect(agentHelpers.resolveFastModelId({ ...scoped, modelIds: ['us.anthropic.claude-sonnet-5'], fallbackModelId: 'us.anthropic.claude-sonnet-5' })).toBe('us.anthropic.claude-sonnet-5')
+        expect(() => agentHelpers.resolveFastModelId({ ...scoped, modelIds: ['us.anthropic.claude-haiku-4-5'], fallbackModelId: 'us.anthropic.claude-opus-4-8' })).toThrow()
+    })
+
+    it('never ships a tier id or an empty string as the fallback model', () => {
+        expect(agentHelpers.resolveFastModelId({ provider: AIProviderName.BEDROCK, fallbackModelId: 'smart' })).toBe('claude-haiku-4-5')
+        expect(agentHelpers.resolveFastModelId({ provider: AIProviderName.BEDROCK, fallbackModelId: '' })).toBe('claude-haiku-4-5')
     })
 })

--- a/packages/server/api/test/unit/app/ee/agent/agent-rpc-handlers.test.ts
+++ b/packages/server/api/test/unit/app/ee/agent/agent-rpc-handlers.test.ts
@@ -402,6 +402,7 @@ describe('agentRpcHandlers.executePieceTool — a configured action runs in its 
         mockRunResolved.mockClear()
         mockResolveInput.mockClear()
         mockFindOneBy.mockResolvedValue(conversation)
+        mockFindOne.mockResolvedValue(conversation)
         mockGetOneWithoutValue.mockResolvedValue({ id: 'ac-1', externalId: 'conn-1', displayName: 'Sales Inbox' })
         const { agentRpcHandlers } = await import('../../../../../src/app/ee/agent/agent-rpc-handlers')
         return agentRpcHandlers(noopLogger as never).executePieceTool({
@@ -628,6 +629,7 @@ describe('agentRpcHandlers.executePieceTool — which account a configured actio
         mockResolveInput.mockClear()
         mockGetOneWithoutValue.mockClear()
         mockFindOneBy.mockResolvedValue(AGENT_CHAT)
+        mockFindOne.mockResolvedValue(AGENT_CHAT)
         mockGetOneWithoutValue.mockResolvedValue(pinnedExists ? { id: 'ac-1', externalId: PINNED, displayName: 'Sales Inbox' } : null)
         const { agentRpcHandlers } = await import('../../../../../src/app/ee/agent/agent-rpc-handlers')
         const response = await agentRpcHandlers(noopLogger as never).executePieceTool({


### PR DESCRIPTION
Fixes [GIT-1840](https://linear.app/activepieces/issue/GIT-1840)
Closes #15260

## Problem
1. Every agent run on a Bedrock provider fails on step 1 with `The provided model identifier is invalid`: the hardcoded fast tier (`anthropic/claude-haiku-4.5`) is transformed by stripping the vendor prefix and swapping dots for dashes into `claude-haiku-4-5`, which Bedrock rejects. Azure and Mistral hit the same path.
2. The run dies before the configured model (valid, works via direct Converse) handles a single step, and the surfaced error names the configured model instead of the failing request's model.

## Fix
- `agent-helpers.ts` — `resolveModelIdForProvider` gains an optional `fallbackModelId`, used only when the provider has no curated list and no admin catalog; the fallback still goes through `pickAllowedModel` (modelScope/modelIds allow-list enforced, fail-closed) and tier ids / empty strings are never used as model ids. `resolveFastModelId` requires it; `resolveTierModel`/`resolveFastModel` thread it optionally.
- `agent-rpc-handlers.ts` — getAgentConfig passes the run's resolved model as the fast-model fallback; executePieceTool passes the conversation's stored model; `configuredToolConversationOrThrow` now selects only the four columns it reads.
- `chat-personalization-service.ts` — hoists the resolved modelId and reuses it as the fallback (drops a duplicate resolution).

## Verification
- Regression test red-first: the BEDROCK fallback test fails on pre-fix code (returns `claude-haiku-4-5`), passes with the fix. 170 agent unit tests green.
- Live end-to-end on this branch (EE stack, real worker + engine, AWS stubbed at the socket): agent step 1 request is `POST /model/us.anthropic.claude-sonnet-5/converse-stream`, `claude-haiku-4-5` appears nowhere on the wire. Same scenario on the official 0.89.0 image reproduces the reported failure byte-for-byte.
- Allow-list inverse: a fallback outside a modelScope=selected key's modelIds still throws (pinned by test); curated providers keep their cheap fast tier (pinned by test).
- `npx turbo run build --filter=api` and `npm run lint-dev` clean. Full `test/unit` carries 47 pre-existing env-dependent failures (redis-memory-server), identical on clean upstream/main, none in agent files.
- Visual: none - backend-only, no user-visible change.
- Other affected paths: chat-surface smart-tier resolution (CHAT source), `agent-memory-ai.ts`, `agent-draft-ai.ts`, `agent-service.ts#withDefaultModel` still fabricate ids on catalog-less providers — no configured model exists to fall back to at those sites; tracked as follow-ups on [GIT-1840](https://linear.app/activepieces/issue/GIT-1840).
- Repro: reproduced on the 0.89.0 image and fix wire-verified live — full steps in the Reproduction block.

<details>
<summary>Plan & reasoning</summary>

## Plan
- One guard at the shared choke point (`resolveModelIdForProvider`) instead of per-caller patches; the three call sites with a real configured model supply it as the fallback.
- Footprint estimate: 3 files, ~20 product lines; actual ~30 after review hardening (allow-list routing, tier-id/empty-string guards).

## Non-happy scenarios considered
- modelScope=selected key, fallback outside modelIds → ENTITY_NOT_FOUND, fail-closed (same as pre-fix).
- Stored `conversation.modelName` is a tier id (`smart`, persisted when a step names no model) or empty → fallback ignored, behavior unchanged.
- AGENT-source conversation with null modelName → fallback dropped by `spreadIfDefined`, unchanged.
- Curated/catalog providers → fallback never consulted, fast tier keeps the cheap model.

## Alternatives rejected
- Optional `fastModelId` through the worker contract: 4+ files and a core package version bump for identical behavior.
- Curated Bedrock model list: a hand-maintained catalog duplicating what `ListFoundationModels` already serves, goes stale.
- Returning the fallback without `pickAllowedModel`: bypasses the admin model allow-list (flagged in review, fixed).
- Throwing when no catalog exists: breaks chat surfaces that currently degrade instead of failing setup.
</details>

<details>
<summary>Reproduction</summary>

## Environment
- Bug: official image `activepieces/activepieces:0.89.0`, `AP_EDITION=ee`, `AP_EXECUTION_MODE=SANDBOX_CODE_ONLY`, fresh Postgres DB, separate Redis DB index, fake AWS credentials.
- Fix verification: this branch via `npx turbo run serve --filter=api --filter=@activepieces/engine --filter=worker`, `AP_EDITION=ee`, `AP_DEV_PIECES=webhook,ai`.
- Both lanes: outbound AWS intercepted in-process with `NODE_OPTIONS="--require shim.cjs"` — logs every Bedrock request (URL + toolConfig names) and answers with an AWS-faithful 400 ValidationException for any model except the configured profile; the Bedrock control plane (ListFoundationModels/ListInferenceProfiles over `https.request`) is stubbed so provider creation passes without real credentials.

## Harness
Public gist: https://gist.github.com/majewskibartosz/22a29958a9ff223929e652c20b539c62 — `shim.cjs` (interceptor), `scenario.mjs` (drives sign-up → Bedrock provider → flow build → webhook fire → run state), `README.md` (exact commands), plus both captured wire logs. Run: `git clone https://gist.github.com/22a29958a9ff223929e652c20b539c62.git git-1840-repro && cd git-1840-repro` and follow README.md.

## Trigger
Published flow: Catch Webhook (authType none) → Run Agent (provider `bedrock`, model `us.anthropic.claude-sonnet-5`, no tools, max steps 3, prompt "Return exactly: LOCAL_BEDROCK_SONNET_5_OK"); fire the webhook.

## Results
- 0.89.0: conversation-title generation hits the configured model, then agent step 1 = `POST /model/claude-haiku-4-5/converse-stream` (toolConfig `["ap_fetch_url"]`) → 400; flow run FAILED with `bedrock (us.anthropic.claude-sonnet-5): undefined: The provided model identifier is invalid.` — the error names the configured model while the wire shows the haiku request, which is why logs alone mislead.
- Branch: step 1 = `POST /model/us.anthropic.claude-sonnet-5/converse-stream`; `claude-haiku-4-5` absent from the entire capture; the run reaches the provider and fails only against the reject-everything stub.
</details>

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)
