### PR TITLE
fix(worker): use internal API URL for piece bundle downloads

### DIFF
--- a/packages/server/sandbox/src/lib/cache/local-execution-cache.ts
+++ b/packages/server/sandbox/src/lib/cache/local-execution-cache.ts
@@ -13,7 +13,7 @@ export const localExecutionCache = (log: ApLogger, basePath: string, getSettings
     async provision({
         pieces,
         codeSteps,
-        publicApiUrl,
+        internalApiUrl,
         engineToken,
     }: ProvisionParams): Promise<void> {
         await wideEvent.timed({
@@ -55,7 +55,7 @@ export const localExecutionCache = (log: ApLogger, basePath: string, getSettings
                             await pieceInstaller(log, basePath, getSettings).install({
                                 pieces: uniquePieces,
                                 includeFilters: true,
-                                publicApiUrl,
+                                internalApiUrl,
                                 engineToken,
                             })
                             log.info({
@@ -112,6 +112,6 @@ type InstallCodeStepParams = {
 type ProvisionParams = {
     pieces: PiecePackage[]
     codeSteps: CodeArtifact[]
-    publicApiUrl: string
+    internalApiUrl: string
     engineToken: string
 }

--- a/packages/server/sandbox/src/lib/cache/pieces/piece-installer.ts
+++ b/packages/server/sandbox/src/lib/cache/pieces/piece-installer.ts
@@ -15,10 +15,10 @@ const relativePiecePath = (piece: PiecePackage) => join('./', 'pieces', `${piece
 const piecePath = (rootWorkspace: string, piece: PiecePackage) => join(rootWorkspace, 'pieces', `${piece.pieceName}-${piece.pieceVersion}`)
 
 export const pieceInstaller = (log: ApLogger, basePath: string, getSettings: () => SandboxSettings) => ({
-    async install({ pieces, includeFilters, publicApiUrl, engineToken }: InstallParams): Promise<void> {
+    async install({ pieces, includeFilters, internalApiUrl, engineToken }: InstallParams): Promise<void> {
         const groupedPieces = groupPiecesByPackagePath(pieces, basePath, getSettings)
         const installPromises = Object.entries(groupedPieces).map(async ([packagePath, piecesInGroup]) => {
-            await installPieces(packagePath, piecesInGroup, includeFilters, log, { publicApiUrl, engineToken }, getSettings)
+            await installPieces(packagePath, piecesInGroup, includeFilters, log, { internalApiUrl, engineToken }, getSettings)
         })
         await Promise.all(installPromises)
     },
@@ -247,13 +247,13 @@ function bundleTgzPath(rootWorkspace: string, piece: PiecePackage): string {
 // `fetch` follows the redirect and carries the engine token in the Authorization header.
 // ARCHIVE pieces are fetched by archiveId (they may not be registered in metadata yet, e.g. during
 // EXTRACT_PIECE_METADATA); REGISTRY pieces by name@version.
-async function saveBundlesToDiskIfNotCached(rootWorkspace: string, pieces: PiecePackage[], { publicApiUrl, engineToken }: BundleSource): Promise<void> {
+async function saveBundlesToDiskIfNotCached(rootWorkspace: string, pieces: PiecePackage[], { internalApiUrl, engineToken }: BundleSource): Promise<void> {
     await Promise.all(pieces.map(async (piece) => {
         const bundlePath = bundleTgzPath(rootWorkspace, piece)
         if (await fileSystemUtils.fileExists(bundlePath)) {
             return
         }
-        const url = pieceBundleEndpointUrl(publicApiUrl, piece)
+        const url = pieceBundleEndpointUrl(internalApiUrl, piece)
         const response = await fetch(url, { headers: { Authorization: `Bearer ${engineToken}` } })
         if (!response.ok) {
             throw new Error(`Failed to fetch piece bundle ${piece.pieceName}@${piece.pieceVersion}: ${response.status} ${response.statusText}`)
@@ -263,8 +263,8 @@ async function saveBundlesToDiskIfNotCached(rootWorkspace: string, pieces: Piece
     }))
 }
 
-function pieceBundleEndpointUrl(publicApiUrl: string, piece: PiecePackage): string {
-    const base = `${ensureTrailingSlash(publicApiUrl)}v1/engine/pieces/bundle`
+function pieceBundleEndpointUrl(internalApiUrl: string, piece: PiecePackage): string {
+    const base = `${ensureTrailingSlash(internalApiUrl)}v1/engine/pieces/bundle`
     if (piece.packageType === PackageType.ARCHIVE) {
         return `${base}?archiveId=${encodeURIComponent(piece.archiveId)}`
     }
@@ -319,12 +319,12 @@ async function markPiecesAsUsed(rootWorkspace: string, pieces: PiecePackage[]): 
 type InstallParams = {
     pieces: PiecePackage[]
     includeFilters: boolean
-    publicApiUrl: string
+    internalApiUrl: string
     engineToken: string
 }
 
 type BundleSource = {
-    publicApiUrl: string
+    internalApiUrl: string
     engineToken: string
 }
 

--- a/packages/server/sandbox/src/lib/resolver.ts
+++ b/packages/server/sandbox/src/lib/resolver.ts
@@ -48,7 +48,7 @@ export function createResolver({ apiClient, basePath, getSettings, log }: Create
                 flowVersionId: flowVersion?.id,
                 pieces: uniquePieces,
                 codes,
-                publicApiUrl: input.publicApiUrl,
+                internalApiUrl: input.internalApiUrl,
                 engineToken: input.engineToken,
             }
             return { kind: 'ready', provision, flowVersion }

--- a/packages/server/sandbox/src/lib/sandbox.ts
+++ b/packages/server/sandbox/src/lib/sandbox.ts
@@ -43,7 +43,7 @@ export function createSandboxRuntime({ concurrency = 1, basePath, getSettings }:
             const { error: provisionError } = await tryCatch(() => localExecutionCache(log, basePath, getSettings).provision({
                 pieces: provision.pieces,
                 codeSteps: provision.codes,
-                publicApiUrl: provision.publicApiUrl,
+                internalApiUrl: provision.internalApiUrl,
                 engineToken: provision.engineToken,
             }))
             if (provisionError) {
@@ -112,8 +112,8 @@ export function createSandboxRuntime({ concurrency = 1, basePath, getSettings }:
                     busy: info.busy,
                 }))
         },
-        async prewarm({ log, apiClient, publicApiUrl, flow }: PreWarmSandboxParams): Promise<void> {
-            if (isNil(apiClient) || isNil(publicApiUrl)) {
+        async prewarm({ log, apiClient, internalApiUrl, flow }: PreWarmSandboxParams): Promise<void> {
+            if (isNil(apiClient) || isNil(internalApiUrl)) {
                 return
             }
             const startedAt = Date.now()
@@ -124,10 +124,10 @@ export function createSandboxRuntime({ concurrency = 1, basePath, getSettings }:
                     flow,
                 })
                 const resolver = createResolver({ apiClient, basePath, getSettings, log })
-                const provisions = await resolveFlowsForPrewarm({ resolver, flows, platformId, publicApiUrl, engineToken, log })
+                const provisions = await resolveFlowsForPrewarm({ resolver, flows, platformId, internalApiUrl, engineToken, log })
                 const pieces = provisions.flatMap((provision) => provision.pieces)
                 const codeSteps = provisions.flatMap((provision) => provision.codes)
-                await localExecutionCache(log, basePath, getSettings).provision({ pieces, codeSteps, publicApiUrl, engineToken })
+                await localExecutionCache(log, basePath, getSettings).provision({ pieces, codeSteps, internalApiUrl, engineToken })
                 log.info({ flowCount: flows.length, pieceCount: pieces.length, durationMs: Date.now() - startedAt }, 'Prewarmed sandbox cache')
             })
             if (error) {
@@ -140,11 +140,11 @@ export function createSandboxRuntime({ concurrency = 1, basePath, getSettings }:
     }
 }
 
-async function resolveFlowsForPrewarm({ resolver, flows, platformId, publicApiUrl, engineToken, log }: ResolveFlowsForPrewarmParams): Promise<ProvisionInput[]> {
+async function resolveFlowsForPrewarm({ resolver, flows, platformId, internalApiUrl, engineToken, log }: ResolveFlowsForPrewarmParams): Promise<ProvisionInput[]> {
     const provisions: ProvisionInput[] = []
     for (const batch of chunk(flows, PREWARM_RESOLVE_CONCURRENCY)) {
         const resolvedBatch = await Promise.all(batch.map(async (flow) => {
-            const { data: resolved, error: flowError } = await tryCatch(() => resolver.resolve({ flow, platformId, publicApiUrl, engineToken }))
+            const { data: resolved, error: flowError } = await tryCatch(() => resolver.resolve({ flow, platformId, internalApiUrl, engineToken }))
             if (flowError) {
                 log.warn({ error: String(flowError), flow: { id: flow.id } }, 'Failed to resolve flow for prewarm')
                 return null
@@ -168,7 +168,7 @@ type ResolveFlowsForPrewarmParams = {
     resolver: Resolver
     flows: { id: string, versionId: string, projectId: string }[]
     platformId: string
-    publicApiUrl: string
+    internalApiUrl: string
     engineToken: string
     log: ApLogger
 }

--- a/packages/server/sandbox/src/lib/types.ts
+++ b/packages/server/sandbox/src/lib/types.ts
@@ -14,7 +14,7 @@ export type Resolver = {
 
 export type ResolveInput = {
     platformId: string
-    publicApiUrl: string
+    internalApiUrl: string
     engineToken: string
     flow?: { id: string, versionId: string, projectId: string }
     pieces?: PiecePackage[]
@@ -49,22 +49,22 @@ export type ExecuteParams = {
 export type PreWarmSandboxParams = {
     log: ApLogger
     apiClient?: WorkerToApiContract
-    publicApiUrl?: string
+    internalApiUrl?: string
     // Warm just this flow (e.g. on publish) instead of the platform's whole active set.
     flow?: { id: string, versionId: string, projectId: string }
 }
 
 // The Resolver's output and the pool's input. The pool installs each piece straight from a link: it
-// builds `${publicApiUrl}v1/engine/pieces/bundle?name=&version=&token=` per piece and hands that URL
+// builds `${internalApiUrl}v1/engine/pieces/bundle?name=&version=&token=` per piece and hands that URL
 // to `bun install`, which follows the endpoint's redirect to npm / signed-S3 (or streams the custom
 // archive). No bytes cross the worker socket and the pool never imports WorkerToApiContract; the link
-// is publicApiUrl-based so it is reachable from a remote pool (Cloud Run). See ADR 0002.
+// is internalApiUrl-based for service-to-service communication. See ADR 0002.
 export type ProvisionInput = {
     platformId: string
     flowVersionId?: string
     pieces: PiecePackage[]
     codes: CodeArtifact[]
-    publicApiUrl: string
+    internalApiUrl: string
     engineToken: string
 }
 

--- a/packages/server/sandbox/test/lib/cache/piece-installer.test.ts
+++ b/packages/server/sandbox/test/lib/cache/piece-installer.test.ts
@@ -73,7 +73,7 @@ const fakeLog = {
 } as unknown as ApLogger
 
 // Every piece is installed from its bundle link; the dependency value is the engine bundle endpoint.
-const bundleSource = { publicApiUrl: 'http://localhost:3000/api/', engineToken: 'test-token' }
+const bundleSource = { internalApiUrl: 'http://localhost:3000/api/', engineToken: 'test-token' }
 
 const fakeGetSettings = () => ({
     EXECUTION_MODE: 'UNSANDBOXED',
@@ -283,6 +283,50 @@ describe('pieceInstaller', () => {
         expect(mockInstall.mock.calls[2]?.[0]).toMatchObject({
             filtersPath: [expect.stringContaining(`${piece2.pieceName}-${piece2.pieceVersion}`)],
         })
+    })
+
+    it('downloads piece bundles using internalApiUrl and not publicApiUrl', async () => {
+        const piece = makePiece('@activepieces/piece-test')
+        const installer = pieceInstaller(fakeLog, testWorkspace, fakeGetSettings)
+        mockInstall.mockResolvedValueOnce({ output: '' })
+
+        const internalApiUrl = 'http://internal-api.local:3000/api/'
+        const publicApiUrl = 'https://public.activepieces.com/api/'
+
+        const fetchMock = vi.fn().mockImplementation((url: string) => {
+            if (url.startsWith(internalApiUrl)) {
+                return Promise.resolve({
+                    ok: true,
+                    arrayBuffer: async () => new TextEncoder().encode('tgz').buffer,
+                })
+            }
+            return Promise.resolve({
+                ok: false,
+                status: 502,
+                statusText: 'Bad Gateway - worker cannot route to publicApiUrl',
+            })
+        })
+        vi.stubGlobal('fetch', fetchMock)
+
+        await installer.install({
+            pieces: [piece],
+            includeFilters: true,
+            internalApiUrl,
+            engineToken: 'test-token',
+        })
+
+        expect(fetchMock).toHaveBeenCalledOnce()
+        expect(fetchMock).toHaveBeenCalledWith(
+            expect.stringContaining(`${internalApiUrl}v1/engine/pieces/bundle`),
+            expect.objectContaining({
+                headers: { Authorization: 'Bearer test-token' },
+            }),
+        )
+        expect(fetchMock).not.toHaveBeenCalledWith(
+            expect.stringContaining(publicApiUrl),
+            expect.anything(),
+        )
+        expect(await pathExists(readyFilePath(piece))).toBe(true)
     })
 })
 

--- a/packages/server/sandbox/test/lib/sandbox.test.ts
+++ b/packages/server/sandbox/test/lib/sandbox.test.ts
@@ -69,7 +69,7 @@ function buildExecuteParams(workerIndex: number, expiresAt?: number) {
             flowVersionId: 'fv1',
             pieces: [],
             codes: [],
-            publicApiUrl: 'http://localhost/api/',
+            internalApiUrl: 'http://localhost/api/',
             engineToken: 't',
         },
     } as never

--- a/packages/server/worker/src/lib/api-notify-service.ts
+++ b/packages/server/worker/src/lib/api-notify-service.ts
@@ -2,14 +2,14 @@ import { Runtime } from '@activepieces/sandbox'
 import { ApLogger } from '@activepieces/server-utils'
 import { ApiToWorkerContract, WorkerToApiContract } from '@activepieces/shared'
 
-export function createApiToWorkerHandlers({ getRuntime, apiClient, getPublicApiUrl, log }: CreateApiToWorkerHandlersParams): ApiToWorkerContract {
+export function createApiToWorkerHandlers({ getRuntime, apiClient, getInternalApiUrl, log }: CreateApiToWorkerHandlersParams): ApiToWorkerContract {
     return {
         flowPublished({ flowId, flowVersionId, projectId }) {
             log.info({ flowId, flowVersionId, projectId, message: 'Flow published, prewarming flow cache' })
             void getRuntime()?.prewarm({
                 log,
                 apiClient,
-                publicApiUrl: getPublicApiUrl(),
+                internalApiUrl: getInternalApiUrl(),
                 flow: { id: flowId, versionId: flowVersionId, projectId },
             })
         },
@@ -19,6 +19,6 @@ export function createApiToWorkerHandlers({ getRuntime, apiClient, getPublicApiU
 type CreateApiToWorkerHandlersParams = {
     getRuntime: () => Runtime | null
     apiClient: WorkerToApiContract
-    getPublicApiUrl: () => string
+    getInternalApiUrl: () => string
     log: ApLogger
 }

--- a/packages/server/worker/src/lib/execute/jobs/execute-action.ts
+++ b/packages/server/worker/src/lib/execute/jobs/execute-action.ts
@@ -10,7 +10,7 @@ export const executeActionJob: JobHandler<ExecuteActionJobData, SynchronousJobRe
     jobType: WorkerJobType.EXECUTE_ACTION,
     async execute(ctx: JobContext, data: ExecuteActionJobData): Promise<SynchronousJobResult> {
         const { codes, namespace: codeNamespace } = await resolveCodeStep({ step: data.step, platformId: data.platformId })
-        const resolved = await ctx.resolver.resolve({ platformId: data.platformId, publicApiUrl: ctx.publicApiUrl, engineToken: ctx.engineToken, pieces: data.piece ? [data.piece] : [], codes })
+        const resolved = await ctx.resolver.resolve({ platformId: data.platformId, internalApiUrl: ctx.internalApiUrl, engineToken: ctx.engineToken, pieces: data.piece ? [data.piece] : [], codes })
         if (resolved.kind !== 'ready') {
             throw new Error(`Unexpected resolve outcome "${resolved.kind}" for action-run action job`)
         }

--- a/packages/server/worker/src/lib/execute/jobs/execute-flow.ts
+++ b/packages/server/worker/src/lib/execute/jobs/execute-flow.ts
@@ -13,7 +13,7 @@ export const executeFlowJob: JobHandler<ExecuteFlowJobData, FireAndForgetJobResu
         const timeoutInSeconds = workerSettings.getSettings().FLOW_TIMEOUT_SECONDS
 
         const { data: resolved, error: provisionError } = await tryCatch(() =>
-            ctx.resolver.resolve({ platformId: data.platformId, publicApiUrl: ctx.publicApiUrl, engineToken: ctx.engineToken, flow: { id: data.flowId, versionId: data.flowVersionId, projectId: data.projectId } }),
+            ctx.resolver.resolve({ platformId: data.platformId, internalApiUrl: ctx.internalApiUrl, engineToken: ctx.engineToken, flow: { id: data.flowId, versionId: data.flowVersionId, projectId: data.projectId } }),
         )
         if (provisionError) {
             await reportFlowStatus({ ctx, data, status: FlowRunStatus.INTERNAL_ERROR, internalError: toInternalError(RunInternalErrorSource.WORKER, provisionError) })

--- a/packages/server/worker/src/lib/execute/jobs/execute-polling.ts
+++ b/packages/server/worker/src/lib/execute/jobs/execute-polling.ts
@@ -10,7 +10,7 @@ export const executePollingJob: JobHandler<PollingJobData, FireAndForgetJobResul
     async execute(ctx: JobContext, data: PollingJobData): Promise<FireAndForgetJobResult> {
         const timeoutInSeconds = workerSettings.getSettings().TRIGGER_TIMEOUT_SECONDS
 
-        const resolved = await ctx.resolver.resolve({ platformId: data.platformId, publicApiUrl: ctx.publicApiUrl, engineToken: ctx.engineToken, flow: { id: data.flowId, versionId: data.flowVersionId, projectId: data.projectId } })
+        const resolved = await ctx.resolver.resolve({ platformId: data.platformId, internalApiUrl: ctx.internalApiUrl, engineToken: ctx.engineToken, flow: { id: data.flowId, versionId: data.flowVersionId, projectId: data.projectId } })
 
         if (resolved.kind === 'flow-not-found') {
             ctx.log.info({ flowVersion: { id: data.flowVersionId } }, 'Flow version not found for polling trigger, skipping')

--- a/packages/server/worker/src/lib/execute/jobs/execute-property.ts
+++ b/packages/server/worker/src/lib/execute/jobs/execute-property.ts
@@ -10,7 +10,7 @@ export const executePropertyJob: JobHandler<ExecutePropertyJobData, SynchronousJ
     async execute(ctx: JobContext, data: ExecutePropertyJobData): Promise<SynchronousJobResult> {
         const timeoutInSeconds = workerSettings.getSettings().TRIGGER_TIMEOUT_SECONDS
 
-        const resolved = await ctx.resolver.resolve({ platformId: data.platformId, publicApiUrl: ctx.publicApiUrl, engineToken: ctx.engineToken, pieces: [data.piece] })
+        const resolved = await ctx.resolver.resolve({ platformId: data.platformId, internalApiUrl: ctx.internalApiUrl, engineToken: ctx.engineToken, pieces: [data.piece] })
         if (resolved.kind !== 'ready') {
             throw new Error(`Unexpected resolve outcome "${resolved.kind}" for piece-only job`)
         }

--- a/packages/server/worker/src/lib/execute/jobs/execute-token-refresh.ts
+++ b/packages/server/worker/src/lib/execute/jobs/execute-token-refresh.ts
@@ -15,7 +15,7 @@ export const executeTokenRefreshJob: JobHandler<ExecuteTokenRefreshJobData, Sync
     async execute(ctx: JobContext, data: ExecuteTokenRefreshJobData): Promise<SynchronousJobResult> {
         const timeoutInSeconds = workerSettings.getSettings().TRIGGER_TIMEOUT_SECONDS
 
-        const resolved = await ctx.resolver.resolve({ platformId: data.platformId, publicApiUrl: ctx.publicApiUrl, engineToken: ctx.engineToken, pieces: [data.piece] })
+        const resolved = await ctx.resolver.resolve({ platformId: data.platformId, internalApiUrl: ctx.internalApiUrl, engineToken: ctx.engineToken, pieces: [data.piece] })
         if (resolved.kind !== 'ready') {
             throw new Error(`Unexpected resolve outcome "${resolved.kind}" for piece-only job`)
         }

--- a/packages/server/worker/src/lib/execute/jobs/execute-trigger-hook.ts
+++ b/packages/server/worker/src/lib/execute/jobs/execute-trigger-hook.ts
@@ -11,7 +11,7 @@ export const executeTriggerHookJob: JobHandler<ExecuteTriggerHookJobData, Synchr
     async execute(ctx: JobContext, data: ExecuteTriggerHookJobData): Promise<SynchronousJobResult> {
         const timeoutInSeconds = workerSettings.getSettings().TRIGGER_HOOKS_TIMEOUT_SECONDS
 
-        const resolved = await ctx.resolver.resolve({ platformId: data.platformId, publicApiUrl: ctx.publicApiUrl, engineToken: ctx.engineToken, flow: { id: data.flowId, versionId: data.flowVersionId, projectId: data.projectId } })
+        const resolved = await ctx.resolver.resolve({ platformId: data.platformId, internalApiUrl: ctx.internalApiUrl, engineToken: ctx.engineToken, flow: { id: data.flowId, versionId: data.flowVersionId, projectId: data.projectId } })
 
         if (resolved.kind === 'flow-not-found') {
             ctx.log.info({ flowVersion: { id: data.flowVersionId } }, 'Flow version not found for trigger hook, skipping')

--- a/packages/server/worker/src/lib/execute/jobs/execute-validation.ts
+++ b/packages/server/worker/src/lib/execute/jobs/execute-validation.ts
@@ -9,7 +9,7 @@ export const executeValidationJob: JobHandler<ExecuteValidateAuthJobData, Synchr
     async execute(ctx: JobContext, data: ExecuteValidateAuthJobData): Promise<SynchronousJobResult> {
         const timeoutInSeconds = workerSettings.getSettings().TRIGGER_TIMEOUT_SECONDS
 
-        const resolved = await ctx.resolver.resolve({ platformId: data.platformId, publicApiUrl: ctx.publicApiUrl, engineToken: ctx.engineToken, pieces: [data.piece] })
+        const resolved = await ctx.resolver.resolve({ platformId: data.platformId, internalApiUrl: ctx.internalApiUrl, engineToken: ctx.engineToken, pieces: [data.piece] })
         if (resolved.kind !== 'ready') {
             throw new Error(`Unexpected resolve outcome "${resolved.kind}" for piece-only job`)
         }

--- a/packages/server/worker/src/lib/execute/jobs/execute-webhook.ts
+++ b/packages/server/worker/src/lib/execute/jobs/execute-webhook.ts
@@ -27,7 +27,7 @@ export const executeWebhookJob: JobHandler<WebhookJobData, FireAndForgetJobResul
         const settings = workerSettings.getSettings()
         const timeoutInSeconds = settings.TRIGGER_TIMEOUT_SECONDS
 
-        const resolved = await ctx.resolver.resolve({ platformId: data.platformId, publicApiUrl: ctx.publicApiUrl, engineToken: ctx.engineToken, flow: { id: data.flowId, versionId: data.flowVersionIdToRun, projectId: data.projectId } })
+        const resolved = await ctx.resolver.resolve({ platformId: data.platformId, internalApiUrl: ctx.internalApiUrl, engineToken: ctx.engineToken, flow: { id: data.flowId, versionId: data.flowVersionIdToRun, projectId: data.projectId } })
 
         if (resolved.kind === 'flow-not-found') {
             ctx.log.info({ flowVersion: { id: data.flowVersionIdToRun } }, 'Flow version not found for webhook, skipping')

--- a/packages/server/worker/src/lib/execute/jobs/extract-piece-info.ts
+++ b/packages/server/worker/src/lib/execute/jobs/extract-piece-info.ts
@@ -12,7 +12,7 @@ export const extractPieceInfoJob: JobHandler<ExecuteExtractPieceMetadataJobData,
     async execute(ctx: JobContext, data: ExecuteExtractPieceMetadataJobData): Promise<SynchronousJobResult> {
         const timeoutInSeconds = workerSettings.getSettings().TRIGGER_TIMEOUT_SECONDS
 
-        const resolved = await ctx.resolver.resolve({ platformId: data.platformId, publicApiUrl: ctx.publicApiUrl, engineToken: ctx.engineToken, pieces: [data.piece] })
+        const resolved = await ctx.resolver.resolve({ platformId: data.platformId, internalApiUrl: ctx.internalApiUrl, engineToken: ctx.engineToken, pieces: [data.piece] })
         if (resolved.kind !== 'ready') {
             throw new Error(`Unexpected resolve outcome "${resolved.kind}" for piece-only job`)
         }

--- a/packages/server/worker/src/lib/execute/jobs/renew-webhook.ts
+++ b/packages/server/worker/src/lib/execute/jobs/renew-webhook.ts
@@ -9,7 +9,7 @@ export const renewWebhookJob: JobHandler<RenewWebhookJobData, FireAndForgetJobRe
     async execute(ctx: JobContext, data: RenewWebhookJobData): Promise<FireAndForgetJobResult> {
         const timeoutInSeconds = workerSettings.getSettings().TRIGGER_HOOKS_TIMEOUT_SECONDS
 
-        const resolved = await ctx.resolver.resolve({ platformId: data.platformId, publicApiUrl: ctx.publicApiUrl, engineToken: ctx.engineToken, flow: { id: data.flowId, versionId: data.flowVersionId, projectId: data.projectId } })
+        const resolved = await ctx.resolver.resolve({ platformId: data.platformId, internalApiUrl: ctx.internalApiUrl, engineToken: ctx.engineToken, flow: { id: data.flowId, versionId: data.flowVersionId, projectId: data.projectId } })
 
         if (resolved.kind === 'flow-not-found') {
             ctx.log.info({ flowVersion: { id: data.flowVersionId } }, 'Flow version not found for renew webhook, skipping')

--- a/packages/server/worker/src/lib/execute/jobs/resolve-connection-identifier.ts
+++ b/packages/server/worker/src/lib/execute/jobs/resolve-connection-identifier.ts
@@ -8,7 +8,7 @@ export const resolveConnectionIdentifierJob: JobHandler<ExecuteResolveConnection
     async execute(ctx: JobContext, data: ExecuteResolveConnectionIdentifierJobData): Promise<SynchronousJobResult> {
         const timeoutInSeconds = workerSettings.getSettings().TRIGGER_TIMEOUT_SECONDS
 
-        const resolved = await ctx.resolver.resolve({ platformId: data.platformId, publicApiUrl: ctx.publicApiUrl, engineToken: ctx.engineToken, pieces: [data.piece] })
+        const resolved = await ctx.resolver.resolve({ platformId: data.platformId, internalApiUrl: ctx.internalApiUrl, engineToken: ctx.engineToken, pieces: [data.piece] })
         if (resolved.kind !== 'ready') {
             throw new Error(`Unexpected resolve outcome "${resolved.kind}" for piece-only job`)
         }

--- a/packages/server/worker/src/lib/worker.ts
+++ b/packages/server/worker/src/lib/worker.ts
@@ -109,7 +109,7 @@ export const worker = {
             logger.info('Connected to API server via Socket.IO')
             resetPollLoopLiveness({ loopCount: 0 })
             await fetchAndStoreSettings(socket!)
-            void startPollingWorkers(apiClient).catch((err) => {
+            void startPollingWorkers(apiClient, apiUrl).catch((err) => {
                 logger.error({ error: err }, 'Polling workers crashed unexpectedly')
             })
         })
@@ -144,7 +144,7 @@ export const worker = {
         createNotifyServer<ApiToWorkerContract>(socket, createApiToWorkerHandlers({
             getRuntime: () => runtime,
             apiClient,
-            getPublicApiUrl: () => ensurePublicApiUrl(workerSettings.getSettings().PUBLIC_URL),
+            getInternalApiUrl: () => apiUrl,
             log: logger,
         }), logger)
 
@@ -173,7 +173,7 @@ export const worker = {
     },
 }
 
-async function startPollingWorkers(apiClient: WorkerToApiContract): Promise<void> {
+async function startPollingWorkers(apiClient: WorkerToApiContract, apiUrl: string): Promise<void> {
     if (polling) return
     polling = true
 
@@ -213,7 +213,7 @@ async function startPollingWorkers(apiClient: WorkerToApiContract): Promise<void
         const { error: prewarmError } = await tryCatch(() => createdRuntime.prewarm({
             log: logger,
             apiClient,
-            publicApiUrl: ensurePublicApiUrl(workerSettings.getSettings().PUBLIC_URL),
+            internalApiUrl: apiUrl,
         }))
         if (prewarmError) {
             logger.error({ error: prewarmError }, 'Prewarm failed, continuing without a warm cache')

--- a/packages/server/worker/test/lib/execute/jobs/execute-flow.test.ts
+++ b/packages/server/worker/test/lib/execute/jobs/execute-flow.test.ts
@@ -85,7 +85,7 @@ function makeMockContext(opts?: { resolveResult?: unknown, apiOverrides?: Record
         resolve: vi.fn().mockResolvedValue(
             opts?.resolveResult ?? {
                 kind: 'ready',
-                provision: { platformId: 'plat-1', pieces: [], codes: [], publicApiUrl: 'http://localhost:3000/api/', engineToken: 'test-token' },
+                provision: { platformId: 'plat-1', pieces: [], codes: [], internalApiUrl: 'http://localhost:3000/api/', engineToken: 'test-token' },
                 flowVersion: makeFlowVersion(),
             },
         ),


### PR DESCRIPTION
## Description

Fixes an issue where worker-side piece bundle downloads use `publicApiUrl` instead of the worker's internal API endpoint.

In split APP/WORKER deployments where workers cannot reliably reach the public API endpoint, cold piece provisioning can fail when downloading piece bundles.

The repository architecture documentation identifies the public-URL dependency as a leftover from the retired remote execution pool.

### What changed

- Use `internalApiUrl` throughout the sandbox provisioning → resolver → piece installer path.
- Update worker execution and prewarm callers to provide the internal API URL.
- Preserve `publicApiUrl` for engine runtime and other user-facing URL behavior.
- Add a regression test verifying that piece bundle downloads use `internalApiUrl`.

### How was this tested?

- Sandbox TypeScript check: passed
- Worker TypeScript check: passed
- Piece installer regression test: passed
- Sandbox test suite: passed
- Worker `execute-flow` test suite: passed
- Targeted sandbox/worker lint: passed
- `git diff --check`: passed

Note: the full `piece-installer.test.ts` suite has 3 pre-existing Windows path-separator failures unrelated to this change. The new regression test passes.

Fixes #14654