### PR TITLE
fix(ai): Ask AI and Summarize Text no longer fail on models that reject the temperature setting

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -336,7 +336,7 @@
     },
     "packages/pieces/community/ai": {
       "name": "@activepieces/piece-ai",
-      "version": "0.10.0",
+      "version": "0.10.1",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -362,6 +362,7 @@
       "devDependencies": {
         "@types/mime-types": "2.1.1",
         "tslib": "2.6.2",
+        "vitest": "3.2.6",
       },
     },
     "packages/pieces/community/aianswer": {
@@ -1127,7 +1128,7 @@
     },
     "packages/pieces/community/bettermode": {
       "name": "@activepieces/piece-bettermode",
-      "version": "0.1.8",
+      "version": "0.1.9",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",

--- a/packages/pieces/community/ai/package.json
+++ b/packages/pieces/community/ai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-ai",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
@@ -29,10 +29,12 @@
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",
     "bundle": "node ../../../../dist/packages/cli/src/index.js pieces bundle",
-    "lint": "eslint 'src/**/*.ts'"
+    "lint": "eslint 'src/**/*.ts'",
+    "test": "vitest run"
   },
   "devDependencies": {
     "@types/mime-types": "2.1.1",
-    "tslib": "2.6.2"
+    "tslib": "2.6.2",
+    "vitest": "3.2.6"
   }
 }

--- a/packages/pieces/community/ai/src/lib/actions/text/ask-ai.ts
+++ b/packages/pieces/community/ai/src/lib/actions/text/ask-ai.ts
@@ -1,9 +1,5 @@
-import {
-  createAction,
-  Property,
-} from '@activepieces/pieces-framework';
 import { ModelMessage, generateText, stepCountIs } from 'ai';
-import { AIProviderName, getEffectiveProviderAndModel, spreadIfDefined } from '@activepieces/pieces-framework';
+import { AIProviderName, createAction, getEffectiveProviderAndModel, isNil, Property, spreadIfDefined } from '@activepieces/pieces-framework';
 import { aiProps, aiProviderSelection } from '../../common/props';
 import { createAIModel } from '../../common/ai-sdk';
 import { buildWebSearchOptionsProperty, buildWebSearchConfig, WebSearchOptions } from '../../common/web-search';
@@ -29,7 +25,6 @@ export const askAI = createAction({
     creativity: Property.Number({
       displayName: 'Creativity',
       required: false,
-      defaultValue: 100,
       description:
         'Controls the creativity of the AI response. A higher value will make the AI more creative and a lower value will make it more deterministic.',
     }),
@@ -109,7 +104,7 @@ export const askAI = createAction({
         },
       ],
       maxOutputTokens: context.propsValue.maxOutputTokens,
-      temperature: (context.propsValue.creativity ?? 100) / 100,
+      ...spreadIfDefined('temperature', isNil(context.propsValue.creativity) ? undefined : context.propsValue.creativity / 100),
       tools: webSearchTools,
       stopWhen,
       providerOptions,

--- a/packages/pieces/community/ai/src/lib/actions/text/summarize-text.ts
+++ b/packages/pieces/community/ai/src/lib/actions/text/summarize-text.ts
@@ -10,7 +10,7 @@ export const summarizeText = createAction({
   classification: 'READ',
   displayName: 'Summarize Text',
   description: 'Summarize long emails, articles, or documents into what matters.',
-  aiMetadata: { description: 'Condenses one block of supplied text into a shorter summary using a chosen text model. Pick it when the goal is a shorter version of text you already have; use extractStructuredData for specific typed fields, classifyText for a label, or askAi for open-ended questions. Requires a provider/model, the text inline (it fetches no URLs and reads no files) and the Prompt prop, which carries a default guide instruction but is still required; not idempotent, as generation runs at temperature 1, so identical text returns differently worded summaries.', idempotent: false },
+  aiMetadata: { description: 'Condenses one block of supplied text into a shorter summary using a chosen text model. Pick it when the goal is a shorter version of text you already have; use extractStructuredData for specific typed fields, classifyText for a label, or askAi for open-ended questions. Requires a provider/model, the text inline (it fetches no URLs and reads no files) and the Prompt prop, which carries a default guide instruction but is still required; not idempotent, as generation is non-deterministic, so identical text returns differently worded summaries.', idempotent: false },
   props: {
     provider: aiProps({ modelType: 'text' }).provider,
     model: aiProps({ modelType: 'text' }).model,
@@ -54,7 +54,6 @@ export const summarizeText = createAction({
         },
       ],
       maxOutputTokens: context.propsValue.maxOutputTokens,
-      temperature: 1,
       providerOptions: {
         [provider]: {
           ...(provider === AIProviderName.OPENAI ? { reasoning_effort: 'minimal' } : {}),

--- a/packages/pieces/community/ai/src/lib/actions/text/temperature.test.ts
+++ b/packages/pieces/community/ai/src/lib/actions/text/temperature.test.ts
@@ -1,0 +1,69 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createMockActionContext } from '@activepieces/pieces-framework';
+import { generateText } from 'ai';
+import { askAI } from './ask-ai';
+import { summarizeText } from './summarize-text';
+
+vi.mock('ai', () => ({
+  generateText: vi.fn(async () => ({ text: 'ok', sources: [] })),
+  stepCountIs: vi.fn(),
+}));
+
+vi.mock('../../common/ai-sdk', () => ({
+  createAIModel: vi.fn(async () => ({})),
+}));
+
+const generateTextMock = vi.mocked(generateText);
+
+const baseProps = {
+  provider: { provider: 'openai', configId: 'config1' },
+  model: 'gpt-test',
+  maxOutputTokens: 2000,
+};
+
+async function askAiGenerateTextArgs({ creativity }: { creativity: number | null | undefined }) {
+  await askAI.run(createMockActionContext({
+    propsValue: { ...baseProps, prompt: 'hello', webSearch: false, creativity },
+  }));
+  return generateTextMock.mock.calls[0][0];
+}
+
+beforeEach(() => {
+  generateTextMock.mockClear();
+});
+
+describe('askAI temperature', () => {
+  it('omits temperature when creativity is not set', async () => {
+    const args = await askAiGenerateTextArgs({ creativity: undefined });
+    expect(args).not.toHaveProperty('temperature');
+  });
+
+  it('omits temperature when creativity is null', async () => {
+    const args = await askAiGenerateTextArgs({ creativity: null });
+    expect(args).not.toHaveProperty('temperature');
+  });
+
+  it('sends temperature scaled from an explicit creativity', async () => {
+    const args = await askAiGenerateTextArgs({ creativity: 50 });
+    expect(args.temperature).toBe(0.5);
+  });
+
+  it('sends temperature 1 for the previously seeded default of 100', async () => {
+    const args = await askAiGenerateTextArgs({ creativity: 100 });
+    expect(args.temperature).toBe(1);
+  });
+
+  it('sends temperature 0 when creativity is 0', async () => {
+    const args = await askAiGenerateTextArgs({ creativity: 0 });
+    expect(args.temperature).toBe(0);
+  });
+});
+
+describe('summarizeText temperature', () => {
+  it('sends no temperature', async () => {
+    await summarizeText.run(createMockActionContext({
+      propsValue: { ...baseProps, text: 'long text', prompt: 'Summarize' },
+    }));
+    expect(generateTextMock.mock.calls[0][0]).not.toHaveProperty('temperature');
+  });
+});

--- a/packages/pieces/community/ai/tsconfig.lib.json
+++ b/packages/pieces/community/ai/tsconfig.lib.json
@@ -16,5 +16,6 @@
     "declarationMap": true,
     "types": ["node"]
   },
+  "exclude": ["src/**/*.spec.ts", "src/**/*.test.ts"],
   "include": ["src/**/*.ts"]
 }

--- a/packages/pieces/community/ai/vitest.config.ts
+++ b/packages/pieces/community/ai/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+  },
+})


### PR DESCRIPTION
Fixes [GIT-1841](https://linear.app/activepieces/issue/GIT-1841)
Closes #15261

## Problem

1. Ask AI always sends `temperature` — `(creativity ?? 100) / 100` — so a blank Creativity field still sends `1.0`. Models that reject the parameter (GPT-5 family on Bedrock, e.g. `us.openai.gpt-5.6-luna`) fail every run with `AI_APICallError: This model doesn't support the temperature field.` There is no way to turn it off.
2. Summarize Text hardcodes `temperature: 1` — same failure, no user control at all.
3. Bedrock is called directly from the piece (SigV4 via `createAmazonBedrock`), so no server-side layer can strip the field; the piece is the only place to fix this.

## Fix

- `ask-ai.ts` — send temperature only when Creativity is set (`spreadIfDefined` + `isNil` guard so an explicit `0` still sends `0`); drop `defaultValue: 100` so new steps omit it by default.
- `summarize-text.ts` — delete the hardcoded `temperature: 1`; update `aiMetadata` wording that referenced it.
- `package.json` — patch bump `0.10.0 → 0.10.1` so pinned steps auto-heal; add vitest for the regression test.

Blank Creativity now means the provider default (1.0 on OpenAI/Anthropic/Google/Claude-on-Bedrock; Mistral 0.7). Steps with an explicit Creativity value are unchanged — an explicit `100` on a rejecting model still errors, intentionally, since silently dropping an explicit user value would be worse than the provider's honest error.

Product decision embedded: blank Creativity means "omit temperature" (provider default) instead of silently sending 1.0; alternative considered: keep seeding the 100 default, rejected because new steps would stay broken by default on temperature-rejecting models.

## Verification

- Regression test `temperature.test.ts` (6 cases), proven red-first: 3 fail on pre-fix code (blank, null, summarize), all pass with the fix.
- Wire capture on the published `@activepieces/piece-ai@0.9.0` bundle (customer's exact version) reproduced the bug: blank/null/default Creativity all send `inferenceConfig.temperature: 1` to `bedrock-runtime`. Same harness against this branch's build: blank/null send no temperature key; explicit `100`/`0` still send `1`/`0`.
- Repro: published-bundle harness with stubbed Bedrock endpoint, all five input permutations captured at the network boundary — full steps in the Reproduction block.
- `npx turbo run lint --filter=@activepieces/piece-ai` clean; `npx turbo run test --filter=@activepieces/piece-ai` clean.
- Visual: real dev app (`localhost:4200`), Ask AI step form driven as a user — before (v0.10.0): Creativity prefilled 100; after (v0.10.1): Creativity empty, Max Tokens default 2000 unaffected. Screenshots in the Visual verification comment.
- Other affected paths: checked — Classify Text, Extract Structured Data, Generate Image send no temperature; vendor-specific pieces (claude, azure-openai, groq, …) expose temperature as their own explicit props (different contract, untouched); EE agent internals send `temperature: 0` on curated models (separate surface).
- `bun.lock` also picks up the bettermode `0.1.8 → 0.1.9` entry that #15257 bumped in `package.json` without regenerating the lockfile — lockfile sync, not part of this fix.

<details>
<summary>Plan & reasoning</summary>

## Plan

- Omit-when-unset at the two send sites; no new props, no model catalog. Footprint estimate: 3 files, ~8 product lines — actual: 3 product files +4/−6, plus test file, vitest config, and a tsconfig test-exclude.
- `spreadIfDefined` with `isNil` guard because `null / 100 === 0` and `0` must remain a valid explicit value.
- Patch (not minor) bump so `~0.10.x`-pinned steps pick the fix up without user action, matching the fillout-forms precedent.

## Non-happy scenarios considered

- Creativity `0` → still sends `temperature: 0` (deterministic mode preserved; covered by test + wire capture).
- Existing steps with a stored explicit `100` → unchanged behavior; on rejecting models the user clears the field once (the provider error says exactly that).
- Empty-string creativity from an expression → same as pre-fix (`'' / 100 === 0`), no regression.

## Alternatives rejected

- Model deny-list ("strip temperature for gpt-5*") → Bedrock model IDs are customer-typed and unbounded; ID pattern-matching caused GIT-1840.
- Catch-and-retry without temperature → per-provider error-string sniffing, doubles cost on the failure path, silently overrides explicit user input.
- Server-side stripping → impossible; the piece signs and calls Bedrock directly.
</details>

<details>
<summary>Reproduction</summary>

## Environment

Published `@activepieces/piece-ai@0.9.0` bundle from npm (self-contained, node builtins only), plain `node`, no server/DB. Local HTTP stub serves `GET /v1/ai-providers/bedrock/config` (region + fake keys); a `globalThis.fetch` shim intercepts requests to `*.amazonaws.com`, records the JSON body, and returns Bedrock's real rejection message as a 400.

## Harness

```js
const http = require('http');

const captured = [];
const realFetch = globalThis.fetch;
globalThis.fetch = async (input, init) => {
  const url = typeof input === 'string' ? input : input.url;
  if (url.includes('amazonaws.com')) {
    const body = init?.body ? JSON.parse(init.body) : null;
    captured.push({ url, body });
    return new Response(JSON.stringify({ message: "This model doesn't support the temperature field. Remove temperature and try again." }), { status: 400, headers: { 'content-type': 'application/json' } });
  }
  return realFetch(input, init);
};

const mod = require('./package/src/index.js');
const piece = Object.values(mod).find((v) => v && typeof v.actions === 'function');
const actions = piece.actions();

function makeCtx({ port, props }) {
  return {
    propsValue: {
      provider: { provider: 'bedrock', configId: 'cfg1' },
      model: 'us.openai.gpt-5.6-luna',
      prompt: 'Say "Hello World"',
      conversationKey: undefined,
      webSearch: false,
      webSearchOptions: {},
      maxOutputTokens: 2000,
      ...props,
    },
    server: { token: 'engine-token', apiUrl: `http://127.0.0.1:${port}/`, publicUrl: `http://127.0.0.1:${port}/` },
    project: { id: 'proj1' },
    flows: { current: { id: 'flow1' } },
    run: { id: 'run1' },
    store: { get: async () => null, put: async () => null, delete: async () => null },
  };
}

(async () => {
  const server = http.createServer((q, s) => {
    s.writeHead(200, { 'content-type': 'application/json' });
    s.end(JSON.stringify({
      config: { region: 'us-east-1' },
      auth: { accessKeyId: 'AKIAFAKE', secretAccessKey: 'fakesecret' },
      platformId: 'plat1',
    }));
  });
  await new Promise((r) => server.listen(0, '127.0.0.1', r));
  const port = server.address().port;

  const cases = [
    ['askAi creativity=undefined (blank, customer case)', 'askAi', { creativity: undefined }],
    ['askAi creativity=100 (default)', 'askAi', { creativity: 100 }],
    ['askAi creativity=0', 'askAi', { creativity: 0 }],
    ['askAi creativity=null', 'askAi', { creativity: null }],
    ['summarizeText', 'summarizeText', { text: 'hello world text', prompt: 'Summarize', creativity: undefined }],
  ];

  for (const [label, actionName, props] of cases) {
    captured.length = 0;
    const action = actions[actionName];
    if (!action) { console.log(`${label} -> NO SUCH ACTION`); continue; }
    try {
      const out = await action.run(makeCtx({ port, props }));
      console.log(`${label} -> OK ${JSON.stringify(out).slice(0, 80)}`);
    } catch (e) {
      console.log(`${label} -> THREW ${e.name || e.constructor.name}: ${String(e.message).slice(0, 90)}`);
    }
    for (const c of captured) {
      console.log(`   inferenceConfig: ${JSON.stringify(c.body?.inferenceConfig)}`);
    }
    if (captured.length === 0) console.log('   wire: NO BEDROCK CALL CAPTURED');
  }
  process.exit(0);
})();
```

Run: `npm pack @activepieces/piece-ai@0.9.0 && tar xzf *.tgz && node repro.cjs` (save the harness as `repro.cjs` beside `package/`). To test the fixed build, point the `require` at this branch's `packages/pieces/community/ai/dist/src/index.js` after `npx turbo run build --filter=@activepieces/piece-ai`.

## Trigger

Calling `askAi.run()` with `creativity` absent — the exact state of the reporting customer's step (their step config showed `creativity` empty). No real AWS account needed: the assertion is on the outbound request body, and the stub returns Bedrock's documented rejection for GPT-5-family models.

## Results

| Case | 0.9.0 (published) | this branch |
| --- | --- | --- |
| Ask AI, Creativity blank | `{"maxTokens":2000,"temperature":1}` | `{"maxTokens":2000}` |
| Ask AI, Creativity null | `temperature: 1` | no temperature key |
| Ask AI, Creativity 100 | `temperature: 1` | `temperature: 1` (unchanged) |
| Ask AI, Creativity 0 | `temperature: 0` | `temperature: 0` (unchanged) |
| Summarize Text | `temperature: 1` | no temperature key |

Blank-input rows prove the bug and the fix; explicit-value rows prove no behavior change for set values.
</details>

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

No self-hoster or API consumer action required: steps with an explicit Creativity keep their behavior; blank-Creativity steps stop force-sending 1.0, which is the defect under fix. Delivered as a piece patch bump.

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)
