### PR TITLE
fix(pieces-common): correctly encode array params in form-urlencoded request bodies

### DIFF
--- a/packages/pieces/common/src/lib/http/core/fetch-http-client.ts
+++ b/packages/pieces/common/src/lib/http/core/fetch-http-client.ts
@@ -125,6 +125,19 @@ function serializeBody(
   }
   const contentType = headers['Content-Type'] ?? headers['content-type'] ?? '';
   if (contentType.includes('application/x-www-form-urlencoded')) {
+    if (typeof body === 'object' && body !== null) {
+      const params = new URLSearchParams();
+      for (const [key, value] of Object.entries(body)) {
+        if (Array.isArray(value)) {
+          for (const item of value) {
+            params.append(`${key}[]`, String(item));
+          }
+        } else if (!isNil(value)) {
+          params.append(key, String(value));
+        }
+      }
+      return { body: params.toString(), extraHeaders: {}, isStream: false };
+    }
     return { body: new URLSearchParams(body as Record<string, string>).toString(), extraHeaders: {}, isStream: false };
   }
   return { body: JSON.stringify(body), extraHeaders: {}, isStream: false };


### PR DESCRIPTION
## Problem

When sending requests with `Content-Type: application/x-www-form-urlencoded` containing array fields (such as Stripe webhook endpoint creation in `@activepieces/piece-stripe` with `enabled_events`), `serializeBody` coerced the body using `new URLSearchParams(body as Record<string, string>)`. This caused arrays to be converted into comma-separated strings or scalars without bracket/index notation (`enabled_events=refund.created` instead of `enabled_events[]=refund.created`), causing services like Stripe to reject the request with `"Invalid array"`.

## Root Cause

In `packages/pieces/common/src/lib/http/core/fetch-http-client.ts`:
```ts
if (contentType.includes(\x27application/x-www-form-urlencoded\x27)) {
    return { body: new URLSearchParams(body as Record<string, string>).toString(), extraHeaders: {}, isStream: false };
}
```
Passing an object containing array properties directly to `new URLSearchParams()` does not expand array elements.

## Fix

Iterate over the body keys and expand array values with bracket notation (`key[]`), matching standard form-urlencoded conventions:
```ts
if (typeof body === \x27object\x27 && body !== null) {
    const params = new URLSearchParams();
    for (const [key, value] of Object.entries(body)) {
        if (Array.isArray(value)) {
            for (const item of value) {
                params.append(`${key}[]`, String(item));
            }
        } else if (!isNil(value)) {
            params.append(key, String(value));
        }
    }
    return { body: params.toString(), extraHeaders: {}, isStream: false };
}
```

## Verification

- Verified bracketed parameter expansion for array and scalar values in form-urlencoded serialization.

Fixes #14972