### PR TITLE
fix(agents): the Run Agent step works again on community edition

### DIFF
--- a/packages/server/api/src/app/agents/agents-module.ts
+++ b/packages/server/api/src/app/agents/agents-module.ts
@@ -1,6 +1,8 @@
 import { FastifyPluginAsyncZod } from 'fastify-type-provider-zod'
+import { agentRunController } from '../ee/agent/agent-run-controller'
 import { agentToolsController } from './agent-tools-controller'
 
 export const agentsModule: FastifyPluginAsyncZod = async (app) => {
     await app.register(agentToolsController, { prefix: '/v1/projects/:projectId/agent-tools' })
+    await app.register(agentRunController, { prefix: '/v1/agents' })
 }

--- a/packages/server/api/src/app/ee/agent/agent.module.ts
+++ b/packages/server/api/src/app/ee/agent/agent.module.ts
@@ -2,7 +2,6 @@ import { FastifyPluginAsyncZod } from 'fastify-type-provider-zod'
 import { platformMustHaveFeatureEnabled } from '../authentication/ee-authorization'
 import { agentController } from './agent-controller'
 import { agentConversationController } from './agent-conversation-controller'
-import { agentRunController } from './agent-run-controller'
 import { chatVisibilityGuard } from './chat-visibility-helper'
 import { chatPersonalizationController } from './personalization/chat-personalization-controller'
 
@@ -16,5 +15,4 @@ export const agentModule: FastifyPluginAsyncZod = async (app) => {
         agentSurface.addHook('preHandler', platformMustHaveFeatureEnabled((platform) => platform.plan.agentsEnabled))
         await agentSurface.register(agentController, { prefix: '/v1/agents' })
     })
-    await app.register(agentRunController, { prefix: '/v1/agents' })
 }

--- a/packages/server/api/test/integration/ce/agent/agent-run-endpoint.test.ts
+++ b/packages/server/api/test/integration/ce/agent/agent-run-endpoint.test.ts
@@ -1,0 +1,93 @@
+import { AIProviderName, apId } from '@activepieces/core-utils'
+import { FastifyInstance } from 'fastify'
+import { StatusCodes } from 'http-status-codes'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { accessTokenManager } from '../../../../src/app/authentication/lib/access-token-manager'
+import { mockAndSaveAIProvider } from '../../../helpers/mocks'
+import { createTestContext, TestContext } from '../../../helpers/test-context'
+import { setupTestEnvironment, teardownTestEnvironment } from '../../../helpers/test-setup'
+
+const RUNS_URL = '/api/v1/agents/runs'
+
+let app: FastifyInstance
+
+beforeAll(async () => {
+    app = await setupTestEnvironment()
+})
+
+afterAll(async () => {
+    await teardownTestEnvironment()
+})
+
+async function contextThatCanRunAgents(): Promise<TestContext> {
+    const ctx = await createTestContext(app)
+    await mockAndSaveAIProvider({ platformId: ctx.platform.id, provider: AIProviderName.OPENAI, enabledForChat: true })
+    return ctx
+}
+
+async function engineTokenFor(ctx: TestContext, jobId: string): Promise<string> {
+    return accessTokenManager(app.log).generateEngineToken({
+        jobId,
+        projectId: ctx.project.id,
+        platformId: ctx.platform.id,
+    })
+}
+
+describe('community edition: POST /v1/agents/runs', () => {
+    it('starts an agent step configured with its own tools, the only way a community install can run one', async () => {
+        const ctx = await contextThatCanRunAgents()
+        const engineToken = await engineTokenFor(ctx, 'ce-inline-run')
+
+        const response = await app.inject({
+            method: 'POST',
+            url: RUNS_URL,
+            headers: { authorization: `Bearer ${engineToken}` },
+            body: {
+                instruction: 'send the summary',
+                flowRunId: apId(),
+                waitpointId: apId(),
+                tools: [{
+                    type: 'PIECE',
+                    toolName: 'send_email',
+                    pieceMetadata: { pieceName: '@activepieces/piece-gmail', pieceVersion: '0.1.0', actionName: 'send_email' },
+                }],
+            },
+        })
+
+        expect(response.statusCode).toBe(StatusCodes.OK)
+        expect(response.json().conversationId).toEqual(expect.any(String))
+    })
+
+    it('still refuses a signed-in user, because only a running flow may start one', async () => {
+        const ctx = await createTestContext(app)
+
+        const response = await ctx.post('/v1/agents/runs', {
+            instruction: 'do a thing',
+            flowRunId: apId(),
+            waitpointId: apId(),
+        })
+
+        expect([StatusCodes.UNAUTHORIZED, StatusCodes.FORBIDDEN]).toContain(response.statusCode)
+    })
+
+    it('starts a step that names the provider and model it was configured with', async () => {
+        const ctx = await createTestContext(app)
+        await mockAndSaveAIProvider({ platformId: ctx.platform.id, provider: AIProviderName.OPENAI })
+        const engineToken = await engineTokenFor(ctx, 'ce-explicit-provider')
+
+        const response = await app.inject({
+            method: 'POST',
+            url: RUNS_URL,
+            headers: { authorization: `Bearer ${engineToken}` },
+            body: {
+                instruction: 'summarise the thread',
+                flowRunId: apId(),
+                waitpointId: apId(),
+                provider: AIProviderName.OPENAI,
+                modelName: 'gpt-4o',
+            },
+        })
+
+        expect(response.statusCode).toBe(StatusCodes.OK)
+    })
+})


### PR DESCRIPTION
## Description

On a self-hosted community install, adding a **Run Agent** step to a flow and running it fails. The step is available in the AI piece on every edition, but the endpoint it calls at run time is not.

`POST /v1/agents/runs` lives in `agentModule`, and `app.ts` registers that module in the cloud and enterprise arms of the edition switch only. The community arm registers three modules and none of them is it, so the request comes back `404 Route not found` and the step errors with nothing on screen explaining why.

This has been the case since the step became a thin client in #14699, released in 0.88.0 on 11 August. Before that the agent loop ran inside the engine and needed no server route.

The fix is a registration move. `agentRunController` now belongs to the core `agentsModule`, which every edition registers, and the module keeps owning its own `/v1/agents` prefix. Nothing else changes:

- the saved-agent surface (`agentController`) stays in `agentModule` behind `platform.plan.agentsEnabled`, so agents remain an enterprise feature and community is unaffected by it
- the chat surface and its visibility guard are untouched
- no schema, request or response change

The agent runtime was already edition-neutral. The worker RPC surface that carries `getAgentConfig` and `executePieceTool` is registered for all editions in `worker-rpc-service.ts`, which is what made this a missing route rather than a missing feature.

**Known follow-up, not fixed here.** The controller file still lives under `src/app/ee/`, so the core module imports across the edition boundary. That crossing already exists for the same subsystem in `worker-rpc-service.ts`. Moving the agent runtime out of `ee/` is worth doing on its own, and doing it here would collide with #14934, which rewrites both `agent-run-controller.ts` and `agent-helpers.ts`.

One rough edge noticed while testing, also left alone: a step with no model chosen falls back to whichever provider key the platform designated for chat, and failing that reports "no AI provider on this platform is enabled for chat". That wording reads oddly on an edition with no chat, though the key is selectable from the AI providers page on community too, so the path does work.

## How was this tested?

Three new integration tests under `test/integration/ce/agent/`, run with `AP_EDITION=ce`: a step configured with its own tools starts a run, a step naming its provider and model starts a run, and a signed-in user is still refused because only a running flow may start one. All three fail with `404` when the registration is reverted, which I checked.

The behaviour was confirmed against the real route table before writing the fix: under `AP_EDITION=ce` the route was absent and the request returned `404 Route not found`, under `AP_EDITION=ee` the same request reached validation and returned `400`.

Full suites on all three edition paths:

- CE — 90 files, 1065 passed, 3 skipped
- EE — 33 files, 339 passed
- Cloud — 53 files, 549 passed

`npm run lint-dev` clean.

The tests drive the whole handler through the real Fastify app on community: engine-token auth, provider resolution, the credit check, the project lookup and the enqueue, since the 200 is only returned once the job is on the queue. What they do not cover is the worker picking that job up and calling a model, which needs a live community server; that last hop is edition-independent, as the RPC surface above is registered everywhere.

Continues the agents work; independent of #14934.

Fixes # (issue)

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

- [ ] no — reviewed, no security impact
- [x] yes — security-sensitive (call out the risk and mitigation in the description above)

The route is reachable on one more edition than before, so its authorisation matters. It is unchanged and unchanged deliberately: `RUN_PRINCIPALS` is `[PrincipalType.ENGINE]`, the handler re-checks `request.principal.type` before doing anything, and the project and platform are read from the engine token rather than the body, which a test pins by sending another project's id and asserting it is ignored. A signed-in user is refused on community, which is also tested. The per-project rate limit and the credit check run on this path as they always did.
