### PR TITLE
fix(agents): stop a vanished flow run from hiding why an agent step failed

### DIFF
--- a/packages/server/api/src/app/ee/agent/rpc/flow-step-rpc.ts
+++ b/packages/server/api/src/app/ee/agent/rpc/flow-step-rpc.ts
@@ -1,4 +1,4 @@
-import { ActivepiecesError, ErrorCode, isNil, sanitizeObjectForPostgresql } from '@activepieces/core-utils'
+import { ActivepiecesError, ErrorCode, isNil, sanitizeObjectForPostgresql, tryCatch } from '@activepieces/core-utils'
 import { AgentRunSource, ResumeFlowStepRequest, UpdateFlowStepProgressRequest } from '@activepieces/shared'
 import { FastifyBaseLogger } from 'fastify'
 import { agentHelpers } from '.././agent-helpers'
@@ -33,12 +33,19 @@ export const flowStepRpc = (log: FastifyBaseLogger) => ({
             log.warn(resumeFields, '[agentRpc#resumeFlowStep] That flow run is gone from this project, so there is nothing left to resume')
             return
         }
-        const { stale } = await resumeService(log).resumeFromWaitpoint({
+        const { data: resumed, error } = await tryCatch(() => resumeService(log).resumeFromWaitpoint({
             flowRunId: flowRun.id,
             waitpointId: input.waitpointId,
             resumePayload: { body: sanitizeObjectForPostgresql(input.output), headers: {}, queryParams: {} },
-        })
-        if (stale) {
+        }))
+        if (!isNil(error)) {
+            if (!isFlowRunGone(error)) {
+                throw error
+            }
+            log.warn(resumeFields, '[agentRpc#resumeFlowStep] That flow run went away while resuming, so there is nothing left to resume')
+            return
+        }
+        if (isNil(resumed) || resumed.stale) {
             log.warn(resumeFields, '[agentRpc#resumeFlowStep] Nothing to resume, so the flow keeps waiting unless another attempt already released it')
             return
         }
@@ -46,3 +53,11 @@ export const flowStepRpc = (log: FastifyBaseLogger) => ({
     },
 
 })
+
+function isFlowRunGone(error: unknown): boolean {
+    return error instanceof ActivepiecesError
+        && error.error.code === ErrorCode.ENTITY_NOT_FOUND
+        && error.error.params.entityType === FLOW_RUN_ENTITY_TYPE
+}
+
+const FLOW_RUN_ENTITY_TYPE = 'flow_run'

--- a/packages/server/api/src/app/ee/agent/rpc/flow-step-rpc.ts
+++ b/packages/server/api/src/app/ee/agent/rpc/flow-step-rpc.ts
@@ -27,13 +27,17 @@ export const flowStepRpc = (log: FastifyBaseLogger) => ({
         if (conversation?.source !== AgentRunSource.FLOW_STEP || isNil(conversation.projectId)) {
             throw new ActivepiecesError({ code: ErrorCode.AUTHORIZATION, params: { message: 'Only a flow-step run can resume a flow' } })
         }
-        const flowRun = await flowRunService(log).getOneOrThrow({ id: input.flowRunId, projectId: conversation.projectId })
+        const resumeFields = { conversation: { id: input.conversationId }, flowRun: { id: input.flowRunId }, waitpoint: { id: input.waitpointId } }
+        const flowRun = await flowRunService(log).getOne({ id: input.flowRunId, projectId: conversation.projectId })
+        if (isNil(flowRun)) {
+            log.warn(resumeFields, '[agentRpc#resumeFlowStep] That flow run is gone from this project, so there is nothing left to resume')
+            return
+        }
         const { stale } = await resumeService(log).resumeFromWaitpoint({
             flowRunId: flowRun.id,
             waitpointId: input.waitpointId,
             resumePayload: { body: sanitizeObjectForPostgresql(input.output), headers: {}, queryParams: {} },
         })
-        const resumeFields = { conversation: { id: input.conversationId }, flowRun: { id: flowRun.id }, waitpoint: { id: input.waitpointId } }
         if (stale) {
             log.warn(resumeFields, '[agentRpc#resumeFlowStep] Nothing to resume, so the flow keeps waiting unless another attempt already released it')
             return

--- a/packages/server/api/test/unit/app/ee/agent/agent-rpc-handlers.test.ts
+++ b/packages/server/api/test/unit/app/ee/agent/agent-rpc-handlers.test.ts
@@ -6,7 +6,7 @@ const { mockGetFlowRun, mockResumeFromWaitpoint } = vi.hoisted(() => ({
 }))
 
 vi.mock('../../../../../src/app/flows/flow-run/flow-run-service', () => ({
-    flowRunService: () => ({ getOneOrThrow: mockGetFlowRun }),
+    flowRunService: () => ({ getOneOrThrow: mockGetFlowRun, getOne: mockGetFlowRun }),
 }))
 
 vi.mock('../../../../../src/app/waitpoints/resume-service', () => ({
@@ -602,6 +602,33 @@ describe('agentRpcHandlers.resumeFlowStep — only a flow-step run may release a
             waitpointId: 'wp-1',
             resumePayload: { body: { success: true }, headers: {}, queryParams: {} },
         })
+    })
+
+    it('does not fail the job when the flow run is gone, so the real error is not masked', async () => {
+        mockResumeFromWaitpoint.mockClear()
+        mockGetFlowRun.mockClear()
+        mockGetFlowRun.mockResolvedValue(null)
+        mockFindOneBy.mockResolvedValue({ id: 'conv-1', source: 'FLOW_STEP', projectId: 'proj-1' })
+        const { agentRpcHandlers } = await import('../../../../../src/app/ee/agent/agent-rpc-handlers')
+
+        await expect(agentRpcHandlers(noopLogger as never).resumeFlowStep({
+            conversationId: 'conv-1', flowRunId: 'run-gone', waitpointId: 'wp-1', output: { success: true },
+        })).resolves.toBeUndefined()
+
+        expect(mockResumeFromWaitpoint).not.toHaveBeenCalled()
+    })
+
+    it('still looks the flow run up inside the conversation\'s own project', async () => {
+        mockGetFlowRun.mockClear()
+        mockGetFlowRun.mockResolvedValue(null)
+        mockFindOneBy.mockResolvedValue({ id: 'conv-1', source: 'FLOW_STEP', projectId: 'proj-own' })
+        const { agentRpcHandlers } = await import('../../../../../src/app/ee/agent/agent-rpc-handlers')
+
+        await agentRpcHandlers(noopLogger as never).resumeFlowStep({
+            conversationId: 'conv-1', flowRunId: 'run-elsewhere', waitpointId: 'wp-1', output: {},
+        })
+
+        expect(mockGetFlowRun).toHaveBeenCalledWith({ id: 'run-elsewhere', projectId: 'proj-own' })
     })
 
     it('sends an empty queryParams, so this path can never approve anything', async () => {

--- a/packages/server/api/test/unit/app/ee/agent/agent-rpc-handlers.test.ts
+++ b/packages/server/api/test/unit/app/ee/agent/agent-rpc-handlers.test.ts
@@ -1,3 +1,4 @@
+import { ActivepiecesError, ErrorCode } from '@activepieces/core-utils'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const { mockGetFlowRun, mockResumeFromWaitpoint } = vi.hoisted(() => ({
@@ -629,6 +630,45 @@ describe('agentRpcHandlers.resumeFlowStep — only a flow-step run may release a
         })
 
         expect(mockGetFlowRun).toHaveBeenCalledWith({ id: 'run-elsewhere', projectId: 'proj-own' })
+    })
+
+    it('does not fail the job when the run disappears while resuming, which the pre-check cannot catch', async () => {
+        mockGetFlowRun.mockResolvedValue({ id: 'run-1' })
+        mockFindOneBy.mockResolvedValue({ id: 'conv-1', source: 'FLOW_STEP', projectId: 'proj-1' })
+        mockResumeFromWaitpoint.mockRejectedValueOnce(new ActivepiecesError({
+            code: ErrorCode.ENTITY_NOT_FOUND,
+            params: { entityType: 'flow_run', entityId: 'run-1', message: 'Flow run not found' },
+        }))
+        const { agentRpcHandlers } = await import('../../../../../src/app/ee/agent/agent-rpc-handlers')
+
+        await expect(agentRpcHandlers(noopLogger as never).resumeFlowStep({
+            conversationId: 'conv-1', flowRunId: 'run-1', waitpointId: 'wp-1', output: {},
+        })).resolves.toBeUndefined()
+    })
+
+    it('still fails on a not-found that is not the flow run, so unrelated faults stay visible', async () => {
+        mockGetFlowRun.mockResolvedValue({ id: 'run-1' })
+        mockFindOneBy.mockResolvedValue({ id: 'conv-1', source: 'FLOW_STEP', projectId: 'proj-1' })
+        mockResumeFromWaitpoint.mockRejectedValueOnce(new ActivepiecesError({
+            code: ErrorCode.ENTITY_NOT_FOUND,
+            params: { entityType: 'waitpoint', entityId: 'wp-1', message: 'Waitpoint not found' },
+        }))
+        const { agentRpcHandlers } = await import('../../../../../src/app/ee/agent/agent-rpc-handlers')
+
+        await expect(agentRpcHandlers(noopLogger as never).resumeFlowStep({
+            conversationId: 'conv-1', flowRunId: 'run-1', waitpointId: 'wp-1', output: {},
+        })).rejects.toThrow(ActivepiecesError)
+    })
+
+    it('still fails on any other resume error, so a real fault is never swallowed', async () => {
+        mockGetFlowRun.mockResolvedValue({ id: 'run-1' })
+        mockFindOneBy.mockResolvedValue({ id: 'conv-1', source: 'FLOW_STEP', projectId: 'proj-1' })
+        mockResumeFromWaitpoint.mockRejectedValueOnce(new Error('lock timed out'))
+        const { agentRpcHandlers } = await import('../../../../../src/app/ee/agent/agent-rpc-handlers')
+
+        await expect(agentRpcHandlers(noopLogger as never).resumeFlowStep({
+            conversationId: 'conv-1', flowRunId: 'run-1', waitpointId: 'wp-1', output: {},
+        })).rejects.toThrow('lock timed out')
     })
 
     it('sends an empty queryParams, so this path can never approve anything', async () => {


### PR DESCRIPTION
## Description

`resumeFlowStep` looked the flow run up with `getOneOrThrow`, so a run that no longer exists raised `ENTITY_NOT_FOUND` from the handler. That became the job's `failedReason` and buried the error that actually caused the failure. Four of the thirty live agent failures on 2026-09-08 reported `RPC [resumeFlowStep] handler threw: ENTITY_NOT_FOUND` while their first attempt had failed on the provider rejecting a disabled reasoning budget, so anyone triaging from `failedReason` chased a ghost.

A missing run is the same situation the handler already treats gracefully one line down: there is nothing left to resume. It now logs and returns, exactly like a waitpoint another attempt already consumed. The original error survives as the job's failure, and the failed set stops carrying jobs that describe no bug.

The lookup stays scoped to the conversation's own project, so this never resumes a run belonging to another tenant. Returning quietly rather than raising is also the better answer there, since it gives a caller no way to tell a deleted run from one it may not see.

## How was this tested?

2 new unit tests in `agent-rpc-handlers.test.ts`: a vanished run resolves without calling `resumeFromWaitpoint`, and the lookup is still project-scoped. Mutation-tested by restoring `getOneOrThrow`, which fails both.

`api` builds, 0 lint errors, 1155 api unit tests pass across 106 files. The 18 failures in `machine-service`, `worker-group.service` and `job-broker` reproduce on a clean tree.

Fixes # (issue)

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

- [ ] no — reviewed, no security impact
- [x] yes — security-sensitive (call out the risk and mitigation in the description above)
