### PR TITLE
fix(flows): turning a flow off no longer fails when its connection is rejected

### DIFF
--- a/packages/server/api/src/app/flows/flow/flow-service-side-effects.ts
+++ b/packages/server/api/src/app/flows/flow/flow-service-side-effects.ts
@@ -29,7 +29,7 @@ export const flowSideEffects = (log: FastifyBaseLogger) => ({
                     flowId: publishedFlowVersion.flowId,
                     projectId: flowToUpdate.projectId,
                     simulate: false,
-                    ignoreError: false,
+                    ignoreError: true,
                     templateId,
                 })
                 break

--- a/packages/server/api/src/app/trigger/trigger-source/flow-trigger-side-effect.ts
+++ b/packages/server/api/src/app/trigger/trigger-source/flow-trigger-side-effect.ts
@@ -1,4 +1,4 @@
-import { ActivepiecesError, ErrorCode, FlowId, FlowVersionId, isNil, tryCatch } from '@activepieces/core-utils'
+import { ActivepiecesError, ErrorCode, FlowId, FlowVersionId, formatPieceError, isNil, tryCatch, tryParseFriendlyPieceError } from '@activepieces/core-utils'
 import {
     TriggerBase,
     TriggerStrategy,
@@ -14,8 +14,6 @@ import { userInteractionWatcher } from '../../workers/user-interaction-watcher'
 import { appEventRoutingService } from '../app-event-routing/app-event-routing.service'
 
 const environment = system.getOrThrow<ApEnvironment>(AppSystemProp.ENVIRONMENT)
-
-const IGNORED_DISABLE_ERROR = '[flowTriggerSideEffect#disable] Ignored error during trigger disable'
 
 export const flowTriggerSideEffect = (log: FastifyBaseLogger) => {
     return {
@@ -100,7 +98,7 @@ export const flowTriggerSideEffect = (log: FastifyBaseLogger) => {
                 assertEngineResponseIsOk(engineHelperResponse!, flowId, flowVersionId)
             }
             else if (engineHelperResponse?.status !== EngineResponseStatus.OK) {
-                log.warn({ flow: { id: flowId }, error: engineHelperResponse?.error }, IGNORED_DISABLE_ERROR)
+                log.warn({ flow: { id: flowId }, error: sanitizeIgnoredError(engineHelperResponse?.error) }, IGNORED_DISABLE_ERROR)
             }
             switch (pieceTrigger.type) {
                 case TriggerStrategy.APP_WEBHOOK:
@@ -129,6 +127,10 @@ export const flowTriggerSideEffect = (log: FastifyBaseLogger) => {
         },
 
     }
+}
+
+function sanitizeIgnoredError(error: string | undefined): string {
+    return tryParseFriendlyPieceError(error)?.message ?? formatPieceError(error).message
 }
 
 async function handleAppWebhookTrigger({ engineHelperResponse, flowId, projectId, pieceName }: ActiveTriggerParams): Promise<ActiveTriggerReturn> {
@@ -204,6 +206,8 @@ async function handlePollingTrigger({ engineHelperResponse, flowId, flowVersionI
         scheduleOptions,
     }
 }
+
+const IGNORED_DISABLE_ERROR = '[flowTriggerSideEffect#disable] Ignored error during trigger disable'
 
 function assertEngineResponseIsOk(engineHelperResponse: EngineResponse<ExecuteTriggerResponse<TriggerHookType.ON_ENABLE | TriggerHookType.ON_DISABLE>>, flowId: FlowId, flowVersionId: FlowVersionId) {
     if (isNil(engineHelperResponse) || engineHelperResponse.status !== EngineResponseStatus.OK) {

--- a/packages/server/api/src/app/trigger/trigger-source/flow-trigger-side-effect.ts
+++ b/packages/server/api/src/app/trigger/trigger-source/flow-trigger-side-effect.ts
@@ -15,6 +15,8 @@ import { appEventRoutingService } from '../app-event-routing/app-event-routing.s
 
 const environment = system.getOrThrow<ApEnvironment>(AppSystemProp.ENVIRONMENT)
 
+const IGNORED_DISABLE_ERROR = '[flowTriggerSideEffect#disable] Ignored error during trigger disable'
+
 export const flowTriggerSideEffect = (log: FastifyBaseLogger) => {
     return {
         async enable(params: EnableFlowTriggerParams): Promise<ActiveTriggerReturn> {
@@ -92,10 +94,13 @@ export const flowTriggerSideEffect = (log: FastifyBaseLogger) => {
                 if (!params.ignoreError) {
                     throw error
                 }
-                log.warn({ flow: { id: flowId }, error: error.message }, '[flowTriggerSideEffect#disable] Ignored error during trigger disable')
+                log.warn({ flow: { id: flowId }, error: error.message }, IGNORED_DISABLE_ERROR)
             }
             else if (!params.ignoreError) {
                 assertEngineResponseIsOk(engineHelperResponse!, flowId, flowVersionId)
+            }
+            else if (engineHelperResponse?.status !== EngineResponseStatus.OK) {
+                log.warn({ flow: { id: flowId }, error: engineHelperResponse?.error }, IGNORED_DISABLE_ERROR)
             }
             switch (pieceTrigger.type) {
                 case TriggerStrategy.APP_WEBHOOK:

--- a/packages/server/api/test/unit/app/flows/flow/flow-status-disable-cleanup.test.ts
+++ b/packages/server/api/test/unit/app/flows/flow/flow-status-disable-cleanup.test.ts
@@ -1,0 +1,204 @@
+import { TriggerStrategy } from '@activepieces/pieces-framework'
+import { ApEnvironment, EngineResponseStatus, FlowStatus } from '@activepieces/shared'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mockSubmitAndWaitForResponse = vi.fn()
+const mockFindOneBy = vi.fn()
+const mockSoftDelete = vi.fn()
+const mockSave = vi.fn()
+const mockGetFlowVersionOrThrow = vi.fn()
+const mockGetPieceTrigger = vi.fn()
+const mockGetPieceTriggerOrThrow = vi.fn()
+const mockRemoveRepeatingJob = vi.fn()
+const mockAddJob = vi.fn()
+
+vi.mock('../../../../../src/app/helper/system/system', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('../../../../../src/app/helper/system/system')>()
+    const { AppSystemProp } = await import('../../../../../src/app/helper/system/system-props')
+    return {
+        ...actual,
+        system: {
+            ...actual.system,
+            getOrThrow: (key: string) => key === AppSystemProp.ENVIRONMENT
+                ? ApEnvironment.PRODUCTION
+                : actual.system.getOrThrow(key),
+        },
+    }
+})
+
+vi.mock('../../../../../src/app/core/db/repo-factory', () => ({
+    repoFactory: vi.fn(() => () => ({
+        findOneBy: mockFindOneBy,
+        softDelete: mockSoftDelete,
+        save: mockSave,
+    })),
+}))
+
+vi.mock('../../../../../src/app/project/project-service', () => ({
+    projectService: vi.fn(() => ({
+        getPlatformId: vi.fn().mockResolvedValue('platform-1'),
+    })),
+}))
+
+vi.mock('../../../../../src/app/workers/user-interaction-watcher', () => ({
+    userInteractionWatcher: {
+        submitAndWaitForResponse: (...args: unknown[]) => mockSubmitAndWaitForResponse(...args),
+    },
+}))
+
+vi.mock('../../../../../src/app/flows/flow-version/flow-version.service', () => ({
+    flowVersionService: vi.fn(() => ({
+        getOneOrThrow: mockGetFlowVersionOrThrow,
+        getFlowVersionOrThrow: mockGetFlowVersionOrThrow,
+    })),
+}))
+
+vi.mock('../../../../../src/app/trigger/trigger-source/trigger-utils', () => ({
+    triggerUtils: vi.fn(() => ({
+        getPieceTrigger: mockGetPieceTrigger,
+        getPieceTriggerOrThrow: mockGetPieceTriggerOrThrow,
+    })),
+}))
+
+vi.mock('../../../../../src/app/template/template-telemetry/template-telemetry.service', () => ({
+    templateTelemetryService: vi.fn(() => ({ sendEvent: vi.fn() })),
+}))
+
+vi.mock('../../../../../src/app/workers/job-queue/job-queue', () => ({
+    jobQueue: vi.fn(() => ({
+        removeRepeatingJob: mockRemoveRepeatingJob,
+        add: mockAddJob,
+    })),
+    JobType: { ONE_TIME: 'ONE_TIME', REPEATING: 'REPEATING' },
+}))
+
+vi.mock('../../../../../src/app/trigger/app-event-routing/app-event-routing.service', () => ({
+    appEventRoutingService: {
+        deleteListeners: vi.fn(),
+        createListeners: vi.fn(),
+    },
+}))
+
+vi.mock('../../../../../src/app/helper/application-events', () => ({
+    applicationEvents: vi.fn(() => ({ sendUserEvent: vi.fn() })),
+    ApplicationEventName: {},
+}))
+
+vi.mock('../../../../../src/app/flows/step-run/sample-data.service', () => ({
+    sampleDataService: vi.fn(() => ({ deleteForFlow: vi.fn() })),
+}))
+
+import { flowSideEffects } from '../../../../../src/app/flows/flow/flow-service-side-effects'
+
+const mockLog = {
+    info: vi.fn(),
+    debug: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+    child: vi.fn(),
+    fatal: vi.fn(),
+    trace: vi.fn(),
+    silent: vi.fn(),
+    level: 'info',
+} as never
+
+const TRIGGER_SOURCE_ID = 'ts-1'
+
+const FLOW_TO_UPDATE = {
+    id: 'flow-1',
+    projectId: 'proj-1',
+    publishedVersionId: 'fv-1',
+    status: FlowStatus.ENABLED,
+} as never
+
+const PUBLISHED_FLOW_VERSION = {
+    id: 'fv-1',
+    flowId: 'flow-1',
+    trigger: {
+        settings: {
+            pieceName: '@activepieces/piece-linear',
+            pieceVersion: '0.5.1',
+        },
+    },
+} as never
+
+function webhookTrigger() {
+    return {
+        name: 'new_issue',
+        displayName: 'New Issue',
+        description: 'Test',
+        props: {},
+        requireAuth: true,
+        type: TriggerStrategy.WEBHOOK,
+        sampleData: {},
+        testStrategy: 'SIMULATION',
+    }
+}
+
+function refusedCleanupResponse() {
+    return {
+        status: EngineResponseStatus.ERROR,
+        response: undefined,
+        error: '{"__apErrorVersion":1,"message":"Authentication required, not authenticated - You need to authenticate to access this operation.","errorName":"_","status":401}',
+    }
+}
+
+describe('flowSideEffects.preUpdateStatus disabling a flow whose trigger cleanup is refused', () => {
+    beforeEach(() => {
+        vi.clearAllMocks()
+        mockFindOneBy.mockResolvedValue({
+            id: TRIGGER_SOURCE_ID,
+            flowId: 'flow-1',
+            flowVersionId: 'fv-1',
+            projectId: 'proj-1',
+            pieceName: '@activepieces/piece-linear',
+            simulate: false,
+        })
+        mockGetFlowVersionOrThrow.mockResolvedValue(PUBLISHED_FLOW_VERSION)
+        mockGetPieceTrigger.mockResolvedValue(webhookTrigger())
+        mockGetPieceTriggerOrThrow.mockResolvedValue(webhookTrigger())
+        mockSave.mockImplementation(async (row: Record<string, unknown>) => row)
+    })
+
+    it('commits the disable when the piece refuses the remote cleanup, so the flow stops instead of staying live', async () => {
+        mockSubmitAndWaitForResponse.mockResolvedValue(refusedCleanupResponse())
+
+        await flowSideEffects(mockLog).preUpdateStatus({
+            flowToUpdate: FLOW_TO_UPDATE,
+            publishedFlowVersion: PUBLISHED_FLOW_VERSION,
+            newStatus: FlowStatus.DISABLED,
+        })
+
+        expect(mockSoftDelete).toHaveBeenCalledWith({
+            id: TRIGGER_SOURCE_ID,
+            projectId: 'proj-1',
+        })
+    })
+
+    it('commits the disable when the worker never answers the cleanup hook', async () => {
+        mockSubmitAndWaitForResponse.mockRejectedValue(new Error('Worker did not respond within the safety timeout'))
+
+        await flowSideEffects(mockLog).preUpdateStatus({
+            flowToUpdate: FLOW_TO_UPDATE,
+            publishedFlowVersion: PUBLISHED_FLOW_VERSION,
+            newStatus: FlowStatus.DISABLED,
+        })
+
+        expect(mockSoftDelete).toHaveBeenCalledWith({
+            id: TRIGGER_SOURCE_ID,
+            projectId: 'proj-1',
+        })
+    })
+
+    it('still refuses to enable a flow whose trigger registration fails', async () => {
+        mockSubmitAndWaitForResponse.mockResolvedValue(refusedCleanupResponse())
+
+        await expect(
+            flowSideEffects(mockLog).preUpdateStatus({
+                flowToUpdate: { ...FLOW_TO_UPDATE, status: FlowStatus.DISABLED },
+                publishedFlowVersion: PUBLISHED_FLOW_VERSION,
+                newStatus: FlowStatus.ENABLED,
+            }),
+        ).rejects.toThrow()
+    })
+})

--- a/packages/server/api/test/unit/app/flows/trigger/flow-trigger-side-effect.test.ts
+++ b/packages/server/api/test/unit/app/flows/trigger/flow-trigger-side-effect.test.ts
@@ -209,6 +209,11 @@ describe('flowTriggerSideEffect', () => {
                 pieceTrigger: makeManualTrigger(),
                 ignoreError: true,
             })
+
+            expect(mockLog.warn).toHaveBeenCalledWith(
+                expect.objectContaining({ flow: { id: 'flow-1' }, error: 'Engine failed' }),
+                expect.stringContaining('Ignored error'),
+            )
         })
 
         it('should throw when submitAndWaitForResponse throws and ignoreError is false', async () => {

--- a/packages/server/api/test/unit/app/flows/trigger/flow-trigger-side-effect.test.ts
+++ b/packages/server/api/test/unit/app/flows/trigger/flow-trigger-side-effect.test.ts
@@ -216,6 +216,41 @@ describe('flowTriggerSideEffect', () => {
             )
         })
 
+        it('should log only the plain message when the ignored engine error carries http details', async () => {
+            const serializedPieceError = JSON.stringify({
+                __apErrorVersion: 1,
+                message: 'Authentication required, not authenticated - You need to authenticate to access this operation.',
+                errorName: '_',
+                status: 401,
+                responseHeaders: { 'set-cookie': 'session=super-secret-value' },
+                requestBody: { apiKey: 'lin_api_should_never_be_logged' },
+                raw: 'Error: Authentication required\n    at j (/usr/src/app/cache/v14/common/node_modules/...)',
+            })
+            mockSubmitAndWaitForResponse.mockResolvedValue({
+                status: EngineResponseStatus.ERROR,
+                response: undefined,
+                error: serializedPieceError,
+            })
+
+            await flowTriggerSideEffect(mockLog).disable({
+                ...BASE_PARAMS,
+                pieceTrigger: makeManualTrigger(),
+                ignoreError: true,
+            })
+
+            expect(mockLog.warn).toHaveBeenCalledWith(
+                {
+                    flow: { id: 'flow-1' },
+                    error: 'Authentication required, not authenticated - You need to authenticate to access this operation.',
+                },
+                expect.stringContaining('Ignored error'),
+            )
+            const logged = JSON.stringify(vi.mocked(mockLog.warn).mock.calls)
+            expect(logged).not.toContain('super-secret-value')
+            expect(logged).not.toContain('lin_api_should_never_be_logged')
+            expect(logged).not.toContain('set-cookie')
+        })
+
         it('should throw when submitAndWaitForResponse throws and ignoreError is false', async () => {
             mockSubmitAndWaitForResponse.mockRejectedValue(
                 new ActivepiecesError({


### PR DESCRIPTION
Fixes [GIT-1847](https://linear.app/activepieces/issue/GIT-1847)
Closes #15277

## Description

A published flow whose webhook trigger's `onDisable` cleanup was refused by the third party could not be turned off at all. `CHANGE_STATUS -> DISABLED` returned 400, the flow stayed `ENABLED` with a live `trigger_source` row, and it kept producing production runs. The customer reported it as a false logout, because the dialog printed Linear's own 401 text verbatim.

Manual disable was the only caller passing `ignoreError: false`. Delete, republish, trigger-edit simulation and webhook teardown already pass `true`. This aligns the outlier.

Safe because the webhook route drops deliveries for a `DISABLED` flow, so once the status commits the flow stops even when the remote webhook survives. Verified live: webhook POST returns 404 and no run is created.

A refused cleanup arriving as an engine ERROR response was also swallowed **silently**, the existing warn only covered the thrown-error path, so this adds the missing log.

**Reviewer note:** this endpoint now returns 200 where this one failure mode returned 400. Nothing depends on "disable fails" and that 400 was the bug, but say so if you read it as functional-breaking. This path is taken by **every** flow status change, so it wants a flows reviewer rather than just green CI.

**Fix**
- `flow-service-side-effects.ts` in `preUpdateStatus`, `case FlowStatus.DISABLED`: pass `ignoreError: true`
- `flow-trigger-side-effect.ts` in `disable()`: warn when the engine response is not OK while the error is being ignored

## How was this tested?

- Regression test across the `flowSideEffects -> triggerSourceService -> flowTriggerSideEffect` seam, **red-first**: 2 of 3 fail pre-fix with `TRIGGER_UPDATE_STATUS` (stack: `preUpdateStatus -> disable -> disable -> assertEngineResponseIsOk`), and the ENABLED guard test passes on both sides so it is a real no-regression check. The silent-swallow assertion was red-first too (`warn` calls: 0 pre-fix).
- An integration test cannot reach this path: `flowTriggerSideEffect.disable` returns early when `ApEnvironment.TESTING`, so the engine hook never runs under `test-api`. Hence the unit-level seam.
- `packages/server/api` flows unit suite 223/223. `turbo run lint --filter=api` 0 errors (492 warnings, identical to the pre-change baseline). `tsc -p tsconfig.app.json --noEmit` clean. Full pre-push `test-unit` green.
- Live drive, CE, local `api` + `@activepieces/engine` + `worker` against a scratch Postgres, with a Linear connection whose key Linear refuses. Inverse drive off -> on -> off. Before: 400, stays `ENABLED`, webhook POST 200 and a new run completes `SUCCEEDED` in `PRODUCTION`. After: 200, `DISABLED`, `trigger_source` soft-deleted, webhook POST 404, no run.
- Not verified: EE and Cloud edition paths. The diff contains no edition-gated code and no `src/app/ee` imports.

Visual: real app at `/flows/<id>`, builder toggle driven off against a visibly broken connection, before (Status update failed dialog, toggle stays on) and after (toggle off, no dialog). Screenshots in the `Visual verification` comment.

Other affected paths: checked, after this change the only remaining `ignoreError: false` in the repo is `testTriggerService.cancel` (`simulate: true`, cancelling a trigger *test*). Same shape, left deliberately: simulation-only, and someone actively testing a trigger should see the failure.

Repro: a dead `lin_api_` key plus a stored webhook id makes `webhookDelete` return 401, which aborted the status change, full steps in the Reproduction block.

Product decision embedded: disable now succeeds while the refused remote cleanup is left undone and surfaced only in the server log; alternative considered: keep blocking, which leaves the flow running against the user's explicit instruction. The user-visible notice is split to [GIT-1855](https://linear.app/activepieces/issue/GIT-1855).

Size: 7 lines of product code across 2 files, against a 1-line plan estimate. Two came from the warn branch, added after runtime verification showed the ERROR-response path was silent; the rest are the `sanitizeIgnoredError` helper and its import, added in review.

Deliberately out of scope, each with its own ticket: [GIT-1855](https://linear.app/activepieces/issue/GIT-1855) tell the user the remote cleanup was refused, [GIT-1857](https://linear.app/activepieces/issue/GIT-1857) stop the dialog printing the raw piece error, [GIT-1856](https://linear.app/activepieces/issue/GIT-1856) Linear `validate` only checks the `lin_api_` prefix. No piece-level try/catch: 771 webhook trigger files define `onDisable` and roughly 614 have no `try` anywhere, so per-piece guards were rejected in favour of this one choke point. The enable side stays strict per [GIT-721](https://linear.app/activepieces/issue/GIT-721).

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no, reviewed, not breaking
- [ ] yes, technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes, functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

- [x] no, reviewed, no security impact
- [ ] yes, security-sensitive (call out the risk and mitigation in the description above)

<details>
<summary>Plan &amp; reasoning</summary>

## Plan
- Fix at the shared choke point every flow status change routes through, not per caller and not per piece. One boolean on one branch.
- Reviewed all three `applyStatusChange` callers: `LOCK_AND_PUBLISH` defaults to `ENABLED` so a publish whose trigger registration fails still fails loudly; the EE flow-approval caller already passes `ignoreError: true` on its own disable.
- Rejected: try/catch around the `triggerSourceService.disable` call (duplicates what `ignoreError` already expresses); making `flowTriggerSideEffect.disable` never throw (removes a working knob for every caller); per-piece try/catch (~614 webhook triggers).
- Rejected during `/simplify`: collapsing the three post-hook branches into one throw-decision plus one warn. It rewrites ~10 lines of existing test-covered logic for no functional gain. Applied instead: hoisted the now-duplicated warn message into `IGNORED_DISABLE_ERROR`.
- Footprint: planned 1 file / 1 line; actual 2 files / 3 lines plus 2 test files.

## Non-happy scenarios considered
- Worker never answers the disable hook (timeout), covered by a test; disable still commits, which is the point: an unreachable worker must not trap a flow in the on state.
- Remote webhook survives, flow still stops, because the webhook route gates on `flow.status`. Confirmed live with a 404.
- Valid but non-admin third-party key, reproduces the same wall with `403 "Invalid role: admin required"` instead of `401`, which is why the fix targets any refused cleanup rather than expired credentials.
- Bulk paths (flow delete, platform teardown, republish) already passed `ignoreError: true` and now also emit the warn. All low-frequency, no hot loop; more operator signal is the intent.
- Publish to an explicit `DISABLED` status takes the changed branch, but publishing to DISABLED registers nothing, so there is nothing to fail.

## Alternatives rejected
- Report the refused cleanup to the user in this PR, needs a design call on the surface, split to [GIT-1855](https://linear.app/activepieces/issue/GIT-1855).
- Fix the dialog that prints the raw piece error, real problem, different surface, split to [GIT-1857](https://linear.app/activepieces/issue/GIT-1857).
- Make Linear's `validate` call the API so a dead or non-admin key fails at connect time, piece-side, split to [GIT-1856](https://linear.app/activepieces/issue/GIT-1856).

## Note on the new log line
First draft logged `engineHelperResponse.error` directly. Greptile flagged that as a P1 and was right: on the ignore path nothing was logged before this PR, so the serialized payload (which can carry request bodies, response bodies and headers) would have been a first-time disclosure, not a repeat of what the non-ignore path already sends to the client. Fixed in c431d58e80: it now logs only the bounded plain message via `tryParseFriendlyPieceError` / `formatPieceError` from `core-utils`, pinned by a test that puts a `set-cookie` header and an api key in the payload and asserts neither reaches the log (red-first: both appeared verbatim without the sanitizer). The sibling thrown-error branch still logs `error.message`, which only ever sees transport errors from `userInteractionWatcher`, not the piece payload.
</details>

<details>
<summary>Reproduction</summary>

Harness, runnable: https://gist.github.com/majewskibartosz/6a214220d0cfa8455e69a6ba06429983

```bash
git clone https://gist.github.com/6a214220d0cfa8455e69a6ba06429983.git git-1847-repro && cd git-1847-repro
```

## Environment
- Postgres + Redis from `docker-compose.dev.yml`; scratch database `repro_1847`, Redis DB index 4, so dev data is untouched
- `api` + `@activepieces/engine` + `worker` served from the working tree on `AP_PORT=3010`
- `AP_DEV_PIECES=linear`, `AP_ENVIRONMENT=dev`, CE
- Reported on 0.89.0 with `@activepieces/piece-linear` 0.5.0; reproduced on main. The four files in the chain are byte-identical between tag 0.89.0 and main, and the engine hook file (renamed `core/piece/trigger-runner.ts` -> `helper/trigger-helper.ts`) still does `await runHook('onDisable')` with no guard.

## Harness
- `README.md`, environment, the one stub and why, steps, results table, state-inspection SQL
- `scenario.mjs`. API driver: `setup` / `publish` / `status` / `get` / `fire` / `delete` / `rekey`
- `env.sh`, the throwaway stack's env, with the Postgres password and JWT secret left as placeholders

One deliberate stub, disclosed: the Linear API only lets **workspace admins** manage webhooks, so a non-admin key cannot register one to tear down later. `onEnable` in `new-issue.ts` was temporarily replaced with a store write that seeds a fixed webhook id. `onDisable` was **not** modified, and every server-side hop under test ran unmodified code. The stub was reverted before committing.

## Trigger
`POST /v1/flows/<id>` with `{"type":"CHANGE_STATUS","request":{"status":"DISABLED"}}` while the flow's Linear connection holds a key Linear refuses. `onDisable` calls `webhookDelete`, Linear answers 401 `AUTHENTICATION_ERROR`, and pre-fix that aborted the status change before `softDelete` and before `flowRepo().save({ status })`.

## Results

| Build | `CHANGE_STATUS DISABLED` | `flow.status` | `trigger_source.deleted` | webhook POST afterwards |
|---|---|---|---|---|
| pre-fix | 400 `TRIGGER_UPDATE_STATUS` | `ENABLED` | `NULL` | 200, new run `SUCCEEDED` in `PRODUCTION` |
| post-fix | 200 | `DISABLED` | set | 404, no new run |

API request logs pin the hop. Pre-fix a failing disable stops after `[engineWatcher#listen]` and never prints `Soft deleted trigger source`; the control run prints both.

Controls, which isolate the cause to the cleanup **call** rather than the credential:
- delete the store entry so the piece's `if (response && response.webhookId)` guard short-circuits, disable then succeeds even pre-fix, with the same dead key
- `DELETE /v1/flows/<id>` returns 204 even pre-fix, because that path already passes `ignoreError: true`

A valid but non-admin Linear key reproduces the same wall with `403 "Invalid role: admin required"`, ruling out "expired credential" as the defining condition.
</details>

