### PR TITLE
feat(flow-helper): add Create Waitpoint + Wait for Resume actions

### DIFF
--- a/packages/pieces/community/flow-helper/package.json
+++ b/packages/pieces/community/flow-helper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-flow-helper",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {

--- a/packages/pieces/community/flow-helper/src/index.ts
+++ b/packages/pieces/community/flow-helper/src/index.ts
@@ -8,7 +8,7 @@ import { createWaitpoint } from "./lib/actions/create-waitpoint";
 export const flowHelper = createPiece({
   displayName: "Flow Helper",
   auth: PieceAuth.None(),
-  minimumSupportedRelease: '0.36.1',
+  minimumSupportedRelease: '0.82.0',
   logoUrl: "https://cdn.activepieces.com/pieces/flow-helper.svg",
   authors: ["AbdulTheActivePiecer","AnkitSharmaOnGithub"],
   actions: [getRunId, failFlow, stopFlow, createWaitpoint, waitForResume],

--- a/packages/pieces/community/flow-helper/src/index.ts
+++ b/packages/pieces/community/flow-helper/src/index.ts
@@ -2,6 +2,8 @@ import { createPiece, PieceAuth } from "@activepieces/pieces-framework";
 import { getRunId } from "./lib/actions/get-run-id";
 import { failFlow } from "./lib/actions/fail-flow";
 import { stopFlow } from "./lib/actions/stop-flow";
+import { waitForResume } from "./lib/actions/wait-for-resume";
+import { createWaitpoint } from "./lib/actions/create-waitpoint";
 
 export const flowHelper = createPiece({
   displayName: "Flow Helper",
@@ -9,6 +11,6 @@ export const flowHelper = createPiece({
   minimumSupportedRelease: '0.36.1',
   logoUrl: "https://cdn.activepieces.com/pieces/flow-helper.svg",
   authors: ["AbdulTheActivePiecer","AnkitSharmaOnGithub"],
-  actions: [getRunId, failFlow, stopFlow],
+  actions: [getRunId, failFlow, stopFlow, createWaitpoint, waitForResume],
   triggers: [],
 });

--- a/packages/pieces/community/flow-helper/src/lib/actions/create-waitpoint.ts
+++ b/packages/pieces/community/flow-helper/src/lib/actions/create-waitpoint.ts
@@ -1,0 +1,43 @@
+import { createAction, PieceAuth } from '@activepieces/pieces-framework';
+import { MarkdownVariant, Property } from '@activepieces/pieces-framework';
+import { createWaitpointActionOutputSchema } from '../output-schemas';
+
+export const createWaitpoint = createAction({
+  audience: 'both',
+  auth: PieceAuth.None(),
+  name: 'create_waitpoint',
+  classification: 'READ',
+  displayName: 'Create Waitpoint',
+  description:
+    'Creates a resumable waitpoint and returns its resume URL immediately, without pausing the flow. Pair with Wait for Resume.',
+  aiMetadata: {
+    description:
+      "Mints a resumable waitpoint for the current flow run and returns its id and resume URL without pausing, so a later step can embed the URL in a control you post yourself (e.g. a Slack button whose value is the resume URL). Calling that URL resumes the run. Pick this together with Wait for Resume when you want full control over the message/UI that carries the resume action; use Wait for Approval for a simple built-in approve/disapprove gate. Takes no inputs. Not idempotent, since each call creates a new waitpoint.",
+    idempotent: false,
+  },
+  outputSchema: createWaitpointActionOutputSchema,
+  props: {
+    markdown: Property.MarkDown({
+      variant: MarkdownVariant.INFO,
+      value:
+        'Returns a **resume URL** without pausing. Post your own control (e.g. a Slack button) whose value is this URL, then use **Wait for Resume** to pause and read the full payload when it is called.',
+    }),
+  },
+  errorHandlingOptions: {
+    continueOnFailure: {
+      hide: true,
+    },
+    retryOnFailure: {
+      hide: true,
+    },
+  },
+  async run(ctx) {
+    const waitpoint = await ctx.run.createWaitpoint({
+      type: 'WEBHOOK',
+    });
+    return {
+      waitpointId: waitpoint.id,
+      resumeUrl: waitpoint.resumeUrl,
+    };
+  },
+});

--- a/packages/pieces/community/flow-helper/src/lib/actions/create-waitpoint.ts
+++ b/packages/pieces/community/flow-helper/src/lib/actions/create-waitpoint.ts
@@ -20,7 +20,7 @@ export const createWaitpoint = createAction({
     markdown: Property.MarkDown({
       variant: MarkdownVariant.INFO,
       value:
-        'Returns a **resume URL** without pausing. Post your own control (e.g. a Slack button) whose value is this URL, then use **Wait for Resume** to pause and read the full payload when it is called.',
+        'Returns a **resume URL** without pausing. Post your own control (e.g. a Slack button) whose value is this URL, then use **Wait for Resume** to pause and read the full payload when it is called.\n\n**Only one waitpoint can be pending per flow run at a time** — create it, embed its URL, and pause with Wait for Resume before creating another.',
     }),
   },
   errorHandlingOptions: {

--- a/packages/pieces/community/flow-helper/src/lib/actions/wait-for-resume.ts
+++ b/packages/pieces/community/flow-helper/src/lib/actions/wait-for-resume.ts
@@ -34,11 +34,22 @@ export const waitForResume = createAction({
   },
   async run(ctx) {
     if (ctx.executionType === ExecutionType.BEGIN) {
+      // Fail fast on a blank id rather than parking the run un-resumably. The engine's
+      // waitForWaitpoint just flags the run paused (it does not look the id up), so the
+      // run resumes only if a live waitpoint exists for it — which Create Waitpoint must
+      // have minted earlier in this same run. A missing/blank id is the realistic
+      // misconfiguration (Create Waitpoint not wired in) that would otherwise strand the
+      // run, so reject it before pausing.
+      const waitpointId = ctx.propsValue.waitpointId?.trim();
+      if (!waitpointId) {
+        throw new Error(
+          'Wait for Resume: waitpointId is empty. Wire in the "Waitpoint ID" output of a Create Waitpoint step that runs earlier in this same flow run.'
+        );
+      }
       // Park on the waitpoint that Create Waitpoint already minted — do NOT create a
-      // new one. The engine's waitForWaitpoint just flags the run paused; the pending
-      // waitpoint (whose id + resume URL came from Create Waitpoint) is what resumes it,
-      // and it is validated + consumed on resume (single-use).
-      ctx.run.waitForWaitpoint(ctx.propsValue.waitpointId);
+      // new one. The pending waitpoint (whose id + resume URL came from Create Waitpoint)
+      // is what resumes the run, and it is validated + consumed on resume (single-use).
+      ctx.run.waitForWaitpoint(waitpointId);
       return {
         payload: null,
         queryParams: {},

--- a/packages/pieces/community/flow-helper/src/lib/actions/wait-for-resume.ts
+++ b/packages/pieces/community/flow-helper/src/lib/actions/wait-for-resume.ts
@@ -1,0 +1,52 @@
+import { createAction, PieceAuth } from '@activepieces/pieces-framework';
+import { ExecutionType, MarkdownVariant, Property } from '@activepieces/pieces-framework';
+import { waitForResumeActionOutputSchema } from '../output-schemas';
+
+export const waitForResume = createAction({
+  audience: 'both',
+  auth: PieceAuth.None(),
+  name: 'wait_for_resume',
+  classification: 'READ',
+  displayName: 'Wait for Resume',
+  description:
+    'Pauses the flow until its resume URL is called, then returns the full resume payload (body + query params).',
+  aiMetadata: {
+    description:
+      "Pauses the current flow run and resumes only when the run's waitpoint resume URL is called, returning the caller's full payload (request body and query params) rather than just an approve/disapprove boolean. Pick this when you post your own interactive control (e.g. a Slack button whose value is a resume URL from Create Approval Links) and need to inspect who acted or what they sent on resume. Takes no inputs. Not idempotent, since each execution creates a new waitpoint.",
+    idempotent: false,
+  },
+  outputSchema: waitForResumeActionOutputSchema,
+  props: {
+    markdown: Property.MarkDown({
+      variant: MarkdownVariant.INFO,
+      value:
+        'Pair this with **Create Approval Links** (which hands out a resume URL without pausing): post your own control (button/link) with that URL, then use this action to pause and read back the full payload when it is called.',
+    }),
+  },
+  errorHandlingOptions: {
+    continueOnFailure: {
+      hide: true,
+    },
+    retryOnFailure: {
+      hide: true,
+    },
+  },
+  async run(ctx) {
+    if (ctx.executionType === ExecutionType.BEGIN) {
+      const waitpoint = await ctx.run.createWaitpoint({
+        type: 'WEBHOOK',
+      });
+      ctx.run.waitForWaitpoint(waitpoint.id);
+
+      return {
+        payload: null,
+        queryParams: {},
+      };
+    }
+
+    return {
+      payload: ctx.resumePayload?.body ?? null,
+      queryParams: ctx.resumePayload?.queryParams ?? {},
+    };
+  },
+});

--- a/packages/pieces/community/flow-helper/src/lib/actions/wait-for-resume.ts
+++ b/packages/pieces/community/flow-helper/src/lib/actions/wait-for-resume.ts
@@ -1,5 +1,5 @@
 import { createAction, PieceAuth } from '@activepieces/pieces-framework';
-import { ExecutionType, MarkdownVariant, Property } from '@activepieces/pieces-framework';
+import { ExecutionType, Property } from '@activepieces/pieces-framework';
 import { waitForResumeActionOutputSchema } from '../output-schemas';
 
 export const waitForResume = createAction({
@@ -9,18 +9,19 @@ export const waitForResume = createAction({
   classification: 'READ',
   displayName: 'Wait for Resume',
   description:
-    'Pauses the flow until its resume URL is called, then returns the full resume payload (body + query params).',
+    "Pauses the flow on a waitpoint created by Create Waitpoint, and returns the full resume payload (body + query params) when that waitpoint's resume URL is called.",
   aiMetadata: {
     description:
-      "Pauses the current flow run and resumes only when the run's waitpoint resume URL is called, returning the caller's full payload (request body and query params) rather than just an approve/disapprove boolean. Pick this when you post your own interactive control (e.g. a Slack button whose value is a resume URL from Create Approval Links) and need to inspect who acted or what they sent on resume. Takes no inputs. Not idempotent, since each execution creates a new waitpoint.",
+      "Pauses the current flow run on a specific waitpoint (from Create Waitpoint) and resumes only when that waitpoint's resume URL is called, returning the caller's full payload (request body and query params) rather than just an approve/disapprove boolean. Pass the waitpointId returned by Create Waitpoint. Pick this when you post your own interactive control (e.g. a Slack button whose value is the waitpoint's resume URL) and need to inspect who acted or what they sent. Not idempotent, since the waitpoint is consumed on resume.",
     idempotent: false,
   },
   outputSchema: waitForResumeActionOutputSchema,
   props: {
-    markdown: Property.MarkDown({
-      variant: MarkdownVariant.INFO,
-      value:
-        'Pair this with **Create Approval Links** (which hands out a resume URL without pausing): post your own control (button/link) with that URL, then use this action to pause and read back the full payload when it is called.',
+    waitpointId: Property.ShortText({
+      displayName: 'Waitpoint ID',
+      description:
+        "The waitpoint id returned by Create Waitpoint. The flow pauses until this waitpoint's resume URL is called.",
+      required: true,
     }),
   },
   errorHandlingOptions: {
@@ -33,11 +34,11 @@ export const waitForResume = createAction({
   },
   async run(ctx) {
     if (ctx.executionType === ExecutionType.BEGIN) {
-      const waitpoint = await ctx.run.createWaitpoint({
-        type: 'WEBHOOK',
-      });
-      ctx.run.waitForWaitpoint(waitpoint.id);
-
+      // Park on the waitpoint that Create Waitpoint already minted — do NOT create a
+      // new one. The engine's waitForWaitpoint just flags the run paused; the pending
+      // waitpoint (whose id + resume URL came from Create Waitpoint) is what resumes it,
+      // and it is validated + consumed on resume (single-use).
+      ctx.run.waitForWaitpoint(ctx.propsValue.waitpointId);
       return {
         payload: null,
         queryParams: {},

--- a/packages/pieces/community/flow-helper/src/lib/output-schemas.ts
+++ b/packages/pieces/community/flow-helper/src/lib/output-schemas.ts
@@ -13,3 +13,17 @@ export const stopFlowActionOutputSchema: OutputSchema = {
     { key: 'message', label: 'Message' },
   ],
 };
+
+export const waitForResumeActionOutputSchema: OutputSchema = {
+  fields: [
+    { key: 'payload', label: 'Resume payload' },
+    { key: 'queryParams', label: 'Query params' },
+  ],
+};
+
+export const createWaitpointActionOutputSchema: OutputSchema = {
+  fields: [
+    { key: 'waitpointId', label: 'Waitpoint ID' },
+    { key: 'resumeUrl', label: 'Resume URL', format: 'url' },
+  ],
+};


### PR DESCRIPTION
### What

Two new actions in the **Flow Helper** piece:

- **Create Waitpoint** — creates a resumable waitpoint and returns `{ waitpointId, resumeUrl }` immediately, **without pausing** the flow.
- **Wait for Resume** — takes a `waitpointId` (from Create Waitpoint), **pauses** the run on that waitpoint, and returns the **full** resume payload (`{ payload, queryParams }`) when its resume URL is called.

### Why

There's currently no way to pause a flow on a control **you post yourself** and read back who acted / what they sent:

- `approval/create_approval_links` hands out a `/confirm` link, and `approval/wait_for_approval` discards the payload (returns only `{ approved }` from the query string), and mints its own waitpoint — so the URL you hand out belongs to a *different* waitpoint than the one it parks on.
- `slack/request_action_message` returns the full interaction payload but insists on posting its own message.

This pair returns the **bare resume URL** and the **full payload**, and `Wait for Resume` parks on the **same** waitpoint whose URL you embedded. That lets you, for example, add a button as an accessory on a message you already manage (value = the resume URL), then read the interaction body (incl. the acting user) when it's clicked.

### Notes

- One waitpoint per pause, addressed by id: `Wait for Resume` calls `waitForWaitpoint(waitpointId)` without minting its own, so the pending waitpoint from `Create Waitpoint` is the one that resumes it. (`createForPause` is only invoked by the waitpoint controller, never by the engine on pause.)
- Validated + single-use: on resume, `handleResumeSignal` looks up `{ id, flowRunId }` (unknown/stale ids are ignored) and deletes the waitpoint, so a resume URL is one-shot.
- `minimumSupportedRelease` set to `0.82.0` to match the sibling pieces that use the same `createWaitpoint`/`waitForWaitpoint` hooks (`approval`, `delay`, `webhook`, `subflows`).
- Flow Helper version bumped 0.1.8 → 0.1.9. Follows the existing action conventions (`audience`, `aiMetadata`, `classification`, `errorHandlingOptions`, output schemas).