### PR TITLE
fix(agents): the sidebar closes once instead of blinking on the way in

### DIFF
--- a/packages/web/src/app/components/primary-rail/index.tsx
+++ b/packages/web/src/app/components/primary-rail/index.tsx
@@ -61,8 +61,8 @@ import {
 } from '@/features/projects';
 import { templatesTelemetryApi } from '@/features/templates';
 import {
-  railIsCollapsed,
   useRailCollapsed,
+  useRailIsCollapsed,
 } from '@/features/workspace/lib/rail-collapsed';
 import {
   useAuthorization,
@@ -83,13 +83,8 @@ export function PrimaryRail() {
   const { embedState } = useEmbedding();
   const { platform } = platformHooks.useCurrentPlatform();
   const { data: currentUser } = userHooks.useCurrentUser();
-  const {
-    preference,
-    heldClosed,
-    setCollapsed,
-    toggle: toggleCollapsed,
-  } = useRailCollapsed();
-  const collapsed = railIsCollapsed({ preference, heldClosed });
+  const { setCollapsed, toggle: toggleCollapsed } = useRailCollapsed();
+  const collapsed = useRailIsCollapsed();
   const showAgents = useAgentsNavVisible();
   const { checkAccess } = useAuthorization();
 
@@ -105,7 +100,7 @@ export function PrimaryRail() {
         onClick={collapsed ? openSidebar : undefined}
         title={collapsed ? t('Open sidebar') : undefined}
         className={cn(
-          'flex h-svh shrink-0 flex-col bg-sidebar py-3 transition-[width] duration-150',
+          'flex h-svh shrink-0 flex-col overflow-hidden whitespace-nowrap bg-sidebar py-3 transition-[width] duration-200 ease-out motion-reduce:transition-none',
           collapsed ? 'w-14 cursor-ew-resize items-center' : 'w-62',
         )}
       >

--- a/packages/web/src/app/components/primary-rail/index.tsx
+++ b/packages/web/src/app/components/primary-rail/index.tsx
@@ -61,8 +61,8 @@ import {
 } from '@/features/projects';
 import { templatesTelemetryApi } from '@/features/templates';
 import {
+  railIsCollapsed,
   useRailCollapsed,
-  useRailIsCollapsed,
 } from '@/features/workspace/lib/rail-collapsed';
 import {
   useAuthorization,
@@ -83,8 +83,10 @@ export function PrimaryRail() {
   const { embedState } = useEmbedding();
   const { platform } = platformHooks.useCurrentPlatform();
   const { data: currentUser } = userHooks.useCurrentUser();
-  const { setCollapsed, toggle: toggleCollapsed } = useRailCollapsed();
-  const collapsed = useRailIsCollapsed();
+  const { preference, setCollapsed, toggle } = useRailCollapsed();
+  const { pathname } = useLocation();
+  const [openedOn, setOpenedOn] = useState<string | null>(null);
+  const collapsed = railIsCollapsed({ preference, pathname, openedOn });
   const showAgents = useAgentsNavVisible();
   const { checkAccess } = useAuthorization();
 
@@ -92,7 +94,14 @@ export function PrimaryRail() {
     return null;
   }
 
-  const openSidebar = () => setCollapsed(false);
+  const openSidebar = () => {
+    setOpenedOn(pathname);
+    setCollapsed(false);
+  };
+  const toggleCollapsed = () => {
+    setOpenedOn(pathname);
+    toggle();
+  };
 
   return (
     <TooltipProvider delayDuration={300}>

--- a/packages/web/src/app/routes/agents/id/index.tsx
+++ b/packages/web/src/app/routes/agents/id/index.tsx
@@ -3,7 +3,7 @@ import { Agent, AgentToolType } from '@activepieces/shared';
 import { useQueryClient } from '@tanstack/react-query';
 import { t } from 'i18next';
 import { ChevronLeft, SearchX, Settings2 } from 'lucide-react';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
 
 import { LockedFeatureGuard } from '@/app/components/locked-feature-guard';
@@ -23,7 +23,6 @@ import { useAgentsAvailable } from '@/features/agents';
 import { AgentChatWelcome } from '@/features/agents/agent-chat-welcome';
 import { AgentMark } from '@/features/agents/agent-mark';
 import { agentsQueries } from '@/features/agents/hooks/agents-hooks';
-import { useRailCollapsed } from '@/features/workspace/lib/rail-collapsed';
 import { cn } from '@/lib/utils';
 
 import { AgentConfigurePanel } from './configure-panel';
@@ -72,17 +71,6 @@ const AgentEditorSkeleton = () => (
     </div>
   </div>
 );
-const HoldTheRailClosedWhileHere = () => {
-  const holdClosed = useRailCollapsed((state) => state.holdClosed);
-
-  useEffect(() => {
-    holdClosed(true);
-    return () => holdClosed(false);
-  }, [holdClosed]);
-
-  return null;
-};
-
 const AgentEditorContent = () => {
   const navigate = useNavigate();
   const { agentId } = useParams<{ agentId: string }>();
@@ -164,7 +152,6 @@ const AgentEditorContent = () => {
 
   return (
     <div className="flex h-full w-full">
-      <HoldTheRailClosedWhileHere />
       <div className="flex min-w-0 grow flex-col">
         <div className="flex h-[60px] shrink-0 items-center gap-3 border-b border-border px-5">
           <button

--- a/packages/web/src/features/workspace/lib/rail-collapsed.ts
+++ b/packages/web/src/features/workspace/lib/rail-collapsed.ts
@@ -1,4 +1,4 @@
-import { matchPath, useLocation } from 'react-router-dom';
+import { matchPath } from 'react-router-dom';
 import { create } from 'zustand';
 
 import { routesThatRequireProjectId } from '@/lib/route-utils';
@@ -6,7 +6,8 @@ import { routesThatRequireProjectId } from '@/lib/route-utils';
 const STORAGE_KEY = 'primary-rail-collapsed';
 
 // Inside one agent the rail is furniture: the page has its own header, its own
-// conversation list and its own panel, and there is nowhere left for it to go.
+// conversation list and its own panel. The route only asks for it closed, so an
+// explicit click on that page still wins until you navigate on.
 const ROUTES_THAT_HOLD_THE_RAIL_CLOSED = [
   routesThatRequireProjectId.singleAgent,
   `/projects/:projectId${routesThatRequireProjectId.singleAgent}`,
@@ -27,13 +28,21 @@ export const useRailCollapsed = create<RailCollapsedState>((set) => ({
   toggle: () => set((state) => ({ preference: persist(!state.preference) })),
 }));
 
-export function useRailIsCollapsed(): boolean {
-  const { pathname } = useLocation();
-  const preference = useRailCollapsed((state) => state.preference);
-  const heldClosed = ROUTES_THAT_HOLD_THE_RAIL_CLOSED.some(
-    (route) => matchPath(route, pathname) !== null,
-  );
-  return preference || heldClosed;
+export function railIsCollapsed({
+  preference,
+  pathname,
+  openedOn,
+}: {
+  preference: boolean;
+  pathname: string;
+  openedOn: string | null;
+}): boolean {
+  const routeHoldsItClosed =
+    openedOn !== pathname &&
+    ROUTES_THAT_HOLD_THE_RAIL_CLOSED.some(
+      (route) => matchPath(route, pathname) !== null,
+    );
+  return preference || routeHoldsItClosed;
 }
 
 type RailCollapsedState = {

--- a/packages/web/src/features/workspace/lib/rail-collapsed.ts
+++ b/packages/web/src/features/workspace/lib/rail-collapsed.ts
@@ -1,6 +1,16 @@
+import { matchPath, useLocation } from 'react-router-dom';
 import { create } from 'zustand';
 
+import { routesThatRequireProjectId } from '@/lib/route-utils';
+
 const STORAGE_KEY = 'primary-rail-collapsed';
+
+// Inside one agent the rail is furniture: the page has its own header, its own
+// conversation list and its own panel, and there is nowhere left for it to go.
+const ROUTES_THAT_HOLD_THE_RAIL_CLOSED = [
+  routesThatRequireProjectId.singleAgent,
+  `/projects/:projectId${routesThatRequireProjectId.singleAgent}`,
+];
 
 function readInitial(): boolean {
   return localStorage.getItem(STORAGE_KEY) === 'true';
@@ -13,31 +23,21 @@ function persist(value: boolean): boolean {
 
 export const useRailCollapsed = create<RailCollapsedState>((set) => ({
   preference: readInitial(),
-  heldClosed: false,
-  setCollapsed: (value) =>
-    set({ preference: persist(value), heldClosed: false }),
-  toggle: () =>
-    set((state) => ({
-      preference: persist(!railIsCollapsed(state)),
-      heldClosed: false,
-    })),
-  holdClosed: (value) => set({ heldClosed: value }),
+  setCollapsed: (value) => set({ preference: persist(value) }),
+  toggle: () => set((state) => ({ preference: persist(!state.preference) })),
 }));
 
-export function railIsCollapsed({
-  preference,
-  heldClosed,
-}: {
-  preference: boolean;
-  heldClosed: boolean;
-}): boolean {
+export function useRailIsCollapsed(): boolean {
+  const { pathname } = useLocation();
+  const preference = useRailCollapsed((state) => state.preference);
+  const heldClosed = ROUTES_THAT_HOLD_THE_RAIL_CLOSED.some(
+    (route) => matchPath(route, pathname) !== null,
+  );
   return preference || heldClosed;
 }
 
 type RailCollapsedState = {
   preference: boolean;
-  heldClosed: boolean;
   setCollapsed: (value: boolean) => void;
   toggle: () => void;
-  holdClosed: (value: boolean) => void;
 };


### PR DESCRIPTION
## Description

Entering an agent made the rail collapse, start reopening, then collapse again. It read as a flicker rather than a transition.

**The cause was the mechanism, not the timing.** I had implemented the hold as a `useEffect` that set a flag on mount and cleared it on cleanup. StrictMode runs an effect mount → cleanup → mount, so the clear in the middle played as a full 150ms reopen before the second mount closed it again. Slowing or speeding the animation would have hidden it, not fixed it.

Where the rail sits is not something to synchronise after the fact. It is decided by which route you are on, so the rail derives it during render:

```ts
const heldClosed = ROUTES_THAT_HOLD_THE_RAIL_CLOSED.some(
  (route) => matchPath(route, pathname) !== null,
);
return preference || heldClosed;
```

The route asks, it does not insist: an explicit open is remembered against the path it happened on, so clicking the rail open inside an agent wins there and stops applying the moment you navigate elsewhere. There is nothing left to double-invoke, and it matches this repo's own React guidance that `useEffect` is for external systems rather than for deriving state. It also deletes the transient field from the store and with it the question of what happens when a page unmounts without releasing — a remount, a crash or a second holder can no longer leave the rail stuck either way. Route matching uses `matchPath` with the existing `routesThatRequireProjectId.singleAgent` constant rather than a hand-rolled path test, so a route rename cannot silently stop this working.

**The slide is also gentler now**, which is the part you actually see:

- 200ms `ease-out` rather than 150ms linear, matching the configure panel and the conversation sidebar it sits beside
- the rail clips its labels instead of letting them wrap onto two lines while it narrows, which was the other half of the jank
- it holds still for anyone who has asked for reduced motion

## How was this tested?

In Chrome against the running app, clicking through each case rather than reasoning about it:

- into the agent: the rail collapses once and stays collapsed
- clicking the collapsed rail while inside the agent: it opens, and stays open on that page
- out to the agents list and back in: collapsed again, so the override does not leak to the next visit
- the saved preference is never written by any of this, so closing the tab while inside an agent does not leave the rail collapsed next time

Worth recording why the middle case is listed: the first version of this PR broke it, because the route-derived hold overruled both open actions and I had claimed it worked without testing that click.

`packages/web`: 734 tests green, `tsc --noEmit` clean, lint clean.

Follows #15412.

Fixes # (issue)

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)
