### PR TITLE
feat(linear): filter Updated Issue trigger by changed fields

### DIFF
--- a/packages/pieces/community/linear/package.json
+++ b/packages/pieces/community/linear/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-linear",
-  "version": "0.5.2",
+  "version": "0.6.0",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "dependencies": {

--- a/packages/pieces/community/linear/src/i18n/translation.json
+++ b/packages/pieces/community/linear/src/i18n/translation.json
@@ -66,5 +66,11 @@
   "Authors": "Authors",
   "Filter by teams": "Filter by teams",
   "Filter by authors": "Filter by authors",
-  "Filter by project status (leave empty to include all)": "Filter by project status (leave empty to include all)"
+  "Filter by project status (leave empty to include all)": "Filter by project status (leave empty to include all)",
+  "Estimate": "Estimate",
+  "Due date": "Due date",
+  "Cycle": "Cycle",
+  "Parent": "Parent",
+  "Only when these fields change": "Only when these fields change",
+  "Trigger only when at least one of the selected fields changed. Leave empty to trigger on every update.": "Trigger only when at least one of the selected fields changed. Leave empty to trigger on every update."
 }

--- a/packages/pieces/community/linear/src/lib/triggers/updated-issue.test.ts
+++ b/packages/pieces/community/linear/src/lib/triggers/updated-issue.test.ts
@@ -1,0 +1,82 @@
+/// <reference types="vitest/globals" />
+
+import { vi } from 'vitest';
+
+vi.mock('@linear/sdk', () => ({
+  LinearClient: class {},
+  LinearDocument: {},
+}));
+
+import '../../index';
+import { linearUpdatedIssue } from './updated-issue';
+
+const buildContext = (body: unknown, changed_fields?: string[]) =>
+  ({
+    payload: {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body,
+      queryParams: {},
+    },
+    propsValue: { changed_fields },
+  } as never);
+
+const updateBody = (updatedFrom: Record<string, unknown>) => ({
+  action: 'update',
+  data: { id: 'issue_1' },
+  updatedFrom,
+});
+
+describe('linear updated-issue run()', () => {
+  test('no filter selected returns every update', async () => {
+    const body = updateBody({ updatedAt: 'x', sortOrder: 1 });
+
+    expect(await linearUpdatedIssue.run(buildContext(body))).toEqual([body]);
+    expect(await linearUpdatedIssue.run(buildContext(body, []))).toEqual([body]);
+  });
+
+  test('non-update actions are always dropped', async () => {
+    expect(
+      await linearUpdatedIssue.run(buildContext({ action: 'create' }))
+    ).toEqual([]);
+    expect(
+      await linearUpdatedIssue.run(
+        buildContext({ action: 'remove' }, ['stateId'])
+      )
+    ).toEqual([]);
+  });
+
+  test('keeps the event when a selected field is in updatedFrom', async () => {
+    const body = updateBody({ updatedAt: 'x', stateId: 'state_1' });
+
+    expect(
+      await linearUpdatedIssue.run(buildContext(body, ['stateId']))
+    ).toEqual([body]);
+  });
+
+  test('drops the event when only noise fields changed', async () => {
+    const body = updateBody({ updatedAt: 'x', sortOrder: 1 });
+
+    expect(
+      await linearUpdatedIssue.run(buildContext(body, ['stateId', 'assigneeId']))
+    ).toEqual([]);
+  });
+
+  test('drops the event when updatedFrom is missing entirely', async () => {
+    expect(
+      await linearUpdatedIssue.run(
+        buildContext({ action: 'update', data: {} }, ['stateId'])
+      )
+    ).toEqual([]);
+  });
+
+  test('matches on any one of several selected fields', async () => {
+    const body = updateBody({ updatedAt: 'x', priority: 2 });
+
+    expect(
+      await linearUpdatedIssue.run(
+        buildContext(body, ['stateId', 'assigneeId', 'priority'])
+      )
+    ).toEqual([body]);
+  });
+});

--- a/packages/pieces/community/linear/src/lib/triggers/updated-issue.ts
+++ b/packages/pieces/community/linear/src/lib/triggers/updated-issue.ts
@@ -1,4 +1,8 @@
-import { createTrigger, TriggerStrategy } from '@activepieces/pieces-framework';
+import {
+  createTrigger,
+  Property,
+  TriggerStrategy,
+} from '@activepieces/pieces-framework';
 import { linearAuth } from '../..';
 import { makeClient } from '../common/client';
 import { props } from '../common/props';
@@ -15,6 +19,27 @@ export const linearUpdatedIssue = createTrigger({
   },
   props: {
     team_id: props.team_id(false),
+    changed_fields: Property.StaticMultiSelectDropdown({
+      displayName: 'Only when these fields change',
+      description:
+        'Trigger only when at least one of the selected fields changed. Leave empty to trigger on every update.',
+      required: false,
+      options: {
+        options: [
+          { label: 'Status', value: 'stateId' },
+          { label: 'Assignee', value: 'assigneeId' },
+          { label: 'Priority', value: 'priority' },
+          { label: 'Title', value: 'title' },
+          { label: 'Description', value: 'description' },
+          { label: 'Labels', value: 'labelIds' },
+          { label: 'Estimate', value: 'estimate' },
+          { label: 'Due date', value: 'dueDate' },
+          { label: 'Project', value: 'projectId' },
+          { label: 'Cycle', value: 'cycleId' },
+          { label: 'Parent', value: 'parentId' },
+        ],
+      },
+    }),
   },
   sampleData: {
     // Sample data structure based on Linear's webhook payload for issues
@@ -124,11 +149,22 @@ export const linearUpdatedIssue = createTrigger({
     }
   },
   async run(context) {
-    const body = context.payload.body as { action: string; data: unknown };
-    if (body.action === 'update') {
-      return [body];
+    const body = context.payload.body as {
+      action: string;
+      data: unknown;
+      updatedFrom?: Record<string, unknown>;
+    };
+    if (body.action !== 'update') {
+      return [];
     }
-    return [];
+    const selected = context.propsValue.changed_fields ?? [];
+    if (selected.length > 0) {
+      const changed = Object.keys(body.updatedFrom ?? {});
+      if (!selected.some((field) => changed.includes(field))) {
+        return [];
+      }
+    }
+    return [body];
   },
 });
 


### PR DESCRIPTION
## Description

The Linear **Updated Issue** trigger is `TriggerStrategy.WEBHOOK`, and Linear's "Issue" webhook fires on **every** field change (and, when no team is set, over `allPublicTeams` — the whole workspace). This makes a flow on that trigger run on any edit, most of them irrelevant (`updatedFrom` is often just `updatedAt`/`sortOrder`).

This adds an optional **"Only when these fields change"** multi-select to the trigger. When one or more fields are selected, `run()` keeps the event only if at least one of them appears in Linear's `updatedFrom`; otherwise it returns `[]` and no flow run is created. Leaving it empty preserves today's behaviour (fires on every update), so existing flows are unaffected until a user opts in.

Selectable fields: Status, Assignee, Priority, Title, Description, Labels, Estimate, Due date, Project, Cycle, Parent. Noise keys (`updatedAt`, `sortOrder`) are deliberately not offered.

Follows the existing `updatedFrom` filter precedent in `updated-project.ts`.

## How was this tested?

- `npx turbo run lint --filter=@activepieces/piece-linear` — passes (0 errors).
- Unit check of the `run()` filter logic: noise-only change with a Status filter → dropped; Status change with a Status filter → kept; empty selection → always kept on update; non-update action → dropped.
- Piece-only change; no server/edition-specific paths touched.

Closes GIT-1874

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
