### PR TITLE
refactor(engine): name the engine process exit codes

### DIFF
--- a/packages/core/execution/src/lib/engine/engine-exit-codes.ts
+++ b/packages/core/execution/src/lib/engine/engine-exit-codes.ts
@@ -1,0 +1,8 @@
+export const EngineExitCode = {
+    UNCAUGHT_EXCEPTION: 3,
+    UNHANDLED_REJECTION: 4,
+    WORKER_HANDSHAKE_TIMEOUT: 5,
+    WORKER_SOCKET_DISCONNECTED: 6,
+} as const
+
+export type EngineExitCode = (typeof EngineExitCode)[keyof typeof EngineExitCode]

--- a/packages/core/execution/src/lib/engine/index.ts
+++ b/packages/core/execution/src/lib/engine/index.ts
@@ -2,6 +2,7 @@ export * from './engine-operation'
 export * from './engine-contract'
 export * from './requests'
 export * from './engine-constants'
+export * from './engine-exit-codes'
 export * from './execution-errors'
 
 export enum ExecutionMode {

--- a/packages/server/engine/src/lib/worker-socket.ts
+++ b/packages/server/engine/src/lib/worker-socket.ts
@@ -3,6 +3,7 @@ import {
     createNotifyClient,
     createRpcServer,
     EngineContract,
+    EngineExitCode,
     EngineResponse,
     ERROR_MESSAGES_TO_REDACT,
     WorkerNotifyContract,
@@ -37,7 +38,7 @@ export const workerSocket = {
             initialConnectWatchdog = undefined
             // eslint-disable-next-line no-console
             console.error('[engine] Failed to connect to worker within 60s, exiting')
-            process.exit(5)
+            process.exit(EngineExitCode.WORKER_HANDSHAKE_TIMEOUT)
         }, INITIAL_CONNECT_TIMEOUT_MS)
 
         notifyClient = createNotifyClient<WorkerNotifyContract>(socket)
@@ -57,7 +58,7 @@ export const workerSocket = {
             }
             // eslint-disable-next-line no-console
             console.error(`[engine] Worker socket disconnected (${reason}), exiting`)
-            process.exit(6)
+            process.exit(EngineExitCode.WORKER_SOCKET_DISCONNECTED)
         })
 
         const originalLog = console.log

--- a/packages/server/engine/src/main.ts
+++ b/packages/server/engine/src/main.ts
@@ -1,4 +1,5 @@
 import { isNil } from '@activepieces/core-utils'
+import { EngineExitCode } from '@activepieces/shared'
 import { flowRunProgressReporter } from './lib/helper/flow-run-progress-reporter'
 import { ssrfGuard } from './lib/network/ssrf-guard'
 import { workerSocket } from './lib/worker-socket'
@@ -15,10 +16,10 @@ if (!isNil(SANDBOX_ID)) {
 
 process.on('uncaughtException', (error) => {
     workerSocket.sendError(error)
-    process.exit(3)
+    process.exit(EngineExitCode.UNCAUGHT_EXCEPTION)
 })
 
 process.on('unhandledRejection', (reason) => {
     workerSocket.sendError(reason)
-    process.exit(4)
+    process.exit(EngineExitCode.UNHANDLED_REJECTION)
 })


### PR DESCRIPTION
## Description

`process.exit(3 / 4 / 5 / 6)` at the engine boundary required code-diving to know what each number meant. This PR introduces a shared `EngineExitCode` `as const` enum-object (with a derived union type) and swaps every raw call site to the named constant.

**Pure refactor — no behavior change.**

| Constant | Value | Site |
|---|---|---|
| `EngineExitCode.UNCAUGHT_EXCEPTION` | `3` | `main.ts` process handler |
| `EngineExitCode.UNHANDLED_REJECTION` | `4` | `main.ts` process handler |
| `EngineExitCode.WORKER_HANDSHAKE_TIMEOUT` | `5` | `worker-socket.ts` init watchdog |
| `EngineExitCode.WORKER_SOCKET_DISCONNECTED` | `6` | `worker-socket.ts` disconnect handler |

Placed in `@activepieces/core-execution` so both the engine (thin, bundled) and the sandbox (`server-utils`) can consume the same values via `@activepieces/shared`.

### History note

An earlier version of this PR also split exit-6 into `WORKER_SOCKET_PING_TIMEOUT (6)` vs `WORKER_SOCKET_TRANSPORT_CLOSED (7)`, and reclassified exit-6 in `sandbox.ts`'s `handleProcessExit` as `SANDBOX_EXECUTION_TIMEOUT`. Reviewer P1 correctly pointed out that a socket.io `ping timeout` doesn't uniquely identify an engine hang — the worker's own event loop can be CPU-starved and fail to send the heartbeat. Misclassifying that case as `TIMEOUT` would strip the retry that recovers a transient worker-side outage. That reclassification has been reverted; exit-6 keeps its original fall-through to `SANDBOX_INTERNAL_ERROR` (retryable). Only the naming refactor remains.

## How was this tested?

- `npx turbo run lint --filter=@activepieces/core-execution --filter=@activepieces/engine --filter=@activepieces/sandbox` — 0 errors.
- `cd packages/server/sandbox && npx vitest run test/lib/sandbox/sandbox.test.ts` — **51/51 pass** (unchanged from main).

No behavior change to test — every swap is a compile-checked equivalent of the previous integer.

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

Named substitutions for the exact same integer values the engine has always emitted. No API, env var, or on-disk change.

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)

Naming refactor only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)