### PR TITLE
fix(pieces): send known-length multipart bodies with Content-Length instead of chunked

### DIFF
--- a/packages/pieces/common/package.json
+++ b/packages/pieces/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/pieces-common",
-  "version": "0.13.2",
+  "version": "0.13.3",
   "type": "commonjs",
   "sideEffects": false,
   "main": "./dist/src/index.js",

--- a/packages/pieces/common/src/lib/http/core/fetch-http-client.ts
+++ b/packages/pieces/common/src/lib/http/core/fetch-http-client.ts
@@ -244,7 +244,7 @@ type NodeFormData = {
 };
 
 // ponytail: transient double-buffering cap — above it we stream chunked exactly as before this fix.
-const MAX_BUFFERED_FORM_DATA_BYTES = 10 * 1024 * 1024;
+const MAX_BUFFERED_FORM_DATA_BYTES = 100 * 1024 * 1024;
 
 type ResponseType = NonNullable<HttpRequest['responseType']>;
 

--- a/packages/pieces/common/src/lib/http/core/fetch-http-client.ts
+++ b/packages/pieces/common/src/lib/http/core/fetch-http-client.ts
@@ -243,7 +243,6 @@ type NodeFormData = {
   getBuffer: () => Buffer;
 };
 
-// ponytail: transient double-buffering cap — above it we stream chunked exactly as before this fix.
 const MAX_BUFFERED_FORM_DATA_BYTES = 100 * 1024 * 1024;
 
 type ResponseType = NonNullable<HttpRequest['responseType']>;

--- a/packages/pieces/common/src/lib/http/core/fetch-http-client.ts
+++ b/packages/pieces/common/src/lib/http/core/fetch-http-client.ts
@@ -1,4 +1,5 @@
 import { PassThrough, Readable } from 'node:stream';
+import { tryCatchSync } from '@activepieces/core-utils';
 import { BaseHttpClient } from './base-http-client';
 import { DelegatingAuthenticationConverter } from './delegating-authentication-converter';
 import { HttpError } from './http-error';
@@ -105,9 +106,12 @@ function serializeBody(
   }
   if (isNodeFormData(body)) {
     // A buffered multipart body lets undici send Content-Length; a streamed one is sent
-    // chunked without a length, which strict multipart parsers reject with a 500.
-    if (body.hasKnownLength()) {
-      return { body: body.getBuffer(), extraHeaders: body.getHeaders(), isStream: false };
+    // chunked without a length, which strict multipart parsers reject with a 500. Streaming
+    // with an explicit content-length header is not an option: undici stalls or throws
+    // RequestContentLengthMismatchError on stream bodies that carry one.
+    const buffered = bufferFormDataIfSafe(body);
+    if (buffered !== null) {
+      return { body: buffered, extraHeaders: body.getHeaders(), isStream: false };
     }
     const stream = new PassThrough();
     body.on('error', (error) => stream.destroy(error));
@@ -207,6 +211,15 @@ function toHttpHeaders(headers: Headers): HttpHeaders {
   return result;
 }
 
+function bufferFormDataIfSafe(body: NodeFormData): Buffer | null {
+  if (!body.hasKnownLength() || body.getLengthSync() > MAX_BUFFERED_FORM_DATA_BYTES) {
+    return null;
+  }
+  // getBuffer throws on stream parts appended with an explicit knownLength; fall back to streaming.
+  const { data } = tryCatchSync(() => body.getBuffer());
+  return data;
+}
+
 function isNodeFormData(body: unknown): body is NodeFormData {
   return (
     typeof body === 'object' &&
@@ -226,8 +239,12 @@ type NodeFormData = {
   pipe: (...args: unknown[]) => unknown;
   on: (event: 'error', listener: (error: Error) => void) => unknown;
   hasKnownLength: () => boolean;
+  getLengthSync: () => number;
   getBuffer: () => Buffer;
 };
+
+// ponytail: transient double-buffering cap — above it we stream chunked exactly as before this fix.
+const MAX_BUFFERED_FORM_DATA_BYTES = 10 * 1024 * 1024;
 
 type ResponseType = NonNullable<HttpRequest['responseType']>;
 

--- a/packages/pieces/common/src/lib/http/core/fetch-http-client.ts
+++ b/packages/pieces/common/src/lib/http/core/fetch-http-client.ts
@@ -104,6 +104,11 @@ function serializeBody(
     return { body: undefined, extraHeaders: {}, isStream: false };
   }
   if (isNodeFormData(body)) {
+    // A buffered multipart body lets undici send Content-Length; a streamed one is sent
+    // chunked without a length, which strict multipart parsers reject with a 500.
+    if (body.hasKnownLength()) {
+      return { body: body.getBuffer(), extraHeaders: body.getHeaders(), isStream: false };
+    }
     const stream = new PassThrough();
     body.on('error', (error) => stream.destroy(error));
     body.pipe(stream);
@@ -220,6 +225,8 @@ type NodeFormData = {
   getHeaders: () => Record<string, string>;
   pipe: (...args: unknown[]) => unknown;
   on: (event: 'error', listener: (error: Error) => void) => unknown;
+  hasKnownLength: () => boolean;
+  getBuffer: () => Buffer;
 };
 
 type ResponseType = NonNullable<HttpRequest['responseType']>;

--- a/packages/pieces/core/http/package.json
+++ b/packages/pieces/core/http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-http",
-  "version": "0.11.21",
+  "version": "0.11.22",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "dependencies": {

--- a/packages/pieces/core/http/test/form-data-content-length.test.ts
+++ b/packages/pieces/core/http/test/form-data-content-length.test.ts
@@ -81,7 +81,7 @@ describe('multipart form-data body framing', () => {
 
   test('a form over the buffering cap streams chunked instead of double-buffering', async () => {
     const formData = new FormData();
-    formData.append('file', Buffer.alloc(11 * 1024 * 1024), { filename: 'big.bin' });
+    formData.append('file', Buffer.alloc(101 * 1024 * 1024), { filename: 'big.bin' });
 
     await httpClient.sendRequest({
       method: HttpMethod.POST,
@@ -92,7 +92,7 @@ describe('multipart form-data body framing', () => {
     expect(seen[0].contentType).toContain('multipart/form-data');
     expect(seen[0].transferEncoding).toBe('chunked');
     expect(seen[0].contentLength).toBeUndefined();
-    expect(seen[0].bodyBytes).toBeGreaterThan(11 * 1024 * 1024);
+    expect(seen[0].bodyBytes).toBeGreaterThan(101 * 1024 * 1024);
   });
 
   test('form-data with an unknown-length stream part still streams chunked', async () => {

--- a/packages/pieces/core/http/test/form-data-content-length.test.ts
+++ b/packages/pieces/core/http/test/form-data-content-length.test.ts
@@ -1,0 +1,77 @@
+/// <reference types="vitest/globals" />
+
+import http from 'node:http';
+import { Readable } from 'node:stream';
+import { httpClient, HttpMethod } from '@activepieces/pieces-common';
+import FormData from 'form-data';
+
+type SeenRequest = {
+  contentLength: string | undefined;
+  transferEncoding: string | undefined;
+  contentType: string | undefined;
+  bodyBytes: number;
+};
+
+let server: http.Server;
+let baseUrl: string;
+const seen: SeenRequest[] = [];
+
+beforeAll(async () => {
+  server = http.createServer((req, res) => {
+    const chunks: Buffer[] = [];
+    req.on('data', (chunk) => chunks.push(chunk));
+    req.on('end', () => {
+      seen.push({
+        contentLength: req.headers['content-length'],
+        transferEncoding: req.headers['transfer-encoding'],
+        contentType: req.headers['content-type'],
+        bodyBytes: Buffer.concat(chunks).length,
+      });
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({ ok: true }));
+    });
+  });
+  await new Promise<void>((resolve) => server.listen(0, resolve));
+  baseUrl = `http://127.0.0.1:${(server.address() as { port: number }).port}/`;
+});
+
+afterAll(() => server.close());
+
+beforeEach(() => {
+  seen.length = 0;
+});
+
+describe('multipart form-data body framing', () => {
+  test('known-length form-data is sent with Content-Length, not chunked', async () => {
+    const formData = new FormData();
+    formData.append('greeting', 'hello world');
+    formData.append('file', Buffer.from('file content'), { filename: 'a.txt' });
+
+    await httpClient.sendRequest({
+      method: HttpMethod.POST,
+      url: baseUrl,
+      body: formData,
+    });
+
+    expect(seen[0].contentType).toContain('multipart/form-data');
+    expect(seen[0].transferEncoding).toBeUndefined();
+    expect(seen[0].contentLength).toBe(String(seen[0].bodyBytes));
+    expect(seen[0].bodyBytes).toBeGreaterThan(0);
+  });
+
+  test('form-data with an unknown-length stream part still streams chunked', async () => {
+    const formData = new FormData();
+    formData.append('file', Readable.from(['streamed content']), { filename: 'b.txt' });
+
+    await httpClient.sendRequest({
+      method: HttpMethod.POST,
+      url: baseUrl,
+      body: formData,
+    });
+
+    expect(seen[0].contentType).toContain('multipart/form-data');
+    expect(seen[0].transferEncoding).toBe('chunked');
+    expect(seen[0].contentLength).toBeUndefined();
+    expect(seen[0].bodyBytes).toBeGreaterThan(0);
+  });
+});

--- a/packages/pieces/core/http/test/form-data-content-length.test.ts
+++ b/packages/pieces/core/http/test/form-data-content-length.test.ts
@@ -59,6 +59,42 @@ describe('multipart form-data body framing', () => {
     expect(seen[0].bodyBytes).toBeGreaterThan(0);
   });
 
+  test('a stream part with knownLength does not crash and falls back to chunked streaming', async () => {
+    const formData = new FormData();
+    const content = 'streamed with known length';
+    formData.append('file', Readable.from([content]), {
+      filename: 'c.txt',
+      knownLength: content.length,
+    });
+
+    await httpClient.sendRequest({
+      method: HttpMethod.POST,
+      url: baseUrl,
+      body: formData,
+    });
+
+    expect(seen[0].contentType).toContain('multipart/form-data');
+    expect(seen[0].transferEncoding).toBe('chunked');
+    expect(seen[0].contentLength).toBeUndefined();
+    expect(seen[0].bodyBytes).toBeGreaterThan(0);
+  });
+
+  test('a form over the buffering cap streams chunked instead of double-buffering', async () => {
+    const formData = new FormData();
+    formData.append('file', Buffer.alloc(11 * 1024 * 1024), { filename: 'big.bin' });
+
+    await httpClient.sendRequest({
+      method: HttpMethod.POST,
+      url: baseUrl,
+      body: formData,
+    });
+
+    expect(seen[0].contentType).toContain('multipart/form-data');
+    expect(seen[0].transferEncoding).toBe('chunked');
+    expect(seen[0].contentLength).toBeUndefined();
+    expect(seen[0].bodyBytes).toBeGreaterThan(11 * 1024 * 1024);
+  });
+
   test('form-data with an unknown-length stream part still streams chunked', async () => {
     const formData = new FormData();
     formData.append('file', Readable.from(['streamed content']), { filename: 'b.txt' });


### PR DESCRIPTION
## Description

Since the axios → fetch migration of the pieces HTTP client, multipart `form-data` bodies were always piped as a stream, so undici sent them with `Transfer-Encoding: chunked` and **no `Content-Length`**. Strict multipart parsers (Java servlet containers, some PHP/nginx setups, S3-style APIs) reject chunked multipart uploads with a bare 500 and an empty body, which surfaced in flows as:

```
HttpError: {"response":{"status":500},"request":{"body":{"_overheadLength":...}}}
responseBody: undefined
```

With this change, when every part's length is synchronously known (strings and Buffers — always the case for the HTTP piece's Form Data mode, including file fields), the body is sent buffered via `getBuffer()`, so undici sets `Content-Length` — matching the old axios wire behaviour. Bodies with unknown-length stream parts keep the streaming path. A side benefit: buffered form bodies are retry-safe again, since there is no drained stream to replay.

Bumped `@activepieces/pieces-common` to 0.13.3 and `@activepieces/piece-http` to 0.11.22 so published flows pick up the fix.

## How was this tested?

- Reproduced on a local CE dev server: a published flow (Catch Webhook → Send HTTP request, Form Data body) against a local server that rejects chunked multipart. Before the fix the request went out `Transfer-Encoding: chunked` with no `Content-Length` and the run failed with the exact reported error; after the fix the same flow sends `Content-Length: 310`, no chunked encoding, and the run succeeds.
- New regression test `packages/pieces/core/http/test/form-data-content-length.test.ts` asserts known-length form-data is framed with `Content-Length` and that unknown-length stream parts still stream chunked.
- `turbo run lint` and `turbo run build` pass for `@activepieces/pieces-common` and `@activepieces/piece-http`.

Fixes # (issue)

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

- [x] yes — security-sensitive (call out the risk and mitigation in the description above)
- [ ] no — reviewed, no security impact

**Risk assessment:** this touches the shared outbound HTTP client (`fetch-http-client.ts`), but only the request-body framing (buffered + `Content-Length` vs streamed + chunked). URL resolution, redirects, dispatcher/proxy handling, and the engine's SSRF guards are untouched.
