### PR TITLE
feat(builder): add a date and time picker to DATE_TIME properties

### DIFF
--- a/packages/web/public/locales/en/translation.json
+++ b/packages/web/public/locales/en/translation.json
@@ -275,6 +275,7 @@
   "Info": "Info",
   "File Input i.e a url or file passed from a previous step": "File Input i.e a url or file passed from a previous step",
   "Date Input must comply with ISO 8601 format": "Date Input must comply with ISO 8601 format",
+  "Pick a date and time": "Pick a date and time",
   "After": "After",
   "Before": "Before",
   "Select an option": "Select an option",

--- a/packages/web/src/app/builder/piece-properties/date-time-input.tsx
+++ b/packages/web/src/app/builder/piece-properties/date-time-input.tsx
@@ -20,19 +20,6 @@ import {
 
 import { FormFieldMentionInput } from './text-input-with-mentions';
 
-const LOCAL_ISO_FORMAT = "yyyy-MM-dd'T'HH:mm:ssXXX";
-
-function parseSelectedDate(value: unknown): Date | undefined {
-  if (typeof value !== 'string') {
-    return undefined;
-  }
-  if (value.trim().length === 0 || value.includes('{{')) {
-    return undefined;
-  }
-  const parsed = new Date(value);
-  return Number.isNaN(parsed.getTime()) ? undefined : parsed;
-}
-
 export function DateTimeInput({
   value,
   onChange,
@@ -64,7 +51,7 @@ export function DateTimeInput({
   };
 
   return (
-    <div className="relative">
+    <div className="relative [&_[role=textbox]]:pr-9">
       <FormFieldMentionInput
         key={editorKey}
         initialValue={value}
@@ -111,6 +98,19 @@ export function DateTimeInput({
     </div>
   );
 }
+
+function parseSelectedDate(value: unknown): Date | undefined {
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+  if (value.trim().length === 0 || value.includes('{{')) {
+    return undefined;
+  }
+  const parsed = new Date(value);
+  return Number.isNaN(parsed.getTime()) ? undefined : parsed;
+}
+
+const LOCAL_ISO_FORMAT = "yyyy-MM-dd'T'HH:mm:ssXXX";
 
 type DateTimeInputProps = {
   value: unknown;

--- a/packages/web/src/app/builder/piece-properties/date-time-input.tsx
+++ b/packages/web/src/app/builder/piece-properties/date-time-input.tsx
@@ -57,7 +57,7 @@ export function DateTimeInput({
     nextDate.setHours(
       timeSource.getHours(),
       timeSource.getMinutes(),
-      timeSource.getSeconds(),
+      selectedDate?.getSeconds() ?? 0,
       0,
     );
     commitDate(nextDate);

--- a/packages/web/src/app/builder/piece-properties/date-time-input.tsx
+++ b/packages/web/src/app/builder/piece-properties/date-time-input.tsx
@@ -1,0 +1,120 @@
+import { isNil } from '@activepieces/core-utils';
+import { format } from 'date-fns';
+import { t } from 'i18next';
+import { CalendarIcon } from 'lucide-react';
+import { useState } from 'react';
+
+import { TimePicker } from '@/components/custom/time-picker';
+import { Button } from '@/components/ui/button';
+import { Calendar } from '@/components/ui/calendar';
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@/components/ui/popover';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/components/ui/tooltip';
+
+import { FormFieldMentionInput } from './text-input-with-mentions';
+
+const LOCAL_ISO_FORMAT = "yyyy-MM-dd'T'HH:mm:ssXXX";
+
+function parseSelectedDate(value: unknown): Date | undefined {
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+  if (value.trim().length === 0 || value.includes('{{')) {
+    return undefined;
+  }
+  const parsed = new Date(value);
+  return Number.isNaN(parsed.getTime()) ? undefined : parsed;
+}
+
+export function DateTimeInput({
+  value,
+  onChange,
+  placeholder,
+  disabled,
+}: DateTimeInputProps) {
+  const [editorKey, setEditorKey] = useState(0);
+  const [isPickerOpen, setIsPickerOpen] = useState(false);
+  const selectedDate = parseSelectedDate(value);
+
+  const commitDate = (nextDate: Date) => {
+    onChange(format(nextDate, LOCAL_ISO_FORMAT));
+    setEditorKey((previousKey) => previousKey + 1);
+  };
+
+  const handleDaySelect = (day: Date | undefined) => {
+    if (isNil(day)) {
+      return;
+    }
+    const timeSource = selectedDate ?? new Date();
+    const nextDate = new Date(day);
+    nextDate.setHours(
+      timeSource.getHours(),
+      timeSource.getMinutes(),
+      timeSource.getSeconds(),
+      0,
+    );
+    commitDate(nextDate);
+  };
+
+  return (
+    <div className="relative">
+      <FormFieldMentionInput
+        key={editorKey}
+        initialValue={value}
+        onChange={onChange}
+        placeholder={placeholder}
+        disabled={disabled}
+      />
+      <Popover open={isPickerOpen} onOpenChange={setIsPickerOpen}>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <PopoverTrigger asChild>
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                disabled={disabled}
+                aria-label={t('Pick a date and time')}
+                className="absolute right-1 top-1 h-7 w-7 text-foreground/55 hover:text-foreground"
+              >
+                <CalendarIcon className="h-4 w-4" />
+              </Button>
+            </PopoverTrigger>
+          </TooltipTrigger>
+          <TooltipContent side="bottom">
+            {t('Pick a date and time')}
+          </TooltipContent>
+        </Tooltip>
+        <PopoverContent className="w-auto p-2" align="end">
+          <Calendar
+            mode="single"
+            selected={selectedDate}
+            onSelect={handleDaySelect}
+            defaultMonth={selectedDate}
+          />
+          <div className="flex justify-center border-t pt-2">
+            <TimePicker
+              date={selectedDate}
+              setDate={commitDate}
+              showSeconds={false}
+            />
+          </div>
+        </PopoverContent>
+      </Popover>
+    </div>
+  );
+}
+
+type DateTimeInputProps = {
+  value: unknown;
+  onChange: (value: string) => void;
+  placeholder?: string;
+  disabled?: boolean;
+};

--- a/packages/web/src/app/builder/piece-properties/properties-utils.tsx
+++ b/packages/web/src/app/builder/piece-properties/properties-utils.tsx
@@ -25,6 +25,7 @@ import { AutoFormFieldWrapper } from './auto-form-field-wrapper';
 import { BuilderJsonEditorWrapper } from './builder-json-wrapper';
 import CustomProperty from './custom-property';
 import { DateRangeProperty } from './date-range-property';
+import { DateTimeInput } from './date-time-input';
 import { DynamicDropdownPieceProperty } from './dynamic-dropdown-piece-property';
 import { DynamicProperties } from './dynamic-piece-property';
 import { NumberStepper } from './number-stepper';
@@ -335,6 +336,41 @@ export const selectGenericFormComponentForProperty = ({
         </AutoFormFieldWrapper>
       );
     case PropertyType.DATE_TIME:
+      return (
+        <AutoFormFieldWrapper
+          property={property}
+          inputName={inputName}
+          field={field}
+          hideLabel={hideLabel}
+          hideDescription={hideDescription}
+          propertyName={propertyName}
+          disabled={disabled}
+          allowDynamicValues={false}
+          dynamicInputModeToggled={dynamicInputModeToggled}
+        >
+          {useMentionTextInput ? (
+            <DateTimeInput
+              value={field.value}
+              onChange={field.onChange}
+              disabled={disabled}
+              placeholder={
+                'placeholder' in property ? property.placeholder : undefined
+              }
+            ></DateTimeInput>
+          ) : (
+            <SecretInput
+              ref={field.ref}
+              value={field.value}
+              onChange={field.onChange}
+              disabled={disabled}
+              placeholder={
+                'placeholder' in property ? property.placeholder : undefined
+              }
+              type="text"
+            ></SecretInput>
+          )}
+        </AutoFormFieldWrapper>
+      );
     case PropertyType.SHORT_TEXT:
     case PropertyType.LONG_TEXT:
     case PropertyType.FILE:


### PR DESCRIPTION
## Description

`DATE_TIME` properties had no date picker. The type shared one `case` block with `SHORT_TEXT` in `properties-utils.tsx`, so every date field in the product was a plain mention text box, and the only affordance was a tooltip on the label reading *"Date Input must comply with ISO 8601 format"*. Users hand-typed timestamps. This affects every piece using `Property.DateTime`.

**`piece-properties/date-time-input.tsx` (new)** — the mention input keeps being the field, with a calendar button inside it:

- The button opens a popover holding the existing `Calendar` (`components/ui/calendar.tsx`) and `TimePicker` (`components/custom/time-picker.tsx`). Nothing new is built; this is a subtraction from what `date-time-picker-range.tsx` already composes for `DATE_RANGE`.
- **The text stays the source of truth.** The picker writes a string into the field rather than replacing the input, so `{{ }}` mentions keep working, the persisted value shape is unchanged, and no dynamic-value (`ƒ`) toggle is introduced — which matters, because that would change the stored `propertySettings` shape for every `DATE_TIME` prop in the catalogue.
- **The written value carries an explicit UTC offset** (`format(date, "yyyy-MM-dd'T'HH:mm:ssXXX")` → `2026-08-05T14:30:00+03:00`) rather than being converted to `Z`. Picking 14:30 and reading back `11:30Z` would be baffling; an explicit offset is unambiguous and the engine's `dateTimeProcessor` honours it, resolving that example to `12:30:00.000Z` for `+02:00`. This is the one design decision here worth arguing about — the alternative is storing `Z` and displaying local, which is a one-line change to `LOCAL_ISO_FORMAT`.
- **The field is remounted with a new `key` after a pick.** `TiptapEditor` sets its `content` only at editor creation and there is no effect syncing `initialValue` afterwards, so without this the form value would update while the visible field did not. The cost is that focus is lost after a pick.
- A value containing `{{` is not parsed into the calendar, so a bound field opens the picker empty rather than showing a misleading date.

**`piece-properties/properties-utils.tsx`** — `DATE_TIME` is split out of the `case` block it shared with `SHORT_TEXT` / `LONG_TEXT` / `FILE` / `SECRET_TEXT`. Those four are untouched and keep the identical branch. The new `DATE_TIME` branch keeps the same `AutoFormFieldWrapper` configuration (including `allowDynamicValues={false}`) and keeps the existing `SecretInput` fallback for `useMentionTextInput === false`, so contexts outside the builder are unaffected.

**`public/locales/en/translation.json`** — one key, `Pick a date and time`, for the button's tooltip and `aria-label`. Inserted next to the existing `Date Input must comply with ISO 8601 format` key rather than appended or re-sorted; the file is not alphabetically ordered, so re-sorting it would have produced a diff of thousands of lines.

## How was this tested?

`turbo run typecheck --filter=web` on this branch reports two errors, `approvals/index.tsx(133,8)` and `use-event-labels.ts(5,3)`. Both are **pre-existing on `main`** — the identical two errors, and only those two, appear when the same worktree is detached to a clean `origin/main` and typechecked with the same installed dependencies. This branch introduces **zero new type errors**. Both files are in the approvals feature and are untouched here.

`eslint` on both changed files is clean (run from within the `packages/web` workspace so the `@/` alias resolves — running it from the repo root produces spurious `import/no-unresolved` on the files' pre-existing imports).

The branch was rebased onto current `main`, which caught a real drift: `text-input-with-mentions/index.tsx` now exports `FormFieldMentionInput`, which injects `id={formItemId}` via `useFormField`, and `properties-utils.tsx` uses it in its form-field branches. The component was originally written against the older `TextInputWithMentions` export, which would have left the date field as the only input in the form without that label/`id` association. It now uses `FormFieldMentionInput`, matching the sibling branches. Every prop passed (`initialValue`, `onChange`, `placeholder`, `disabled`) was checked against `TiptapEditorProps` on current `main`, and the absence of any `initialValue`-syncing effect — which the remount works around — was re-confirmed on `main` rather than assumed from the older checkout.

`TimePicker` handles an empty field: `TimeUnitPickerInput` falls back to `props.date || new Date(new Date().setHours(0,0,0,0))`, so opening the picker on a never-set property does not crash.

Edition paths: this is builder UI with no feature gating, no EE import and no platform-dependent behaviour, so it is identical on CE, EE and Cloud. No branding or white-labelled surface is touched.

**Not yet verified, and the reason this wants a careful review:** the rendered picker has not been exercised by hand in the browser on this branch — the local dev server is on a different branch that predates the `FormFieldMentionInput` change, so what runs locally is not what is in this commit. Keyboard-only interaction and the focus loss after a pick in particular deserve a look. Worth a second opinion too: whether an offset-carrying ISO string is safe for every existing `DATE_TIME` consumer, specifically anything comparing these values lexicographically, since `+03:00` and `Z` strings do not sort alike.

Fixes # (issue)

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)
