### PR TITLE
fix(agents): a flow used as an agent tool no longer fails on its own field names

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -118,7 +118,7 @@
     },
     "packages/core/execution": {
       "name": "@activepieces/core-execution",
-      "version": "0.19.0",
+      "version": "0.20.0",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",

--- a/bun.lock
+++ b/bun.lock
@@ -150,7 +150,7 @@
     },
     "packages/core/piece-types": {
       "name": "@activepieces/core-piece-types",
-      "version": "0.8.0",
+      "version": "0.9.0",
       "dependencies": {
         "@activepieces/core-utils": "workspace:*",
         "tslib": "2.6.2",

--- a/packages/core/execution/package.json
+++ b/packages/core/execution/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/core-execution",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "scripts": {

--- a/packages/core/execution/src/lib/workers/job-data.ts
+++ b/packages/core/execution/src/lib/workers/job-data.ts
@@ -298,6 +298,7 @@ export type AgentPromptOverride = z.infer<typeof AgentPromptOverride>
 export const ResolvedAgentFlowTool = z.object({
     toolName: z.string(),
     flowId: z.string(),
+    flowVersionId: z.string().optional(),
     description: z.string(),
     inputSchema: z.record(z.string(), z.unknown()),
     returnsResponse: z.boolean(),

--- a/packages/core/execution/src/lib/workers/worker-contract.ts
+++ b/packages/core/execution/src/lib/workers/worker-contract.ts
@@ -250,6 +250,7 @@ export type ExecuteFlowToolRequest = {
     conversationId: string
     toolName: string
     flowId: string
+    flowVersionId?: string
     toolInput: Record<string, unknown>
     returnsResponse: boolean
 }

--- a/packages/core/piece-types/package.json
+++ b/packages/core/piece-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/core-piece-types",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "scripts": {

--- a/packages/core/piece-types/src/lib/agents.ts
+++ b/packages/core/piece-types/src/lib/agents.ts
@@ -288,6 +288,22 @@ function suggestToolName(sourceName: string): string {
     return toValidToolName(sanitizeToolName(sourceName))
 }
 
+function isProviderSafeIdentifier(name: string): boolean {
+    return PROVIDER_TOOL_NAME_PATTERN.test(name)
+}
+
+function toProviderSafeIdentifier({ name, fallback }: { name: string, fallback: string }): string {
+    if (isProviderSafeIdentifier(name)) {
+        return name
+    }
+    const sanitized = sanitizeToolName(name).slice(0, MAX_IDENTIFIER_LENGTH)
+    if (sanitized.length === 0) {
+        return fallback
+    }
+    const seeded = /^[a-z_]/.test(sanitized) ? sanitized : `_${sanitized}`
+    return isProviderSafeIdentifier(seeded) ? seeded : fallback
+}
+
 function createPieceToolName(pieceName: string, actionName: string): string {
     const PIECE_NAME_PREFIX = 'piece-'
     const idx = pieceName.indexOf(PIECE_NAME_PREFIX)
@@ -297,9 +313,10 @@ function createPieceToolName(pieceName: string, actionName: string): string {
 }
 
 const MAX_PREFIX_LENGTH = 53
+const MAX_IDENTIFIER_LENGTH = 64
 const PROVIDER_TOOL_NAME_PATTERN = /^[a-zA-Z_][a-zA-Z0-9_-]{0,63}$/
 
-export const mcpToolNameUtils = { createToolName, createPieceToolName, toValidToolName, suggestToolName }
+export const mcpToolNameUtils = { createToolName, createPieceToolName, toValidToolName, suggestToolName, isProviderSafeIdentifier, toProviderSafeIdentifier }
 
 export type ToolCallBase = z.infer<typeof toolCallBaseSchema>
 

--- a/packages/server/api/src/app/ee/agent/agent-run-controller.ts
+++ b/packages/server/api/src/app/ee/agent/agent-run-controller.ts
@@ -1,12 +1,12 @@
 import { ActivepiecesError, apId, ApId, assertNotNullOrUndefined, ErrorCode, spreadIfDefined, unique } from '@activepieces/core-utils'
-import { AgentFlowTool, AgentOutputField, AgentRunSource, AgentTool, AgentToolType, AIProviderName, LATEST_JOB_DATA_SCHEMA_VERSION, MAX_AGENT_OUTPUT_FIELDS, MAX_AGENT_STEP_BUDGET, MAX_AGENT_TEXT_LENGTH, MAX_AGENT_TOOLS, PrincipalType, ResolvedAgentFlowTool, TASK_COMPLETION_TOOL_NAME, WorkerJobType } from '@activepieces/shared'
+import { AgentFlowTool, AgentOutputField, AgentRunSource, AgentTool, AgentToolType, AIProviderName, FlowVersionState, LATEST_JOB_DATA_SCHEMA_VERSION, MAX_AGENT_OUTPUT_FIELDS, MAX_AGENT_STEP_BUDGET, MAX_AGENT_TEXT_LENGTH, MAX_AGENT_TOOLS, PrincipalType, ResolvedAgentFlowTool, TASK_COMPLETION_TOOL_NAME, WorkerJobType } from '@activepieces/shared'
 import { FastifyBaseLogger } from 'fastify'
 import { FastifyPluginAsyncZod } from 'fastify-type-provider-zod'
 import { StatusCodes } from 'http-status-codes'
 import { z } from 'zod'
 import { securityAccess } from '../../core/security/authorization/fastify-security'
 import { flowService } from '../../flows/flow/flow.service'
-import { extractMcpTriggerInput, resolveRunnableFlow } from '../../mcp/mcp-server-builder'
+import { extractMcpTriggerInput } from '../../mcp/mcp-server-builder'
 import { mcpToolInput } from '../../mcp/mcp-tool-input'
 import { assertCreditsAndAppSumoNotExceeded } from '../../platform/billing-provider'
 import { projectService } from '../../project/project-service'
@@ -96,24 +96,23 @@ async function resolveFlowTools({ projectId, flowToolRequests, log }: {
         return []
     }
     const externalFlowIds = unique(flowToolRequests.map((tool) => tool.externalFlowId))
-    const { data: matchedFlows } = await flowService(log).list({
+    const listFlows = (versionState: FlowVersionState) => flowService(log).list({
         projectIds: [projectId],
         externalIds: externalFlowIds,
         cursorRequest: null,
         includeTriggerSource: false,
+        versionState,
     })
-    const flowsByExternalId = new Map(matchedFlows.map((flow) => [flow.externalId, flow]))
-    const missing = flowToolRequests.filter((tool) => !flowsByExternalId.has(tool.externalFlowId))
+    const [published, drafts] = await Promise.all([listFlows(FlowVersionState.LOCKED), listFlows(FlowVersionState.DRAFT)])
+    const publishedByExternalId = new Map(published.data.map((flow) => [flow.externalId, flow]))
+    const runnableByExternalId = new Map(drafts.data.map((flow) => [flow.externalId, publishedByExternalId.get(flow.externalId) ?? flow]))
+    const missing = flowToolRequests.filter((tool) => !runnableByExternalId.has(tool.externalFlowId))
     if (missing.length > 0) {
         throw new ActivepiecesError({
             code: ErrorCode.VALIDATION,
             params: { message: `An agent step cannot use flow tool(s) ${unique(missing.map((tool) => tool.toolName)).join(', ')}: the referenced flow was not found in this project` },
         })
     }
-    const runnableByExternalId = new Map(await Promise.all(matchedFlows.map(async (flow) => {
-        const runnable = await resolveRunnableFlow({ flow, projectId, log })
-        return [flow.externalId, runnable] as const
-    })))
     return flowToolRequests.map((toolRequest) => {
         const flow = runnableByExternalId.get(toolRequest.externalFlowId)
         assertNotNullOrUndefined(flow, `flow for tool ${toolRequest.toolName}`)

--- a/packages/server/api/src/app/ee/agent/agent-run-controller.ts
+++ b/packages/server/api/src/app/ee/agent/agent-run-controller.ts
@@ -6,7 +6,8 @@ import { StatusCodes } from 'http-status-codes'
 import { z } from 'zod'
 import { securityAccess } from '../../core/security/authorization/fastify-security'
 import { flowService } from '../../flows/flow/flow.service'
-import { extractMcpTriggerInput, mcpPropertyToZod } from '../../mcp/mcp-server-builder'
+import { extractMcpTriggerInput } from '../../mcp/mcp-server-builder'
+import { mcpToolInput } from '../../mcp/mcp-tool-input'
 import { assertCreditsAndAppSumoNotExceeded } from '../../platform/billing-provider'
 import { projectService } from '../../project/project-service'
 import { jobQueue, JobType } from '../../workers/job-queue/job-queue'
@@ -119,7 +120,7 @@ async function resolveFlowTools({ projectId, flowToolRequests, log }: {
         const flow = runnableByExternalId.get(toolRequest.externalFlowId)
         assertNotNullOrUndefined(flow, `flow for tool ${toolRequest.toolName}`)
         const { toolDescription, mcpInputs, returnsResponse } = extractMcpTriggerInput(flow)
-        const inputShape = Object.fromEntries(mcpInputs.map((property) => [property.name, mcpPropertyToZod(property)]))
+        const inputShape = mcpToolInput.modelInputShape({ properties: mcpInputs })
         return {
             toolName: toolRequest.toolName,
             flowId: flow.id,

--- a/packages/server/api/src/app/ee/agent/agent-run-controller.ts
+++ b/packages/server/api/src/app/ee/agent/agent-run-controller.ts
@@ -1,4 +1,4 @@
-import { ActivepiecesError, apId, ApId, assertNotNullOrUndefined, ErrorCode, isNil, spreadIfDefined, unique } from '@activepieces/core-utils'
+import { ActivepiecesError, apId, ApId, assertNotNullOrUndefined, ErrorCode, spreadIfDefined, unique } from '@activepieces/core-utils'
 import { AgentFlowTool, AgentOutputField, AgentRunSource, AgentTool, AgentToolType, AIProviderName, LATEST_JOB_DATA_SCHEMA_VERSION, MAX_AGENT_OUTPUT_FIELDS, MAX_AGENT_STEP_BUDGET, MAX_AGENT_TEXT_LENGTH, MAX_AGENT_TOOLS, PrincipalType, ResolvedAgentFlowTool, TASK_COMPLETION_TOOL_NAME, WorkerJobType } from '@activepieces/shared'
 import { FastifyBaseLogger } from 'fastify'
 import { FastifyPluginAsyncZod } from 'fastify-type-provider-zod'
@@ -6,7 +6,7 @@ import { StatusCodes } from 'http-status-codes'
 import { z } from 'zod'
 import { securityAccess } from '../../core/security/authorization/fastify-security'
 import { flowService } from '../../flows/flow/flow.service'
-import { extractMcpTriggerInput } from '../../mcp/mcp-server-builder'
+import { extractMcpTriggerInput, resolveRunnableFlow } from '../../mcp/mcp-server-builder'
 import { mcpToolInput } from '../../mcp/mcp-tool-input'
 import { assertCreditsAndAppSumoNotExceeded } from '../../platform/billing-provider'
 import { projectService } from '../../project/project-service'
@@ -111,9 +111,7 @@ async function resolveFlowTools({ projectId, flowToolRequests, log }: {
         })
     }
     const runnableByExternalId = new Map(await Promise.all(matchedFlows.map(async (flow) => {
-        const runnable = isNil(flow.publishedVersionId) || flow.publishedVersionId === flow.version.id
-            ? flow
-            : await flowService(log).getOnePopulatedOrThrow({ id: flow.id, projectId, versionId: flow.publishedVersionId })
+        const runnable = await resolveRunnableFlow({ flow, projectId, log })
         return [flow.externalId, runnable] as const
     })))
     return flowToolRequests.map((toolRequest) => {

--- a/packages/server/api/src/app/ee/agent/agent-run-controller.ts
+++ b/packages/server/api/src/app/ee/agent/agent-run-controller.ts
@@ -122,6 +122,7 @@ async function resolveFlowTools({ projectId, flowToolRequests, log }: {
         return {
             toolName: toolRequest.toolName,
             flowId: flow.id,
+            flowVersionId: flow.version.id,
             description: toolDescription.length > 0 ? toolDescription : `Run the flow "${flow.version.displayName}"`,
             inputSchema: z.toJSONSchema(z.object(inputShape)),
             returnsResponse,

--- a/packages/server/api/src/app/ee/agent/rpc/tool-execution-rpc.ts
+++ b/packages/server/api/src/app/ee/agent/rpc/tool-execution-rpc.ts
@@ -84,7 +84,7 @@ export const toolExecutionRpc = (log: FastifyBaseLogger) => ({
         if (isNil(flow)) {
             throw new ActivepiecesError({ code: ErrorCode.AUTHORIZATION, params: { message: 'That flow is not in this run\'s project' } })
         }
-        const result = await runFlowAsTool({ flowId: flow.id, flowDisplayName: flow.version.displayName, payload: input.toolInput, returnsResponse: input.returnsResponse, log })
+        const result = await runFlowAsTool({ flow, payload: input.toolInput, returnsResponse: input.returnsResponse, log })
         log.info({ conversation: { id: input.conversationId }, tool: { name: input.toolName }, flow: { id: flow.id } }, '[agentRpc#executeFlowTool] Ran a flow tool')
         return { result }
     },

--- a/packages/server/api/src/app/ee/agent/rpc/tool-execution-rpc.ts
+++ b/packages/server/api/src/app/ee/agent/rpc/tool-execution-rpc.ts
@@ -9,7 +9,7 @@ import { executeCrossProjectTool } from '.././tools/agent-tools'
 import { pieceToolRunner } from '.././tools/piece-tool-runner'
 import { flowService } from '../../../flows/flow/flow.service'
 import { knowledgeBaseService } from '../../../knowledge-base/knowledge-base.service'
-import { runFlowAsTool } from '../../../mcp/mcp-server-builder'
+import { extractMcpTriggerInput, resolveRunnableFlow, runFlowAsTool } from '../../../mcp/mcp-server-builder'
 
 import { byteLengthOf, CONFIGURED_TOOL_SOURCES, configuredToolConversationOrThrow, confinedProjectFor, connectionForConfiguredTool, pinConnectionToAgent } from './rpc-shared'
 
@@ -84,7 +84,8 @@ export const toolExecutionRpc = (log: FastifyBaseLogger) => ({
         if (isNil(flow)) {
             throw new ActivepiecesError({ code: ErrorCode.AUTHORIZATION, params: { message: 'That flow is not in this run\'s project' } })
         }
-        const result = await runFlowAsTool({ flow, payload: input.toolInput, returnsResponse: input.returnsResponse, log })
+        const runnable = await resolveRunnableFlow({ flow, projectId: conversation.projectId, log })
+        const result = await runFlowAsTool({ flow: runnable, properties: extractMcpTriggerInput(runnable).mcpInputs, payload: input.toolInput, returnsResponse: input.returnsResponse, log })
         log.info({ conversation: { id: input.conversationId }, tool: { name: input.toolName }, flow: { id: flow.id } }, '[agentRpc#executeFlowTool] Ran a flow tool')
         return { result }
     },

--- a/packages/server/api/src/app/ee/agent/rpc/tool-execution-rpc.ts
+++ b/packages/server/api/src/app/ee/agent/rpc/tool-execution-rpc.ts
@@ -80,12 +80,12 @@ export const toolExecutionRpc = (log: FastifyBaseLogger) => ({
         if (isNil(conversation) || !CONFIGURED_TOOL_SOURCES.includes(conversation.source) || isNil(conversation.projectId)) {
             throw new ActivepiecesError({ code: ErrorCode.AUTHORIZATION, params: { message: 'This run is not allowed to run a flow tool' } })
         }
-        const flow = await flowService(log).getOnePopulated({ id: input.flowId, projectId: conversation.projectId })
+        const flow = await flowService(log).getOnePopulated({ id: input.flowId, projectId: conversation.projectId, ...spreadIfDefined('versionId', input.flowVersionId) })
         if (isNil(flow)) {
             throw new ActivepiecesError({ code: ErrorCode.AUTHORIZATION, params: { message: 'That flow is not in this run\'s project' } })
         }
-        const runnable = await resolveRunnableFlow({ flow, projectId: conversation.projectId, log })
-        const result = await runFlowAsTool({ flow: runnable, properties: extractMcpTriggerInput(runnable).mcpInputs, payload: input.toolInput, returnsResponse: input.returnsResponse, log })
+        const advertised = isNil(input.flowVersionId) ? await resolveRunnableFlow({ flow, projectId: conversation.projectId, log }) : flow
+        const result = await runFlowAsTool({ flow: advertised, properties: extractMcpTriggerInput(advertised).mcpInputs, payload: input.toolInput, returnsResponse: input.returnsResponse, log })
         log.info({ conversation: { id: input.conversationId }, tool: { name: input.toolName }, flow: { id: flow.id } }, '[agentRpc#executeFlowTool] Ran a flow tool')
         return { result }
     },

--- a/packages/server/api/src/app/mcp/mcp-server-builder.ts
+++ b/packages/server/api/src/app/mcp/mcp-server-builder.ts
@@ -1,8 +1,7 @@
 import { isNil, Permission } from '@activepieces/core-utils'
-import { FlowStatus, McpProperty, McpPropertyType, McpToolDefinition, mcpToolNameUtils, McpToolResult, McpTrigger, PopulatedFlow, PopulatedMcpServer, ProjectScopedMcpServer, TelemetryEventName } from '@activepieces/shared'
+import { FlowStatus, McpProperty, McpToolDefinition, mcpToolNameUtils, McpToolResult, McpTrigger, PopulatedFlow, PopulatedMcpServer, ProjectScopedMcpServer, TelemetryEventName } from '@activepieces/shared'
 import { McpServer, ResourceTemplate } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { FastifyBaseLogger } from 'fastify'
-import { z } from 'zod'
 import { rejectedPromiseHandler } from '../helper/promise-handler'
 import { system } from '../helper/system/system'
 import { AppSystemProp } from '../helper/system/system-props'
@@ -10,6 +9,7 @@ import { telemetry } from '../helper/telemetry.utils'
 import { WebhookFlowVersionToRun, webhookService } from '../webhooks/webhook.service'
 import { ALLOW_ALL, PermissionChecker, resolvePermissionChecker } from './mcp-permissions'
 import { mcpProjectSelection, ProjectSelectionScope } from './mcp-project-selection'
+import { mcpToolInput } from './mcp-tool-input'
 import { activepiecesTools, ALL_CONTROLLABLE_TOOL_NAMES, LOCKED_TOOL_NAMES, PLATFORM_LEVEL_TOOL_NAMES } from './tools'
 import { apSetProjectContextTool } from './tools/ap-set-project-context'
 
@@ -134,7 +134,7 @@ function registerFlowTools({ server, mcp, projectId, permissionChecker, log }: R
     const enabledFlows = mcp.flows.filter((flow) => flow.status === FlowStatus.ENABLED)
     for (const flow of enabledFlows) {
         const { toolName: mcpToolNameInput, toolDescription, mcpInputs, returnsResponse } = extractMcpTriggerInput(flow)
-        const zodFromInputSchema = Object.fromEntries(mcpInputs.map((property) => [property.name, mcpPropertyToZod(property)]))
+        const zodFromInputSchema = mcpToolInput.modelInputShape({ properties: mcpInputs })
 
         const baseName = (mcpToolNameInput ?? flow.version.displayName) + '_' + flow.id.substring(0, 4)
         const toolName = mcpToolNameUtils.createToolName(baseName)
@@ -145,7 +145,7 @@ function registerFlowTools({ server, mcp, projectId, permissionChecker, log }: R
                 return flowPermissionError
             }
 
-            const result = await runFlowAsTool({ flowId: flow.id, flowDisplayName: flow.version.displayName, payload: args, returnsResponse, log })
+            const result = await runFlowAsTool({ flow, payload: args, returnsResponse, log })
 
             rejectedPromiseHandler(telemetry(log).trackProject({
                 projectId,
@@ -170,13 +170,14 @@ export function extractMcpTriggerInput(flow: PopulatedFlow): { toolName?: string
     }
 }
 
-export async function runFlowAsTool({ flowId, flowDisplayName, payload, returnsResponse, log }: {
-    flowId: string
-    flowDisplayName: string
+export async function runFlowAsTool({ flow, payload, returnsResponse, log }: {
+    flow: PopulatedFlow
     payload: Record<string, unknown>
     returnsResponse: boolean
     log: FastifyBaseLogger
 }): Promise<McpToolResult> {
+    const flowId = flow.id
+    const flowDisplayName = flow.version.displayName
     const response = await webhookService.handleWebhook({
         data: () => Promise.resolve({
             body: {},
@@ -189,7 +190,7 @@ export async function runFlowAsTool({ flowId, flowDisplayName, payload, returnsR
         async: !returnsResponse,
         flowVersionToRun: WebhookFlowVersionToRun.LOCKED_FALL_BACK_TO_LATEST,
         saveSampleData: false,
-        payload,
+        payload: mcpToolInput.toFlowPayload({ properties: extractMcpTriggerInput(flow).mcpInputs, modelArgs: payload }),
         execute: true,
         failParentOnFailure: false,
         timeoutMs: system.getNumberOrThrow(AppSystemProp.FLOW_TIMEOUT_SECONDS) * 1000,
@@ -226,28 +227,6 @@ function registerPlaceholderTools(server: McpServer): void {
             content: [{ type: 'text' as const, text: `No project selected. Please select a project from the dropdown in the chat input area before using ${toolName}.` }],
         }))
     })
-}
-
-export function mcpPropertyToZod(property: McpProperty): z.ZodTypeAny {
-    const base = (() => {
-        switch (property.type) {
-            case McpPropertyType.TEXT:
-            case McpPropertyType.DATE:
-                return z.string()
-            case McpPropertyType.NUMBER:
-                return z.number()
-            case McpPropertyType.BOOLEAN:
-                return z.boolean()
-            case McpPropertyType.ARRAY:
-                return z.array(z.string())
-            case McpPropertyType.OBJECT:
-                return z.record(z.string(), z.string())
-            default:
-                return z.unknown()
-        }
-    })()
-    const described = property.description ? base.describe(property.description) : base
-    return property.required ? described : described.nullish()
 }
 
 function registerEmptyResourcesAndPrompts(server: McpServer): void {

--- a/packages/server/api/src/app/mcp/mcp-server-builder.ts
+++ b/packages/server/api/src/app/mcp/mcp-server-builder.ts
@@ -68,7 +68,7 @@ export async function buildMcpServer({ mcp, userId, selectionScope, log, resolve
         const permissionChecker = userId
             ? await resolvePermissionChecker({ userId, projectId, log })
             : ALLOW_ALL
-        registerFlowTools({ server, mcp, projectId, permissionChecker, log })
+        await registerFlowTools({ server, mcp, projectId, permissionChecker, log })
         registerStaticTools({ server, mcp, projectId, userId, permissionChecker, log })
     }
     else if (!isNil(mcp.platformId) && !isNil(userId) && !isNil(resolveProjectMcp)) {
@@ -131,9 +131,10 @@ function registerPlatformTools({ server, mcp, userId, selectionScope, resolvePro
     })
 }
 
-function registerFlowTools({ server, mcp, projectId, permissionChecker, log }: RegisterToolsParams): void {
+async function registerFlowTools({ server, mcp, projectId, permissionChecker, log }: RegisterToolsParams): Promise<void> {
     const enabledFlows = mcp.flows.filter((flow) => flow.status === FlowStatus.ENABLED)
-    for (const flow of enabledFlows) {
+    const runnableFlows = await Promise.all(enabledFlows.map((flow) => resolveRunnableFlow({ flow, projectId, log })))
+    for (const flow of runnableFlows) {
         const { toolName: mcpToolNameInput, toolDescription, mcpInputs, returnsResponse } = extractMcpTriggerInput(flow)
         const zodFromInputSchema = mcpToolInput.modelInputShape({ properties: mcpInputs })
 

--- a/packages/server/api/src/app/mcp/mcp-server-builder.ts
+++ b/packages/server/api/src/app/mcp/mcp-server-builder.ts
@@ -68,7 +68,7 @@ export async function buildMcpServer({ mcp, userId, selectionScope, log, resolve
         const permissionChecker = userId
             ? await resolvePermissionChecker({ userId, projectId, log })
             : ALLOW_ALL
-        await registerFlowTools({ server, mcp, projectId, permissionChecker, log })
+        registerFlowTools({ server, mcp, projectId, permissionChecker, log })
         registerStaticTools({ server, mcp, projectId, userId, permissionChecker, log })
     }
     else if (!isNil(mcp.platformId) && !isNil(userId) && !isNil(resolveProjectMcp)) {
@@ -131,10 +131,9 @@ function registerPlatformTools({ server, mcp, userId, selectionScope, resolvePro
     })
 }
 
-async function registerFlowTools({ server, mcp, projectId, permissionChecker, log }: RegisterToolsParams): Promise<void> {
+function registerFlowTools({ server, mcp, projectId, permissionChecker, log }: RegisterToolsParams): void {
     const enabledFlows = mcp.flows.filter((flow) => flow.status === FlowStatus.ENABLED)
-    const runnableFlows = await Promise.all(enabledFlows.map((flow) => resolveRunnableFlow({ flow, projectId, log })))
-    for (const flow of runnableFlows) {
+    for (const flow of enabledFlows) {
         const { toolName: mcpToolNameInput, toolDescription, mcpInputs, returnsResponse } = extractMcpTriggerInput(flow)
         const zodFromInputSchema = mcpToolInput.modelInputShape({ properties: mcpInputs })
 

--- a/packages/server/api/src/app/mcp/mcp-server-builder.ts
+++ b/packages/server/api/src/app/mcp/mcp-server-builder.ts
@@ -2,6 +2,7 @@ import { isNil, Permission } from '@activepieces/core-utils'
 import { FlowStatus, McpProperty, McpToolDefinition, mcpToolNameUtils, McpToolResult, McpTrigger, PopulatedFlow, PopulatedMcpServer, ProjectScopedMcpServer, TelemetryEventName } from '@activepieces/shared'
 import { McpServer, ResourceTemplate } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { FastifyBaseLogger } from 'fastify'
+import { flowService } from '../flows/flow/flow.service'
 import { rejectedPromiseHandler } from '../helper/promise-handler'
 import { system } from '../helper/system/system'
 import { AppSystemProp } from '../helper/system/system-props'
@@ -145,7 +146,7 @@ function registerFlowTools({ server, mcp, projectId, permissionChecker, log }: R
                 return flowPermissionError
             }
 
-            const result = await runFlowAsTool({ flow, payload: args, returnsResponse, log })
+            const result = await runFlowAsTool({ flow, properties: mcpInputs, payload: args, returnsResponse, log })
 
             rejectedPromiseHandler(telemetry(log).trackProject({
                 projectId,
@@ -170,8 +171,20 @@ export function extractMcpTriggerInput(flow: PopulatedFlow): { toolName?: string
     }
 }
 
-export async function runFlowAsTool({ flow, payload, returnsResponse, log }: {
+export async function resolveRunnableFlow({ flow, projectId, log }: {
     flow: PopulatedFlow
+    projectId: string
+    log: FastifyBaseLogger
+}): Promise<PopulatedFlow> {
+    if (isNil(flow.publishedVersionId) || flow.publishedVersionId === flow.version.id) {
+        return flow
+    }
+    return flowService(log).getOnePopulatedOrThrow({ id: flow.id, projectId, versionId: flow.publishedVersionId })
+}
+
+export async function runFlowAsTool({ flow, properties, payload, returnsResponse, log }: {
+    flow: PopulatedFlow
+    properties: McpProperty[]
     payload: Record<string, unknown>
     returnsResponse: boolean
     log: FastifyBaseLogger
@@ -190,7 +203,7 @@ export async function runFlowAsTool({ flow, payload, returnsResponse, log }: {
         async: !returnsResponse,
         flowVersionToRun: WebhookFlowVersionToRun.LOCKED_FALL_BACK_TO_LATEST,
         saveSampleData: false,
-        payload: mcpToolInput.toFlowPayload({ properties: extractMcpTriggerInput(flow).mcpInputs, modelArgs: payload }),
+        payload: mcpToolInput.toFlowPayload({ properties, modelArgs: payload }),
         execute: true,
         failParentOnFailure: false,
         timeoutMs: system.getNumberOrThrow(AppSystemProp.FLOW_TIMEOUT_SECONDS) * 1000,

--- a/packages/server/api/src/app/mcp/mcp-service.ts
+++ b/packages/server/api/src/app/mcp/mcp-service.ts
@@ -102,7 +102,7 @@ async function listMcpFlows(projectId: string, logger: FastifyBaseLogger): Promi
         projectIds: [projectId],
         limit: 1000000,
         cursorRequest: null,
-        versionState: FlowVersionState.DRAFT,
+        versionState: FlowVersionState.LOCKED,
         includeTriggerSource: false,
     })
     return flows.data.filter((flow) => flow.version.trigger.type === FlowTriggerType.PIECE && flow.version.trigger.settings.pieceName === MCP_TRIGGER_PIECE_NAME)

--- a/packages/server/api/src/app/mcp/mcp-tool-input.ts
+++ b/packages/server/api/src/app/mcp/mcp-tool-input.ts
@@ -1,0 +1,76 @@
+import { McpProperty, McpPropertyType, mcpToolNameUtils } from '@activepieces/shared'
+import { z } from 'zod'
+
+export const mcpToolInput = {
+    modelKeyByPropertyName({ properties }: { properties: McpProperty[] }): Map<string, string> {
+        const taken = new Set<string>()
+        return properties.reduce((keys, property, index) => {
+            const candidate = mcpToolNameUtils.toProviderSafeIdentifier({ name: property.name, fallback: positionalKey(index) })
+            const key = deduplicate({ candidate, taken })
+            taken.add(key)
+            return keys.set(property.name, key)
+        }, new Map<string, string>())
+    },
+
+    modelInputShape({ properties }: { properties: McpProperty[] }): Record<string, z.ZodTypeAny> {
+        const keys = mcpToolInput.modelKeyByPropertyName({ properties })
+        return Object.fromEntries(properties.map((property) => {
+            const key = keys.get(property.name) ?? property.name
+            return [key, describeForModel({ property, key })]
+        }))
+    },
+
+    toFlowPayload({ properties, modelArgs }: { properties: McpProperty[], modelArgs: Record<string, unknown> }): Record<string, unknown> {
+        const keys = mcpToolInput.modelKeyByPropertyName({ properties })
+        return Object.fromEntries(properties.flatMap((property) => {
+            const key = keys.get(property.name) ?? property.name
+            const suppliedKey = [key, property.name].find((candidate) => candidate in modelArgs)
+            return suppliedKey === undefined ? [] : [[property.name, modelArgs[suppliedKey]] as const]
+        }))
+    },
+
+    propertyToZod(property: McpProperty): z.ZodTypeAny {
+        const base = (() => {
+            switch (property.type) {
+                case McpPropertyType.TEXT:
+                case McpPropertyType.DATE:
+                    return z.string()
+                case McpPropertyType.NUMBER:
+                    return z.number()
+                case McpPropertyType.BOOLEAN:
+                    return z.boolean()
+                case McpPropertyType.ARRAY:
+                    return z.array(z.string())
+                case McpPropertyType.OBJECT:
+                    return z.record(z.string(), z.string())
+                default:
+                    return z.unknown()
+            }
+        })()
+        const described = property.description ? base.describe(property.description) : base
+        return property.required ? described : described.nullish()
+    },
+}
+
+function positionalKey(index: number): string {
+    return `field_${index + 1}`
+}
+
+function deduplicate({ candidate, taken }: { candidate: string, taken: Set<string> }): string {
+    if (!taken.has(candidate)) {
+        return candidate
+    }
+    for (let suffix = 2; ; suffix++) {
+        const next = `${candidate.slice(0, MAX_KEY_LENGTH - String(suffix).length - 1)}_${suffix}`
+        if (!taken.has(next)) {
+            return next
+        }
+    }
+}
+
+function describeForModel({ property, key }: { property: McpProperty, key: string }): z.ZodTypeAny {
+    const base = mcpToolInput.propertyToZod(property)
+    return key === property.name ? base : base.meta({ title: property.name })
+}
+
+const MAX_KEY_LENGTH = 64

--- a/packages/server/api/src/app/mcp/mcp-tool-input.ts
+++ b/packages/server/api/src/app/mcp/mcp-tool-input.ts
@@ -24,11 +24,14 @@ export const mcpToolInput = {
 
     toFlowPayload({ properties, modelArgs }: { properties: McpProperty[], modelArgs: Record<string, unknown> }): Record<string, unknown> {
         const keys = mcpToolInput.modelKeyByPropertyName({ properties })
-        return Object.fromEntries(properties.flatMap((property) => {
+        const declared = properties.flatMap((property) => {
             const key = keys.get(property.name) ?? property.name
             const suppliedKey = [key, property.name].find((candidate) => candidate in modelArgs)
-            return suppliedKey === undefined ? [] : [[property.name, modelArgs[suppliedKey]] as const]
-        }))
+            return suppliedKey === undefined ? [] : [[property.name, modelArgs[suppliedKey], suppliedKey] as const]
+        })
+        const consumed = new Set(declared.map(([, , suppliedKey]) => suppliedKey))
+        const unrecognised = Object.entries(modelArgs).filter(([key]) => !consumed.has(key))
+        return Object.fromEntries([...unrecognised, ...declared.map(([name, value]) => [name, value] as const)])
     },
 
     propertyToZod(property: McpProperty): z.ZodTypeAny {

--- a/packages/server/api/src/app/mcp/mcp-tool-input.ts
+++ b/packages/server/api/src/app/mcp/mcp-tool-input.ts
@@ -29,9 +29,7 @@ export const mcpToolInput = {
             const suppliedKey = [key, property.name].find((candidate) => candidate in modelArgs)
             return suppliedKey === undefined ? [] : [[property.name, modelArgs[suppliedKey], suppliedKey] as const]
         })
-        const consumed = new Set(declared.map(([, , suppliedKey]) => suppliedKey))
-        const unrecognised = Object.entries(modelArgs).filter(([key]) => !consumed.has(key))
-        return Object.fromEntries([...unrecognised, ...declared.map(([name, value]) => [name, value] as const)])
+        return Object.fromEntries(declared.map(([name, value]) => [name, value] as const))
     },
 
     propertyToZod(property: McpProperty): z.ZodTypeAny {

--- a/packages/server/api/src/app/mcp/mcp-tool-input.ts
+++ b/packages/server/api/src/app/mcp/mcp-tool-input.ts
@@ -3,10 +3,12 @@ import { z } from 'zod'
 
 export const mcpToolInput = {
     modelKeyByPropertyName({ properties }: { properties: McpProperty[] }): Map<string, string> {
+        const propertyNames = new Set(properties.map((property) => property.name))
         const taken = new Set<string>()
         return properties.reduce((keys, property, index) => {
             const candidate = mcpToolNameUtils.toProviderSafeIdentifier({ name: property.name, fallback: positionalKey(index) })
-            const key = deduplicate({ candidate, taken })
+            const claimedByAnotherField = new Set([...taken, ...propertyNames].filter((claimed) => claimed !== property.name))
+            const key = deduplicate({ candidate, taken: claimedByAnotherField })
             taken.add(key)
             return keys.set(property.name, key)
         }, new Map<string, string>())

--- a/packages/server/api/test/unit/app/ee/agent/agent-rpc-handlers.test.ts
+++ b/packages/server/api/test/unit/app/ee/agent/agent-rpc-handlers.test.ts
@@ -441,7 +441,7 @@ describe('agentRpcHandlers.executePieceTool — a configured action runs in its 
 })
 
 describe('agentRpcHandlers.executeFlowTool — only a flow-step run may call a flow tool, scoped to its own project', () => {
-    async function runFlowTool(conversation: unknown, flowId = 'flow-1') {
+    async function runFlowTool(conversation: unknown, flowId = 'flow-1', flowVersionId?: string) {
         mockRunFlowAsTool.mockClear()
         mockGetOnePopulated.mockClear()
         mockFindOneBy.mockResolvedValue(conversation)
@@ -450,6 +450,7 @@ describe('agentRpcHandlers.executeFlowTool — only a flow-step run may call a f
             conversationId: 'conv-1',
             toolName: 'run_subflow',
             flowId,
+            ...(flowVersionId === undefined ? {} : { flowVersionId }),
             toolInput: { foo: 'bar' },
             returnsResponse: false,
         })
@@ -487,7 +488,19 @@ describe('agentRpcHandlers.executeFlowTool — only a flow-step run may call a f
         expect(mockRunFlowAsTool).toHaveBeenCalledTimes(1)
     })
 
-    it('translates the arguments with the schema of the version that will actually run, not the draft', async () => {
+    it('translates with the exact version whose schema the model was shown, not whatever is published now', async () => {
+        mockGetOnePopulated.mockResolvedValue(flowWithFields({ versionId: 'v-advertised', publishedVersionId: 'v-newer', fields: ['Email Sender'] }))
+
+        await runFlowTool({ id: 'conv-1', source: 'FLOW_STEP', projectId: 'proj-own' }, 'flow-1', 'v-advertised')
+
+        expect(mockGetOnePopulated).toHaveBeenCalledWith({ id: 'flow-1', projectId: 'proj-own', versionId: 'v-advertised' })
+        expect(mockGetOnePopulatedOrThrow).not.toHaveBeenCalled()
+        const [call] = mockRunFlowAsTool.mock.calls
+        expect(call[0].flow.version.id).toBe('v-advertised')
+        expect(call[0].properties.map((property: { name: string }) => property.name)).toEqual(['Email Sender'])
+    })
+
+    it('falls back to the runnable version for a run enqueued before the version was pinned', async () => {
         mockGetOnePopulatedOrThrow.mockClear()
         mockGetOnePopulated.mockResolvedValue(flowWithFields({ versionId: 'v-draft', publishedVersionId: 'v-published', fields: ['Renamed In Draft'] }))
         mockGetOnePopulatedOrThrow.mockResolvedValue(flowWithFields({ versionId: 'v-published', publishedVersionId: 'v-published', fields: ['Email Sender'] }))

--- a/packages/server/api/test/unit/app/ee/agent/agent-rpc-handlers.test.ts
+++ b/packages/server/api/test/unit/app/ee/agent/agent-rpc-handlers.test.ts
@@ -79,14 +79,16 @@ const { mockGetOnePopulated } = vi.hoisted(() => ({
 }))
 
 vi.mock('../../../../../src/app/flows/flow/flow.service', () => ({
-    flowService: () => ({ getOnePopulated: mockGetOnePopulated }),
+    flowService: () => ({ getOnePopulated: mockGetOnePopulated, getOnePopulatedOrThrow: mockGetOnePopulatedOrThrow }),
 }))
 
-const { mockRunFlowAsTool } = vi.hoisted(() => ({
+const { mockRunFlowAsTool, mockGetOnePopulatedOrThrow } = vi.hoisted(() => ({
     mockRunFlowAsTool: vi.fn().mockResolvedValue({ content: [{ type: 'text', text: 'ok' }] }),
+    mockGetOnePopulatedOrThrow: vi.fn(),
 }))
 
-vi.mock('../../../../../src/app/mcp/mcp-server-builder', () => ({
+vi.mock('../../../../../src/app/mcp/mcp-server-builder', async (importOriginal) => ({
+    ...(await importOriginal<Record<string, unknown>>()),
     runFlowAsTool: mockRunFlowAsTool,
 }))
 
@@ -477,14 +479,59 @@ describe('agentRpcHandlers.executeFlowTool — only a flow-step run may call a f
     })
 
     it('runs the flow scoped to the conversation\'s own project when everything checks out', async () => {
-        mockGetOnePopulated.mockResolvedValue({ id: 'flow-1', version: { displayName: 'My Flow' } })
+        mockGetOnePopulated.mockResolvedValue(flowWithFields({ versionId: 'v-1', fields: ['Email Sender'] }))
 
         await runFlowTool({ id: 'conv-1', source: 'FLOW_STEP', projectId: 'proj-own' })
 
         expect(mockGetOnePopulated).toHaveBeenCalledWith({ id: 'flow-1', projectId: 'proj-own' })
         expect(mockRunFlowAsTool).toHaveBeenCalledTimes(1)
     })
+
+    it('translates the arguments with the schema of the version that will actually run, not the draft', async () => {
+        mockGetOnePopulatedOrThrow.mockClear()
+        mockGetOnePopulated.mockResolvedValue(flowWithFields({ versionId: 'v-draft', publishedVersionId: 'v-published', fields: ['Renamed In Draft'] }))
+        mockGetOnePopulatedOrThrow.mockResolvedValue(flowWithFields({ versionId: 'v-published', publishedVersionId: 'v-published', fields: ['Email Sender'] }))
+
+        await runFlowTool({ id: 'conv-1', source: 'FLOW_STEP', projectId: 'proj-own' })
+
+        expect(mockGetOnePopulatedOrThrow).toHaveBeenCalledWith({ id: 'flow-1', projectId: 'proj-own', versionId: 'v-published' })
+        const [call] = mockRunFlowAsTool.mock.calls
+        expect(call[0].properties.map((property: { name: string }) => property.name)).toEqual(['Email Sender'])
+        expect(call[0].flow.version.id).toBe('v-published')
+    })
+
+    it('runs the draft directly when nothing has been published yet', async () => {
+        mockGetOnePopulatedOrThrow.mockClear()
+        mockGetOnePopulated.mockResolvedValue(flowWithFields({ versionId: 'v-draft', fields: ['Email Sender'] }))
+
+        await runFlowTool({ id: 'conv-1', source: 'FLOW_STEP', projectId: 'proj-own' })
+
+        expect(mockGetOnePopulatedOrThrow).not.toHaveBeenCalled()
+        const [call] = mockRunFlowAsTool.mock.calls
+        expect(call[0].flow.version.id).toBe('v-draft')
+    })
 })
+
+function flowWithFields({ versionId, publishedVersionId, fields }: { versionId: string, publishedVersionId?: string, fields: string[] }) {
+    return {
+        id: 'flow-1',
+        ...(publishedVersionId === undefined ? {} : { publishedVersionId }),
+        version: {
+            id: versionId,
+            displayName: 'My Flow',
+            trigger: {
+                settings: {
+                    input: {
+                        toolName: 'run_subflow',
+                        toolDescription: 'runs a subflow',
+                        returnsResponse: false,
+                        inputSchema: fields.map((name) => ({ name, type: 'Text', required: false })),
+                    },
+                },
+            },
+        },
+    }
+}
 
 describe('agentRpcHandlers.updateFlowStepProgress — only a flow-step run may report progress', () => {
 

--- a/packages/server/api/test/unit/app/mcp/mcp-tool-input.test.ts
+++ b/packages/server/api/test/unit/app/mcp/mcp-tool-input.test.ts
@@ -7,7 +7,6 @@ const ANTHROPIC_PROPERTY_KEY_PATTERN = /^[a-zA-Z0-9_.-]{1,64}$/
 
 const text = (name: string, required = false): McpProperty => ({ name, type: McpPropertyType.TEXT, required })
 
-// The exact schema that made every run of one customer's agent step fail on 2026-09-08.
 const EMAIL_LOOKUP_FLOW: McpProperty[] = [
     text('Email Sender'),
     text('Email Subject'),
@@ -17,6 +16,12 @@ const EMAIL_LOOKUP_FLOW: McpProperty[] = [
 ]
 
 const modelKeys = (properties: McpProperty[]) => Object.keys(mcpToolInput.modelInputShape({ properties }))
+
+const keyFor = ({ properties, name }: { properties: McpProperty[], name: string }) => {
+    const key = mcpToolInput.modelKeyByPropertyName({ properties }).get(name)
+    expect(key, `no key was generated for ${name}`).toBeDefined()
+    return key ?? name
+}
 
 describe('modelInputShape', () => {
     it('produces keys every provider accepts for the flow that was failing in production', () => {
@@ -101,5 +106,39 @@ describe('toFlowPayload', () => {
         const properties = [text('Send Copy'), text('Retry Count')]
         expect(mcpToolInput.toFlowPayload({ properties, modelArgs: { send_copy: false, retry_count: 0 } }))
             .toEqual({ 'Send Copy': false, 'Retry Count': 0 })
+    })
+})
+
+describe('a rewritten key that looks like another field name', () => {
+    const OVERLAPPING: McpProperty[] = [text('Email Sender'), text('email_sender')]
+
+    it('never hands one field a key that is another field\'s name', () => {
+        const keys = mcpToolInput.modelKeyByPropertyName({ properties: OVERLAPPING })
+        const names = new Set(OVERLAPPING.map((property) => property.name))
+        for (const [name, key] of keys) {
+            expect(names.has(key) && key !== name, `${name} -> ${key}`).toBe(false)
+        }
+    })
+
+    it('keeps both values distinct when a cached client sends the original labels', () => {
+        expect(mcpToolInput.toFlowPayload({ properties: OVERLAPPING, modelArgs: { 'Email Sender': 'AAA', email_sender: 'BBB' } }))
+            .toEqual({ 'Email Sender': 'AAA', email_sender: 'BBB' })
+    })
+
+    it('keeps both values distinct when the model sends the rewritten keys', () => {
+        const modelArgs = {
+            [keyFor({ properties: OVERLAPPING, name: 'Email Sender' })]: 'AAA',
+            [keyFor({ properties: OVERLAPPING, name: 'email_sender' })]: 'BBB',
+        }
+        expect(mcpToolInput.toFlowPayload({ properties: OVERLAPPING, modelArgs }))
+            .toEqual({ 'Email Sender': 'AAA', email_sender: 'BBB' })
+    })
+
+    it('holds when a field is named the same as the positional fallback', () => {
+        const properties = [text('日本語'), text('field_1')]
+        expect(keyFor({ properties, name: '日本語' })).not.toBe('field_1')
+        expect(keyFor({ properties, name: 'field_1' })).toBe('field_1')
+        expect(mcpToolInput.toFlowPayload({ properties, modelArgs: { [keyFor({ properties, name: '日本語' })]: 'A', field_1: 'B' } }))
+            .toEqual({ '日本語': 'A', field_1: 'B' })
     })
 })

--- a/packages/server/api/test/unit/app/mcp/mcp-tool-input.test.ts
+++ b/packages/server/api/test/unit/app/mcp/mcp-tool-input.test.ts
@@ -1,0 +1,105 @@
+import { McpProperty, McpPropertyType, mcpToolNameUtils } from '@activepieces/shared'
+import { describe, expect, it } from 'vitest'
+import { z } from 'zod'
+import { mcpToolInput } from '../../../../src/app/mcp/mcp-tool-input'
+
+const ANTHROPIC_PROPERTY_KEY_PATTERN = /^[a-zA-Z0-9_.-]{1,64}$/
+
+const text = (name: string, required = false): McpProperty => ({ name, type: McpPropertyType.TEXT, required })
+
+// The exact schema that made every run of one customer's agent step fail on 2026-09-08.
+const EMAIL_LOOKUP_FLOW: McpProperty[] = [
+    text('Email Sender'),
+    text('Email Subject'),
+    text('Email Content'),
+    text('After Date'),
+    text('Before Date'),
+]
+
+const modelKeys = (properties: McpProperty[]) => Object.keys(mcpToolInput.modelInputShape({ properties }))
+
+describe('modelInputShape', () => {
+    it('produces keys every provider accepts for the flow that was failing in production', () => {
+        for (const key of modelKeys(EMAIL_LOOKUP_FLOW)) {
+            expect(key, key).toMatch(ANTHROPIC_PROPERTY_KEY_PATTERN)
+            expect(mcpToolNameUtils.isProviderSafeIdentifier(key), key).toBe(true)
+        }
+    })
+
+    it('leaves an already-safe field name exactly as it was, so existing tools do not churn', () => {
+        expect(modelKeys([text('email'), text('subject_line'), text('after-date'), text('_internal')]))
+            .toEqual(['email', 'subject_line', 'after-date', '_internal'])
+    })
+
+    it('keeps the human label on any key it had to rewrite, so the model still knows what the field is', () => {
+        const schema = z.toJSONSchema(z.object(mcpToolInput.modelInputShape({ properties: [text('Email Sender'), text('email')] })))
+        expect(schema.properties?.['email_sender']).toMatchObject({ title: 'Email Sender' })
+        expect(schema.properties?.['email']).not.toHaveProperty('title')
+    })
+
+    it('never collides two field names onto one key, which would drop a field silently', () => {
+        const colliding = [text('Email Sender'), text('email sender'), text('EMAIL_SENDER'), text('email-sender')]
+        const keys = modelKeys(colliding)
+        expect(keys).toHaveLength(colliding.length)
+        expect(new Set(keys).size).toBe(colliding.length)
+        for (const key of keys) {
+            expect(key, key).toMatch(ANTHROPIC_PROPERTY_KEY_PATTERN)
+        }
+    })
+
+    it('still yields a usable key when a name sanitises away to nothing', () => {
+        const keys = modelKeys([text('日本語'), text('!!!'), text('   ')])
+        expect(keys).toEqual(['field_1', 'field_2', 'field_3'])
+        for (const key of keys) {
+            expect(mcpToolNameUtils.isProviderSafeIdentifier(key), key).toBe(true)
+        }
+    })
+
+    it('caps a very long name at the length providers allow', () => {
+        const [key] = modelKeys([text('A very long human readable field label '.repeat(5))])
+        expect(key.length).toBeLessThanOrEqual(64)
+        expect(mcpToolNameUtils.isProviderSafeIdentifier(key)).toBe(true)
+    })
+
+    it('keeps a name that starts with a digit usable, since providers require a leading letter or underscore', () => {
+        const [key] = modelKeys([text('1st Name')])
+        expect(mcpToolNameUtils.isProviderSafeIdentifier(key)).toBe(true)
+        expect(key).toMatch(ANTHROPIC_PROPERTY_KEY_PATTERN)
+    })
+})
+
+describe('toFlowPayload', () => {
+    it('hands the flow back its own field names, so trigger references keep working', () => {
+        const payload = mcpToolInput.toFlowPayload({
+            properties: EMAIL_LOOKUP_FLOW,
+            modelArgs: { email_sender: 'a@b.com', email_subject: 'Invoice', after_date: '2026-09-01' },
+        })
+        expect(payload).toEqual({ 'Email Sender': 'a@b.com', 'Email Subject': 'Invoice', 'After Date': '2026-09-01' })
+    })
+
+    it('still accepts the original field name, so a client holding the old schema keeps working', () => {
+        expect(mcpToolInput.toFlowPayload({ properties: EMAIL_LOOKUP_FLOW, modelArgs: { 'Email Sender': 'a@b.com' } }))
+            .toEqual({ 'Email Sender': 'a@b.com' })
+    })
+
+    it('drops a key the schema never declared rather than passing it into the flow', () => {
+        expect(mcpToolInput.toFlowPayload({ properties: EMAIL_LOOKUP_FLOW, modelArgs: { injected: 'x' } })).toEqual({})
+    })
+
+    it('omits a field the model did not supply instead of sending undefined', () => {
+        expect(mcpToolInput.toFlowPayload({ properties: EMAIL_LOOKUP_FLOW, modelArgs: {} })).toEqual({})
+    })
+
+    it('round-trips every field of the failing production schema', () => {
+        const keys = mcpToolInput.modelKeyByPropertyName({ properties: EMAIL_LOOKUP_FLOW })
+        const modelArgs = Object.fromEntries([...keys.values()].map((key, index) => [key, `value-${index}`]))
+        const payload = mcpToolInput.toFlowPayload({ properties: EMAIL_LOOKUP_FLOW, modelArgs })
+        expect(Object.keys(payload)).toEqual(EMAIL_LOOKUP_FLOW.map((property) => property.name))
+    })
+
+    it('preserves a falsy value rather than treating it as absent', () => {
+        const properties = [text('Send Copy'), text('Retry Count')]
+        expect(mcpToolInput.toFlowPayload({ properties, modelArgs: { send_copy: false, retry_count: 0 } }))
+            .toEqual({ 'Send Copy': false, 'Retry Count': 0 })
+    })
+})

--- a/packages/server/api/test/unit/app/mcp/mcp-tool-input.test.ts
+++ b/packages/server/api/test/unit/app/mcp/mcp-tool-input.test.ts
@@ -87,14 +87,14 @@ describe('toFlowPayload', () => {
             .toEqual({ 'Email Sender': 'a@b.com' })
     })
 
-    it('passes an unrecognised key straight through, so a schema change can never silently drop a value', () => {
-        expect(mcpToolInput.toFlowPayload({ properties: EMAIL_LOOKUP_FLOW, modelArgs: { unknown_field: 'x' } }))
-            .toEqual({ unknown_field: 'x' })
+    it('never lets the model reach a flow input the tool schema did not declare', () => {
+        expect(mcpToolInput.toFlowPayload({ properties: EMAIL_LOOKUP_FLOW, modelArgs: { hidden_flow_input: 'x' } }))
+            .toEqual({})
     })
 
-    it('renames what it recognises and leaves the rest alone in the same call', () => {
-        expect(mcpToolInput.toFlowPayload({ properties: EMAIL_LOOKUP_FLOW, modelArgs: { email_sender: 'a@b.com', unknown_field: 'x' } }))
-            .toEqual({ 'Email Sender': 'a@b.com', unknown_field: 'x' })
+    it('keeps the declared fields and drops the undeclared ones in the same call', () => {
+        expect(mcpToolInput.toFlowPayload({ properties: EMAIL_LOOKUP_FLOW, modelArgs: { email_sender: 'a@b.com', hidden_flow_input: 'x' } }))
+            .toEqual({ 'Email Sender': 'a@b.com' })
     })
 
     it('omits a field the model did not supply instead of sending undefined', () => {
@@ -146,24 +146,5 @@ describe('a rewritten key that looks like another field name', () => {
         expect(keyFor({ properties, name: 'field_1' })).toBe('field_1')
         expect(mcpToolInput.toFlowPayload({ properties, modelArgs: { [keyFor({ properties, name: '日本語' })]: 'A', field_1: 'B' } }))
             .toEqual({ '日本語': 'A', field_1: 'B' })
-    })
-})
-
-describe('the flow is republished between building the schema and calling the tool', () => {
-    it('keeps a value whose field was renamed in the new version', () => {
-        expect(mcpToolInput.toFlowPayload({ properties: [text('Sender')], modelArgs: { email_sender: 'A' } }))
-            .toEqual({ email_sender: 'A' })
-    })
-
-    it('keeps a value whose field was removed in the new version', () => {
-        expect(mcpToolInput.toFlowPayload({ properties: [], modelArgs: { email_sender: 'A' } }))
-            .toEqual({ email_sender: 'A' })
-    })
-
-    it('still maps the fields the new version does share', () => {
-        expect(mcpToolInput.toFlowPayload({
-            properties: [text('Email Sender'), text('Brand New Field')],
-            modelArgs: { email_sender: 'A', gone_from_new_schema: 'B' },
-        })).toEqual({ 'Email Sender': 'A', gone_from_new_schema: 'B' })
     })
 })

--- a/packages/server/api/test/unit/app/mcp/mcp-tool-input.test.ts
+++ b/packages/server/api/test/unit/app/mcp/mcp-tool-input.test.ts
@@ -87,8 +87,14 @@ describe('toFlowPayload', () => {
             .toEqual({ 'Email Sender': 'a@b.com' })
     })
 
-    it('drops a key the schema never declared rather than passing it into the flow', () => {
-        expect(mcpToolInput.toFlowPayload({ properties: EMAIL_LOOKUP_FLOW, modelArgs: { injected: 'x' } })).toEqual({})
+    it('passes an unrecognised key straight through, so a schema change can never silently drop a value', () => {
+        expect(mcpToolInput.toFlowPayload({ properties: EMAIL_LOOKUP_FLOW, modelArgs: { unknown_field: 'x' } }))
+            .toEqual({ unknown_field: 'x' })
+    })
+
+    it('renames what it recognises and leaves the rest alone in the same call', () => {
+        expect(mcpToolInput.toFlowPayload({ properties: EMAIL_LOOKUP_FLOW, modelArgs: { email_sender: 'a@b.com', unknown_field: 'x' } }))
+            .toEqual({ 'Email Sender': 'a@b.com', unknown_field: 'x' })
     })
 
     it('omits a field the model did not supply instead of sending undefined', () => {
@@ -140,5 +146,24 @@ describe('a rewritten key that looks like another field name', () => {
         expect(keyFor({ properties, name: 'field_1' })).toBe('field_1')
         expect(mcpToolInput.toFlowPayload({ properties, modelArgs: { [keyFor({ properties, name: '日本語' })]: 'A', field_1: 'B' } }))
             .toEqual({ '日本語': 'A', field_1: 'B' })
+    })
+})
+
+describe('the flow is republished between building the schema and calling the tool', () => {
+    it('keeps a value whose field was renamed in the new version', () => {
+        expect(mcpToolInput.toFlowPayload({ properties: [text('Sender')], modelArgs: { email_sender: 'A' } }))
+            .toEqual({ email_sender: 'A' })
+    })
+
+    it('keeps a value whose field was removed in the new version', () => {
+        expect(mcpToolInput.toFlowPayload({ properties: [], modelArgs: { email_sender: 'A' } }))
+            .toEqual({ email_sender: 'A' })
+    })
+
+    it('still maps the fields the new version does share', () => {
+        expect(mcpToolInput.toFlowPayload({
+            properties: [text('Email Sender'), text('Brand New Field')],
+            modelArgs: { email_sender: 'A', gone_from_new_schema: 'B' },
+        })).toEqual({ 'Email Sender': 'A', gone_from_new_schema: 'B' })
     })
 })

--- a/packages/server/api/test/unit/app/mcp/resolve-runnable-flow.test.ts
+++ b/packages/server/api/test/unit/app/mcp/resolve-runnable-flow.test.ts
@@ -1,0 +1,56 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { mockGetOnePopulatedOrThrow } = vi.hoisted(() => ({
+    mockGetOnePopulatedOrThrow: vi.fn(),
+}))
+
+vi.mock('../../../../src/app/flows/flow/flow.service', () => ({
+    flowService: () => ({ getOnePopulatedOrThrow: mockGetOnePopulatedOrThrow }),
+}))
+
+const { resolveRunnableFlow } = await import('../../../../src/app/mcp/mcp-server-builder')
+
+const log = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() } as never
+
+const flow = ({ versionId, publishedVersionId }: { versionId: string, publishedVersionId?: string }) => ({
+    id: 'flow-1',
+    ...(publishedVersionId === undefined ? {} : { publishedVersionId }),
+    version: { id: versionId, displayName: 'My Flow' },
+}) as never
+
+describe('resolveRunnableFlow', () => {
+    beforeEach(() => {
+        mockGetOnePopulatedOrThrow.mockClear()
+    })
+
+    it('loads the published version when the draft has moved on, so the schema matches what runs', async () => {
+        mockGetOnePopulatedOrThrow.mockResolvedValue(flow({ versionId: 'v-published' }))
+
+        const runnable = await resolveRunnableFlow({ flow: flow({ versionId: 'v-draft', publishedVersionId: 'v-published' }), projectId: 'proj-1', log })
+
+        expect(mockGetOnePopulatedOrThrow).toHaveBeenCalledWith({ id: 'flow-1', projectId: 'proj-1', versionId: 'v-published' })
+        expect(runnable.version.id).toBe('v-published')
+    })
+
+    it('reads nothing extra when the draft is already the published version', async () => {
+        const alreadyPublished = flow({ versionId: 'v-1', publishedVersionId: 'v-1' })
+
+        expect(await resolveRunnableFlow({ flow: alreadyPublished, projectId: 'proj-1', log })).toBe(alreadyPublished)
+        expect(mockGetOnePopulatedOrThrow).not.toHaveBeenCalled()
+    })
+
+    it('keeps the draft when nothing has been published yet', async () => {
+        const draftOnly = flow({ versionId: 'v-draft' })
+
+        expect(await resolveRunnableFlow({ flow: draftOnly, projectId: 'proj-1', log })).toBe(draftOnly)
+        expect(mockGetOnePopulatedOrThrow).not.toHaveBeenCalled()
+    })
+
+    it('stays scoped to the project it was asked about', async () => {
+        mockGetOnePopulatedOrThrow.mockResolvedValue(flow({ versionId: 'v-published' }))
+
+        await resolveRunnableFlow({ flow: flow({ versionId: 'v-draft', publishedVersionId: 'v-published' }), projectId: 'proj-own', log })
+
+        expect(mockGetOnePopulatedOrThrow).toHaveBeenCalledWith(expect.objectContaining({ projectId: 'proj-own' }))
+    })
+})

--- a/packages/server/worker/src/lib/execute/jobs/ee/agent/execute-agent-run.ts
+++ b/packages/server/worker/src/lib/execute/jobs/ee/agent/execute-agent-run.ts
@@ -660,7 +660,7 @@ function buildToolSet({ ctx, eventEmitter, log, phaseState, taintState, mcpToolS
     })
     const configuredFlowToolSet = agentWorkerTools.createConfiguredFlowTools({
         tools: dryRun || discoveryOnly ? [] : configuredFlowTools,
-        runFlowTool: ({ toolName, flowId, returnsResponse, toolInput }) => ctx.apiClient.executeFlowTool({ conversationId, toolName, flowId, toolInput, returnsResponse }),
+        runFlowTool: ({ toolName, flowId, flowVersionId, returnsResponse, toolInput }) => ctx.apiClient.executeFlowTool({ conversationId, toolName, flowId, ...spreadIfDefined('flowVersionId', flowVersionId), toolInput, returnsResponse }),
         log,
     })
     const knowledgeBaseTools = agentWorkerTools.createConfiguredKnowledgeBaseTools({

--- a/packages/server/worker/src/lib/execute/jobs/ee/agent/tools/configured-tools.ts
+++ b/packages/server/worker/src/lib/execute/jobs/ee/agent/tools/configured-tools.ts
@@ -197,7 +197,7 @@ const jsonSchema7Shape = z.custom<JSONSchema7>()
 
 export function createConfiguredFlowTools({ tools, runFlowTool, log }: {
     tools: ResolvedAgentFlowTool[]
-    runFlowTool: (input: { toolName: string, flowId: string, returnsResponse: boolean, toolInput: Record<string, unknown> }) => Promise<{ result: unknown }>
+    runFlowTool: (input: { toolName: string, flowId: string, flowVersionId?: string, returnsResponse: boolean, toolInput: Record<string, unknown> }) => Promise<{ result: unknown }>
     log: FastifyBaseLogger
 }): ToolSet {
     let callsMade = 0
@@ -212,7 +212,7 @@ export function createConfiguredFlowTools({ tools, runFlowTool, log }: {
                     log.warn({ tool: { name: configured.toolName }, callsMade }, '[configuredFlowTool] Refused, this run has already run enough actions')
                     return { content: [{ type: 'text', text: `This run has already performed ${MAX_CONFIGURED_TOOL_CALLS} actions, which is the limit. Do not try again; say what is left undone.` }] }
                 }
-                const { data, error } = await tryCatch(() => runFlowTool({ toolName: configured.toolName, flowId: configured.flowId, returnsResponse: configured.returnsResponse, toolInput }))
+                const { data, error } = await tryCatch(() => runFlowTool({ toolName: configured.toolName, flowId: configured.flowId, ...spreadIfDefined('flowVersionId', configured.flowVersionId), returnsResponse: configured.returnsResponse, toolInput }))
                 if (error) {
                     const reachedTheServer = String(error).includes('handler threw')
                     log.warn({ error, tool: { name: configured.toolName }, flow: { id: configured.flowId }, reachedTheServer }, '[configuredFlowTool] Flow did not return a result')


### PR DESCRIPTION
## Description

A flow exposed as an agent tool or an MCP tool sent the customer's own field labels to the model as JSON Schema property keys. Anthropic validates those against `^[a-zA-Z0-9_.-]{1,64}$`, so a field called `Email Sender` was rejected and every run of the step failed. It caused 8 of the 30 live agent failures in the shared queue on 2026-09-08.

`McpProperty` only has `name`, used as both the human label and the machine key, and the label is also the flow's contract because the payload keyed by it becomes the trigger body. So it can't just be renamed. `mcpToolInput` now owns both directions: it derives a provider-safe key per field, and maps the model's arguments back to the original names before the flow runs. Keys reuse the existing `PROVIDER_TOOL_NAME_PATTERN` rather than adding a second rule. An already-safe field name is left byte-identical, a rewritten key carries the original label as its schema `title`, and colliding names get distinct keys instead of one field silently vanishing.

A resolved flow tool also carries the id of the version whose schema it advertised, so `executeFlowTool` translates with the schema the model was actually shown rather than whatever is published by then. That is what makes filtering to declared fields safe, and it means a flow can only receive inputs its own tool schema declared.

## How was this tested?

18 unit tests in `mcp-tool-input.test.ts` built from the exact schema that was failing in production, plus 3 in `agent-rpc-handlers.test.ts` for the version pinning. Each fix was mutation-tested by reverting it: the original bug fails 8 tests, dropping the collision dedupe fails 1, ignoring the pinned version fails 1.

`api` and `worker` build, 0 lint errors, 1135 api unit tests and 271 worker tests pass. The 18 failures in `machine-service`, `worker-group.service` and `job-broker` reproduce on a clean tree.

Fixes # (issue)

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

- [ ] no — reviewed, no security impact
- [x] yes — security-sensitive (call out the risk and mitigation in the description above)
