### PR TITLE
docs(skills): step-form review guide, scanner and fit-the-box copy rules

### DIFF
--- a/.agents/skills/design/SKILL.md
+++ b/.agents/skills/design/SKILL.md
@@ -71,6 +71,10 @@ Matter-of-fact, second-person, verb-first. No "Click here". No "Please". No hype
 - **Empty states**: state the fact, then the action. *"No flows yet. Create your first flow to start automating."*
 - **Do**: "Your flow is live.", "Add a step", "Connect your Google account"
 - **Don't**: "Awesome! 🎉 Your flow is now live!", "Click here to add a step", "Please authorize Google"
+- **Text must fit its box.** When text is longer than its container, change the container — full width, a Markdown block, stacked fields, an option `description` — or shorten the text. Clipped text is never the third option. The three limits below are that rule measured.
+- **Field help text is 70 characters max.** Step-form descriptions under inputs truncate to `... show more` past 70 characters, so one short sentence per field. Longer guidance goes in a Markdown block, not a description.
+- **Half-width fields are ~20 characters wide** in the step panel. Reserve them for short values. If the value or its help text outgrows that, stack the fields full width instead.
+- **Dropdown labels hold one idea.** The trigger shows roughly 40 characters and only the label, so never pack a human name and its code into one label. Options take a `description` that renders as a dimmed second line and is searchable: the recognisable value goes in the label, the code or pattern goes there.
 
 ## Quick-reference tokens
 

--- a/.agents/skills/piece-builder/SKILL.md
+++ b/.agents/skills/piece-builder/SKILL.md
@@ -66,6 +66,7 @@ The condensed rules in this file (Quick Auth Reference, Quick Piece Definition T
 | Your first action in this piece (full file shape) | `action-patterns.md` |
 | A trigger — polling, webhook, handshake, or renewal | `trigger-patterns.md` |
 | **Choosing which prop component, display mode, or layout/grouping fits a use case** | `property-ui-selection.md` |
+| **Improving an existing piece's step forms** (copy, Advanced placement, what reviewers flag, the `check-step-form.mjs` scanner) | `step-form-review.md` |
 | The exact syntax of a prop type (dropdowns, dynamic, arrays, files) | `props-patterns.md` |
 | Shared API helper, pagination, or `createCustomApiCallAction` | `common-patterns.md` |
 | An advanced UX pattern (source selectors, AWS-style auth) | `ux-guidelines.md` |

--- a/.agents/skills/piece-builder/property-ui-selection.md
+++ b/.agents/skills/piece-builder/property-ui-selection.md
@@ -90,6 +90,8 @@ These live directly on the property. They fine-tune placement without changing t
 
 **Advanced section rule:** every prop renders in the main form by default, required or not. Opt a field *out* with `advanced: true`. Don't set it on a required prop — the Advanced section starts collapsed, so a mandatory field hidden there only surfaces as a validation error.
 
+Before flagging a field `advanced`, ask four questions; any "yes" keeps it on the primary form: is it required? does its **default change the result** (a "Number of Rows" that defaults to 1)? does it change **what the step reads at run time**, not just what a dropdown lists (an "Include Shared Drives" toggle on a search or trigger)? is it the **form's only field**? `advanced` exists from release **0.88.2** — set `minimumSupportedRelease` accordingly or older self-hosted installs render the field inline. Full reasoning and the review history: `step-form-review.md` §4.
+
 ---
 
 ## 4. Grouping props with `propertyGroups`
@@ -114,6 +116,7 @@ propertyGroups: [{ key, display, label?, description?, icon?, props: ['fieldA', 
 - Every prop named in a group must exist in `props`.
 - Only ungrouped props honour `advanced: true` — members of `tabs` and `section` groups are always essential; the flag is ignored on them. In a sectioned layout, checkbox `reveals` targets are forced essential too: they render inline under their toggle, never in Advanced.
 - **One `builder` or `footer` group disables the Advanced section for the whole action/trigger** — every prop is forced essential and `advanced: true` stops working form-wide. Don't combine a filter builder with Advanced props.
+- **Ungrouped props render below every `section` card**, in declaration order. A section meant to hold "the top fields" pushes everything ungrouped underneath it — either group all the primary fields or none of them.
 - Give `section` and `builder` groups a `label` and `icon` so cards/categories read clearly.
 
 ---
@@ -181,5 +184,9 @@ props: {
 - **`Property.Json` as an escape hatch.** If the shape is known, model it with real props or an `Array` of fields.
 - **`Property.DynamicProperties` for a static form.** It's the heaviest widget; only use it when fields truly depend on runtime data.
 - **`advanced: true` on a required prop.** Advanced starts collapsed; a mandatory field hidden there only surfaces as a validation error.
+- **`advanced: true` on a field whose default decides the outcome.** A result limit defaulting to 1 hidden in Advanced means a search silently returns one row; keep it visible and hide the offset instead.
+- **Units or formats in the label.** `Timeout (in seconds)`, `Text (Markdown)` — the unit goes in the description, the label stays a noun.
+- **A `?` on a toggle label.** `Response is Binary ?` — a checkbox is a statement, not a question, and never takes a space before punctuation.
+- **The same prop with two labels.** If `useHeaderNames` is `Use Column Names` on three actions it is not `Use Header Names` on the fourth, and a Custom API Call form matches the HTTP piece's labels rather than inventing its own. Grep the siblings before naming anything.
 
 Full type syntax and dynamic-dropdown/refresher mechanics: `props-patterns.md`. Rendered previews of every option: `docs/build-pieces/piece-reference/properties.mdx`.

--- a/.agents/skills/piece-builder/scripts/check-step-form.mjs
+++ b/.agents/skills/piece-builder/scripts/check-step-form.mjs
@@ -1,9 +1,11 @@
 #!/usr/bin/env node
 
+import { readFileSync } from 'node:fs';
+
 const DESCRIPTION_FOLD_LIMIT = 70;
 const ADVANCED_MIN_RELEASE = '0.88.2';
 const TITLE_CASE_SMALL_WORDS = new Set([
-  'a', 'an', 'the', 'and', 'or', 'of', 'to', 'in', 'on', 'for', 'by', 'with', 'as', 'at', 'from', 'per', 'vs',
+  'a', 'an', 'the', 'and', 'or', 'of', 'to', 'in', 'on', 'for', 'by', 'with', 'as', 'at', 'from', 'per', 'vs', 'is',
 ]);
 const PLACEHOLDER_RENDERING_TYPES = new Set(['SHORT_TEXT', 'LONG_TEXT']);
 const GROUP_DISPLAYS_THAT_DISABLE_ADVANCED = new Set(['builder', 'footer']);
@@ -12,8 +14,10 @@ const GROUP_DISPLAYS_THAT_FORCE_ESSENTIAL = new Set(['tabs', 'section']);
 function usage() {
   return [
     'Usage: node check-step-form.mjs <piece-dir-name> [--url http://localhost:4200] [--include-ai] [--json]',
+    '       node check-step-form.mjs --file <piece.json> [--include-ai] [--json]',
     '',
-    'Fetches the piece the local dev server serves (AP_DEV_PIECES must include it) and reports',
+    'Fetches the piece the local dev server serves (AP_DEV_PIECES must include it), or reads a saved',
+    'GET /api/v1/pieces/<name> response from --file, and reports',
     'every step-form problem a reviewer would flag: descriptions past the read-more fold,',
     'required props hidden in Advanced, labels with units or question marks, markdown in plain-text',
     'descriptions, placeholders on inputs that never render them, the same prop labelled differently',
@@ -23,18 +27,28 @@ function usage() {
   ].join('\n');
 }
 
+const FLAGS_WITH_VALUES = new Set(['--url', '--file']);
+
 function parseArgs(argv) {
-  const positional = argv.filter((arg) => !arg.startsWith('--'));
+  const positional = argv.filter((arg, index) => !arg.startsWith('--') && !FLAGS_WITH_VALUES.has(argv[index - 1]));
   const flagValue = (name) => {
     const index = argv.indexOf(name);
     return index === -1 ? undefined : argv[index + 1];
   };
   return {
     pieceDirName: positional[0],
+    file: flagValue('--file'),
     url: flagValue('--url') ?? 'http://localhost:4200',
     includeAi: argv.includes('--include-ai'),
     json: argv.includes('--json'),
   };
+}
+
+function loadPiece({ file, url, pieceDirName }) {
+  if (file) {
+    return JSON.parse(readFileSync(file, 'utf8'));
+  }
+  return fetchPiece({ url, pieceDirName });
 }
 
 async function fetchPiece({ url, pieceDirName }) {
@@ -60,7 +74,7 @@ function compareSemver({ left, right }) {
 }
 
 function isTitleCase(label) {
-  const words = label.split(/\s+/).filter((word) => /^[A-Za-z]/.test(word));
+  const words = label.replace(/\(.*?\)/g, '').split(/\s+/).filter((word) => /^[A-Za-z]/.test(word));
   return words.every((word, index) => {
     const lower = word.toLowerCase();
     if (index > 0 && TITLE_CASE_SMALL_WORDS.has(lower)) {
@@ -217,11 +231,11 @@ function render({ piece, steps, skippedAi, findings }) {
 
 async function main() {
   const args = parseArgs(process.argv.slice(2));
-  if (!args.pieceDirName) {
+  if (!args.pieceDirName && !args.file) {
     console.log(usage());
     process.exit(2);
   }
-  const piece = await fetchPiece(args);
+  const piece = await loadPiece(args);
   const steps = humanSteps({ piece, includeAi: args.includeAi });
   const skippedAi = Object.values(piece.actions ?? {}).length - steps.filter((step) => step.kind === 'action').length;
   const findings = [

--- a/.agents/skills/piece-builder/scripts/check-step-form.mjs
+++ b/.agents/skills/piece-builder/scripts/check-step-form.mjs
@@ -1,0 +1,243 @@
+#!/usr/bin/env node
+
+const DESCRIPTION_FOLD_LIMIT = 70;
+const ADVANCED_MIN_RELEASE = '0.88.2';
+const TITLE_CASE_SMALL_WORDS = new Set([
+  'a', 'an', 'the', 'and', 'or', 'of', 'to', 'in', 'on', 'for', 'by', 'with', 'as', 'at', 'from', 'per', 'vs',
+]);
+const PLACEHOLDER_RENDERING_TYPES = new Set(['SHORT_TEXT', 'LONG_TEXT']);
+const GROUP_DISPLAYS_THAT_DISABLE_ADVANCED = new Set(['builder', 'footer']);
+const GROUP_DISPLAYS_THAT_FORCE_ESSENTIAL = new Set(['tabs', 'section']);
+
+function usage() {
+  return [
+    'Usage: node check-step-form.mjs <piece-dir-name> [--url http://localhost:4200] [--include-ai] [--json]',
+    '',
+    'Fetches the piece the local dev server serves (AP_DEV_PIECES must include it) and reports',
+    'every step-form problem a reviewer would flag: descriptions past the read-more fold,',
+    'required props hidden in Advanced, labels with units or question marks, markdown in plain-text',
+    'descriptions, placeholders on inputs that never render them, the same prop labelled differently',
+    'across sibling actions, and a release floor too low for the advanced flag.',
+    '',
+    'Exit code 1 when any finding is an error, 0 otherwise.',
+  ].join('\n');
+}
+
+function parseArgs(argv) {
+  const positional = argv.filter((arg) => !arg.startsWith('--'));
+  const flagValue = (name) => {
+    const index = argv.indexOf(name);
+    return index === -1 ? undefined : argv[index + 1];
+  };
+  return {
+    pieceDirName: positional[0],
+    url: flagValue('--url') ?? 'http://localhost:4200',
+    includeAi: argv.includes('--include-ai'),
+    json: argv.includes('--json'),
+  };
+}
+
+async function fetchPiece({ url, pieceDirName }) {
+  const endpoint = `${url}/api/v1/pieces/${encodeURIComponent(`@activepieces/piece-${pieceDirName}`)}`;
+  const response = await fetch(endpoint).catch(() => {
+    throw new Error(`No dev server answering at ${url}. Start it with "npm start" and make sure "${pieceDirName}" is in AP_DEV_PIECES.`);
+  });
+  if (!response.ok) {
+    throw new Error(`${endpoint} responded ${response.status}. Is the dev server up and is "${pieceDirName}" in AP_DEV_PIECES?`);
+  }
+  return response.json();
+}
+
+function compareSemver({ left, right }) {
+  const leftParts = left.split('.').map(Number);
+  const rightParts = right.split('.').map(Number);
+  for (let index = 0; index < 3; index += 1) {
+    if (leftParts[index] !== rightParts[index]) {
+      return leftParts[index] - rightParts[index];
+    }
+  }
+  return 0;
+}
+
+function isTitleCase(label) {
+  const words = label.split(/\s+/).filter((word) => /^[A-Za-z]/.test(word));
+  return words.every((word, index) => {
+    const lower = word.toLowerCase();
+    if (index > 0 && TITLE_CASE_SMALL_WORDS.has(lower)) {
+      return true;
+    }
+    return word[0] === word[0].toUpperCase();
+  });
+}
+
+function humanSteps({ piece, includeAi }) {
+  const actions = Object.values(piece.actions ?? {})
+    .filter((action) => includeAi || action.audience !== 'ai')
+    .map((action) => ({ kind: 'action', ...action }));
+  const triggers = Object.values(piece.triggers ?? {}).map((trigger) => ({ kind: 'trigger', ...trigger }));
+  return [...actions, ...triggers];
+}
+
+function propFindings({ step, propName, prop }) {
+  const findings = [];
+  const label = prop.displayName ?? '';
+  const description = prop.description ?? '';
+  const type = prop.type;
+  const add = (level, rule, message) => findings.push({ level, rule, step: step.displayName, prop: propName, message });
+
+  if (type === 'MARKDOWN') {
+    if (prop.advanced) {
+      add('error', 'markdown-advanced', 'Property.MarkDown does not accept advanced (TS2353); the build will fail.');
+    }
+    return findings;
+  }
+  if (description.length > DESCRIPTION_FOLD_LIMIT) {
+    add('error', 'description-fold', `Description is ${description.length} chars; the builder folds anything over ${DESCRIPTION_FOLD_LIMIT} behind "show more".`);
+  }
+  if (/\*\*|`|\[.*\]\(.*\)/.test(description)) {
+    add('error', 'description-markdown', 'Description renders as plain text; markdown markers show literally.');
+  }
+  if (/\n/.test(description)) {
+    add('warn', 'description-newline', 'Description contains a line break; it renders as a single wrapped line.');
+  }
+  if (prop.required && prop.advanced) {
+    add('error', 'required-advanced', 'Required prop hidden in Advanced only surfaces as a validation error.');
+  }
+  if (prop.required && type === 'CHECKBOX') {
+    add('warn', 'required-checkbox', 'A checkbox is always answered; required only adds a misleading asterisk.');
+  }
+  if (prop.required && type === 'OBJECT') {
+    add('warn', 'required-object', 'Empty {} passes the OBJECT schema; required is never enforced, only shown.');
+  }
+  if (/\?\s*$/.test(label)) {
+    add('warn', 'label-question', 'Toggle and field labels are nouns, not questions; drop the "?".');
+  }
+  if (/\(.*\)/.test(label)) {
+    add('warn', 'label-parenthetical', 'Units and formats belong in the description, not the label ("Timeout (in seconds)").');
+  }
+  if (label && !isTitleCase(label)) {
+    add('warn', 'label-casing', 'Piece prop labels are Title Case (197:25 across Google pieces); match sibling forms first.');
+  }
+  if (prop.placeholder && !PLACEHOLDER_RENDERING_TYPES.has(type)) {
+    add('warn', 'placeholder-not-rendered', `${type} never renders a placeholder; move the example into the description or drop it.`);
+  }
+  return findings;
+}
+
+function stepFindings({ step }) {
+  const findings = [];
+  const props = Object.entries(step.props ?? {});
+  const add = (level, rule, message) => findings.push({ level, rule, step: step.displayName, prop: '', message });
+
+  props.forEach(([propName, prop]) => findings.push(...propFindings({ step, propName, prop })));
+
+  const inputProps = props.filter(([, prop]) => prop.type !== 'MARKDOWN');
+  const advancedProps = inputProps.filter(([, prop]) => prop.advanced);
+  if (inputProps.length > 0 && advancedProps.length === inputProps.length) {
+    add('error', 'all-advanced', `Every input is in Advanced; the form opens as "Advanced, ${advancedProps.length} option(s)" and nothing else.`);
+  }
+
+  const groups = step.propertyGroups ?? [];
+  const disablesAdvanced = groups.some((group) => GROUP_DISPLAYS_THAT_DISABLE_ADVANCED.has(group.display));
+  if (disablesAdvanced && advancedProps.length > 0) {
+    add('error', 'advanced-with-builder', 'A builder or footer group forces every prop essential; advanced does nothing here.');
+  }
+  groups
+    .filter((group) => GROUP_DISPLAYS_THAT_FORCE_ESSENTIAL.has(group.display))
+    .forEach((group) => {
+      group.props
+        .filter((memberName) => step.props?.[memberName]?.advanced)
+        .forEach((memberName) => add('warn', 'advanced-in-group', `"${memberName}" is in the ${group.display} group "${group.key}", so advanced is ignored.`));
+    });
+  const grouped = new Set(groups.flatMap((group) => group.props));
+  if (groups.some((group) => group.display === 'section') && inputProps.some(([name]) => !grouped.has(name))) {
+    add('warn', 'ungrouped-below-sections', 'Ungrouped props render below every section card; check the resulting order.');
+  }
+  return findings;
+}
+
+function siblingFindings({ steps }) {
+  const byPropName = new Map();
+  steps.forEach((step) => {
+    Object.entries(step.props ?? {}).forEach(([propName, prop]) => {
+      if (prop.type === 'MARKDOWN') {
+        return;
+      }
+      const entries = byPropName.get(propName) ?? [];
+      entries.push({ step: step.displayName, label: prop.displayName ?? '', description: prop.description ?? '' });
+      byPropName.set(propName, entries);
+    });
+  });
+  const findings = [];
+  byPropName.forEach((entries, propName) => {
+    const labels = new Set(entries.map((entry) => entry.label));
+    const descriptions = new Set(entries.map((entry) => entry.description));
+    if (labels.size > 1) {
+      findings.push({ level: 'warn', rule: 'sibling-label', step: entries.map((entry) => entry.step).join(', '), prop: propName, message: `Same prop, ${labels.size} labels: ${[...labels].map((label) => `"${label}"`).join(' / ')}.` });
+    }
+    if (descriptions.size > 1) {
+      findings.push({ level: 'warn', rule: 'sibling-description', step: entries.map((entry) => entry.step).join(', '), prop: propName, message: `Same prop, ${descriptions.size} descriptions; pick one and use it everywhere.` });
+    }
+  });
+  return findings;
+}
+
+function pieceFindings({ piece, steps }) {
+  const findings = [];
+  const usesAdvanced = steps.some((step) => Object.values(step.props ?? {}).some((prop) => prop.advanced));
+  const floor = piece.minimumSupportedRelease ?? '0.0.0';
+  if (usesAdvanced && compareSemver({ left: floor, right: ADVANCED_MIN_RELEASE }) < 0) {
+    findings.push({ level: 'error', rule: 'min-release', step: '', prop: '', message: `advanced needs minimumSupportedRelease >= ${ADVANCED_MIN_RELEASE}; piece declares ${floor}, older self-hosted renders the fields inline.` });
+  }
+  return findings;
+}
+
+function render({ piece, steps, skippedAi, findings }) {
+  const lines = [];
+  lines.push(`${piece.displayName} ${piece.version} — ${steps.filter((step) => step.kind === 'action').length} human actions, ${steps.filter((step) => step.kind === 'trigger').length} triggers (${skippedAi} AI-only actions skipped)`);
+  lines.push('');
+  const byStep = new Map();
+  findings.forEach((finding) => {
+    const key = finding.step || '(piece)';
+    byStep.set(key, [...(byStep.get(key) ?? []), finding]);
+  });
+  byStep.forEach((stepFindingsList, stepName) => {
+    lines.push(stepName);
+    stepFindingsList.forEach((finding) => {
+      const target = finding.prop ? ` ${finding.prop}` : '';
+      lines.push(`  ${finding.level.toUpperCase().padEnd(5)} ${finding.rule.padEnd(24)}${target}: ${finding.message}`);
+    });
+    lines.push('');
+  });
+  const errors = findings.filter((finding) => finding.level === 'error').length;
+  const warnings = findings.length - errors;
+  lines.push(`${errors} error(s), ${warnings} warning(s)`);
+  return lines.join('\n');
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (!args.pieceDirName) {
+    console.log(usage());
+    process.exit(2);
+  }
+  const piece = await fetchPiece(args);
+  const steps = humanSteps({ piece, includeAi: args.includeAi });
+  const skippedAi = Object.values(piece.actions ?? {}).length - steps.filter((step) => step.kind === 'action').length;
+  const findings = [
+    ...steps.flatMap((step) => stepFindings({ step })),
+    ...siblingFindings({ steps }),
+    ...pieceFindings({ piece, steps }),
+  ];
+  if (args.json) {
+    console.log(JSON.stringify({ piece: piece.displayName, version: piece.version, findings }, null, 2));
+  } else {
+    console.log(render({ piece, steps, skippedAi, findings }));
+  }
+  process.exit(findings.some((finding) => finding.level === 'error') ? 1 : 0);
+}
+
+main().catch((error) => {
+  console.error(error.message);
+  process.exit(2);
+});

--- a/.agents/skills/piece-builder/scripts/check-step-form.mjs
+++ b/.agents/skills/piece-builder/scripts/check-step-form.mjs
@@ -44,15 +44,16 @@ function parseArgs(argv) {
   };
 }
 
-function loadPiece({ file, url, pieceDirName }) {
+function loadPiece({ file, url, pieceDirName, includeAi }) {
   if (file) {
     return JSON.parse(readFileSync(file, 'utf8'));
   }
-  return fetchPiece({ url, pieceDirName });
+  return fetchPiece({ url, pieceDirName, includeAi });
 }
 
-async function fetchPiece({ url, pieceDirName }) {
-  const endpoint = `${url}/api/v1/pieces/${encodeURIComponent(`@activepieces/piece-${pieceDirName}`)}`;
+async function fetchPiece({ url, pieceDirName, includeAi }) {
+  const audience = includeAi ? '?audience=all' : '';
+  const endpoint = `${url}/api/v1/pieces/${encodeURIComponent(`@activepieces/piece-${pieceDirName}`)}${audience}`;
   const response = await fetch(endpoint).catch(() => {
     throw new Error(`No dev server answering at ${url}. Start it with "npm start" and make sure "${pieceDirName}" is in AP_DEV_PIECES.`);
   });
@@ -124,10 +125,10 @@ function propFindings({ step, propName, prop }) {
     add('warn', 'required-object', 'Empty {} passes the OBJECT schema; required is never enforced, only shown.');
   }
   if (/\?\s*$/.test(label)) {
-    add('warn', 'label-question', 'Toggle and field labels are nouns, not questions; drop the "?".');
+    add('warn', 'label-question', `"${label}": labels are nouns, not questions; drop the "?".`);
   }
   if (/\(.*\)/.test(label)) {
-    add('warn', 'label-parenthetical', 'Units and formats belong in the description, not the label ("Timeout (in seconds)").');
+    add('warn', 'label-parenthetical', `"${label}": the parenthetical belongs in the description, not the label.`);
   }
   if (label && !isTitleCase(label)) {
     add('warn', 'label-casing', 'Piece prop labels are Title Case (197:25 across Google pieces); match sibling forms first.');
@@ -190,7 +191,7 @@ function siblingFindings({ steps }) {
       findings.push({ level: 'warn', rule: 'sibling-label', step: entries.map((entry) => entry.step).join(', '), prop: propName, message: `Same prop, ${labels.size} labels: ${[...labels].map((label) => `"${label}"`).join(' / ')}.` });
     }
     if (descriptions.size > 1) {
-      findings.push({ level: 'warn', rule: 'sibling-description', step: entries.map((entry) => entry.step).join(', '), prop: propName, message: `Same prop, ${descriptions.size} descriptions; pick one and use it everywhere.` });
+      findings.push({ level: 'info', rule: 'sibling-description', step: entries.map((entry) => entry.step).join(', '), prop: propName, message: `Same prop, ${descriptions.size} descriptions; fine when the context differs, a defect when it does not.` });
     }
   });
   return findings;
@@ -208,7 +209,12 @@ function pieceFindings({ piece, steps }) {
 
 function render({ piece, steps, skippedAi, findings }) {
   const lines = [];
-  lines.push(`${piece.displayName} ${piece.version} — ${steps.filter((step) => step.kind === 'action').length} human actions, ${steps.filter((step) => step.kind === 'trigger').length} triggers (${skippedAi} AI-only actions skipped)`);
+  const aiCount = Object.values(piece.actions ?? {}).filter((action) => action.audience === 'ai').length;
+  const aiNote = aiCount === 0
+    ? ' (the server already filtered AI-only actions out)'
+    : skippedAi > 0 ? ` (${skippedAi} AI-only actions skipped)` : ` (${aiCount} AI-only actions included)`;
+  const actionWord = skippedAi === 0 && aiCount > 0 ? 'actions' : 'human actions';
+  lines.push(`${piece.displayName} ${piece.version} — ${steps.filter((step) => step.kind === 'action').length} ${actionWord}, ${steps.filter((step) => step.kind === 'trigger').length} triggers${aiNote}`);
   lines.push('');
   const byStep = new Map();
   findings.forEach((finding) => {
@@ -223,9 +229,8 @@ function render({ piece, steps, skippedAi, findings }) {
     });
     lines.push('');
   });
-  const errors = findings.filter((finding) => finding.level === 'error').length;
-  const warnings = findings.length - errors;
-  lines.push(`${errors} error(s), ${warnings} warning(s)`);
+  const count = (level) => findings.filter((finding) => finding.level === level).length;
+  lines.push(`${count('error')} error(s), ${count('warn')} warning(s), ${count('info')} info`);
   return lines.join('\n');
 }
 

--- a/.agents/skills/piece-builder/scripts/check-step-form.mjs
+++ b/.agents/skills/piece-builder/scripts/check-step-form.mjs
@@ -3,6 +3,9 @@
 import { readFileSync } from 'node:fs';
 
 const DESCRIPTION_FOLD_LIMIT = 70;
+const DROPDOWN_TRIGGER_WIDTH = 40;
+const HALF_WIDTH_CHARS = 20;
+const CARD_OPTION_LIMIT = 4;
 const ADVANCED_MIN_RELEASE = '0.88.2';
 const TITLE_CASE_SMALL_WORDS = new Set([
   'a', 'an', 'the', 'and', 'or', 'of', 'to', 'in', 'on', 'for', 'by', 'with', 'as', 'at', 'from', 'per', 'vs', 'is',
@@ -20,8 +23,9 @@ function usage() {
     'GET /api/v1/pieces/<name> response from --file, and reports',
     'every step-form problem a reviewer would flag: descriptions past the read-more fold,',
     'required props hidden in Advanced, labels with units or question marks, markdown in plain-text',
-    'descriptions, placeholders on inputs that never render them, the same prop labelled differently',
-    'across sibling actions, and a release floor too low for the advanced flag.',
+    'descriptions, placeholders on inputs that never render them, dropdown option labels wider than',
+    'the closed trigger, the same prop labelled differently across sibling actions, and a release',
+    'floor too low for the advanced flag.',
     '',
     'Exit code 1 when any finding is an error, 0 otherwise.',
   ].join('\n');
@@ -135,6 +139,33 @@ function propFindings({ step, propName, prop }) {
   }
   if (prop.placeholder && !PLACEHOLDER_RENDERING_TYPES.has(type)) {
     add('warn', 'placeholder-not-rendered', `${type} never renders a placeholder; move the example into the description or drop it.`);
+  }
+  findings.push(...optionFindings({ step, propName, prop }));
+  return findings;
+}
+
+function optionFindings({ step, propName, prop }) {
+  const options = prop.options?.options;
+  if (!Array.isArray(options) || options.length === 0) {
+    return [];
+  }
+  const findings = [];
+  const add = (level, rule, message) => findings.push({ level, rule, step: step.displayName, prop: propName, message });
+  const labels = options.map((option) => option.label ?? '');
+  const longest = labels.reduce((left, right) => (right.length > left.length ? right : left), '');
+  const pastFold = labels.filter((label) => label.length > DESCRIPTION_FOLD_LIMIT).length;
+  const pastTrigger = labels.filter((label) => label.length > DROPDOWN_TRIGGER_WIDTH).length;
+  const worst = `longest is "${longest}" at ${longest.length}`;
+  if (pastFold > 0) {
+    add('error', 'option-label-fold', `${pastFold} option label(s) over ${DESCRIPTION_FOLD_LIMIT} chars, ${worst}; the list clips them.`);
+  } else if (pastTrigger > 0) {
+    add('warn', 'option-label-width', `${pastTrigger} option label(s) over ${DROPDOWN_TRIGGER_WIDTH} chars, ${worst}; the closed dropdown is about ${DROPDOWN_TRIGGER_WIDTH} wide and shows the label only. Move the code or pattern into the option description.`);
+  }
+  if (prop.width === 'half' && longest.length > HALF_WIDTH_CHARS) {
+    add('warn', 'half-width-option', `A half-width field is about ${HALF_WIDTH_CHARS} chars wide, ${worst}; stack the field full width or shorten the labels.`);
+  }
+  if (prop.display === 'cards' && options.length > CARD_OPTION_LIMIT) {
+    add('warn', 'cards-option-count', `${options.length} options as cards; cards hold ${CARD_OPTION_LIMIT} short modes, more belongs in a plain dropdown.`);
   }
   return findings;
 }

--- a/.agents/skills/piece-builder/step-form-review.md
+++ b/.agents/skills/piece-builder/step-form-review.md
@@ -1,0 +1,163 @@
+# Step-Form Review: improving an existing piece's forms
+
+Use this when the task is "improve the UI of piece X" — copy, labels, descriptions, Advanced
+placement — on a piece that already works. Nothing here changes `run()`. It distills what the
+maintainers actually asked for on the HTTP (#15188), Google Sheets (#15200) and Custom API Call
+(#15248) form passes, so the next pass gets it right on the first review.
+
+Read `property-ui-selection.md` first for component choice; this file is about the review that
+follows. `ux-guidelines.md` §2 holds the copy rules (70-character fold, option labels).
+
+---
+
+## 1. Find the human surface before touching anything
+
+The builder hides `audience: 'ai'` actions from people (`filterActionsByAudience`, server-side).
+Triggers carry no `audience` and are always visible. So:
+
+- **Only edit human-visible actions and triggers.** AI-only actions have their own copy for agents;
+  changing it is out of scope and touches strings a reviewer did not ask about.
+- **`createCustomApiCallAction` is not the piece's code.** It lives in
+  `packages/pieces/common/src/lib/helpers/index.ts`, is `audience: 'human'`, and is shared by
+  ~470 pieces. For many pieces it is the *only* human action. Fix it once there; every consumer
+  keeps its `...(props?.x ?? {})` override, so do not remove those spreads and add one for any prop
+  you newly make `advanced`.
+- A piece whose human surface is one action plus the connection modal is usually a small task with
+  the real defects in the auth description, not the form.
+
+`node .agents/skills/piece-builder/scripts/check-step-form.mjs <piece-dir>` prints the human
+surface and every finding below in one pass. Run it before and after.
+
+---
+
+## 2. What the builder does with your metadata (verified, with sources)
+
+| Behaviour | Where | Consequence |
+|---|---|---|
+| Descriptions over **70 chars** fold behind "show more" | `packages/web/src/components/custom/read-more-description.tsx` | One short sentence per field. Count it. |
+| Descriptions are **plain text** | same component (`whitespace-pre-wrap`, no markdown) | `**bold**` shows as literal asterisks. Markdown goes in `Property.MarkDown`. |
+| The **whole label turns red** when a required field is empty | `packages/web/src/components/ui/form.tsx` `data-[error=true]:text-destructive` | Not a bug. It is why `Inputs *` reads red on a fresh trigger. |
+| `SHORT_TEXT`, `LONG_TEXT`, `FILE`, `SECRET_TEXT`, `DATE_TIME` show **no `ƒ` toggle** | `packages/web/src/app/builder/piece-properties/properties-utils.tsx` | They accept `{{ }}` inline via `TextInputWithMentions`. Intentional. |
+| `placeholder` renders only on `ShortText` / `LongText` | same file | `Number` and `Object` (`DictionaryInput`) drop it silently. |
+| `Property.MarkDown` rejects `advanced` | framework types (TS2353) | Instructions cannot be tucked into Advanced. |
+| `Property.MarkDown` takes no condition | `MarkDownProperty` is a static value | A "when X is enabled…" banner shows always. Reorder it below the toggle and use `TIP`, or accept it. |
+| **Ungrouped props render below every `section` card** | `packages/web/src/app/builder/piece-properties/filter-layout.tsx` | A section for the "top" fields pushes the rest under it. |
+| Section members are **forced essential** | `collectForcedEssentialNames` | `advanced` is ignored inside `tabs`/`section`; `builder`/`footer` disable Advanced form-wide. |
+| `display: 'cards'` truncates long option labels | card component | Cards are for 2–4 short modes. |
+| `display: 'stepper'` implies bounds | stepper needs `min`/`max` | Uncapped numbers (timeouts) stay plain `Number`. |
+| `OBJECT` accepts `{}` when required | `packages/pieces/framework/src/lib/property/util.ts` | `required: true` on a dictionary only paints an asterisk. |
+| `advanced` exists from release **0.88.2** | | Set `minimumSupportedRelease: '0.88.2'` when you use it; older self-hosted renders the fields inline. |
+
+---
+
+## 3. Copy rules the reviewers enforce
+
+**The governing rule: text fits its box.** Every container in the step panel has a fixed visible
+width at the default 400 px panel — a description folds at 70 characters, a dropdown trigger shows
+about 40, a `width: 'half'` field about 20, a code-style URL box clips before the query string (the
+Published and Draft form URLs looked identical because `?useDraft=true` fell off the end), a card
+option truncates a long label, and the step header truncates the action name. When the text is
+longer than its box you have exactly two moves: **change the container** (full width instead of
+half, a `Property.MarkDown` block that wraps instead of a description, a stacked layout instead of
+two-up, an option `description` line instead of a longer label) **or shorten the text**. Shipping
+clipped text is never the third option. `ux-guidelines.md` §2 gives the per-widget limits; the rules
+below are the recurring cases.
+
+1. **≤ 70 characters, one sentence.** Examples move into `placeholder` where the input renders one
+   (`ShortText`/`LongText`); otherwise drop them. "Same rule as on the HTTP PR: one short sentence,
+   examples go in placeholders." — #15200 review.
+2. **Units and formats live in the description, never the label.** `Timeout (in seconds)` →
+   `Timeout` + "Seconds to wait…"; `Text (Markdown)` → `Message` + "Markdown is rendered."
+3. **No question marks on toggles**, and no space before punctuation. `Response is Binary ?` and
+   `Include Shared Drive Sheets ?` were both flagged.
+4. **Title Case for prop labels** (197:25 across the Google pieces) — *except* when a sibling form
+   already uses another casing. See rule 6.
+5. **Say what is true.** "Empty means no timeout" was wrong because `AP_FLOW_TIMEOUT_SECONDS` still
+   applies; the accepted line is "Seconds to wait for a response. Empty: up to the flow limit
+   (10 min)." Check the runtime before describing a default.
+6. **Consistency beats local polish.** When the same prop appears on several actions — or the same
+   form exists in two pieces (HTTP ↔ Custom API Call) — it gets **one label and one description**
+   everywhere, and the existing one wins over your new one. #15248 was sent back because
+   `Binary Response` / `Follow Redirects` differed from HTTP's `Response is Binary` /
+   `Follow redirects`; #15200 because one toggle was `Use Column Names` on three actions and
+   `Use Header Names` on the fourth. The checker's `sibling-*` rules catch the within-piece case;
+   grep the nearest sibling piece for the cross-piece one.
+7. **A description that restates the label is a line of wasted height.** `Bot Name` — "The name of
+   the chatbot" says nothing; either add information or remove it.
+
+---
+
+## 4. Deciding what goes into Advanced
+
+`advanced: true` collapses a prop into a section that starts closed. Ask four questions; any "yes"
+keeps the field on the primary form:
+
+1. **Is it required?** Never hide it — the docs forbid it and it only surfaces as an error.
+2. **Does its default change the result?** Find Rows' `Number of Rows` defaults to `1`; hiding it
+   means a search silently returns one row. Keep it visible; hide `Starting Row` instead.
+3. **Does it change what the step reads at run time, not just what a dropdown lists?**
+   `Include Shared Drives` only filters the Spreadsheet picker on most actions — Advanced is right.
+   On New Spreadsheet and Find Spreadsheet(s) it changes which files the step sees — keep it visible.
+   Give the shared prop a `{ advanced }` parameter rather than forking it.
+4. **Is it the form's only field?** "Advanced, 1 option" with nothing above it is wrong.
+
+Everything else — binary response, retries, follow redirects, timeouts, proxy settings — is a good
+Advanced candidate when it is optional and has a default.
+
+---
+
+## 5. Do not touch
+
+- `run()`, prop **names**, `defaultValue`s that alter behaviour, `audience`, `classification`.
+- AI-only actions' copy.
+- Locale files under `src/i18n/*.json`. `translation.json` is the Crowdin *source* and is
+  regenerated (`npm run cli -- pieces generate-translation-file <piece-dir>`; it runs `bun install`,
+  so restore `bun.lock` afterwards). Renaming a label orphans its translations until Crowdin
+  catches up; say so in the PR, do not hand-fix it.
+
+---
+
+## 6. Verify like the reviewer will
+
+1. Build: `npx turbo run build lint --filter=@activepieces/piece-<name> --force`. Report warning
+   counts honestly and separate pre-existing from new.
+2. Serve it: put the **directory** name in `AP_DEV_PIECES` (Human Input is `forms`), rebuild, restart
+   the API (metadata is cached until restart), then read what is actually served:
+   `curl -s "http://localhost:4200/api/v1/pieces/%40activepieces%2Fpiece-<name>"`.
+3. `node .agents/skills/piece-builder/scripts/check-step-form.mjs <name>` — zero errors.
+4. Click through every changed form at the **default panel width** with a fresh step. Selecting a
+   connection, a parent item and a child item so dependent fields render; flip each toggle that
+   drives `DynamicProperties`.
+5. Bump the piece `package.json` version. `pieces-common` is never published on its own; a change
+   there reaches users only when consumers are bumped — say which in the PR.
+
+---
+
+## 7. The PR
+
+- Fill both template sections — **Breaking change?** and **Security impact?** — with exactly one
+  box each, or `breaking-change-check` fails. Label `🌟 feature` or `🐛 bug`, plus
+  `🧩 area/third-party-pieces` or `🧩 area/core-pieces`.
+- **Before/after screenshots** of the forms the reviewer will open, same conditions both sides:
+  fresh step, default width, Advanced collapsed, scrolled to top. Name the height difference
+  honestly ("~150 px shorter") rather than implying more.
+- State the i18n consequence of renamed labels and that no locale files were edited.
+- Name anything you deliberately left alone that a reviewer will hit while testing (a known crash
+  with an open fix, an unrelated stale comment) so it is not filed against your PR.
+- Every claim in the description must be true of the diff. Greptile caught "every prop keeps its
+  override spread" when two did not.
+
+---
+
+## 8. What the maintainers asked for, verbatim by theme
+
+| Theme | Ask | PR |
+|---|---|---|
+| Fold | "The builder cuts descriptions at 70 and adds 'show more'… one short sentence, examples go in placeholders." | #15200 |
+| Consistency | "Same toggle, two names… Pick one label and one description for all four." | #15200 |
+| Consistency | "HTTP piece uses 'Response is Binary'… requested matching labels between the two most similar forms in the product." | #15248 |
+| Advanced | "Number of Rows defaults to 1 and is now inside Advanced, so a user searching for matches gets one row back and the control that changes that is hidden." | #15200 |
+| Advanced | "On New Spreadsheet… it also changes what the step sees at run time… Keep it visible on those two." | #15200 |
+| Accuracy | "'Leave empty for no limit' is inaccurate; should match… 'Empty: up to the flow limit (10 min)'." | #15248 |
+| Widgets | Timeout as a capped stepper; section headers duplicating the field label; cards truncating options. | #15188 |
+| Process | Missing template sections; `minimumSupportedRelease` still 0.86.4 with `advanced` in use; before/after screenshots. | #15200 |

--- a/.agents/skills/piece-builder/step-form-review.md
+++ b/.agents/skills/piece-builder/step-form-review.md
@@ -25,7 +25,8 @@ Triggers carry no `audience` and are always visible. So:
 - A piece whose human surface is one action plus the connection modal is usually a small task with
   the real defects in the auth description, not the form.
 
-`node .agents/skills/piece-builder/scripts/check-step-form.mjs <piece-dir>` prints the human
+`node .agents/skills/piece-builder/scripts/check-step-form.mjs <piece-dir>` (or `--file <saved.json>`
+from a `curl` of `/api/v1/pieces/@activepieces/piece-<dir>`, no server needed) prints the human
 surface and every finding below in one pass. Run it before and after.
 
 ---
@@ -124,7 +125,9 @@ Advanced candidate when it is optional and has a default.
 2. Serve it: put the **directory** name in `AP_DEV_PIECES` (Human Input is `forms`), rebuild, restart
    the API (metadata is cached until restart), then read what is actually served:
    `curl -s "http://localhost:4200/api/v1/pieces/%40activepieces%2Fpiece-<name>"`.
-3. `node .agents/skills/piece-builder/scripts/check-step-form.mjs <name>` — zero errors.
+3. `node .agents/skills/piece-builder/scripts/check-step-form.mjs <name>` — zero errors. Save the
+   before/after JSON with `curl … > before.json` and run `--file` on each to show the reviewer the
+   finding count dropped.
 4. Click through every changed form at the **default panel width** with a fresh step. Selecting a
    connection, a parent item and a child item so dependent fields render; flip each toggle that
    drives `DynamicProperties`.

--- a/.agents/skills/piece-builder/ux-guidelines.md
+++ b/.agents/skills/piece-builder/ux-guidelines.md
@@ -43,13 +43,48 @@ Dropdown labels should combine the human-readable name with a disambiguator:
 
 ## 2. Write Descriptions That Teach
 
-**BAD:** `description: 'The thread timestamp'`
+**Hard limit: property descriptions must be 70 characters or fewer.** The builder renders anything longer as a truncated line ending in `... show more`, so the user sees a cut-off sentence and a link instead of help. Every `description` on a prop, and every dropdown option `label`, must be readable in full at 70 characters. Put long setup instructions in a `Property.MarkDown()` instead (see §3).
 
-**GOOD:** `description: 'The ts (timestamp) of the parent message to reply in a thread. Get it by clicking the three dots next to a message → Copy link. The timestamp is the number at the end of the URL (e.g. 1710304378.475129).'`
+**Dropdown option labels: one idea per label, code on the second line.** A `DropdownOption` takes an optional `description`, which the builder's select renders as a dimmed second line under the label and includes in the search. Put the human-readable value in `label` and any pattern, code or ID in `description` — never both in the label. The dropdown trigger shows only the label and is about 40 characters wide, so a label carrying two things is guaranteed to truncate.
 
-**BAD:** `description: 'Enter the chat ID'`
+```typescript
+// GOOD — trigger reads "Sun Sep 17 2023 11:23:58"
+{ label: 'Sun Sep 17 2023 11:23:58', value: 'DDD MMM DD YYYY HH:mm:ss', description: 'DDD MMM DD YYYY HH:mm:ss' }
 
-**GOOD:** `description: 'The unique ID of the chat. To find it: 1) Search @getmyid_bot in Telegram, 2) Send /my_id, 3) Copy the number it replies with.'`
+// BAD — trigger truncates mid-token
+{ label: 'DDD MMM DD YYYY HH:mm:ss (Sun Sep 17 2023 11:23:58)', value: 'DDD MMM DD YYYY HH:mm:ss' }
+```
+
+**`width: 'half'` only suits short values.** The step panel is narrow, so a half-width field is roughly 20 characters wide. Use it for a first/last name or a bounded number. Never for a dropdown whose selected label is longer than that, or for a field whose help text then wraps to more lines than the field is tall — stacked full-width fields read better than a cramped two-up row.
+
+**Do not repeat the same example twice in one form.** If a dropdown option already shows the example value, the text field above it should not carry the identical string as its `placeholder`. Point at the neighbouring field in the description instead.
+
+**BAD:** `description: 'The thread timestamp'` — accurate and useless.
+
+**ALSO BAD:** teaches, but blows the limit and renders as a clipped line plus `... show more`:
+
+`description: 'The ts (timestamp) of the parent message to reply in a thread. Get it by clicking the three dots next to a message → Copy link. The timestamp is the number at the end of the URL (e.g. 1710304378.475129).'`
+
+**GOOD:** the description stays inside the limit and the how-to moves to a Markdown block, where it has room to be numbered and formatted:
+
+```typescript
+props: {
+  threadHelp: Property.MarkDown({
+    value: `To reply in a thread, you need the parent message's timestamp:
+
+1. Click the three dots next to the message
+2. Choose **Copy link**
+3. The timestamp is the number at the end of the URL, e.g. \`1710304378.475129\``,
+  }),
+  threadTs: Property.ShortText({
+    displayName: 'Thread Timestamp',
+    description: 'The ts of the parent message to reply under.',
+    required: false,
+  }),
+}
+```
+
+A chat ID works the same way: `description: 'The unique ID of the chat to post in.'`, with the "search @getmyid_bot, send /my_id" steps in the Markdown block above it — never crammed into the description.
 
 ---
 
@@ -243,6 +278,9 @@ PieceAuth.CustomAuth({
 
 - [ ] No prop asks users to type an ID when a dropdown could be used
 - [ ] Every prop has a `description` explaining what it is and how to find it
+- [ ] Every prop `description` and option `label` is 70 characters or fewer (no `show more` truncation)
+- [ ] Option labels hold one idea; patterns, codes and IDs live in the option `description`
+- [ ] No example string appears twice in the same form (placeholder vs. option label)
 - [ ] Complex setup steps use `Property.MarkDown()` with numbered instructions
 - [ ] Optional props have sensible `defaultValue` where applicable
 - [ ] Display names use plain language (`"Create Contact"` not `"POST /contacts"`)


### PR DESCRIPTION
## Description

Folds what the maintainers asked for on the last three step-form PRs — HTTP (#15188), Google
Sheets (#15200) and Custom API Call (#15248) — into the `piece-builder` and `design` skills, so the
next form pass clears review the first time instead of the second.

**`piece-builder/step-form-review.md` (new)** — the guide for "improve piece X's forms":

- Find the human surface first: `audience: 'ai'` actions are hidden from people, triggers are always
  visible, and `createCustomApiCallAction` is shared code in `pieces-common`, not the piece.
- What the builder does with each piece of metadata, each row sourced to the file that proves it:
  the 70-character fold, plain-text descriptions, the whole-label-red rule, where placeholders
  render, `MarkDown` rejecting `advanced`, ungrouped props landing below sections, the 0.88.2 floor.
- The copy rules reviewers enforce, led by one principle — **text fits its box: change the container
  or shorten the text, clipped text is never the third option** — and consistency across sibling
  actions and sibling pieces beating local polish.
- The four questions that decide Advanced placement, with the Number of Rows and Include Shared
  Drives cases that were sent back.
- Verify and PR protocol: served-metadata check, version bump, template sections, before/after
  screenshots, the i18n consequence of renamed labels.
- A verbatim table of what was asked for, by theme and PR.

**`piece-builder/scripts/check-step-form.mjs` (new)** — reads the piece the dev server serves and
reports every finding a reviewer would: descriptions over 70, markdown in descriptions,
required-and-advanced, question-mark and parenthetical labels, casing, placeholders on inputs that
never render them, every field in Advanced, `advanced` inside groups, the release floor, and the
same prop labelled differently across actions. Exit 1 on errors. Node only, no dependencies.

**`piece-builder/ux-guidelines.md`, `design/SKILL.md`** — the measured limits (70 / ~40 / ~20
characters), dropdown options carrying their code in the option `description`, and the GOOD
description example rewritten so the guidance no longer breaks the limit it sets.

**`piece-builder/property-ui-selection.md`** — the Advanced decision test, the
ungrouped-below-sections rule, and five anti-patterns from the reviews.

**`piece-builder/SKILL.md`** — one index row pointing at the new guide.

## How was this tested?

Documentation and a standalone script; no product code changed.

The scanner was run against a fixture piece carrying one instance of every defect it looks for
(over-long and markdown descriptions, required-and-advanced, a `MarkDown` prop marked advanced,
question-mark and parenthetical labels, a lowercase label, a placeholder on a `Number`, an
all-Advanced form, `advanced` inside a `section`, the same prop with two labels across actions, an
AI-only action with a long description, and a 0.86.4 release floor). Every expected finding
appears exactly once, the AI-only action is skipped, and exit code is 1. Testing surfaced and
fixed two bugs: a `--url` value could be read as the piece name, and the casing rule flagged
`Response is Binary` — the HTTP label sibling forms are meant to match. `--file` mode lets it run on
a saved `/api/v1/pieces` response with no server. Against a stopped server it prints the intended
"start the dev server" message.

Then run live against four pieces served by the dev server from `main`: Google Sheets (0 errors,
consistent with #15200's approval), HTTP (finds two Parse URL descriptions over the fold, 82 and
227 chars), Human Input (0 errors) and Google Forms (its Custom API Call form reports exactly the
items raised on #15248, and the New Response trigger has a 71-char description). The live run
prompted the final tuning: messages quote the offending label, description-only differences across
sibling actions are `info` because a shared prop often reads differently in context, and
`--include-ai` requests `audience=all` since the server strips AI-only actions before the scanner
sees them.

Fixes # (issue)

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)