### PR TITLE
fix(web): show friendly trigger errors in standardError wrapper

### DIFF
--- a/packages/web/src/components/custom/ap-error-dialog/ap-error-dialog.tsx
+++ b/packages/web/src/components/custom/ap-error-dialog/ap-error-dialog.tsx
@@ -21,7 +21,15 @@ const ApErrorDialog = () => {
 
   if (isNil(params)) return null;
 
-  const friendlyError = tryParseFriendlyPieceError(params.error);
+  const friendlyError =
+    tryParseFriendlyPieceError(params.error) ??
+    tryParseFriendlyPieceError(
+      isNil(params.error) ||
+        typeof params.error !== 'object' ||
+        Array.isArray(params.error)
+        ? undefined
+        : params.error.standardError,
+    );
 
   return (
     <Dialog open={!!params} onOpenChange={closeDialog}>

--- a/packages/web/src/components/custom/ap-error-dialog/ap-error-dialog.tsx
+++ b/packages/web/src/components/custom/ap-error-dialog/ap-error-dialog.tsx
@@ -1,4 +1,4 @@
-import { isNil } from '@activepieces/core-utils';
+import { isNil, tryParseFriendlyPieceError } from '@activepieces/core-utils';
 import { t } from 'i18next';
 import { AlertCircleIcon } from 'lucide-react';
 
@@ -21,6 +21,8 @@ const ApErrorDialog = () => {
 
   if (isNil(params)) return null;
 
+  const friendlyError = tryParseFriendlyPieceError(params.error);
+
   return (
     <Dialog open={!!params} onOpenChange={closeDialog}>
       <DialogContent>
@@ -41,6 +43,11 @@ const ApErrorDialog = () => {
                   {params.description}
                 </DialogDescription>
               )}
+              {friendlyError && (
+                <p className="text-sm text-foreground">
+                  {friendlyError.message}
+                </p>
+              )}
             </div>
           </div>
         </DialogHeader>
@@ -48,7 +55,7 @@ const ApErrorDialog = () => {
           <CollapsibleJson
             json={params?.error}
             label={t('Technical Details')}
-            defaultOpen={true}
+            defaultOpen={!friendlyError}
             className="w-full text-left"
           />
         </div>

--- a/packages/web/src/features/flows/hooks/flow-hooks.tsx
+++ b/packages/web/src/features/flows/hooks/flow-hooks.tsx
@@ -3,7 +3,6 @@ import {
   isNil,
   ErrorCode,
   SeekPage,
-  tryParseFriendlyPieceError,
 } from '@activepieces/core-utils';
 import {
   ApFlagId,
@@ -144,9 +143,6 @@ export const flowHooks = {
         const apError = error.response.data as ApErrorParams;
         if (apError.code === ErrorCode.TRIGGER_UPDATE_STATUS) {
           const params = apError.params as Record<string, string>;
-          const friendlyError = tryParseFriendlyPieceError(
-            params.standardError,
-          );
           openDialog({
             title:
               change === 'publish'
@@ -160,7 +156,7 @@ export const flowHooks = {
               </p>
             ),
             error: {
-              standardError: friendlyError ?? params.standardError ?? '',
+              standardError: params.standardError ?? '',
               standardOutput: params.standardOutput || '',
             },
           });

--- a/packages/web/src/features/flows/hooks/flow-hooks.tsx
+++ b/packages/web/src/features/flows/hooks/flow-hooks.tsx
@@ -3,6 +3,7 @@ import {
   isNil,
   ErrorCode,
   SeekPage,
+  tryParseFriendlyPieceError,
 } from '@activepieces/core-utils';
 import {
   ApFlagId,
@@ -143,6 +144,9 @@ export const flowHooks = {
         const apError = error.response.data as ApErrorParams;
         if (apError.code === ErrorCode.TRIGGER_UPDATE_STATUS) {
           const params = apError.params as Record<string, string>;
+          const friendlyError = tryParseFriendlyPieceError(
+            params.standardError,
+          );
           openDialog({
             title:
               change === 'publish'
@@ -156,7 +160,7 @@ export const flowHooks = {
               </p>
             ),
             error: {
-              standardError: params.standardError || '',
+              standardError: friendlyError ?? params.standardError ?? '',
               standardOutput: params.standardOutput || '',
             },
           });

--- a/packages/web/test/components/custom/ap-error-dialog.test.tsx
+++ b/packages/web/test/components/custom/ap-error-dialog.test.tsx
@@ -88,4 +88,30 @@ describe('ApErrorDialog', () => {
     expect(container.textContent).not.toContain('stack trace and request details');
     expect(collapsibleJsonMock.defaultOpen).toBe(false);
   });
+
+  it('shows the friendly nested standardError and keeps technical details collapsed', () => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+
+    act(() => {
+      useApErrorDialogStore.getState().openDialog({
+        title: 'Status update failed',
+        description: <p>Could not update the flow.</p>,
+        error: {
+          standardError: JSON.stringify({
+            __apErrorVersion: 1,
+            message: 'Authentication required',
+            raw: 'stack trace and request details',
+          }),
+          standardOutput: 'not used',
+        },
+      });
+      root.render(<ApErrorDialog />);
+    });
+
+    expect(container.textContent).toContain('Authentication required');
+    expect(container.textContent).not.toContain('stack trace and request details');
+    expect(collapsibleJsonMock.defaultOpen).toBe(false);
+  });
 });

--- a/packages/web/test/components/custom/ap-error-dialog.test.tsx
+++ b/packages/web/test/components/custom/ap-error-dialog.test.tsx
@@ -1,0 +1,91 @@
+/**
+ * @vitest-environment jsdom
+ */
+import * as React from 'react';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const collapsibleJsonMock = vi.hoisted(() => ({
+  defaultOpen: undefined as boolean | undefined,
+}));
+
+vi.mock('i18next', () => ({ t: (key: string) => key }));
+
+vi.mock('lucide-react', () => ({
+  AlertCircleIcon: () => null,
+}));
+
+vi.mock('@/components/ui/button', () => ({
+  Button: ({
+    children,
+    ...props
+  }: React.ComponentProps<'button'>) => <button {...props}>{children}</button>,
+}));
+
+vi.mock('@/components/ui/dialog', () => ({
+  Dialog: ({ children }: React.PropsWithChildren) => <>{children}</>,
+  DialogContent: ({ children }: React.PropsWithChildren) => <div>{children}</div>,
+  DialogDescription: ({ children }: React.PropsWithChildren) => (
+    <div>{children}</div>
+  ),
+  DialogFooter: ({ children }: React.PropsWithChildren) => <div>{children}</div>,
+  DialogHeader: ({ children }: React.PropsWithChildren) => <div>{children}</div>,
+  DialogTitle: ({ children }: React.PropsWithChildren) => <h1>{children}</h1>,
+}));
+
+vi.mock('@/components/custom/collapsible-json', () => ({
+  CollapsibleJson: ({ defaultOpen }: { defaultOpen?: boolean }) => {
+    collapsibleJsonMock.defaultOpen = defaultOpen;
+    return null;
+  },
+}));
+
+// eslint-disable-next-line import/first
+import { ApErrorDialog } from '@/components/custom/ap-error-dialog/ap-error-dialog';
+// eslint-disable-next-line import/first
+import { useApErrorDialogStore } from '@/components/custom/ap-error-dialog/ap-error-dialog-store';
+
+declare global {
+  // eslint-disable-next-line no-var
+  var IS_REACT_ACT_ENVIRONMENT: boolean;
+}
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+let container: HTMLDivElement;
+let root: Root;
+
+afterEach(() => {
+  act(() => {
+    root.unmount();
+  });
+  container.remove();
+  useApErrorDialogStore.getState().closeDialog();
+  collapsibleJsonMock.defaultOpen = undefined;
+});
+
+describe('ApErrorDialog', () => {
+  it('shows the friendly piece message and keeps technical details collapsed', () => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+
+    act(() => {
+      useApErrorDialogStore.getState().openDialog({
+        title: 'Status update failed',
+        description: <p>Could not update the flow.</p>,
+        error: JSON.stringify({
+          __apErrorVersion: 1,
+          message: 'Authentication required',
+          raw: 'stack trace and request details',
+        }),
+      });
+      root.render(<ApErrorDialog />);
+    });
+
+    expect(container.textContent).toContain('Authentication required');
+    expect(container.textContent).not.toContain('stack trace and request details');
+    expect(collapsibleJsonMock.defaultOpen).toBe(false);
+  });
+});


### PR DESCRIPTION
This is a follow-up to 15357 for the production status-change path. It fixes dialog parsing for wrapped standardError and adds regression coverage for nested standardError shape.