### PR TITLE
feat: add output schemas to FTP/SFTP, ntfy, Coda, Pushover and Systeme.io

### DIFF
--- a/packages/pieces/community/coda/package.json
+++ b/packages/pieces/community/coda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-coda",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {

--- a/packages/pieces/community/coda/src/lib/actions/create-row.ts
+++ b/packages/pieces/community/coda/src/lib/actions/create-row.ts
@@ -3,6 +3,7 @@ import { codaAuth } from '../auth';
 import { codaClient } from '../common/types';
 import { docIdDropdown, tableIdDropdown, tableRowsDynamicProps } from '../common/props';
 import { isNil } from '@activepieces/pieces-framework';
+import { createRowActionOutputSchema } from '../output-schemas';
 
 export const createRowAction = createAction({
 	auth: codaAuth,
@@ -17,6 +18,7 @@ export const createRowAction = createAction({
 		tableId: tableIdDropdown,
 		rowData: tableRowsDynamicProps,
 	},
+	outputSchema: createRowActionOutputSchema,
 	async run(context) {
 		const { docId, tableId, rowData } = context.propsValue;
 		const client = codaClient(context.auth);

--- a/packages/pieces/community/coda/src/lib/actions/find-row.ts
+++ b/packages/pieces/community/coda/src/lib/actions/find-row.ts
@@ -2,6 +2,7 @@ import { Property, createAction } from '@activepieces/pieces-framework';
 import { codaAuth } from '../auth';
 import { CodaRow, codaClient } from '../common/types';
 import { columnIdsDropdown, docIdDropdown, tableIdDropdown } from '../common/props';
+import { findRowActionOutputSchema } from '../output-schemas';
 
 export const findRowAction = createAction({
 	auth: codaAuth,
@@ -20,6 +21,7 @@ export const findRowAction = createAction({
 			required: true,
 		}),
 	},
+	outputSchema: findRowActionOutputSchema,
 	async run(context) {
 		const { docId, tableId, searchColumn, searchValue } = context.propsValue;
 		const client = codaClient(context.auth);

--- a/packages/pieces/community/coda/src/lib/actions/get-row.ts
+++ b/packages/pieces/community/coda/src/lib/actions/get-row.ts
@@ -2,6 +2,7 @@ import { Property, createAction } from '@activepieces/pieces-framework';
 import { codaAuth } from '../auth';
 import { codaClient } from '../common/types';
 import { docIdDropdown, tableIdDropdown } from '../common/props';
+import { getRowActionOutputSchema } from '../output-schemas';
 
 export const getRowAction = createAction({
 	auth: codaAuth,
@@ -19,6 +20,7 @@ export const getRowAction = createAction({
 			required: true,
 		}),
 	},
+	outputSchema: getRowActionOutputSchema,
 	async run(context) {
 		const { docId, tableId, rowIdOrName } = context.propsValue;
 		const client = codaClient(context.auth);

--- a/packages/pieces/community/coda/src/lib/actions/get-table.ts
+++ b/packages/pieces/community/coda/src/lib/actions/get-table.ts
@@ -2,6 +2,7 @@ import { codaAuth } from '../auth';
 import { createAction } from '@activepieces/pieces-framework';
 import { docIdDropdown, tableIdDropdown } from '../common/props';
 import { codaClient } from '../common/types';
+import { getTableActionOutputSchema } from '../output-schemas';
 
 export const getTableAction = createAction({
 	auth: codaAuth,
@@ -15,6 +16,7 @@ export const getTableAction = createAction({
 		docId: docIdDropdown,
 		tableId: tableIdDropdown,
 	},
+	outputSchema: getTableActionOutputSchema,
 	async run(context) {
 		const { docId, tableId } = context.propsValue;
 		const client = codaClient(context.auth);

--- a/packages/pieces/community/coda/src/lib/actions/list-tables.ts
+++ b/packages/pieces/community/coda/src/lib/actions/list-tables.ts
@@ -2,6 +2,7 @@ import { Property, createAction } from '@activepieces/pieces-framework';
 import { codaAuth } from '../auth';
 import { CodaTableReference, codaClient } from '../common/types';
 import { docIdDropdown } from '../common/props';
+import { listTablesActionOutputSchema } from '../output-schemas';
 
 export const listTablesAction = createAction({
 	auth: codaAuth,
@@ -19,6 +20,7 @@ export const listTablesAction = createAction({
 			required: true,
 		}),
 	},
+	outputSchema: listTablesActionOutputSchema,
 	async run(context) {
 		const { docId, max } = context.propsValue;
 		const client = codaClient(context.auth);

--- a/packages/pieces/community/coda/src/lib/actions/update-row.ts
+++ b/packages/pieces/community/coda/src/lib/actions/update-row.ts
@@ -3,6 +3,7 @@ import { codaAuth } from '../auth';
 import { codaClient } from '../common/types';
 import { docIdDropdown, tableIdDropdown, tableRowsDynamicProps } from '../common/props';
 import { isNil } from '@activepieces/pieces-framework';
+import { updateRowActionOutputSchema } from '../output-schemas';
 
 export const updateRowAction = createAction({
 	auth: codaAuth,
@@ -21,6 +22,7 @@ export const updateRowAction = createAction({
 		}),
 		rowData: tableRowsDynamicProps,
 	},
+	outputSchema: updateRowActionOutputSchema,
 	async run(context) {
 		const { docId, tableId, rowIdOrName, rowData } = context.propsValue;
 		const client = codaClient(context.auth);

--- a/packages/pieces/community/coda/src/lib/output-schemas.ts
+++ b/packages/pieces/community/coda/src/lib/output-schemas.ts
@@ -1,0 +1,168 @@
+import { OutputSchema } from '@activepieces/pieces-framework';
+
+const rowFields: OutputSchema['fields'] = [
+  {
+    key: 'id',
+    label: 'Row ID',
+    description: 'Use this to read or update the row in a later step.',
+  },
+  {
+    key: 'name',
+    label: 'Name',
+    description: 'Value of the table\'s display column for this row.',
+  },
+  {
+    key: 'values',
+    label: 'Column Values',
+    dynamicKey: true,
+    labelKey: 'name',
+    description:
+      'The row\'s cells, keyed by your column names. The keys depend on the table, so they differ from doc to doc.',
+  },
+  {
+    key: 'index',
+    label: 'Row Index',
+    format: 'number',
+    description: 'Zero-based position of the row in the table.',
+  },
+  {
+    key: 'createdAt',
+    label: 'Created At',
+    format: 'datetime',
+  },
+  {
+    key: 'updatedAt',
+    label: 'Updated At',
+    format: 'datetime',
+  },
+  {
+    key: 'browserLink',
+    label: 'Browser Link',
+    format: 'url',
+    description: 'Opens the row in Coda.',
+  },
+];
+
+const tableFields: OutputSchema['fields'] = [
+  { key: 'id', label: 'Table ID' },
+  { key: 'name', label: 'Name' },
+  {
+    key: 'tableType',
+    label: 'Table Type',
+    description: 'Either "table" or "view".',
+  },
+  {
+    key: 'browserLink',
+    label: 'Browser Link',
+    format: 'url',
+    description: 'Opens the table in Coda.',
+  },
+  {
+    key: 'parent',
+    label: 'Page',
+    description: 'The doc page the table sits on.',
+    children: [
+      { key: 'id', label: 'Page ID' },
+      { key: 'name', label: 'Name' },
+      { key: 'browserLink', label: 'Browser Link', format: 'url' },
+    ],
+  },
+];
+
+export const createRowActionOutputSchema: OutputSchema = {
+  fields: [
+    {
+      key: 'rowId',
+      label: 'Row ID',
+      description:
+        'Coda applies row writes asynchronously, so the new row may not be readable for a few seconds. Add a short delay before passing this to Get Row.',
+    },
+  ],
+};
+
+export const updateRowActionOutputSchema: OutputSchema = {
+  fields: [
+    {
+      key: 'rowId',
+      label: 'Row ID',
+      description: 'The row that was updated.',
+    },
+  ],
+};
+
+export const getRowActionOutputSchema: OutputSchema = {
+  fields: [
+    ...rowFields,
+    {
+      key: 'parent',
+      label: 'Table',
+      children: [
+        { key: 'id', label: 'Table ID' },
+        { key: 'name', label: 'Name' },
+        { key: 'tableType', label: 'Table Type' },
+        { key: 'browserLink', label: 'Browser Link', format: 'url' },
+      ],
+    },
+  ],
+};
+
+export const findRowActionOutputSchema: OutputSchema = {
+  fields: [
+    {
+      key: 'found',
+      label: 'Found',
+      format: 'boolean',
+      description: 'False when no row matched, in which case Rows is empty.',
+    },
+    {
+      key: 'result',
+      label: 'Rows',
+      labelKey: 'name',
+      description: 'Every matching row, across all pages of results.',
+      listItems: rowFields,
+    },
+  ],
+};
+
+export const listTablesActionOutputSchema: OutputSchema = {
+  fields: [
+    {
+      key: 'found',
+      label: 'Found',
+      format: 'boolean',
+      description: 'False when the doc has no tables, in which case Tables is empty.',
+    },
+    {
+      key: 'result',
+      label: 'Tables',
+      labelKey: 'name',
+      listItems: tableFields,
+    },
+  ],
+};
+
+export const getTableActionOutputSchema: OutputSchema = {
+  fields: [
+    ...tableFields,
+    {
+      key: 'rowCount',
+      label: 'Row Count',
+      format: 'number',
+    },
+    {
+      key: 'displayColumn',
+      label: 'Display Column',
+      description: 'The column whose value names each row. Coda returns its id only, not its name.',
+      children: [{ key: 'id', label: 'Column ID' }],
+    },
+    {
+      key: 'layout',
+      label: 'Layout',
+      description: 'How the table is laid out in the doc, for example "default".',
+    },
+    { key: 'createdAt', label: 'Created At', format: 'datetime' },
+    { key: 'updatedAt', label: 'Updated At', format: 'datetime' },
+  ],
+};
+
+export const newRowCreatedTriggerOutputSchema: OutputSchema = { fields: rowFields };

--- a/packages/pieces/community/coda/src/lib/triggers/new-row-created.ts
+++ b/packages/pieces/community/coda/src/lib/triggers/new-row-created.ts
@@ -8,6 +8,7 @@ import { codaAuth } from '../auth';
 import { CodaRow, codaClient } from '../common/types';
 import dayjs from 'dayjs';
 import { docIdDropdown, tableIdDropdown } from '../common/props';
+import { newRowCreatedTriggerOutputSchema } from '../output-schemas';
 
 type Props = {
 	tableId: string;
@@ -65,6 +66,7 @@ export const newRowCreatedTrigger = createTrigger({
 		docId: docIdDropdown,
 		tableId: tableIdDropdown,
 	},
+	outputSchema: newRowCreatedTriggerOutputSchema,
 	type: TriggerStrategy.POLLING,
 	async onEnable(context) {
 		await pollingHelper.onEnable(polling, {

--- a/packages/pieces/community/ntfy/package.json
+++ b/packages/pieces/community/ntfy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-ntfy",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {

--- a/packages/pieces/community/ntfy/src/lib/actions/send-notification.ts
+++ b/packages/pieces/community/ntfy/src/lib/actions/send-notification.ts
@@ -5,6 +5,7 @@ import {
   HttpMethod,
 } from '@activepieces/pieces-common';
 import { ntfyAuth } from '../..';
+import { sendNotificationActionOutputSchema } from '../output-schemas';
 
 const encodeToRFC2047 = (text: string) => {
   return `=?UTF-8?B?${Buffer.from(text, 'utf-8').toString('base64')}?=`;
@@ -70,6 +71,7 @@ export const sendNotification = createAction({
       required: false,
     }),
   },
+  outputSchema: sendNotificationActionOutputSchema,
   async run({ auth, propsValue }) {
     const baseUrl = auth.props.base_url.replace(/\/$/, '');
     const accessToken = auth.props.access_token;

--- a/packages/pieces/community/ntfy/src/lib/output-schemas.ts
+++ b/packages/pieces/community/ntfy/src/lib/output-schemas.ts
@@ -1,0 +1,91 @@
+import { OutputSchema } from '@activepieces/pieces-framework';
+
+export const sendNotificationActionOutputSchema: OutputSchema = {
+  fields: [
+    {
+      key: 'id',
+      label: 'Message ID',
+      value: 'body.id',
+      description: 'Identifier ntfy assigned to the published message.',
+    },
+    {
+      key: 'topic',
+      label: 'Topic',
+      value: 'body.topic',
+      description: 'The topic the message was published to.',
+    },
+    {
+      key: 'title',
+      label: 'Title',
+      value: 'body.title',
+    },
+    {
+      key: 'message',
+      label: 'Message',
+      value: 'body.message',
+    },
+    {
+      key: 'time',
+      label: 'Delivery Time',
+      value: 'body.time',
+      format: 'datetime',
+      description:
+        'Unix timestamp in seconds for when ntfy delivers the message. Equal to the send time unless Delay was set, in which case it is the scheduled delivery time.',
+    },
+    {
+      key: 'expires',
+      label: 'Expires',
+      value: 'body.expires',
+      format: 'datetime',
+      description:
+        'Unix timestamp in seconds for when ntfy stops caching the message, always 12 hours after Delivery Time.',
+    },
+    {
+      key: 'event',
+      label: 'Event',
+      value: 'body.event',
+      description: 'The ntfy event type, "message" for a published notification.',
+    },
+    {
+      key: 'priority',
+      label: 'Priority',
+      value: 'body.priority',
+      format: 'number',
+      description: '1 (lowest) to 5 (highest). Omitted by ntfy when the default priority 3 was used.',
+    },
+    {
+      key: 'tags',
+      label: 'Tags',
+      value: 'body.tags',
+      description: 'Only present when tags were sent.',
+    },
+    {
+      key: 'click',
+      label: 'Click URL',
+      value: 'body.click',
+      format: 'url',
+      description: 'Opened when the notification is clicked. Only present when a click URL was sent.',
+    },
+    {
+      key: 'icon',
+      label: 'Icon',
+      value: 'body.icon',
+      format: 'image',
+      description: 'Only present when an icon URL was sent.',
+    },
+    {
+      key: 'actions',
+      label: 'Action Buttons',
+      value: 'body.actions',
+      labelKey: 'label',
+      description: 'Only present when action buttons were sent.',
+      listItems: [
+        { key: 'id', label: 'Action ID' },
+        { key: 'action', label: 'Type', description: 'One of "view", "http" or "broadcast".' },
+        { key: 'label', label: 'Label' },
+        { key: 'url', label: 'URL', format: 'url' },
+        { key: 'clear', label: 'Clear Notification', format: 'boolean' },
+      ],
+    },
+  ],
+};

--- a/packages/pieces/community/ntfy/src/lib/output-schemas.ts
+++ b/packages/pieces/community/ntfy/src/lib/output-schemas.ts
@@ -28,7 +28,6 @@ export const sendNotificationActionOutputSchema: OutputSchema = {
       key: 'time',
       label: 'Delivery Time',
       value: 'body.time',
-      format: 'datetime',
       description:
         'Unix timestamp in seconds for when ntfy delivers the message. Equal to the send time unless Delay was set, in which case it is the scheduled delivery time.',
     },
@@ -36,7 +35,6 @@ export const sendNotificationActionOutputSchema: OutputSchema = {
       key: 'expires',
       label: 'Expires',
       value: 'body.expires',
-      format: 'datetime',
       description:
         'Unix timestamp in seconds for when ntfy stops caching the message, always 12 hours after Delivery Time.',
     },

--- a/packages/pieces/community/pushover/package.json
+++ b/packages/pieces/community/pushover/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-pushover",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {

--- a/packages/pieces/community/pushover/src/lib/actions/send-notification.ts
+++ b/packages/pieces/community/pushover/src/lib/actions/send-notification.ts
@@ -1,6 +1,7 @@
 import { createAction, Property } from '@activepieces/pieces-framework';
 import { httpClient, HttpMethod } from '@activepieces/pieces-common';
 import { pushoverAuth } from '../..';
+import { sendNotificationActionOutputSchema } from '../output-schemas';
 
 export const sendNotification = createAction({
   auth: pushoverAuth,
@@ -71,6 +72,7 @@ export const sendNotification = createAction({
       required: false,
     }),
   },
+  outputSchema: sendNotificationActionOutputSchema,
   async run({ auth, propsValue }) {
     const baseUrl = 'https://api.pushover.net/1/messages.json';
     const apiToken = auth.props.api_token;

--- a/packages/pieces/community/pushover/src/lib/output-schemas.ts
+++ b/packages/pieces/community/pushover/src/lib/output-schemas.ts
@@ -1,0 +1,26 @@
+import { OutputSchema } from '@activepieces/pieces-framework';
+
+export const sendNotificationActionOutputSchema: OutputSchema = {
+  fields: [
+    {
+      key: 'status',
+      label: 'Status',
+      value: 'body.status',
+      format: 'number',
+      description: '1 when Pushover accepted the notification. Any other value means it was rejected.',
+    },
+    {
+      key: 'request',
+      label: 'Request ID',
+      value: 'body.request',
+      description: 'Pushover\'s identifier for this request, worth quoting when reporting a delivery problem.',
+    },
+    {
+      key: 'receipt',
+      label: 'Receipt',
+      value: 'body.receipt',
+      description:
+        'Only returned at emergency priority (2). Use it to check whether the notification was acknowledged.',
+    },
+  ],
+};

--- a/packages/pieces/community/systeme-io/package.json
+++ b/packages/pieces/community/systeme-io/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-systeme-io",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/packages/pieces/community/systeme-io/src/lib/actions/add-tag-to-contact.ts
+++ b/packages/pieces/community/systeme-io/src/lib/actions/add-tag-to-contact.ts
@@ -3,6 +3,7 @@ import { HttpMethod } from '@activepieces/pieces-common';
 import { systemeIoAuth } from '../common/auth';
 import { systemeIoCommon } from '../common/client';
 import { systemeIoProps } from '../common/props';
+import { addTagToContactActionOutputSchema } from '../output-schemas';
 
 export const addTagToContact = createAction({
   auth: systemeIoAuth,
@@ -88,6 +89,7 @@ export const addTagToContact = createAction({
       required: false,
     }),
   },
+  outputSchema: addTagToContactActionOutputSchema,
   async run(context) {
     const { contactId, tagSource, existingTagId, newTagName } = context.propsValue;
     

--- a/packages/pieces/community/systeme-io/src/lib/actions/create-contact.ts
+++ b/packages/pieces/community/systeme-io/src/lib/actions/create-contact.ts
@@ -3,6 +3,7 @@ import { HttpMethod } from '@activepieces/pieces-common';
 import { systemeIoAuth } from '../common/auth';
 import { systemeIoCommon } from '../common/client';
 import { systemeIoProps } from '../common/props';
+import { createContactActionOutputSchema } from '../output-schemas';
 
 interface ContactField {
   field: string;
@@ -194,6 +195,7 @@ export const createContact = createAction({
       },
     }),
   },
+  outputSchema: createContactActionOutputSchema,
   async run(context) {
     const { 
       email, 

--- a/packages/pieces/community/systeme-io/src/lib/actions/find-contact-by-email.ts
+++ b/packages/pieces/community/systeme-io/src/lib/actions/find-contact-by-email.ts
@@ -1,6 +1,7 @@
 import { createAction, Property } from '@activepieces/pieces-framework';
 import { systemeIoAuth } from '../common/auth';
 import { systemeIoCommon } from '../common/client';
+import { findContactByEmailActionOutputSchema } from '../output-schemas';
 
 export const findContactByEmail = createAction({
   auth: systemeIoAuth,
@@ -17,6 +18,7 @@ export const findContactByEmail = createAction({
       required: true,
     }),
   },
+  outputSchema: findContactByEmailActionOutputSchema,
   async run(context) {
     const { email } = context.propsValue;
     const searchEmail = email.toLowerCase().trim();

--- a/packages/pieces/community/systeme-io/src/lib/actions/remove-tag-from-contact.ts
+++ b/packages/pieces/community/systeme-io/src/lib/actions/remove-tag-from-contact.ts
@@ -3,6 +3,7 @@ import { HttpMethod } from '@activepieces/pieces-common';
 import { systemeIoAuth } from '../common/auth';
 import { systemeIoCommon } from '../common/client';
 import { systemeIoProps } from '../common/props';
+import { removeTagFromContactActionOutputSchema } from '../output-schemas';
 
 export const removeTagFromContact = createAction({
   auth: systemeIoAuth,
@@ -74,6 +75,7 @@ export const removeTagFromContact = createAction({
       },
     }),
   },
+  outputSchema: removeTagFromContactActionOutputSchema,
   async run(context) {
     const { contactId, tagId } = context.propsValue;
     

--- a/packages/pieces/community/systeme-io/src/lib/actions/update-contact.ts
+++ b/packages/pieces/community/systeme-io/src/lib/actions/update-contact.ts
@@ -3,6 +3,7 @@ import { HttpMethod } from '@activepieces/pieces-common';
 import { systemeIoAuth } from '../common/auth';
 import { systemeIoCommon } from '../common/client';
 import { systemeIoProps } from '../common/props';
+import { updateContactActionOutputSchema } from '../output-schemas';
 
 interface ContactFieldUpdate {
   field: string;
@@ -80,6 +81,7 @@ export const updateContact = createAction({
       },
     }),
   },
+  outputSchema: updateContactActionOutputSchema,
   async run(context) {
     const { 
       contactId, 

--- a/packages/pieces/community/systeme-io/src/lib/output-schemas.ts
+++ b/packages/pieces/community/systeme-io/src/lib/output-schemas.ts
@@ -1,0 +1,239 @@
+import { OutputSchema, OutputSchemaField } from '@activepieces/pieces-framework';
+
+const contactFields: OutputSchema['fields'] = [
+  {
+    key: 'id',
+    label: 'Contact ID',
+    description: 'Use this to add tags to, update, or remove tags from the contact in a later step.',
+  },
+  {
+    key: 'email',
+    label: 'Email',
+    format: 'email',
+  },
+  {
+    key: 'registeredAt',
+    label: 'Registered At',
+    format: 'datetime',
+  },
+  {
+    key: 'locale',
+    label: 'Locale',
+  },
+  {
+    key: 'fields',
+    label: 'Contact Fields',
+    labelKey: 'fieldName',
+    description:
+      'The contact\'s field values. Which fields exist depends on the account, so this list varies.',
+    listItems: [
+      { key: 'fieldName', label: 'Field Name', description: 'Human name, for example "Phone number".' },
+      { key: 'slug', label: 'Slug', description: 'The identifier to use when updating this field.' },
+      { key: 'value', label: 'Value' },
+    ],
+  },
+  {
+    key: 'unsubscribed',
+    label: 'Unsubscribed',
+    format: 'boolean',
+  },
+  {
+    key: 'bounced',
+    label: 'Bounced',
+    format: 'boolean',
+  },
+  {
+    key: 'needsConfirmation',
+    label: 'Needs Confirmation',
+    format: 'boolean',
+  },
+  {
+    key: 'sourceURL',
+    label: 'Source URL',
+    format: 'url',
+    description: 'Where the contact signed up, when Systeme.io recorded it.',
+  },
+];
+
+const tagListField: OutputSchemaField = {
+  key: 'tags',
+  label: 'Tags',
+  labelKey: 'name',
+  listItems: [
+    { key: 'id', label: 'Tag ID' },
+    { key: 'name', label: 'Name' },
+  ],
+};
+
+const contactFieldsWithTags: OutputSchema['fields'] = [...contactFields, tagListField];
+
+export const createContactActionOutputSchema: OutputSchema = {
+  fields: [
+    {
+      key: 'contact',
+      label: 'Contact',
+      description:
+        'The newly created contact. Its Tags list is empty even when tags were requested, because Systeme.io returns the contact before the tags are attached — read Tag Results instead.',
+      children: contactFields,
+    },
+    {
+      key: 'tagResults',
+      label: 'Tag Results',
+      labelKey: 'tagName',
+      description: 'One entry per tag the action tried to attach.',
+      listItems: [
+        { key: 'tagId', label: 'Tag ID' },
+        { key: 'tagName', label: 'Tag Name', description: 'Only set when a new tag was created.' },
+        { key: 'success', label: 'Attached', format: 'boolean' },
+        { key: 'error', label: 'Error', description: 'Only present when this tag failed to attach.' },
+      ],
+    },
+    {
+      key: 'totalTagsAssigned',
+      label: 'Tags Assigned',
+      format: 'number',
+    },
+    {
+      key: 'newTagsCreated',
+      label: 'New Tags Created',
+      format: 'number',
+    },
+    {
+      key: 'tagSource',
+      label: 'Tag Source',
+      description: 'Which tag option the step ran with: "existing", "new", or "none".',
+    },
+    {
+      key: 'dynamicFieldsProcessed',
+      label: 'Contact Fields Set',
+      format: 'number',
+    },
+    {
+      key: 'customFieldsProcessed',
+      label: 'Custom Fields Set',
+      format: 'number',
+    },
+  ],
+};
+
+export const findContactByEmailActionOutputSchema: OutputSchema = {
+  fields: [
+    {
+      key: 'success',
+      label: 'Found',
+      format: 'boolean',
+      description: 'False when no contact has that email, in which case Contact is empty.',
+    },
+    {
+      key: 'contact',
+      label: 'Contact',
+      children: contactFieldsWithTags,
+    },
+    {
+      key: 'message',
+      label: 'Message',
+    },
+  ],
+};
+
+export const updateContactActionOutputSchema: OutputSchema = {
+  fields: [
+    {
+      key: 'success',
+      label: 'Updated',
+      format: 'boolean',
+      description: 'False when no fields were supplied, in which case nothing was changed.',
+    },
+    {
+      key: 'contactId',
+      label: 'Contact ID',
+    },
+    {
+      key: 'updatedFields',
+      label: 'Updated Fields',
+      labelKey: 'slug',
+      description: 'The field values that were written.',
+      listItems: [
+        { key: 'slug', label: 'Slug' },
+        { key: 'value', label: 'Value' },
+      ],
+    },
+    {
+      key: 'response',
+      label: 'Contact',
+      description: 'The contact as it stands after the update.',
+      children: contactFieldsWithTags,
+    },
+    {
+      key: 'dynamicFieldsProcessed',
+      label: 'Contact Fields Set',
+      format: 'number',
+    },
+    {
+      key: 'customFieldsProcessed',
+      label: 'Custom Fields Set',
+      format: 'number',
+    },
+    {
+      key: 'message',
+      label: 'Message',
+      description: 'Only set when the step made no change because no fields were supplied.',
+    },
+  ],
+};
+
+export const addTagToContactActionOutputSchema: OutputSchema = {
+  fields: [
+    { key: 'success', label: 'Attached', format: 'boolean' },
+    { key: 'contactId', label: 'Contact ID' },
+    { key: 'tagId', label: 'Tag ID' },
+    {
+      key: 'tagCreated',
+      label: 'Tag Was Created',
+      format: 'boolean',
+      description: 'True when the step created a new tag rather than attaching an existing one.',
+    },
+    {
+      key: 'tagName',
+      label: 'Tag Name',
+      description: 'Only set when a new tag was created; attaching an existing tag leaves it empty.',
+    },
+    { key: 'message', label: 'Message' },
+  ],
+};
+
+export const removeTagFromContactActionOutputSchema: OutputSchema = {
+  fields: [
+    { key: 'success', label: 'Removed', format: 'boolean' },
+    { key: 'contactId', label: 'Contact ID' },
+    { key: 'tagId', label: 'Tag ID' },
+    {
+      key: 'tagName',
+      label: 'Tag Name',
+      description: 'Falls back to "Unknown Tag" if the tag could not be looked up before removal.',
+    },
+    { key: 'message', label: 'Message' },
+  ],
+};
+
+export const newContactTriggerOutputSchema: OutputSchema = { fields: contactFields };
+
+export const newTagAddedToContactTriggerOutputSchema: OutputSchema = {
+  fields: [
+    {
+      key: 'tag',
+      label: 'Tag',
+      description: 'The tag that was just attached.',
+      children: [
+        { key: 'id', label: 'Tag ID' },
+        { key: 'name', label: 'Name' },
+      ],
+    },
+    {
+      key: 'contact',
+      label: 'Contact',
+      description: 'The contact it was attached to, including its other tags.',
+      children: contactFieldsWithTags,
+    },
+  ],
+};

--- a/packages/pieces/community/systeme-io/src/lib/triggers/new-contact.ts
+++ b/packages/pieces/community/systeme-io/src/lib/triggers/new-contact.ts
@@ -2,6 +2,7 @@ import { createTrigger, TriggerStrategy } from '@activepieces/pieces-framework';
 import { systemeIoAuth } from '../common/auth';
 import { systemeIoCommon } from '../common/client';
 import { randomBytes } from 'crypto';
+import { newContactTriggerOutputSchema } from '../output-schemas';
 
 export const newContact = createTrigger({
     auth: systemeIoAuth,
@@ -52,6 +53,7 @@ export const newContact = createTrigger({
             ]
         }
     },
+    outputSchema: newContactTriggerOutputSchema,
     type: TriggerStrategy.WEBHOOK,
     async onEnable(context) {
         const secret = randomBytes(32).toString('hex');

--- a/packages/pieces/community/systeme-io/src/lib/triggers/new-tag-added-to-contact.ts
+++ b/packages/pieces/community/systeme-io/src/lib/triggers/new-tag-added-to-contact.ts
@@ -2,6 +2,7 @@ import { createTrigger, TriggerStrategy } from '@activepieces/pieces-framework';
 import { systemeIoAuth } from '../common/auth';
 import { systemeIoCommon } from '../common/client';
 import { randomBytes } from 'crypto';
+import { newTagAddedToContactTriggerOutputSchema } from '../output-schemas';
 
 export const newTagAddedToContact = createTrigger({
     auth: systemeIoAuth,
@@ -57,6 +58,7 @@ export const newTagAddedToContact = createTrigger({
         },
         addedAt: "2024-01-01T10:30:00+00:00"
     },
+    outputSchema: newTagAddedToContactTriggerOutputSchema,
     type: TriggerStrategy.WEBHOOK,
     async onEnable(context) {
         const secret = randomBytes(32).toString('hex');

--- a/packages/pieces/core/sftp/package.json
+++ b/packages/pieces/core/sftp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-sftp",
-  "version": "0.5.8",
+  "version": "0.5.9",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "dependencies": {

--- a/packages/pieces/core/sftp/src/lib/actions/create-file.ts
+++ b/packages/pieces/core/sftp/src/lib/actions/create-file.ts
@@ -5,6 +5,7 @@ import { endClient, getClient, getProtocolBackwardCompatibility } from '../commo
 import { sftpAuth } from '../auth';
 import { Readable } from 'stream';
 import { getSftpError } from './common';
+import { createFileActionOutputSchema } from '../output-schemas';
 
 async function createFileWithSFTP(client: Client, fileName: string, fileContent: string) {
     const remotePathExists = await client.exists(fileName);
@@ -45,6 +46,7 @@ export const createFile = createAction({
             required: true,
         }),
     },
+    outputSchema: createFileActionOutputSchema,
     async run(context) {
         const fileName = context.propsValue['fileName'];
         const fileContent = context.propsValue['fileContent'];

--- a/packages/pieces/core/sftp/src/lib/actions/create-folder.ts
+++ b/packages/pieces/core/sftp/src/lib/actions/create-folder.ts
@@ -4,6 +4,7 @@ import { Property, createAction } from '@activepieces/pieces-framework';
 import Client from 'ssh2-sftp-client';
 import { Client as FTPClient, FTPError } from 'basic-ftp';
 import { getSftpError } from './common';
+import { createFolderActionOutputSchema } from '../output-schemas';
 
 export const createFolderAction = createAction({
   audience: 'both',
@@ -26,6 +27,7 @@ export const createFolderAction = createAction({
       description: 'For SFTP only: Create parent directories if they do not exist',
     }),
   },
+  outputSchema: createFolderActionOutputSchema,
   async run(context) {
     const client = await getClient(context.auth.props);
     const directoryPath = context.propsValue.folderPath;

--- a/packages/pieces/core/sftp/src/lib/actions/delete-file.ts
+++ b/packages/pieces/core/sftp/src/lib/actions/delete-file.ts
@@ -4,6 +4,7 @@ import { sftpAuth } from '../auth';
 import { Client as FTPClient, FTPError } from 'basic-ftp';
 import Client from 'ssh2-sftp-client';
 import { getSftpError } from './common';
+import { deleteFileActionOutputSchema } from '../output-schemas';
 
 async function deleteFileFromFTP(client: FTPClient, filePath: string) {
   await client.remove(filePath);
@@ -28,6 +29,7 @@ export const deleteFileAction = createAction({
       description: 'The path of the file to delete e.g. `./myfolder/test.mp3`',
     }),
   },
+  outputSchema: deleteFileActionOutputSchema,
   async run(context) {
     const client = await getClient(context.auth.props);
     const filePath = context.propsValue.filePath;

--- a/packages/pieces/core/sftp/src/lib/actions/delete-folder.ts
+++ b/packages/pieces/core/sftp/src/lib/actions/delete-folder.ts
@@ -4,6 +4,7 @@ import { Client as FTPClient, FTPError } from 'basic-ftp';
 import { endClient, getClient, getProtocolBackwardCompatibility } from '../common';
 import { sftpAuth } from '../auth';
 import { getSftpError } from './common';
+import { deleteFolderActionOutputSchema } from '../output-schemas';
 
 async function deleteFolderFTP(client: FTPClient, directoryPath: string, recursive: boolean) {
   if (recursive) {
@@ -39,6 +40,7 @@ export const deleteFolderAction = createAction({
         'Enable this option to delete the folder and all its contents, including subfolders and files.',
     }),
   },
+  outputSchema: deleteFolderActionOutputSchema,
   async run(context) {
     const client = await getClient(context.auth.props);
     const directoryPath = context.propsValue.folderPath;

--- a/packages/pieces/core/sftp/src/lib/actions/list-files.ts
+++ b/packages/pieces/core/sftp/src/lib/actions/list-files.ts
@@ -5,6 +5,7 @@ import Client from 'ssh2-sftp-client';
 import { Client as FTPClient, FTPError } from 'basic-ftp';
 import { getSftpError } from './common';
 import { unknown } from 'zod';
+import { listFolderContentsActionOutputSchema } from '../output-schemas';
 
 async function listSFTP(client: Client, directoryPath: string) {
   const contents = await client.list(directoryPath);
@@ -45,6 +46,7 @@ export const listFolderContentsAction = createAction({
       description: 'The path of the folder to list e.g. `./myfolder`',
     }),
   },
+  outputSchema: listFolderContentsActionOutputSchema,
   async run(context) {
     const client = await getClient(context.auth.props);
     const directoryPath = context.propsValue.directoryPath;

--- a/packages/pieces/core/sftp/src/lib/actions/read-file.ts
+++ b/packages/pieces/core/sftp/src/lib/actions/read-file.ts
@@ -5,6 +5,7 @@ import Client from 'ssh2-sftp-client';
 import { Client as FTPClient, FTPError } from 'basic-ftp';
 import { PassThrough, Readable } from 'stream';
 import { getSftpError } from './common';
+import { readFileActionOutputSchema } from '../output-schemas';
 
 // Return a Readable and let the transfer run in the background; files.write
 // consumes it, so the file is never fully buffered in the sandbox. The client
@@ -35,6 +36,7 @@ export const readFileContent = createAction({
       required: true,
     }),
   },
+  outputSchema: readFileActionOutputSchema,
   async run(context) {
     const client = await getClient(context.auth.props);
     const filePath = context.propsValue['filePath'];

--- a/packages/pieces/core/sftp/src/lib/actions/rename-file-or-folder.ts
+++ b/packages/pieces/core/sftp/src/lib/actions/rename-file-or-folder.ts
@@ -5,6 +5,7 @@ import Client from 'ssh2-sftp-client';
 import { Client as FTPClient, FTPError } from 'basic-ftp';
 import { MarkdownVariant } from '@activepieces/pieces-framework';
 import { getSftpError } from './common';
+import { renameFileOrFolderActionOutputSchema } from '../output-schemas';
 
 async function renameFTP(client: FTPClient, oldPath: string, newPath: string) {
   await client.rename(oldPath, newPath);
@@ -41,6 +42,7 @@ export const renameFileOrFolderAction = createAction({
         'The new path of the file or folder e.g. `./myfolder/new-name.mp3`',
     }),
   },
+  outputSchema: renameFileOrFolderActionOutputSchema,
   async run(context) {
     const client = await getClient(context.auth.props);
     const oldPath = context.propsValue.oldPath;

--- a/packages/pieces/core/sftp/src/lib/actions/upload-file.ts
+++ b/packages/pieces/core/sftp/src/lib/actions/upload-file.ts
@@ -6,6 +6,7 @@ import { endClient, getClient, getProtocolBackwardCompatibility } from '../commo
 import { sftpAuth } from '../auth';
 import { Readable } from 'stream';
 import { getSftpError } from './common';
+import { uploadFileActionOutputSchema } from '../output-schemas';
 
 async function uploadFileToFTP(client: FTPClient, fileName: string, body: Readable) {
   const remoteDirectory = fileName.substring(0, fileName.lastIndexOf('/'));
@@ -44,6 +45,7 @@ export const uploadFileAction = createAction({
       streaming: true,
     }),
   },
+  outputSchema: uploadFileActionOutputSchema,
   async run(context) {
     const client = await getClient(context.auth.props);
     const fileName = context.propsValue['fileName'];

--- a/packages/pieces/core/sftp/src/lib/output-schemas.ts
+++ b/packages/pieces/core/sftp/src/lib/output-schemas.ts
@@ -1,0 +1,193 @@
+import { OutputSchema } from '@activepieces/pieces-framework';
+
+const errorFields: OutputSchema['fields'] = [
+  {
+    key: 'status',
+    label: 'Status',
+    description:
+      'Either "success" or "error". These actions report a failure here instead of failing the step, so check it before relying on the result.',
+  },
+  {
+    key: 'error',
+    label: 'Error',
+    description: 'Only present when Status is "error".',
+    children: [
+      {
+        key: 'code',
+        label: 'Error Code',
+        description:
+          'On SFTP, the numeric SFTP status code (2 = no such file, 3 = permission denied) or a Node error code such as ERR_BAD_PATH.',
+      },
+      {
+        key: 'error',
+        label: 'Error Detail',
+        description: 'Only populated on FTP and FTPS.',
+      },
+    ],
+  },
+];
+
+const directoryEntryFields: OutputSchema['fields'] = [
+  {
+    key: 'name',
+    label: 'Name',
+    description: 'File or folder name, without the directory path.',
+  },
+  {
+    key: 'type',
+    label: 'Type',
+    description: '"-" for a file and "d" for a folder.',
+  },
+  {
+    key: 'size',
+    label: 'Size',
+    format: 'filesize',
+  },
+  {
+    key: 'modifyTime',
+    label: 'Modified Time',
+    format: 'datetime',
+    description: 'Populated on SFTP only; FTP and FTPS servers leave this empty.',
+  },
+  {
+    key: 'accessTime',
+    label: 'Accessed Time',
+    format: 'datetime',
+    description: 'Populated on SFTP only; FTP and FTPS servers leave this empty.',
+  },
+  {
+    key: 'rights',
+    label: 'Permissions',
+    children: [
+      { key: 'user', label: 'Owner' },
+      { key: 'group', label: 'Group' },
+      { key: 'other', label: 'Other' },
+    ],
+  },
+  {
+    key: 'owner',
+    label: 'Owner ID',
+  },
+  {
+    key: 'group',
+    label: 'Group ID',
+  },
+];
+
+const watchedFileFields: OutputSchema['fields'] = [
+  {
+    key: 'path',
+    label: 'Path',
+    description: 'Full path of the file, built from the watched directory and the file name.',
+  },
+  {
+    key: 'name',
+    label: 'Name',
+    description: 'File or folder name, without the directory path.',
+  },
+  {
+    key: 'size',
+    label: 'Size',
+    format: 'filesize',
+  },
+  {
+    key: 'type',
+    label: 'Type',
+    description:
+      'On SFTP, "-" for a file and "d" for a folder. On FTP and FTPS, a number: 1 = file, 2 = folder, 3 = symbolic link.',
+  },
+  {
+    key: 'modifyTime',
+    label: 'Modified Time',
+    format: 'datetime',
+    description: 'SFTP only. On FTP and FTPS use Raw Modified Time instead.',
+  },
+  {
+    key: 'accessTime',
+    label: 'Accessed Time',
+    format: 'datetime',
+    description: 'SFTP only.',
+  },
+  {
+    key: 'rawModifiedAt',
+    label: 'Raw Modified Time',
+    description:
+      'FTP and FTPS only, as reported by the server without parsing, for example "Sep 07 09:25".',
+  },
+  {
+    key: 'rights',
+    label: 'Permissions',
+    description: 'SFTP only.',
+    children: [
+      { key: 'user', label: 'Owner' },
+      { key: 'group', label: 'Group' },
+      { key: 'other', label: 'Other' },
+    ],
+  },
+  {
+    key: 'permissions',
+    label: 'Unix Permissions',
+    description: 'FTP and FTPS only, as octal digits.',
+    children: [
+      { key: 'user', label: 'Owner', format: 'number' },
+      { key: 'group', label: 'Group', format: 'number' },
+      { key: 'world', label: 'Other', format: 'number' },
+    ],
+  },
+  {
+    key: 'owner',
+    label: 'Owner ID',
+    description: 'SFTP only. On FTP and FTPS use Owner Name instead.',
+  },
+  {
+    key: 'user',
+    label: 'Owner Name',
+    description: 'FTP and FTPS only.',
+  },
+  {
+    key: 'group',
+    label: 'Group',
+    description: 'Numeric group ID on SFTP, group name on FTP and FTPS.',
+  },
+];
+
+export const createFileActionOutputSchema: OutputSchema = { fields: errorFields };
+
+export const uploadFileActionOutputSchema: OutputSchema = { fields: errorFields };
+
+export const deleteFileActionOutputSchema: OutputSchema = { fields: errorFields };
+
+export const createFolderActionOutputSchema: OutputSchema = { fields: errorFields };
+
+export const deleteFolderActionOutputSchema: OutputSchema = { fields: errorFields };
+
+export const renameFileOrFolderActionOutputSchema: OutputSchema = { fields: errorFields };
+
+export const readFileActionOutputSchema: OutputSchema = {
+  fields: [
+    {
+      key: 'file',
+      label: 'File',
+      format: 'url',
+      description: 'The downloaded file, ready to pass to a later step. Absent when Status is "error".',
+    },
+    ...errorFields,
+  ],
+};
+
+export const listFolderContentsActionOutputSchema: OutputSchema = {
+  fields: [
+    {
+      key: 'contents',
+      label: 'Contents',
+      labelKey: 'name',
+      description: 'Immediate entries of the directory, including hidden dotfiles. Not recursive.',
+      listItems: directoryEntryFields,
+    },
+    ...errorFields,
+  ],
+};
+
+export const newOrModifiedFileTriggerOutputSchema: OutputSchema = {
+  fields: watchedFileFields,
+};

--- a/packages/pieces/core/sftp/src/lib/output-schemas.ts
+++ b/packages/pieces/core/sftp/src/lib/output-schemas.ts
@@ -46,14 +46,14 @@ const directoryEntryFields: OutputSchema['fields'] = [
   {
     key: 'modifyTime',
     label: 'Modified Time',
-    format: 'datetime',
-    description: 'Populated on SFTP only; FTP and FTPS servers leave this empty.',
+    description:
+      'Unix timestamp in milliseconds. Populated on SFTP only; FTP and FTPS servers leave this empty.',
   },
   {
     key: 'accessTime',
     label: 'Accessed Time',
-    format: 'datetime',
-    description: 'Populated on SFTP only; FTP and FTPS servers leave this empty.',
+    description:
+      'Unix timestamp in milliseconds. Populated on SFTP only; FTP and FTPS servers leave this empty.',
   },
   {
     key: 'rights',
@@ -99,14 +99,13 @@ const watchedFileFields: OutputSchema['fields'] = [
   {
     key: 'modifyTime',
     label: 'Modified Time',
-    format: 'datetime',
-    description: 'SFTP only. On FTP and FTPS use Raw Modified Time instead.',
+    description:
+      'Unix timestamp in milliseconds, SFTP only. On FTP and FTPS use Raw Modified Time instead.',
   },
   {
     key: 'accessTime',
     label: 'Accessed Time',
-    format: 'datetime',
-    description: 'SFTP only.',
+    description: 'Unix timestamp in milliseconds, SFTP only.',
   },
   {
     key: 'rawModifiedAt',

--- a/packages/pieces/core/sftp/src/lib/triggers/new-modified-file.ts
+++ b/packages/pieces/core/sftp/src/lib/triggers/new-modified-file.ts
@@ -5,6 +5,7 @@ import { sftpAuth } from '../auth';
 import dayjs from 'dayjs';
 import Client from 'ssh2-sftp-client';
 import { Client as FTPClient, FileInfo as FTPFileInfo } from 'basic-ftp';
+import { newOrModifiedFileTriggerOutputSchema } from '../output-schemas';
 
 function getModifyTime(file: Client.FileInfo | FTPFileInfo, protocol: string): number {
   return protocol === 'sftp' ? 
@@ -74,6 +75,7 @@ export const newOrModifiedFile = createTrigger({
       defaultValue: false,
     }),
   },
+  outputSchema: newOrModifiedFileTriggerOutputSchema,
   type: TriggerStrategy.POLLING,
   onEnable: async (context) => {
     await pollingHelper.onEnable(polling, context);


### PR DESCRIPTION
## Description

Five pieces returned raw JSON in the builder, so users had to read the payload to work out what a step produced, and AI/MCP consumers got no usable path map. This adds `outputSchema` to each, so results render as a labelled, typed tree in the data selector.

| Piece | Version | Schemas |
|---|---|---|
| FTP/SFTP | 0.5.8 → 0.5.9 | 9 (8 actions + trigger) |
| ntfy | 0.2.8 → 0.2.9 | 1 |
| Coda | 0.1.8 → 0.1.9 | 7 (6 actions + trigger) |
| Pushover | 0.2.7 → 0.2.8 | 1 |
| Systeme.io | 0.1.8 → 0.1.9 | 7 (5 actions + 2 triggers) |

**25 schemas, 4 of them triggers.** Every one authored from live captured output, never from documentation or a piece's own declared types. One commit per piece; each version bumped exactly once.

### Capture corrected shapes the code itself had wrong

Worth calling out, because several schemas would have been silently broken had they been written from the declared shapes:

- **Systeme.io `newContact`** delivers the contact fields at the **top level**. Its hand-written `sampleData` claims `{ contact: … }` — authoring from that would have left *every* path dead.
- **Systeme.io `newTagAddedToContact`** has no `addedAt` field, which its `sampleData` claims.
- **Coda's own TypeScript interfaces are incomplete**: `CodaTableReference` omits `tableType`, `browserLink` and a nested `parent`; `get-table` returns an undeclared `viewId`, and a `displayColumn` with no `name`.
- **FTP/SFTP's trigger and its list action return different shapes** — the action normalises the FTP shape onto the SFTP one, the trigger passes the raw listing through. The trigger schema describes the union and names the protocol in each field's description.
- **Pushover's `receipt`** is returned only at emergency priority (2), confirmed by sending at both.

### Deliberate skips — decisions, not omissions

- **QR Code** — `text_to_qrcode` returns `context.files.write(...)`, typed `Promise<string>`. A bare string has no fields, so no schema is possible. Untouched.
- **ImageRouter, Socialkit** — no working credential available, so nothing could be captured. Both untouched.
- **Coda `upsert-row`** — returns the literal `{ success: true }`; confirmed by running it.
- **Systeme.io `newSale`** — fires only on a completed purchase, which could not be produced. Deliberately not authored from its unverified `sampleData`.
- **`custom_api_call`** on ntfy and Coda — generic passthrough.

### Known issues found while capturing (reported, not fixed here)

Each is a behaviour change and does not belong in a schema PR, but all were reproduced live against real servers:

- **FTP/SFTP: every action reports SUCCEEDED on failure.** All eight catch and return `{status:'error'}` instead of throwing. This is *why* these schemas describe `status` — it is the only failure signal a downstream step gets.
- **FTP: `list_files` reports every file as a folder and every folder as a file.** It maps `item.type === 1 ? 'd' : '-'`, but basic-ftp's enum is `File = 1`, `Directory = 2`.
- **FTP: `list_files` returns no timestamp** — it maps `modifyTime: item.modifiedAt`, which basic-ftp only populates for MLSD servers.
- **FTP: `list_files` puts a permissions object into a string field** and hardcodes `owner`/`group` empty, discarding data the library supplied.
- **`getSftpError`'s 31-entry table can never produce a hit** — on SFTP the `instanceof FTPError` guard is always false; on FTP the code is an FTP reply code, never an SFTP status code.
- **ntfy `send_notification` throws when Title is left blank**, and Title is `required: false`. ntfy has one action, so the piece breaks for anyone who skips an optional field.
- **Pushover's auth has no `validate`**, so a connection shows ACTIVE with an unusable token.
- **Coda applies row writes asynchronously** — `create-row` returns an id that is briefly unreadable. Documented in that field's description rather than left to surprise people.

## How was this tested?

Every schema was captured and verified against **live** services — a Dockerised SFTP and FTP server, ntfy.sh, and real Coda / Pushover / Systeme.io accounts. No shape was taken from documentation.

**Path resolution.** For each piece, every path the schema emits was re-resolved against the captured runs at the correct scope (top level, `children`, `listItems`), and checked against the **MCP flattener** as well as the builder — the flattener has no wrapper fallback, so a bare key that renders fine in the builder is silently broken for agents. Result: sftp 30/30, ntfy 16/16, Coda 28/28, Pushover 3/3, Systeme.io 56/56 — **0 paths resolve nowhere** on any piece. The validator carries a negative control (a schema resolved against a deliberately wrong root), so the pass is not vacuous.

**Both branches of every union were captured, not assumed** — including the deliberate-failure branch of all six sftp status-only actions, Coda's `find-row` hit *and* miss, Systeme.io's contact-found *and* not-found, and Pushover at default *and* emergency priority.

**Rendering.** 21 of the 25 schemas were additionally asserted in the builder with Playwright: the whole Friendly View tree expanded, every declared label checked, each `format` confirmed to visibly take effect (`21 B` / `5.4 KB` for filesize, `Yes`/`No` for boolean, `Today, 2:48 PM` for ISO datetimes, item labels from `labelKey`), and named secrets asserted **absent**. The four exceptions are Systeme.io's two webhook triggers — "Test Trigger" waits for a live event, so their evidence is captured real webhook deliveries — plus `createContact` and `removeTagFromContact`, which verify through the API and reuse field-sets asserted elsewhere.

**Edition paths:** verified on CE (`AP_EDITION=ce`) locally. This change is edition-agnostic — `outputSchema` is piece metadata with no platform flag, plan gating, or EE code path.

Build and lint clean on all five pieces: 0 errors. Remaining lint warnings are pre-existing in the pieces' own code (`no-explicit-any`, unused imports) — none on a line this PR authors.

Relates to GIT-1858.

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

`outputSchema` is additive metadata. No `run()` return value, prop, default or limit changes, and no new setup step for self-hosters.

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)

No authentication, secret-handling, permission, cryptography, SSRF or file-handling code is touched. Worth noting for review though, since a schema decides what gets surfaced: ntfy, Pushover and every sftp action return a full `HttpResponse`, and sftp's `read_file_content` returns a signed download URL containing a JWT. The schemas deliberately exclude `headers` and `config` throughout, and this is **asserted rather than assumed** — an automated check scans every emitted path for credential-shaped keys, and the Playwright suites assert that real header values and the JWT do not appear in the rendered output.
