### PR TITLE
feat(notion): readable friendly-view output for page & row triggers

### DIFF
--- a/packages/pieces/community/notion/package.json
+++ b/packages/pieces/community/notion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-notion",
-  "version": "0.6.10",
+  "version": "0.7.0",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "dependencies": {
@@ -22,6 +22,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",
     "bundle": "node ../../../../dist/packages/cli/src/index.js pieces bundle",
-    "lint": "eslint 'src/**/*.ts'"
+    "lint": "eslint 'src/**/*.ts'",
+    "test": "vitest run"
   }
 }

--- a/packages/pieces/community/notion/src/lib/common/enrich-page.test.ts
+++ b/packages/pieces/community/notion/src/lib/common/enrich-page.test.ts
@@ -1,0 +1,466 @@
+/// <reference types="vitest/globals" />
+import {
+  richTextToPlain,
+  getPageTitle,
+  getDatabaseTitle,
+  flattenPropertyValue,
+  flattenProperties,
+  enrichPage,
+} from './enrich-page';
+
+// A rich-text segment as Notion serves it.
+const rt = (text: string) => ({
+  type: 'text',
+  text: { content: text, link: null },
+  plain_text: text,
+  href: null,
+  annotations: {},
+});
+const prop = (type: string, extra: Record<string, unknown>) => ({
+  id: 'x',
+  type,
+  ...extra,
+});
+
+describe('richTextToPlain', () => {
+  it('joins all segments and trims', () => {
+    expect(richTextToPlain([rt('Take '), rt('Fig '), rt('on a walk')])).toBe(
+      'Take Fig on a walk'
+    );
+  });
+  it('handles a mention segment (still carries plain_text)', () => {
+    const mention = { type: 'mention', plain_text: '@Kareem', href: null };
+    expect(richTextToPlain([rt('cc '), mention])).toBe('cc @Kareem');
+  });
+  it('empty array -> ""', () => expect(richTextToPlain([])).toBe(''));
+  it('non-array -> ""', () => {
+    expect(richTextToPlain(null)).toBe('');
+    expect(richTextToPlain(undefined)).toBe('');
+  });
+});
+
+describe('flattenPropertyValue — all 24 types', () => {
+  it('1. title -> joined plain text', () =>
+    expect(
+      flattenPropertyValue(
+        prop('title', { title: [rt('Hello'), rt(' World')] })
+      )
+    ).toBe('Hello World'));
+  it('1b. empty title array -> ""', () =>
+    expect(flattenPropertyValue(prop('title', { title: [] }))).toBe(''));
+
+  it('2. rich_text -> joined plain text', () =>
+    expect(
+      flattenPropertyValue(prop('rich_text', { rich_text: [rt('a'), rt('b')] }))
+    ).toBe('ab'));
+  it('2b. empty rich_text -> ""', () =>
+    expect(flattenPropertyValue(prop('rich_text', { rich_text: [] }))).toBe(
+      ''
+    ));
+
+  it('3. select -> name', () =>
+    expect(
+      flattenPropertyValue(prop('select', { select: { name: 'Doing' } }))
+    ).toBe('Doing'));
+  it('3b. select null -> null', () =>
+    expect(flattenPropertyValue(prop('select', { select: null }))).toBeNull());
+
+  it('4. status -> name', () =>
+    expect(
+      flattenPropertyValue(prop('status', { status: { name: 'In progress' } }))
+    ).toBe('In progress'));
+  it('4b. status null -> null', () =>
+    expect(flattenPropertyValue(prop('status', { status: null }))).toBeNull());
+
+  it('5. multi_select -> joined names', () =>
+    expect(
+      flattenPropertyValue(
+        prop('multi_select', { multi_select: [{ name: 'a' }, { name: 'b' }] })
+      )
+    ).toBe('a, b'));
+  it('5b. multi_select [] -> ""', () =>
+    expect(
+      flattenPropertyValue(prop('multi_select', { multi_select: [] }))
+    ).toBe(''));
+
+  it('6. date start only', () =>
+    expect(
+      flattenPropertyValue(
+        prop('date', { date: { start: '2026-09-10', end: null } })
+      )
+    ).toBe('2026-09-10'));
+  it('6b. date with end -> "start → end"', () =>
+    expect(
+      flattenPropertyValue(
+        prop('date', {
+          date: { start: '2026-09-10', end: '2026-09-12', time_zone: 'GMT' },
+        })
+      )
+    ).toBe('2026-09-10 → 2026-09-12'));
+  it('6c. datetime start', () =>
+    expect(
+      flattenPropertyValue(
+        prop('date', { date: { start: '2026-09-10T09:00:00.000Z' } })
+      )
+    ).toBe('2026-09-10T09:00:00.000Z'));
+  it('6d. date null -> null', () =>
+    expect(flattenPropertyValue(prop('date', { date: null }))).toBeNull());
+
+  it('7. people -> names joined; partial (id-only) falls back to id', () =>
+    expect(
+      flattenPropertyValue(
+        prop('people', {
+          people: [
+            { object: 'user', id: 'u1', name: 'Alice' },
+            { object: 'user', id: 'u2' }, // partial, id only — seen live
+          ],
+        })
+      )
+    ).toBe('Alice, u2'));
+
+  it('8. created_by (bot user) -> name', () =>
+    expect(
+      flattenPropertyValue(
+        prop('created_by', {
+          created_by: {
+            object: 'user',
+            id: 'b1',
+            name: 'Activepieces',
+            type: 'bot',
+          },
+        })
+      )
+    ).toBe('Activepieces'));
+  it('8b. created_by without name -> id', () =>
+    expect(
+      flattenPropertyValue(
+        prop('created_by', { created_by: { object: 'user', id: 'b1' } })
+      )
+    ).toBe('b1'));
+
+  it('9. last_edited_by -> name ?? id', () =>
+    expect(
+      flattenPropertyValue(
+        prop('last_edited_by', { last_edited_by: { id: 'u9', name: 'Bob' } })
+      )
+    ).toBe('Bob'));
+
+  it('10. created_time passthrough', () =>
+    expect(
+      flattenPropertyValue(
+        prop('created_time', { created_time: '2023-03-02T01:43:00.000Z' })
+      )
+    ).toBe('2023-03-02T01:43:00.000Z'));
+  it('11. last_edited_time passthrough', () =>
+    expect(
+      flattenPropertyValue(
+        prop('last_edited_time', {
+          last_edited_time: '2023-03-02T01:43:00.000Z',
+        })
+      )
+    ).toBe('2023-03-02T01:43:00.000Z'));
+
+  it('12. number passthrough; 0 is a value', () => {
+    expect(flattenPropertyValue(prop('number', { number: 42 }))).toBe(42);
+    expect(flattenPropertyValue(prop('number', { number: 0 }))).toBe(0);
+    expect(flattenPropertyValue(prop('number', { number: null }))).toBeNull();
+  });
+
+  it('13. checkbox passthrough; false is a value', () => {
+    expect(flattenPropertyValue(prop('checkbox', { checkbox: true }))).toBe(
+      true
+    );
+    expect(flattenPropertyValue(prop('checkbox', { checkbox: false }))).toBe(
+      false
+    );
+  });
+
+  it('14. url / 15. email / 16. phone_number passthrough + null', () => {
+    expect(flattenPropertyValue(prop('url', { url: 'https://x.com' }))).toBe(
+      'https://x.com'
+    );
+    expect(flattenPropertyValue(prop('url', { url: null }))).toBeNull();
+    expect(flattenPropertyValue(prop('email', { email: 'a@b.com' }))).toBe(
+      'a@b.com'
+    );
+    expect(
+      flattenPropertyValue(prop('phone_number', { phone_number: '+123' }))
+    ).toBe('+123');
+    expect(
+      flattenPropertyValue(prop('phone_number', { phone_number: null }))
+    ).toBeNull();
+  });
+
+  it('17. files -> names only (internal + external), never URLs', () =>
+    expect(
+      flattenPropertyValue(
+        prop('files', {
+          files: [
+            {
+              name: 'a.pdf',
+              file: { url: 'https://s3/expiring', expiry_time: 'x' },
+            },
+            { name: 'b.png', external: { url: 'https://ext/b.png' } },
+          ],
+        })
+      )
+    ).toBe('a.pdf, b.png'));
+
+  it('18. formula — all 4 kinds + unsupported', () => {
+    expect(
+      flattenPropertyValue(
+        prop('formula', { formula: { type: 'string', string: 'hi' } })
+      )
+    ).toBe('hi');
+    expect(
+      flattenPropertyValue(
+        prop('formula', { formula: { type: 'number', number: 7 } })
+      )
+    ).toBe(7);
+    expect(
+      flattenPropertyValue(
+        prop('formula', { formula: { type: 'boolean', boolean: false } })
+      )
+    ).toBe(false);
+    expect(
+      flattenPropertyValue(
+        prop('formula', {
+          formula: { type: 'date', date: { start: '2026-01-01' } },
+        })
+      )
+    ).toBe('2026-01-01');
+    expect(
+      flattenPropertyValue(
+        prop('formula', { formula: { type: 'unsupported' } })
+      )
+    ).toBeNull();
+  });
+
+  it('19. rollup — number / date / array; incomplete + unsupported -> null', () => {
+    expect(
+      flattenPropertyValue(
+        prop('rollup', {
+          rollup: { type: 'number', number: 3, function: 'count' },
+        })
+      )
+    ).toBe(3);
+    expect(
+      flattenPropertyValue(
+        prop('rollup', {
+          rollup: {
+            type: 'date',
+            date: { start: '2026-02-02' },
+            function: 'latest_date',
+          },
+        })
+      )
+    ).toBe('2026-02-02');
+    expect(
+      flattenPropertyValue(
+        prop('rollup', {
+          rollup: {
+            type: 'array',
+            function: 'show_original',
+            array: [
+              { type: 'title', title: [rt('One')] },
+              { type: 'select', select: { name: 'Two' } },
+              { type: 'number', number: 3 },
+            ],
+          },
+        })
+      )
+    ).toBe('One, Two, 3');
+    expect(
+      flattenPropertyValue(
+        prop('rollup', { rollup: { type: 'incomplete', function: 'x' } })
+      )
+    ).toBeNull();
+    expect(
+      flattenPropertyValue(
+        prop('rollup', { rollup: { type: 'unsupported', function: 'x' } })
+      )
+    ).toBeNull();
+  });
+
+  it('20. relation -> count', () =>
+    expect(
+      flattenPropertyValue(
+        prop('relation', {
+          relation: [{ id: 'r1' }, { id: 'r2' }],
+          has_more: false,
+        })
+      )
+    ).toBe(2));
+
+  it('21. unique_id -> "PREFIX-123" or "123"; number null -> null', () => {
+    expect(
+      flattenPropertyValue(
+        prop('unique_id', { unique_id: { prefix: 'TASK', number: 123 } })
+      )
+    ).toBe('TASK-123');
+    expect(
+      flattenPropertyValue(
+        prop('unique_id', { unique_id: { prefix: null, number: 7 } })
+      )
+    ).toBe('7');
+    expect(
+      flattenPropertyValue(
+        prop('unique_id', { unique_id: { prefix: 'X', number: null } })
+      )
+    ).toBeNull();
+  });
+
+  it('22. verification -> state', () => {
+    expect(
+      flattenPropertyValue(
+        prop('verification', { verification: { state: 'verified' } })
+      )
+    ).toBe('verified');
+    expect(
+      flattenPropertyValue(
+        prop('verification', { verification: { state: 'unverified' } })
+      )
+    ).toBe('unverified');
+    expect(
+      flattenPropertyValue(prop('verification', { verification: null }))
+    ).toBeNull();
+  });
+
+  it('23. button -> null', () =>
+    expect(flattenPropertyValue(prop('button', { button: {} }))).toBeNull());
+
+  it('24. place -> name ?? address ?? "lat, lon"', () => {
+    expect(
+      flattenPropertyValue(
+        prop('place', {
+          place: { name: 'HQ', address: 'x', latitude: 1, longitude: 2 },
+        })
+      )
+    ).toBe('HQ');
+    expect(
+      flattenPropertyValue(
+        prop('place', {
+          place: { address: '10 Main St', latitude: 1, longitude: 2 },
+        })
+      )
+    ).toBe('10 Main St');
+    expect(
+      flattenPropertyValue(
+        prop('place', { place: { latitude: 1.5, longitude: 2.5 } })
+      )
+    ).toBe('1.5, 2.5');
+  });
+
+  it('forward-compat: unknown type -> null (never throws)', () => {
+    expect(
+      flattenPropertyValue(
+        prop('some_future_type_2027', { some_future_type_2027: { x: 1 } })
+      )
+    ).toBeNull();
+    expect(flattenPropertyValue(null)).toBeNull();
+    expect(flattenPropertyValue(undefined)).toBeNull();
+    expect(flattenPropertyValue({} as never)).toBeNull();
+  });
+});
+
+describe('flattenProperties', () => {
+  it('flattens a whole property bag, keeping column names (incl. spaces)', () => {
+    const props = {
+      Name: prop('title', { title: [rt('fIX ERROR ')] }),
+      Status: prop('select', { select: { name: 'To Do' } }),
+      'Due Date': prop('date', { date: { start: '2025-02-28' } }),
+    };
+    expect(flattenProperties(props)).toEqual({
+      Name: 'fIX ERROR',
+      Status: 'To Do',
+      'Due Date': '2025-02-28',
+    });
+  });
+  it('null/garbage -> {}', () => {
+    expect(flattenProperties(null)).toEqual({});
+    expect(flattenProperties(undefined)).toEqual({});
+  });
+});
+
+describe('getPageTitle', () => {
+  it('finds title by type, any column name (row: "Name")', () => {
+    const page = {
+      properties: {
+        Status: prop('select', { select: { name: 'x' } }),
+        Name: prop('title', { title: [rt('Take Fig on a walk')] }),
+      },
+    };
+    expect(getPageTitle(page)).toBe('Take Fig on a walk');
+  });
+  it('standalone page title column literally named "title"', () => {
+    const page = {
+      properties: { title: prop('title', { title: [rt('Saas Ideas')] }) },
+    };
+    expect(getPageTitle(page)).toBe('Saas Ideas');
+  });
+  it('title NOT first (6th of 6) still found', () => {
+    const page = {
+      properties: {
+        A: prop('rich_text', { rich_text: [rt('a')] }),
+        B: prop('select', { select: { name: 'b' } }),
+        C: prop('date', { date: { start: '2026-01-01' } }),
+        D: prop('people', { people: [] }),
+        E: prop('number', { number: 5 }),
+        Name: prop('title', { title: [rt('Weekly Sync')] }),
+      },
+    };
+    expect(getPageTitle(page)).toBe('Weekly Sync');
+  });
+  it('empty title array -> ""', () => {
+    const page = { properties: { Name: prop('title', { title: [] }) } };
+    expect(getPageTitle(page)).toBe('');
+  });
+  it('no title property / no properties -> ""', () => {
+    expect(
+      getPageTitle({ properties: { Foo: prop('select', { select: null }) } })
+    ).toBe('');
+    expect(getPageTitle({})).toBe('');
+    expect(getPageTitle(null)).toBe('');
+  });
+});
+
+describe('getDatabaseTitle', () => {
+  it('joins top-level title rich-text array', () =>
+    expect(getDatabaseTitle({ title: [rt('My '), rt('DB')] })).toBe('My DB'));
+  it('missing -> ""', () => expect(getDatabaseTitle({})).toBe(''));
+});
+
+describe('enrichPage', () => {
+  it('adds title + property_values, keeps raw properties intact', () => {
+    const page = {
+      object: 'page',
+      id: 'p1',
+      properties: {
+        Name: prop('title', { title: [rt('fIX ERROR ')] }),
+        Status: prop('select', { select: { name: 'To Do' } }),
+      },
+    };
+    const e = enrichPage(page);
+    expect(e.title).toBe('fIX ERROR');
+    expect(e.property_values).toEqual({ Name: 'fIX ERROR', Status: 'To Do' });
+    expect(e.properties).toBe(page.properties); // raw untouched
+    expect(e.id).toBe('p1');
+  });
+  it('empty title row -> title "" (Notion shows "Untitled")', () => {
+    const e = enrichPage({
+      properties: { Name: prop('title', { title: [] }) },
+    });
+    expect(e.title).toBe('');
+  });
+  it('standalone page (only a title column)', () => {
+    const e = enrichPage({
+      parent: { type: 'page_id' },
+      properties: { title: prop('title', { title: [rt('Saas Ideas')] }) },
+    });
+    expect(e.title).toBe('Saas Ideas');
+    expect(e.property_values).toEqual({ title: 'Saas Ideas' });
+  });
+  it('non-object input passes through', () => {
+    expect(enrichPage(null as never)).toBeNull();
+  });
+});

--- a/packages/pieces/community/notion/src/lib/common/enrich-page.ts
+++ b/packages/pieces/community/notion/src/lib/common/enrich-page.ts
@@ -1,0 +1,244 @@
+/**
+ * Friendly-view enrichment for Notion pages and database rows.
+ *
+ * Notion returns every page/row as a bag of richly-typed property objects
+ * (`properties.<UserNamedColumn>.<type>...`). That shape can't be reached by a
+ * static output-schema dot-path (the title column can be named anything and can
+ * sit at any position), so the data selector and the "Friendly View" bury the
+ * title and force 3-4 clicks per property value.
+ *
+ * `enrichPage` adds two computed top-level fields that a static schema CAN point
+ * at, making a Notion payload read like Airtable's flat `fields` map:
+ *   - `title`            plain text of the title property (any column name)
+ *   - `property_values`  { columnName: scalar } for every property, flattened by type
+ *
+ * The raw `properties` object is left untouched, so existing flows and anyone
+ * needing the rich objects keep working.
+ */
+
+type RichTextSegment = { plain_text?: string; text?: { content?: string } };
+type NotionProperty = { type?: string; [key: string]: unknown };
+type NotionUser = { id?: string; name?: string | null };
+
+/** Join every segment of a Notion rich-text array into one trimmed string. */
+export function richTextToPlain(rich: unknown): string {
+  if (!Array.isArray(rich)) {
+    return '';
+  }
+  return rich
+    .map((seg: RichTextSegment) => seg?.plain_text ?? seg?.text?.content ?? '')
+    .join('')
+    .trim();
+}
+
+/**
+ * The title of a page/row lives in the property whose `type` is `title`,
+ * regardless of the column's name or position. Joins all segments so
+ * multi-segment titles (mentions, formatting) aren't truncated.
+ * Empty title array -> "" (viewer renders empty; Notion shows "Untitled").
+ */
+export function getPageTitle(
+  page: { properties?: Record<string, NotionProperty> } | null | undefined
+): string {
+  const properties = page?.properties;
+  if (!properties || typeof properties !== 'object') {
+    return '';
+  }
+  for (const key of Object.keys(properties)) {
+    const prop = properties[key];
+    if (prop?.type === 'title') {
+      return richTextToPlain(prop['title']);
+    }
+  }
+  return '';
+}
+
+/**
+ * A database OBJECT (not a row) carries its name in a top-level `title`
+ * rich-text array. Joins all segments.
+ */
+export function getDatabaseTitle(
+  database: { title?: unknown } | null | undefined
+): string {
+  return richTextToPlain(database?.title);
+}
+
+/**
+ * Flatten a single Notion property value object to a scalar/short string by its
+ * `type`. Every type Notion serves today is handled; anything unknown (a type
+ * Notion adds next year, or a future API-version-only shape) maps to `null` and
+ * never throws, so a new type can't break a live flow.
+ */
+export function flattenPropertyValue(
+  prop: NotionProperty | null | undefined
+): unknown {
+  if (!prop || typeof prop !== 'object') {
+    return null;
+  }
+  const type = prop.type;
+  switch (type) {
+    case 'title':
+    case 'rich_text':
+      return richTextToPlain(prop[type]);
+    case 'select':
+    case 'status': {
+      const opt = prop[type] as { name?: string } | null;
+      return opt?.name ?? null;
+    }
+    case 'multi_select': {
+      const opts = (prop['multi_select'] as { name?: string }[]) ?? [];
+      return opts.map((o) => o?.name ?? '').join(', ');
+    }
+    case 'date': {
+      const d = prop['date'] as { start?: string; end?: string | null } | null;
+      if (!d) {
+        return null;
+      }
+      return d.end ? `${d.start} → ${d.end}` : d.start ?? null;
+    }
+    case 'people': {
+      const users = (prop['people'] as NotionUser[]) ?? [];
+      return users.map((u) => u?.name ?? u?.id ?? '').join(', ');
+    }
+    case 'created_by':
+    case 'last_edited_by': {
+      const u = prop[type] as NotionUser | null;
+      return u?.name ?? u?.id ?? null;
+    }
+    case 'created_time':
+    case 'last_edited_time':
+      return (prop[type] as string) ?? null;
+    case 'number':
+      return (prop['number'] as number) ?? null;
+    case 'checkbox':
+      return (prop['checkbox'] as boolean) ?? null;
+    case 'url':
+    case 'email':
+    case 'phone_number':
+      return (prop[type] as string) ?? null;
+    case 'files': {
+      // Never surface the URL: internal Notion file URLs expire in ~1h.
+      const files = (prop['files'] as { name?: string }[]) ?? [];
+      return files.map((f) => f?.name ?? '').join(', ');
+    }
+    case 'formula': {
+      const f = prop['formula'] as {
+        type?: string;
+        [k: string]: unknown;
+      } | null;
+      if (!f) {
+        return null;
+      }
+      switch (f.type) {
+        case 'string':
+          return (f['string'] as string) ?? null;
+        case 'number':
+          return (f['number'] as number) ?? null;
+        case 'boolean':
+          return (f['boolean'] as boolean) ?? null;
+        case 'date':
+          return (f['date'] as { start?: string } | null)?.start ?? null;
+        default:
+          return null;
+      }
+    }
+    case 'rollup': {
+      const r = prop['rollup'] as {
+        type?: string;
+        [k: string]: unknown;
+      } | null;
+      if (!r) {
+        return null;
+      }
+      switch (r.type) {
+        case 'number':
+          return (r['number'] as number) ?? null;
+        case 'date':
+          return (r['date'] as { start?: string } | null)?.start ?? null;
+        case 'array':
+          return ((r['array'] as NotionProperty[]) ?? [])
+            .map((el) => flattenPropertyValue(el))
+            .filter((v) => v !== null && v !== '')
+            .join(', ');
+        default:
+          // 'incomplete' | 'unsupported'
+          return null;
+      }
+    }
+    case 'relation':
+      // ids are meaningless to a human; the raw object keeps them.
+      return ((prop['relation'] as unknown[]) ?? []).length;
+    case 'unique_id': {
+      const u = prop['unique_id'] as {
+        prefix?: string | null;
+        number?: number | null;
+      } | null;
+      if (!u || u.number === null || u.number === undefined) {
+        return null;
+      }
+      return u.prefix ? `${u.prefix}-${u.number}` : String(u.number);
+    }
+    case 'verification': {
+      const v = prop['verification'] as { state?: string } | null;
+      return v?.state ?? null;
+    }
+    case 'button':
+      return null;
+    case 'place': {
+      const pl = prop['place'] as {
+        name?: string;
+        address?: string;
+        latitude?: number;
+        longitude?: number;
+        lat?: number;
+        lon?: number;
+      } | null;
+      if (!pl) {
+        return null;
+      }
+      const lat = pl.latitude ?? pl.lat;
+      const lon = pl.longitude ?? pl.lon;
+      return (
+        pl.name ??
+        pl.address ??
+        (lat != null && lon != null ? `${lat}, ${lon}` : null)
+      );
+    }
+    default:
+      return null;
+  }
+}
+
+/** Flatten every property of a page/row to `{ columnName: scalar }`. */
+export function flattenProperties(
+  properties: Record<string, NotionProperty> | null | undefined
+): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  if (!properties || typeof properties !== 'object') {
+    return out;
+  }
+  for (const key of Object.keys(properties)) {
+    out[key] = flattenPropertyValue(properties[key]);
+  }
+  return out;
+}
+
+/**
+ * Add `title` + `property_values` to a raw Notion page/row. Returns the page
+ * unchanged if it isn't an object. Non-destructive: raw `properties` is kept.
+ */
+export function enrichPage<
+  T extends { properties?: Record<string, NotionProperty> }
+>(page: T): T & { title: string; property_values: Record<string, unknown> } {
+  if (!page || typeof page !== 'object') {
+    return page as T & {
+      title: string;
+      property_values: Record<string, unknown>;
+    };
+  }
+  return {
+    ...page,
+    title: getPageTitle(page),
+    property_values: flattenProperties(page.properties),
+  };
+}

--- a/packages/pieces/community/notion/src/lib/output-schemas.ts
+++ b/packages/pieces/community/notion/src/lib/output-schemas.ts
@@ -1,112 +1,78 @@
 import { OutputSchema } from '@activepieces/pieces-framework';
 
+/**
+ * Shared output schema for an ENRICHED Notion page/row (see common/enrich-page.ts).
+ * Content-first: the human-readable Title and flattened Properties come first,
+ * metadata below, and the raw `properties` object stays last as "Raw Properties".
+ *
+ * `property_values` and `title` are the two computed fields added by enrichPage;
+ * `property_values` is a `dynamicKey` map so the viewer renders one flat
+ * name -> value row per property (like Airtable's `fields`), instead of forcing
+ * a 3-4 click drill into each rich property object.
+ *
+ * Used by the three page/row triggers (new_database_item, updated_database_item,
+ * updated_page). The raw-page shape used by the AI-action variants lives in
+ * `notionRawPageFields` below (migrated to enrichment in Stage 2).
+ */
+export const notionPageFields: OutputSchema['fields'] = [
+  { key: 'title', label: 'Title', value: 'title' },
+  {
+    key: 'property_values',
+    label: 'Properties',
+    value: 'property_values',
+    dynamicKey: true,
+  },
+  { key: 'url', label: 'Page URL', value: 'url', format: 'url' },
+  {
+    key: 'last_edited_time',
+    label: 'Last Edited Time',
+    value: 'last_edited_time',
+    format: 'datetime',
+  },
+  {
+    key: 'created_time',
+    label: 'Created Time',
+    value: 'created_time',
+    format: 'datetime',
+  },
+  { key: 'id', label: 'Page ID', value: 'id' },
+  { key: 'object', label: 'Object Type', value: 'object' },
+  {
+    key: 'is_archived',
+    label: 'Archived',
+    value: 'is_archived',
+    format: 'boolean',
+  },
+  { key: 'is_locked', label: 'Locked', value: 'is_locked', format: 'boolean' },
+  { key: 'in_trash', label: 'In Trash', value: 'in_trash', format: 'boolean' },
+  {
+    key: 'parent',
+    label: 'Parent',
+    value: 'parent',
+    children: [{ key: 'type', label: 'Parent Type', value: 'type' }],
+  },
+  {
+    key: 'created_by',
+    label: 'Created By',
+    value: 'created_by',
+    children: [{ key: 'id', label: 'User ID', value: 'id' }],
+  },
+  {
+    key: 'last_edited_by',
+    label: 'Last Edited By',
+    value: 'last_edited_by',
+    children: [{ key: 'id', label: 'User ID', value: 'id' }],
+  },
+  {
+    key: 'properties',
+    label: 'Raw Properties',
+    value: 'properties',
+    dynamicKey: true,
+  },
+];
+
 export const updatedPageTriggerOutputSchema: OutputSchema = {
-  fields: [
-    {
-      key: 'id',
-      label: 'Page ID',
-      value: 'id',
-    },
-    {
-      key: 'url',
-      label: 'Page URL',
-      value: 'url',
-      format: 'url',
-    },
-    {
-      key: 'last_edited_time',
-      label: 'Last Edited Time',
-      value: 'last_edited_time',
-      format: 'datetime',
-    },
-    {
-      key: 'created_time',
-      label: 'Created Time',
-      value: 'created_time',
-      format: 'datetime',
-    },
-    {
-      key: 'is_archived',
-      label: 'Archived',
-      value: 'is_archived',
-      format: 'boolean',
-    },
-    {
-      key: 'is_locked',
-      label: 'Locked',
-      value: 'is_locked',
-      format: 'boolean',
-    },
-    {
-      key: 'parent',
-      label: 'Parent',
-      value: 'parent',
-      children: [
-        {
-          key: 'type',
-          label: 'Parent Type',
-          value: 'type',
-        },
-        {
-          key: 'database_id',
-          label: 'Database ID',
-          value: 'database_id',
-        },
-      ],
-    },
-    {
-      key: 'last_edited_by',
-      label: 'Last Edited By',
-      value: 'last_edited_by',
-      children: [
-        {
-          key: 'id',
-          label: 'User ID',
-          value: 'id',
-        },
-      ],
-    },
-    {
-      key: 'created_by',
-      label: 'Created By',
-      value: 'created_by',
-      children: [
-        {
-          key: 'id',
-          label: 'User ID',
-          value: 'id',
-        },
-      ],
-    },
-    {
-      key: 'properties',
-      label: 'Properties',
-      value: 'properties',
-      children: [
-        {
-          key: 'Task name',
-          label: 'Task Name',
-          value: 'Task name.title[0].plain_text',
-        },
-        {
-          key: 'Status',
-          label: 'Status',
-          value: 'Status.status.name',
-        },
-        {
-          key: 'Due date',
-          label: 'Due Date',
-          value: 'Due date.date.start',
-          format: 'date',
-        },
-        {
-          key: 'Assignee',
-          label: 'Assignee User ID',
-          value: 'Assignee.people[0].id',
-        },
-      ],
-    },
-  ],
+  fields: notionPageFields,
 };
 
 export const newCommentTriggerOutputSchema: OutputSchema = {
@@ -177,202 +143,11 @@ export const newCommentTriggerOutputSchema: OutputSchema = {
 };
 
 export const newDatabaseItemTriggerOutputSchema: OutputSchema = {
-  fields: [
-    {
-      key: 'taskName',
-      label: 'Task Name',
-      value: 'properties.Task name.title[0].plain_text',
-    },
-    {
-      key: 'status',
-      label: 'Status',
-      value: 'properties.Status.status.name',
-    },
-    {
-      key: 'dueDate',
-      label: 'Due Date',
-      value: 'properties.Due date.date.start',
-      format: 'date',
-    },
-    {
-      key: 'url',
-      label: 'Page URL',
-      value: 'url',
-      format: 'url',
-    },
-    {
-      key: 'id',
-      label: 'Page ID',
-      value: 'id',
-    },
-    {
-      key: 'createdTime',
-      label: 'Created Time',
-      value: 'created_time',
-      format: 'datetime',
-    },
-    {
-      key: 'lastEditedTime',
-      label: 'Last Edited Time',
-      value: 'last_edited_time',
-      format: 'datetime',
-    },
-    {
-      key: 'createdBy',
-      label: 'Created By User ID',
-      value: 'created_by.id',
-    },
-    {
-      key: 'lastEditedBy',
-      label: 'Last Edited By User ID',
-      value: 'last_edited_by.id',
-    },
-    {
-      key: 'isArchived',
-      label: 'Archived',
-      value: 'is_archived',
-      format: 'boolean',
-    },
-    {
-      key: 'isLocked',
-      label: 'Locked',
-      value: 'is_locked',
-      format: 'boolean',
-    },
-    {
-      key: 'parent',
-      label: 'Parent',
-      children: [
-        {
-          key: 'type',
-          label: 'Type',
-          value: 'type',
-        },
-        {
-          key: 'database_id',
-          label: 'Database ID',
-          value: 'database_id',
-        },
-      ],
-    },
-    {
-      key: 'assignees',
-      label: 'Assignees',
-      value: 'properties.Assignee.people',
-      listItems: [
-        {
-          key: 'id',
-          label: 'User ID',
-          value: 'id',
-        },
-      ],
-    },
-  ],
+  fields: notionPageFields,
 };
 
 export const updatedDatabaseItemTriggerOutputSchema: OutputSchema = {
-  fields: [
-    {
-      key: 'id',
-      label: 'Page ID',
-      value: 'id',
-    },
-    {
-      key: 'url',
-      label: 'Page URL',
-      value: 'url',
-      format: 'url',
-    },
-    {
-      key: 'last_edited_time',
-      label: 'Last Edited Time',
-      value: 'last_edited_time',
-      format: 'datetime',
-    },
-    {
-      key: 'created_time',
-      label: 'Created Time',
-      value: 'created_time',
-      format: 'datetime',
-    },
-    {
-      key: 'object',
-      label: 'Object Type',
-      value: 'object',
-    },
-    {
-      key: 'is_archived',
-      label: 'Archived',
-      value: 'is_archived',
-      format: 'boolean',
-    },
-    {
-      key: 'is_locked',
-      label: 'Locked',
-      value: 'is_locked',
-      format: 'boolean',
-    },
-    {
-      key: 'in_trash',
-      label: 'In Trash',
-      value: 'in_trash',
-      format: 'boolean',
-    },
-    {
-      key: 'parent',
-      label: 'Parent',
-      value: 'parent',
-      children: [
-        {
-          key: 'type',
-          label: 'Type',
-          value: 'type',
-        },
-        {
-          key: 'database_id',
-          label: 'Database ID',
-          value: 'database_id',
-        },
-      ],
-    },
-    {
-      key: 'created_by',
-      label: 'Created By',
-      value: 'created_by',
-      children: [
-        {
-          key: 'id',
-          label: 'User ID',
-          value: 'id',
-        },
-      ],
-    },
-    {
-      key: 'last_edited_by',
-      label: 'Last Edited By',
-      value: 'last_edited_by',
-      children: [
-        {
-          key: 'id',
-          label: 'User ID',
-          value: 'id',
-        },
-      ],
-    },
-    {
-      key: 'properties',
-      label: 'Properties',
-      value: 'properties',
-      dynamicKey: true,
-      children: [
-        {
-          key: 'type',
-          label: 'Property Type',
-          value: 'type',
-        },
-      ],
-    },
-  ],
+  fields: notionPageFields,
 };
 
 export const createDatabaseItemActionOutputSchema: OutputSchema = {
@@ -424,53 +199,9 @@ export const createDatabaseItemActionOutputSchema: OutputSchema = {
     },
     {
       key: 'properties',
-      label: 'Properties',
+      label: 'Raw Properties',
       value: 'properties',
-      children: [
-        {
-          key: 'Task name',
-          label: 'Task Name',
-          value: 'Task name',
-          children: [
-            {
-              key: 'plain_text',
-              label: 'Title Text',
-              value: 'title[0].plain_text',
-            },
-          ],
-        },
-        {
-          key: 'Status',
-          label: 'Status',
-          value: 'Status',
-          children: [
-            {
-              key: 'name',
-              label: 'Status Name',
-              value: 'status.name',
-            },
-          ],
-        },
-        {
-          key: 'Assignee',
-          label: 'Assignee',
-          value: 'Assignee',
-          children: [
-            {
-              key: 'people',
-              label: 'People',
-              value: 'people',
-              listItems: [
-                {
-                  key: 'id',
-                  label: 'User ID',
-                  value: 'id',
-                },
-              ],
-            },
-          ],
-        },
-      ],
+      dynamicKey: true,
     },
     {
       key: 'created_by',
@@ -532,32 +263,9 @@ export const updateDatabaseItemActionOutputSchema: OutputSchema = {
     },
     {
       key: 'properties',
-      label: 'Properties',
+      label: 'Raw Properties',
       value: 'properties',
-      children: [
-        {
-          key: 'Task name',
-          label: 'Task Name',
-          value: 'Task name.title[0].plain_text',
-        },
-        {
-          key: 'Status',
-          label: 'Status',
-          value: 'Status.status.name',
-        },
-        {
-          key: 'Assignee',
-          label: 'Assignee User IDs',
-          value: 'Assignee.people',
-          listItems: [
-            {
-              key: 'id',
-              label: 'User ID',
-              value: 'id',
-            },
-          ],
-        },
-      ],
+      dynamicKey: true,
     },
     {
       key: 'parent',
@@ -603,16 +311,6 @@ export const notionFindDatabaseItemActionOutputSchema: OutputSchema = {
       value: 'results',
       listItems: [
         {
-          key: 'taskName',
-          label: 'Task Name',
-          value: 'properties.Task name.title[0].plain_text',
-        },
-        {
-          key: 'status',
-          label: 'Status',
-          value: 'properties.Status.status.name',
-        },
-        {
           key: 'id',
           label: 'Page ID',
           value: 'id',
@@ -640,29 +338,12 @@ export const notionFindDatabaseItemActionOutputSchema: OutputSchema = {
           label: 'Database ID',
           value: 'parent.database_id',
         },
-        {
-          key: 'assignee',
-          label: 'Assignee IDs',
-          value: 'properties.Assignee.people',
-          listItems: [
-            {
-              key: 'userId',
-              label: 'User ID',
-              value: 'id',
-            },
-          ],
-        },
-        {
-          key: 'dueDate',
-          label: 'Due Date',
-          value: 'properties.Due date.date',
-        },
       ],
     },
   ],
 };
 
-const notionPageFields: OutputSchema['fields'] = [
+const notionRawPageFields: OutputSchema['fields'] = [
   {
     key: 'url',
     label: 'Page URL',
@@ -753,7 +434,7 @@ const notionPageFields: OutputSchema['fields'] = [
 ];
 
 export const createPageActionOutputSchema: OutputSchema = {
-  fields: notionPageFields,
+  fields: notionRawPageFields,
 };
 
 export const appendToPageActionOutputSchema: OutputSchema = {
@@ -1507,7 +1188,7 @@ export const notionSearchActionOutputSchema: OutputSchema = {
 };
 
 export const notionGetPageActionOutputSchema: OutputSchema = {
-  fields: notionPageFields,
+  fields: notionRawPageFields,
 };
 
 export const notionGetDatabaseActionOutputSchema: OutputSchema = {
@@ -1621,7 +1302,7 @@ export const notionQueryDatabaseActionOutputSchema: OutputSchema = {
       key: 'results',
       label: 'Results',
       value: 'results',
-      listItems: notionPageFields,
+      listItems: notionRawPageFields,
     },
     { key: 'count', label: 'Count', value: 'count', format: 'number' },
     {
@@ -1635,7 +1316,7 @@ export const notionQueryDatabaseActionOutputSchema: OutputSchema = {
 };
 
 export const notionCreatePageActionOutputSchema: OutputSchema = {
-  fields: notionPageFields,
+  fields: notionRawPageFields,
 };
 
 export const notionAppendToPageActionOutputSchema: OutputSchema = {
@@ -1663,14 +1344,24 @@ export const notionUpdateBlockActionOutputSchema: OutputSchema = {
 export const notionCreateDatabaseItemActionOutputSchema: OutputSchema = {
   fields: [
     { key: 'success', label: 'Success', value: 'success', format: 'boolean' },
-    { key: 'item', label: 'Item', value: 'item', children: notionPageFields },
+    {
+      key: 'item',
+      label: 'Item',
+      value: 'item',
+      children: notionRawPageFields,
+    },
   ],
 };
 
 export const notionUpdateDatabaseItemActionOutputSchema: OutputSchema = {
   fields: [
     { key: 'success', label: 'Success', value: 'success', format: 'boolean' },
-    { key: 'item', label: 'Item', value: 'item', children: notionPageFields },
+    {
+      key: 'item',
+      label: 'Item',
+      value: 'item',
+      children: notionRawPageFields,
+    },
   ],
 };
 
@@ -1681,14 +1372,14 @@ export const notionFindDatabaseItemsActionOutputSchema: OutputSchema = {
       key: 'results',
       label: 'Results',
       value: 'results',
-      listItems: notionPageFields,
+      listItems: notionRawPageFields,
     },
     { key: 'count', label: 'Count', value: 'count', format: 'number' },
     {
       key: 'firstMatch',
       label: 'First Match',
       value: 'firstMatch',
-      children: notionPageFields,
+      children: notionRawPageFields,
     },
     {
       key: 'has_more',
@@ -1751,11 +1442,11 @@ export const notionRestoreDatabaseItemActionOutputSchema: OutputSchema = {
 };
 
 export const notionArchivePageActionOutputSchema: OutputSchema = {
-  fields: notionPageFields,
+  fields: notionRawPageFields,
 };
 
 export const notionMovePageActionOutputSchema: OutputSchema = {
-  fields: notionPageFields,
+  fields: notionRawPageFields,
 };
 
 export const notionDeleteBlockActionOutputSchema: OutputSchema = {

--- a/packages/pieces/community/notion/src/lib/triggers/new-database-item.ts
+++ b/packages/pieces/community/notion/src/lib/triggers/new-database-item.ts
@@ -14,6 +14,7 @@ import { Client } from '@notionhq/client';
 import { notionAuth } from '../auth';
 import { isNil } from '@activepieces/pieces-framework';
 import { newDatabaseItemTriggerOutputSchema } from '../output-schemas';
+import { enrichPage } from '../common/enrich-page';
 
 export const newDatabaseItem = createTrigger({
   auth: notionAuth,
@@ -30,69 +31,91 @@ export const newDatabaseItem = createTrigger({
   },
   outputSchema: newDatabaseItemTriggerOutputSchema,
   sampleData: {
-    id: 'd23872cd-c106-4afa-b33d-d3fd66064ccb',
-    url: 'https://www.notion.so/Take-Fig-on-a-walk-d23872cdc1064afab33dd3fd66064ccb',
-    icon: {
-      type: 'emoji',
-      emoji: '🐶',
+    object: 'page',
+    id: '1a9fa248-94e2-80a7-aba9-d7200621a1ef',
+    title: 'fIX ERROR',
+    property_values: {
+      Status: 'To Do',
+      Priority: 'Medium',
+      DueDate: '2025-02-28',
+      Name: 'fIX ERROR',
+    },
+    url: 'https://app.notion.com/p/fIX-ERROR-1a9fa24894e280a7aba9d7200621a1ef',
+    public_url: null,
+    created_time: '2025-03-01T13:33:00.000Z',
+    last_edited_time: '2025-03-01T13:33:00.000Z',
+    created_by: {
+      object: 'user',
+      id: 'eb85488e-97f8-46d2-85fa-49b87bc1037d',
+    },
+    last_edited_by: {
+      object: 'user',
+      id: 'eb85488e-97f8-46d2-85fa-49b87bc1037d',
     },
     cover: null,
-    object: 'page',
+    icon: null,
     parent: {
       type: 'database_id',
-      database_id: 'fe1eb968-50b6-4d96-83ca-4d19b96f488e',
+      database_id: '1a9fa248-94e2-81bc-837e-d26e876ba6c0',
     },
+    in_trash: false,
+    is_archived: false,
+    is_locked: false,
     archived: false,
-    created_by: {
-      id: 'f3806fae-a281-4f4e-8563-c816c3e8bd40',
-      object: 'user',
-    },
     properties: {
+      Status: {
+        id: 'H%40%5Bv',
+        type: 'select',
+        select: {
+          id: 'ff441c13-5498-4922-b7b1-0530e7381857',
+          name: 'To Do',
+          color: 'red',
+        },
+      },
+      Priority: {
+        id: 'H%7C%7D%3F',
+        type: 'select',
+        select: {
+          id: 'fd99439b-915e-4cf4-9e1d-39108768e3da',
+          name: 'Medium',
+          color: 'yellow',
+        },
+      },
+      DueDate: {
+        id: 'XsW%7C',
+        type: 'date',
+        date: {
+          start: '2025-02-28',
+          end: null,
+          time_zone: null,
+        },
+      },
       Name: {
         id: 'title',
         type: 'title',
         title: [
           {
-            href: null,
-            text: {
-              link: null,
-              content: 'Take Fig on a walk',
-            },
             type: 'text',
-            plain_text: 'Take Fig on a walk',
+            text: {
+              content: 'fIX ERROR ',
+              link: null,
+            },
             annotations: {
               bold: false,
+              italic: false,
+              strikethrough: false,
+              underline: false,
               code: false,
               color: 'default',
-              italic: false,
-              underline: false,
-              strikethrough: false,
             },
+            plain_text: 'fIX ERROR ',
+            href: null,
           },
         ],
       },
-      Status: {
-        id: '%5EOE%40',
-        type: 'select',
-        select: {
-          id: '2',
-          name: 'Doing',
-          color: 'yellow',
-        },
-      },
-      'Date Created': {
-        id: "'Y6%3C",
-        type: 'created_time',
-        created_time: '2023-03-02T01:43:00.000Z',
-      },
     },
-    created_time: '2023-03-02T01:43:00.000Z',
-    last_edited_by: {
-      id: 'f3806fae-a281-4f4e-8563-c816c3e8bd40',
-      object: 'user',
-    },
-    last_edited_time: '2023-03-02T01:43:00.000Z',
   },
+
   type: TriggerStrategy.POLLING,
   async test(ctx) {
     return await pollingHelper.test(polling, {
@@ -151,7 +174,7 @@ const polling: Polling<
       const object = item as { created_time: string; id: string };
       return {
         id: object.id + '|' + dayjs(object.created_time).valueOf(),
-        data: item,
+        data: enrichPage(item),
       };
     });
   },

--- a/packages/pieces/community/notion/src/lib/triggers/updated-database-item.ts
+++ b/packages/pieces/community/notion/src/lib/triggers/updated-database-item.ts
@@ -14,6 +14,7 @@ import { Client } from '@notionhq/client';
 import { notionAuth } from '../auth';
 import { isNil } from '@activepieces/pieces-framework';
 import { updatedDatabaseItemTriggerOutputSchema } from '../output-schemas';
+import { enrichPage } from '../common/enrich-page';
 
 export const updatedDatabaseItem = createTrigger({
   auth: notionAuth,
@@ -30,69 +31,91 @@ export const updatedDatabaseItem = createTrigger({
   },
   outputSchema: updatedDatabaseItemTriggerOutputSchema,
   sampleData: {
-    id: 'd23872cd-c106-4afa-b33d-d3fd66064ccb',
-    url: 'https://www.notion.so/Take-Fig-on-a-walk-d23872cdc1064afab33dd3fd66064ccb',
-    icon: {
-      type: 'emoji',
-      emoji: '🐶',
+    object: 'page',
+    id: '1a9fa248-94e2-80a7-aba9-d7200621a1ef',
+    title: 'fIX ERROR',
+    property_values: {
+      Status: 'To Do',
+      Priority: 'Medium',
+      DueDate: '2025-02-28',
+      Name: 'fIX ERROR',
+    },
+    url: 'https://app.notion.com/p/fIX-ERROR-1a9fa24894e280a7aba9d7200621a1ef',
+    public_url: null,
+    created_time: '2025-03-01T13:33:00.000Z',
+    last_edited_time: '2025-03-01T13:33:00.000Z',
+    created_by: {
+      object: 'user',
+      id: 'eb85488e-97f8-46d2-85fa-49b87bc1037d',
+    },
+    last_edited_by: {
+      object: 'user',
+      id: 'eb85488e-97f8-46d2-85fa-49b87bc1037d',
     },
     cover: null,
-    object: 'page',
+    icon: null,
     parent: {
       type: 'database_id',
-      database_id: 'fe1eb968-50b6-4d96-83ca-4d19b96f488e',
+      database_id: '1a9fa248-94e2-81bc-837e-d26e876ba6c0',
     },
+    in_trash: false,
+    is_archived: false,
+    is_locked: false,
     archived: false,
-    created_by: {
-      id: 'f3806fae-a281-4f4e-8563-c816c3e8bd40',
-      object: 'user',
-    },
     properties: {
+      Status: {
+        id: 'H%40%5Bv',
+        type: 'select',
+        select: {
+          id: 'ff441c13-5498-4922-b7b1-0530e7381857',
+          name: 'To Do',
+          color: 'red',
+        },
+      },
+      Priority: {
+        id: 'H%7C%7D%3F',
+        type: 'select',
+        select: {
+          id: 'fd99439b-915e-4cf4-9e1d-39108768e3da',
+          name: 'Medium',
+          color: 'yellow',
+        },
+      },
+      DueDate: {
+        id: 'XsW%7C',
+        type: 'date',
+        date: {
+          start: '2025-02-28',
+          end: null,
+          time_zone: null,
+        },
+      },
       Name: {
         id: 'title',
         type: 'title',
         title: [
           {
-            href: null,
-            text: {
-              link: null,
-              content: 'Take Fig on a walk',
-            },
             type: 'text',
-            plain_text: 'Take Fig on a walk',
+            text: {
+              content: 'fIX ERROR ',
+              link: null,
+            },
             annotations: {
               bold: false,
+              italic: false,
+              strikethrough: false,
+              underline: false,
               code: false,
               color: 'default',
-              italic: false,
-              underline: false,
-              strikethrough: false,
             },
+            plain_text: 'fIX ERROR ',
+            href: null,
           },
         ],
       },
-      Status: {
-        id: '%5EOE%40',
-        type: 'select',
-        select: {
-          id: '2',
-          name: 'Doing',
-          color: 'yellow',
-        },
-      },
-      'Date Created': {
-        id: "'Y6%3C",
-        type: 'created_time',
-        created_time: '2023-03-02T01:43:00.000Z',
-      },
     },
-    created_time: '2023-03-02T01:43:00.000Z',
-    last_edited_by: {
-      id: 'f3806fae-a281-4f4e-8563-c816c3e8bd40',
-      object: 'user',
-    },
-    last_edited_time: '2023-03-02T01:43:00.000Z',
   },
+
   type: TriggerStrategy.POLLING,
   async test(ctx) {
     return await pollingHelper.test(polling, {
@@ -152,7 +175,7 @@ const polling: Polling<
       const object = item as { last_edited_time: string; id: string };
       return {
         id: object.id + '|' + dayjs(object.last_edited_time).valueOf(),
-        data: item,
+        data: enrichPage(item),
       };
     });
   },

--- a/packages/pieces/community/notion/src/lib/triggers/updated-page.ts
+++ b/packages/pieces/community/notion/src/lib/triggers/updated-page.ts
@@ -12,6 +12,7 @@ import dayjs from 'dayjs';
 import { getPages, NotionAuthValue } from '../common';
 import { notionAuth } from '../auth';
 import { updatedPageTriggerOutputSchema } from '../output-schemas';
+import { enrichPage } from '../common/enrich-page';
 
 export const updatedPage = createTrigger({
   auth: notionAuth,
@@ -28,37 +29,97 @@ export const updatedPage = createTrigger({
   outputSchema: updatedPageTriggerOutputSchema,
   sampleData: {
     object: 'page',
-    id: '1d4805e9-774b-8056-820b-c1083bff77e3',
-    created_time: '2025-04-13T23:35:00.000Z',
-    last_edited_time: '2025-07-01T07:29:00.000Z',
+    id: '1a8fa248-94e2-8120-8ccc-e464193fe999',
+    title: 'Notes: Meeting Feb 25, 2025 at 09:28 GMT+03:00',
+    property_values: {
+      'Last Edited Time': '2026-06-26T15:56:00.000Z',
+      'Created By': 'Activepieces',
+      Created: '2025-02-28T13:25:00.000Z',
+      Type: 'Ad Hoc',
+      Participants: 'root sudo',
+      Name: 'Notes: Meeting Feb 25, 2025 at 09:28 GMT+03:00',
+    },
+    url: 'https://app.notion.com/p/Notes-Meeting-Feb-25-2025-at-09-28-GMT-03-00-1a8fa24894e281208ccce464193fe999',
+    public_url: null,
+    created_time: '2025-02-28T13:25:00.000Z',
+    last_edited_time: '2026-06-26T15:56:00.000Z',
     created_by: {
       object: 'user',
-      id: '0f46d5cf-06ee-4350-8051-79ad10c898a6',
+      id: '1a8fa248-94e2-81d5-9ba3-00274355c726',
     },
     last_edited_by: {
       object: 'user',
-      id: '0f46d5cf-06ee-4350-8051-79ad10c898a6',
+      id: '1a8fa248-94e2-81d5-9ba3-00274355c726',
     },
     cover: null,
-    icon: {
-      type: 'emoji',
-      emoji: '💰',
-    },
+    icon: null,
     parent: {
-      type: 'workspace',
-      workspace: true,
+      type: 'database_id',
+      database_id: '1a8fa248-94e2-80fa-8798-f9c67ea7ba28',
     },
-    archived: false,
     in_trash: false,
+    is_archived: false,
+    is_locked: false,
+    archived: false,
     properties: {
-      title: {
+      'Last Edited Time': {
+        id: '0AiB',
+        type: 'last_edited_time',
+        last_edited_time: '2026-06-26T15:56:00.000Z',
+      },
+      'Created By': {
+        id: 'F%5D)%3F',
+        type: 'created_by',
+        created_by: {
+          object: 'user',
+          id: '1a8fa248-94e2-81d5-9ba3-00274355c726',
+          name: 'Activepieces',
+          avatar_url:
+            'https://s3-us-west-2.amazonaws.com/public.notion-static.com/5d61a7cb-299e-46d7-9d21-c8d77b1aab18/256x256logo.svg',
+          type: 'bot',
+          bot: {},
+        },
+      },
+      Created: {
+        id: 'Ird4',
+        type: 'created_time',
+        created_time: '2025-02-28T13:25:00.000Z',
+      },
+      Type: {
+        id: '_%7B%5C7',
+        type: 'select',
+        select: {
+          id: '1747fcca-8207-42c8-802f-fd43965c016a',
+          name: 'Ad Hoc',
+          color: 'orange',
+        },
+      },
+      Participants: {
+        id: 'b%3AeA',
+        type: 'people',
+        people: [
+          {
+            object: 'user',
+            id: 'eb85488e-97f8-46d2-85fa-49b87bc1037d',
+            name: 'root sudo',
+            avatar_url:
+              'https://lh3.googleusercontent.com/a/AGNmyxbz-0u47oQeDeTL54d4olDg8tuLpDmMsbJuknV4=s100',
+            type: 'person',
+            person: {
+              email: 'rootsudo2000@gmail.com',
+              email_verified: true,
+            },
+          },
+        ],
+      },
+      Name: {
         id: 'title',
         type: 'title',
         title: [
           {
             type: 'text',
             text: {
-              content: 'Saas Ideas',
+              content: 'Notes: Meeting Feb 25, 2025 at 09:28 GMT+03:00',
               link: null,
             },
             annotations: {
@@ -69,15 +130,14 @@ export const updatedPage = createTrigger({
               code: false,
               color: 'default',
             },
-            plain_text: 'Saas Ideas',
+            plain_text: 'Notes: Meeting Feb 25, 2025 at 09:28 GMT+03:00',
             href: null,
           },
         ],
       },
     },
-    url: 'https://www.notion.so/Saas-Ideas-1d4805e9774b8056820bc1083bff77e3',
-    public_url: null,
   },
+
   type: TriggerStrategy.POLLING,
   async test(ctx) {
     return await pollingHelper.test(polling, {
@@ -130,7 +190,7 @@ const polling: Polling<
       const page = item as { last_edited_time: string; id: string };
       return {
         id: page.id + '|' + dayjs(page.last_edited_time).valueOf(),
-        data: item,
+        data: enrichPage(item),
       };
     });
   },

--- a/packages/pieces/community/notion/vitest.config.ts
+++ b/packages/pieces/community/notion/vitest.config.ts
@@ -1,0 +1,18 @@
+import path from 'path'
+import { defineConfig } from 'vitest/config'
+
+const repoRoot = path.resolve(__dirname, '../../../..')
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+  },
+  resolve: {
+    alias: {
+      '@activepieces/shared': path.resolve(repoRoot, 'packages/core/shared/src/index.ts'),
+      '@activepieces/pieces-framework': path.resolve(repoRoot, 'packages/pieces/framework/src/index.ts'),
+      '@activepieces/pieces-common': path.resolve(repoRoot, 'packages/pieces/common/src/index.ts'),
+    },
+  },
+})


### PR DESCRIPTION
## Problem

The **Updated Database Item**, **New Database Item**, and **Updated Page** triggers produce output that is hard to read in the Friendly View / data selector:

- **No title.** A Notion row's title lives at `properties.<AnyColumnName>.title[0].plain_text`, where the column can be named anything and sit at any position. `OutputSchemaField.value` is a static dot-path with no "the property whose type is `title`" selector, so no static path can reach it. The schema therefore had no title field at all.
- **Every value is 3–4 clicks deep.** `Properties` was the last of 12 fields, and each Notion property is a richly-typed object, so reading one value took `Properties ▸ Name ▸ title ▸ Item 1 ▸ plain_text`.
- **Hardcoded template columns.** Two triggers hardcoded one template database's column names (`Task name`, `Status.status.name`, `Due date.date.start`, `Assignee.people[0].id`), which resolve **empty** on every other database.

## Fix (piece-level, additive)

New `common/enrich-page.ts`. `enrichPage()` adds two computed top-level fields to each emitted page/row, so a static schema can point at them and the payload reads like Airtable's flat `fields` map:

- **`title`** — plain text of the title property, found by `type === 'title'` (any column name/position), all segments joined.
- **`property_values`** — `{ columnName: scalar }` for every property, flattened by type. All 24 Notion property types are handled; an unknown type maps to `null` and never throws, so a future Notion type can't break a live flow.

Applied in the three triggers. All three are now backed by one shared, content-first `notionPageFields` schema (Title, Properties, then metadata, **Raw Properties last**). The raw `properties` object is kept in the payload and schema, so existing flows keep working.

Also in this PR:
- Deleted the hardcoded `Task name`/`Status`/`Due date`/`Assignee` template paths from the three triggers and from the `create_database_item` / `update_database_item` / `notion-find-database-item` action schemas (replaced with a generic raw-properties passthrough).
- Refreshed the three triggers' stale `sampleData` from real payloads (now includes `is_archived`/`is_locked`/`in_trash` plus the two new fields).
- Added a 49-case Vitest covering all 24 property types and real-data edge cases (empty title, empty rich_text, mixed partial/full people, bot user, title-not-first, spaces in column names, forward-compat unknown type).

## Defaults chosen — please confirm in review

- **Empty title → `""`** (viewer shows empty; Notion itself displays "Untitled").
- **`relation` → count** (raw ids stay in `properties`).
- **`files` → names only** (internal Notion file URLs expire in ~1h).
- **`people` / `created_by` / `last_edited_by` → `name ?? id`** (partial id-only users fall back to id).
- **Flatten key is `property_values`** (deliberately not `fields`/`value`/`properties`/`data`, which the viewer treats as drill-down wrappers).
- **`icon` is not flattened** — kept strictly to `title` + `property_values`; raw `icon` stays in the payload.

## Scope / notes

- The pre-existing `notionPageFields` (raw page shape used by the `notion-*` AI-action variants) was renamed **`notionRawPageFields`** — pure rename, no behavior change — so the shared enriched schema could take the `notionPageFields` name. Those AI actions are untouched here.
- **Follow-up (separate ticket):** apply the same enrichment to the database-item **actions** and replace the runtime title guesses (`Object.values(properties)[0]` / hardcoded `Name`) with the new `getPageTitle` helper.
- `Notion-Version` stays pinned at `2022-02-22`; the flattener tolerates `data_source_id`/`custom_emoji` so a future bump can't break it.
- Additive and non-breaking → minor bump `0.6.10 → 0.7.0`.

## Verification

- `tsc` build + `eslint` clean (0 errors; only pre-existing `no-explicit-any` warnings, none in the new file).
- **Vitest: 49/49.**
- Trigger output-schema paths all resolve against the refreshed `sampleData` (0 unresolved).
- Tested live on two real databases: enriched `title` + `property_values` on every row, including an empty-title row → `""`, id-only participants → id, and a bot `created_by` → name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### Breaking change?

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)
