### PR TITLE
fix(linear): a revoked API key no longer connects as if it worked

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5108,7 +5108,7 @@
     },
     "packages/pieces/community/linear": {
       "name": "@activepieces/piece-linear",
-      "version": "0.5.1",
+      "version": "0.5.2",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -5118,6 +5118,7 @@
       },
       "devDependencies": {
         "tslib": "2.6.2",
+        "vitest": "3.2.6",
       },
     },
     "packages/pieces/community/linka": {

--- a/packages/pieces/community/linear/package.json
+++ b/packages/pieces/community/linear/package.json
@@ -11,7 +11,8 @@
     "@activepieces/core-utils": "workspace:*"
   },
   "devDependencies": {
-    "tslib": "2.6.2"
+    "tslib": "2.6.2",
+    "vitest": "3.2.6"
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",

--- a/packages/pieces/community/linear/package.json
+++ b/packages/pieces/community/linear/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-linear",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "dependencies": {
@@ -15,6 +15,7 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",
+    "test": "vitest run",
     "bundle": "node ../../../../dist/packages/cli/src/index.js pieces bundle",
     "lint": "eslint 'src/**/*.ts'"
   }

--- a/packages/pieces/community/linear/src/index.ts
+++ b/packages/pieces/community/linear/src/index.ts
@@ -1,5 +1,6 @@
-import { createPiece, PieceAuth } from '@activepieces/pieces-framework';
+import { createPiece, PieceAuth, tryCatch } from '@activepieces/pieces-framework';
 import { PieceCategory } from '@activepieces/pieces-framework';
+import { LinearClient } from '@linear/sdk';
 import { linearCreateComment } from './lib/actions/comments/create-comment';
 import { linearCreateIssue } from './lib/actions/issues/create-issue';
 import { linearUpdateIssue } from './lib/actions/issues/update-issue';
@@ -26,14 +27,27 @@ export const linearAuth = PieceAuth.SecretText({
   required: true,
   description: markdown,
   validate: async ({ auth }) => {
-    if (auth.startsWith('lin_api_')) {
+    if (!auth.startsWith('lin_api_')) {
+      return {
+        valid: false,
+        error: 'Invalid API Key',
+      };
+    }
+    const { error } = await tryCatch(() => new LinearClient({ apiKey: auth }).viewer);
+    if (!error) {
       return {
         valid: true,
       };
     }
+    if (isUnauthorized(error)) {
+      return {
+        valid: false,
+        error: 'Linear did not accept this API key. It may have been revoked or rotated. Create a new personal API key under Settings, Security & access in Linear, then try again.',
+      };
+    }
     return {
       valid: false,
-      error: 'Invalid API Key',
+      error: 'Could not reach Linear to check this API key. Please try again.',
     };
   },
 });
@@ -64,3 +78,7 @@ export const linear = createPiece({
     linearRemovedProject,
   ],
 });
+
+function isUnauthorized(error: unknown): boolean {
+  return typeof error === 'object' && error !== null && 'status' in error && error.status === 401;
+}

--- a/packages/pieces/community/linear/src/lib/auth-validate.test.ts
+++ b/packages/pieces/community/linear/src/lib/auth-validate.test.ts
@@ -1,0 +1,69 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mockViewer = vi.fn()
+
+vi.mock('@linear/sdk', () => ({
+  LinearClient: class {
+    get viewer() {
+      return mockViewer()
+    }
+  },
+  LinearDocument: {},
+}))
+
+import { linearAuth } from '../index'
+
+function validate(auth: string) {
+  return linearAuth.validate!({ auth, server: {} as never })
+}
+
+function linearError(status: number, type: string) {
+  return Object.assign(new Error('Linear rejected the request'), { status, type })
+}
+
+describe('linearAuth.validate', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('rejects a key that does not look like a Linear personal api key without calling Linear', async () => {
+    const result = await validate('not-a-linear-key')
+
+    expect(result).toEqual({ valid: false, error: 'Invalid API Key' })
+    expect(mockViewer).not.toHaveBeenCalled()
+  })
+
+  it('rejects a well-formed key that Linear refuses, naming the action to take', async () => {
+    mockViewer.mockRejectedValue(linearError(401, 'AuthenticationError'))
+
+    const result = await validate('lin_api_revokedkeyrevokedkeyrevoked')
+
+    expect(result.valid).toBe(false)
+    expect(result.valid === false && result.error).toContain('Linear did not accept this API key')
+  })
+
+  it('accepts a key Linear accepts', async () => {
+    mockViewer.mockResolvedValue({ id: 'user-1', admin: true })
+
+    const result = await validate('lin_api_goodkeygoodkeygoodkeygoodkey')
+
+    expect(result).toEqual({ valid: true })
+  })
+
+  it('accepts a key whose owner is not a workspace admin, so actions-only connections keep working', async () => {
+    mockViewer.mockResolvedValue({ id: 'user-1', admin: false })
+
+    const result = await validate('lin_api_nonadminnonadminnonadminnon')
+
+    expect(result).toEqual({ valid: true })
+  })
+
+  it('separates an unreachable Linear from a refused key', async () => {
+    mockViewer.mockRejectedValue(new Error('getaddrinfo ENOTFOUND api.linear.app'))
+
+    const result = await validate('lin_api_goodkeygoodkeygoodkeygoodkey')
+
+    expect(result.valid).toBe(false)
+    expect(result.valid === false && result.error).toContain('Could not reach Linear')
+  })
+})

--- a/packages/pieces/community/linear/vitest.config.ts
+++ b/packages/pieces/community/linear/vitest.config.ts
@@ -1,0 +1,19 @@
+import path from 'path'
+import { defineConfig } from 'vitest/config'
+
+const repoRoot = path.resolve(__dirname, '../../../..')
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+  },
+  resolve: {
+    alias: {
+      '@activepieces/pieces-framework': path.resolve(repoRoot, 'packages/pieces/framework/src/index.ts'),
+      '@activepieces/pieces-common': path.resolve(repoRoot, 'packages/pieces/common/src/index.ts'),
+      '@activepieces/core-piece-types': path.resolve(repoRoot, 'packages/core/piece-types/src/index.ts'),
+      '@activepieces/core-utils': path.resolve(repoRoot, 'packages/core/utils/src/index.ts'),
+    },
+  },
+})


### PR DESCRIPTION
Fixes [GIT-1856](https://linear.app/activepieces/issue/GIT-1856)
Closes #15323

## Description

`linearAuth.validate` only checked that the key started with `lin_api_` and never called Linear. A revoked or rotated key therefore saved as a connection showing **Active**, then failed at the first real request. Split out of [GIT-1847](https://linear.app/activepieces/issue/GIT-1847), where a customer's revoked key surfaced as an unrelated-looking error.

It now makes one authenticated `viewer` call. A refused credential (401) is rejected with the steps to create a new key; any other failure gets a separate message so a Linear outage does not read as a bad key.

**Keys whose owner is not a workspace admin are still accepted.** Linear refuses every webhook operation for a non-admin key (`403 "Invalid role: admin required"`), so such a key can never enable a Linear trigger, but the piece's six actions work fine with any member key, and `validate` is binary (`{valid:true} | {valid:false, error}`) with no warning channel. Rejecting non-admin keys would block a working actions-only setup, so the trigger failure is left to surface at publish time.

**Fix**
- `src/index.ts` in `validate`: keep the `lin_api_` prefix check as a free pre-check, then `new LinearClient({ apiKey: auth }).viewer` via `tryCatch`, branching on a 401
- `package.json`: 0.5.1 to 0.5.2 (PATCH, bug fix)

## How was this tested?

- 5 unit tests in `src/lib/auth-validate.test.ts` (new `vitest.config.ts` follows the `fillout-forms` precedent), proven **red-first**: the 2 encoding the fix fail against pre-fix code, the 3 encoding preserved behaviour (bad prefix rejected, good key accepted, non-admin accepted) pass on both sides. **CI does not execute these:** `turbo run test` in `ci.yml` is filtered to engine/shared/sandbox/ai-providers/core-execution/pieces-framework/web/worker, so no community-piece test runs there. Run locally with `cd packages/pieces/community/linear && npx vitest run`. The durable evidence is the live drive below.
- `turbo run build lint --filter=@activepieces/piece-linear` clean (0 errors; 5 pre-existing warnings in `common/props.ts`, untouched).
- Live drive against the real Linear API on a local CE stack with the piece loaded via `AP_DEV_PIECES=linear`. Inverse drive, both directions: a dead key is refused and no connection row is written; a real key is accepted and the row is created `ACTIVE`. The real key used is itself `admin: false`, so it doubles as proof that non-admin keys still connect.
- Probed the SDK error shape directly rather than assuming: a bogus key throws with a top-level `status === 401` and `type: 'AuthenticationError'`, which is what makes the guard viable without a cast.
- Not verified: EE and Cloud edition paths. Auth validation is edition-independent and the diff contains no edition-gated code.

Visual: real connection dialog at Connections, New Connection, Linear, driven with a dead key (inline rejection) and with a live key (dialog closes, row `ACTIVE`), plus the pre-fix state showing a dead key saved as **Active**. Screenshots in the `Visual verification` comment. Note the "Connection failed with error" prefix is supplied by the dialog, not the piece.

Other affected paths: checked. No other piece uses a prefix-only `validate`; the pattern here is a bespoke `startsWith` rather than a shared helper, so there is no sibling to sweep. The 7 Linear triggers are untouched.

Repro: a `lin_api_`-shaped but revoked key passed `validate` and saved as `ACTIVE`, full steps and the 401-versus-403 probes in the Reproduction block.

Product decision embedded: non-admin keys are accepted rather than refused, so a Linear connection that can never run a trigger is still creatable; alternative considered: reject them, which names the admin requirement up front but blocks actions-only users. Also: connecting now requires a live round trip to Linear, so a Linear outage blocks creating or testing a Linear connection. Validate runs only on create, update and explicit revalidate (`POST /:id/revalidate`), never on a background sweep, so existing connections are unaffected.

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no, reviewed, not breaking
- [ ] yes, technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes, functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

- [x] no, reviewed, no security impact
- [ ] yes, security-sensitive (call out the risk and mitigation in the description above)

<details>
<summary>Plan &amp; reasoning</summary>

## Plan
- One authenticated call in `validate`, no new files in the piece's runtime path. `viewer { id admin }` answers both questions in a single request: is the key accepted, and is its owner an admin.
- Constructed the SDK client inline rather than adding a `getViewer()` to `LinearClientWrapper`: `common/client.ts` already imports `linearAuth` from `index.ts`, so importing the wrapper into `index.ts` would close a require cycle.
- `tryCatch` comes from `@activepieces/pieces-framework`, not `@activepieces/core-utils`. Every piece's `.eslintrc.json` restricts `@activepieces/core-*`, so the direct import is a hard lint error even though the piece's `package.json` declares `core-utils` as a dependency. Worth resolving separately: the root CLAUDE.md says pieces may import the thin core packages, and the enforced lint rule says they may not.
- 401 detection is a 3-line local type guard rather than `formatPieceError`, which lives in the restricted package. Cast-free and `any`-free.
- Footprint: planned 1 product file (~18 lines) plus a version bump; actual the same, plus 2 test files.

## Non-happy scenarios considered
- Linear unreachable or rate limiting: separate message, connection refused. Failing closed is right, since a key that cannot be checked cannot be used either.
- Key valid for a different workspace: accepted, which is correct.
- `viewer` resolving with no admin field: treated as accepted, matching the decision above.
- Existing connections during a Linear outage: unaffected, validate never runs on a background sweep.
- A server that cannot reach api.linear.app at all: connection creation now fails where it previously succeeded, but the piece was unusable on that host anyway, so failing at connect is the earlier and clearer point.

## Alternatives rejected
- Reject non-admin keys: blocks a working actions-only setup, and `validate` cannot warn instead of blocking.
- Implement `getConnectionIdentifier` to surface admin status on the connection row: larger, and orthogonal to the reported bug.
- Add the admin caveat to the auth `description`: piece prop copy is i18n-keyed, so editing it invalidates every locale file for a caveat that does not fix the bug.
</details>

<details>
<summary>Reproduction</summary>

Probes, runnable: https://gist.github.com/majewskibartosz/62ed1ccd3ed09732a0e8360981dd85b7

```bash
git clone https://gist.github.com/62ed1ccd3ed09732a0e8360981dd85b7.git git-1856-repro && cd git-1856-repro
```

## Environment
- Local CE stack: `api` + `@activepieces/engine` + `worker` + `web` from the working tree, scratch Postgres database and a separate Redis DB index, `AP_DEV_PIECES=linear` so the piece is loaded from source
- Live Linear API; only a personal API key is needed for the probes
- The key used for the accept case is a real key whose owner is **not** a workspace admin

## Harness
- `probe-sdk.mjs` calls `new LinearClient({ apiKey }).viewer` with a bogus key and a real one and prints whether the thrown error carries a branchable top-level `status`. Run it from inside `packages/pieces/community/linear` so `@linear/sdk` resolves.
- `README.md` carries the raw-GraphQL 401-versus-403 probes and the reasoning for accepting non-admin keys.

## Trigger
Connections, New Connection, Linear, paste a `lin_api_`-shaped key that Linear no longer accepts, Save.

## Results

| Build | dead key | connection row | live non-admin key |
|---|---|---|---|
| pre-fix | saved silently | created, status **Active** | created, `ACTIVE` |
| post-fix | refused inline with the steps to create a new key | none written | created, `ACTIVE` |

SDK error shape, from `probe-sdk.mjs`:

```
bogus key -> THREW
   has status prop : true
   status value    : 401
   guard matches401: true
   type            : AuthenticationError
real key  -> OK { id: '7e18836f-...', admin: false }
```

Linear's own distinction, which set the scope:

| Case | HTTP | code |
|---|---|---|
| revoked or bogus key | 401 | `AUTHENTICATION_ERROR` |
| valid non-admin key, webhook operation | 403 | `FORBIDDEN` ("Invalid role: admin required") |
| valid key, `viewer` | 200 | returns `{ id, admin }` |
</details>
