### PR TITLE
test(agents): cover what a community agent step hands to the worker

### DIFF
--- a/packages/server/api/test/integration/ce/agent/agent-run-worker-handoff.test.ts
+++ b/packages/server/api/test/integration/ce/agent/agent-run-worker-handoff.test.ts
@@ -1,0 +1,86 @@
+import { AIProviderName, apId } from '@activepieces/core-utils'
+import { AgentRunSource } from '@activepieces/shared'
+import { FastifyInstance } from 'fastify'
+import { StatusCodes } from 'http-status-codes'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { agentRpcHandlers } from '../../../../src/app/ee/agent/agent-rpc-handlers'
+import { accessTokenManager } from '../../../../src/app/authentication/lib/access-token-manager'
+import { mockAndSaveAIProvider } from '../../../helpers/mocks'
+import { createTestContext, TestContext } from '../../../helpers/test-context'
+import { setupTestEnvironment, teardownTestEnvironment } from '../../../helpers/test-setup'
+
+const RUNS_URL = '/api/v1/agents/runs'
+
+let app: FastifyInstance
+
+beforeAll(async () => {
+    app = await setupTestEnvironment()
+})
+
+afterAll(async () => {
+    await teardownTestEnvironment()
+})
+
+async function startFlowStepRun(ctx: TestContext, jobId: string): Promise<string> {
+    const engineToken = await accessTokenManager(app.log).generateEngineToken({
+        jobId,
+        projectId: ctx.project.id,
+        platformId: ctx.platform.id,
+    })
+    const response = await app.inject({
+        method: 'POST',
+        url: RUNS_URL,
+        headers: { authorization: `Bearer ${engineToken}` },
+        body: {
+            instruction: 'summarise the thread',
+            flowRunId: apId(),
+            waitpointId: apId(),
+            provider: AIProviderName.OPENAI,
+            modelName: 'gpt-4o',
+        },
+    })
+    expect(response.statusCode).toBe(StatusCodes.OK)
+    return response.json().conversationId
+}
+
+describe('community edition: the worker picking up an agent step', () => {
+    it('is handed a provider and a model, so the run does not stall on its first call', async () => {
+        const ctx = await createTestContext(app)
+        await mockAndSaveAIProvider({ platformId: ctx.platform.id, provider: AIProviderName.OPENAI })
+        const conversationId = await startFlowStepRun(ctx, 'ce-handoff')
+
+        const config = await agentRpcHandlers(app.log).getAgentConfig({
+            conversationId,
+            platformId: ctx.platform.id,
+            userId: ctx.user.id,
+            projectId: ctx.project.id,
+            userMessage: 'summarise the thread',
+            modelName: 'gpt-4o',
+            provider: AIProviderName.OPENAI,
+            source: AgentRunSource.FLOW_STEP,
+        })
+
+        expect(config.provider).toBe(AIProviderName.OPENAI)
+        expect(config.modelId).toBe('gpt-4o')
+        expect(config.systemPrompt.length).toBeGreaterThan(0)
+    })
+
+    it('is told the saved-agent surface is unavailable, so the step cannot reach agent tools', async () => {
+        const ctx = await createTestContext(app)
+        await mockAndSaveAIProvider({ platformId: ctx.platform.id, provider: AIProviderName.OPENAI })
+        const conversationId = await startFlowStepRun(ctx, 'ce-handoff-surface')
+
+        const config = await agentRpcHandlers(app.log).getAgentConfig({
+            conversationId,
+            platformId: ctx.platform.id,
+            userId: ctx.user.id,
+            projectId: ctx.project.id,
+            userMessage: 'summarise the thread',
+            modelName: 'gpt-4o',
+            provider: AIProviderName.OPENAI,
+            source: AgentRunSource.FLOW_STEP,
+        })
+
+        expect(config.agentsAvailable).toBe(false)
+    })
+})


### PR DESCRIPTION
## Description

Test-only. Closes the coverage gap named in #15372: that PR proved a community install accepts the request a Run Agent step makes, but not what happens on the next hop, when the worker picks the job up and asks the API for its config. That first RPC is where an edition assumption would have bitten, and nothing covered it.

Two tests, both under `AP_EDITION=ce`. A flow-step run started through the real endpoint, then `getAgentConfig` called the way the worker calls it:

- the config comes back with its provider, the concrete model the step named rather than a chat tier, and a system prompt, so the run does not stall on its first call
- the config reports the saved-agent surface as unavailable, so a community step cannot reach the agent tools that belong to the enterprise surface

The second one is the regression guard worth having. If `agentsAvailable` is ever flipped on for community by accident, that assertion fires rather than the step quietly gaining tools it should not have.

While writing these I checked the rest of the same class rather than assume the route was the only gap, and it was:

- the `agent` and `agent_conversation` entities are registered in `getEntities()` with no edition branch, so persistence works
- every RPC an agent run uses is served by `worker-rpc-service.ts`, which `workerModule` registers before the edition switch
- `emailEnabled` is decided by whether SMTP is configured, not by a plan flag, so a community install with SMTP keeps the email tool

## How was this tested?

`AP_EDITION=ce npx vitest run test/integration/ce/agent/` — 9 passed, the two new ones included. `npm run lint-dev` clean. No source changes, so the EE and Cloud paths are untouched.

Follows #15372.

Fixes # (issue)

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)
