### PR TITLE
fix(web): stop truncating piece selector tab labels

### DIFF
--- a/packages/web/src/features/pieces/components/piece-selector-tabs.tsx
+++ b/packages/web/src/features/pieces/components/piece-selector-tabs.tsx
@@ -35,14 +35,15 @@ export const PieceSelectorTabs = ({
           <TabsTrigger
             key={tab.key}
             value={tab.key}
-            className={`flex flex-col h-full rounded-md w-[85px] max-w-[85px] shrink-0
+            title={tab.name}
+            className={`flex flex-col h-full rounded-md min-w-[5.5rem] flex-1 px-1
               hover:bg-gray-300/30 dark:hover:bg-gray-300/10
                data-[state=active]:text-primary data-[state=active]:shadow-none
                border-transparent data-[state=active]:border-primary data-[state=active]:active data-[state=active]:bg-transparent
                text-accent-foreground [&>svg]:size-5 [&>svg]:shrink-0`}
           >
             {tab.icon}
-            <span className="mt-1.5 text-sm truncate w-full text-center">
+            <span className="mt-1.5 text-sm leading-tight w-full text-center whitespace-normal break-words">
               {tab.name}
             </span>
           </TabsTrigger>


### PR DESCRIPTION
## Summary
Fixes #15039.

Piece selector tabs were locked to `w-[85px] max-w-[85px]` with `truncate` after #13824, so labels such as Approvals and AI & Agents rendered as `Appr...` / `AI & Ag...` even when the row had space, and there was no tooltip.

This restores flexible width and wrapping so the full label is visible, and sets `title` on the trigger as a fallback.

AI-assisted change. I verified the previous and current class lists against the issue write-up.

If this is useful and you still attach Algora tips on merged UI fixes, I can take one. Not required to merge.

## Test plan
- [ ] Open the flow builder piece selector
- [ ] Confirm Explore, AI & Agents, Apps, Utility, Approvals are fully readable
- [ ] Confirm a long custom tab name wraps instead of ellipsizing mid-word
- [ ] Confirm the active tab still uses the primary underline treatment
- [ ] Narrow the panel: tabs still scroll horizontally rather than overflowing the dialog