### PR TITLE
fix(flows): reject flow operations computed against a stale version

### DIFF
--- a/packages/core/execution/src/lib/flows/flow-version.ts
+++ b/packages/core/execution/src/lib/flows/flow-version.ts
@@ -41,11 +41,11 @@ export const FlowVersionMetadata = z.object({
 
 export type FlowVersionMetadata = z.infer<typeof FlowVersionMetadata>
 
-function tokenOf({ id, updated }: Pick<FlowVersion, 'id' | 'updated'>): string {
-    return `${id}:${new Date(updated).getTime()}`
-}
-
 export const flowVersionToken = { of: tokenOf }
 
 export const FLOW_VERSION_TOKEN_HEADER = 'if-match'
+
+function tokenOf({ id, updated }: Pick<FlowVersion, 'id' | 'updated'>): string {
+    return `${id}:${new Date(updated).getTime()}`
+}
 

--- a/packages/core/execution/src/lib/flows/flow-version.ts
+++ b/packages/core/execution/src/lib/flows/flow-version.ts
@@ -41,3 +41,11 @@ export const FlowVersionMetadata = z.object({
 
 export type FlowVersionMetadata = z.infer<typeof FlowVersionMetadata>
 
+function tokenOf({ id, updated }: Pick<FlowVersion, 'id' | 'updated'>): string {
+    return `${id}:${new Date(updated).getTime()}`
+}
+
+export const flowVersionToken = { of: tokenOf }
+
+export const FLOW_VERSION_TOKEN_HEADER = 'if-match'
+

--- a/packages/core/utils/src/lib/activepieces-error.ts
+++ b/packages/core/utils/src/lib/activepieces-error.ts
@@ -25,6 +25,7 @@ export type ApErrorParams =
     | ExistingUserErrorParams
     | FlowOperationErrorParams
     | FlowOperationInProgressErrorParams
+    | FlowVersionConflictErrorParams
     | FlowRunRetryOutsideRetentionErrorParams
     | InvalidApiKeyParams
     | InvalidAppConnectionParams
@@ -273,6 +274,14 @@ export type FlowOperationInProgressErrorParams = BaseErrorParams<
 ErrorCode.FLOW_OPERATION_IN_PROGRESS, {
     message: string
 }>
+
+export type FlowVersionConflictErrorParams = BaseErrorParams<
+ErrorCode.FLOW_VERSION_CONFLICT,
+{
+    expected: string
+    actual: string
+}
+>
 
 export type InvalidJwtTokenErrorParams = BaseErrorParams<
 ErrorCode.INVALID_OR_EXPIRED_JWT_TOKEN,
@@ -548,6 +557,7 @@ export enum ErrorCode {
     FLOW_EXTERNAL_ID_ALREADY_EXISTS = 'FLOW_EXTERNAL_ID_ALREADY_EXISTS',
     FLOW_OPERATION_INVALID = 'FLOW_OPERATION_INVALID',
     FLOW_OPERATION_IN_PROGRESS = 'FLOW_OPERATION_IN_PROGRESS',
+    FLOW_VERSION_CONFLICT = 'FLOW_VERSION_CONFLICT',
     FLOW_RUN_RETRY_OUTSIDE_RETENTION = 'FLOW_RUN_RETRY_OUTSIDE_RETENTION',
     INVALID_API_KEY = 'INVALID_API_KEY',
     INVALID_APP_CONNECTION = 'INVALID_APP_CONNECTION',

--- a/packages/server/api/src/app/flows/flow/flow.controller.ts
+++ b/packages/server/api/src/app/flows/flow/flow.controller.ts
@@ -7,6 +7,7 @@ import { z } from 'zod'
 import { entitiesMustBeOwnedByCurrentProject } from '../../authentication/authorization'
 import { ProjectResourceType } from '../../core/security/authorization/common'
 import { securityAccess } from '../../core/security/authorization/fastify-security'
+import { distributedLock } from '../../database/redis-connections'
 import { assertUserHasPermissionToFlow } from '../../ee/authentication/project-role/rbac-middleware'
 import { platformPlanService } from '../../ee/platform/platform-plan/platform-plan.service'
 import { projectLimitsService } from '../../ee/projects/project-plan/project-plan.service'
@@ -18,6 +19,7 @@ import { FlowEntity } from './flow.entity'
 import { flowService } from './flow.service'
 
 const DEFAULT_PAGE_SIZE = 10
+const FLOW_OPERATION_LOCK_TIMEOUT_SECONDS = 30
 
 export const flowController: FastifyPluginAsyncZod = async (app) => {
     app.addHook('preSerialization', entitiesMustBeOwnedByCurrentProject)
@@ -74,32 +76,45 @@ export const flowController: FastifyPluginAsyncZod = async (app) => {
     }, async (request) => {
         await assertUserHasPermissionToFlow(request.principal, request.projectId, request.body.type, request.log)
 
-        const flow = await flowService(request.log).getOnePopulatedOrThrow({
-            id: request.params.id,
-            projectId: request.projectId,
-        })
+        const expectedVersionToken = request.headers[FLOW_VERSION_TOKEN_HEADER]
 
-        assertOperationIsNotStale({
-            expected: request.headers[FLOW_VERSION_TOKEN_HEADER],
-            actual: flowVersionToken.of(flow.version),
-        })
-
-        const turnOnFlow = request.body.type === FlowOperationType.CHANGE_STATUS && request.body.request.status === FlowStatus.ENABLED && flow.status === FlowStatus.DISABLED
-        const publishDisabledFlow = request.body.type === FlowOperationType.LOCK_AND_PUBLISH && flow.status === FlowStatus.DISABLED
-        if (turnOnFlow || publishDisabledFlow) {
-            await platformPlanService(request.log).checkActiveFlowsExceededLimit(request.principal.platform.id)
-            await projectLimitsService(request.log).checkActiveFlowsExceededLimit({
+        const applyOperation = async (): Promise<PopulatedFlow> => {
+            const flow = await flowService(request.log).getOnePopulatedOrThrow({
+                id: request.params.id,
                 projectId: request.projectId,
             })
+
+            assertOperationIsNotStale({
+                expected: expectedVersionToken,
+                actual: flowVersionToken.of(flow.version),
+            })
+
+            const turnOnFlow = request.body.type === FlowOperationType.CHANGE_STATUS && request.body.request.status === FlowStatus.ENABLED && flow.status === FlowStatus.DISABLED
+            const publishDisabledFlow = request.body.type === FlowOperationType.LOCK_AND_PUBLISH && flow.status === FlowStatus.DISABLED
+            if (turnOnFlow || publishDisabledFlow) {
+                await platformPlanService(request.log).checkActiveFlowsExceededLimit(request.principal.platform.id)
+                await projectLimitsService(request.log).checkActiveFlowsExceededLimit({
+                    projectId: request.projectId,
+                })
+            }
+            return flowService(request.log).update({
+                id: request.params.id,
+                userId: actorUserId(request),
+                platformId: request.principal.platform.id,
+                projectId: request.projectId,
+                operation: cleanOperation(request.body),
+                previousFlow: flow,
+                ip: networkUtils.clientIp(request),
+            })
         }
-        return flowService(request.log).update({
-            id: request.params.id,
-            userId: actorUserId(request),
-            platformId: request.principal.platform.id,
-            projectId: request.projectId,
-            operation: cleanOperation(request.body),
-            previousFlow: flow,
-            ip: networkUtils.clientIp(request),
+
+        if (isNil(expectedVersionToken)) {
+            return applyOperation()
+        }
+        return distributedLock(request.log).runExclusive({
+            key: `flow-operation-${request.params.id}`,
+            timeoutInSeconds: FLOW_OPERATION_LOCK_TIMEOUT_SECONDS,
+            fn: applyOperation,
         })
     })
 

--- a/packages/server/api/src/app/flows/flow/flow.controller.ts
+++ b/packages/server/api/src/app/flows/flow/flow.controller.ts
@@ -1,5 +1,5 @@
-import { ApId, Permission, SeekPage, UserId } from '@activepieces/core-utils'
-import { CountFlowsRequest, CreateFlowRequest, FlowOperationRequest, FlowOperationType, FlowStatus, flowStructureUtil, FlowTrigger, GetFlowQueryParamsRequest, GetFlowTemplateRequestQuery, GitPushOperationType, ListFlowsRequest, PopulatedFlow, PrincipalType, SERVICE_KEY_SECURITY_OPENAPI, SharedTemplate } from '@activepieces/shared'
+import { ActivepiecesError, ApId, ErrorCode, isNil, Permission, SeekPage, UserId } from '@activepieces/core-utils'
+import { CountFlowsRequest, CreateFlowRequest, FLOW_VERSION_TOKEN_HEADER, FlowOperationRequest, FlowOperationType, FlowStatus, flowStructureUtil, FlowTrigger, flowVersionToken, GetFlowQueryParamsRequest, GetFlowTemplateRequestQuery, GitPushOperationType, ListFlowsRequest, PopulatedFlow, PrincipalType, SERVICE_KEY_SECURITY_OPENAPI, SharedTemplate } from '@activepieces/shared'
 import { FastifyRequest } from 'fastify'
 import { FastifyPluginAsyncZod } from 'fastify-type-provider-zod'
 import { StatusCodes } from 'http-status-codes'
@@ -77,6 +77,11 @@ export const flowController: FastifyPluginAsyncZod = async (app) => {
         const flow = await flowService(request.log).getOnePopulatedOrThrow({
             id: request.params.id,
             projectId: request.projectId,
+        })
+
+        assertOperationIsNotStale({
+            expected: request.headers[FLOW_VERSION_TOKEN_HEADER],
+            actual: flowVersionToken.of(flow.version),
         })
 
         const turnOnFlow = request.body.type === FlowOperationType.CHANGE_STATUS && request.body.request.status === FlowStatus.ENABLED && flow.status === FlowStatus.DISABLED
@@ -167,6 +172,16 @@ export const flowController: FastifyPluginAsyncZod = async (app) => {
 
 function actorUserId(request: FastifyRequest): UserId | undefined {
     return request.principal.type === PrincipalType.USER ? request.principal.id : undefined
+}
+
+function assertOperationIsNotStale({ expected, actual }: { expected: string | string[] | undefined, actual: string }): void {
+    if (isNil(expected) || Array.isArray(expected) || expected === actual) {
+        return
+    }
+    throw new ActivepiecesError({
+        code: ErrorCode.FLOW_VERSION_CONFLICT,
+        params: { expected, actual },
+    })
 }
 
 function cleanOperation(operation: FlowOperationRequest): FlowOperationRequest {

--- a/packages/server/api/src/app/helper/error-handler.ts
+++ b/packages/server/api/src/app/helper/error-handler.ts
@@ -103,6 +103,7 @@ const statusCodeMap: Partial<Record<ErrorCode, StatusCodes>> = {
     [ErrorCode.INVALID_GIT_CREDENTIALS]: StatusCodes.BAD_REQUEST,
     [ErrorCode.INVALID_OTP]: StatusCodes.GONE,
     [ErrorCode.VALIDATION]: StatusCodes.CONFLICT,
+    [ErrorCode.FLOW_VERSION_CONFLICT]: StatusCodes.PRECONDITION_FAILED,
     [ErrorCode.FILE_TOO_LARGE]: StatusCodes.REQUEST_TOO_LONG,
     [ErrorCode.INVITATION_ONLY_SIGN_UP]: StatusCodes.FORBIDDEN,
     [ErrorCode.AUTHENTICATION]: StatusCodes.UNAUTHORIZED,

--- a/packages/server/api/test/integration/ce/flows/flow/flow-operations.test.ts
+++ b/packages/server/api/test/integration/ce/flows/flow/flow-operations.test.ts
@@ -1,6 +1,8 @@
 import {
+    FLOW_VERSION_TOKEN_HEADER,
     FlowActionType,
     flowOperations,
+    flowVersionToken,
     FlowOperationType,
     FlowStatus,
     FlowTriggerType,
@@ -11,6 +13,7 @@ import {
     PopulatedFlow,
     StepLocationRelativeToParent,
 } from '@activepieces/shared'
+import { ErrorCode } from '@activepieces/core-utils'
 import { FastifyInstance } from 'fastify'
 import { StatusCodes } from 'http-status-codes'
 import { db } from '../../../../helpers/db'
@@ -826,6 +829,59 @@ describe('Flow Operations API', () => {
             const body = response?.json()
             expect(body.data).toHaveLength(1)
             expect(body.data[0].id).toBe(mockFlowVersion.id)
+        })
+    })
+
+    describe('POST /v1/flows/:id If-Match', () => {
+        const renameWithToken = async (ctx: Awaited<ReturnType<typeof createTestContext>>, flowId: string, token: string | undefined) =>
+            ctx.inject({
+                method: 'POST',
+                url: `/api/v1/flows/${flowId}`,
+                ...(token ? { headers: { [FLOW_VERSION_TOKEN_HEADER]: token } } : {}),
+                payload: {
+                    type: FlowOperationType.CHANGE_NAME,
+                    request: { displayName: 'renamed' },
+                },
+            })
+
+        const createFlow = async (ctx: Awaited<ReturnType<typeof createTestContext>>): Promise<PopulatedFlow> => {
+            const response = await ctx.post('/v1/flows', {
+                displayName: 'concurrency',
+                projectId: ctx.project.id,
+            }, { query: { projectId: ctx.project.id } })
+            return response?.json()
+        }
+
+        it('applies the operation when the token matches the current version', async () => {
+            const ctx = await createTestContext(app!)
+            const flow = await createFlow(ctx)
+
+            const response = await renameWithToken(ctx, flow.id, flowVersionToken.of(flow.version))
+
+            expect(response?.statusCode).toBe(StatusCodes.OK)
+        })
+
+        it('rejects an operation computed against a stale version', async () => {
+            const ctx = await createTestContext(app!)
+            const flow = await createFlow(ctx)
+            const staleToken = flowVersionToken.of(flow.version)
+
+            const first = await renameWithToken(ctx, flow.id, staleToken)
+            expect(first?.statusCode).toBe(StatusCodes.OK)
+
+            const second = await renameWithToken(ctx, flow.id, staleToken)
+
+            expect(second?.statusCode).toBe(StatusCodes.PRECONDITION_FAILED)
+            expect(second?.json().code).toBe(ErrorCode.FLOW_VERSION_CONFLICT)
+        })
+
+        it('stays backwards compatible when no token is sent', async () => {
+            const ctx = await createTestContext(app!)
+            const flow = await createFlow(ctx)
+
+            const response = await renameWithToken(ctx, flow.id, undefined)
+
+            expect(response?.statusCode).toBe(StatusCodes.OK)
         })
     })
 })

--- a/packages/server/api/test/integration/ce/flows/flow/smoke-lifecycle.test.ts
+++ b/packages/server/api/test/integration/ce/flows/flow/smoke-lifecycle.test.ts
@@ -66,7 +66,7 @@ const addAction = (parentStep: string, name: string) => ({
 })
 
 describe('flow lifecycle smoke', () => {
-    it('drives create -> add -> update -> duplicate -> move -> delete -> import -> publish', async () => {
+    it('drives create -> add -> update -> duplicate -> move -> delete -> import', async () => {
         const ctx = await createTestContext(app!)
         const flow = await createFlow(ctx, 'smoke')
 

--- a/packages/server/api/test/integration/ce/flows/flow/smoke-lifecycle.test.ts
+++ b/packages/server/api/test/integration/ce/flows/flow/smoke-lifecycle.test.ts
@@ -165,6 +165,29 @@ describe('flow lifecycle smoke', () => {
         expect(names(final.version)).toEqual(['trigger', 'step_1', 'step_2', 'step_3', 'step_4'])
     })
 
+    // The in-process harness serializes injected requests, so this pins the
+    // outcome rather than the distributed lock that enforces it across processes.
+    it('applies only one of two operations sharing a token', async () => {
+        const ctx = await createTestContext(app!)
+        const flow = await createFlow(ctx, 'smoke-simultaneous')
+        await operate(ctx, flow.id, addAction('trigger', 'step_1'))
+
+        const loaded: PopulatedFlow = (await ctx.get(`/v1/flows/${flow.id}`))?.json()
+        const token = flowVersionToken.of(loaded.version)
+
+        const [first, second] = await Promise.all([
+            operate(ctx, flow.id, addAction('step_1', 'step_2'), token),
+            operate(ctx, flow.id, addAction('step_1', 'step_2'), token),
+        ])
+
+        const statuses = [first?.statusCode, second?.statusCode].sort()
+        expect(statuses).toEqual([StatusCodes.OK, StatusCodes.PRECONDITION_FAILED])
+
+        const final: PopulatedFlow = (await ctx.get(`/v1/flows/${flow.id}`))?.json()
+        expect(duplicates(final.version)).toEqual([])
+        expect(names(final.version)).toEqual(['trigger', 'step_1', 'step_2'])
+    })
+
     it('lets a session continue once it reloads after a conflict', async () => {
         const ctx = await createTestContext(app!)
         const flow = await createFlow(ctx, 'smoke-recover')

--- a/packages/server/api/test/integration/ce/flows/flow/smoke-lifecycle.test.ts
+++ b/packages/server/api/test/integration/ce/flows/flow/smoke-lifecycle.test.ts
@@ -1,0 +1,200 @@
+import { ErrorCode } from '@activepieces/core-utils'
+import {
+    FLOW_VERSION_TOKEN_HEADER,
+    FlowActionType,
+    flowOperations,
+    FlowOperationType,
+    flowStructureUtil,
+    FlowVersion,
+    flowVersionToken,
+    PopulatedFlow,
+    StepLocationRelativeToParent,
+} from '@activepieces/shared'
+import { FastifyInstance } from 'fastify'
+import { StatusCodes } from 'http-status-codes'
+import { createTestContext } from '../../../../helpers/test-context'
+import { setupTestEnvironment, teardownTestEnvironment } from '../../../../helpers/test-setup'
+
+let app: FastifyInstance | null = null
+
+beforeAll(async () => {
+    app = await setupTestEnvironment()
+})
+
+afterAll(async () => {
+    await teardownTestEnvironment()
+})
+
+const SOURCE = { packageJson: '{}', code: 'export const code = async () => ({})' }
+const codeSettings = () => ({
+    sourceCode: SOURCE, input: {}, inputUiInfo: {}, propertySettings: {}, errorHandlingOptions: {},
+})
+
+type Ctx = Awaited<ReturnType<typeof createTestContext>>
+
+const names = (version: FlowVersion): string[] =>
+    flowStructureUtil.getAllSteps(version.trigger).map((step) => step.name)
+
+const duplicates = (version: FlowVersion): string[] => {
+    const seen = new Map<string, number>()
+    names(version).forEach((name) => seen.set(name, (seen.get(name) ?? 0) + 1))
+    return [...seen.entries()].filter(([, count]) => count > 1).map(([name]) => name)
+}
+
+async function createFlow(ctx: Ctx, displayName: string): Promise<PopulatedFlow> {
+    const response = await ctx.post('/v1/flows', { displayName, projectId: ctx.project.id }, { query: { projectId: ctx.project.id } })
+    expect(response?.statusCode).toBe(StatusCodes.CREATED)
+    return response?.json()
+}
+
+async function operate(ctx: Ctx, flowId: string, operation: unknown, token?: string) {
+    return ctx.inject({
+        method: 'POST',
+        url: `/api/v1/flows/${flowId}`,
+        ...(token ? { headers: { [FLOW_VERSION_TOKEN_HEADER]: token } } : {}),
+        payload: operation as Record<string, unknown>,
+    })
+}
+
+const addAction = (parentStep: string, name: string) => ({
+    type: FlowOperationType.ADD_ACTION,
+    request: {
+        parentStep,
+        stepLocationRelativeToParent: StepLocationRelativeToParent.AFTER,
+        action: { type: FlowActionType.CODE, name, displayName: name, valid: true, settings: codeSettings() },
+    },
+})
+
+describe('flow lifecycle smoke', () => {
+    it('drives create -> add -> update -> duplicate -> move -> delete -> import -> publish', async () => {
+        const ctx = await createTestContext(app!)
+        const flow = await createFlow(ctx, 'smoke')
+
+        for (const [parent, name] of [['trigger', 'step_1'], ['step_1', 'step_2'], ['step_2', 'step_3']]) {
+            const added = await operate(ctx, flow.id, addAction(parent, name))
+            expect(added?.statusCode).toBe(StatusCodes.OK)
+        }
+        let current: PopulatedFlow = (await operate(ctx, flow.id, addAction('step_3', 'step_4')))?.json()
+        expect(names(current.version)).toEqual(['trigger', 'step_1', 'step_2', 'step_3', 'step_4'])
+
+        const updated = await operate(ctx, flow.id, {
+            type: FlowOperationType.UPDATE_ACTION,
+            request: { name: 'step_2', displayName: 'renamed step', type: FlowActionType.CODE, valid: true, settings: codeSettings() },
+        })
+        expect(updated?.statusCode, updated?.body?.slice(0, 300)).toBe(StatusCodes.OK)
+        current = updated?.json()
+        expect(flowStructureUtil.getStepOrThrow('step_2', current.version.trigger).displayName).toBe('renamed step')
+        expect(names(current.version)).toHaveLength(5)
+
+        current = (await operate(ctx, flow.id, {
+            type: FlowOperationType.DUPLICATE_ACTION,
+            request: { stepName: 'step_2' },
+        }))?.json()
+        expect(names(current.version)).toHaveLength(6)
+        expect(duplicates(current.version)).toEqual([])
+
+        current = (await operate(ctx, flow.id, {
+            type: FlowOperationType.MOVE_ACTION,
+            request: { name: 'step_4', newParentStep: 'step_1', stepLocationRelativeToNewParent: StepLocationRelativeToParent.AFTER },
+        }))?.json()
+        expect(names(current.version)).toHaveLength(6)
+        expect(duplicates(current.version)).toEqual([])
+
+        current = (await operate(ctx, flow.id, {
+            type: FlowOperationType.DELETE_ACTION,
+            request: { names: ['step_4'] },
+        }))?.json()
+        expect(names(current.version)).toHaveLength(5)
+
+        const imported = await operate(ctx, flow.id, {
+            type: FlowOperationType.IMPORT_FLOW,
+            request: { displayName: 'smoke imported', trigger: current.version.trigger, notes: [] },
+        })
+        expect(imported?.statusCode).toBe(StatusCodes.OK)
+        const afterImport: PopulatedFlow = imported?.json()
+        expect(duplicates(afterImport.version)).toEqual([])
+        expect(names(afterImport.version).sort()).toEqual(names(current.version).sort())
+    })
+
+    it('paste operations from a fresh snapshot allocate unique names', async () => {
+        const ctx = await createTestContext(app!)
+        const flow = await createFlow(ctx, 'smoke-paste')
+        for (const [parent, name] of [['trigger', 'step_1'], ['step_1', 'step_2']]) {
+            await operate(ctx, flow.id, addAction(parent, name))
+        }
+        const loaded: PopulatedFlow = (await ctx.get(`/v1/flows/${flow.id}`))?.json()
+
+        const copied = [flowStructureUtil.getActionOrThrow('step_1', loaded.version.trigger)]
+        const pasteOps = flowOperations.getOperationsForPaste(
+            JSON.parse(JSON.stringify(copied)),
+            loaded.version,
+            { parentStepName: 'step_2', stepLocationRelativeToParent: StepLocationRelativeToParent.AFTER },
+        )
+
+        let latest: PopulatedFlow = loaded
+        for (const operation of pasteOps) {
+            const response = await operate(ctx, flow.id, operation)
+            expect(response?.statusCode).toBe(StatusCodes.OK)
+            latest = response?.json()
+        }
+        expect(duplicates(latest.version)).toEqual([])
+    })
+
+    it('rejects the second of two sessions editing from the same snapshot', async () => {
+        const ctx = await createTestContext(app!)
+        const flow = await createFlow(ctx, 'smoke-two-sessions')
+        for (const [parent, name] of [['trigger', 'step_1'], ['step_1', 'step_2'], ['step_2', 'step_3']]) {
+            await operate(ctx, flow.id, addAction(parent, name))
+        }
+
+        const sessionA: PopulatedFlow = (await ctx.get(`/v1/flows/${flow.id}`))?.json()
+        const sessionB: PopulatedFlow = (await ctx.get(`/v1/flows/${flow.id}`))?.json()
+        const tokenA = flowVersionToken.of(sessionA.version)
+        const tokenB = flowVersionToken.of(sessionB.version)
+        expect(tokenB).toBe(tokenA)
+
+        const firstPaste = await operate(ctx, flow.id, addAction('step_3', 'step_4'), tokenA)
+        expect(firstPaste?.statusCode).toBe(StatusCodes.OK)
+
+        const secondPaste = await operate(ctx, flow.id, addAction('step_2', 'step_4'), tokenB)
+        expect(secondPaste?.statusCode).toBe(StatusCodes.PRECONDITION_FAILED)
+        expect(secondPaste?.json().code).toBe(ErrorCode.FLOW_VERSION_CONFLICT)
+
+        const final: PopulatedFlow = (await ctx.get(`/v1/flows/${flow.id}`))?.json()
+        expect(duplicates(final.version)).toEqual([])
+        expect(names(final.version)).toEqual(['trigger', 'step_1', 'step_2', 'step_3', 'step_4'])
+    })
+
+    it('lets a session continue once it reloads after a conflict', async () => {
+        const ctx = await createTestContext(app!)
+        const flow = await createFlow(ctx, 'smoke-recover')
+        await operate(ctx, flow.id, addAction('trigger', 'step_1'))
+
+        const stale: PopulatedFlow = (await ctx.get(`/v1/flows/${flow.id}`))?.json()
+        await operate(ctx, flow.id, addAction('step_1', 'step_2'))
+
+        const conflicted = await operate(ctx, flow.id, addAction('step_1', 'step_3'), flowVersionToken.of(stale.version))
+        expect(conflicted?.statusCode).toBe(StatusCodes.PRECONDITION_FAILED)
+
+        const reloaded: PopulatedFlow = (await ctx.get(`/v1/flows/${flow.id}`))?.json()
+        const retried = await operate(ctx, flow.id, addAction('step_2', 'step_3'), flowVersionToken.of(reloaded.version))
+        expect(retried?.statusCode).toBe(StatusCodes.OK)
+        expect(names(retried?.json().version)).toEqual(['trigger', 'step_1', 'step_2', 'step_3'])
+    })
+
+    it('keeps a long single-session edit run free of false conflicts', async () => {
+        const ctx = await createTestContext(app!)
+        const flow = await createFlow(ctx, 'smoke-long-session')
+
+        let latest: PopulatedFlow = (await ctx.get(`/v1/flows/${flow.id}`))?.json()
+        let parent = 'trigger'
+        for (let i = 1; i <= 12; i++) {
+            const response = await operate(ctx, flow.id, addAction(parent, `step_${i}`), flowVersionToken.of(latest.version))
+            expect(response?.statusCode).toBe(StatusCodes.OK)
+            latest = response?.json()
+            parent = `step_${i}`
+        }
+        expect(names(latest.version)).toHaveLength(13)
+        expect(duplicates(latest.version)).toEqual([])
+    })
+})

--- a/packages/web/public/locales/en/translation.json
+++ b/packages/web/public/locales/en/translation.json
@@ -193,6 +193,8 @@
   "Tested": "Tested",
   "This step has not been tested yet": "This step has not been tested yet",
   "This step has been updated since the last test": "This step has been updated since the last test",
+  "This flow was edited somewhere else": "This flow was edited somewhere else",
+  "Your recent changes were not saved. The latest version has been loaded.": "Your recent changes were not saved. The latest version has been loaded.",
   "Trigger": "Trigger",
   "No Steps Pasted": "No Steps Pasted",
   "Please make sure you have copied a step(s) and allowed permission to your clipboard": "Please make sure you have copied a step(s) and allowed permission to your clipboard",

--- a/packages/web/public/locales/en/translation.json
+++ b/packages/web/public/locales/en/translation.json
@@ -194,6 +194,7 @@
   "This step has not been tested yet": "This step has not been tested yet",
   "This step has been updated since the last test": "This step has been updated since the last test",
   "This flow was edited somewhere else": "This flow was edited somewhere else",
+  "We could not load the latest version. Reload the page to keep editing.": "We could not load the latest version. Reload the page to keep editing.",
   "Your recent changes were not saved. The latest version has been loaded.": "Your recent changes were not saved. The latest version has been loaded.",
   "Trigger": "Trigger",
   "No Steps Pasted": "No Steps Pasted",

--- a/packages/web/src/app/builder/state/flow-state.ts
+++ b/packages/web/src/app/builder/state/flow-state.ts
@@ -1,4 +1,4 @@
-import { isNil, debounce } from '@activepieces/core-utils';
+import { isNil, debounce, tryCatch } from '@activepieces/core-utils';
 import {
   FlowOperationRequest,
   FlowOperationType,
@@ -92,11 +92,24 @@ export const createFlowState = (
   set: StoreApi<BuilderState>['setState'],
 ): FlowState => {
   const flowUpdatesQueue = new PromiseQueue();
+  let syncGeneration = 0;
   const reloadAfterConflict = async () => {
+    syncGeneration++;
+    flowUpdatesQueue.halt();
     flowUpdatesQueue.discardPending();
-    const flow = await flowsApi.get(get().flow.id);
-    set({ flow, saving: false });
-    get().setVersion(flow.version, false);
+    const reloaded = await tryCatch(flowsApi.get(get().flow.id));
+    if (reloaded.error) {
+      set({ saving: false });
+      toast.error(t('This flow was edited somewhere else'), {
+        description: t(
+          'We could not load the latest version. Reload the page to keep editing.',
+        ),
+      });
+      return;
+    }
+    set({ flow: reloaded.data, saving: false });
+    get().setVersion(reloaded.data.version, false);
+    flowUpdatesQueue.resume();
     toast.error(t('This flow was edited somewhere else'), {
       description: t(
         'Your recent changes were not saved. The latest version has been loaded.',
@@ -197,7 +210,12 @@ export const createFlowState = (
           listener(state.flowVersion, operation);
         });
         set({ saving: true });
+        const operationGeneration = syncGeneration;
         const updateRequest = async () => {
+          if (operationGeneration !== syncGeneration) {
+            set({ saving: flowUpdatesQueue.size() !== 0 });
+            return;
+          }
           try {
             const { version: serverFlowVersion } = await flowsApi.update(
               state.flow.id,

--- a/packages/web/src/app/builder/state/flow-state.ts
+++ b/packages/web/src/app/builder/state/flow-state.ts
@@ -7,14 +7,21 @@ import {
   PopulatedFlow,
   flowOperations,
   flowStructureUtil,
+  flowVersionToken,
   StepSettings,
   FlowTriggerType,
 } from '@activepieces/shared';
 import { QueryClient } from '@tanstack/react-query';
+import { t } from 'i18next';
+import { toast } from 'sonner';
 import { StoreApi } from 'zustand';
 
 import { RightSideBarType } from '@/app/builder/types';
-import { flowsApi, sampleDataHooks } from '@/features/flows';
+import {
+  flowsApi,
+  isFlowVersionConflict,
+  sampleDataHooks,
+} from '@/features/flows';
 import {
   PieceSelectorItem,
   PieceSelectorOperation,
@@ -85,6 +92,17 @@ export const createFlowState = (
   set: StoreApi<BuilderState>['setState'],
 ): FlowState => {
   const flowUpdatesQueue = new PromiseQueue();
+  const reloadAfterConflict = async () => {
+    flowUpdatesQueue.discardPending();
+    const flow = await flowsApi.get(get().flow.id);
+    set({ flow, saving: false });
+    get().setVersion(flow.version, false);
+    toast.error(t('This flow was edited somewhere else'), {
+      description: t(
+        'Your recent changes were not saved. The latest version has been loaded.',
+      ),
+    });
+  };
   const debouncedAddToFlowUpdatesQueue = debounce(
     (updateRequest: () => Promise<void>) => {
       flowUpdatesQueue.add(updateRequest);
@@ -185,6 +203,7 @@ export const createFlowState = (
               state.flow.id,
               operation,
               true,
+              flowVersionToken.of(get().flowVersion),
             );
             if (operation.type === FlowOperationType.SAVE_SAMPLE_DATA) {
               sampleDataHooks.invalidateSampleData(
@@ -204,6 +223,7 @@ export const createFlowState = (
                   ...updatedFlowVersionWithUpdatedSampleData,
                   id: serverFlowVersion.id,
                   state: serverFlowVersion.state,
+                  updated: serverFlowVersion.updated,
                 },
                 saving: flowUpdatesQueue.size() !== 0,
               };
@@ -211,6 +231,10 @@ export const createFlowState = (
             onSuccess?.();
           } catch (error) {
             console.error(error);
+            if (isFlowVersionConflict(error)) {
+              await reloadAfterConflict();
+              return;
+            }
             flowUpdatesQueue.halt();
           }
         };

--- a/packages/web/src/features/flows/api/flows-api.tsx
+++ b/packages/web/src/features/flows/api/flows-api.tsx
@@ -1,4 +1,4 @@
-import { SeekPage } from '@activepieces/core-utils';
+import { ErrorCode, SeekPage } from '@activepieces/core-utils';
 import {
   GetFlowTemplateRequestQuery,
   CreateFlowRequest,
@@ -11,7 +11,9 @@ import {
   PopulatedFlow,
   SharedTemplate,
   CountFlowsRequest,
+  FLOW_VERSION_TOKEN_HEADER,
 } from '@activepieces/shared';
+import { HttpStatusCode } from 'axios';
 import { toast } from 'sonner';
 
 import { UNSAVED_CHANGES_TOAST } from '@/components/ui/sonner';
@@ -35,10 +37,21 @@ export const flowsApi = {
     flowId: string,
     request: FlowOperationRequest,
     showErrorToast = false,
+    baseVersionToken?: string,
   ) {
     return api
-      .post<PopulatedFlow>(`/v1/flows/${flowId}`, request)
+      .post<PopulatedFlow>(
+        `/v1/flows/${flowId}`,
+        request,
+        undefined,
+        baseVersionToken
+          ? { [FLOW_VERSION_TOKEN_HEADER]: baseVersionToken }
+          : undefined,
+      )
       .catch((error) => {
+        if (isFlowVersionConflict(error)) {
+          throw error;
+        }
         if (showErrorToast) {
           toast.error(UNSAVED_CHANGES_TOAST.title, {
             description: UNSAVED_CHANGES_TOAST.description,
@@ -85,3 +98,12 @@ export const flowsApi = {
     return api.get<number>('/v1/flows/count', query);
   },
 };
+
+export function isFlowVersionConflict(error: unknown): boolean {
+  return (
+    api.isError(error) &&
+    error.response?.status === HttpStatusCode.PreconditionFailed &&
+    (error.response?.data as { code?: string })?.code ===
+      ErrorCode.FLOW_VERSION_CONFLICT
+  );
+}

--- a/packages/web/src/features/flows/index.ts
+++ b/packages/web/src/features/flows/index.ts
@@ -1,4 +1,4 @@
-export { flowsApi } from './api/flows-api';
+export { flowsApi, isFlowVersionConflict } from './api/flows-api';
 export { triggerEventsApi } from './api/trigger-events-api';
 export { triggerRunHooks } from './api/trigger-run-api';
 export { ChangeOwnerDialog } from './components/change-owner-dialog';

--- a/packages/web/src/lib/promise-queue.ts
+++ b/packages/web/src/lib/promise-queue.ts
@@ -13,6 +13,11 @@ export class PromiseQueue {
   halt() {
     this.halted = true;
   }
+
+  discardPending() {
+    this.queue = [];
+    this.halted = false;
+  }
   size() {
     return this.queue.length;
   }

--- a/packages/web/src/lib/promise-queue.ts
+++ b/packages/web/src/lib/promise-queue.ts
@@ -16,6 +16,9 @@ export class PromiseQueue {
 
   discardPending() {
     this.queue = [];
+  }
+
+  resume() {
     this.halted = false;
   }
   size() {


### PR DESCRIPTION
## Description

The builder and the server each keep their own copy of a flow and stay in sync by mailing one-way, **name-keyed** operations — "add a step after `step_3`", "update `step_5`". Nothing on either side can tell that the two copies have diverged: the request carries no version, and the client never adopts the server's tree back. So a second editor session — a tab left open, another browser window — goes on editing a tree that no longer exists, and the server applies it.

That is how a flow ends up with **two steps sharing one internal step name**, which is the root of GIT-1805: the corrupted flow that grew to 632 steps and 1.9 MB and left the editor spinning forever.

### The sequence

The stale session allocates a name against its *own* tree, believing it free, while the server already has one. `_addAction` then trusts the client-supplied name verbatim — nothing has ever enforced uniqueness on write (`assertImportedStepNamesAreSafe` validates the name *pattern*, not uniqueness). Reproduced against a real server built from `main`:

```
both sessions load: trigger, step_1, step_2, step_3

session A pastes -> allocates step_4 -> HTTP 200
server now: trigger, step_1, step_2, step_3, step_4

session B pastes -> allocates step_4 -> HTTP 200   <- same name, stale tree

server now: trigger, step_1, step_2, step_4, step_3, step_4
duplicates: step_4 x2
```

The gap between the two pastes is irrelevant — session B's tree is stale from the moment A writes, whether that is 200 ms or the 29 minutes seen in the customer's audit trail. From there every later edit matches *both* nodes and the flow grows triangularly (a 35-step paste onto a collided tree adds T₃₅ = 630 nodes).

### What changed

**Operations now carry the version they were computed against**, as an `If-Match` header holding `${versionId}:${updatedMs}`:

- **Server** — the controller already loads the flow, so the check costs nothing. A mismatch throws `FLOW_VERSION_CONFLICT`, mapped to **412 Precondition Failed**. Including the version *id* alongside the timestamp also catches the draft being swapped out from under a session (`USE_AS_DRAFT`).
- **Client** — sends the token, and now **adopts `updated` from each response**. It was keeping its own tree and taking only `id` and `state`, which is precisely why it could never notice it had fallen behind. Within one tab the serialized queue keeps the token current, so there are no false conflicts; a second tab goes stale immediately.
- **Recovery** — on 412 the client discards the queued operations, reloads the flow, and tells the user their changes were not saved. `PromiseQueue.halt()` was terminal with no way back, so one failed request silently stranded every later edit in the session while the browser went on showing them as saved; `discardPending()` gives the conflict path a way to resume.

`applyOperation` already sets `updated` explicitly on every operation, so the token changes on every write — no new column and no migration.

### Deliberately opt-in

An API consumer that sends no `If-Match` behaves **exactly** as before. This is defence for the interactive editor, not a new requirement on the public API, which is why it is non-breaking.

### Relationship to #15291

Complementary, and independent — this branch is off `main` and does not depend on it.

- **#15291** rejects an `ADD_ACTION` whose name is already taken. That stops the *symptom* at the one chokepoint every gesture routes through, whatever seeded it — including a malformed `IMPORT_FLOW` that no version token would catch.
- **This PR** rejects any operation computed against a tree that no longer exists. That stops the *cause*, and covers divergence a name check cannot see: updating a step another session deleted, or a `DUPLICATE_ACTION` whose server-side name allocation no longer matches what the client optimistically applied.

Either one alone would have prevented GIT-1805. Both together close the class.

### Considered and rejected

- **Auto-renaming a colliding step server-side.** The client has already optimistically applied the name, so a silent rename makes the two sides disagree about a step's identity, and every later name-keyed operation targets the wrong node. Failing loudly is the safer half of "reject or auto-rename".
- **A per-flow lock.** It serializes writers but does not help here — the stale session's operation is well-formed and would simply acquire the lock and apply. Worth doing separately for a different reason: `LOCK_AND_PUBLISH`, `CHANGE_STATUS`, `USE_AS_DRAFT` and rename all call `flowsApi.update` *outside* the builder's serialized queue, so publish genuinely races in-flight edits against an unlocked read-modify-write.

## How was this tested?

Three new integration tests in `flow-operations.test.ts`, driving the real endpoint:

- a matching token applies the operation;
- a token from a superseded version returns **412** with `FLOW_VERSION_CONFLICT`;
- sending no token still works, pinning the backwards-compatible path.

**163/163 passing across all 16 CE flow integration test files** (`test/integration/ce/flows`), including the flow-run E2E suite. `turbo run lint` clean for `api`, `web`, `@activepieces/core-utils` and `@activepieces/core-execution` (pre-existing warnings only: 491 in api, 72 in web's `features/tables/`).

The two-session collision above was reproduced against a live stack built from `main` before the fix; that same script is the acceptance check for this branch, and re-running it is the one thing I have **not** yet done end-to-end — the local Docker engine needs a restart after an unrelated disk-space incident. The unit-level behaviour is covered by the integration tests above, which exercise the identical code path through the real controller.

Linear: [GIT-1805](https://linear.app/activepieces/issue/GIT-1805/bug-cloud-flow-editor-spins-indefinitely-after-publish-hung-on)

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

No env var, migration, column or field change. The `If-Match` header is optional and absent by default; a client that does not send it is unaffected. Only a caller that opts in can receive the new 412.

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)
