### PR TITLE
fix(stripe): triggers no longer fail to enable with "Invalid array"

### DIFF
--- a/packages/pieces/community/stripe/package.json
+++ b/packages/pieces/community/stripe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-stripe",
-  "version": "0.6.13",
+  "version": "0.6.14",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {

--- a/packages/pieces/community/stripe/src/lib/common/index.ts
+++ b/packages/pieces/community/stripe/src/lib/common/index.ts
@@ -40,7 +40,7 @@ export const stripeCommon = {
         'Content-Type': 'application/x-www-form-urlencoded',
       },
       body: {
-        enabled_events: [eventName],
+        'enabled_events[]': eventName,
         url: webhookUrl,
       },
       authentication: {


### PR DESCRIPTION
## Description

Enabling any Stripe trigger failed with a `400 Invalid array` error from Stripe, so no Stripe trigger could be published:

```
"message": "Invalid array", "param": "enabled_events", "type": "invalid_request_error"
```

Stripe's `/v1` API [accepts form-encoded request bodies only](https://docs.stripe.com/api), and array parameters must be sent as repeated bracket keys (`enabled_events[]=charge.succeeded`). The shared `stripeCommon.subscribeWebhook` helper passed `enabled_events` as a raw JS array, which the HTTP client form-encodes via `new URLSearchParams(body)`. `URLSearchParams` has no array expansion — it stringifies values with `String()`, collapsing the array to a scalar `enabled_events=charge.succeeded`. Stripe then rejected the parameter as not being an array.

The fix sends the value under the bracket key Stripe expects, matching the convention already used elsewhere in this piece for arrays and nested params (`create-checkout-session.ts` → `line_items[0][price]`, `create-price.ts` → `recurring[interval]`).

All 13 Stripe triggers register their webhook through this one helper, so this single line fixes every one of them: new charge, new customer, new payment, new refund, new invoice, new dispute, new subscription, new payment link, checkout session completed, invoice payment failed, payment failed, canceled subscription, updated subscription.

## How was this tested?

Manually, on a local backend with an ngrok tunnel against a Stripe test account:

- Published the **New Charge** trigger — webhook endpoint now created successfully (previously `400 Invalid array`).
- Published the **New Customer** trigger — also confirmed working.
- Both triggers share the identical code path as the remaining 11; only the event name differs, so the encoding is the same for all of them.
- Verified the encoded body is `enabled_events[]=charge.succeeded&url=...`.
- Verified only one `POST /webhook_endpoints` call site exists in the piece, and all 13 trigger files call the shared helper — no trigger has its own webhook-creation code.
- `npx turbo run lint --filter=@activepieces/piece-stripe` passes with no warnings.

Edition paths: piece-level change with no edition-specific or server-side behaviour, so it applies identically on CE / EE / Cloud.

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)
