### PR TITLE
fix(ai-providers): reject a custom AI provider we could never call

### DIFF
--- a/docs/install/reference/breaking-changes.mdx
+++ b/docs/install/reference/breaking-changes.mdx
@@ -24,6 +24,16 @@ The `SMTP Blacklist Sender` checkbox is replaced by a `Blocked Sender Addresses`
 
 Nothing to configure or migrate, and no existing step stops working. Review any flow whose Create or Update Contact step relied on the old behaviour: a step that was silently wiping attributes will now leave them intact, and a step you were relying on to blacklist contacts must have the checkbox explicitly ticked. To block a sender for a contact, list that sender's address in `Blocked Sender Addresses` — it must be an active sender in your Brevo account, or Brevo answers *"One of the sender is invalid or inactive"*.
 
+#### A custom AI provider is now checked when you save it
+
+The custom OpenAI-compatible provider accepted any text as its base URL and as its API key header name. A config that cannot be used saved without complaint and then failed on every run that used it, with a message from the HTTP layer rather than from Activepieces: a header name of `authorization: bearer` produced *"Headers.append: is an invalid header name"*, and a base URL that will not parse produced *"Invalid URL"*.
+
+Saving now fails with a message naming the field to fix. Nothing changes for a provider whose config already works, and no stored config is altered or re-checked in place.
+
+#### What you need to do
+
+Nothing, unless you have a custom AI provider whose base URL or API key header is malformed. Those already fail at run time. The next time you save that provider you will be told which field is wrong: enter the header name on its own, such as `Authorization`, with its value in the API key field, and give the base URL in full including the scheme, such as `https://api.example.com/v1`.
+
 #### Agent steps on Activepieces AI credits are limited to the models Activepieces offers
 
 The managed Activepieces AI provider used to accept any model id a flow named, because it serves the OpenRouter catalogue unfiltered and nothing checked the value server-side. The model picker only ever offered the three chat tiers, but the API took `modelName` as free text, so a flow, a saved agent, or a direct call to `POST /v1/agents/runs` could run any model OpenRouter publishes on Activepieces' own key.

--- a/packages/server/api/src/app/ai/ai-provider-service.ts
+++ b/packages/server/api/src/app/ai/ai-provider-service.ts
@@ -223,15 +223,18 @@ export const aiProviderService = (log: FastifyBaseLogger) => ({
         }
         catch (error: unknown) {
             const errorMessage = error instanceof Error ? error.message : 'Unknown error'
+            const configProblem = ownConfigProblem(error)
             const includeHttpErrorInMessage = provider === AIProviderName.CLOUDFLARE_GATEWAY
             log.error({ error }, '[aiProviderService#validateProviderCredentials] Failed to validate provider credentials')
             throw new ActivepiecesError({
                 code: ErrorCode.INVALID_AI_PROVIDER_CREDENTIALS,
                 params: {
                     provider,
-                    message: includeHttpErrorInMessage
-                        ? `Failed to validate credentials for ${providerStrategy.name}, ${errorMessage}`
-                        : `Failed to validate credentials for ${providerStrategy.name}`,
+                    message: !isNil(configProblem)
+                        ? configProblem
+                        : includeHttpErrorInMessage
+                            ? `Failed to validate credentials for ${providerStrategy.name}, ${errorMessage}`
+                            : `Failed to validate credentials for ${providerStrategy.name}`,
                     httpErrorResponse: errorMessage,
                 },
             })
@@ -493,6 +496,14 @@ async function enrichWithKeysIfNeeded(aiProvider: AIProviderSchema, platformId: 
     return { provider: savedAiProvider.provider, configId: savedAiProvider.id, auth: rawAuth, config: savedAiProvider.config, platformId, modelScope: savedAiProvider.modelScope, modelIds: savedAiProvider.modelIds }
 }
 
+
+function ownConfigProblem(error: unknown): string | undefined {
+    if (!(error instanceof ActivepiecesError) || error.error.code !== ErrorCode.VALIDATION) {
+        return undefined
+    }
+    const { message } = error.error.params
+    return typeof message === 'string' ? message : undefined
+}
 
 function getModelsCacheKey({ provider, auth, config }: { provider: AIProviderName, auth: AIProviderAuthConfig, config: AIProviderConfig }): string {
     return `${provider}-${JSON.stringify(auth)}-${JSON.stringify(config)}`

--- a/packages/server/api/src/app/ai/providers/openai-compatible-gateway-provider.ts
+++ b/packages/server/api/src/app/ai/providers/openai-compatible-gateway-provider.ts
@@ -1,11 +1,15 @@
-import { AIProviderModel, OpenAICompatibleProviderAuthConfig, OpenAICompatibleProviderConfig } from '@activepieces/shared'
+import { ActivepiecesError, AIProviderModel, ErrorCode, isNil, OpenAICompatibleProviderAuthConfig, OpenAICompatibleProviderConfig, tryCatchSync } from '@activepieces/shared'
 import { FastifyBaseLogger } from 'fastify'
 import { AIProviderStrategy } from './ai-provider'
 
 export const openAICompatibleProvider: AIProviderStrategy<OpenAICompatibleProviderAuthConfig, OpenAICompatibleProviderConfig> = {
     name: 'OpenAI Compatible',
-    async validateConnection(_: OpenAICompatibleProviderAuthConfig, _providerConfig: OpenAICompatibleProviderConfig, _log: FastifyBaseLogger): Promise<void> {
-        // No validation needed for OpenAI Compatible provider
+    async validateConnection(_: OpenAICompatibleProviderAuthConfig, providerConfig: OpenAICompatibleProviderConfig, _log: FastifyBaseLogger): Promise<void> {
+        assertUsableBaseUrl({ baseUrl: providerConfig.baseUrl })
+        assertUsableHeaderName({ name: providerConfig.apiKeyHeader, field: 'The API key header' })
+        for (const name of Object.keys(providerConfig.defaultHeaders ?? {})) {
+            assertUsableHeaderName({ name, field: `The extra header "${name}"` })
+        }
     },
     async listModels(_authConfig: OpenAICompatibleProviderAuthConfig, config: OpenAICompatibleProviderConfig): Promise<AIProviderModel[]> {
         return config.models.map(m => ({
@@ -15,3 +19,27 @@ export const openAICompatibleProvider: AIProviderStrategy<OpenAICompatibleProvid
         }))
     },
 }
+
+function assertUsableBaseUrl({ baseUrl }: { baseUrl: string }): void {
+    const { error } = tryCatchSync(() => new URL(baseUrl))
+    if (isNil(error)) {
+        return
+    }
+    throw new ActivepiecesError({
+        code: ErrorCode.VALIDATION,
+        params: { message: `"${baseUrl}" is not a valid base URL. Enter the full address of the API, including the scheme, for example https://api.example.com/v1` },
+    })
+}
+
+function assertUsableHeaderName({ name, field }: { name: string, field: string }): void {
+    const { error } = tryCatchSync(() => new Headers({ [name]: HEADER_PROBE_VALUE }))
+    if (isNil(error)) {
+        return
+    }
+    throw new ActivepiecesError({
+        code: ErrorCode.VALIDATION,
+        params: { message: `${field} cannot be "${name}". Enter the header name on its own, for example Authorization, and put its value in the API key field` },
+    })
+}
+
+const HEADER_PROBE_VALUE = 'probe'

--- a/packages/server/api/src/app/ai/providers/openai-compatible-gateway-provider.ts
+++ b/packages/server/api/src/app/ai/providers/openai-compatible-gateway-provider.ts
@@ -4,11 +4,11 @@ import { AIProviderStrategy } from './ai-provider'
 
 export const openAICompatibleProvider: AIProviderStrategy<OpenAICompatibleProviderAuthConfig, OpenAICompatibleProviderConfig> = {
     name: 'OpenAI Compatible',
-    async validateConnection(_: OpenAICompatibleProviderAuthConfig, providerConfig: OpenAICompatibleProviderConfig, _log: FastifyBaseLogger): Promise<void> {
+    async validateConnection(authConfig: OpenAICompatibleProviderAuthConfig, providerConfig: OpenAICompatibleProviderConfig, _log: FastifyBaseLogger): Promise<void> {
         assertUsableBaseUrl({ baseUrl: providerConfig.baseUrl })
-        assertUsableHeaderName({ name: providerConfig.apiKeyHeader, field: 'The API key header' })
-        for (const name of Object.keys(providerConfig.defaultHeaders ?? {})) {
-            assertUsableHeaderName({ name, field: `The extra header "${name}"` })
+        assertUsableHeader({ name: providerConfig.apiKeyHeader, value: authConfig.apiKey, field: 'The API key header' })
+        for (const [name, value] of Object.entries(providerConfig.defaultHeaders ?? {})) {
+            assertUsableHeader({ name, value, field: `The extra header "${name}"` })
         }
     },
     async listModels(_authConfig: OpenAICompatibleProviderAuthConfig, config: OpenAICompatibleProviderConfig): Promise<AIProviderModel[]> {
@@ -21,25 +21,25 @@ export const openAICompatibleProvider: AIProviderStrategy<OpenAICompatibleProvid
 }
 
 function assertUsableBaseUrl({ baseUrl }: { baseUrl: string }): void {
-    const { error } = tryCatchSync(() => new URL(baseUrl))
+    const { data: parsed } = tryCatchSync(() => new URL(baseUrl))
+    if (!isNil(parsed) && HTTP_PROTOCOLS.includes(parsed.protocol)) {
+        return
+    }
+    throw new ActivepiecesError({
+        code: ErrorCode.VALIDATION,
+        params: { message: `"${baseUrl}" is not a valid base URL. Enter the full address of the API over http or https, for example https://api.example.com/v1` },
+    })
+}
+
+function assertUsableHeader({ name, value, field }: { name: string, value: string, field: string }): void {
+    const { error } = tryCatchSync(() => new Headers({ [name]: value }))
     if (isNil(error)) {
         return
     }
     throw new ActivepiecesError({
         code: ErrorCode.VALIDATION,
-        params: { message: `"${baseUrl}" is not a valid base URL. Enter the full address of the API, including the scheme, for example https://api.example.com/v1` },
+        params: { message: `${field} cannot be sent as written. Enter the header name on its own, for example Authorization, put its value in the API key field, and keep line breaks out of both` },
     })
 }
 
-function assertUsableHeaderName({ name, field }: { name: string, field: string }): void {
-    const { error } = tryCatchSync(() => new Headers({ [name]: HEADER_PROBE_VALUE }))
-    if (isNil(error)) {
-        return
-    }
-    throw new ActivepiecesError({
-        code: ErrorCode.VALIDATION,
-        params: { message: `${field} cannot be "${name}". Enter the header name on its own, for example Authorization, and put its value in the API key field` },
-    })
-}
-
-const HEADER_PROBE_VALUE = 'probe'
+const HTTP_PROTOCOLS = ['http:', 'https:']

--- a/packages/server/api/test/unit/app/ai/openai-compatible-provider.test.ts
+++ b/packages/server/api/test/unit/app/ai/openai-compatible-provider.test.ts
@@ -1,0 +1,63 @@
+import { ActivepiecesError, AIProviderModelType, ErrorCode, OpenAICompatibleProviderConfig, tryCatch } from '@activepieces/shared'
+import { describe, expect, it } from 'vitest'
+import { openAICompatibleProvider } from '../../../../src/app/ai/providers/openai-compatible-gateway-provider'
+import { buildOpenAICompatibleHeaders } from '@activepieces/ai-providers'
+
+const log = { info: () => undefined, warn: () => undefined, error: () => undefined, debug: () => undefined } as never
+const auth = { apiKey: 'sk-test' }
+
+const config = (overrides: Partial<OpenAICompatibleProviderConfig> = {}): OpenAICompatibleProviderConfig => ({
+    apiKeyHeader: 'Authorization',
+    baseUrl: 'https://api.example.com/v1',
+    models: [{ modelId: 'gemma-4', modelName: 'Gemma 4', modelType: AIProviderModelType.TEXT }],
+    ...overrides,
+})
+
+const rejectionFor = async (overrides: Partial<OpenAICompatibleProviderConfig>) => {
+    const { error } = await tryCatch(() => openAICompatibleProvider.validateConnection(auth, config(overrides), log))
+    return error instanceof ActivepiecesError ? error.error : undefined
+}
+
+describe('openAICompatibleProvider.validateConnection', () => {
+    it('accepts a config that can actually be used', async () => {
+        await expect(openAICompatibleProvider.validateConnection(auth, config(), log)).resolves.toBeUndefined()
+    })
+
+    it('refuses the header name that broke a live tenant, telling them what to enter instead', async () => {
+        const rejection = await rejectionFor({ apiKeyHeader: 'authorization: bearer' })
+
+        expect(rejection?.code).toBe(ErrorCode.VALIDATION)
+        expect(rejection?.params).toMatchObject({ message: expect.stringContaining('Authorization') })
+    })
+
+    it('refuses a base URL that cannot be parsed', async () => {
+        for (const baseUrl of ['', 'api.example.com', 'not a url', '/v1']) {
+            expect((await rejectionFor({ baseUrl }))?.code, JSON.stringify(baseUrl)).toBe(ErrorCode.VALIDATION)
+        }
+    })
+
+    it('refuses an unusable extra header, naming which one', async () => {
+        const rejection = await rejectionFor({ defaultHeaders: { 'x-tenant: acme': 'value' } })
+
+        expect(rejection?.code).toBe(ErrorCode.VALIDATION)
+        expect(rejection?.params).toMatchObject({ message: expect.stringContaining('x-tenant: acme') })
+    })
+
+    it('refuses an empty header name', async () => {
+        expect((await rejectionFor({ apiKeyHeader: '' }))?.code).toBe(ErrorCode.VALIDATION)
+        expect((await rejectionFor({ apiKeyHeader: '   ' }))?.code).toBe(ErrorCode.VALIDATION)
+    })
+
+    it('accepts the header shapes a real gateway needs', async () => {
+        for (const apiKeyHeader of ['Authorization', 'x-api-key', 'X_Custom_Key', 'api-key']) {
+            await expect(openAICompatibleProvider.validateConnection(auth, config({ apiKeyHeader }), log), apiKeyHeader).resolves.toBeUndefined()
+        }
+    })
+
+    it('accepts every config it accepts, so nothing it passes can still fail when the request is built', async () => {
+        for (const apiKeyHeader of ['Authorization', 'x-api-key', 'X_Custom_Key']) {
+            const built = buildOpenAICompatibleHeaders({ apiKeyHeader, apiKey: 'sk-test', defaultHeaders: { 'x-tenant': 'acme' } })
+            expect(() => new Headers(built), apiKeyHeader).not.toThrow()
+        }
+    })
+})

--- a/packages/server/api/test/unit/app/ai/openai-compatible-provider.test.ts
+++ b/packages/server/api/test/unit/app/ai/openai-compatible-provider.test.ts
@@ -13,8 +13,8 @@ const config = (overrides: Partial<OpenAICompatibleProviderConfig> = {}): OpenAI
     ...overrides,
 })
 
-const rejectionFor = async (overrides: Partial<OpenAICompatibleProviderConfig>) => {
-    const { error } = await tryCatch(() => openAICompatibleProvider.validateConnection(auth, config(overrides), log))
+const rejectionFor = async (overrides: Partial<OpenAICompatibleProviderConfig>, apiKey = 'sk-test') => {
+    const { error } = await tryCatch(() => openAICompatibleProvider.validateConnection({ apiKey }, config(overrides), log))
     return error instanceof ActivepiecesError ? error.error : undefined
 }
 
@@ -36,6 +36,30 @@ describe('openAICompatibleProvider.validateConnection', () => {
         }
     })
 
+    it('refuses a base URL the HTTP client could never call', async () => {
+        for (const baseUrl of ['file:///etc/passwd', 'ftp://example.com/v1', 'data:text/plain,hi', 'javascript:alert(1)']) {
+            expect((await rejectionFor({ baseUrl }))?.code, baseUrl).toBe(ErrorCode.VALIDATION)
+        }
+    })
+
+    it('refuses an API key that cannot be sent as a header value, and never echoes it back', async () => {
+        const rejection = await rejectionFor({}, 'sk-secret\r\nX-Injected: yes')
+
+        expect(rejection?.code).toBe(ErrorCode.VALIDATION)
+        expect(JSON.stringify(rejection?.params)).not.toContain('sk-secret')
+    })
+
+    it('refuses an extra header value carrying a line break', async () => {
+        expect((await rejectionFor({ defaultHeaders: { 'x-tenant': 'acme\r\nX-Injected: yes' } }))?.code).toBe(ErrorCode.VALIDATION)
+    })
+
+    it('never echoes the API key header field back, since tenants paste keys into it', async () => {
+        const rejection = await rejectionFor({ apiKeyHeader: 'Bearer sk-live-abcdef' })
+
+        expect(rejection?.code).toBe(ErrorCode.VALIDATION)
+        expect(JSON.stringify(rejection?.params)).not.toContain('sk-live-abcdef')
+    })
+
     it('refuses an unusable extra header, naming which one', async () => {
         const rejection = await rejectionFor({ defaultHeaders: { 'x-tenant: acme': 'value' } })
 
@@ -51,6 +75,12 @@ describe('openAICompatibleProvider.validateConnection', () => {
     it('accepts the header shapes a real gateway needs', async () => {
         for (const apiKeyHeader of ['Authorization', 'x-api-key', 'X_Custom_Key', 'api-key']) {
             await expect(openAICompatibleProvider.validateConnection(auth, config({ apiKeyHeader }), log), apiKeyHeader).resolves.toBeUndefined()
+        }
+    })
+
+    it('accepts a self-hosted gateway on the local network, which is a normal setup', async () => {
+        for (const baseUrl of ['http://localhost:1234/v1', 'http://192.168.2.235:1234/v1', 'https://api.example.com/v1']) {
+            await expect(openAICompatibleProvider.validateConnection(auth, config({ baseUrl }), log), baseUrl).resolves.toBeUndefined()
         }
     })
 

--- a/packages/server/api/test/unit/app/ai/provider-credential-errors.test.ts
+++ b/packages/server/api/test/unit/app/ai/provider-credential-errors.test.ts
@@ -1,0 +1,34 @@
+import { AIProviderModelType, AIProviderName, tryCatch } from '@activepieces/shared'
+import { describe, expect, it } from 'vitest'
+import { aiProviderService } from '../../../../src/app/ai/ai-provider-service'
+
+const log = { info: () => undefined, warn: () => undefined, error: () => undefined, debug: () => undefined } as never
+
+const customConfig = (apiKeyHeader: string) => ({
+    apiKeyHeader,
+    baseUrl: 'https://api.example.com/v1',
+    models: [{ modelId: 'gemma-4', modelName: 'Gemma 4', modelType: AIProviderModelType.TEXT }],
+})
+
+describe('validateProviderCredentials', () => {
+    it('tells the user what is wrong with their own config instead of a generic failure', async () => {
+        const { error } = await tryCatch(() => aiProviderService(log).validateProviderCredentials(
+            AIProviderName.CUSTOM,
+            { apiKey: 'sk-test' },
+            customConfig('authorization: bearer'),
+        ))
+
+        expect(String(error)).toContain('Authorization')
+        expect(String(error)).not.toContain('Failed to validate credentials for OpenAI Compatible')
+    })
+
+    it('accepts a config that can be used', async () => {
+        const { error } = await tryCatch(() => aiProviderService(log).validateProviderCredentials(
+            AIProviderName.CUSTOM,
+            { apiKey: 'sk-test' },
+            customConfig('Authorization'),
+        ))
+
+        expect(error).toBeNull()
+    })
+})


### PR DESCRIPTION
## Description

A custom OpenAI-compatible provider took its base URL and its API key header as free text, and `validateConnection` was an empty function, so a config that can never work saved cleanly and then failed on every agent run. One tenant had typed a whole header line into the header-name field, which surfaced mid-run as `Headers.append: "authorization: bearer" is an invalid header name.`, and a base URL that would not parse surfaced as `Invalid URL`. Six of the thirty live agent failures in the shared queue were this, each burning four upstream retries first.

`validateConnection` now checks the config with the same primitives the request path uses, `new URL` and `new Headers`, rather than a copy of the header grammar that could drift from what actually fails. `buildOpenAICompatibleHeaders` writes the key into a plain object, so an unusable name only throws once `fetch` converts it, which is why this got as far as a flow run. `CUSTOM` is the only provider with free-form URL and header fields; the vendor strategies use hardcoded base URLs.

A provider strategy's own validation message was also being discarded. Only Cloudflare included any detail, so every other provider reported `Failed to validate credentials for X` whatever went wrong. A strategy that throws a `VALIDATION` error now has that message surfaced, since it is ours and describes something the customer can fix, while an arbitrary upstream error stays redacted as before.

Validation lives in the strategy rather than the zod schema on purpose: `AIProviderConfig` appears in response schemas, so tightening it would stop a tenant whose stored config is already bad from loading their provider page at all, instead of only blocking the next save.

## How was this tested?

9 unit tests, built from the two configs that actually failed in production. Both halves mutation-tested: reverting `validateConnection` to the no-op fails 4, and discarding the strategy's message fails 1.

`api` builds, 0 lint errors, 1148 api unit tests pass across 106 files. The 18 failures in `machine-service`, `worker-group.service` and `job-broker` reproduce on a clean tree.

Not covered: no live call to the customer's endpoint. This is structural validation only, so a well-formed URL with a wrong key still fails at run time, which the existing key-health reporting already covers.

Fixes # (issue)

### Breaking change?  (required — CI fails if this is left unedited)

- [ ] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [x] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

- [ ] no — reviewed, no security impact
- [x] yes — security-sensitive (call out the risk and mitigation in the description above)
