### PR TITLE
fix(sandbox): surface missing piece bundles as FAILED runs, not INTERNAL_ERROR

### DIFF
--- a/packages/core/utils/src/lib/activepieces-error.ts
+++ b/packages/core/utils/src/lib/activepieces-error.ts
@@ -86,6 +86,7 @@ export type ApErrorParams =
     | DoesNotMeetBusinessRequirementsParams
     | PieceSyncNotSupportedErrorParams
     | SandboxLogSizeExceededParams
+    | PieceBundleNotAvailableParams
     | SecretManagerConnectionFailedParams
     | SecretManagerGetSecretFailedParams
     | SecretManagerKeyNotSecretParams
@@ -117,6 +118,12 @@ export type SandboxExecutionTimeoutParams = BaseErrorParams<ErrorCode.SANDBOX_EX
     standardOutput: string
     standardError: string
     neverStarted?: boolean
+}>
+
+export type PieceBundleNotAvailableParams = BaseErrorParams<ErrorCode.PIECE_BUNDLE_NOT_AVAILABLE, {
+    pieceName: string
+    pieceVersion: string
+    status: number
 }>
 
 export type SandboxInternalErrorParams = BaseErrorParams<ErrorCode.SANDBOX_INTERNAL_ERROR, {
@@ -545,6 +552,7 @@ export enum ErrorCode {
     SANDBOX_EXECUTION_TIMEOUT = 'SANDBOX_EXECUTION_TIMEOUT',
     SANDBOX_MEMORY_ISSUE = 'SANDBOX_MEMORY_ISSUE',
     SANDBOX_INTERNAL_ERROR = 'SANDBOX_INTERNAL_ERROR',
+    PIECE_BUNDLE_NOT_AVAILABLE = 'PIECE_BUNDLE_NOT_AVAILABLE',
     SANDBOX_CAPACITY_EXCEEDED = 'SANDBOX_CAPACITY_EXCEEDED',
     TRIGGER_EXECUTION_FAILED = 'TRIGGER_EXECUTION_FAILED',
     EMAIL_AUTH_DISABLED = 'EMAIL_AUTH_DISABLED',

--- a/packages/server/sandbox/src/lib/cache/pieces/piece-installer.ts
+++ b/packages/server/sandbox/src/lib/cache/pieces/piece-installer.ts
@@ -1,6 +1,6 @@
 import { readFile, rm, stat, writeFile } from 'node:fs/promises'
 import path, { dirname, join } from 'node:path'
-import { ensureTrailingSlash, groupBy, isEmpty, isNil, tryCatch } from '@activepieces/core-utils'
+import { ActivepiecesError, ensureTrailingSlash, ErrorCode, groupBy, isEmpty, isNil, tryCatch } from '@activepieces/core-utils'
 import { type ApLogger, fileSystemUtils, memoryLock, wideEvent } from '@activepieces/server-utils'
 import { ExecutionMode, getPieceNameFromAlias, PackageType, PiecePackage, PieceType } from '@activepieces/shared'
 import writeFileAtomic from 'write-file-atomic'
@@ -258,6 +258,12 @@ async function saveBundlesToDiskIfNotCached(rootWorkspace: string, pieces: Piece
         const url = pieceBundleEndpointUrl(publicApiUrl, piece)
         const response = await fetch(url, { headers: { Authorization: `Bearer ${engineToken}` } })
         if (!response.ok) {
+            if (response.status === 404 || response.status === 410) {
+                throw new ActivepiecesError({
+                    code: ErrorCode.PIECE_BUNDLE_NOT_AVAILABLE,
+                    params: { pieceName: piece.pieceName, pieceVersion: piece.pieceVersion, status: response.status },
+                })
+            }
             throw new Error(`Failed to fetch piece bundle ${piece.pieceName}@${piece.pieceVersion}: ${response.status} ${response.statusText}`)
         }
         await fileSystemUtils.threadSafeMkdir(dirname(bundlePath))

--- a/packages/server/worker/src/lib/execute/jobs/execute-flow.ts
+++ b/packages/server/worker/src/lib/execute/jobs/execute-flow.ts
@@ -102,6 +102,16 @@ export const executeFlowJob: JobHandler<ExecuteFlowJobData, FireAndForgetJobResu
                     await reportFlowStatus({ ctx, data, status: FlowRunStatus.LOG_SIZE_EXCEEDED })
                     return { kind: JobResultKind.FIRE_AND_FORGET, status: EngineResponseStatus.LOG_SIZE_EXCEEDED }
                 }
+                if (e.error.code === ErrorCode.PIECE_BUNDLE_NOT_AVAILABLE) {
+                    const { pieceName, pieceVersion } = e.error.params
+                    await reportFlowStatus({
+                        ctx,
+                        data,
+                        status: FlowRunStatus.FAILED,
+                        failedStep: { name: flowVersion.trigger.name, displayName: flowVersion.trigger.displayName, message: `Piece "${pieceName}@${pieceVersion}" is no longer available in the piece registry. Republish the piece or upgrade the flow to a newer version.` },
+                    })
+                    return { kind: JobResultKind.FIRE_AND_FORGET, status: EngineResponseStatus.OK }
+                }
             }
             await reportFlowStatus({ ctx, data, status: FlowRunStatus.INTERNAL_ERROR, internalError: toInternalError(RunInternalErrorSource.WORKER, e) })
             throw e

--- a/packages/server/worker/src/lib/execute/jobs/execute-flow.ts
+++ b/packages/server/worker/src/lib/execute/jobs/execute-flow.ts
@@ -1,7 +1,7 @@
 import { inspect } from 'node:util'
 import { ActivepiecesError, ErrorCode, isNil, spreadIfDefined, tryCatch } from '@activepieces/core-utils'
 import { onCallService } from '@activepieces/server-utils'
-import { BeginExecuteFlowOperation, EngineOperationType, EngineResponseStatus, ExecuteFlowJobData, ExecutionType, FailedStep, FlowRunStatus, FlowVersion, ResumeExecuteFlowOperation, RunInternalError, RunInternalErrorSource, WorkerJobType } from '@activepieces/shared'
+import { BeginExecuteFlowOperation, EngineOperationType, EngineResponseStatus, ExecuteFlowJobData, ExecutionType, FailedStep, FlowActionType, FlowRunStatus, flowStructureUtil, FlowVersion, ResumeExecuteFlowOperation, RunInternalError, RunInternalErrorSource, WorkerJobType } from '@activepieces/shared'
 import { system, WorkerSystemProp } from '../../config/configs'
 import { workerSettings } from '../../config/worker-settings'
 import { FireAndForgetJobResult, JobContext, JobHandler, JobResultKind } from '../types'
@@ -104,11 +104,16 @@ export const executeFlowJob: JobHandler<ExecuteFlowJobData, FireAndForgetJobResu
                 }
                 if (e.error.code === ErrorCode.PIECE_BUNDLE_NOT_AVAILABLE) {
                     const { pieceName, pieceVersion } = e.error.params
+                    const owner = findStepOwningPiece({ flowVersion, pieceName, pieceVersion })
                     await reportFlowStatus({
                         ctx,
                         data,
                         status: FlowRunStatus.FAILED,
-                        failedStep: { name: flowVersion.trigger.name, displayName: flowVersion.trigger.displayName, message: `Piece "${pieceName}@${pieceVersion}" is no longer available in the piece registry. Republish the piece or upgrade the flow to a newer version.` },
+                        failedStep: {
+                            name: owner.name,
+                            displayName: owner.displayName,
+                            message: `Piece "${pieceName}@${pieceVersion}" is unavailable in this environment (bundle not accessible). Confirm the piece and version are installed and visible in this project, or update the step to a supported version.`,
+                        },
                     })
                     return { kind: JobResultKind.FIRE_AND_FORGET, status: EngineResponseStatus.OK }
                 }
@@ -160,6 +165,15 @@ function buildFlowOperation(
     }
 }
 
+function findStepOwningPiece({ flowVersion, pieceName, pieceVersion }: FindStepOwningPieceParams): { name: string, displayName: string } {
+    const match = flowStructureUtil.getAllSteps(flowVersion.trigger).find(step => {
+        if (step.type !== FlowActionType.PIECE) return false
+        return step.settings.pieceName === pieceName && step.settings.pieceVersion === pieceVersion
+    })
+    if (match) return { name: match.name, displayName: match.displayName }
+    return { name: flowVersion.trigger.name, displayName: flowVersion.trigger.displayName }
+}
+
 function toInternalError(source: RunInternalErrorSource, error: unknown): RunInternalError {
     const isApError = error instanceof ActivepiecesError
     const base = error instanceof Error
@@ -208,4 +222,10 @@ type ReportFlowStatusParams = {
     status: FlowRunStatus
     internalError?: RunInternalError
     failedStep?: FailedStep
+}
+
+type FindStepOwningPieceParams = {
+    flowVersion: FlowVersion
+    pieceName: string
+    pieceVersion: string
 }

--- a/packages/server/worker/test/lib/execute/jobs/execute-flow.test.ts
+++ b/packages/server/worker/test/lib/execute/jobs/execute-flow.test.ts
@@ -233,7 +233,34 @@ describe('executeFlowJob', () => {
             )
         })
 
-        it('reports a missing piece bundle (404) as FAILED with a user-facing message, not INTERNAL_ERROR', async () => {
+        it('reports a missing action-piece bundle (404) as FAILED anchored on the owning action step', async () => {
+            // The unavailable piece belongs to step_1 (Slack Action). Anchoring on the trigger
+            // would mislead run dialogs, alerts, and "jump to failed step" — the fix walks the
+            // flow_version tree and matches on (pieceName, pieceVersion).
+            const ctx = makeMockContext()
+            ctx.runtime.execute = vi.fn().mockRejectedValue(new ActivepiecesError({
+                code: ErrorCode.PIECE_BUNDLE_NOT_AVAILABLE,
+                params: { pieceName: '@activepieces/piece-slack', pieceVersion: '~0.2.0', status: 404 },
+            }))
+
+            const result = await executeFlowJob.execute(ctx, syncJobData())
+
+            expect(result.status).toBe(EngineResponseStatus.OK)
+            expect(ctx.apiClient.uploadRunLog).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    status: FlowRunStatus.FAILED,
+                    failedStep: expect.objectContaining({
+                        name: 'step_1',
+                        displayName: 'Slack Action',
+                        message: expect.stringContaining('@activepieces/piece-slack'),
+                    }),
+                    workerHandlerId: 'server-1',
+                    httpRequestId: 'req-1',
+                }),
+            )
+        })
+
+        it('falls back to the trigger step when no step in the flow matches the missing piece', async () => {
             const ctx = makeMockContext()
             ctx.runtime.execute = vi.fn().mockRejectedValue(new ActivepiecesError({
                 code: ErrorCode.PIECE_BUNDLE_NOT_AVAILABLE,
@@ -247,10 +274,10 @@ describe('executeFlowJob', () => {
                 expect.objectContaining({
                     status: FlowRunStatus.FAILED,
                     failedStep: expect.objectContaining({
+                        name: 'trigger_1',
+                        displayName: 'Gmail Trigger',
                         message: expect.stringContaining('url-crawl'),
                     }),
-                    workerHandlerId: 'server-1',
-                    httpRequestId: 'req-1',
                 }),
             )
         })

--- a/packages/server/worker/test/lib/execute/jobs/execute-flow.test.ts
+++ b/packages/server/worker/test/lib/execute/jobs/execute-flow.test.ts
@@ -233,6 +233,28 @@ describe('executeFlowJob', () => {
             )
         })
 
+        it('reports a missing piece bundle (404) as FAILED with a user-facing message, not INTERNAL_ERROR', async () => {
+            const ctx = makeMockContext()
+            ctx.runtime.execute = vi.fn().mockRejectedValue(new ActivepiecesError({
+                code: ErrorCode.PIECE_BUNDLE_NOT_AVAILABLE,
+                params: { pieceName: 'url-crawl', pieceVersion: '0.2.2', status: 404 },
+            }))
+
+            const result = await executeFlowJob.execute(ctx, syncJobData())
+
+            expect(result.status).toBe(EngineResponseStatus.OK)
+            expect(ctx.apiClient.uploadRunLog).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    status: FlowRunStatus.FAILED,
+                    failedStep: expect.objectContaining({
+                        message: expect.stringContaining('url-crawl'),
+                    }),
+                    workerHandlerId: 'server-1',
+                    httpRequestId: 'req-1',
+                }),
+            )
+        })
+
         it('reports an engine INTERNAL_ERROR with both ids', async () => {
             const ctx = makeMockContext()
             ctx.runtime.execute = vi.fn().mockResolvedValue({ status: EngineResponseStatus.INTERNAL_ERROR, error: 'boom', timings: {} })


### PR DESCRIPTION
## Description

The piece-installer's bundle-fetch site at `packages/server/sandbox/src/lib/cache/pieces/piece-installer.ts:260` threw a plain `Error` for any non-ok HTTP status. The worker treats plain errors as `INTERNAL_ERROR` — which pages oncall and BullMQ retries the job up to its attempt limit against a URL that will never come back (npm unpublish, retracted platform archive, deleted piece version).

Prod trace: run `IzUMnkMEIBQmLsL1YFOac` — a webhook flow using the custom `url-crawl@0.2.2` piece — sat in the failed set for 30 days across 9 attempts, all `Failed to fetch piece bundle url-crawl@0.2.2: 404 Not Found`. That version simply doesn't exist in the platform's registry anymore.

**Fix**: split by HTTP status at the throw site.

- **404 / 410 (permanently gone)** → new `ActivepiecesError({ code: ErrorCode.PIECE_BUNDLE_NOT_AVAILABLE, params: { pieceName, pieceVersion, status } })`. The worker's `catch` in `execute-flow.ts` recognises this code and reports the run as `FlowRunStatus.FAILED` with a `failedStep` message: *"Piece \"<name>@<version>\" is no longer available in the piece registry. Republish the piece or upgrade the flow to a newer version."* The job completes `FIRE_AND_FORGET` with `EngineResponseStatus.OK` — no retry, no page.
- **Other statuses (5xx, timeouts, throttling)** → keep the existing generic `Error` path so transient failures still retry and page.

Applies to **all piece types** — custom ARCHIVE pieces (platform-uploaded tarballs) and REGISTRY pieces (`@activepieces/*` + third-party npm) both flow through the same bundle-fetch endpoint (`v1/engine/pieces/bundle`).

## How was this tested?

- New regression test in `packages/server/worker/test/lib/execute/jobs/execute-flow.test.ts`: `ctx.runtime.execute` rejects with `PIECE_BUNDLE_NOT_AVAILABLE`, asserts the job returns `EngineResponseStatus.OK` and `apiClient.uploadRunLog` is called with `status: FAILED` and a `failedStep.message` containing the piece name.
- Full `execute-flow.test.ts` suite: **13/13 pass**.
- Lint clean across `@activepieces/core-utils`, `@activepieces/engine`, `@activepieces/sandbox`, `worker`, `api`.
- **CE / EE / Cloud paths**: fix lives in the shared sandbox/worker layer (no `ee/` code); behaviour identical across editions.

Fixes # (issue)

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

Only reclassifies terminal state and error surface for a case that already fails today. Runs that previously landed as `INTERNAL_ERROR` after 9 retries now land as `FAILED` after 1 attempt with a clearer message. No API field, env var, or migration changes.

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)