### PR TITLE
fix(sandbox): route worker→engine RPC-ack timeouts to SANDBOX_EXECUTION_TIMEOUT

### DIFF
--- a/packages/core/execution/src/lib/engine/rpc.ts
+++ b/packages/core/execution/src/lib/engine/rpc.ts
@@ -37,7 +37,7 @@ export function createRpcClient<T extends Contract>(
                     if (error instanceof Error && error.message.startsWith('RPC [')) {
                         throw error
                     }
-                    throw new Error(`RPC [${method}] failed (timeout: ${timeoutMs}ms): ${toError(error).message}`)
+                    throw new RpcTimeoutError({ method, timeoutMs, cause: error })
                 }
             }
         },
@@ -109,6 +109,16 @@ export function apErrorOf(error: unknown): RpcApError | undefined {
 
 function isRpcErrorEnvelope(value: unknown): value is { __rpcError: string, __rpcApError?: unknown } {
     return isObject(value) && '__rpcError' in value
+}
+
+export class RpcTimeoutError extends Error {
+    readonly method: string
+    readonly timeoutMs: number
+    constructor({ method, timeoutMs, cause }: { method: string, timeoutMs: number, cause: unknown }) {
+        super(`RPC [${method}] failed (timeout: ${timeoutMs}ms): ${toError(cause).message}`)
+        this.method = method
+        this.timeoutMs = timeoutMs
+    }
 }
 
 export type RpcTimeout = number | ((method: string) => number)

--- a/packages/core/execution/test/automation/engine/rpc.test.ts
+++ b/packages/core/execution/test/automation/engine/rpc.test.ts
@@ -1,6 +1,6 @@
 import { ActivepiecesError, ErrorCode } from '@activepieces/core-utils'
 import { describe, expect, it } from 'vitest'
-import { apErrorOf, createRpcClient, createRpcServer } from '../../../src/lib/engine/rpc'
+import { apErrorOf, createRpcClient, createRpcServer, RpcTimeoutError } from '../../../src/lib/engine/rpc'
 
 type TestContract = {
     boom: (input: unknown) => Promise<unknown>
@@ -42,6 +42,8 @@ describe('rpc timeout', () => {
 
         expect(String(quick)).toContain('failed (timeout: 1000ms)')
         expect(String(long)).toContain('failed (timeout: 600000ms)')
+        expect(quick).toBeInstanceOf(RpcTimeoutError)
+        expect(long).toBeInstanceOf(RpcTimeoutError)
     })
 })
 

--- a/packages/server/sandbox/src/lib/sandbox/sandbox.ts
+++ b/packages/server/sandbox/src/lib/sandbox/sandbox.ts
@@ -3,7 +3,7 @@ import { randomBytes, timingSafeEqual } from 'crypto'
 import { createServer, Server as HttpServer } from 'http'
 import path from 'path'
 import { ActivepiecesError, assertNotNullOrUndefined, ErrorCode, isNil, tryCatch } from '@activepieces/core-utils'
-import { createNotifyServer, createRpcClient, EngineContract, EngineOperation, EngineOperationType, EngineResponse, EngineStderr, EngineStdout, WorkerNotifyContract } from '@activepieces/shared'
+import { createNotifyServer, createRpcClient, EngineContract, EngineOperation, EngineOperationType, EngineResponse, EngineStderr, EngineStdout, RpcTimeoutError, WorkerNotifyContract } from '@activepieces/shared'
 import { Socket, Server as SocketIOServer } from 'socket.io'
 import treeKill from 'tree-kill'
 import { cacheUtils } from '../cache/cache-paths'
@@ -290,7 +290,12 @@ export function createSandbox(
                     resolve({ ...engineResponse, logs: buildLogs(stdOut, stdError) })
                 }).catch((error: unknown) => {
                     log.error({ sandbox: { id: sandboxId }, error: String(error) }, '[Sandbox] RPC call failed')
-                    reject(error)
+                    reject(error instanceof RpcTimeoutError
+                        ? new ActivepiecesError({
+                            code: ErrorCode.SANDBOX_EXECUTION_TIMEOUT,
+                            params: { standardOutput: stdOut + nativeStdOut, standardError: stdError + nativeStdError },
+                        })
+                        : error)
                 })
             })
 


### PR DESCRIPTION
## Description

A hung code step that ignores SIGTERM (e.g. a raw TLS socket stalled in kernel networking) races two independent sandbox timeouts:

1. **Outer process-kill** (`sandbox.ts:260-266`): `setTimeout(..., timeoutInSeconds * 1000)` = 600 s. When it fires, marks `killedByTimeout=true` and calls `killProcess`. The `ActivepiecesError({ SANDBOX_EXECUTION_TIMEOUT })` only gets thrown once the child's `'close'` event fires (`handleProcessExit`).
2. **Inner RPC-ack timeout** (`sandbox.ts:287-288`): `operationTimeoutMs = (timeoutInSeconds + 5) * 1000` = 605 s. When socket.io's `emitWithAck.timeout()` fires, `rpc.ts` threw a bare `Error("RPC [executeOperation] failed (timeout: 605000ms)")`.

The 5-second gap was the whole safety margin. When the outer kill takes >5 s to produce a `'close'` event (SIGTERM-ignoring child + SIGKILL fallback), the RPC-ack wins the race. The bare `Error` fell through `isSandboxTimeout(e)` in `execute-flow.ts:91` (which checks `ActivepiecesError` code `SANDBOX_EXECUTION_TIMEOUT`, not a bare `Error`), landed as `FlowRunStatus.INTERNAL_ERROR`, and — on dedicated workers — paged oncall.

### Fix

Replace the bare `Error` in the RPC-client timeout arm with a typed `RpcTimeoutError` marker class, and translate it to `ActivepiecesError({ SANDBOX_EXECUTION_TIMEOUT })` at the sandbox boundary. Every existing `isSandboxTimeout(e)` caller (8 sites: execute-flow, action, validation, property, token-refresh, webhook, trigger-hook, resolve-connection-identifier) now catches this branch for free — no caller changes needed.

Translation happens in `sandbox.ts` (per-caller) rather than globally in `rpc.ts`, because timeouts on different RPC directions mean different things: worker→engine timeout = the sandbox is stuck; worker→app timeout (a separate `createRpcClient` in `worker.ts`) = the app is slow/dead. Blanket-translating in `rpc.ts` would mislabel an `uploadRunLog` timeout as a sandbox timeout, which it isn't.

Message string on the class is kept identical to the previous bare-Error string so existing log/dashboard searches on `"RPC [executeOperation] failed (timeout:"` still hit — the change is the *type*, not the wording.

### Real-world impact

Observed on cloud 2026-09-06: **44 failed jobs** in the `workerJobs` failed set, all `EXECUTE_FLOW BEGIN` with `failedReason = RPC [executeOperation] failed (timeout: 605000ms): operation has timed out`. 28 of 44 (64%) came from a single flow whose code step opened a raw TLS socket to `imap.gmail.com` without `socket.setTimeout` / `AbortController`. With this fix, that class routes to `FlowRunStatus.TIMEOUT` (correct classification), no oncall page, and the customer sees a clean timeout rather than "internal error".

## How was this tested?

- `npx vitest run packages/core/execution/test/automation/engine/rpc.test.ts` — 4/4 pass. Added `toBeInstanceOf(RpcTimeoutError)` assertion on the existing timeout test.
- `cd packages/server/sandbox && npx vitest run test/lib/sandbox/sandbox.test.ts` — 51/51 pass, including the existing `SANDBOX_EXECUTION_TIMEOUT on real timeout` test which proves the outer-kill path still wins when it's fast enough.
- `npx turbo run lint --filter=@activepieces/core-execution --filter=@activepieces/sandbox` — 0 errors.

Skipped: a dedicated sandbox test for the RPC-ack-wins path (would need faking a >5 s hang in `killProcess`, slow test). The rpc.test.ts `instanceof` assertion + the existing outer-kill test together cover both branches.

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

This is purely a classification fix inside the worker: previously the run landed as `INTERNAL_ERROR`, now it lands as `TIMEOUT` (the correct outcome). No API field, env var, migration, or self-hoster action.

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)

Error-type classification only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)