### PR TITLE
fix(ci): run the agent eval gate on the agent code again

### DIFF
--- a/.github/workflows/agent-evals.yml
+++ b/.github/workflows/agent-evals.yml
@@ -1,7 +1,7 @@
 name: Chat Evals
 
-# Regression gate for the AI Copilot chat prompt + agent loop.
-#   gate — every PR touching chat/prompt/eval files: deterministic replay + assertion
+# Regression gate for the AI agent prompt + agent loop.
+#   gate — every PR touching agent/prompt/eval files: deterministic replay + assertion
 #          tests, no key, hermetic. Blocks the PR.
 #   live — nightly + manual: fixtures against the real model + LLM-judge, key from secrets.
 #          Nightly runs the regression fixtures only (cheap + stable); run the full suite
@@ -10,11 +10,14 @@ name: Chat Evals
 on:
   pull_request:
     paths:
-      - packages/server/worker/src/lib/execute/jobs/ee/chat/**
+      - packages/server/worker/src/lib/execute/jobs/ee/agent/**
       - packages/server/worker/test/lib/agent-eval/**
-      - packages/server/api/src/app/ee/chat/**
+      - packages/server/api/src/app/ee/agent/**
       - packages/server/api/src/assets/prompts/**
-      - packages/core/shared/src/lib/ee/chat/**
+      - packages/core/shared/src/lib/ee/agent/**
+      - packages/server/utils/src/agent-ai-utils.ts
+      - packages/server/utils/src/agent-provider-options.ts
+      - packages/core/piece-types/src/lib/ai-providers.ts
       - .github/workflows/agent-evals.yml
   schedule:
     - cron: '0 6 * * *'

--- a/.github/workflows/agent-evals.yml
+++ b/.github/workflows/agent-evals.yml
@@ -69,8 +69,11 @@ jobs:
       - name: Build worker dependency graph
         run: npx turbo run build --filter=worker
 
-      - name: Run deterministic chat evals
+      - name: Run deterministic agent evals
         run: npm run agent-evals:ci
+
+      - name: Run the tests covering the gated provider code
+        run: npx turbo run test --filter=@activepieces/server-utils --filter=@activepieces/core-piece-types
 
   live:
     name: Live judge gate

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,7 +149,7 @@ jobs:
           set -euo pipefail
           pids=()
 
-          npx turbo run test --filter=@activepieces/engine --filter=@activepieces/shared --filter=@activepieces/sandbox --filter=@activepieces/ai-providers --filter=@activepieces/core-execution --filter=@activepieces/pieces-framework --filter=web --filter=worker &
+          npx turbo run test --filter=@activepieces/engine --filter=@activepieces/shared --filter=@activepieces/sandbox --filter=@activepieces/ai-providers --filter=@activepieces/core-execution --filter=@activepieces/core-piece-types --filter=@activepieces/server-utils --filter=@activepieces/pieces-framework --filter=web --filter=worker &
           pids+=($!)
 
           npx turbo run test-ce test-ee test-cloud check-migrations --filter=api &

--- a/bun.lock
+++ b/bun.lock
@@ -2067,7 +2067,7 @@
     },
     "packages/pieces/community/coda": {
       "name": "@activepieces/piece-coda",
-      "version": "0.1.8",
+      "version": "0.1.9",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -3711,7 +3711,7 @@
     },
     "packages/pieces/community/gmail": {
       "name": "@activepieces/piece-gmail",
-      "version": "0.14.0",
+      "version": "0.15.0",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -6363,7 +6363,7 @@
     },
     "packages/pieces/community/ntfy": {
       "name": "@activepieces/piece-ntfy",
-      "version": "0.2.8",
+      "version": "0.2.9",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -7308,7 +7308,7 @@
     },
     "packages/pieces/community/pushover": {
       "name": "@activepieces/piece-pushover",
-      "version": "0.2.7",
+      "version": "0.2.8",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -8789,7 +8789,7 @@
     },
     "packages/pieces/community/systeme-io": {
       "name": "@activepieces/piece-systeme-io",
-      "version": "0.1.8",
+      "version": "0.1.9",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -10533,7 +10533,7 @@
     },
     "packages/pieces/core/sftp": {
       "name": "@activepieces/piece-sftp",
-      "version": "0.5.8",
+      "version": "0.5.9",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",

--- a/packages/core/piece-types/package.json
+++ b/packages/core/piece-types/package.json
@@ -5,7 +5,8 @@
   "main": "./dist/src/index.js",
   "scripts": {
     "build": "tsc -p tsconfig.lib.json",
-    "lint": "eslint 'src/**/*.ts'"
+    "lint": "eslint 'src/**/*.ts'",
+    "test": "vitest run"
   },
   "dependencies": {
     "@activepieces/core-utils": "workspace:*",

--- a/packages/server/worker/test/lib/agent-eval/agent-turn-provider-options.test.ts
+++ b/packages/server/worker/test/lib/agent-eval/agent-turn-provider-options.test.ts
@@ -1,0 +1,72 @@
+import { AIProviderName } from '@activepieces/core-utils'
+import { SharedV3ProviderOptions } from '@ai-sdk/provider'
+import { convertArrayToReadableStream, MockLanguageModelV3 } from 'ai/test'
+import { describe, expect, it } from 'vitest'
+import { runAgentTurn } from '../../../src/lib/execute/jobs/ee/agent/run-agent-turn'
+
+const silentLog = { debug: () => undefined, info: () => undefined, warn: () => undefined, error: () => undefined } as never
+
+const TIER = { id: 'fast', thinkingBudget: 5_000, modelId: 'anthropic/claude-haiku-4.5' }
+
+async function capturedProviderOptions({ provider, modelId }: { provider: AIProviderName, modelId: string }): Promise<SharedV3ProviderOptions[]> {
+    const sent: SharedV3ProviderOptions[] = []
+    const model = new MockLanguageModelV3({
+        doStream: async ({ providerOptions }) => {
+            sent.push(providerOptions ?? {})
+            return {
+                stream: convertArrayToReadableStream([
+                    { type: 'stream-start', warnings: [] },
+                    { type: 'text-start', id: 'text-1' },
+                    { type: 'text-delta', id: 'text-1', delta: 'On it.' },
+                    { type: 'text-end', id: 'text-1' },
+                    { type: 'finish', finishReason: 'stop', usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 } },
+                ]),
+            }
+        },
+    })
+
+    await runAgentTurn({
+        model,
+        provider,
+        systemPrompt: 'You are a test agent.',
+        messages: [{ role: 'user', content: 'hello' }],
+        tools: {},
+        allToolNames: [],
+        tier: TIER,
+        modelId,
+        phaseState: { phase: 'discovery' },
+        abortSignal: new AbortController().signal,
+        log: silentLog,
+    })
+
+    return sent
+}
+
+describe('the agent loop asks a provider for the reasoning it can actually give', () => {
+    it('never asks a reasoning-native managed model to switch reasoning off', async () => {
+        const [first] = await capturedProviderOptions({ provider: AIProviderName.ACTIVEPIECES, modelId: 'google/gemini-3.8-flash' })
+
+        expect(first.openrouter?.reasoning).not.toHaveProperty('enabled')
+        expect(first.openrouter?.reasoning).not.toMatchObject({ effort: 'none' })
+        expect(first.openrouter?.reasoning).toEqual({ effort: 'minimal' })
+    })
+
+    it('keeps the zero-reasoning first step for a model documented to allow it', async () => {
+        const [first] = await capturedProviderOptions({ provider: AIProviderName.ACTIVEPIECES, modelId: TIER.modelId })
+
+        expect(first.openrouter?.reasoning).toEqual({ enabled: false })
+    })
+
+    it('still sends the ephemeral prompt cache alongside it', async () => {
+        const [first] = await capturedProviderOptions({ provider: AIProviderName.ACTIVEPIECES, modelId: TIER.modelId })
+
+        expect(first.openrouter?.cache_control).toEqual({ type: 'ephemeral' })
+    })
+
+    it('sends Anthropic its own thinking switch rather than an OpenRouter one', async () => {
+        const [first] = await capturedProviderOptions({ provider: AIProviderName.ANTHROPIC, modelId: TIER.modelId })
+
+        expect(first.anthropic?.thinking).toEqual({ type: 'disabled' })
+        expect(first.openrouter).toBeUndefined()
+    })
+})

--- a/packages/server/worker/test/lib/agent-eval/eval-gate-coverage.test.ts
+++ b/packages/server/worker/test/lib/agent-eval/eval-gate-coverage.test.ts
@@ -6,12 +6,12 @@ import { describe, expect, it } from 'vitest'
 const repoRoot = fileURLToPath(new URL('../../../../../../', import.meta.url))
 const workflowPath = join(repoRoot, '.github/workflows/agent-evals.yml')
 
-const GATED_SURFACES = [
-    'packages/server/worker/src/lib/execute/jobs/ee/agent',
-    'packages/server/worker/test/lib/agent-eval',
-    'packages/server/api/src/app/ee/agent',
-    'packages/server/api/src/assets/prompts',
-    'packages/core/shared/src/lib/ee/agent',
+const GATED_FILTERS = [
+    'packages/server/worker/src/lib/execute/jobs/ee/agent/**',
+    'packages/server/worker/test/lib/agent-eval/**',
+    'packages/server/api/src/app/ee/agent/**',
+    'packages/server/api/src/assets/prompts/**',
+    'packages/core/shared/src/lib/ee/agent/**',
     'packages/server/utils/src/agent-ai-utils.ts',
     'packages/server/utils/src/agent-provider-options.ts',
     'packages/core/piece-types/src/lib/ai-providers.ts',
@@ -23,16 +23,33 @@ describe('the agent eval gate covers the code it is meant to guard', () => {
     })
 
     it('names only paths that still exist, so a rename cannot quietly disable the gate', () => {
-        for (const surface of GATED_SURFACES) {
-            expect(existsSync(join(repoRoot, surface)), `${surface} no longer exists; update it here and in agent-evals.yml`).toBe(true)
+        for (const filter of GATED_FILTERS) {
+            const target = join(repoRoot, filter.replace(/\/\*\*$/, ''))
+            expect(existsSync(target), `${filter} no longer exists; update it here and in agent-evals.yml`).toBe(true)
         }
     })
 
-    it('triggers on every one of them', () => {
-        const workflow = readFileSync(workflowPath, 'utf8')
-        const triggers = workflow.slice(workflow.indexOf('pull_request:'), workflow.indexOf('schedule:'))
-        for (const surface of GATED_SURFACES) {
-            expect(triggers, `agent-evals.yml does not run for changes under ${surface}`).toContain(surface)
+    it('declares each filter exactly, so narrowing one cannot slip past this test', () => {
+        const declared = pullRequestPathFilters()
+        for (const filter of GATED_FILTERS) {
+            expect(declared, `agent-evals.yml does not run for changes matching ${filter}`).toContain(filter)
         }
     })
 })
+
+function pullRequestPathFilters(): string[] {
+    const lines = readFileSync(workflowPath, 'utf8').split('\n')
+    const start = lines.findIndex((line) => line.trim() === 'pull_request:')
+    const pathsAt = lines.findIndex((line, index) => index > start && line.trim() === 'paths:')
+    expect(start, 'agent-evals.yml has no pull_request trigger').toBeGreaterThan(-1)
+    expect(pathsAt, 'the pull_request trigger declares no paths').toBeGreaterThan(start)
+    const entries: string[] = []
+    for (const line of lines.slice(pathsAt + 1)) {
+        const entry = line.match(/^\s+-\s+(\S+)\s*$/)
+        if (entry === null) {
+            break
+        }
+        entries.push(entry[1])
+    }
+    return entries
+}

--- a/packages/server/worker/test/lib/agent-eval/eval-gate-coverage.test.ts
+++ b/packages/server/worker/test/lib/agent-eval/eval-gate-coverage.test.ts
@@ -1,0 +1,38 @@
+import { existsSync, readFileSync } from 'fs'
+import { join } from 'path'
+import { fileURLToPath } from 'url'
+import { describe, expect, it } from 'vitest'
+
+const repoRoot = fileURLToPath(new URL('../../../../../../', import.meta.url))
+const workflowPath = join(repoRoot, '.github/workflows/agent-evals.yml')
+
+const GATED_SURFACES = [
+    'packages/server/worker/src/lib/execute/jobs/ee/agent',
+    'packages/server/worker/test/lib/agent-eval',
+    'packages/server/api/src/app/ee/agent',
+    'packages/server/api/src/assets/prompts',
+    'packages/core/shared/src/lib/ee/agent',
+    'packages/server/utils/src/agent-ai-utils.ts',
+    'packages/server/utils/src/agent-provider-options.ts',
+    'packages/core/piece-types/src/lib/ai-providers.ts',
+]
+
+describe('the agent eval gate covers the code it is meant to guard', () => {
+    it('finds the workflow it is asserting about', () => {
+        expect(existsSync(workflowPath), workflowPath).toBe(true)
+    })
+
+    it('names only paths that still exist, so a rename cannot quietly disable the gate', () => {
+        for (const surface of GATED_SURFACES) {
+            expect(existsSync(join(repoRoot, surface)), `${surface} no longer exists; update it here and in agent-evals.yml`).toBe(true)
+        }
+    })
+
+    it('triggers on every one of them', () => {
+        const workflow = readFileSync(workflowPath, 'utf8')
+        const triggers = workflow.slice(workflow.indexOf('pull_request:'), workflow.indexOf('schedule:'))
+        for (const surface of GATED_SURFACES) {
+            expect(triggers, `agent-evals.yml does not run for changes under ${surface}`).toContain(surface)
+        }
+    })
+})

--- a/packages/server/worker/test/lib/agent-eval/eval-gate-triggers.test.ts
+++ b/packages/server/worker/test/lib/agent-eval/eval-gate-triggers.test.ts
@@ -17,7 +17,12 @@ const GATED_FILTERS = [
     'packages/core/piece-types/src/lib/ai-providers.ts',
 ]
 
-describe('the agent eval gate covers the code it is meant to guard', () => {
+const PACKAGES_UNDER_GATE = [
+    '@activepieces/server-utils',
+    '@activepieces/core-piece-types',
+]
+
+describe('the agent eval gate is wired to the code it gates', () => {
     it('finds the workflow it is asserting about', () => {
         expect(existsSync(workflowPath), workflowPath).toBe(true)
     })
@@ -33,6 +38,13 @@ describe('the agent eval gate covers the code it is meant to guard', () => {
         const declared = pullRequestPathFilters()
         for (const filter of GATED_FILTERS) {
             expect(declared, `agent-evals.yml does not run for changes matching ${filter}`).toContain(filter)
+        }
+    })
+
+    it('runs the tests for every package it gates, so a gated file is not merely a trigger', () => {
+        const gate = readFileSync(workflowPath, 'utf8')
+        for (const pkg of PACKAGES_UNDER_GATE) {
+            expect(gate, `the gate triggers on ${pkg} but never runs its tests`).toContain(`--filter=${pkg}`)
         }
     })
 })

--- a/packages/server/worker/test/lib/agent-eval/eval-gate-triggers.test.ts
+++ b/packages/server/worker/test/lib/agent-eval/eval-gate-triggers.test.ts
@@ -42,9 +42,9 @@ describe('the agent eval gate is wired to the code it gates', () => {
     })
 
     it('runs the tests for every package it gates, so a gated file is not merely a trigger', () => {
-        const gate = readFileSync(workflowPath, 'utf8')
+        const commands = pullRequestGateCommands()
         for (const pkg of PACKAGES_UNDER_GATE) {
-            expect(gate, `the gate triggers on ${pkg} but never runs its tests`).toContain(`--filter=${pkg}`)
+            expect(commands, `the pull-request gate triggers on ${pkg} but never runs its tests`).toContain(`--filter=${pkg}`)
         }
     })
 })
@@ -64,4 +64,13 @@ function pullRequestPathFilters(): string[] {
         entries.push(entry[1])
     }
     return entries
+}
+
+function pullRequestGateCommands(): string {
+    const lines = readFileSync(workflowPath, 'utf8').split('\n')
+    const gateAt = lines.findIndex((line) => /^ {2}gate:\s*$/.test(line))
+    expect(gateAt, 'agent-evals.yml has no gate job').toBeGreaterThan(-1)
+    const nextJobAt = lines.findIndex((line, index) => index > gateAt && /^ {2}\S+:\s*$/.test(line))
+    const gate = lines.slice(gateAt, nextJobAt === -1 ? lines.length : nextJobAt)
+    return gate.filter((line) => !line.trim().startsWith('#')).join('\n')
 }


### PR DESCRIPTION
## Description

Three of the five `paths` in `agent-evals.yml` point at directories that no longer exist. Renaming the chat module to agent (#14551) left the workflow behind, so the deterministic gate stopped firing for any change to the agent loop, the agent API module, or the shared agent types. Nobody noticed because a skipped job looks like a job that was never needed.

Of the four agent fixes merged this week the gate ran on exactly one, #15346, and only because that PR happened to edit the eval runner, which is one of the two paths still resolving. #15349, #15350 and #15352 changed the agent loop and the provider request builder and ran no eval at all.

The paths now point at the directories that exist, and also at the three files that decide what we send a provider: `agent-ai-utils`, `agent-provider-options` and `ai-providers`. The reasoning directive that every reasoning-native model rejected was changed in the first of those, with no eval.

`eval-gate-coverage.test.ts` keeps the two in step: it asserts each gated path still exists and that the trigger declares it exactly, globs included, so a rename or a narrowed filter breaks a test instead of quietly turning the gate off. It runs in the worker suite, which CI does run, and it sits in the eval directory it protects so touching it also triggers the gate.

To be clear about what this does and does not buy: the PR gate is hermetic by design, with no provider key, so `agent-eval.test.ts` skips on a PR and the deterministic replay and assertion tests are what run. This restores that coverage for agent changes, which had been off entirely. It would **not** have caught the reasoning-directive incident, because that is a provider-contract failure only the live suite can see. A managed-model contract check on the nightly live job, asserting a first token for each model on both arms of `buildProviderOptions`, is the piece that would, and it is a separate PR.

## How was this tested?

3 new tests, mutation-tested both ways: restoring the stale `ee/chat` paths fails 1, and dropping `agent-ai-utils.ts` from the trigger fails 1. Worker suite 274 pass, 0 lint errors.

This PR touches an agent-gated path, so the gate should now run on it.

## Found while doing this, not fixed here

`packages/server/api/test/unit/**` runs in no workflow. There is no turbo `test-unit` task and no CI step invokes it, so 1158 api unit tests gate nothing, including the ones added for #15349, #15350 and #15352. Wiring it up needs the 18 that currently fail on main to be fixed first: 6 in `job-broker` (`tryDequeue` returns null where the test expects a job), 10 in `worker-group.service`, 2 in `machine-service`. Those are three unrelated subsystems and someone else's area, so they want their own PR.

Fixes # (issue)

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)

