### PR TITLE
fix(google-sheets): stop New Row trigger OOMing on large sheets

### DIFF
--- a/packages/pieces/community/google-sheets/package.json
+++ b/packages/pieces/community/google-sheets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-google-sheets",
-  "version": "0.16.11",
+  "version": "0.16.12",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "dependencies": {

--- a/packages/pieces/community/google-sheets/src/lib/triggers/new-row-added-webhook.ts
+++ b/packages/pieces/community/google-sheets/src/lib/triggers/new-row-added-webhook.ts
@@ -57,9 +57,9 @@ export const newRowAddedTrigger = createTrigger({
 		const spreadsheetId = inputSpreadsheetId as string;
 
 		const sheetName = await getWorkSheetName(context.auth, spreadsheetId, sheetId);
-		const currentSheetValues = await getWorkSheetValues(context.auth, spreadsheetId, sheetName);
+		const firstColumn = await getWorkSheetValues(context.auth, spreadsheetId, `${sheetName}!A:A`);
 
-		await context.store.put(`${sheetId}`, currentSheetValues.length);
+		await context.store.put(`${sheetId}`, firstColumn.length);
 
 		const fileNotificationRes = await createFileNotification(
 			context.auth,
@@ -105,10 +105,13 @@ export const newRowAddedTrigger = createTrigger({
 		const oldRowCount = (await context.store.get(`${sheetId}`)) as number;
 
 		const sheetName = await getWorkSheetName(context.auth, spreadsheetId, sheetId);
-		const currentRowValues = await getWorkSheetValues(context.auth, spreadsheetId, sheetName);
-		const currentRowCount = currentRowValues.length;
+		const [firstColumn, headerRow] = await Promise.all([
+			getWorkSheetValues(context.auth, spreadsheetId, `${sheetName}!A:A`),
+			getWorkSheetValues(context.auth, spreadsheetId, `${sheetName}!1:1`),
+		]);
+		const currentRowCount = firstColumn.length;
 
-		const headers =  currentRowValues[0] ?? [];
+		const headers =  headerRow[0] ?? [];
 		const headerCount = headers.length;
 
 		if (oldRowCount >= currentRowCount) {


### PR DESCRIPTION
## Description

The `googlesheets_new_row_added` trigger fetched the ENTIRE sheet (every row × every column) on each webhook fire, then used only `.length` and `[0]` from the returned array. On a growing sheet this OOMs the sandbox during trigger polling.

`new-row-added-webhook.ts:108` (before):

```ts
const currentRowValues = await getWorkSheetValues(context.auth, spreadsheetId, sheetName);
//                              ^^^^^^^^^^^^^^^^^^ no range → Google returns every row × every column
const currentRowCount = currentRowValues.length;
const headers = currentRowValues[0] ?? [];
```

The trigger loads the whole sheet just to compute `array.length` and read the header row. The subsequent range-scoped fetch of the new rows (line 124) is fine and already bounded.

Same wasteful whole-sheet fetch in `onEnable` on line 60.

### Fix

Fetch only column A (for row count) and row 1 (for headers), in parallel:

```ts
const [firstColumn, headerRow] = await Promise.all([
    getWorkSheetValues(context.auth, spreadsheetId, `${sheetName}!A:A`),
    getWorkSheetValues(context.auth, spreadsheetId, `${sheetName}!1:1`),
]);
const currentRowCount = firstColumn.length;
const headers = headerRow[0] ?? [];
```

Same trigger semantics, orders of magnitude less memory. For a 9-column sheet, that's ~9× less data per fire; for a wide sheet, the reduction is larger.

Column A is the safe proxy for data row count: `values.get` only returns rows that actually have data (empty grid rows are elided), so `.length` = data row count. If a customer has rows where col A is empty but other columns have data, this undercounts — but that's exactly the case where "new row" is ambiguous to the user anyway, and one spurious re-fire on the next new row is a much better failure mode than OOMing the sandbox.

### Real-world impact

Observed on cloud 2026-09-05: 9 `EXECUTE_WEBHOOK` jobs in the `workerJobs` failed set, all for one customer's flow (project `igTctUSuN2KqV6x2kLNWp`), all with:

- `failedReason: SANDBOX_MEMORY_ISSUE / stderr: Caught fatal signal 9`
- `operationType: EXECUTE_TRIGGER_HOOK` (confirmed trigger `run()` path)
- `sandboxRunMs: ~59s` (loading + serializing the whole sheet)
- `code: 1, signal: null` — classic isolate-mode container OOM (kernel OOM-kills the V8 isolate inside the isolate binary)

The flow *runs* themselves (`EXECUTE_FLOW`) succeed fine in ~3-5s — only the trigger polling was OOMing.

## How was this tested?

- `npx turbo run lint --filter=@activepieces/piece-google-sheets` — 0 errors.
- Change is a narrow substitution: same helper, tighter range. The semantic assertion "data row count = length of values in column A" is straightforward from the Google Sheets `values.get` contract.

Manual verification on staging pending, before merge:
- New row added → trigger fires with the new row's values.
- Multiple new rows added → trigger fires with all new rows.
- Sheet with an empty col A row → does not fire (documented limitation; no crash).

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

Trigger name, output schema, and observable behavior for the common case (col A has data on every row) are unchanged. The one edge-case difference — rows where col A is blank but other columns have data — is a change from "counted (may OOM)" to "not counted". Acceptable, given the alternative is a crashing trigger.

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)