### PR TITLE
fix(ci): push release tag with explicit refspec so a same-named branch cannot shadow it

### DIFF
--- a/.github/workflows/release-self-hosted.yml
+++ b/.github/workflows/release-self-hosted.yml
@@ -90,7 +90,7 @@ jobs:
       - name: Create git tag
         run: |
           git tag -f ${{ inputs.tag }}
-          git push origin ${{ inputs.tag }} --force
+          git push origin refs/tags/${{ inputs.tag }}:refs/tags/${{ inputs.tag }} --force
 
       - name: Create or update changelog via release-drafter
         if: ${{ !contains(inputs.tag, '-rc') || inputs.publish_rc_release }}


### PR DESCRIPTION
The Release Self-Hosted run for 0.88.4-hotfix.2 failed at the "Create git tag" step with `error: src refspec 0.88.4-hotfix.2 matches more than one`, because the release was dispatched from a branch named identically to the tag. Pushing the fully qualified `refs/tags/<tag>:refs/tags/<tag>` refspec makes the push unambiguous regardless of branch names.

## Breaking change?

- [ ] Yes
- [x] No

🤖 Generated with [Claude Code](https://claude.com/claude-code)