### PR TITLE
fix(flows): connection filter on the Automations page no longer shows tables

### DIFF
--- a/packages/web/src/features/automations/hooks/use-automations-data.ts
+++ b/packages/web/src/features/automations/hooks/use-automations-data.ts
@@ -64,17 +64,23 @@ export function useAutomationsData({
 
   const folderIds = foldersQuery.data?.map((f) => f.id).join(',') ?? '';
 
+  const hasConnectionFilter = filters.connectionFilter.length > 0;
+  const skipFlows =
+    filters.typeFilter.length > 0 && !filters.typeFilter.includes('flow');
+  const skipTables =
+    (filters.typeFilter.length > 0 && !filters.typeFilter.includes('table')) ||
+    hasConnectionFilter;
+
   const folderCounts = useMemo(() => {
     const folders = foldersQuery.data ?? [];
     return new Map(
       folders.map((folder) => [
         folder.id,
-        hideTables
-          ? folder.numberOfFlows
-          : folder.numberOfFlows + folder.numberOfTables,
+        (skipFlows ? 0 : folder.numberOfFlows) +
+          (hideTables || skipTables ? 0 : folder.numberOfTables),
       ]),
     );
-  }, [foldersQuery.data, hideTables]);
+  }, [foldersQuery.data, hideTables, skipFlows, skipTables]);
 
   const folderContentsQuery = useQuery<FolderContentsMap>({
     queryKey: ['all-folder-contents', projectId, folderIds, hideTables],
@@ -104,11 +110,6 @@ export function useAutomationsData({
     refetchOnMount: 'always',
   });
 
-  const skipFlows =
-    filters.typeFilter.length > 0 && !filters.typeFilter.includes('flow');
-  const skipTables =
-    filters.typeFilter.length > 0 && !filters.typeFilter.includes('table');
-
   const rootFlowsQuery = useQuery({
     queryKey: ['root-flows', projectId, filters, sort],
     queryFn: () =>
@@ -122,10 +123,9 @@ export function useAutomationsData({
           filters.statusFilter.length > 0
             ? (filters.statusFilter as FlowStatus[])
             : undefined,
-        connectionExternalIds:
-          filters.connectionFilter.length > 0
-            ? filters.connectionFilter
-            : undefined,
+        connectionExternalIds: hasConnectionFilter
+          ? filters.connectionFilter
+          : undefined,
         sortBy: sort === 'default' ? undefined : 'NAME',
         order: sortOrder(sort),
       }),
@@ -194,7 +194,11 @@ export function useAutomationsData({
     let folders = foldersQuery.data ?? [];
     let rootFlows = rootFlowsQuery.data?.data ?? [];
     let rootTables = rootTablesQuery.data?.data ?? [];
-    const folderContents = folderContentsQuery.data ?? new Map();
+    const folderContents = stripSkippedFolderContents({
+      folderContents: folderContentsQuery.data ?? new Map(),
+      skipFlows,
+      skipTables,
+    });
 
     const hasFolderFilter = filters.folderFilter.length > 0;
 
@@ -260,6 +264,8 @@ export function useAutomationsData({
     filters.folderFilter,
     pinnedList,
     sort,
+    skipFlows,
+    skipTables,
   ]);
 
   const hasFolderFilter = filters.folderFilter.length > 0;
@@ -365,6 +371,29 @@ function buildFolderContentsMap(
     }
   });
   return map;
+}
+
+function stripSkippedFolderContents({
+  folderContents,
+  skipFlows,
+  skipTables,
+}: {
+  folderContents: FolderContentsMap;
+  skipFlows: boolean;
+  skipTables: boolean;
+}): FolderContentsMap {
+  if (!skipFlows && !skipTables) {
+    return folderContents;
+  }
+  return new Map(
+    [...folderContents].map(([folderId, content]) => [
+      folderId,
+      {
+        flows: skipFlows ? [] : content.flows,
+        tables: skipTables ? [] : content.tables,
+      },
+    ]),
+  );
 }
 
 function emptyTablePage(): SeekPage<Table> {

--- a/packages/web/src/features/automations/hooks/use-automations-data.ts
+++ b/packages/web/src/features/automations/hooks/use-automations-data.ts
@@ -194,11 +194,20 @@ export function useAutomationsData({
     let folders = foldersQuery.data ?? [];
     let rootFlows = rootFlowsQuery.data?.data ?? [];
     let rootTables = rootTablesQuery.data?.data ?? [];
-    const folderContents = stripSkippedFolderContents({
+    const folderContents = filterFolderContents({
       folderContents: folderContentsQuery.data ?? new Map(),
       skipFlows,
       skipTables,
+      connectionFilter: filters.connectionFilter,
     });
+    const effectiveFolderCounts = hasConnectionFilter
+      ? new Map(
+          [...folderContents].map(([folderId, content]) => [
+            folderId,
+            content.flows.length + content.tables.length,
+          ]),
+        )
+      : folderCounts;
 
     const hasFolderFilter = filters.folderFilter.length > 0;
 
@@ -223,7 +232,7 @@ export function useAutomationsData({
         pinnedList,
         searchTerm: filters.searchTerm,
         folderContents,
-        folderCounts,
+        folderCounts: effectiveFolderCounts,
         sort,
       });
       return { treeItems: items, totalPageItems: totalItems };
@@ -262,6 +271,8 @@ export function useAutomationsData({
     isFiltered,
     filters.searchTerm,
     filters.folderFilter,
+    filters.connectionFilter,
+    hasConnectionFilter,
     pinnedList,
     sort,
     skipFlows,
@@ -373,23 +384,31 @@ function buildFolderContentsMap(
   return map;
 }
 
-function stripSkippedFolderContents({
+function filterFolderContents({
   folderContents,
   skipFlows,
   skipTables,
+  connectionFilter,
 }: {
   folderContents: FolderContentsMap;
   skipFlows: boolean;
   skipTables: boolean;
+  connectionFilter: string[];
 }): FolderContentsMap {
-  if (!skipFlows && !skipTables) {
+  if (!skipFlows && !skipTables && connectionFilter.length === 0) {
     return folderContents;
   }
+  const connectionSet = new Set(connectionFilter);
+  const keepFlow = (flow: PopulatedFlow) =>
+    connectionSet.size === 0 ||
+    flow.version.connectionIds.some((connectionId) =>
+      connectionSet.has(connectionId),
+    );
   return new Map(
     [...folderContents].map(([folderId, content]) => [
       folderId,
       {
-        flows: skipFlows ? [] : content.flows,
+        flows: skipFlows ? [] : content.flows.filter(keepFlow),
         tables: skipTables ? [] : content.tables,
       },
     ]),

--- a/packages/web/test/features/automations/use-automations-data.test.tsx
+++ b/packages/web/test/features/automations/use-automations-data.test.tsx
@@ -59,6 +59,17 @@ const flowInFolder = {
   ...flow,
   id: 'flow_2',
   folderId: 'folder_1',
+  version: {
+    displayName: 'Linear sync flow',
+    connectionIds: ['conn_external_id'],
+  },
+} as unknown as PopulatedFlow;
+
+const unrelatedFlowInFolder = {
+  ...flow,
+  id: 'flow_3',
+  folderId: 'folder_1',
+  version: { displayName: 'Unrelated flow', connectionIds: [] },
 } as unknown as PopulatedFlow;
 
 const tableInFolder = {
@@ -129,7 +140,7 @@ describe('useAutomationsData', () => {
     listFolders.mockResolvedValue([folder]);
     listFlows.mockImplementation((request: { folderIds?: string[] }) =>
       Promise.resolve({
-        data: request.folderIds ? [flowInFolder] : [],
+        data: request.folderIds ? [flowInFolder, unrelatedFlowInFolder] : [],
         next: null,
         previous: null,
       }),
@@ -156,5 +167,10 @@ describe('useAutomationsData', () => {
     expect(
       result.current.treeItems.filter((item) => item.type === 'table'),
     ).toEqual([]);
+    const flowItems = result.current.treeItems.filter(
+      (item) => item.type === 'flow',
+    );
+    expect(flowItems).toHaveLength(1);
+    expect(flowItems[0].id).toBe('flow_2');
   });
 });

--- a/packages/web/test/features/automations/use-automations-data.test.tsx
+++ b/packages/web/test/features/automations/use-automations-data.test.tsx
@@ -1,0 +1,160 @@
+// @vitest-environment jsdom
+import { FolderDto, PopulatedFlow, Table } from '@activepieces/shared';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import { ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('react-router-dom', () => ({
+  useParams: () => ({ projectId: 'test_project' }),
+}));
+vi.mock('@/components/providers/embed-provider', () => ({
+  useEmbedding: () => ({ embedState: { hideTables: false } }),
+}));
+vi.mock('@/lib/authentication-session', () => ({
+  authenticationSession: { getProjectId: () => 'test_project' },
+}));
+
+const listFlows = vi.fn();
+const listFolders = vi.fn();
+const listTables = vi.fn();
+vi.mock('@/features/flows/api/flows-api', () => ({
+  flowsApi: { list: (request: unknown) => listFlows(request) },
+}));
+vi.mock('@/features/folders/api/folders-api', () => ({
+  foldersApi: { list: () => listFolders() },
+}));
+vi.mock('@/features/tables/api/tables-api', () => ({
+  tablesApi: { list: (request: unknown) => listTables(request) },
+}));
+
+import { useAutomationsData } from '@/features/automations/hooks/use-automations-data';
+import { AutomationsFilters } from '@/features/automations/lib/types';
+
+const flow = {
+  id: 'flow_1',
+  created: '2026-01-01T00:00:00.000Z',
+  updated: '2026-01-02T00:00:00.000Z',
+  folderId: null,
+  version: { displayName: 'Linear sync flow' },
+  status: 'ENABLED',
+} as unknown as PopulatedFlow;
+
+const table = {
+  id: 'table_1',
+  created: '2026-01-01T00:00:00.000Z',
+  updated: '2026-01-02T00:00:00.000Z',
+  name: 'lifecycle_shadow',
+  folderId: null,
+} as unknown as Table;
+
+const folder = {
+  id: 'folder_1',
+  displayName: 'Marketing',
+  numberOfFlows: 1,
+  numberOfTables: 1,
+} as unknown as FolderDto;
+
+const flowInFolder = {
+  ...flow,
+  id: 'flow_2',
+  folderId: 'folder_1',
+} as unknown as PopulatedFlow;
+
+const tableInFolder = {
+  ...table,
+  id: 'table_2',
+  name: 'ea_reviews',
+  folderId: 'folder_1',
+} as unknown as Table;
+
+const emptyFilters: AutomationsFilters = {
+  searchTerm: '',
+  typeFilter: [],
+  statusFilter: [],
+  connectionFilter: [],
+  ownerFilter: [],
+  folderFilter: [],
+};
+
+function renderAutomationsData(filters: AutomationsFilters) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+  return renderHook(() => useAutomationsData({ filters, sort: 'default' }), {
+    wrapper,
+  });
+}
+
+describe('useAutomationsData', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    listFolders.mockResolvedValue([]);
+    listFlows.mockResolvedValue({ data: [flow], next: null, previous: null });
+    listTables.mockResolvedValue({ data: [table], next: null, previous: null });
+  });
+
+  it('does not fetch or show tables when a connection filter is active', async () => {
+    const { result } = renderAutomationsData({
+      ...emptyFilters,
+      connectionFilter: ['conn_external_id'],
+    });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(listTables).not.toHaveBeenCalled();
+    expect(
+      result.current.treeItems.filter((item) => item.type === 'table'),
+    ).toEqual([]);
+    expect(
+      result.current.treeItems.filter((item) => item.type === 'flow'),
+    ).toHaveLength(1);
+  });
+
+  it('still fetches and shows tables when no filters are active', async () => {
+    const { result } = renderAutomationsData(emptyFilters);
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(listTables).toHaveBeenCalled();
+    expect(
+      result.current.treeItems.filter((item) => item.type === 'table'),
+    ).toHaveLength(1);
+  });
+
+  it('keeps tables out of name-matched folder contents when a connection filter is active', async () => {
+    listFolders.mockResolvedValue([folder]);
+    listFlows.mockImplementation((request: { folderIds?: string[] }) =>
+      Promise.resolve({
+        data: request.folderIds ? [flowInFolder] : [],
+        next: null,
+        previous: null,
+      }),
+    );
+    listTables.mockImplementation((request: { folderIds?: string[] }) =>
+      Promise.resolve({
+        data: request.folderIds ? [tableInFolder] : [table],
+        next: null,
+        previous: null,
+      }),
+    );
+
+    const { result } = renderAutomationsData({
+      ...emptyFilters,
+      searchTerm: 'mark',
+      connectionFilter: ['conn_external_id'],
+    });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(
+      result.current.treeItems.filter((item) => item.type === 'folder'),
+    ).toHaveLength(1);
+    expect(
+      result.current.treeItems.filter((item) => item.type === 'table'),
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
Fixes [GIT-1865](https://linear.app/activepieces/issue/GIT-1865)
Closes #15391

## Problem

1. Automations page: applying a Connections filter shows every table in the project alongside the matching flows. Tables have no connections. Also hit via the Connections tab "used by N flows" click-through. Ref: Pylon 5924.
2. Same leak through a second path: when the search term matches a folder name, the folder's contents render unfiltered, so its tables, connection-unrelated flows, and type-filtered-out items appear too.

## Fix

`packages/web/src/features/automations/hooks/use-automations-data.ts`:
- `skipTables` is now also true when a connection filter is active, disabling the root tables query (same mechanism the type filter already uses; the tables API has no connection parameter).
- `filterFolderContents` cleans folder contents before tree building, closing the folder-name-search path: skipped kinds are emptied (`skipTables`/`skipFlows`), and with a connection filter active only flows whose `version.connectionIds` intersect the selection are kept; folder child counts derive from the filtered contents in that state.

## Verification

- Regression tests in `packages/web/test/features/automations/use-automations-data.test.tsx`, proven red-first: both connection-filter cases fail on the pre-fix hook (tables fetched / folder tables rendered) and pass with the fix; the folder-contents case also pins that connection-unrelated folder flows are filtered out; the no-filter case passes on both. Full web suite green.
- `npm run lint-dev` clean.
- Driven end to end on a local dev stack: connection filter → flow only; clear filter → tables return; type "Tables" + connection filter → "No results found" state, no crash.
- Visual: driven states — connection filter before/after, no filter, type Tables + connection filter; screenshots in the Visual verification comment.
- Other affected paths: checked — status filter leaks tables the same way (tables carry their own `TableAutomationStatus`, tables list API has no status param; mapping vs excluding is a product decision, left out deliberately); owner filter is UI-only and never applied to either query (pre-existing, separate defect).

<details>
<summary>Plan & reasoning</summary>

## Plan
- Extend the existing `skipTables` predicate rather than filtering fetched tables or touching the backend; the disabled query yields an empty page and `isLoading`/`isError` already branch on `skipTables`.
- Review (internal pass + Greptile P1) surfaced the folder-name-search branch of `buildFilteredTreeItems` injecting unfiltered folder contents — tables AND connection-unrelated flows; fixed at the hook by filtering the contents map (`filterFolderContents`), keeping the tree builder filter-agnostic.
- Footprint estimate: 2 files, ~6 lines product code — actual: 1 product file, ~50 lines, growth is the folder-contents filtering + derived child counts from the review findings.

## Non-happy scenarios considered
- Type filter "Tables" + connection filter → both queries skipped → renders the no-results state (driven in the real app); the empty intersection is the only correct result.
- Embed mode `hideTables` → unchanged, composes with `skipTables` in the query's `enabled` and in the counts.
- Unfiltered view → skip flags are always false there, so folder contents and counts are untouched.

## Alternatives rejected
- Map the connection filter onto the tables API → tables have no connection concept; would be a fake parameter.
- Client-side filter of fetched tables → wasted fetch for rows that can never match.
- Teach `buildFilteredTreeItems` about `AutomationsFilters` → leaks filter semantics into a pure tree builder.
- Fix the status-filter leak in the same PR → needs a shared DTO + backend param and a product decision (match `TableAutomationStatus` vs exclude); separate ticket material.
</details>

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)
