### PR TITLE
fix(builder): lead collapsed object previews with meaningful keys, not ids

### DIFF
--- a/packages/web/src/components/custom/smart-output-viewer/object-preview.test.ts
+++ b/packages/web/src/components/custom/smart-output-viewer/object-preview.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('i18next', () => ({
+  t: (key: string, options?: { count?: number }) =>
+    key === 'itemCount'
+      ? `${options?.count} items`
+      : `${options?.count} fields`,
+}));
+
+import { previewObject } from './object-preview';
+
+const prop = (type: string, payload: unknown) => ({
+  id: '%3Bo%3A%5E',
+  type,
+  [type]: payload,
+});
+
+describe('previewObject — typed envelopes', () => {
+  it('names the type once and shows the value (was "id: …, type: email")', () => {
+    expect(previewObject(prop('email', 'kitchen@example.com'))).toBe(
+      'email: kitchen@example.com',
+    );
+  });
+
+  it('counts arrays instead of hiding them behind an ellipsis', () => {
+    expect(previewObject(prop('files', [{ name: 'a' }, { name: 'b' }]))).toBe(
+      'files: 2 items',
+    );
+  });
+
+  it('keeps falsy scalars that are real values', () => {
+    expect(previewObject(prop('number', 0))).toBe('number: 0');
+    expect(previewObject(prop('checkbox', false))).toBe('checkbox: false');
+  });
+
+  it('drills one level into a wrapper object via its display key', () => {
+    expect(
+      previewObject(prop('select', { id: 'o1', name: 'Doing', color: 'blue' })),
+    ).toBe('select: Doing');
+    expect(
+      previewObject(prop('date', { start: '2026-09-10', end: null })),
+    ).toBe('date: 2026-09-10');
+  });
+
+  it('unwraps a nested envelope (formula, rollup)', () => {
+    expect(previewObject(prop('formula', { type: 'number', number: 84 }))).toBe(
+      'formula: 84',
+    );
+    expect(
+      previewObject(
+        prop('rollup', {
+          type: 'array',
+          function: 'show_original',
+          array: [1, 2],
+        }),
+      ),
+    ).toBe('rollup: 2 items');
+  });
+
+  it('falls back to the wrapper display key when the inner envelope is empty', () => {
+    expect(
+      previewObject(
+        prop('created_by', {
+          object: 'user',
+          id: 'b1',
+          name: 'Activepieces',
+          type: 'bot',
+          bot: {},
+        }),
+      ),
+    ).toBe('created_by: Activepieces');
+  });
+
+  it('falls back to a placeholder when the payload has no short form', () => {
+    expect(previewObject(prop('select', null))).toBe('select: …');
+    expect(previewObject(prop('button', {}))).toBe('button: …');
+  });
+
+  it('ignores a type that names nothing, or names itself', () => {
+    expect(previewObject({ type: 'message', text: 'hi', user: 'U1' })).toBe(
+      'type: message, text: hi',
+    );
+    expect(previewObject({ type: 'type' })).toBe('type: type');
+  });
+});
+
+describe('previewObject — plain objects', () => {
+  it('moves identifier keys behind meaningful ones', () => {
+    expect(
+      previewObject({ id: 'rec1', createdTime: '2026-01-01', name: 'Row' }),
+    ).toBe('createdTime: 2026-01-01, name: Row');
+  });
+
+  it('treats *_id, *Id and uuid as identifiers, but not words ending in id', () => {
+    expect(previewObject({ database_id: 'd', userId: 'u', paid: true })).toBe(
+      'paid: true, database_id: d',
+    );
+  });
+
+  it('still shows identifiers when the object has nothing else', () => {
+    expect(previewObject({ object: 'user', id: 'u1' })).toBe(
+      'object: user, id: u1',
+    );
+  });
+
+  it('counts fields when every entry is empty, and handles {}', () => {
+    expect(previewObject({})).toBe('0 fields');
+    expect(previewObject({ a: null, b: '' })).toBe('a: …, b: …');
+  });
+});

--- a/packages/web/src/components/custom/smart-output-viewer/object-preview.ts
+++ b/packages/web/src/components/custom/smart-output-viewer/object-preview.ts
@@ -1,0 +1,95 @@
+import { isNil, isObject } from '@activepieces/core-utils';
+import { t } from 'i18next';
+
+const IDENTIFIER_KEY = /^(id|uuid|object)$|_id$|Id$/;
+
+const DISPLAY_KEYS = [
+  'name',
+  'title',
+  'label',
+  'text',
+  'plain_text',
+  'value',
+  'start',
+  'url',
+  'email',
+];
+
+const UNKNOWN = '…';
+const MAX_UNWRAP_DEPTH = 4;
+
+type TypedEnvelope = { type: string; payload: unknown };
+
+function asTypedEnvelope(value: Record<string, unknown>): TypedEnvelope | null {
+  const type = value['type'];
+  if (
+    typeof type !== 'string' ||
+    type === 'type' ||
+    !Object.prototype.hasOwnProperty.call(value, type)
+  ) {
+    return null;
+  }
+  return { type, payload: value[type] };
+}
+
+function orderEntriesForPreview(
+  value: Record<string, unknown>,
+): [string, unknown][] {
+  const entries = Object.entries(value);
+  const meaningful = entries.filter(([key]) => !IDENTIFIER_KEY.test(key));
+  if (meaningful.length === 0) {
+    return entries;
+  }
+  return [
+    ...meaningful,
+    ...entries.filter(([key]) => IDENTIFIER_KEY.test(key)),
+  ];
+}
+
+function summarizeValue(value: unknown, depth = 0): string | null {
+  if (isNil(value) || value === '') {
+    return null;
+  }
+  if (Array.isArray(value)) {
+    return t('itemCount', { count: value.length });
+  }
+  if (isObject(value)) {
+    if (depth >= MAX_UNWRAP_DEPTH) {
+      return null;
+    }
+    const record = value as Record<string, unknown>;
+    const envelope = asTypedEnvelope(record);
+    if (envelope) {
+      const unwrapped = summarizeValue(envelope.payload, depth + 1);
+      if (!isNil(unwrapped)) {
+        return unwrapped;
+      }
+    }
+    for (const key of DISPLAY_KEYS) {
+      const inner = record[key];
+      if (
+        !isNil(inner) &&
+        inner !== '' &&
+        !isObject(inner) &&
+        !Array.isArray(inner)
+      ) {
+        return String(inner);
+      }
+    }
+    return null;
+  }
+  return String(value);
+}
+
+export function previewObject(value: Record<string, unknown>): string {
+  const envelope = asTypedEnvelope(value);
+  if (envelope) {
+    return `${envelope.type}: ${summarizeValue(envelope.payload) ?? UNKNOWN}`;
+  }
+  const entries = orderEntriesForPreview(value);
+  const preview = entries
+    .slice(0, 2)
+    .map(([key, entry]) => `${key}: ${summarizeValue(entry) ?? UNKNOWN}`)
+    .join(', ');
+  return preview || t('fieldCount', { count: entries.length });
+}

--- a/packages/web/src/components/custom/smart-output-viewer/shared-value-rendering.tsx
+++ b/packages/web/src/components/custom/smart-output-viewer/shared-value-rendering.tsx
@@ -8,6 +8,7 @@ import { VirtualizedList } from '@/components/ui/virtualized-list';
 import { isStepFileUrl } from '@/lib/dom-utils';
 
 import { FieldTypeIcon } from './field-type-icon';
+import { previewObject } from './object-preview';
 
 const MAX_NESTED_DEPTH = 10;
 
@@ -15,15 +16,7 @@ function truncateValue(value: unknown): string {
   if (isNil(value) || value === '') return '';
   if (Array.isArray(value)) return t('itemCount', { count: value.length });
   if (isObject(value)) {
-    const entries = Object.entries(value);
-    const preview = entries
-      .slice(0, 2)
-      .map(([k, v]) => {
-        const vs = isNil(v) || typeof v === 'object' ? '…' : String(v);
-        return `${k}: ${vs}`;
-      })
-      .join(', ');
-    return preview || t('fieldCount', { count: entries.length });
+    return previewObject(value as Record<string, unknown>);
   }
   return String(value);
 }


### PR DESCRIPTION
Linear: GIT-1866. Found while verifying the Notion friendly-view PR #15394.

## Problem

The Friendly View previews a collapsed object as its **first two keys**. For API payloads that wrap every value in a typed envelope, those are the least useful keys, so the actual value never appears. Notion's raw properties rendered like this:

```
Email          id: %3Bo%3A%5E, type: email
Formula Num    id: %3ER%3BC, type: formula
Stage          id: %5C7, type: select
```

`%3Bo%3A%5E` is Notion's URL-encoded internal property id; `kitchen@example.com` sits in the third key.

## Fix

New pure module `smart-output-viewer/object-preview.ts`, used by `truncateValue()`:

- **A typed envelope** `{ id, type: 'email', email }` previews as `email: kitchen@example.com` — the type named **once**, then the value it points at.
- **Wrapper objects are drilled one level** through a display key (`name`, `title`, `label`, `text`, `plain_text`, `value`, `start`, `url`, `email`), so `select: { id, name: 'Doing', color }` reads `select: Doing`. A nested envelope is unwrapped too: `formula: { type: 'number', number: 84 }` reads `formula: 84`. If the inner envelope carries nothing — a Notion bot user is `{ name, type: 'bot', bot: {} }` — it falls back to the wrapper's own display key.
- **Identifier-only keys** (`id`, `uuid`, `object`, `*_id`, `*Id`) move to the end. An object with nothing else, such as Notion's partial user, still shows them, so no preview goes blank.
- **Arrays** preview as `N items` instead of an ellipsis.

Falsy scalars stay visible (`checkbox: false`, `number: 0`). Anything with no short form keeps today's ellipsis.

Same Notion row, before and after (live, local builder):

```
before                                after
id: %3Bo%3A%5E, type: email           email: kitchen@example.com
id: …, type: created_by               created_by: Activepieces
id: …, type: select                   select: Doing
id: …, type: formula                  formula: 84
id: …, type: files                    files: 2 items
id: …, type: checkbox                 checkbox: true
```

Airtable records move from `id: rec…, createdTime: …` to `createdTime: …, fields: …`. Objects with no `type`/id pattern are untouched, and the hover title still shows the full JSON.

## Verification

- **12 unit tests** (`object-preview.test.ts`): every rule above, plus falsy scalars, an empty-payload envelope, a `type` that names nothing, a self-referential `type: 'type'`, `paid` not being mistaken for an identifier, and `{}`.
- ESLint clean (`turbo run lint --filter=web`, what CI runs).
- Verified live in a local builder against a Notion database containing **all 24 property types**, on a fully-populated row and on a row of zeroes/empties, confirming `checkbox: false` and `number: 0` survive while nulls fall back to the ellipsis.

### Breaking change?

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)


