### PR TITLE
fix(ai-providers): list gpt-5.6 Sol models for BYO OpenAI keys (Fixes #15278)

### DIFF
--- a/packages/core/piece-types/src/lib/ai-providers.ts
+++ b/packages/core/piece-types/src/lib/ai-providers.ts
@@ -232,7 +232,7 @@ const CF_GATEWAY_SUBMODEL_TO_PROVIDER: Record<string, AIProviderName> = {
     'google-vertex-ai': AIProviderName.GOOGLE,
 }
 
-const OPENAI_CHAT_MODELS = ['gpt-5.5', 'gpt-5.4-mini', 'gpt-5.4-nano', 'gpt-4.1', 'gpt-4.1-mini'] as const
+const OPENAI_CHAT_MODELS = ['gpt-5.6-sol', 'gpt-5.6-sol-pro', 'gpt-5.5', 'gpt-5.4-mini', 'gpt-5.4-nano', 'gpt-4.1', 'gpt-4.1-mini'] as const
 const ANTHROPIC_CHAT_MODELS = ['claude-sonnet-4-6', 'claude-opus-4-7', 'claude-haiku-4-5'] as const
 const ANTHROPIC_OPENROUTER_CHAT_MODELS = ['claude-sonnet-4.6', 'claude-opus-4.7', 'claude-opus-4.8', 'claude-haiku-4.5'] as const
 const GOOGLE_CHAT_MODELS = ['gemini-2.5-pro', 'gemini-2.5-flash', 'gemini-3.7-flash', 'gemini-3.1-pro-preview', 'gemini-3-flash-preview'] as const
@@ -254,6 +254,8 @@ export const ALLOWED_CHAT_MODELS_BY_PROVIDER: Partial<Record<AIProviderName, rea
 }
 
 const CHAT_MODEL_LABELS: Record<string, string> = {
+    'gpt-5.6-sol': 'GPT-5.6 Sol',
+    'gpt-5.6-sol-pro': 'GPT-5.6 Sol Pro',
     'gpt-5.5': 'GPT-5.5',
     'gpt-5.4-mini': 'GPT-5.4 mini',
     'gpt-5.4-nano': 'GPT-5.4 nano',


### PR DESCRIPTION
Fixes #15278.

## What changed

Added `gpt-5.6-sol` and `gpt-5.6-sol-pro` to `OPENAI_CHAT_MODELS` and to `CHAT_MODEL_LABELS` in `packages/core/piece-types/src/lib/ai-providers.ts`. Nothing else touched.

## Why these ids

I did not guess the names. The credit costs map in this same file already prices both `openai/gpt-5.6-sol` and `openai/gpt-5.6-sol-pro` (the entries landed with #15356), so those are the 5.6 family ids this repo acknowledges. They just never made it into the curated list, which still tops out at `gpt-5.5`. Result: a user with their own key can reach 5.6 models, but the picker filters them out and the server-side resolver treats them as uncurated.

With this change, BYO-key users see the two 5.6 models in the dropdown with proper labels, and `resolveModelIdForProvider` stops redirecting them to an older model.

## The longer-term path

The issue also mentions not wanting a code change per model release. I left that alone on purpose since it is a product decision, but for what it is worth: prefix curation (`gpt-5.` pass-through of ids returned by `/v1/models` for the OPENAI provider) would have fixed this case with no list churn, at the cost of listing every variant (image, audio, codex) the API returns. A middle ground would be a `KNOWN_NON_CHAT` blocklist instead of a allowlist. Happy to take a shot at either if the team wants it.

## Testing

- Ran the file through esbuild transform to confirm no syntax break.
- Monorepo build not run locally (heavy); the change is two data lists, no types touched. `CHAT_MODEL_LABELS` lookups fall back to the raw id via `?? id`, so even a label typo could not break the picker.
