### PR TITLE
test(core): add gateway timeout plain text string invariant parsing spec

### DIFF
--- a/packages/core/shared/test/core/common/friendly-piece-error.test.ts
+++ b/packages/core/shared/test/core/common/friendly-piece-error.test.ts
@@ -324,4 +324,10 @@ describe('tryParseFriendlyPieceError', () => {
         expect(tryParseFriendlyPieceError(null)).toBeNull()
         expect(tryParseFriendlyPieceError(undefined)).toBeNull()
     })
+
+    it('returns null safely for gateway timeout plain text strings without crashing', () => {
+        expect(tryParseFriendlyPieceError('504 Gateway Time-out')).toBeNull()
+        expect(tryParseFriendlyPieceError('ECONNRESET')).toBeNull()
+    })
 })
+


### PR DESCRIPTION
### Summary
- Adds unit tests to `packages/core/shared/test/core/common/friendly-piece-error.test.ts` verifying that non-structured plain text gateway timeout strings (such as 504 Gateway Time-out or ECONNRESET) return null safely without parsing exceptions.