### PR TITLE
feat(gmail): add label management and archive actions

### DIFF
--- a/packages/pieces/community/gmail/package.json
+++ b/packages/pieces/community/gmail/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-gmail",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "dependencies": {

--- a/packages/pieces/community/gmail/src/index.ts
+++ b/packages/pieces/community/gmail/src/index.ts
@@ -31,6 +31,10 @@ import { gmailGetLabelAction } from './lib/actions/get-label-action';
 import { gmailGetProfileAction } from './lib/actions/get-profile-action';
 import { gmailListHistoryAction } from './lib/actions/list-history-action';
 import { gmailStopWatchAction } from './lib/actions/stop-watch-action';
+import { gmailCreateLabelAction } from './lib/actions/create-label-action';
+import { gmailAddLabelToEmailAction } from './lib/actions/add-label-to-email-action';
+import { gmailRemoveLabelFromEmailAction } from './lib/actions/remove-label-from-email-action';
+import { gmailArchiveEmailAction } from './lib/actions/archive-email-action';
 
 export {
   gmailAuth,
@@ -72,6 +76,10 @@ export const gmail = createPiece({
     gmailGetProfileAction,
     gmailListHistoryAction,
     gmailStopWatchAction,
+    gmailCreateLabelAction,
+    gmailAddLabelToEmailAction,
+    gmailRemoveLabelFromEmailAction,
+    gmailArchiveEmailAction,
     createCustomApiCallAction({
       baseUrl: () => 'https://gmail.googleapis.com/gmail/v1',
       auth: gmailAuth,

--- a/packages/pieces/community/gmail/src/lib/actions/add-label-to-email-action.ts
+++ b/packages/pieces/community/gmail/src/lib/actions/add-label-to-email-action.ts
@@ -1,0 +1,58 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { gmailAuth, createGoogleClient } from '../auth';
+import { gmail as googleGmail } from '@googleapis/gmail';
+import { GmailProps } from '../common/props';
+import { gmailAddLabelToEmailActionOutputSchema } from '../output-schemas';
+
+export const gmailAddLabelToEmailAction = createAction({
+  auth: gmailAuth,
+  name: 'gmail_add_label_to_email',
+  classification: 'WRITE',
+  displayName: 'Add Label to Email',
+  description: 'Apply a label to an email message.',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Applies an existing label to a single email message by message ID, without removing any of its current labels. Look up the label with List Labels and the message ID with Search Email or Get Message. Idempotent: true — applying a label the message already carries has no additional effect.',
+    idempotent: true,
+  },
+  props: {
+    message_id: Property.ShortText({
+      displayName: 'Message ID',
+      description:
+        'The Gmail message ID to label (obtain from Search Email or Get Message).',
+      required: true,
+    }),
+    label: GmailProps.label({
+      description: 'The label to apply to the message.',
+      required: true,
+    }),
+  },
+  outputSchema: gmailAddLabelToEmailActionOutputSchema,
+  async run(context) {
+    const authClient = await createGoogleClient(context.auth);
+    const gmail = googleGmail({ version: 'v1', auth: authClient });
+
+    try {
+      const response = await gmail.users.messages.modify({
+        userId: 'me',
+        id: context.propsValue.message_id,
+        requestBody: {
+          addLabelIds: [context.propsValue.label.id],
+        },
+      });
+      return response.data;
+    } catch (error: any) {
+      if (error.code === 403) {
+        throw new Error(
+          'Insufficient permissions to modify labels on a message. Ensure the gmail.modify scope is granted.'
+        );
+      } else if (error.code === 404) {
+        throw new Error(
+          `Message not found: "${context.propsValue.message_id}". Use Search Email or Get Message to find a valid message ID.`
+        );
+      }
+      throw new Error(`Failed to add label to email: ${error.message}`);
+    }
+  },
+});

--- a/packages/pieces/community/gmail/src/lib/actions/archive-email-action.ts
+++ b/packages/pieces/community/gmail/src/lib/actions/archive-email-action.ts
@@ -1,0 +1,53 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { gmailAuth, createGoogleClient } from '../auth';
+import { gmail as googleGmail } from '@googleapis/gmail';
+import { gmailArchiveEmailActionOutputSchema } from '../output-schemas';
+
+export const gmailArchiveEmailAction = createAction({
+  auth: gmailAuth,
+  name: 'gmail_archive_email',
+  classification: 'WRITE',
+  displayName: 'Archive Email',
+  description: 'Archive an email message by removing it from the inbox.',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Archives a single email message by message ID, removing the INBOX label so it no longer appears in the inbox while remaining searchable and in its thread. Does not delete the message or move it to Trash. Obtain the message ID from Search Email or Get Message. Idempotent: true — archiving an already-archived message has no additional effect.',
+    idempotent: true,
+  },
+  props: {
+    message_id: Property.ShortText({
+      displayName: 'Message ID',
+      description:
+        'The Gmail message ID to archive (obtain from Search Email or Get Message).',
+      required: true,
+    }),
+  },
+  outputSchema: gmailArchiveEmailActionOutputSchema,
+  async run(context) {
+    const authClient = await createGoogleClient(context.auth);
+    const gmail = googleGmail({ version: 'v1', auth: authClient });
+
+    try {
+      const response = await gmail.users.messages.modify({
+        userId: 'me',
+        id: context.propsValue.message_id,
+        requestBody: {
+          removeLabelIds: ['INBOX'],
+        },
+      });
+      return response.data;
+    } catch (error: any) {
+      if (error.code === 403) {
+        throw new Error(
+          'Insufficient permissions to modify labels on a message. Ensure the gmail.modify scope is granted.'
+        );
+      } else if (error.code === 404) {
+        throw new Error(
+          `Message not found: "${context.propsValue.message_id}". Use Search Email or Get Message to find a valid message ID.`
+        );
+      }
+      throw new Error(`Failed to archive email: ${error.message}`);
+    }
+  },
+});

--- a/packages/pieces/community/gmail/src/lib/actions/create-label-action.ts
+++ b/packages/pieces/community/gmail/src/lib/actions/create-label-action.ts
@@ -1,0 +1,51 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { gmailAuth, createGoogleClient } from '../auth';
+import { gmail as googleGmail } from '@googleapis/gmail';
+import { gmailCreateLabelActionOutputSchema } from '../output-schemas';
+
+export const gmailCreateLabelAction = createAction({
+  auth: gmailAuth,
+  name: 'gmail_create_label',
+  classification: 'WRITE',
+  displayName: 'Create Label',
+  description: 'Create a new label in the mailbox.',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Creates a new user label in the mailbox with the given name and visibility settings. Look it up first with List Labels to avoid creating a duplicate, since Gmail allows two labels with the same name. Idempotent: false — each call creates a new label, even if one with the same name already exists.',
+    idempotent: false,
+  },
+  props: {
+    name: Property.ShortText({
+      displayName: 'Label Name',
+      description: 'The display name of the new label, e.g. "Follow Up".',
+      required: true,
+    }),
+  },
+  outputSchema: gmailCreateLabelActionOutputSchema,
+  async run(context) {
+    const authClient = await createGoogleClient(context.auth);
+    const gmail = googleGmail({ version: 'v1', auth: authClient });
+
+    try {
+      const response = await gmail.users.labels.create({
+        userId: 'me',
+        requestBody: {
+          name: context.propsValue.name,
+        },
+      });
+      return response.data;
+    } catch (error: any) {
+      if (error.code === 403) {
+        throw new Error(
+          'Insufficient permissions to create a label. Ensure the gmail.modify scope is granted.'
+        );
+      } else if (error.code === 400 || error.code === 409) {
+        throw new Error(
+          `Failed to create label "${context.propsValue.name}": ${error.message}. A label with this name may already exist.`
+        );
+      }
+      throw new Error(`Failed to create label: ${error.message}`);
+    }
+  },
+});

--- a/packages/pieces/community/gmail/src/lib/actions/create-label-action.ts
+++ b/packages/pieces/community/gmail/src/lib/actions/create-label-action.ts
@@ -12,7 +12,7 @@ export const gmailCreateLabelAction = createAction({
   audience: 'both',
   aiMetadata: {
     description:
-      'Creates a new user label in the mailbox with the given name and visibility settings. Look it up first with List Labels to avoid creating a duplicate, since Gmail allows two labels with the same name. Idempotent: false — each call creates a new label, even if one with the same name already exists.',
+      'Creates a new user label in the mailbox with the given name. Look it up first with List Labels to avoid attempting to create a duplicate. Idempotent: false — each call creates a new label, and a duplicate name fails the request rather than reusing the existing label.',
     idempotent: false,
   },
   props: {

--- a/packages/pieces/community/gmail/src/lib/actions/remove-label-from-email-action.ts
+++ b/packages/pieces/community/gmail/src/lib/actions/remove-label-from-email-action.ts
@@ -1,0 +1,58 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { gmailAuth, createGoogleClient } from '../auth';
+import { gmail as googleGmail } from '@googleapis/gmail';
+import { GmailProps } from '../common/props';
+import { gmailRemoveLabelFromEmailActionOutputSchema } from '../output-schemas';
+
+export const gmailRemoveLabelFromEmailAction = createAction({
+  auth: gmailAuth,
+  name: 'gmail_remove_label_from_email',
+  classification: 'WRITE',
+  displayName: 'Remove Label From Email',
+  description: 'Remove a label from an email message.',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Removes an existing label from a single email message by message ID, leaving its other labels untouched. Look up the label with List Labels and the message ID with Search Email or Get Message. Idempotent: true — removing a label the message does not carry has no additional effect.',
+    idempotent: true,
+  },
+  props: {
+    message_id: Property.ShortText({
+      displayName: 'Message ID',
+      description:
+        'The Gmail message ID to unlabel (obtain from Search Email or Get Message).',
+      required: true,
+    }),
+    label: GmailProps.label({
+      description: 'The label to remove from the message.',
+      required: true,
+    }),
+  },
+  outputSchema: gmailRemoveLabelFromEmailActionOutputSchema,
+  async run(context) {
+    const authClient = await createGoogleClient(context.auth);
+    const gmail = googleGmail({ version: 'v1', auth: authClient });
+
+    try {
+      const response = await gmail.users.messages.modify({
+        userId: 'me',
+        id: context.propsValue.message_id,
+        requestBody: {
+          removeLabelIds: [context.propsValue.label.id],
+        },
+      });
+      return response.data;
+    } catch (error: any) {
+      if (error.code === 403) {
+        throw new Error(
+          'Insufficient permissions to modify labels on a message. Ensure the gmail.modify scope is granted.'
+        );
+      } else if (error.code === 404) {
+        throw new Error(
+          `Message not found: "${context.propsValue.message_id}". Use Search Email or Get Message to find a valid message ID.`
+        );
+      }
+      throw new Error(`Failed to remove label from email: ${error.message}`);
+    }
+  },
+});

--- a/packages/pieces/community/gmail/src/lib/auth.ts
+++ b/packages/pieces/community/gmail/src/lib/auth.ts
@@ -11,6 +11,7 @@ const gmailServiceAccountScopes = [
   'https://www.googleapis.com/auth/gmail.send',
   'https://www.googleapis.com/auth/gmail.readonly',
   'https://www.googleapis.com/auth/gmail.compose',
+  'https://www.googleapis.com/auth/gmail.modify',
 ];
 
 export const gmailScopes = [...gmailServiceAccountScopes, 'email'];

--- a/packages/pieces/community/gmail/src/lib/output-schemas.ts
+++ b/packages/pieces/community/gmail/src/lib/output-schemas.ts
@@ -973,6 +973,22 @@ export const gmailGetLabelActionOutputSchema: OutputSchema = {
   ],
 };
 
+export const gmailCreateLabelActionOutputSchema: OutputSchema = {
+  fields: gmailLabelBaseFields,
+};
+
+export const gmailAddLabelToEmailActionOutputSchema: OutputSchema = {
+  fields: gmailMessageResourceFields,
+};
+
+export const gmailRemoveLabelFromEmailActionOutputSchema: OutputSchema = {
+  fields: gmailMessageResourceFields,
+};
+
+export const gmailArchiveEmailActionOutputSchema: OutputSchema = {
+  fields: gmailMessageResourceFields,
+};
+
 export const gmailGetProfileActionOutputSchema: OutputSchema = {
   fields: [
     { key: 'emailAddress', label: 'Email Address', format: 'email' },


### PR DESCRIPTION
## Description

Adds 4 new Gmail actions:
- **Create Label** — create a new label in the mailbox
- **Add Label to Email** — apply a label to a message
- **Remove Label From Email** — remove a label from a message
- **Archive Email** — archive a message by removing the `INBOX` label

These require the `gmail.modify` OAuth scope, added alongside the existing `gmail.send`, `gmail.readonly`, and `gmail.compose` scopes. Existing connections are unaffected for every action they already use; the new scope is only requested going forward (new/reconnected connections), and only the 4 new actions need it.

Closes PIE-491.

## How was this tested?

- Manually tested all 4 actions against a real Gmail connection
- `npx turbo run build --filter=@activepieces/piece-gmail` — passes
- `npx turbo run lint --filter=@activepieces/piece-gmail` — 0 errors (pre-existing warnings only, none in new files)

Fixes # (issue)

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact