### PR TITLE
fix(agents): the configure panel breathes again, and the sidebar steps aside

### DIFF
--- a/packages/web/src/app/components/primary-rail/index.tsx
+++ b/packages/web/src/app/components/primary-rail/index.tsx
@@ -60,7 +60,10 @@ import {
   projectCollectionUtils,
 } from '@/features/projects';
 import { templatesTelemetryApi } from '@/features/templates';
-import { useRailCollapsed } from '@/features/workspace/lib/rail-collapsed';
+import {
+  railIsCollapsed,
+  useRailCollapsed,
+} from '@/features/workspace/lib/rail-collapsed';
 import {
   useAuthorization,
   useIsPlatformAdmin,
@@ -81,10 +84,12 @@ export function PrimaryRail() {
   const { platform } = platformHooks.useCurrentPlatform();
   const { data: currentUser } = userHooks.useCurrentUser();
   const {
-    collapsed,
+    preference,
+    heldClosed,
     setCollapsed,
     toggle: toggleCollapsed,
   } = useRailCollapsed();
+  const collapsed = railIsCollapsed({ preference, heldClosed });
   const showAgents = useAgentsNavVisible();
   const { checkAccess } = useAuthorization();
 

--- a/packages/web/src/app/routes/agents/id/configure-panel/index.tsx
+++ b/packages/web/src/app/routes/agents/id/configure-panel/index.tsx
@@ -99,14 +99,14 @@ const AgentProjectRow = ({ agent }: { agent: Agent }) => {
   }
 
   return (
-    <FormItem className="flex flex-col gap-[9px]">
+    <FormItem className="flex flex-col gap-2">
       <PanelSectionLabel label={t('Project')} />
-      <div className="flex items-center justify-between gap-3">
+      <div className="flex items-center justify-between gap-3 rounded-[10px] border border-border px-3 py-2.5">
         <ApProjectDisplay
           title={getProjectName(home)}
           icon={home.icon}
           projectType={home.type}
-          titleClassName="text-[13px] leading-4 text-muted-foreground"
+          titleClassName="text-sm leading-5"
         />
         <Button
           type="button"
@@ -148,10 +148,10 @@ const AgentDangerZone = ({
   }
 
   return (
-    <div className="flex flex-col gap-[9px] border-t border-border pt-4">
+    <div className="flex flex-col gap-2 border-t border-border pt-5">
       <PanelSectionLabel label={t('Delete this agent')} />
-      <div className="flex items-start justify-between gap-3">
-        <span className="text-[13px] leading-4 text-muted-foreground">
+      <div className="flex items-start justify-between gap-4">
+        <span className="text-sm leading-5 text-muted-foreground">
           {t(
             'Its instructions, its tools, and every conversation held with it go with it.',
           )}
@@ -185,7 +185,7 @@ const AdvancedSection = ({ children }: { children: React.ReactNode }) => {
   const [open, setOpen] = useState(false);
 
   return (
-    <div className="flex flex-col gap-[9px] border-t border-border pt-4">
+    <div className="flex flex-col gap-2 border-t border-border pt-5">
       <button
         type="button"
         onClick={() => setOpen((current) => !current)}
@@ -197,7 +197,7 @@ const AdvancedSection = ({ children }: { children: React.ReactNode }) => {
         />
         {t('Advanced')}
       </button>
-      {open && <div className="flex flex-col gap-[20px]">{children}</div>}
+      {open && <div className="flex flex-col gap-6 pt-1">{children}</div>}
     </div>
   );
 };
@@ -222,7 +222,7 @@ const ConfigureBehaviorTab = ({
         control={form.control}
         name="draft.instructions"
         render={({ field }) => (
-          <FormItem className="flex flex-col gap-[9px]">
+          <FormItem className="flex flex-col gap-2">
             <PanelSectionLabel label={t('Instructions')} required />
             <FormControl>
               <Textarea
@@ -232,14 +232,14 @@ const ConfigureBehaviorTab = ({
                 placeholder={t(
                   'Reply to refund requests. Check the order in Stripe first, and escalate anything over $200.',
                 )}
-                className="rounded-[10px] px-[13px] py-3 text-[13px] leading-[155%]"
+                className="rounded-[10px] px-3 py-3 text-sm leading-relaxed"
               />
             </FormControl>
             <FormMessage />
           </FormItem>
         )}
       />
-      <FormItem className="flex flex-col gap-[9px]">
+      <FormItem className="flex flex-col gap-2">
         <PanelSectionLabel label={t('Model')} />
         {needsModel && (
           <p className="text-[13px] leading-4 text-destructive">
@@ -279,7 +279,7 @@ const ConfigureBehaviorTab = ({
         control={form.control}
         name="draft.tools"
         render={({ field }) => (
-          <FormItem className="flex flex-col gap-[9px]">
+          <FormItem className="flex flex-col gap-2">
             <AgentTools
               toolsField={field}
               selectedProvider={form.watch('draft.provider') ?? undefined}
@@ -293,7 +293,7 @@ const ConfigureBehaviorTab = ({
           control={form.control}
           name="draft.structuredOutput"
           render={({ field }) => (
-            <FormItem className="flex flex-col gap-[9px]">
+            <FormItem className="flex flex-col gap-2">
               <AgentStructuredOutput
                 disabled={false}
                 structuredOutputField={field}
@@ -306,7 +306,7 @@ const ConfigureBehaviorTab = ({
           control={form.control}
           name="draft.maxSteps"
           render={({ field }) => (
-            <FormItem className="flex flex-col gap-[9px]">
+            <FormItem className="flex flex-col gap-2">
               <PanelSectionLabel label={t('Max steps')} />
               <FormControl>
                 <Input
@@ -346,7 +346,7 @@ const ConfigureSettingsTab = ({
       control={form.control}
       name="displayName"
       render={({ field }) => (
-        <FormItem className="flex flex-col gap-[9px]">
+        <FormItem className="flex flex-col gap-2">
           <PanelSectionLabel label={t('Name')} required />
           <FormControl>
             <Input {...field} />
@@ -359,7 +359,7 @@ const ConfigureSettingsTab = ({
       control={form.control}
       name="description"
       render={({ field }) => (
-        <FormItem className="flex flex-col gap-[9px]">
+        <FormItem className="flex flex-col gap-2">
           <PanelSectionLabel label={t('Description')} />
           <FormControl>
             <Textarea {...field} minRows={2} maxRows={4} />
@@ -372,9 +372,9 @@ const ConfigureSettingsTab = ({
       control={form.control}
       name="icon"
       render={({ field }) => (
-        <FormItem className="flex flex-col gap-[9px]">
+        <FormItem className="flex flex-col gap-2">
           <PanelSectionLabel label={t('Shape')} />
-          <div className="grid grid-cols-6 gap-2">
+          <div className="grid grid-cols-6 gap-2.5 rounded-[10px] border border-border p-3">
             {Object.values(AgentIcon).map((iconName) => (
               <button
                 key={iconName}
@@ -402,9 +402,9 @@ const ConfigureSettingsTab = ({
       control={form.control}
       name="color"
       render={({ field }) => (
-        <FormItem className="flex flex-col gap-[9px]">
+        <FormItem className="flex flex-col gap-2">
           <PanelSectionLabel label={t('Color')} />
-          <div className="grid grid-cols-6 gap-2">
+          <div className="grid grid-cols-6 gap-2.5 rounded-[10px] border border-border p-3">
             {Object.values(ColorName).map((colorName) => (
               <button
                 key={colorName}
@@ -748,11 +748,17 @@ const AgentConfigurePanel = ({
             </TabsList>
           </div>
           <ScrollFade className="min-h-0 grow">
-            <div className="flex flex-col gap-5 p-[18px]">
-              <TabsContent value="behavior" className="mt-0">
+            <div className="p-[18px]">
+              <TabsContent
+                value="behavior"
+                className="mt-0 flex flex-col gap-6"
+              >
                 <ConfigureBehaviorTab form={form} needsModel={formNeedsModel} />
               </TabsContent>
-              <TabsContent value="settings" className="mt-0">
+              <TabsContent
+                value="settings"
+                className="mt-0 flex flex-col gap-6"
+              >
                 <ConfigureSettingsTab
                   agent={agent}
                   form={form}
@@ -762,7 +768,7 @@ const AgentConfigurePanel = ({
                 />
               </TabsContent>
               {form.formState.errors.root?.serverError && (
-                <p className="text-sm leading-4 text-destructive">
+                <p className="mt-5 text-sm leading-4 text-destructive">
                   {form.formState.errors.root.serverError.message}
                 </p>
               )}

--- a/packages/web/src/app/routes/agents/id/index.tsx
+++ b/packages/web/src/app/routes/agents/id/index.tsx
@@ -3,7 +3,7 @@ import { Agent, AgentToolType } from '@activepieces/shared';
 import { useQueryClient } from '@tanstack/react-query';
 import { t } from 'i18next';
 import { ChevronLeft, SearchX, Settings2 } from 'lucide-react';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
 
 import { LockedFeatureGuard } from '@/app/components/locked-feature-guard';
@@ -18,12 +18,12 @@ import {
   EmptyTitle,
 } from '@/components/custom/empty';
 import { Button } from '@/components/ui/button';
-import { useSidebar } from '@/components/ui/sidebar-shadcn';
 import { Skeleton } from '@/components/ui/skeleton';
 import { useAgentsAvailable } from '@/features/agents';
 import { AgentChatWelcome } from '@/features/agents/agent-chat-welcome';
 import { AgentMark } from '@/features/agents/agent-mark';
 import { agentsQueries } from '@/features/agents/hooks/agents-hooks';
+import { useRailCollapsed } from '@/features/workspace/lib/rail-collapsed';
 import { cn } from '@/lib/utils';
 
 import { AgentConfigurePanel } from './configure-panel';
@@ -72,19 +72,13 @@ const AgentEditorSkeleton = () => (
     </div>
   </div>
 );
-const CollapseAppSidebarWhileHere = () => {
-  const sidebar = useSidebar();
-  const sidebarRef = useRef(sidebar);
-  sidebarRef.current = sidebar;
+const HoldTheRailClosedWhileHere = () => {
+  const holdClosed = useRailCollapsed((state) => state.holdClosed);
 
   useEffect(() => {
-    const wasOpen = sidebarRef.current.open;
-    if (!wasOpen) {
-      return;
-    }
-    sidebarRef.current.setOpen(false);
-    return () => sidebarRef.current.setOpen(true);
-  }, []);
+    holdClosed(true);
+    return () => holdClosed(false);
+  }, [holdClosed]);
 
   return null;
 };
@@ -170,7 +164,7 @@ const AgentEditorContent = () => {
 
   return (
     <div className="flex h-full w-full">
-      <CollapseAppSidebarWhileHere />
+      <HoldTheRailClosedWhileHere />
       <div className="flex min-w-0 grow flex-col">
         <div className="flex h-[60px] shrink-0 items-center gap-3 border-b border-border px-5">
           <button

--- a/packages/web/src/features/workspace/lib/rail-collapsed.ts
+++ b/packages/web/src/features/workspace/lib/rail-collapsed.ts
@@ -6,22 +6,38 @@ function readInitial(): boolean {
   return localStorage.getItem(STORAGE_KEY) === 'true';
 }
 
-type RailCollapsedState = {
-  collapsed: boolean;
-  setCollapsed: (value: boolean) => void;
-  toggle: () => void;
-};
+function persist(value: boolean): boolean {
+  localStorage.setItem(STORAGE_KEY, String(value));
+  return value;
+}
 
 export const useRailCollapsed = create<RailCollapsedState>((set) => ({
-  collapsed: readInitial(),
-  setCollapsed: (value) => {
-    localStorage.setItem(STORAGE_KEY, String(value));
-    set({ collapsed: value });
-  },
+  preference: readInitial(),
+  heldClosed: false,
+  setCollapsed: (value) =>
+    set({ preference: persist(value), heldClosed: false }),
   toggle: () =>
-    set((state) => {
-      const next = !state.collapsed;
-      localStorage.setItem(STORAGE_KEY, String(next));
-      return { collapsed: next };
-    }),
+    set((state) => ({
+      preference: persist(!railIsCollapsed(state)),
+      heldClosed: false,
+    })),
+  holdClosed: (value) => set({ heldClosed: value }),
 }));
+
+export function railIsCollapsed({
+  preference,
+  heldClosed,
+}: {
+  preference: boolean;
+  heldClosed: boolean;
+}): boolean {
+  return preference || heldClosed;
+}
+
+type RailCollapsedState = {
+  preference: boolean;
+  heldClosed: boolean;
+  setCollapsed: (value: boolean) => void;
+  toggle: () => void;
+  holdClosed: (value: boolean) => void;
+};


### PR DESCRIPTION
## Description

Two things you hit after deploying #15400.

**The configure panel had lost its spacing.** Every label sat directly on its field and every section ran into the next one, worst in Settings where twelve shapes and twelve colours had nothing separating them from the headings above and below.

The cause was mine, from the last PR: moving the tab bodies into `TabsContent` left the `flex flex-col gap-5` wrapper spacing the two *tab panels* instead of the fields inside them. A container with two children where there used to be a dozen, so the gap had nothing left to do. Each tab spaces its own fields now, 24px between fields and 8px from a label to its control, and:

- the shape and colour grids sit in bordered panels instead of floating against the next heading
- the project row does the same, so it reads as a value rather than loose text
- the delete section is separated by a rule with room above it
- the arbitrary `text-[13px]` / `leading-[155%]` / `gap-[9px]` are the type-scale tokens the web guide asks for, since `text-sm` **is** the 13px they were spelling out by hand

**Entering an agent now closes the rail.** The hook meant to do this in #15400 reached for the wrong sidebar: it toggled the hover panel inside the layout while the wide rail carrying Chat, MCP, Agents and Projects lives *outside* it with its own Zustand store. Verified in Chrome, which is the only reason I found it — it typechecked and tested green while doing nothing.

The rail can now be held closed by a route without touching the saved preference:

- leaving the agent gives the rail back exactly as you had it
- closing the tab while inside an agent does not leave it collapsed for ever, which a plain `setCollapsed(true)` would have, since that writes localStorage
- clicking it open while inside an agent still wins, because an explicit toggle clears the hold

The `pinned` field I added to the shared sidebar context along the way is gone with the hook that needed it.

## How was this tested?

In Chrome against the running app, which is what caught the sidebar bug in the first place: entered the agent and confirmed the rail collapses to icons, opened Configure and walked both tabs top to bottom. Screenshots of Behavior and Settings before and after are what drove the spacing values.

`packages/web`: 734 tests green, `tsc --noEmit` clean, lint clean.

Follows #15400.

Fixes # (issue)

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)
