### PR TITLE
fix(docker): pin apt to snapshot.debian.org (bullseye EOL broke package fetches)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,13 @@ ENV LANG=C.UTF-8 \
     LC_ALL=C.UTF-8 \
     REDISMS_VERSION=7.4.2
 
+# bullseye LTS ended 2026-08-31: deb.debian.org's index and pool now drift (404s on fetch), and
+# archive.debian.org has not picked bullseye up yet. Pin apt to a dated snapshot.debian.org
+# mirror (frozen, so Release files expire — hence Check-Valid-Until off) until the base image
+# moves to bookworm.
+RUN printf 'deb http://snapshot.debian.org/archive/debian/20260825T000000Z bullseye main\ndeb http://snapshot.debian.org/archive/debian-security/20260825T000000Z bullseye-security main\n' > /etc/apt/sources.list && \
+    echo 'Acquire::Check-Valid-Until "false";' > /etc/apt/apt.conf.d/99snapshot
+
 # Install all system dependencies in a single layer. No apt cache mounts: docker-clean in the
 # node base image wipes /var/cache/apt anyway, and a persisted /var/lib/apt/lists goes stale
 # against rotated bullseye-security packages, failing the build with hash/size fetch errors.

--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -8,6 +8,13 @@
 ### STAGE 1: Build (toolchain lives here only, never in the final image) ###
 FROM node:24.14.0-bullseye-slim AS build
 
+# bullseye LTS ended 2026-08-31: deb.debian.org's index and pool now drift (404s on fetch), and
+# archive.debian.org has not picked bullseye up yet. Pin apt to a dated snapshot.debian.org
+# mirror (frozen, so Release files expire — hence Check-Valid-Until off) until the base image
+# moves to bookworm.
+RUN printf 'deb http://snapshot.debian.org/archive/debian/20260825T000000Z bullseye main\ndeb http://snapshot.debian.org/archive/debian-security/20260825T000000Z bullseye-security main\n' > /etc/apt/sources.list && \
+    echo 'Acquire::Check-Valid-Until "false";' > /etc/apt/apt.conf.d/99snapshot
+
 RUN apt-get update && \
     apt-get install -y --no-install-recommends python3 g++ build-essential curl ca-certificates unzip git
 
@@ -43,6 +50,9 @@ RUN --mount=type=cache,target=/root/.bun/install/cache cd /usr/src && bun instal
 
 ### STAGE 2: Run (minimal) ###
 FROM node:24.14.0-bullseye-slim AS run
+
+RUN printf 'deb http://snapshot.debian.org/archive/debian/20260825T000000Z bullseye main\ndeb http://snapshot.debian.org/archive/debian-security/20260825T000000Z bullseye-security main\n' > /etc/apt/sources.list && \
+    echo 'Acquire::Check-Valid-Until "false";' > /etc/apt/apt.conf.d/99snapshot
 
 # ca-certificates: TLS for piece downloads. procps: `ps`, which tree-kill spawns to reap the engine.
 RUN apt-get update && \


### PR DESCRIPTION
## Description

Cloud CD (and any image build) started failing on 2026-09-07 in the base-stage `apt-get install` with 404s from `deb.debian.org/debian-security` (e.g. [this run](https://github.com/activepieces/activepieces/actions/runs/34101656054/job/101677260476): `libpython3.9-minimal_3.9.2-1+deb11u7_arm64.deb`, `git_2.30.2-1+deb11u5_arm64.deb` → 404, apt exits 100).

**Root cause:** Debian 11 (bullseye) LTS ended **2026-08-31**. `deb.debian.org`'s package index and pool are now drifting apart as post-EOL rotation happens, so `apt-get update && apt-get install` fetches URLs that no longer exist. This won't self-heal. `archive.debian.org` hasn't picked bullseye up yet (its `debian-security` dists stop at buster), so the usual EOL redirect isn't available either.

**Fix (stopgap):** pin all three apt stages (`Dockerfile` base, `Dockerfile.worker` build + run) to a frozen `snapshot.debian.org` mirror dated `20260825T000000Z` (pre-EOL, index and pool guaranteed consistent), with `Acquire::Check-Valid-Until off` since frozen Release files expire. Package versions installed are identical to what images built in late August shipped.

**Follow-up (real fix):** move both Dockerfiles from `node:24.14.0-bullseye-slim` to bookworm. That changes glibc/Python/poppler and rebuilds all native modules, so it deserves its own PR with a proper smoke test rather than riding an unblock.

## How was this tested?

Ran the snapshot sources + `apt-get update && apt-get install` (git, poppler-utils, libcap2, iptables, procps) inside `node:24.14.0-bullseye-slim` on arm64 — the platform that failed in CI — and it completes cleanly (`git version 2.30.2`).

Fixes cloud CD run 34101656054.

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)