### PR TITLE
feat(gmail): add label management, archive/delete actions and starred/conversation triggers

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -2721,6 +2721,15 @@
         "tslib": "^2.3.0",
       },
     },
+    "packages/pieces/community/docuseal": {
+      "name": "@activepieces/piece-docuseal",
+      "version": "0.0.1",
+      "dependencies": {
+        "@activepieces/pieces-common": "workspace:*",
+        "@activepieces/pieces-framework": "workspace:*",
+        "tslib": "2.6.2",
+      },
+    },
     "packages/pieces/community/docusign": {
       "name": "@activepieces/piece-docusign",
       "version": "0.2.6",
@@ -3158,7 +3167,7 @@
     },
     "packages/pieces/community/fillout-forms": {
       "name": "@activepieces/piece-fillout-forms",
-      "version": "0.1.9",
+      "version": "0.1.10",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -5096,7 +5105,7 @@
     },
     "packages/pieces/community/line": {
       "name": "@activepieces/piece-line",
-      "version": "0.1.8",
+      "version": "0.1.9",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -6057,7 +6066,7 @@
     },
     "packages/pieces/community/monday": {
       "name": "@activepieces/piece-monday",
-      "version": "0.3.7",
+      "version": "0.3.8",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -8666,7 +8675,7 @@
     },
     "packages/pieces/community/stripe": {
       "name": "@activepieces/piece-stripe",
-      "version": "0.6.13",
+      "version": "0.6.14",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -11507,6 +11516,8 @@
 
     "@activepieces/piece-documerge": ["@activepieces/piece-documerge@workspace:packages/pieces/community/documerge"],
 
+    "@activepieces/piece-docuseal": ["@activepieces/piece-docuseal@workspace:packages/pieces/community/docuseal"],
+
     "@activepieces/piece-docusign": ["@activepieces/piece-docusign@workspace:packages/pieces/community/docusign"],
 
     "@activepieces/piece-drip": ["@activepieces/piece-drip@workspace:packages/pieces/community/drip"],
@@ -12972,8 +12983,6 @@
     "@babel/traverse": ["@babel/traverse@7.29.0", "", { "dependencies": { "@babel/code-frame": "^7.29.0", "@babel/generator": "^7.29.0", "@babel/helper-globals": "^7.28.0", "@babel/parser": "^7.29.0", "@babel/template": "^7.28.6", "@babel/types": "^7.29.0", "debug": "^4.3.1" } }, "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA=="],
 
     "@babel/types": ["@babel/types@7.29.0", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A=="],
-
-    "@balena/dockerignore": ["@balena/dockerignore@1.0.2", "", {}, "sha512-wMue2Sy4GAVTk6Ic4tJVcnfdau+gx2EnG7S+uAEe+TWJFqE4YoWN4/H8MSLj4eYJKxGg26lZwboEniNiNwZQ6Q=="],
 
     "@base44/sdk": ["@base44/sdk@0.8.27", "", { "dependencies": { "axios": "^1.6.2", "socket.io-client": "^4.7.5", "uuid": "^13.0.0" } }, "sha512-TkCQ6TZb0Fqq48Ig6xc1o+SU9LYg0sgzDHTIE0JiRcAmRkoO7Jm8kVzNEe2Nmh3msP6P8sxs0GFwGfukMUoCzg=="],
 
@@ -15305,10 +15314,6 @@
 
     "disposable-email-domains": ["disposable-email-domains@1.0.62", "", {}, "sha512-LBQvhRw7mznQTPoyZbsmYeNOZt1pN5aCsx4BAU/3siVFuiM9f2oyKzUaB8v1jbxFjE3aYqYiMo63kAL4pHgfWQ=="],
 
-    "docker-modem": ["docker-modem@5.0.7", "", { "dependencies": { "debug": "^4.1.1", "readable-stream": "^3.5.0", "split-ca": "^1.0.1", "ssh2": "^1.15.0" } }, "sha512-XJgGhoR/CLpqshm4d3L7rzH6t8NgDFUIIpztYlLHIApeJjMZKYJMz2zxPsYxnejq5h3ELYSw/RBsi3t5h7gNTA=="],
-
-    "dockerode": ["dockerode@4.0.7", "", { "dependencies": { "@balena/dockerignore": "^1.0.2", "@grpc/grpc-js": "^1.11.1", "@grpc/proto-loader": "^0.7.13", "docker-modem": "^5.0.6", "protobufjs": "^7.3.2", "tar-fs": "~2.1.2", "uuid": "^10.0.0" } }, "sha512-R+rgrSRTRdU5mH14PZTCPZtW/zw3HDWNTS/1ZAQpL/5Upe/ye5K9WQkIysu4wBoiMwKynsz0a8qWuGsHgEvSAA=="],
-
     "doctrine": ["doctrine@3.0.0", "", { "dependencies": { "esutils": "^2.0.2" } }, "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w=="],
 
     "docusign-esign": ["docusign-esign@8.1.0", "", { "dependencies": { "@devhigley/parse-proxy": "^1.0.3", "axios": "^1.6.8", "csv-stringify": "^1.0.0", "jsonwebtoken": "^9.0.0", "passport-oauth2": "^1.6.1", "safe-buffer": "^5.1.2" } }, "sha512-p+YgSlAv5OspREJT6NvgEZMR5L8j1SGMZRUM2NEVvdcW35dmklB3Kx2ia8SrKfq5/U9sTSEiSQJiphKQGBgU0w=="],
@@ -17384,8 +17389,6 @@
     "spdx-expression-parse": ["spdx-expression-parse@3.0.1", "", { "dependencies": { "spdx-exceptions": "^2.1.0", "spdx-license-ids": "^3.0.0" } }, "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q=="],
 
     "spdx-license-ids": ["spdx-license-ids@3.0.23", "", {}, "sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw=="],
-
-    "split-ca": ["split-ca@1.0.1", "", {}, "sha512-Q5thBSxp5t8WPTTJQS59LrGqOZqOsrhDGDVm8azCqIBjSBd7nd9o2PM+mDulQQkh8h//4U6hFZnc/mul8t5pWQ=="],
 
     "split-on-first": ["split-on-first@3.0.0", "", {}, "sha512-qxQJTx2ryR0Dw0ITYyekNQWpz6f8dGd7vffGNflQQ3Iqj9NJ6qiZ7ELpZsJ/QBhIVAiDfXdag3+Gp8RvWa62AA=="],
 
@@ -19957,14 +19960,6 @@
 
     "did-jwt/uint8arrays": ["uint8arrays@3.1.1", "", { "dependencies": { "multiformats": "^9.4.2" } }, "sha512-+QJa8QRnbdXVpHYjLoTpJIdCTiw9Ir62nocClWuXIq2JIh4Uta0cQsTSpFL678p2CN8B+XSApwcU+pQEqVpKWg=="],
 
-    "docker-modem/readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
-
-    "dockerode/@grpc/proto-loader": ["@grpc/proto-loader@0.7.15", "", { "dependencies": { "lodash.camelcase": "^4.3.0", "long": "^5.0.0", "protobufjs": "^7.2.5", "yargs": "^17.7.2" }, "bin": { "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js" } }, "sha512-tMXdRCfYVixjuFK+Hk0Q1s38gV9zDiDJfWL3h1rv4Qc39oILCu1TRTDt7+fGUI8K4G1Fj125Hx/ru3azECWTyQ=="],
-
-    "dockerode/protobufjs": ["protobufjs@7.5.6", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.2", "@protobufjs/base64": "^1.1.2", "@protobufjs/codegen": "^2.0.5", "@protobufjs/eventemitter": "^1.1.0", "@protobufjs/fetch": "^1.1.0", "@protobufjs/float": "^1.0.2", "@protobufjs/inquire": "^1.1.1", "@protobufjs/path": "^1.1.2", "@protobufjs/pool": "^1.1.0", "@protobufjs/utf8": "^1.1.1", "@types/node": ">=13.7.0", "long": "^5.0.0" } }, "sha512-M71sTMB146U3u0di3yup8iM+zv8yPRNQVr1KK4tyBitl3qFvEGucq/rGDRShD2rsJhtN02RJaJ7j5X5hmy8SJg=="],
-
-    "dockerode/uuid": ["uuid@10.0.0", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ=="],
-
     "docusign-esign/csv-stringify": ["csv-stringify@1.1.2", "", { "dependencies": { "lodash.get": "~4.4.2" } }, "sha512-3NmNhhd+AkYs5YtM1GEh01VR6PKj6qch2ayfQaltx5xpcAdThjnbbI5eT8CzRVpXfGKAxnmrSYLsNl/4f3eWiw=="],
 
     "dom-helpers/@babel/runtime": ["@babel/runtime@7.29.2", "", {}, "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g=="],
@@ -20058,8 +20053,6 @@
     "find-cache-dir/make-dir": ["make-dir@3.1.0", "", { "dependencies": { "semver": "^6.0.0" } }, "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw=="],
 
     "flat-cache/rimraf": ["rimraf@3.0.2", "", { "dependencies": { "glob": "^7.1.3" }, "bin": { "rimraf": "bin.js" } }, "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA=="],
-
-    "flux/react": ["react@18.3.1", "", { "dependencies": { "loose-envify": "^1.1.0" } }, "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ=="],
 
     "form-data/hasown": ["hasown@2.0.4", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A=="],
 
@@ -20420,10 +20413,6 @@
     "raw-body/iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
 
     "rc/strip-json-comments": ["strip-json-comments@2.0.1", "", {}, "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ=="],
-
-    "react-json-view/react": ["react@18.3.1", "", { "dependencies": { "loose-envify": "^1.1.0" } }, "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ=="],
-
-    "react-json-view/react-dom": ["react-dom@18.3.1", "", { "dependencies": { "loose-envify": "^1.1.0", "scheduler": "^0.23.2" }, "peerDependencies": { "react": "^18.3.1" } }, "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw=="],
 
     "react-markdown/remark-parse": ["remark-parse@11.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-from-markdown": "^2.0.0", "micromark-util-types": "^2.0.0", "unified": "^11.0.0" } }, "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA=="],
 
@@ -21343,12 +21332,6 @@
 
     "did-jwt/elliptic/bn.js": ["bn.js@4.12.3", "", {}, "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g=="],
 
-    "docker-modem/readable-stream/string_decoder": ["string_decoder@1.3.0", "", { "dependencies": { "safe-buffer": "~5.2.0" } }, "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA=="],
-
-    "dockerode/@grpc/proto-loader/long": ["long@5.3.2", "", {}, "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA=="],
-
-    "dockerode/protobufjs/long": ["long@5.3.2", "", {}, "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA=="],
-
     "duplexify/readable-stream/string_decoder": ["string_decoder@1.3.0", "", { "dependencies": { "safe-buffer": "~5.2.0" } }, "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA=="],
 
     "eslint-plugin-import-x/minimatch/brace-expansion": ["brace-expansion@2.1.0", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w=="],
@@ -21724,8 +21707,6 @@
     "qrcode/yargs/y18n": ["y18n@4.0.3", "", {}, "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ=="],
 
     "qrcode/yargs/yargs-parser": ["yargs-parser@18.1.3", "", { "dependencies": { "camelcase": "^5.0.0", "decamelize": "^1.2.0" } }, "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ=="],
-
-    "react-json-view/react-dom/scheduler": ["scheduler@0.23.2", "", { "dependencies": { "loose-envify": "^1.1.0" } }, "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ=="],
 
     "react-markdown/remark-parse/mdast-util-from-markdown": ["mdast-util-from-markdown@2.0.3", "", { "dependencies": { "@types/mdast": "^4.0.0", "@types/unist": "^3.0.0", "decode-named-character-reference": "^1.0.0", "devlop": "^1.0.0", "mdast-util-to-string": "^4.0.0", "micromark": "^4.0.0", "micromark-util-decode-numeric-character-reference": "^2.0.0", "micromark-util-decode-string": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0", "unist-util-stringify-position": "^4.0.0" } }, "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q=="],
 

--- a/packages/pieces/community/gmail/package.json
+++ b/packages/pieces/community/gmail/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-gmail",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "dependencies": {

--- a/packages/pieces/community/gmail/src/index.ts
+++ b/packages/pieces/community/gmail/src/index.ts
@@ -31,6 +31,14 @@ import { gmailGetLabelAction } from './lib/actions/get-label-action';
 import { gmailGetProfileAction } from './lib/actions/get-profile-action';
 import { gmailListHistoryAction } from './lib/actions/list-history-action';
 import { gmailStopWatchAction } from './lib/actions/stop-watch-action';
+import { gmailAddLabelToEmailAction } from './lib/actions/add-label-to-email-action';
+import { gmailRemoveLabelFromEmailAction } from './lib/actions/remove-label-from-email-action';
+import { gmailRemoveLabelFromThreadAction } from './lib/actions/remove-label-from-thread-action';
+import { gmailCreateLabelAction } from './lib/actions/create-label-action';
+import { gmailArchiveEmailAction } from './lib/actions/archive-email-action';
+import { gmailDeleteEmailAction } from './lib/actions/delete-email-action';
+import { gmailNewConversationTrigger } from './lib/triggers/new-conversation';
+import { gmailNewStarredEmailTrigger } from './lib/triggers/new-starred-email';
 
 export {
   gmailAuth,
@@ -72,6 +80,12 @@ export const gmail = createPiece({
     gmailGetProfileAction,
     gmailListHistoryAction,
     gmailStopWatchAction,
+    gmailAddLabelToEmailAction,
+    gmailRemoveLabelFromEmailAction,
+    gmailRemoveLabelFromThreadAction,
+    gmailCreateLabelAction,
+    gmailArchiveEmailAction,
+    gmailDeleteEmailAction,
     createCustomApiCallAction({
       baseUrl: () => 'https://gmail.googleapis.com/gmail/v1',
       auth: gmailAuth,
@@ -102,6 +116,8 @@ export const gmail = createPiece({
     gmailNewLabeledEmailTrigger,
     gmailNewAttachmentTrigger,
     gmailNewLabelTrigger,
+    gmailNewConversationTrigger,
+    gmailNewStarredEmailTrigger,
   ],
   auth: gmailAuth,
 });

--- a/packages/pieces/community/gmail/src/index.ts
+++ b/packages/pieces/community/gmail/src/index.ts
@@ -110,6 +110,7 @@ export const gmail = createPiece({
     'AdamSelene',
     'sanket-a11y',
     'onyedikachi-david',
+    'pyelandon-tech',
   ],
   triggers: [
     gmailNewEmailTrigger,

--- a/packages/pieces/community/gmail/src/lib/actions/add-label-to-email-action.ts
+++ b/packages/pieces/community/gmail/src/lib/actions/add-label-to-email-action.ts
@@ -1,0 +1,69 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { gmailAuth, createGoogleClient } from '../auth';
+import { gmail as googleGmail } from '@googleapis/gmail';
+import { GmailProps } from '../common/props';
+import {
+  getGmailApiErrorCode,
+  getGmailApiErrorMessage,
+} from '../common/errors';
+import { gmailAddLabelToEmailActionOutputSchema } from '../output-schemas';
+
+export const gmailAddLabelToEmailAction = createAction({
+  auth: gmailAuth,
+  name: 'add_label_to_email',
+  classification: 'WRITE',
+  displayName: 'Add Label to Email',
+  description: 'Add a label to an individual email.',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Adds an existing label to a single email message identified by its Gmail message ID. Use Create Label first if the label does not exist, or Remove Label from Email to undo. Idempotent: adding a label the message already carries succeeds without change.',
+    idempotent: true,
+  },
+  props: {
+    message_id: GmailProps.message,
+    label: GmailProps.label({
+      displayName: 'Label',
+      description: 'The label to add to the email.',
+      required: true,
+    }),
+  },
+  outputSchema: gmailAddLabelToEmailActionOutputSchema,
+  async run(context) {
+    const authClient = await createGoogleClient(context.auth);
+    const gmail = googleGmail({ version: 'v1', auth: authClient });
+
+    try {
+      const response = await gmail.users.messages.modify({
+        userId: 'me',
+        id: context.propsValue.message_id,
+        requestBody: {
+          addLabelIds: [context.propsValue.label.id],
+        },
+      });
+      return response.data;
+    } catch (error) {
+      const errorCode = getGmailApiErrorCode(error);
+      if (errorCode === 403) {
+        throw new Error(
+          'Insufficient permissions to modify message labels. Reconnect your Gmail account so the gmail.modify scope is granted.'
+        );
+      } else if (errorCode === 404) {
+        throw new Error(
+          `No message with ID "${context.propsValue.message_id}" was found.`
+        );
+      } else if (errorCode === 400) {
+        throw new Error(
+          `Invalid label "${context.propsValue.label.name}". It may have been deleted — refresh the label list and try again.`
+        );
+      } else if (errorCode === 429) {
+        throw new Error(
+          'Gmail API rate limit exceeded. Please try again later.'
+        );
+      }
+      throw new Error(
+        `Failed to add label to email: ${getGmailApiErrorMessage(error)}`
+      );
+    }
+  },
+});

--- a/packages/pieces/community/gmail/src/lib/actions/archive-email-action.ts
+++ b/packages/pieces/community/gmail/src/lib/actions/archive-email-action.ts
@@ -1,0 +1,60 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { gmailAuth, createGoogleClient } from '../auth';
+import { gmail as googleGmail } from '@googleapis/gmail';
+import { GmailProps } from '../common/props';
+import {
+  getGmailApiErrorCode,
+  getGmailApiErrorMessage,
+} from '../common/errors';
+import { gmailArchiveEmailActionOutputSchema } from '../output-schemas';
+
+export const gmailArchiveEmailAction = createAction({
+  auth: gmailAuth,
+  name: 'archive_email',
+  classification: 'WRITE',
+  displayName: 'Archive Email',
+  description: 'Archive an email (move it out of the inbox to All Mail).',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Archives an email message by removing it from the inbox; the message stays in All Mail and keeps its other labels. Use Delete Email to move a message to Trash instead. Idempotent: archiving an already-archived message succeeds without change.',
+    idempotent: true,
+  },
+  props: {
+    message_id: GmailProps.message,
+  },
+  outputSchema: gmailArchiveEmailActionOutputSchema,
+  async run(context) {
+    const authClient = await createGoogleClient(context.auth);
+    const gmail = googleGmail({ version: 'v1', auth: authClient });
+
+    try {
+      const response = await gmail.users.messages.modify({
+        userId: 'me',
+        id: context.propsValue.message_id,
+        requestBody: {
+          removeLabelIds: ['INBOX'],
+        },
+      });
+      return response.data;
+    } catch (error) {
+      const errorCode = getGmailApiErrorCode(error);
+      if (errorCode === 403) {
+        throw new Error(
+          'Insufficient permissions to archive messages. Reconnect your Gmail account so the gmail.modify scope is granted.'
+        );
+      } else if (errorCode === 404) {
+        throw new Error(
+          `No message with ID "${context.propsValue.message_id}" was found.`
+        );
+      } else if (errorCode === 429) {
+        throw new Error(
+          'Gmail API rate limit exceeded. Please try again later.'
+        );
+      }
+      throw new Error(
+        `Failed to archive email: ${getGmailApiErrorMessage(error)}`
+      );
+    }
+  },
+});

--- a/packages/pieces/community/gmail/src/lib/actions/create-label-action.ts
+++ b/packages/pieces/community/gmail/src/lib/actions/create-label-action.ts
@@ -1,0 +1,96 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { gmailAuth, createGoogleClient } from '../auth';
+import { gmail as googleGmail } from '@googleapis/gmail';
+import {
+  getGmailApiErrorCode,
+  getGmailApiErrorMessage,
+} from '../common/errors';
+import { gmailCreateLabelActionOutputSchema } from '../output-schemas';
+
+export const gmailCreateLabelAction = createAction({
+  auth: gmailAuth,
+  name: 'create_label',
+  classification: 'WRITE',
+  displayName: 'Create Label',
+  description: 'Create a new user label in Gmail.',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Creates a new user-defined Gmail label with optional sidebar and message-list visibility settings. Use Add Label to Email or Remove Label from Email to apply or strip it afterwards. Not idempotent: creating a label whose name already exists fails with a conflict error.',
+    idempotent: false,
+  },
+  props: {
+    name: Property.ShortText({
+      displayName: 'Label Name',
+      description:
+        'Name for the new label. Use "/" to nest it under an existing label (e.g. "Clients/Acme").',
+      required: true,
+    }),
+    label_list_visibility: Property.StaticDropdown({
+      displayName: 'Label List Visibility',
+      description:
+        'Whether the label appears in the label list in the Gmail sidebar.',
+      required: false,
+      defaultValue: 'labelShow',
+      options: {
+        disabled: false,
+        options: [
+          { label: 'Show', value: 'labelShow' },
+          { label: 'Show if unread', value: 'labelShowIfUnread' },
+          { label: 'Hide', value: 'labelHide' },
+        ],
+      },
+    }),
+    message_list_visibility: Property.StaticDropdown({
+      displayName: 'Message List Visibility',
+      description:
+        'Whether messages with this label appear in the message list.',
+      required: false,
+      defaultValue: 'show',
+      options: {
+        disabled: false,
+        options: [
+          { label: 'Show', value: 'show' },
+          { label: 'Hide', value: 'hide' },
+        ],
+      },
+    }),
+  },
+  outputSchema: gmailCreateLabelActionOutputSchema,
+  async run(context) {
+    const authClient = await createGoogleClient(context.auth);
+    const gmail = googleGmail({ version: 'v1', auth: authClient });
+
+    try {
+      const response = await gmail.users.labels.create({
+        userId: 'me',
+        requestBody: {
+          name: context.propsValue.name,
+          labelListVisibility:
+            context.propsValue.label_list_visibility ?? 'labelShow',
+          messageListVisibility:
+            context.propsValue.message_list_visibility ?? 'show',
+        },
+      });
+      return response.data;
+    } catch (error) {
+      const errorCode = getGmailApiErrorCode(error);
+      if (errorCode === 403) {
+        throw new Error(
+          'Insufficient permissions to create labels. Reconnect your Gmail account so the gmail.labels scope is granted.'
+        );
+      } else if (errorCode === 409) {
+        throw new Error(
+          `A label named "${context.propsValue.name}" already exists.`
+        );
+      } else if (errorCode === 429) {
+        throw new Error(
+          'Gmail API rate limit exceeded. Please try again later.'
+        );
+      }
+      throw new Error(
+        `Failed to create label: ${getGmailApiErrorMessage(error)}`
+      );
+    }
+  },
+});

--- a/packages/pieces/community/gmail/src/lib/actions/delete-email-action.ts
+++ b/packages/pieces/community/gmail/src/lib/actions/delete-email-action.ts
@@ -1,0 +1,57 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { gmailAuth, createGoogleClient } from '../auth';
+import { gmail as googleGmail } from '@googleapis/gmail';
+import { GmailProps } from '../common/props';
+import {
+  getGmailApiErrorCode,
+  getGmailApiErrorMessage,
+} from '../common/errors';
+import { gmailDeleteEmailActionOutputSchema } from '../output-schemas';
+
+export const gmailDeleteEmailAction = createAction({
+  auth: gmailAuth,
+  name: 'delete_email',
+  classification: 'DESTRUCTIVE',
+  displayName: 'Delete Email',
+  description: 'Move an email to Trash.',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Moves an email message to Trash by its Gmail message ID; Gmail permanently purges trashed mail after about 30 days. Use Archive Email to remove a message from the inbox without deleting it. Idempotent: trashing an already-trashed message succeeds without change.',
+    idempotent: true,
+  },
+  props: {
+    message_id: GmailProps.message,
+  },
+  outputSchema: gmailDeleteEmailActionOutputSchema,
+  async run(context) {
+    const authClient = await createGoogleClient(context.auth);
+    const gmail = googleGmail({ version: 'v1', auth: authClient });
+
+    try {
+      const response = await gmail.users.messages.trash({
+        userId: 'me',
+        id: context.propsValue.message_id,
+      });
+      return response.data;
+    } catch (error) {
+      const errorCode = getGmailApiErrorCode(error);
+      if (errorCode === 403) {
+        throw new Error(
+          'Insufficient permissions to trash messages. Reconnect your Gmail account so the gmail.modify scope is granted.'
+        );
+      } else if (errorCode === 404) {
+        throw new Error(
+          `No message with ID "${context.propsValue.message_id}" was found — it may already be deleted, or the ID is invalid.`
+        );
+      } else if (errorCode === 429) {
+        throw new Error(
+          'Gmail API rate limit exceeded. Please try again later.'
+        );
+      }
+      throw new Error(
+        `Failed to delete email: ${getGmailApiErrorMessage(error)}`
+      );
+    }
+  },
+});

--- a/packages/pieces/community/gmail/src/lib/actions/remove-label-from-email-action.ts
+++ b/packages/pieces/community/gmail/src/lib/actions/remove-label-from-email-action.ts
@@ -1,0 +1,69 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { gmailAuth, createGoogleClient } from '../auth';
+import { gmail as googleGmail } from '@googleapis/gmail';
+import { GmailProps } from '../common/props';
+import {
+  getGmailApiErrorCode,
+  getGmailApiErrorMessage,
+} from '../common/errors';
+import { gmailRemoveLabelFromEmailActionOutputSchema } from '../output-schemas';
+
+export const gmailRemoveLabelFromEmailAction = createAction({
+  auth: gmailAuth,
+  name: 'remove_label_from_email',
+  classification: 'WRITE',
+  displayName: 'Remove Label from Email',
+  description: 'Remove a specific label from an email.',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Removes a label from a single email message identified by its Gmail message ID. Use Remove Label from Thread to strip the label from every message in a conversation instead. Idempotent: removing a label the message does not carry succeeds without change.',
+    idempotent: true,
+  },
+  props: {
+    message_id: GmailProps.message,
+    label: GmailProps.label({
+      displayName: 'Label',
+      description: 'The label to remove from the email.',
+      required: true,
+    }),
+  },
+  outputSchema: gmailRemoveLabelFromEmailActionOutputSchema,
+  async run(context) {
+    const authClient = await createGoogleClient(context.auth);
+    const gmail = googleGmail({ version: 'v1', auth: authClient });
+
+    try {
+      const response = await gmail.users.messages.modify({
+        userId: 'me',
+        id: context.propsValue.message_id,
+        requestBody: {
+          removeLabelIds: [context.propsValue.label.id],
+        },
+      });
+      return response.data;
+    } catch (error) {
+      const errorCode = getGmailApiErrorCode(error);
+      if (errorCode === 403) {
+        throw new Error(
+          'Insufficient permissions to modify message labels. Reconnect your Gmail account so the gmail.modify scope is granted.'
+        );
+      } else if (errorCode === 404) {
+        throw new Error(
+          `No message with ID "${context.propsValue.message_id}" was found.`
+        );
+      } else if (errorCode === 400) {
+        throw new Error(
+          `Invalid label "${context.propsValue.label.name}". It may have been deleted — refresh the label list and try again.`
+        );
+      } else if (errorCode === 429) {
+        throw new Error(
+          'Gmail API rate limit exceeded. Please try again later.'
+        );
+      }
+      throw new Error(
+        `Failed to remove label from email: ${getGmailApiErrorMessage(error)}`
+      );
+    }
+  },
+});

--- a/packages/pieces/community/gmail/src/lib/actions/remove-label-from-thread-action.ts
+++ b/packages/pieces/community/gmail/src/lib/actions/remove-label-from-thread-action.ts
@@ -1,0 +1,69 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { gmailAuth, createGoogleClient } from '../auth';
+import { gmail as googleGmail } from '@googleapis/gmail';
+import { GmailProps } from '../common/props';
+import {
+  getGmailApiErrorCode,
+  getGmailApiErrorMessage,
+} from '../common/errors';
+import { gmailRemoveLabelFromThreadActionOutputSchema } from '../output-schemas';
+
+export const gmailRemoveLabelFromThreadAction = createAction({
+  auth: gmailAuth,
+  name: 'remove_label_from_thread',
+  classification: 'WRITE',
+  displayName: 'Remove Label from Thread',
+  description: 'Remove a label from all emails in a thread.',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Strips a label from every message in a Gmail thread identified by its thread ID. Use Remove Label from Email to remove the label from a single message instead. Idempotent: removing a label the thread does not carry succeeds without change.',
+    idempotent: true,
+  },
+  props: {
+    thread_id: GmailProps.thread,
+    label: GmailProps.label({
+      displayName: 'Label',
+      description: 'The label to remove from all emails in the thread.',
+      required: true,
+    }),
+  },
+  outputSchema: gmailRemoveLabelFromThreadActionOutputSchema,
+  async run(context) {
+    const authClient = await createGoogleClient(context.auth);
+    const gmail = googleGmail({ version: 'v1', auth: authClient });
+
+    try {
+      const response = await gmail.users.threads.modify({
+        userId: 'me',
+        id: context.propsValue.thread_id,
+        requestBody: {
+          removeLabelIds: [context.propsValue.label.id],
+        },
+      });
+      return response.data;
+    } catch (error) {
+      const errorCode = getGmailApiErrorCode(error);
+      if (errorCode === 403) {
+        throw new Error(
+          'Insufficient permissions to modify thread labels. Reconnect your Gmail account so the gmail.modify scope is granted.'
+        );
+      } else if (errorCode === 404) {
+        throw new Error(
+          `No thread with ID "${context.propsValue.thread_id}" was found.`
+        );
+      } else if (errorCode === 400) {
+        throw new Error(
+          `Invalid label "${context.propsValue.label.name}". It may have been deleted — refresh the label list and try again.`
+        );
+      } else if (errorCode === 429) {
+        throw new Error(
+          'Gmail API rate limit exceeded. Please try again later.'
+        );
+      }
+      throw new Error(
+        `Failed to remove label from thread: ${getGmailApiErrorMessage(error)}`
+      );
+    }
+  },
+});

--- a/packages/pieces/community/gmail/src/lib/auth.ts
+++ b/packages/pieces/community/gmail/src/lib/auth.ts
@@ -11,6 +11,8 @@ const gmailServiceAccountScopes = [
   'https://www.googleapis.com/auth/gmail.send',
   'https://www.googleapis.com/auth/gmail.readonly',
   'https://www.googleapis.com/auth/gmail.compose',
+  'https://www.googleapis.com/auth/gmail.modify',
+  'https://www.googleapis.com/auth/gmail.labels',
 ];
 
 export const gmailScopes = [...gmailServiceAccountScopes, 'email'];

--- a/packages/pieces/community/gmail/src/lib/common/errors.ts
+++ b/packages/pieces/community/gmail/src/lib/common/errors.ts
@@ -1,0 +1,16 @@
+export function getGmailApiErrorCode(error: unknown): number | undefined {
+  if (typeof error === 'object' && error !== null && 'code' in error) {
+    const { code } = error;
+    if (typeof code === 'number') {
+      return code;
+    }
+  }
+  return undefined;
+}
+
+export function getGmailApiErrorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  return String(error);
+}

--- a/packages/pieces/community/gmail/src/lib/output-schemas.ts
+++ b/packages/pieces/community/gmail/src/lib/output-schemas.ts
@@ -1059,3 +1059,59 @@ export const gmailListHistoryActionOutputSchema: OutputSchema = {
     },
   ],
 };
+
+export const gmailAddLabelToEmailActionOutputSchema: OutputSchema = {
+  fields: historyRecordMessageFields,
+};
+
+export const gmailRemoveLabelFromEmailActionOutputSchema: OutputSchema = {
+  fields: historyRecordMessageFields,
+};
+
+export const gmailArchiveEmailActionOutputSchema: OutputSchema = {
+  fields: historyRecordMessageFields,
+};
+
+export const gmailDeleteEmailActionOutputSchema: OutputSchema = {
+  fields: historyRecordMessageFields,
+};
+
+export const gmailRemoveLabelFromThreadActionOutputSchema: OutputSchema = {
+  fields: [
+    { key: 'id', label: 'Thread ID' },
+    { key: 'historyId', label: 'History ID' },
+    {
+      key: 'messages',
+      label: 'Messages',
+      labelKey: 'id',
+      listItems: historyRecordMessageFields,
+    },
+  ],
+};
+
+export const gmailCreateLabelActionOutputSchema: OutputSchema = {
+  fields: gmailLabelBaseFields,
+};
+
+export const newStarredEmailTriggerOutputSchema: OutputSchema = {
+  fields: newLabeledEmailTriggerOutputSchema.fields.map(
+    (field): OutputSchema['fields'][number] => {
+      if (field.key === 'addedAt') {
+        return {
+          key: 'starredAt',
+          label: 'Starred At',
+          value: 'data.starInfo.starredAt',
+          format: 'datetime',
+        };
+      }
+      if (field.key === 'id') {
+        return {
+          key: 'id',
+          label: 'Message ID',
+          value: 'data.starInfo.messageId',
+        };
+      }
+      return field;
+    }
+  ),
+};

--- a/packages/pieces/community/gmail/src/lib/triggers/new-conversation.ts
+++ b/packages/pieces/community/gmail/src/lib/triggers/new-conversation.ts
@@ -138,6 +138,10 @@ export const gmailNewConversationTrigger = createTrigger({
   classification: 'READ',
   displayName: 'New Conversation',
   description: 'Triggers when a new email conversation (thread) begins',
+  aiMetadata: {
+    description:
+      'Fires once when a brand-new email thread starts (an incoming message that is not a reply to an existing conversation). Each payload carries the thread summary and the parsed first message; replies within existing threads never fire it.',
+  },
   props: {
     from: {
       ...GmailProps.from,

--- a/packages/pieces/community/gmail/src/lib/triggers/new-starred-email.ts
+++ b/packages/pieces/community/gmail/src/lib/triggers/new-starred-email.ts
@@ -1,0 +1,204 @@
+import {
+  createTrigger,
+  TriggerStrategy,
+  FilesService,
+} from '@activepieces/pieces-framework';
+import { gmailAuth, createGoogleClient } from '../auth';
+import { gmail as googleGmail, gmail_v1 } from '@googleapis/gmail';
+import { parseStream, convertAttachment } from '../common/data';
+import { getGmailApiErrorCode } from '../common/errors';
+import { newStarredEmailTriggerOutputSchema } from '../output-schemas';
+
+const STARRED_LABEL_ID = 'STARRED';
+const MAX_STARRED_EMAIL_AGE_MS = 2 * 24 * 60 * 60 * 1000;
+
+async function enrichStarredMessage({
+  gmail,
+  messageId,
+  files,
+}: {
+  gmail: gmail_v1.Gmail;
+  messageId: string;
+  files: FilesService;
+}) {
+  const rawMailResponse = await gmail.users.messages.get({
+    userId: 'me',
+    id: messageId,
+    format: 'raw',
+  });
+
+  const threadResponse = await gmail.users.threads.get({
+    userId: 'me',
+    id: rawMailResponse.data.threadId ?? undefined,
+  });
+
+  const parsedMailResponse = await parseStream(
+    Buffer.from(rawMailResponse.data.raw as string, 'base64').toString('utf-8')
+  );
+
+  return {
+    internalDateMs: Number(rawMailResponse.data.internalDate ?? 0),
+    data: {
+      message: {
+        ...parsedMailResponse,
+        attachments: await convertAttachment(
+          parsedMailResponse.attachments,
+          files
+        ),
+      },
+      thread: threadResponse.data,
+      starInfo: {
+        messageId,
+        starredAt: Date.now(),
+      },
+    },
+  };
+}
+
+export const gmailNewStarredEmailTrigger = createTrigger({
+  auth: gmailAuth,
+  name: 'new_starred_email',
+  classification: 'READ',
+  displayName: 'New Starred Email',
+  description:
+    'Triggers when an email is starred (for emails received within the last 2 days)',
+  aiMetadata: {
+    description:
+      'Fires once per email message that gets starred, limited to messages received within the last 2 days. Each payload carries the parsed starred message, its thread, and when the star was detected.',
+  },
+  props: {},
+  outputSchema: newStarredEmailTriggerOutputSchema,
+  sampleData: {},
+  type: TriggerStrategy.POLLING,
+  onEnable: async (context) => {
+    const authClient = await createGoogleClient(context.auth);
+    const gmail = googleGmail({ version: 'v1', auth: authClient });
+
+    const profile = await gmail.users.getProfile({
+      userId: 'me',
+    });
+
+    await context.store.put('lastHistoryId', profile.data.historyId);
+  },
+  onDisable: async (context) => {
+    await context.store.delete('lastHistoryId');
+  },
+  run: async (context) => {
+    const authClient = await createGoogleClient(context.auth);
+    const gmail = googleGmail({ version: 'v1', auth: authClient });
+
+    const lastHistoryId = await context.store.get('lastHistoryId');
+    const cutoffTime = Date.now() - MAX_STARRED_EMAIL_AGE_MS;
+
+    try {
+      const historyResponse = await gmail.users.history.list({
+        userId: 'me',
+        startHistoryId: lastHistoryId as string,
+        labelId: STARRED_LABEL_ID,
+        historyTypes: ['labelAdded', 'messageAdded'],
+      });
+
+      const starredMessages = new Map<string, string>();
+      const results = [];
+
+      if (historyResponse.data.history) {
+        for (const history of historyResponse.data.history) {
+          if (history.labelsAdded) {
+            for (const labelAdded of history.labelsAdded) {
+              if (
+                labelAdded.labelIds?.includes(STARRED_LABEL_ID) &&
+                labelAdded.message?.id
+              ) {
+                starredMessages.set(
+                  labelAdded.message.id,
+                  history.id?.toString() || ''
+                );
+              }
+            }
+          } else if (history.messagesAdded) {
+            for (const messageAdded of history.messagesAdded) {
+              if (
+                messageAdded.message?.id &&
+                messageAdded.message.labelIds?.includes(STARRED_LABEL_ID)
+              ) {
+                starredMessages.set(
+                  messageAdded.message.id,
+                  history.id?.toString() || ''
+                );
+              }
+            }
+          }
+        }
+      }
+
+      for (const [messageId, historyId] of starredMessages) {
+        const enrichedMessage = await enrichStarredMessage({
+          gmail,
+          messageId,
+          files: context.files,
+        });
+
+        if (enrichedMessage.internalDateMs < cutoffTime) {
+          continue;
+        }
+
+        if (lastHistoryId !== historyId) {
+          results.push({
+            id: `${messageId}_${historyId}`,
+            data: enrichedMessage.data,
+          });
+        }
+      }
+
+      if (historyResponse.data.historyId) {
+        await context.store.put(
+          'lastHistoryId',
+          historyResponse.data.historyId
+        );
+      }
+
+      return results;
+    } catch (error) {
+      if (getGmailApiErrorCode(error) === 404) {
+        const profile = await gmail.users.getProfile({ userId: 'me' });
+        await context.store.put('lastHistoryId', profile.data.historyId);
+        return [];
+      }
+      throw error;
+    }
+  },
+  test: async (context) => {
+    const authClient = await createGoogleClient(context.auth);
+    const gmail = googleGmail({ version: 'v1', auth: authClient });
+
+    const messagesResponse = await gmail.users.messages.list({
+      userId: 'me',
+      labelIds: [STARRED_LABEL_ID],
+      q: 'newer_than:2d',
+      maxResults: 5,
+    });
+
+    const results = [];
+
+    if (messagesResponse.data.messages) {
+      for (const message of messagesResponse.data.messages) {
+        const messageId = message.id;
+        if (!messageId) {
+          continue;
+        }
+        const enrichedMessage = await enrichStarredMessage({
+          gmail,
+          messageId,
+          files: context.files,
+        });
+
+        results.push({
+          id: messageId,
+          data: enrichedMessage.data,
+        });
+      }
+    }
+
+    return results;
+  },
+});

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -420,6 +420,9 @@
       "@activepieces/piece-docsbot": [
         "packages/pieces/community/docsbot/src/index.ts"
       ],
+      "@activepieces/piece-docuseal": [
+        "packages/pieces/community/docuseal/src/index.ts"
+      ],
       "@activepieces/piece-docusign": [
         "packages/pieces/community/docusign/src/index.ts"
       ],


### PR DESCRIPTION
## What
Implements the remaining scope of the $200 bounty issue — Closes #8072

/claim #8072

**Actions added:** Add Label to Email, Remove Label from Email, Create Label, Archive Email, Delete Email (trash, DESTRUCTIVE), Remove Label from Thread — all via users.messages/threads/labels endpoints, reusing the piece's existing OAuth2/service-account auth and GmailProps dropdowns.
**Triggers:** New Starred Email (history-based polling on STARRED with 2-day internalDate cutoff + 404 historyId reset, per the issue) and registered the existing-but-unregistered New Conversation trigger (+ its missing aiMetadata).
Everything not listed here from the issue (Reply, Draft Reply, Find Email, other triggers) already exists in main and was left untouched. Added scopes: gmail.modify, gmail.labels. Version 0.14.0 → 0.14.1.

## Why a new PR
Issue #8072 is locked so /attempt was impossible there. The previously designated PR #8083 was closed unmerged on Jul 16 with no activity since. I asked first in #15284 before submitting; given other contributors are now racing claims, submitting ready work seemed better than waiting. Happy to defer if #8083 revives, and happy to address any review feedback quickly.

## Verification
- turbo build + lint green (zero new lint warnings; piece warnings went 47 → 40)
- vitest 16/16 pass; runtime smoke test: 32 actions / 6 triggers register with correct audience/aiMetadata/classification/outputSchema per the piece-builder skill
- No live Gmail calls made; implementations follow Google's documented v1 schemas 1:1

## Breaking change?
- [x] No
