### PR TITLE
fix(migrations): re-running the chat-memory migration stops failing on its own constraints

### DIFF
--- a/packages/server/api/src/app/database/migration/postgres/1817000000000-AddUserChatMemory.ts
+++ b/packages/server/api/src/app/database/migration/postgres/1817000000000-AddUserChatMemory.ts
@@ -8,6 +8,20 @@ export class AddUserChatMemory1817000000000 implements Migration {
     transaction = true
 
     public async up(queryRunner: QueryRunner): Promise<void> {
+        // A database that recorded this migration under its previous number, 1796000000000, sees
+        // this one as unapplied and runs it again — possibly long after
+        // RenameChatTablesToAgent1822000000000 turned user_chat_memory into a compatibility view.
+        // Indexing or altering a view fails, so there is nothing to do once the rename has happened.
+        const [{ alreadyRenamed }] = await queryRunner.query(`
+            SELECT EXISTS (
+                SELECT 1 FROM pg_class c
+                JOIN pg_namespace n ON n.oid = c.relnamespace
+                WHERE n.nspname = 'public' AND c.relname = 'user_memory' AND c.relkind = 'r'
+            ) AS "alreadyRenamed"
+        `)
+        if (alreadyRenamed) {
+            return
+        }
         await queryRunner.query(`
             CREATE TABLE IF NOT EXISTS "user_chat_memory" (
                 "id" character varying(21) NOT NULL,

--- a/packages/server/api/src/app/database/migration/postgres/1817000000000-AddUserChatMemory.ts
+++ b/packages/server/api/src/app/database/migration/postgres/1817000000000-AddUserChatMemory.ts
@@ -24,12 +24,26 @@ export class AddUserChatMemory1817000000000 implements Migration {
             CREATE UNIQUE INDEX IF NOT EXISTS "idx_user_chat_memory_platform_user" ON "user_chat_memory" ("platformId", "userId")
         `)
         await queryRunner.query(`
-            ALTER TABLE "user_chat_memory"
-            ADD CONSTRAINT "fk_user_chat_memory_platform_id" FOREIGN KEY ("platformId") REFERENCES "platform" ("id") ON DELETE CASCADE ON UPDATE NO ACTION
+            DO $$
+            BEGIN
+                IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'fk_user_chat_memory_platform_id') THEN
+                    ALTER TABLE "user_chat_memory"
+                    ADD CONSTRAINT "fk_user_chat_memory_platform_id"
+                    FOREIGN KEY ("platformId") REFERENCES "platform" ("id")
+                    ON DELETE CASCADE ON UPDATE NO ACTION;
+                END IF;
+            END $$
         `)
         await queryRunner.query(`
-            ALTER TABLE "user_chat_memory"
-            ADD CONSTRAINT "fk_user_chat_memory_user_id" FOREIGN KEY ("userId") REFERENCES "user" ("id") ON DELETE CASCADE ON UPDATE NO ACTION
+            DO $$
+            BEGIN
+                IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'fk_user_chat_memory_user_id') THEN
+                    ALTER TABLE "user_chat_memory"
+                    ADD CONSTRAINT "fk_user_chat_memory_user_id"
+                    FOREIGN KEY ("userId") REFERENCES "user" ("id")
+                    ON DELETE CASCADE ON UPDATE NO ACTION;
+                END IF;
+            END $$
         `)
     }
 


### PR DESCRIPTION
## Description

`AddUserChatMemory` was renumbered from `1796000000000` to `1817000000000`. Any database that recorded the old name sees the new one as unapplied and runs the migration again — and it is only half idempotent. The `CREATE TABLE` and `CREATE INDEX` are written `IF NOT EXISTS`, but the two `ADD CONSTRAINT` statements are not, so the api dies at boot with:

```
constraint "fk_user_chat_memory_platform_id" for relation "user_chat_memory" already exists
QueryFailedError ... at AddUserChatMemory1817000000000.up
[main#start] Failed to start server
```

The api never starts, so **every migration behind it stays unapplied** — in the case I hit, 28 of them, which left the database with no `agent` or `agent_conversation` tables.

Both statements now check `pg_constraint` first, which is the same shape `AddWaitpointSignals1821000000000` already uses three migrations later.

## How was this tested?

Against a real Postgres, in a rolled-back transaction:

- the new form, run twice: two `DO` blocks succeed, `pg_constraint` holds exactly 1 row
- the old form, run twice: `ERROR: constraint "tmp_fk_ucm2" for relation "tmp_ucm2" already exists` — the failure this fixes

Also checked on the database that hit it: renaming the recorded row to the new name let the 28 pending migrations apply cleanly, and the api booted. `tsc` clean, `check-migration-rollback.ts` passes.

A database already past this point is unaffected: `RenameChatTablesToAgent1822000000000` renames the table to `user_memory`, so the guarded statements simply never run again.

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)