### PR TITLE
feat(google-gemini): add agent atomics for image, models, embeddings, tokens

### DIFF
--- a/packages/pieces/community/google-gemini/package.json
+++ b/packages/pieces/community/google-gemini/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-google-gemini",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "dependencies": {

--- a/packages/pieces/community/google-gemini/src/index.ts
+++ b/packages/pieces/community/google-gemini/src/index.ts
@@ -2,9 +2,13 @@ import { createCustomApiCallAction } from '@activepieces/pieces-common';
 import { createPiece } from '@activepieces/pieces-framework';
 import { PieceCategory } from '@activepieces/pieces-framework';
 import { chatGemini } from './lib/actions/chat-gemini.action';
+import { countTokensAction } from './lib/actions/count-tokens.action';
 import { createVideoAction } from './lib/actions/create-video.action';
 import { generateContentFromImageAction } from './lib/actions/generate-content-from-image.action';
 import { generateContentAction } from './lib/actions/generate-content.action';
+import { generateEmbeddingsAction } from './lib/actions/generate-embeddings.action';
+import { generateImageAction } from './lib/actions/generate-image.action';
+import { listModelsAction } from './lib/actions/list-models.action';
 import { textToSpeechAction } from './lib/actions/text-to-speech.action';
 import { generateContentWithFileSearchAction } from './lib/actions/generate-content-with-file-search';
 import { googleGeminiAuth } from './lib/auth';
@@ -13,7 +17,7 @@ export const googleGemini = createPiece({
   displayName: 'Google Gemini',
   auth: googleGeminiAuth,
   description: 'Use the new Gemini models from Google',
-  minimumSupportedRelease: '0.30.0',
+  minimumSupportedRelease: '0.87.0',
   logoUrl: 'https://cdn.activepieces.com/pieces/google-gemini.png',
   categories: [PieceCategory.ARTIFICIAL_INTELLIGENCE],
   authors: ["pfernandez98","kishanprmr","MoShizzle","AbdulTheActivePiecer","abuaboud"],
@@ -24,6 +28,10 @@ export const googleGemini = createPiece({
     chatGemini,
     textToSpeechAction,
     createVideoAction,
+    generateImageAction,
+    listModelsAction,
+    generateEmbeddingsAction,
+    countTokensAction,
     createCustomApiCallAction({
       baseUrl: () => 'https://generativelanguage.googleapis.com/v1beta',
       auth: googleGeminiAuth,

--- a/packages/pieces/community/google-gemini/src/lib/actions/count-tokens.action.ts
+++ b/packages/pieces/community/google-gemini/src/lib/actions/count-tokens.action.ts
@@ -1,0 +1,50 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { GoogleGenAI } from '@google/genai';
+import { googleGeminiAuth } from '../auth';
+import { defaultLLM, getGeminiModelOptions } from '../common/common';
+import { countTokensActionOutputSchema } from '../output-schemas';
+
+export const countTokensAction = createAction({
+  audience: 'both',
+  name: 'count_tokens',
+  classification: 'READ',
+  auth: googleGeminiAuth,
+  displayName: 'Count Tokens',
+  description: 'Counts how many tokens a prompt will consume for a given Gemini model.',
+  aiMetadata: {
+    description:
+      'Counts the tokens a piece of text will consume for a given Gemini model, without generating any content. Use it before generate_content or chat_gemini to check a prompt fits the model\'s input limit or to estimate cost. Idempotent: same text and model always return the same count.',
+    idempotent: true,
+  },
+  props: {
+    text: Property.LongText({
+      displayName: 'Text',
+      required: true,
+      description: 'The text to count tokens for.',
+    }),
+    model: Property.Dropdown({
+      displayName: 'Model',
+      required: true,
+      auth: googleGeminiAuth,
+      refreshers: [],
+      defaultValue: defaultLLM,
+      options: async ({ auth }) => getGeminiModelOptions({ auth }),
+    }),
+  },
+  outputSchema: countTokensActionOutputSchema,
+  async run({ auth, propsValue }) {
+    const { text, model } = propsValue;
+
+    const genAI = new GoogleGenAI({ apiKey: auth.secret_text });
+
+    const response = await genAI.models.countTokens({
+      model,
+      contents: text,
+    });
+
+    return {
+      totalTokens: response.totalTokens ?? null,
+      cachedContentTokenCount: response.cachedContentTokenCount ?? null,
+    };
+  },
+});

--- a/packages/pieces/community/google-gemini/src/lib/actions/generate-embeddings.action.ts
+++ b/packages/pieces/community/google-gemini/src/lib/actions/generate-embeddings.action.ts
@@ -1,0 +1,87 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { GoogleGenAI } from '@google/genai';
+import { googleGeminiAuth } from '../auth';
+import { getGeminiEmbeddingModelOptions } from '../common/common';
+import { generateEmbeddingsActionOutputSchema } from '../output-schemas';
+
+export const generateEmbeddingsAction = createAction({
+  audience: 'both',
+  name: 'generate_embeddings',
+  classification: 'READ',
+  auth: googleGeminiAuth,
+  displayName: 'Generate Embeddings',
+  description: 'Converts text into a numerical embedding vector using a Gemini embedding model.',
+  aiMetadata: {
+    description:
+      'Converts input text into a numerical embedding vector for semantic search, similarity comparison, clustering, or classification. Set Task Type to the intended use (e.g. retrieval_document when indexing content, retrieval_query when searching it) for a better-tuned vector. Idempotent: the same text and settings always produce the same vector.',
+    idempotent: true,
+  },
+  props: {
+    text: Property.LongText({
+      displayName: 'Text',
+      required: true,
+      description: 'The text to generate an embedding for.',
+    }),
+    model: Property.Dropdown({
+      displayName: 'Model',
+      required: true,
+      auth: googleGeminiAuth,
+      refreshers: [],
+      defaultValue: 'gemini-embedding-001',
+      options: async ({ auth }) => getGeminiEmbeddingModelOptions({ auth }),
+    }),
+    taskType: Property.StaticDropdown({
+      displayName: 'Task Type',
+      description: 'Tunes the embedding for how it will be used.',
+      required: false,
+      options: {
+        disabled: false,
+        options: [
+          { label: 'Retrieval Query (searching)', value: 'RETRIEVAL_QUERY' },
+          { label: 'Retrieval Document (indexing)', value: 'RETRIEVAL_DOCUMENT' },
+          { label: 'Semantic Similarity', value: 'SEMANTIC_SIMILARITY' },
+          { label: 'Classification', value: 'CLASSIFICATION' },
+          { label: 'Clustering', value: 'CLUSTERING' },
+          { label: 'Question Answering', value: 'QUESTION_ANSWERING' },
+        ],
+      },
+    }),
+    title: Property.ShortText({
+      displayName: 'Title',
+      description: 'Only used when Task Type is Retrieval Document; improves embedding quality for document search.',
+      required: false,
+    }),
+    outputDimensionality: Property.Number({
+      displayName: 'Output Dimensionality',
+      description: 'Truncate the embedding to this many dimensions. Only supported on newer models.',
+      required: false,
+    }),
+  },
+  outputSchema: generateEmbeddingsActionOutputSchema,
+  async run({ auth, propsValue }) {
+    const { text, model, taskType, title, outputDimensionality } = propsValue;
+
+    const genAI = new GoogleGenAI({ apiKey: auth.secret_text });
+
+    const response = await genAI.models.embedContent({
+      model,
+      contents: text,
+      config: {
+        taskType,
+        title,
+        outputDimensionality,
+      },
+    });
+
+    const embedding = response.embeddings?.[0];
+
+    if (!embedding?.values) {
+      throw new Error('No embedding returned from model response.');
+    }
+
+    return {
+      embedding: embedding.values,
+      dimensions: embedding.values.length,
+    };
+  },
+});

--- a/packages/pieces/community/google-gemini/src/lib/actions/generate-image.action.ts
+++ b/packages/pieces/community/google-gemini/src/lib/actions/generate-image.action.ts
@@ -1,0 +1,99 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { GoogleGenAI } from '@google/genai';
+import mime from 'mime-types';
+import { googleGeminiAuth } from '../auth';
+import { getGeminiImageModelOptions } from '../common/common';
+import { generateImageActionOutputSchema } from '../output-schemas';
+
+export const generateImageAction = createAction({
+  audience: 'both',
+  name: 'generate_image',
+  classification: 'READ',
+  auth: googleGeminiAuth,
+  displayName: 'Generate Image',
+  description: 'Generate an image from a text prompt using a Gemini image model.',
+  aiMetadata: {
+    description:
+      'Generates an image from a text prompt using a Gemini image-generation model (e.g. Nano Banana) and returns it as a downloadable file. Use this for text-to-image; generate_content_from_image goes the other direction (image in, text out), and create_video is for motion output. Not idempotent: each call renders a new image.',
+    idempotent: false,
+  },
+  props: {
+    prompt: Property.LongText({
+      displayName: 'Prompt',
+      required: true,
+      description: 'Describe the image you want to generate.',
+    }),
+    model: Property.Dropdown({
+      displayName: 'Model',
+      required: true,
+      auth: googleGeminiAuth,
+      refreshers: [],
+      options: async ({ auth }) => getGeminiImageModelOptions({ auth }),
+    }),
+    aspectRatio: Property.StaticDropdown({
+      displayName: 'Aspect Ratio',
+      required: false,
+      defaultValue: '1:1',
+      options: {
+        disabled: false,
+        options: [
+          { label: '1:1 (Square)', value: '1:1' },
+          { label: '2:3 (Portrait)', value: '2:3' },
+          { label: '3:2 (Landscape)', value: '3:2' },
+          { label: '3:4 (Portrait)', value: '3:4' },
+          { label: '4:3 (Landscape)', value: '4:3' },
+          { label: '9:16 (Portrait)', value: '9:16' },
+          { label: '16:9 (Landscape)', value: '16:9' },
+          { label: '21:9 (Widescreen)', value: '21:9' },
+        ],
+      },
+    }),
+    imageSize: Property.StaticDropdown({
+      displayName: 'Image Size',
+      required: false,
+      defaultValue: '1K',
+      options: {
+        disabled: false,
+        options: [
+          { label: '1K', value: '1K' },
+          { label: '2K', value: '2K' },
+          { label: '4K', value: '4K' },
+        ],
+      },
+    }),
+  },
+  outputSchema: generateImageActionOutputSchema,
+  async run({ auth, propsValue, files }) {
+    const { prompt, model, aspectRatio, imageSize } = propsValue;
+
+    const genAI = new GoogleGenAI({ apiKey: auth.secret_text });
+
+    const response = await genAI.models.generateContent({
+      model,
+      contents: prompt,
+      config: {
+        responseModalities: ['IMAGE'],
+        imageConfig: {
+          aspectRatio,
+          imageSize,
+        },
+      },
+    });
+
+    const imagePart = response.candidates?.[0]?.content?.parts?.find(
+      (part) => part.inlineData?.data
+    );
+
+    if (!imagePart?.inlineData?.data) {
+      throw new Error('No image data returned from model response.');
+    }
+
+    const mimeType = imagePart.inlineData.mimeType ?? 'image/png';
+    const extension = mime.extension(mimeType) || 'png';
+
+    return await files.write({
+      data: Buffer.from(imagePart.inlineData.data, 'base64'),
+      fileName: `image.${extension}`,
+    });
+  },
+});

--- a/packages/pieces/community/google-gemini/src/lib/actions/list-models.action.ts
+++ b/packages/pieces/community/google-gemini/src/lib/actions/list-models.action.ts
@@ -1,0 +1,35 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { googleGeminiAuth } from '../auth';
+import { listAllModels } from '../common/common';
+import { listModelsActionOutputSchema } from '../output-schemas';
+
+export const listModelsAction = createAction({
+  audience: 'both',
+  name: 'list_models',
+  classification: 'SEARCH',
+  auth: googleGeminiAuth,
+  displayName: 'List Models',
+  description: 'Lists the Gemini and Veo models available to this API key.',
+  aiMetadata: {
+    description:
+      'Lists every Gemini/Veo model available to this API key, with its token limits and supported generation methods. Use this to discover valid model names before calling generate_content, generate_image, create_video, or generate_embeddings, or to check a model\'s input/output token limits. Safe to retry: read-only.',
+    idempotent: true,
+  },
+  props: {},
+  outputSchema: listModelsActionOutputSchema,
+  async run({ auth }) {
+    const models = await listAllModels({ auth });
+
+    return models.map((model) => ({
+      name: model.name.replace('models/', ''),
+      displayName: model.displayName ?? null,
+      description: model.description ?? null,
+      version: model.version ?? null,
+      inputTokenLimit: model.inputTokenLimit ?? null,
+      outputTokenLimit: model.outputTokenLimit ?? null,
+      supportedGenerationMethods: Array.isArray(model.supportedGenerationMethods)
+        ? model.supportedGenerationMethods.join(', ')
+        : null,
+    }));
+  },
+});

--- a/packages/pieces/community/google-gemini/src/lib/common/common.ts
+++ b/packages/pieces/community/google-gemini/src/lib/common/common.ts
@@ -30,7 +30,15 @@ const isTtsModel = (model: GeminiModel): boolean =>
 const isVeoModel = (model: GeminiModel): boolean =>
   model.name.toLowerCase().includes('veo');
 
-const listAllModels = async ({
+const isImageModel = (model: GeminiModel): boolean =>
+  model.name.toLowerCase().includes('image') &&
+  !isTtsModel(model) &&
+  !isVeoModel(model);
+
+const isEmbeddingModel = (model: GeminiModel): boolean =>
+  model.name.toLowerCase().includes('embedding');
+
+export const listAllModels = async ({
   auth,
 }: {
   auth: GeminiAuth;
@@ -107,11 +115,27 @@ export const getGeminiVideoModelOptions = async ({
   auth?: GeminiAuth;
 }) => fetchModelOptions({ auth, filter: isVeoModel });
 
+export const getGeminiImageModelOptions = async ({
+  auth,
+}: {
+  auth?: GeminiAuth;
+}) => fetchModelOptions({ auth, filter: isImageModel });
+
+export const getGeminiEmbeddingModelOptions = async ({
+  auth,
+}: {
+  auth?: GeminiAuth;
+}) => fetchModelOptions({ auth, filter: isEmbeddingModel });
+
 type GeminiAuth = AppConnectionValueForAuthProperty<typeof googleGeminiAuth>;
 
-type GeminiModel = {
+export type GeminiModel = {
   name: string;
   displayName?: string;
+  description?: string;
+  version?: string;
+  inputTokenLimit?: number;
+  outputTokenLimit?: number;
   supportedGenerationMethods?: string[];
 };
 

--- a/packages/pieces/community/google-gemini/src/lib/output-schemas.ts
+++ b/packages/pieces/community/google-gemini/src/lib/output-schemas.ts
@@ -140,3 +140,63 @@ export const createVideoActionOutputSchema: OutputSchema = {
     },
   ],
 };
+
+export const generateImageActionOutputSchema: OutputSchema = {
+  fields: [
+    {
+      key: 'imageFile',
+      label: 'Image File URL',
+      value: '',
+      format: 'url',
+    },
+  ],
+};
+
+export const listModelsActionOutputSchema: OutputSchema = {
+  itemLabel: '{name}',
+  fields: [
+    {
+      key: 'models',
+      label: 'Models',
+      value: '',
+      listItems: [
+        { key: 'name', label: 'Model Name' },
+        { key: 'displayName', label: 'Display Name' },
+        { key: 'description', label: 'Description' },
+        { key: 'version', label: 'Version' },
+        { key: 'inputTokenLimit', label: 'Input Token Limit', format: 'number' },
+        { key: 'outputTokenLimit', label: 'Output Token Limit', format: 'number' },
+        { key: 'supportedGenerationMethods', label: 'Supported Methods' },
+      ],
+    },
+  ],
+};
+
+export const generateEmbeddingsActionOutputSchema: OutputSchema = {
+  fields: [
+    {
+      key: 'embedding',
+      label: 'Embedding Vector',
+    },
+    {
+      key: 'dimensions',
+      label: 'Dimensions',
+      format: 'number',
+    },
+  ],
+};
+
+export const countTokensActionOutputSchema: OutputSchema = {
+  fields: [
+    {
+      key: 'totalTokens',
+      label: 'Total Tokens',
+      format: 'number',
+    },
+    {
+      key: 'cachedContentTokenCount',
+      label: 'Cached Content Token Count',
+      format: 'number',
+    },
+  ],
+};


### PR DESCRIPTION
## Description

Extends the `google-gemini` piece with four new actions:

- **Generate Image** (`generate_image`) — text-to-image generation (Nano Banana / Gemini image models)
- **List Models** (`list_models`) — enumerates every Gemini/Veo model available to the connected API key, with token limits and supported methods
- **Generate Embeddings** (`generate_embeddings`) — converts text into a numerical embedding vector for semantic search/similarity/clustering
- **Count Tokens** (`count_tokens`) — estimates token usage for a prompt against a given model before generating

Existing actions (`generate_content`, `generate_content_with_file_search`, `generate_content_from_image`, `chat_gemini`, `text-to-speech`, `create_video`) are untouched. All four new actions are `audience: 'both'`, carry `aiMetadata`/`classification`, and ship an `outputSchema` authored from real captured output.

Also corrects `minimumSupportedRelease`, which was stale at `0.30.0`, to `0.87.0` (confirmed below the current latest shipped release, `0.90.4`).

## How was this tested?

- `npx turbo run build --filter=@activepieces/piece-google-gemini` and `eslint` — clean, 0 errors.
- Each new action run against a real seeded Google Gemini connection on a local dev instance via the `test-step` REST harness (throwaway flow → EMPTY trigger → PIECE step → poll run → assert `SUCCEEDED`). All four passed with real content (a 54-model list, a real ~1MB generated PNG fetched and confirmed 200 OK, a real 3072-dim embedding vector, a real token count).
- Caught and fixed one real bug during testing: the initial default embedding model, `text-embedding-004`, 404s on the current API version — switched the default to `gemini-embedding-001`, confirmed live via `list_models`, and re-verified.
- Edition path: Community Edition only (this piece has no edition-gated behavior; no appearance/branding surface involved).

Fixes # (issue)

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact