### PR TITLE
perf(pieces): cache translated metadata lists with bounded memory

### DIFF
--- a/brain/knowledge/pieces-engine/pieces.md
+++ b/brain/knowledge/pieces-engine/pieces.md
@@ -19,6 +19,8 @@ The metadata catalog of automation integrations ("pieces") — each a named inte
 - **OutputSchema** — optional per-action/trigger structured render hint (`fields`, `itemLabel`); set by the piece author, consumed by the builder's Smart Output Viewer and data selector. Opt-in and non-breaking.
 
 ### Gotchas
+- Completed translated lists are cached by release, platform and locale for 60 seconds; project visibility, audience, search and sorting still run on each request. The cache retains at most four serialized lists within a 96 MiB payload budget and allows four fills at a time. It is bypassed with `AP_DEV_PIECES` and in tests.
+- Catalogue invalidation clears completed lists locally and through the existing Redis channel. In-flight fills carry a generation so an invalidated result cannot repopulate the cache. Returned lists are independently deserialized to prevent cross-request mutation; usage counts can lag by up to the TTL. The payload budget excludes transient query/parsed objects, and the first request after expiry still pays the database and translation cost.
 - Available all editions; base listing + install is Community-level.
 - EE/Cloud per-piece and per-action/trigger visibility flows through `resolveVisibility` (`ee/pieces/filters/piece-filtering-utils.ts`), which returns a `VisibilityPolicy` or `null` on CE / when `platformId`/`projectId` is nil (callers treat `null` as no filtering). The policy is derived from the project's **piece set** (via `project.pieceSetId`, falling back to the platform Default).
 - Install and sync also enqueue a tool-search reindex, but only when `isToolSearchEnabled()`; no-op otherwise.

--- a/packages/server/api/src/app/pieces/metadata/piece-cache.ts
+++ b/packages/server/api/src/app/pieces/metadata/piece-cache.ts
@@ -1,4 +1,4 @@
-import { isNil } from '@activepieces/core-utils'
+import { isNil, tryCatch } from '@activepieces/core-utils'
 import { ApEnvironment, PieceType } from '@activepieces/shared'
 import { FastifyBaseLogger } from 'fastify'
 import { repoFactory } from '../../core/db/repo-factory'
@@ -15,18 +15,28 @@ const isTestingEnvironment = environment === ApEnvironment.TESTING
 let cachedRegistry: PieceRegistryEntry[] | null = null
 let registryGeneration = 0
 
+const LIST_TTL_MS = 60_000
+const LIST_MAX_ENTRIES = 4
+const LIST_MAX_PENDING = 4
+const LIST_MAX_BYTES = 96 * 1024 * 1024
+const cachedLists = new Map<string, { json: string, expiresAt: number }>()
+const pendingLists = new Map<string, Promise<string>>()
+let cachedListBytes = 0
+
 export const pieceCache = (log: FastifyBaseLogger) => {
     return {
         async setup(): Promise<void> {
             log.info('[pieceCache] Registry cache initialized')
             if (!isTestingEnvironment) {
                 await pubsub.subscribe(PIECE_REGISTRY_INVALIDATION_CHANNEL, () => {
-                    cachedRegistry = null
-                    registryGeneration++
+                    invalidateLocalCache()
                     log.debug('[pieceCache] Registry invalidated via pubsub')
                 })
             }
         },
+
+        getGeneration: (): number => registryGeneration,
+        loadList,
 
         async loadRegistry(): Promise<PieceRegistryEntry[]> {
             const persistedRegistry = await loadPersistedRegistry()
@@ -35,12 +45,92 @@ export const pieceCache = (log: FastifyBaseLogger) => {
         },
 
         async invalidate(): Promise<void> {
-            cachedRegistry = null
-            registryGeneration++
+            invalidateLocalCache()
             if (!isTestingEnvironment) {
                 await pubsub.publish(PIECE_REGISTRY_INVALIDATION_CHANNEL, '1')
             }
         },
+    }
+}
+
+function invalidateLocalCache(): void {
+    cachedRegistry = null
+    registryGeneration++
+    cachedLists.clear()
+    cachedListBytes = 0
+}
+
+function removeList(key: string): void {
+    const entry = cachedLists.get(key)
+    if (entry) {
+        cachedListBytes -= entry.json.length * 2
+        cachedLists.delete(key)
+    }
+}
+
+function storeList({ key, json }: { key: string, json: string }): void {
+    const bytes = json.length * 2
+    if (bytes > LIST_MAX_BYTES) {
+        return
+    }
+    for (const [entryKey, entry] of cachedLists) {
+        if (entry.expiresAt <= Date.now()) {
+            removeList(entryKey)
+        }
+    }
+    removeList(key)
+    while (cachedLists.size >= LIST_MAX_ENTRIES || cachedListBytes + bytes > LIST_MAX_BYTES) {
+        const oldestKey = cachedLists.keys().next().value
+        if (isNil(oldestKey)) {
+            return
+        }
+        removeList(oldestKey)
+    }
+    cachedLists.set(key, { json, expiresAt: Date.now() + LIST_TTL_MS })
+    cachedListBytes += bytes
+}
+
+async function loadList({ key, loader }: LoadListParams): Promise<PieceMetadataSchema[]> {
+    if (isTestingEnvironment || system.get(AppSystemProp.DEV_PIECES)) {
+        return loader()
+    }
+    for (;;) {
+        const generation = registryGeneration
+        const cached = cachedLists.get(key)
+        if (cached && cached.expiresAt > Date.now()) {
+            cachedLists.delete(key)
+            cachedLists.set(key, cached)
+            return JSON.parse(cached.json)
+        }
+        removeList(key)
+        const pendingKey = `${generation}:${key}`
+        let pending = pendingLists.get(pendingKey)
+        if (!pending) {
+            if (pendingLists.size >= LIST_MAX_PENDING) {
+                await tryCatch(() => Promise.race(pendingLists.values()))
+                continue
+            }
+            pending = (async () => {
+                const json = JSON.stringify(await loader())
+                if (generation === registryGeneration) {
+                    storeList({ key, json })
+                }
+                return json
+            })()
+            pendingLists.set(pendingKey, pending)
+        }
+        let json: string
+        try {
+            json = await pending
+        }
+        finally {
+            if (pendingLists.get(pendingKey) === pending) {
+                pendingLists.delete(pendingKey)
+            }
+        }
+        if (generation === registryGeneration) {
+            return JSON.parse(json)
+        }
     }
 }
 
@@ -87,4 +177,9 @@ export type PieceRegistryEntry = {
     version: string
     minimumSupportedRelease?: string
     maximumSupportedRelease?: string
+}
+
+type LoadListParams = {
+    key: string
+    loader: () => Promise<PieceMetadataSchema[]>
 }

--- a/packages/server/api/src/app/pieces/metadata/piece-metadata-service.ts
+++ b/packages/server/api/src/app/pieces/metadata/piece-metadata-service.ts
@@ -23,11 +23,11 @@ export const pieceMetadataService = (log: FastifyBaseLogger) => {
         },
         async list(params: ListParams): Promise<PieceMetadataModelSummary[]> {
             const locale = params.locale ?? LocalesEnum.ENGLISH
-            const translatedPieces = await dedupe(`list:${params.platformId ?? ''}:${locale}`, () => fetchLatestPieces({
-                platformId: params.platformId,
-                locale,
-                log,
-            }))
+            const key = JSON.stringify([apVersionUtil.getCurrentRelease(), params.platformId ?? null, locale])
+            const translatedPieces = await pieceCache(log).loadList({
+                key,
+                loader: () => fetchLatestPieces({ platformId: params.platformId, locale, log }),
+            })
             const policy = await resolveVisibility({ platformId: params.platformId, projectId: params.projectId, log })
             const audience = params.audience ?? PieceAudienceFilter.HUMAN
             const audiencePieces = translatedPieces.map((piece) => ({ ...piece, actions: filterActionsByAudience(piece.actions, audience) }))
@@ -406,7 +406,7 @@ const increaseMajorVersion = (version: string): string => {
 async function fetchLatestPieces({ platformId, locale = LocalesEnum.ENGLISH, log }: FetchLatestPiecesParams): Promise<PieceMetadataSchema[]> {
     const currentRelease = apVersionUtil.getCurrentRelease()
 
-    const latestPieces = await dedupe(`latest-pieces:${currentRelease}`, () => fetchLatestCompatiblePiecesFromDB(currentRelease))
+    const latestPieces = await dedupe(`latest-pieces:${currentRelease}:${pieceCache(log).getGeneration()}`, () => fetchLatestCompatiblePiecesFromDB(currentRelease))
     const translatedPieces = translatePieces(latestPieces, locale)
 
     const devPieces = await loadDevPiecesIfEnabled(log)

--- a/packages/server/api/test/unit/app/pieces/piece-cache.test.ts
+++ b/packages/server/api/test/unit/app/pieces/piece-cache.test.ts
@@ -1,0 +1,271 @@
+import { apId } from '@activepieces/core-utils'
+import { ApEnvironment, PackageType, PieceType } from '@activepieces/shared'
+import { fastify } from 'fastify'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { PieceMetadataSchema } from '../../../../src/app/pieces/metadata/piece-metadata-entity'
+
+const mocks = vi.hoisted(() => {
+    const properties = new Map<string, string>()
+    const listeners: ((message: string) => void)[] = []
+    return {
+        properties,
+        listeners,
+        publish: vi.fn(),
+        subscribe: vi.fn(async (_channel: string, listener: (message: string) => void) => {
+            listeners.push(listener)
+        }),
+    }
+})
+
+vi.mock('../../../../src/app/core/db/repo-factory', () => ({
+    repoFactory: vi.fn(() => vi.fn()),
+}))
+
+vi.mock('../../../../src/app/helper/pubsub', () => ({
+    pubsub: {
+        publish: mocks.publish,
+        subscribe: mocks.subscribe,
+    },
+}))
+
+vi.mock('../../../../src/app/helper/system/system', () => ({
+    system: {
+        get: vi.fn((prop: string) => mocks.properties.get(prop)),
+    },
+}))
+
+vi.mock('../../../../src/app/pieces/metadata/utils', () => ({
+    loadDevPiecesIfEnabled: vi.fn().mockResolvedValue([]),
+}))
+
+type Deferred = {
+    promise: Promise<void>
+    resolve: () => void
+}
+
+function deferred(): Deferred {
+    let resolve = (): void => {}
+    const promise = new Promise<void>((done) => {
+        resolve = done
+    })
+    return { promise, resolve }
+}
+
+function piece({ name, description = 'description' }: { name: string, description?: string }): PieceMetadataSchema {
+    return {
+        id: apId(),
+        created: '2026-01-01T00:00:00.000Z',
+        updated: '2026-01-01T00:00:00.000Z',
+        name,
+        displayName: name,
+        logoUrl: 'https://example.com/logo.svg',
+        description,
+        authors: [],
+        version: '1.0.0',
+        actions: {},
+        triggers: {},
+        contextInfo: undefined,
+        projectUsage: 0,
+        pieceType: PieceType.OFFICIAL,
+        packageType: PackageType.REGISTRY,
+    }
+}
+
+async function loadCache() {
+    vi.resetModules()
+    const { pieceCache } = await import('../../../../src/app/pieces/metadata/piece-cache')
+    return pieceCache(fastify().log)
+}
+
+beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.listeners.length = 0
+    mocks.properties.clear()
+    mocks.properties.set('ENVIRONMENT', ApEnvironment.PRODUCTION)
+})
+
+afterEach(() => {
+    vi.useRealTimers()
+})
+
+describe('pieceCache list cache', () => {
+    it('caches tenant and locale lists independently and returns copied graphs', async () => {
+        const cache = await loadCache()
+        const french = vi.fn().mockResolvedValue([piece({ name: 'fr' })])
+        const english = vi.fn().mockResolvedValue([piece({ name: 'en' })])
+        const key = JSON.stringify(['0.90.2', 'platform-a', 'fr'])
+        const first = await cache.loadList({ key, loader: french })
+        first[0].authors.push('changed')
+        const second = await cache.loadList({ key, loader: french })
+        await cache.loadList({ key: JSON.stringify(['0.90.2', 'platform-a', 'en']), loader: english })
+        await cache.loadList({ key: JSON.stringify(['0.90.2', 'platform-b', 'fr']), loader: french })
+        expect(second[0].displayName).toBe('fr')
+        expect(second[0].authors).toEqual([])
+        expect(french).toHaveBeenCalledTimes(2)
+        expect(english).toHaveBeenCalledTimes(1)
+    })
+
+    it('shares four concurrent fills for one key', async () => {
+        const cache = await loadCache()
+        const gate = deferred()
+        const loader = vi.fn(async () => {
+            await gate.promise
+            return [piece({ name: 'shared' })]
+        })
+        const requests = [
+            cache.loadList({ key: 'shared', loader }),
+            cache.loadList({ key: 'shared', loader }),
+            cache.loadList({ key: 'shared', loader }),
+            cache.loadList({ key: 'shared', loader }),
+        ]
+        await Promise.resolve()
+        expect(loader).toHaveBeenCalledTimes(1)
+        gate.resolve()
+        const results = await Promise.all(requests)
+        expect(results).toHaveLength(4)
+        results[0][0].authors.push('changed')
+        expect(results[1][0].authors).toEqual([])
+        expect(results[0][0]).not.toBe(results[1][0])
+    })
+
+    it('does not serve a fill that was invalidated before it completed', async () => {
+        const cache = await loadCache()
+        const gate = deferred()
+        const loader = vi.fn()
+            .mockImplementationOnce(async () => {
+                await gate.promise
+                return [piece({ name: 'stale' })]
+            })
+            .mockResolvedValueOnce([piece({ name: 'fresh' })])
+        const started = cache.loadList({ key: 'freshness', loader })
+        const generation = cache.getGeneration()
+        await cache.invalidate()
+        gate.resolve()
+
+        await expect(started).resolves.toMatchObject([{ name: 'fresh' }])
+        expect(cache.getGeneration()).toBe(generation + 1)
+        expect(loader).toHaveBeenCalledTimes(2)
+    })
+
+    it('invalidates locally and through pubsub', async () => {
+        const cache = await loadCache()
+        const loader = vi.fn()
+            .mockResolvedValueOnce([piece({ name: 'first' })])
+            .mockResolvedValueOnce([piece({ name: 'second' })])
+            .mockResolvedValueOnce([piece({ name: 'third' })])
+
+        await cache.setup()
+        await cache.loadList({ key: 'invalidate', loader })
+        await cache.invalidate()
+        await cache.loadList({ key: 'invalidate', loader })
+        const listener = mocks.listeners.at(0)
+        listener?.('1')
+        await cache.loadList({ key: 'invalidate', loader })
+
+        expect(mocks.publish).toHaveBeenCalledTimes(1)
+        expect(loader).toHaveBeenCalledTimes(3)
+    })
+
+    it('expires entries after sixty seconds', async () => {
+        vi.useFakeTimers()
+        const cache = await loadCache()
+        const loader = vi.fn()
+            .mockResolvedValueOnce([piece({ name: 'first' })])
+            .mockResolvedValueOnce([piece({ name: 'second' })])
+
+        await cache.loadList({ key: 'ttl', loader })
+        await vi.advanceTimersByTimeAsync(60_001)
+        await cache.loadList({ key: 'ttl', loader })
+        expect(loader).toHaveBeenCalledTimes(2)
+    })
+
+    it('evicts the oldest entry after four cached lists', async () => {
+        const cache = await loadCache()
+        const loaders = Array.from({ length: 5 }, (_, index) => vi.fn().mockResolvedValue([piece({ name: `piece-${index}` })]))
+
+        for (const [index, loader] of loaders.slice(0, 4).entries()) {
+            await cache.loadList({ key: `entry-${index}`, loader })
+        }
+        await cache.loadList({ key: 'entry-0', loader: loaders[0] })
+        await cache.loadList({ key: 'entry-4', loader: loaders[4] })
+        await cache.loadList({ key: 'entry-0', loader: loaders[0] })
+        await cache.loadList({ key: 'entry-1', loader: loaders[1] })
+
+        expect(loaders[0]).toHaveBeenCalledTimes(1)
+        expect(loaders[1]).toHaveBeenCalledTimes(2)
+    })
+
+    it('evicts cached lists when their combined serialized size exceeds the byte budget', async () => {
+        const cache = await loadCache()
+        const loader = vi.fn().mockResolvedValue([piece({ name: 'large', description: 'x'.repeat(25 * 1024 * 1024) })])
+
+        await cache.loadList({ key: 'first', loader })
+        await cache.loadList({ key: 'second', loader })
+        await cache.loadList({ key: 'second', loader })
+        expect(loader).toHaveBeenCalledTimes(2)
+        await cache.loadList({ key: 'first', loader })
+        expect(loader).toHaveBeenCalledTimes(3)
+    })
+
+    it('does not cache a serialized list larger than ninety-six MiB', async () => {
+        const cache = await loadCache()
+        const loader = vi.fn().mockResolvedValue([piece({
+            name: 'large',
+            description: 'x'.repeat(51 * 1024 * 1024),
+        })])
+
+        await cache.loadList({ key: 'large', loader })
+        await cache.loadList({ key: 'large', loader })
+
+        expect(loader).toHaveBeenCalledTimes(2)
+    })
+
+    it('waits for one of four pending fills before starting another', async () => {
+        const cache = await loadCache()
+        const gates = Array.from({ length: 4 }, deferred)
+        const pending = gates.map((gate, index) => cache.loadList({
+            key: `pending-${index}`,
+            loader: async () => {
+                await gate.promise
+                return [piece({ name: `pending-${index}` })]
+            },
+        }))
+        const fifth = vi.fn().mockResolvedValue([piece({ name: 'fifth' })])
+        const request = cache.loadList({ key: 'pending-4', loader: fifth })
+
+        await Promise.resolve()
+        expect(fifth).not.toHaveBeenCalled()
+        gates[0].resolve()
+        await request
+        gates.slice(1).forEach((gate) => gate.resolve())
+        await Promise.all(pending)
+
+        expect(fifth).toHaveBeenCalledTimes(1)
+    })
+
+    it('clears a rejected fill and bypasses caching in development and tests', async () => {
+        const cache = await loadCache()
+        const rejected = vi.fn().mockRejectedValueOnce(new Error('database failed'))
+        const recovered = vi.fn().mockResolvedValue([piece({ name: 'recovered' })])
+
+        await expect(cache.loadList({ key: 'rejected', loader: rejected })).rejects.toThrow('database failed')
+        await cache.loadList({ key: 'rejected', loader: recovered })
+
+        mocks.properties.set('DEV_PIECES', 'local-piece')
+        const developmentCache = await loadCache()
+        const developmentLoader = vi.fn().mockResolvedValue([piece({ name: 'development' })])
+        await developmentCache.loadList({ key: 'development', loader: developmentLoader })
+        await developmentCache.loadList({ key: 'development', loader: developmentLoader })
+
+        mocks.properties.delete('DEV_PIECES')
+        mocks.properties.set('ENVIRONMENT', ApEnvironment.TESTING)
+        const testingCache = await loadCache()
+        const testingLoader = vi.fn().mockResolvedValue([piece({ name: 'testing' })])
+        await testingCache.loadList({ key: 'testing', loader: testingLoader })
+        await testingCache.loadList({ key: 'testing', loader: testingLoader })
+
+        expect(recovered).toHaveBeenCalledTimes(1)
+        expect(developmentLoader).toHaveBeenCalledTimes(2)
+        expect(testingLoader).toHaveBeenCalledTimes(2)
+    })
+})


### PR DESCRIPTION
## Description

Repeated `GET /v1/pieces` requests currently reload and translate the entire catalogue: the existing deduplication shares in-flight work but retains no completed result. This adds a bounded cache of translated lists, before project visibility, audience filtering, search and sorting.

The cache is keyed by release, platform and locale, retains at most four lists within a 96 MiB serialized-payload budget, and expires entries after 60 seconds. Local and Redis catalogue invalidation clear completed entries; a generation check discards and retries work invalidated while loading. At most four fills run concurrently. Each caller receives an independently parsed object graph, including callers sharing a fill. Development pieces and testing environments bypass the cache.

This addresses the memory-growth concern behind #13228 with explicit entry, payload and fill limits. The payload budget conservatively counts two bytes per string character; it is **not** a total heap limit, since loading and parsing still allocate temporary objects. Usage/popularity values may lag by up to 60 seconds. The first request after expiry or invalidation still pays the database/translation cost.

Related: #15296. Its locale-projection change is not included here. The measurements below used self-hosted 0.90.2 with that projection applied to **both** the baseline and the cached version, isolating the additional cache change:

| Request | Before cache | Warm cache |
| --- | ---: | ---: |
| French | 1.830 s | 0.433 s |
| English | 0.660 s | 0.404 s |

Catalogue: 763 pieces. These are HTTP total-time medians of three sequential requests after one initial request per locale, measured on the same deployment; they are small operational samples, not a controlled load benchmark. One warm French request took 0.892 s. Both locale responses were identical before/after. A real Redis invalidation was followed by a 3.298 s refill and a 0.438 s warm response.

## How was this tested?

- `cd packages/server/api && vitest run test/unit/app/pieces/piece-cache.test.ts test/unit/app/pieces/piece-searching.test.ts --bail=1`: **13 tests pass**, including 10 new cache tests.
- `tsc -p packages/server/api/tsconfig.app.json --noEmit`: passes.
- `npm run lint-dev`: all 33 tasks pass; existing warnings remain.
- Production-mode cache unit tests exercise expiry, key separation, deep-copy isolation, local/pubsub invalidation, invalidation during loading, rejected fills, entry/byte limits, fill concurrency and development/testing bypasses.
- Self-hosted deployment and authenticated page verified. Full CE/EE/Cloud integration suites were not run; the cache precedes edition-specific visibility and does not retain policy results.

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

- [ ] no — reviewed, no security impact
- [x] yes — security-sensitive (call out the risk and mitigation in the description above)

The cache retains platform-scoped metadata. Platform and locale are part of the key; project visibility and component filtering are reapplied on every request, and cached objects are never returned by reference. No authentication checks or stored credentials are changed.
