### PR TITLE
feat(manual-trigger): rewrite the step copy

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -10455,7 +10455,7 @@
     },
     "packages/pieces/core/manual-trigger": {
       "name": "@activepieces/piece-manual-trigger",
-      "version": "0.0.7",
+      "version": "0.0.8",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",

--- a/packages/pieces/core/manual-trigger/package.json
+++ b/packages/pieces/core/manual-trigger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-manual-trigger",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/packages/pieces/core/manual-trigger/src/i18n/translation.json
+++ b/packages/pieces/core/manual-trigger/src/i18n/translation.json
@@ -1,6 +1,7 @@
 {
+  "Start a flow on demand with a button click.": "Start a flow on demand with a button click.",
   "Manual Trigger": "Manual Trigger",
-  "Manually start your own flow without any extra configurations": "Manually start your own flow without any extra configurations",
+  "Start the flow on demand with the Run Flow button": "Start the flow on demand with the Run Flow button",
   "Markdown": "Markdown",
-  "Manual triggers are used to start a flow on demand, publish your flow and click (Run Flow) at the start of the flow.": "Manual triggers are used to start a flow on demand, publish your flow and click (Run Flow) at the start of the flow."
+  "Publish the flow, then click **Run Flow** on the canvas to start it.\n\nThis trigger passes no data, so later steps have nothing to map from it.": "Publish the flow, then click **Run Flow** on the canvas to start it.\n\nThis trigger passes no data, so later steps have nothing to map from it."
 }

--- a/packages/pieces/core/manual-trigger/src/index.ts
+++ b/packages/pieces/core/manual-trigger/src/index.ts
@@ -5,6 +5,7 @@ import { PieceCategory } from "@activepieces/pieces-framework";
 
 export const manualTriggerPiece = createPiece({
       displayName: "Manual Trigger",
+      description: 'Start a flow on demand with a button click.',
       auth: PieceAuth.None(),
       minimumSupportedRelease: '0.78.0',
       logoUrl: "https://cdn.activepieces.com/pieces/new-core/manual-trigger.svg",

--- a/packages/pieces/core/manual-trigger/src/lib/triggers/manual-trigger.ts
+++ b/packages/pieces/core/manual-trigger/src/lib/triggers/manual-trigger.ts
@@ -6,13 +6,15 @@ export const manualTrigger = createTrigger({
 name: 'manual_trigger',
 classification: 'READ',
 displayName: 'Manual Trigger',
-description: 'Manually start your own flow without any extra configurations',
+description: 'Start the flow on demand with the Run Flow button',
 aiMetadata: {
   description: 'Fires when a published flow is started manually on demand, for example a user clicking Run Flow, rather than in response to an external event; the event itself carries no payload. Use it as the entry point for flows an operator or agent invokes directly, and prefer a webhook trigger for external app events, a schedule trigger for time-based runs, or the Web Form, Chat UI, or Callable Flow triggers when the invoker must supply input.',
 },
 props: {
     markdown: Property.MarkDown({
-        value: `Manual triggers are used to start a flow on demand, publish your flow and click (Run Flow) at the start of the flow.`,
+        value: `Publish the flow, then click **Run Flow** on the canvas to start it.
+
+This trigger passes no data, so later steps have nothing to map from it.`,
         variant: MarkdownVariant.INFO,
     }),
 },


### PR DESCRIPTION
## Description

Copy pass on the Manual Trigger core piece. The piece has one trigger, no actions and no inputs; its whole step form is a single informational block. The builder drives the run itself: **Run Flow** on the published version fires the flow with no payload, and the trigger's props play no part in it. So this PR changes wording only.

### Trigger picker

The description was "Manually start your own flow without any extra configurations". It is now "Start the flow on demand with the Run Flow button", which names the control the user will actually click.

### Step panel

The info block read "Manual triggers are used to start a flow on demand, publish your flow and click (Run Flow) at the start of the flow." It is now two short lines:

- Publish the flow, then click **Run Flow** on the canvas to start it.
- This trigger passes no data, so later steps have nothing to map from it.

The second line closes a dead end. The trigger's output is an empty object, and nothing told the user that before they went looking for fields in the data selector.

### Piece picker

The piece had no description while Human Input and Webhook both do. It now reads "Start a flow on demand with a button click."

### Metadata

- Version 0.0.7 → 0.0.8, with the matching version line in `bun.lock`.
- `src/i18n/translation.json` regenerated from the built piece. No locale files were hand-edited; the three rewritten strings fall back to English until Crowdin catches up.
- `minimumSupportedRelease` stays at 0.78.0. No new widgets or flags are used.

### Deliberately left out

- `run()` and `test()` still return an empty payload. Giving a manual run real data, such as who started it and when, would be useful but is a runtime and server change, not a copy pass.
- The Run Flow button, the hidden Test button and the suppressed sample-data affordances are web-app behaviour keyed on this piece's name, not piece metadata.

No prop names, prop types or lifecycle methods change, so steps saved on 0.0.7 keep working unchanged.


## How was this tested?

- Served the piece from `AP_DEV_PIECES` on a local CE build and opened a fresh Manual Trigger step at default panel width; checked the info block and the trigger picker description.
- Ran the step-form checker on the served metadata before and after: 0 findings both times, and the `--before` comparison against the 0.0.7 metadata reports no prop type changed or removed.
- `tsc --noEmit` and `eslint` on the piece pass.
- Edition paths: CE checked locally. The change is piece copy only, with no edition-specific code, so EE and Cloud render the same block.

### Breaking change?  (required — CI fails if this is left unedited)

<!-- Tick exactly one box. If either "yes", apply the "⛓️‍💥 breaking-change" label AND add an entry to docs/install/reference/breaking-changes.mdx (what changed + the action self-hosters must take). -->

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

<!-- Tick exactly one box. "Security-sensitive" = touches authentication, secrets, permissions/roles, cryptography, SSRF / outbound HTTP, or file handling. -->

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)
