### PR TITLE
feat(pieces): add Scrupp

### DIFF
--- a/packages/pieces/community/scrupp/.eslintrc.json
+++ b/packages/pieces/community/scrupp/.eslintrc.json
@@ -1,0 +1,47 @@
+{
+  "extends": [
+    "../../../../.eslintrc.json"
+  ],
+  "ignorePatterns": [
+    "!**/*"
+  ],
+  "overrides": [
+    {
+      "files": [
+        "*.ts",
+        "*.tsx",
+        "*.js",
+        "*.jsx"
+      ],
+      "rules": {}
+    },
+    {
+      "files": [
+        "*.ts",
+        "*.tsx"
+      ],
+      "rules": {
+        "no-restricted-imports": [
+          "error",
+          {
+            "patterns": [
+              "lodash",
+              "lodash/*",
+              "@activepieces/core-*",
+              "@activepieces/server*",
+              "@activepieces/engine",
+              "@activepieces/shared"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "files": [
+        "*.js",
+        "*.jsx"
+      ],
+      "rules": {}
+    }
+  ]
+}

--- a/packages/pieces/community/scrupp/README.md
+++ b/packages/pieces/community/scrupp/README.md
@@ -1,0 +1,11 @@
+# Scrupp
+
+Export Sales Navigator and LinkedIn searches into people, run Apollo searches, find decision makers at a company, enrich LinkedIn profiles, and find and verify email addresses.
+
+An API key is created in Scrupp under **Settings → API Keys**. API access is included on every paid plan.
+
+Extraction is asynchronous: each action creates a job, waits for it, and returns the records. Every create call carries an `Idempotency-Key` derived from the run, so an Activepieces retry returns the original job instead of starting a second, billable one.
+
+Billing is one credit per record returned; records that come back empty are refunded automatically.
+
+Docs: https://scrupp.com/docs

--- a/packages/pieces/community/scrupp/package.json
+++ b/packages/pieces/community/scrupp/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@activepieces/piece-scrupp",
+  "version": "0.1.0",
+  "type": "commonjs",
+  "main": "./dist/src/index.js",
+  "types": "./dist/src/index.d.ts",
+  "dependencies": {
+    "@activepieces/pieces-common": "workspace:*",
+    "@activepieces/pieces-framework": "workspace:*",
+    "@activepieces/core-piece-types": "workspace:*",
+    "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "^2.3.0"
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.lib.json && cp package.json dist/",
+    "bundle": "node ../../../../dist/packages/cli/src/index.js pieces bundle",
+    "lint": "eslint 'src/**/*.ts'"
+  }
+}

--- a/packages/pieces/community/scrupp/src/index.ts
+++ b/packages/pieces/community/scrupp/src/index.ts
@@ -1,0 +1,28 @@
+import { createPiece, PieceCategory } from '@activepieces/pieces-framework';
+import { scruppAuth } from './lib/auth';
+import { enrichCompanyAction } from './lib/actions/enrich-company';
+import { enrichLinkedinProfileAction } from './lib/actions/enrich-linkedin-profile';
+import { exportSearchAction } from './lib/actions/export-search';
+import { findDecisionMakersAction } from './lib/actions/find-decision-makers';
+import { findEmailAction } from './lib/actions/find-email';
+import { verifyEmailAction } from './lib/actions/verify-email';
+
+export const scrupp = createPiece({
+  displayName: 'Scrupp',
+  description:
+    'Export Sales Navigator, LinkedIn and Apollo searches into people, find decision makers at a company, enrich profiles, and find and verify email addresses.',
+  auth: scruppAuth,
+  minimumSupportedRelease: '0.36.1',
+  logoUrl: 'https://scrupp.com/img/logo.png',
+  authors: ['scrupp'],
+  categories: [PieceCategory.SALES_AND_CRM],
+  actions: [
+    enrichCompanyAction,
+    enrichLinkedinProfileAction,
+    exportSearchAction,
+    findDecisionMakersAction,
+    findEmailAction,
+    verifyEmailAction,
+  ],
+  triggers: [],
+});

--- a/packages/pieces/community/scrupp/src/lib/actions/enrich-company.ts
+++ b/packages/pieces/community/scrupp/src/lib/actions/enrich-company.ts
@@ -1,0 +1,48 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { scruppAuth } from '../auth';
+import { runScruppJob } from '../common';
+import { timeoutProp } from '../common/props';
+
+export const enrichCompanyAction = createAction({
+  auth: scruppAuth,
+  name: 'enrich-company',
+  displayName: 'Enrich Company',
+  description: 'Look up a company by domain, name or LinkedIn URL and return its firmographic data.',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Enriches a company from a domain, a name or a LinkedIn company URL, returning firmographics such as size, industry and location. Set "Look Up By" to match the identifier you have. Costs one credit per record returned; empty results are refunded.',
+    idempotent: true,
+  },
+  props: {
+    lookupBy: Property.StaticDropdown({
+      displayName: 'Look Up By',
+      required: true,
+      defaultValue: 'company.domain',
+      options: {
+        options: [
+          { label: 'Domain', value: 'company.domain' },
+          { label: 'Name', value: 'company.name' },
+          { label: 'LinkedIn URL', value: 'company.linkedin' },
+        ],
+      },
+    }),
+    company: Property.ShortText({
+      displayName: 'Company',
+      description: 'The domain, name or LinkedIn URL, matching the option above.',
+      required: true,
+    }),
+    timeoutSeconds: timeoutProp,
+  },
+  async run(context) {
+    const { lookupBy, company, timeoutSeconds } = context.propsValue;
+
+    return runScruppJob({
+      auth: context.auth,
+      type: lookupBy,
+      input: { items: [company] },
+      idempotencyKey: `ap-${context.run.id}-company`,
+      timeoutSeconds: timeoutSeconds ?? 900,
+    });
+  },
+});

--- a/packages/pieces/community/scrupp/src/lib/actions/enrich-linkedin-profile.ts
+++ b/packages/pieces/community/scrupp/src/lib/actions/enrich-linkedin-profile.ts
@@ -1,0 +1,41 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { scruppAuth } from '../auth';
+import { runScruppJob } from '../common';
+import { timeoutProp } from '../common/props';
+
+export const enrichLinkedinProfileAction = createAction({
+  auth: scruppAuth,
+  name: 'enrich-linkedin-profile',
+  displayName: 'Enrich LinkedIn Profile',
+  description: 'Return the full profile behind a LinkedIn profile URL.',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Enriches a LinkedIn profile URL into structured data: name, headline, current role, company and location. Optionally finds the email as well. Costs one credit per record returned; empty results are refunded.',
+    idempotent: true,
+  },
+  props: {
+    profileUrl: Property.ShortText({
+      displayName: 'LinkedIn Profile URL',
+      description: 'For example https://www.linkedin.com/in/williamhgates/',
+      required: true,
+    }),
+    withEmail: Property.Checkbox({
+      displayName: 'Also Find Email',
+      required: false,
+      defaultValue: false,
+    }),
+    timeoutSeconds: timeoutProp,
+  },
+  async run(context) {
+    const { profileUrl, withEmail, timeoutSeconds } = context.propsValue;
+
+    return runScruppJob({
+      auth: context.auth,
+      type: withEmail ? 'email.linkedin' : 'linkedin.profile',
+      input: { items: [profileUrl] },
+      idempotencyKey: `ap-${context.run.id}-enrich-profile`,
+      timeoutSeconds: timeoutSeconds ?? 900,
+    });
+  },
+});

--- a/packages/pieces/community/scrupp/src/lib/actions/export-search.ts
+++ b/packages/pieces/community/scrupp/src/lib/actions/export-search.ts
@@ -1,0 +1,67 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { scruppAuth } from '../auth';
+import { runScruppJob } from '../common';
+import { maxRecordsProp, timeoutProp, withEmailsProp } from '../common/props';
+
+export const exportSearchAction = createAction({
+  auth: scruppAuth,
+  name: 'export-search',
+  displayName: 'Export Search',
+  description:
+    'Turn a Sales Navigator, LinkedIn or Apollo search URL into the people behind it.',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Exports the people matching a saved search. Build the filters in Sales Navigator, LinkedIn or Apollo, copy the search URL, and pass it here; the action returns one item per person, optionally with email addresses. Apollo searches and personal Sales Navigator searches need a connected account email. Costs one credit per record returned.',
+    idempotent: true,
+  },
+  props: {
+    platform: Property.StaticDropdown({
+      displayName: 'Platform',
+      required: true,
+      defaultValue: 'sales_navigator.search',
+      options: {
+        options: [
+          { label: 'Sales Navigator', value: 'sales_navigator.search' },
+          { label: 'LinkedIn', value: 'linkedin.search' },
+          { label: 'Apollo', value: 'apollo.search' },
+        ],
+      },
+    }),
+    url: Property.ShortText({
+      displayName: 'Search URL',
+      description: 'Build the filters in the platform, then paste the URL of the results page.',
+      required: true,
+    }),
+    withEmails: withEmailsProp,
+    max: maxRecordsProp,
+    account: Property.ShortText({
+      displayName: 'Account Email',
+      description:
+        'Connected account to run with. Required for Apollo, and for Sales Navigator searches that use personal or saved filters.',
+      required: false,
+    }),
+    timeoutSeconds: timeoutProp,
+  },
+  async run(context) {
+    const { platform, url, withEmails, max, account, timeoutSeconds } = context.propsValue;
+
+    const input: Record<string, unknown> = {
+      url,
+      with_emails: withEmails ?? true,
+      max: max ?? 100,
+    };
+
+    if (account) {
+      input['account'] = account;
+    }
+
+    return runScruppJob({
+      auth: context.auth,
+      type: platform,
+      input,
+      idempotencyKey: `ap-${context.run.id}-export-search`,
+      timeoutSeconds: timeoutSeconds ?? 900,
+    });
+  },
+});

--- a/packages/pieces/community/scrupp/src/lib/actions/find-decision-makers.ts
+++ b/packages/pieces/community/scrupp/src/lib/actions/find-decision-makers.ts
@@ -1,0 +1,53 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { scruppAuth } from '../auth';
+import { runScruppJob } from '../common';
+import { timeoutProp } from '../common/props';
+
+export const findDecisionMakersAction = createAction({
+  auth: scruppAuth,
+  name: 'find-decision-makers',
+  displayName: 'Find Decision Makers',
+  description: 'Find the decision makers at a company by domain, company name or company LinkedIn URL.',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Finds decision makers at a company. Identify the company by domain (openai.com), by name, or by its LinkedIn company URL, and set "Find By" to match. Returns one item per person with name, title and, where available, email. Costs one credit per record returned; empty results are refunded.',
+    idempotent: true,
+  },
+  props: {
+    findBy: Property.StaticDropdown({
+      displayName: 'Find By',
+      required: true,
+      defaultValue: 'contact.decision_maker.domain',
+      options: {
+        options: [
+          { label: 'Company domain', value: 'contact.decision_maker.domain' },
+          { label: 'Company name', value: 'contact.decision_maker.name' },
+          { label: 'Company LinkedIn URL', value: 'contact.decision_maker.linkedin' },
+        ],
+      },
+    }),
+    company: Property.ShortText({
+      displayName: 'Company',
+      description: 'The domain, name or LinkedIn URL, matching the option above.',
+      required: true,
+    }),
+    max: Property.Number({
+      displayName: 'Decision Makers per Company',
+      required: false,
+      defaultValue: 10,
+    }),
+    timeoutSeconds: timeoutProp,
+  },
+  async run(context) {
+    const { findBy, company, max, timeoutSeconds } = context.propsValue;
+
+    return runScruppJob({
+      auth: context.auth,
+      type: findBy,
+      input: { items: [company], max: max ?? 10 },
+      idempotencyKey: `ap-${context.run.id}-decision-makers`,
+      timeoutSeconds: timeoutSeconds ?? 900,
+    });
+  },
+});

--- a/packages/pieces/community/scrupp/src/lib/actions/find-email.ts
+++ b/packages/pieces/community/scrupp/src/lib/actions/find-email.ts
@@ -1,0 +1,40 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { scruppAuth } from '../auth';
+import { runScruppJob } from '../common';
+import { timeoutProp } from '../common/props';
+
+export const findEmailAction = createAction({
+  auth: scruppAuth,
+  name: 'find-email',
+  displayName: 'Find Email',
+  description: "Find someone's email address from their first name, last name and company domain.",
+  audience: 'both',
+  aiMetadata: {
+    description:
+      "Finds a work email address from a person's first name, last name and their company domain. Returns the address with a confidence indication when one is found. Billed only for emails actually found.",
+    idempotent: true,
+  },
+  props: {
+    firstName: Property.ShortText({ displayName: 'First Name', required: true }),
+    lastName: Property.ShortText({ displayName: 'Last Name', required: true }),
+    domain: Property.ShortText({
+      displayName: 'Company Domain',
+      description: 'For example openai.com',
+      required: true,
+    }),
+    timeoutSeconds: timeoutProp,
+  },
+  async run(context) {
+    const { firstName, lastName, domain, timeoutSeconds } = context.propsValue;
+
+    return runScruppJob({
+      auth: context.auth,
+      type: 'email.initials',
+      input: {
+        items: [{ first_name: firstName, last_name: lastName, domain }],
+      },
+      idempotencyKey: `ap-${context.run.id}-find-email`,
+      timeoutSeconds: timeoutSeconds ?? 900,
+    });
+  },
+});

--- a/packages/pieces/community/scrupp/src/lib/actions/verify-email.ts
+++ b/packages/pieces/community/scrupp/src/lib/actions/verify-email.ts
@@ -1,0 +1,28 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { scruppAuth } from '../auth';
+import { scruppApiCall } from '../common';
+
+export const verifyEmailAction = createAction({
+  auth: scruppAuth,
+  name: 'verify-email',
+  displayName: 'Verify Email',
+  description: 'Check whether a single email address is deliverable.',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Verifies one email address and reports whether it is deliverable. Synchronous — unlike the extraction actions it returns immediately rather than creating a job. Use before sending to avoid bounces.',
+    idempotent: true,
+  },
+  props: {
+    email: Property.ShortText({ displayName: 'Email', required: true }),
+  },
+  async run(context) {
+    return scruppApiCall<unknown>({
+      auth: context.auth,
+      method: HttpMethod.POST,
+      endpoint: '/email/verify',
+      body: { email: context.propsValue.email },
+    });
+  },
+});

--- a/packages/pieces/community/scrupp/src/lib/auth.ts
+++ b/packages/pieces/community/scrupp/src/lib/auth.ts
@@ -1,0 +1,8 @@
+import { PieceAuth } from '@activepieces/pieces-framework';
+
+export const scruppAuth = PieceAuth.SecretText({
+  displayName: 'API Key',
+  required: true,
+  description:
+    'Create a key in Scrupp under **Settings → API Keys** ([app.scrupp.com](https://app.scrupp.com)). API access is included on every paid plan.',
+});

--- a/packages/pieces/community/scrupp/src/lib/common/index.ts
+++ b/packages/pieces/community/scrupp/src/lib/common/index.ts
@@ -1,0 +1,115 @@
+import {
+  HttpMethod,
+  HttpRequest,
+  httpClient,
+} from '@activepieces/pieces-common';
+import { AppConnectionValueForAuthProperty } from '@activepieces/pieces-framework';
+import { scruppAuth } from '../auth';
+
+export type ScruppAuth = AppConnectionValueForAuthProperty<typeof scruppAuth>;
+
+const BASE_URL = 'https://api.scrupp.com/api/v1';
+
+/** Statuses Scrupp reports for a job. */
+type JobStatus = 'queued' | 'running' | 'succeeded' | 'failed';
+
+export async function scruppApiCall<T>({
+  auth,
+  method,
+  endpoint,
+  body,
+  headers,
+}: {
+  auth: ScruppAuth;
+  method: HttpMethod;
+  endpoint: string;
+  body?: unknown;
+  headers?: Record<string, string>;
+}): Promise<T> {
+  const request: HttpRequest = {
+    url: `${BASE_URL}${endpoint}`,
+    method,
+    headers: {
+      Authorization: `Bearer ${auth.secret_text}`,
+      ...(headers ?? {}),
+    },
+    body,
+  };
+
+  const response = await httpClient.sendRequest<T>(request);
+  return response.body;
+}
+
+/**
+ * Scrupp extraction is asynchronous: create a job, poll it, then read the
+ * result. This runs the whole loop and hands back the records.
+ *
+ * The Idempotency-Key matters here — Activepieces retries a failed step, and
+ * without it a retry would start (and charge for) a second job. With it the
+ * retry is handed the original one.
+ */
+export async function runScruppJob({
+  auth,
+  type,
+  input,
+  idempotencyKey,
+  timeoutSeconds,
+}: {
+  auth: ScruppAuth;
+  type: string;
+  input: Record<string, unknown>;
+  idempotencyKey: string;
+  timeoutSeconds: number;
+}): Promise<unknown[]> {
+  const created = await scruppApiCall<{ job_id: number }>({
+    auth,
+    method: HttpMethod.POST,
+    endpoint: '/jobs',
+    headers: { 'Idempotency-Key': idempotencyKey },
+    body: { type, input },
+  });
+
+  const jobId = created.job_id;
+  const deadline = Date.now() + timeoutSeconds * 1000;
+  let status: JobStatus = 'queued';
+
+  while (Date.now() < deadline) {
+    const state = await scruppApiCall<{
+      status: JobStatus;
+      retry_after?: number;
+      error?: string | null;
+    }>({
+      auth,
+      method: HttpMethod.GET,
+      endpoint: `/jobs/${jobId}`,
+    });
+
+    status = state.status;
+
+    if (status === 'succeeded') {
+      break;
+    }
+
+    if (status === 'failed') {
+      throw new Error(state.error ?? `Scrupp job ${jobId} failed.`);
+    }
+
+    // The API tells us how long to wait; honouring it keeps the poll count down.
+    const waitSeconds = state.retry_after && state.retry_after > 0 ? state.retry_after : 5;
+    await new Promise((resolve) => setTimeout(resolve, waitSeconds * 1000));
+  }
+
+  if (status !== 'succeeded') {
+    throw new Error(
+      `Scrupp job ${jobId} did not finish within ${timeoutSeconds} seconds. It is still running and can be fetched later with its job ID.`
+    );
+  }
+
+  const result = await scruppApiCall<{ data?: { items?: unknown[] } }>({
+    auth,
+    method: HttpMethod.GET,
+    endpoint: `/jobs/${jobId}/result`,
+  });
+
+  return result.data?.items ?? [];
+}

--- a/packages/pieces/community/scrupp/src/lib/common/props.ts
+++ b/packages/pieces/community/scrupp/src/lib/common/props.ts
@@ -1,0 +1,24 @@
+import { Property } from '@activepieces/pieces-framework';
+
+export const timeoutProp = Property.Number({
+  displayName: 'Timeout (seconds)',
+  description:
+    'How long to wait for the job to finish. It keeps running on Scrupp after a timeout and can be fetched later by its job ID.',
+  required: false,
+  defaultValue: 900,
+});
+
+export const withEmailsProp = Property.Checkbox({
+  displayName: 'Find Emails',
+  description: 'Also find email addresses for the extracted people.',
+  required: false,
+  defaultValue: true,
+});
+
+export const maxRecordsProp = Property.Number({
+  displayName: 'Max Records',
+  description:
+    'Upper bound on records to extract. This sets the upfront credit hold; unused credits are refunded.',
+  required: false,
+  defaultValue: 100,
+});

--- a/packages/pieces/community/scrupp/tsconfig.json
+++ b/packages/pieces/community/scrupp/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "importHelpers": true,
+    "noImplicitOverride": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "noPropertyAccessFromIndexSignature": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/packages/pieces/community/scrupp/tsconfig.lib.json
+++ b/packages/pieces/community/scrupp/tsconfig.lib.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "baseUrl": ".",
+    "paths": {},
+    "outDir": "./dist",
+    "declaration": true,
+    "declarationMap": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
Adds a piece for [Scrupp](https://scrupp.com), a lead-data API for Sales Navigator, LinkedIn and Apollo. I work on Scrupp, so the API side is maintained.

### Actions

| Action | What it does |
| --- | --- |
| Export Search | Turns a Sales Navigator, LinkedIn or Apollo search URL into the people behind it |
| Find Decision Makers | Decision makers at a company, by domain, name or company LinkedIn URL |
| Enrich Company | Firmographics from a domain, name or LinkedIn URL |
| Enrich LinkedIn Profile | Full profile from a profile URL, optionally with the email |
| Find Email | Work email from first name, last name and domain |
| Verify Email | Deliverability check for one address (synchronous) |

Auth is a secret API key (`Authorization: Bearer`), created in Scrupp under Settings → API Keys.

### Notes for review

- **Async by design.** Scrupp extraction creates a job, so `runScruppJob` in `src/lib/common/index.ts` creates, polls and reads the result in one action. It sleeps for the `retry_after` the API returns rather than a fixed interval, so poll counts stay low on long exports.
- **Retries do not double-charge.** Every create call sends an `Idempotency-Key` derived from `context.run.id`. A retried step gets the original job back instead of starting a second, billable one.
- **Timeout is a prop, not a hang.** A large export can outlive any sensible step timeout, so the action fails with a message saying the job is still running and can be fetched by its ID, rather than blocking forever.
- No new dependencies; only `pieces-common` and `pieces-framework`.
- Docs, OpenAPI spec and a Postman collection are public: https://scrupp.com/docs · https://scrupp.com/api-docs/openapi-v1.yaml

Happy to adjust naming, action split or the `aiMetadata` wording to match your conventions.