### PR TITLE
fix(web): prevent truncation of piece selector tab labels (#15039)

### DIFF
--- a/packages/web/src/features/pieces/components/piece-selector-tabs.tsx
+++ b/packages/web/src/features/pieces/components/piece-selector-tabs.tsx
@@ -35,14 +35,14 @@ export const PieceSelectorTabs = ({
           <TabsTrigger
             key={tab.key}
             value={tab.key}
-            className={`flex flex-col h-full rounded-md w-[85px] max-w-[85px] shrink-0
+            className={`flex flex-col h-full rounded-md min-w-[85px] px-3 shrink-0
               hover:bg-gray-300/30 dark:hover:bg-gray-300/10
                data-[state=active]:text-primary data-[state=active]:shadow-none
                border-transparent data-[state=active]:border-primary data-[state=active]:active data-[state=active]:bg-transparent
                text-accent-foreground [&>svg]:size-5 [&>svg]:shrink-0`}
           >
             {tab.icon}
-            <span className="mt-1.5 text-sm truncate w-full text-center">
+            <span className="mt-1.5 text-sm whitespace-nowrap text-center">
               {tab.name}
             </span>
           </TabsTrigger>


### PR DESCRIPTION
Fixes #15039
@algora-pbc /claim #15039

## Description
Fixes an issue where piece selector tab labels (e.g. "Approvals", "AI & Agents") were truncated mid-word with ellipses due to fixed `w-[85px] max-w-[85px]` and `truncate` constraints.

## Changes
- Updates `TabsTrigger` to use `min-w-[85px] px-3` allowing tabs to naturally fit content while preserving horizontal scrolling.
- Replaces `truncate` with `whitespace-nowrap` on tab label spans to ensure full text readability.

Closes #15039