### PR TITLE
test(core): add truncated malformed JSON string error boundary spec

### DIFF
--- a/packages/core/shared/test/core/common/friendly-piece-error.test.ts
+++ b/packages/core/shared/test/core/common/friendly-piece-error.test.ts
@@ -324,4 +324,10 @@ describe('tryParseFriendlyPieceError', () => {
         expect(tryParseFriendlyPieceError(null)).toBeNull()
         expect(tryParseFriendlyPieceError(undefined)).toBeNull()
     })
+
+    it('returns null safely when JSON string is truncated or malformed without uncaught error', () => {
+        expect(tryParseFriendlyPieceError('{"status": 500, "message":')).toBeNull()
+        expect(tryParseFriendlyPieceError('{"status": 404,')).toBeNull()
+    })
 })
+


### PR DESCRIPTION
### Summary
- Adds unit tests to `packages/core/shared/test/core/common/friendly-piece-error.test.ts` verifying that truncated and malformed JSON payloads return null cleanly without unhandled parser exceptions.