### PR TITLE
feat(postwire): add PostWire piece

### DIFF
--- a/packages/pieces/community/postwire/.babelrc
+++ b/packages/pieces/community/postwire/.babelrc
@@ -1,0 +1,3 @@
+{
+  "presets": [["@nx/js/babel", { "useBuiltIns": "usage" }]]
+}

--- a/packages/pieces/community/postwire/.eslintrc.json
+++ b/packages/pieces/community/postwire/.eslintrc.json
@@ -1,0 +1,47 @@
+{
+  "extends": [
+    "../../../../.eslintrc.json"
+  ],
+  "ignorePatterns": [
+    "!**/*"
+  ],
+  "overrides": [
+    {
+      "files": [
+        "*.ts",
+        "*.tsx",
+        "*.js",
+        "*.jsx"
+      ],
+      "rules": {}
+    },
+    {
+      "files": [
+        "*.ts",
+        "*.tsx"
+      ],
+      "rules": {
+        "no-restricted-imports": [
+          "error",
+          {
+            "patterns": [
+              "lodash",
+              "lodash/*",
+              "@activepieces/core-*",
+              "@activepieces/server*",
+              "@activepieces/engine",
+              "@activepieces/shared"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "files": [
+        "*.js",
+        "*.jsx"
+      ],
+      "rules": {}
+    }
+  ]
+}

--- a/packages/pieces/community/postwire/README.md
+++ b/packages/pieces/community/postwire/README.md
@@ -1,0 +1,5 @@
+# pieces-postwire
+
+## Building
+
+Run `turbo run build --filter=@activepieces/piece-postwire` to build the library.

--- a/packages/pieces/community/postwire/package.json
+++ b/packages/pieces/community/postwire/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@activepieces/piece-postwire",
+  "version": "0.1.0",
+  "main": "./dist/src/index.js",
+  "types": "./dist/src/index.d.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.lib.json && cp package.json dist/",
+    "bundle": "node ../../../../dist/packages/cli/src/index.js pieces bundle",
+    "lint": "eslint 'src/**/*.ts'"
+  },
+  "dependencies": {
+    "@activepieces/pieces-common": "workspace:*",
+    "@activepieces/pieces-framework": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
+  }
+}

--- a/packages/pieces/community/postwire/src/i18n/translation.json
+++ b/packages/pieces/community/postwire/src/i18n/translation.json
@@ -1,0 +1,19 @@
+{
+  "API Key": "API Key",
+  "Networks": "Networks",
+  "Text": "Text",
+  "Idea": "Idea",
+  "Media URL": "Media URL",
+  "Brand": "Brand",
+  "Brand Voice": "Brand Voice",
+  "Publish At": "Publish At",
+  "Publish": "Publish",
+  "Write and Publish": "Write and Publish",
+  "Schedule a Post": "Schedule a Post",
+  "Get Account": "Get Account",
+  "Publish the same text to one or more social networks.": "Publish the same text to one or more social networks.",
+  "Turn one idea into a native post per network, then publish it.": "Turn one idea into a native post per network, then publish it.",
+  "Queue a post for a later time. Its rules are checked now, not when it fires.": "Queue a post for a later time. Its rules are checked now, not when it fires.",
+  "Plan, posts used this month and connected networks.": "Plan, posts used this month and connected networks.",
+  "Connect these in the PostWire dashboard first.": "Connect these in the PostWire dashboard first."
+}

--- a/packages/pieces/community/postwire/src/index.ts
+++ b/packages/pieces/community/postwire/src/index.ts
@@ -1,0 +1,36 @@
+import { createCustomApiCallAction } from '@activepieces/pieces-common';
+import { createPiece, PieceCategory } from '@activepieces/pieces-framework';
+import { postwireAuth } from './lib/auth';
+import { POSTWIRE_API } from './lib/common';
+import { getAccount } from './lib/actions/get-account';
+import { publish } from './lib/actions/publish';
+import { schedulePost } from './lib/actions/schedule-post';
+import { writeAndPublish } from './lib/actions/write-and-publish';
+
+export { postwireAuth };
+
+export const postwire = createPiece({
+  displayName: 'PostWire',
+  description:
+    'Publish one idea natively to TikTok, Instagram, YouTube, LinkedIn, X, Facebook, Reddit, Bluesky, Mastodon, Telegram and Discord, rewritten per network rather than copied.',
+  minimumSupportedRelease: '0.87.0',
+  logoUrl: 'https://postwire.io/icon-1024.png',
+  categories: [PieceCategory.MARKETING],
+  auth: postwireAuth,
+  authors: ['renzom13'],
+  actions: [
+    writeAndPublish,
+    publish,
+    schedulePost,
+    getAccount,
+    createCustomApiCallAction({
+      baseUrl: () => POSTWIRE_API,
+      auth: postwireAuth,
+      authMapping: async (auth) => ({
+        Authorization: `Bearer ${auth}`,
+        'X-PostWire-Source': 'activepieces',
+      }),
+    }),
+  ],
+  triggers: [],
+});

--- a/packages/pieces/community/postwire/src/lib/actions/get-account.ts
+++ b/packages/pieces/community/postwire/src/lib/actions/get-account.ts
@@ -1,0 +1,15 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { postwireAuth } from '../auth';
+import { postwireCommon } from '../common';
+
+export const getAccount = createAction({
+  auth: postwireAuth,
+  name: 'get_account',
+  displayName: 'Get Account',
+  description: 'Plan, posts used this month and connected networks.',
+  props: {},
+  async run(context) {
+    return postwireCommon.request(context.auth, HttpMethod.GET, '/api/me');
+  },
+});

--- a/packages/pieces/community/postwire/src/lib/actions/publish.ts
+++ b/packages/pieces/community/postwire/src/lib/actions/publish.ts
@@ -1,0 +1,58 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { postwireAuth } from '../auth';
+import { postwireCommon, PostWireResponse } from '../common';
+
+export const publish = createAction({
+  auth: postwireAuth,
+  name: 'publish',
+  displayName: 'Publish',
+  description: 'Publish the same text to one or more social networks.',
+  props: {
+    platforms: Property.StaticMultiSelectDropdown({
+      displayName: 'Networks',
+      required: true,
+      description: 'Connect these in the PostWire dashboard first.',
+      options: { options: postwireCommon.platformOptions() },
+    }),
+    text: Property.LongText({
+      displayName: 'Text',
+      required: true,
+      description: 'Anything longer than a network allows is trimmed to fit that network.',
+    }),
+    mediaUrl: Property.ShortText({
+      displayName: 'Media URL',
+      required: false,
+      description:
+        'Direct link to an .mp4 or an image. TikTok and YouTube refuse a post with no video and Instagram needs a photo or video. A Google Drive share link returns a web page, not a file.',
+    }),
+    brandId: Property.ShortText({
+      displayName: 'Brand',
+      required: false,
+      description: 'Publish as a specific brand. Leave empty if you only have one.',
+    }),
+  },
+  async run(context) {
+    const platforms = context.propsValue.platforms;
+    const mediaUrl = context.propsValue.mediaUrl?.trim() ?? '';
+
+    const problem = postwireCommon.mediaProblem(platforms, mediaUrl);
+    if (problem !== null) throw new Error(problem);
+
+    const body = await postwireCommon.request<PostWireResponse>(
+      context.auth,
+      HttpMethod.POST,
+      '/api/post',
+      {
+        platforms,
+        text: context.propsValue.text,
+        brand_id: context.propsValue.brandId,
+        ...postwireCommon.mediaFields(mediaUrl),
+      },
+    );
+
+    const failure = postwireCommon.allFailed(body.results ?? []);
+    if (failure !== null) throw new Error(failure);
+    return body;
+  },
+});

--- a/packages/pieces/community/postwire/src/lib/actions/schedule-post.ts
+++ b/packages/pieces/community/postwire/src/lib/actions/schedule-post.ts
@@ -1,0 +1,51 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { postwireAuth } from '../auth';
+import { postwireCommon } from '../common';
+
+export const schedulePost = createAction({
+  auth: postwireAuth,
+  name: 'schedule_post',
+  displayName: 'Schedule a Post',
+  description: 'Queue a post for a later time. Its rules are checked now, not when it fires.',
+  props: {
+    platforms: Property.StaticMultiSelectDropdown({
+      displayName: 'Networks',
+      required: true,
+      description: 'Connect these in the PostWire dashboard first.',
+      options: { options: postwireCommon.platformOptions() },
+    }),
+    text: Property.LongText({ displayName: 'Text', required: true }),
+    runAt: Property.DateTime({
+      displayName: 'Publish At',
+      required: true,
+      description:
+        'PostWire validates the post now, so a missing video is caught here rather than tomorrow morning.',
+    }),
+    mediaUrl: Property.ShortText({
+      displayName: 'Media URL',
+      required: false,
+      description: 'Direct link to an .mp4 or an image.',
+    }),
+    brandId: Property.ShortText({
+      displayName: 'Brand',
+      required: false,
+      description: 'Publish as a specific brand. Leave empty if you only have one.',
+    }),
+  },
+  async run(context) {
+    const platforms = context.propsValue.platforms;
+    const mediaUrl = context.propsValue.mediaUrl?.trim() ?? '';
+
+    const problem = postwireCommon.mediaProblem(platforms, mediaUrl);
+    if (problem !== null) throw new Error(problem);
+
+    return postwireCommon.request(context.auth, HttpMethod.POST, '/api/schedule', {
+      platforms,
+      text: context.propsValue.text,
+      run_at: context.propsValue.runAt,
+      brand_id: context.propsValue.brandId,
+      ...postwireCommon.mediaFields(mediaUrl),
+    });
+  },
+});

--- a/packages/pieces/community/postwire/src/lib/actions/write-and-publish.ts
+++ b/packages/pieces/community/postwire/src/lib/actions/write-and-publish.ts
@@ -1,0 +1,77 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { postwireAuth } from '../auth';
+import { postwireCommon, PostWireResponse } from '../common';
+
+type GenerateResponse = { drafts: Record<string, unknown> };
+
+export const writeAndPublish = createAction({
+  auth: postwireAuth,
+  name: 'write_and_publish',
+  displayName: 'Write and Publish',
+  description: 'Turn one idea into a native post per network, then publish it.',
+  props: {
+    platforms: Property.StaticMultiSelectDropdown({
+      displayName: 'Networks',
+      required: true,
+      description: 'Connect these in the PostWire dashboard first.',
+      options: { options: postwireCommon.platformOptions() },
+    }),
+    prompt: Property.LongText({
+      displayName: 'Idea',
+      required: true,
+      description:
+        'What you want to say. PostWire rewrites it per network — length, tone, hashtags and link handling — rather than sending the same text everywhere.',
+    }),
+    mediaUrl: Property.ShortText({
+      displayName: 'Media URL',
+      required: false,
+      description: 'Direct link to an .mp4 or an image. Required by TikTok, YouTube and Instagram.',
+    }),
+    brandVoice: Property.ShortText({
+      displayName: 'Brand Voice',
+      required: false,
+      description: 'A sentence describing how you want to sound, applied to every draft.',
+    }),
+    brandId: Property.ShortText({
+      displayName: 'Brand',
+      required: false,
+      description: 'Publish as a specific brand. Leave empty if you only have one.',
+    }),
+  },
+  async run(context) {
+    const platforms = context.propsValue.platforms;
+    const mediaUrl = context.propsValue.mediaUrl?.trim() ?? '';
+
+    const problem = postwireCommon.mediaProblem(platforms, mediaUrl);
+    if (problem !== null) throw new Error(problem);
+
+    const generated = await postwireCommon.request<GenerateResponse>(
+      context.auth,
+      HttpMethod.POST,
+      '/api/generate',
+      {
+        prompt: context.propsValue.prompt,
+        platforms,
+        media_url: mediaUrl.length > 0 ? mediaUrl : undefined,
+        brand_voice: context.propsValue.brandVoice,
+      },
+    );
+
+    const body = await postwireCommon.request<PostWireResponse>(
+      context.auth,
+      HttpMethod.POST,
+      '/api/post',
+      {
+        platforms,
+        per_platform: generated.drafts,
+        brand_id: context.propsValue.brandId,
+        ...postwireCommon.mediaFields(mediaUrl),
+      },
+    );
+
+    const failure = postwireCommon.allFailed(body.results ?? []);
+    if (failure !== null) throw new Error(failure);
+    return { drafts: generated.drafts, results: body.results };
+  },
+});

--- a/packages/pieces/community/postwire/src/lib/auth.ts
+++ b/packages/pieces/community/postwire/src/lib/auth.ts
@@ -1,0 +1,24 @@
+import { PieceAuth } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { postwireCommon } from './common';
+
+const description = `Get a key at [postwire.io](https://postwire.io/dashboard.html). The free plan
+covers one brand with every network it connects and 30 posts a month, with no card. A post is
+counted **per network**, so one idea sent to three accounts spends three of them.`;
+
+export const postwireAuth = PieceAuth.SecretText({
+  displayName: 'API Key',
+  description,
+  required: true,
+  validate: async ({ auth }) => {
+    try {
+      await postwireCommon.request(auth, HttpMethod.GET, '/api/me');
+      return { valid: true };
+    } catch {
+      return {
+        valid: false,
+        error: 'That key was rejected by PostWire. Copy it again from the dashboard.',
+      };
+    }
+  },
+});

--- a/packages/pieces/community/postwire/src/lib/common/index.ts
+++ b/packages/pieces/community/postwire/src/lib/common/index.ts
@@ -1,0 +1,95 @@
+import { HttpMethod, httpClient } from '@activepieces/pieces-common';
+
+async function postwireRequest<T>(
+  apiKey: string,
+  method: HttpMethod,
+  path: string,
+  body?: unknown,
+): Promise<T> {
+  const response = await httpClient.sendRequest<T>({
+    method,
+    url: `${POSTWIRE_API}${path}`,
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      'Content-Type': 'application/json',
+      'X-PostWire-Source': 'activepieces',
+    },
+    body,
+  });
+  return response.body;
+}
+
+function needsOf(value: string): MediaNeed {
+  return PLATFORMS.find((platform) => platform.value === value)?.needs ?? null;
+}
+
+function isVideoUrl(url: string): boolean {
+  return /\.(mp4|mov|webm|m3u8|avi|mkv|m4v)(\?|$)/i.test(url);
+}
+
+function mediaProblem(platforms: string[], mediaUrl: string): string | null {
+  const video = isVideoUrl(mediaUrl);
+  const blocked = platforms.filter((platform) => {
+    const need = needsOf(platform);
+    if (need === null) return false;
+    return need === 'video' ? !video : mediaUrl.length === 0;
+  });
+  if (blocked.length === 0) return null;
+  const wantsVideo = blocked.some((platform) => needsOf(platform) === 'video');
+  const what = wantsVideo ? 'a video' : 'an image or video';
+  const which = blocked.length > 1 ? 'those networks' : 'that network';
+  return `${blocked.join(' and ')} will not accept a post without ${what}. Set Media URL to a direct file link, or remove ${which}.`;
+}
+
+function allFailed(results: PostWireResult[]): string | null {
+  const failed = results.filter((result) => result.ok === false);
+  if (results.length === 0 || failed.length !== results.length) return null;
+  const why = failed
+    .map((result) => `${result.platform ?? '?'}: ${result.error ?? result.code ?? 'failed'}`)
+    .join('; ');
+  const limited = failed.find((result) => result.upgrade_url !== undefined);
+  const upgrade = limited?.upgrade_url ? ` — upgrade: ${limited.upgrade_url}` : '';
+  return `PostWire published to none of the ${results.length} selected network(s). ${why}${upgrade}`;
+}
+
+function mediaFields(mediaUrl: string): { video_url?: string; photo_url?: string } {
+  if (mediaUrl.length === 0) return {};
+  return isVideoUrl(mediaUrl) ? { video_url: mediaUrl } : { photo_url: mediaUrl };
+}
+
+export const POSTWIRE_API = 'https://postwire.io';
+
+export const PLATFORMS: ReadonlyArray<{ label: string; value: string; needs: MediaNeed }> = [
+  { label: 'TikTok', value: 'tiktok', needs: 'video' },
+  { label: 'Instagram', value: 'instagram', needs: 'any' },
+  { label: 'YouTube', value: 'youtube', needs: 'video' },
+  { label: 'LinkedIn', value: 'linkedin', needs: null },
+  { label: 'X (Twitter)', value: 'x', needs: null },
+  { label: 'Facebook', value: 'facebook', needs: null },
+  { label: 'Reddit', value: 'reddit', needs: null },
+  { label: 'Bluesky', value: 'bluesky', needs: null },
+  { label: 'Mastodon', value: 'mastodon', needs: null },
+  { label: 'Telegram', value: 'telegram', needs: null },
+  { label: 'Discord', value: 'discord', needs: null },
+];
+
+export const postwireCommon = {
+  request: postwireRequest,
+  mediaProblem,
+  mediaFields,
+  allFailed,
+  platformOptions: () => PLATFORMS.map((platform) => ({ label: platform.label, value: platform.value })),
+};
+
+export type MediaNeed = 'video' | 'any' | null;
+
+export type PostWireResult = {
+  ok: boolean;
+  platform?: string;
+  url?: string;
+  error?: string;
+  code?: string;
+  upgrade_url?: string;
+};
+
+export type PostWireResponse = { results: PostWireResult[] };

--- a/packages/pieces/community/postwire/tsconfig.json
+++ b/packages/pieces/community/postwire/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ],
+  "compilerOptions": {
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  }
+}

--- a/packages/pieces/community/postwire/tsconfig.lib.json
+++ b/packages/pieces/community/postwire/tsconfig.lib.json
@@ -1,0 +1,15 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "rootDir": ".",
+    "baseUrl": ".",
+    "paths": {},
+    "outDir": "./dist",
+    "declaration": true,
+    "declarationMap": true,
+    "types": ["node"]
+  },
+  "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"],
+  "include": ["src/**/*.ts"]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1031,6 +1031,9 @@
       "@activepieces/piece-posthog": [
         "packages/pieces/community/posthog/src/index.ts"
       ],
+      "@activepieces/piece-postwire": [
+        "packages/pieces/community/postwire/src/index.ts"
+      ],
       "@activepieces/piece-postiz": [
         "packages/pieces/community/postiz/src/index.ts"
       ],


### PR DESCRIPTION
## Description

Adds a piece for **PostWire**, an API that publishes one idea to eleven social networks — TikTok, Instagram, YouTube, LinkedIn, X, Facebook, Reddit, Bluesky, Mastodon, Telegram and Discord — rewriting it per network instead of sending the same text everywhere.

**Actions**

| Action | What it does |
| --- | --- |
| Write and Publish | One idea in, a native draft per network, then publishes |
| Publish | Publishes the same text to the selected networks |
| Schedule a Post | Queues a post; its rules are validated at queue time |
| Get Account | Plan, posts used this month, connected networks |

Plus the standard custom API call.

**Two behaviours worth flagging**, both mirrored from the server so a flow fails where someone can act on it:

- **Media requirements are checked before the request.** TikTok and YouTube reject a post with no video and Instagram needs a photo or video, and their own errors do not say which network refused. The piece names the network and the fix instead.
- **A 200 whose every network failed throws.** The API answers 200 with per-network results, so a response where nothing published would otherwise leave the step green with the reason buried in its output — a scheduled flow can publish nothing for weeks that way.

Note for reviewers: PostWire counts a post **per network**, so one idea sent to three accounts spends three of the monthly allowance. That is stated in the auth field description because it is the single thing users misread.

## How was this tested?

Manually, against the live API with a real account, on a local CE instance:

- Connection test (`validate` on the auth) passes with a valid key and reports a clear error with an invalid one.
- **Write and Publish** and **Publish** verified end to end — posts appeared on Mastodon and Bluesky and the returned URLs resolve to the live posts.
- **Get Account** returns plan, usage and connected networks.
- **Schedule a Post** queues and the scheduled post fires.
- Media guard verified: selecting TikTok with no video fails in the editor with the message naming TikTok, rather than at publish time.
- All-networks-failed path verified by publishing to a network that was not connected: the step fails instead of finishing green.

Fixes # (issue)

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)

Reasoning, so a reviewer can disagree: the piece adds a new integration only. Credentials use the framework's own `PieceAuth.SecretText`, every request goes through `httpClient` from `@activepieces/pieces-common`, the base URL is a constant rather than user input, and there is no file handling or custom cryptography.
