### PR TITLE
chore(brain): add context page, fill the spine, swap to brain plugin

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -7,7 +7,7 @@
   "enabledPlugins": {
     "frontend-design@claude-plugins-official": true,
     "ponytail@ponytail": true,
-    "craftspace@craftspace": true
+    "brain@brain": true
   },
   "extraKnownMarketplaces": {
     "ponytail": {
@@ -17,10 +17,10 @@
         "ref": "v4.8.4"
       }
     },
-    "craftspace": {
+    "brain": {
       "source": {
         "source": "github",
-        "repo": "abuaboud/craftspace-plugin"
+        "repo": "abuaboud/brain-plugin"
       }
     }
   },

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ pieces-cache-db-*.sqlite
 .claude/launch.json
 CONTEXT.md
 !.agents/contexts/**/CONTEXT.md
+!brain/knowledge/context.md
 packages/server/worker/test/lib/chat-eval/live/results/
 
 # compiled output

--- a/brain/knowledge/context.md
+++ b/brain/knowledge/context.md
@@ -1,0 +1,70 @@
+# Context
+
+Activepieces is an open-source, AI-first workflow automation platform — an extensible replacement for Zapier — run either as self-hosted software or as our Cloud. It is built for the people automating their own work (technical and not) and for the platforms that white-label and embed it.
+
+## Vocabulary
+
+**Piece** — an integration package (`@activepieces/piece-*`) declaring its auth plus a set of actions and triggers. It is both an npm-shaped bundle the engine installs and a `piece_metadata` row the catalog serves.
+
+**Flow** — a versioned directed graph of one trigger and its actions, stored as JSONB. Every one of the 26 ways to modify it goes through the single `POST /v1/flows/:id` endpoint.
+
+**Flow Version** — a snapshot of a flow's graph. `DRAFT` is the editable copy edits land on; `LOCKED` is immutable and is what published runs execute.
+
+**Trigger** — the definition of how a flow starts, realised as a `TriggerSource` row. Four strategies: POLLING, WEBHOOK, APP_WEBHOOK, MANUAL.
+
+**Action Run** — a single piece action or code step executed on its own, synchronously, outside any flow. The unit behind MCP `ap_run_action` and the chat tools.
+
+**Connection** — an encrypted credential record (AES-256) a step uses to call an external service, in one of eight auth shapes (`OAUTH2`, `SECRET_TEXT`, `CUSTOM_AUTH`, …). Scoped `PROJECT` or `PLATFORM`, and referenced from flows by a stable `externalId`.
+_Avoid_: "app connection" in prose — that is the entity name, not the word we speak.
+
+**Platform** — the top-level tenant namespace: branding, auth config, plan, and the projects under it. Every install has at least one.
+
+**Project** — the workspace inside a platform that owns flows, connections and tables. `PERSONAL` (auto-created per user) or `TEAM`.
+
+**Edition** — which build of the product is running, set by `AP_EDITION`: `ce` (Community), `ee` (self-hosted Enterprise), `cloud`. EE extends CE by injecting hooks, never by CE importing EE.
+
+**Engine** — the bundled runtime that actually executes a flow or a step. It runs as a child process inside the sandbox and posts its own run-time callbacks straight to the app over HTTP.
+
+**Worker** — the container that polls jobs off the queue, resolves them, and runs them. It is both the deployment unit and the execution unit, and it holds the only `apiClient`.
+
+**Sandbox** — the in-process execution box the worker hands a fully-resolved job to. It materializes inputs to disk, runs exactly one engine operation, and returns the result; it has no connection back to the app.
+_Avoid_: "pool" — the old sandbox-pool server is gone; parallelism at the destination is worker replicas.
+
+**Resolver** — the worker-side step that turns a queued job into materialized box inputs: it resolves the flow version and piece metadata and hands back a ready **Flow Bundle**. It always runs before execution, so the sandbox only ever sees complete, compiled inputs.
+
+**Flow Bundle** — the per-locked-flow-version artifact in S3/DB: a frozen manifest of piece versions plus the compiled code. The sandbox only ever consumes one that is already built.
+
+**Piece Bundle** — the installable `.tgz` for one `name@version`, addressed as a link and resolved lazily in source order (own S3 bucket → Activepieces CDN → npm).
+
+**Piece Set** — a named, reusable piece/action/trigger visibility configuration a platform admin assigns to projects. Visibility is derived at read time, so a newly installed piece needs no backfill.
+
+**Agent** — a flow step that runs an autonomous LLM loop instead of a single call, over tools that are handles to Pieces, Flows, MCP servers, or a Knowledge Base.
+
+**AI Credits** — the metered currency for AI usage, 1000 credits = $1. A quota, not a wallet.
+_Avoid_: "tokens" for the billing unit — tokens are the model's unit, credits are ours.
+
+**MCP Server** — the per-project endpoint that exposes Activepieces tools to an outside AI assistant. Distinct from a piece that *calls* somebody else's MCP server.
+
+**Formula** — a user-authored data transform written in a builder text input via the `/` editor, saved inline as `ap-formula-v1::{…}::ap-formula-v1` so it round-trips through flow JSON. Evaluated synchronously in the engine, on every edition.
+
+## Key files
+
+- `packages/server/api/src/app/` — the Fastify app: every module, controller and service. Entry point: `app.ts`, which holds the edition switch.
+- `packages/server/api/src/app/ee/` — every commercial module, registered only for `ee`/`cloud`. CE reaches it only through `hooksFactory` (`app/helper/hooks-factory.ts`).
+- `packages/server/api/src/app/database/` — TypeORM wiring and migrations. Entry point: `getEntities()` in `database-connection.ts`.
+- `packages/server/worker/` — the poll loop, worker groups and job dispatch. Entry point: `worker` in `src/lib/worker.ts`.
+- `packages/server/sandbox/` — resolution, caching and the execution box. Entry points: `createResolver()` and `createSandboxRuntime()`.
+- `packages/server/engine/` — the runtime that executes steps; one file per operation under `src/lib/operations/`.
+- `packages/pieces/framework/` — the type-safe piece SDK. Entry points: `createPiece()`, `createAction()`, `createTrigger()`.
+- `packages/pieces/community/` — the ~730 third-party integrations. `packages/pieces/core/` holds the first-party ones (http, forms, tables, subflows, schedule…).
+- `packages/core/shared/` — `@activepieces/shared`: DB/EE schemas and the shared helpers. Thin, bundleable siblings live in `packages/core/{utils,piece-types,formula,execution}` — pieces and the engine may import those, never `shared`.
+- `packages/web/src/features/` — the React app, one folder per feature; the builder canvas lives here.
+
+## Gotchas
+
+- **A new entity is invisible until you register it.** TypeORM does not auto-discover: add it to `getEntities()` in `packages/server/api/src/app/database/database-connection.ts` or it silently does not exist at runtime.
+- **CE code must never import `src/app/ee/`.** CE declares a hook interface via `hooksFactory.create<T>(ceDefault)` and EE calls `.set(eeImpl)` in the `app.ts` edition switch. An import across that seam builds fine and breaks the Community build.
+- **Connection queries filter on the `projectIds[]` array, not a scalar `projectId`.** Use `ArrayContains([projectId])` (or `scope = PLATFORM` for shared ones). A scalar filter compiles and quietly returns nothing.
+- **Deleting a connection does not cascade to the flows using it.** They keep their reference and fail at runtime instead of at delete time.
+- **A wrong Flow Bundle is sticky forever.** The manifest is only invalidated on a schema-version change, so a bundle published by buggy worker code keeps being served for that locked flow version and fixing the resolver does not heal it — delete the `FLOW_BUNDLE` file row plus its S3 object, or republish the flow. See decision 000005.
+- **Nothing typechecks the engine.** `@activepieces/engine` builds with esbuild (types stripped) and lints with eslint only — there is no `tsc --noEmit` in CI, so type errors ship. Run tsc yourself and diff the error list against `main`; a green run is not the baseline.

--- a/brain/knowledge/index.md
+++ b/brain/knowledge/index.md
@@ -12,11 +12,19 @@ as Decisions, not here.
 
 ## Areas
 
-Add one folder per Area that fits what this project actually holds — an engineering project grows different
-ones than a sales project does. `decisions/` is the only one every repo starts with. Replace these examples
-with your own and keep the shape: **bold name**, then the one line that says what a reader will find there.
+One line per Area, pointing at the page that holds it. Start at **context** if you are new here.
 
-- **Example Area** — what this Area covers, and the one gotcha that bites people in it
+- **[context](context.md)** — the vocabulary, where things live, and the traps. The two-minute entry page.
+- **[flows-execution](flows-execution/index.md)** — how flows are authored, triggered, executed and organised
+- **[pieces-engine](pieces-engine/index.md)** — the piece catalog, visibility, formulas and how the engine runs a step
+- **[execution-runtime](execution-runtime/index.md)** — where a job runs: the worker is the sandbox, concurrency 1 plus replicas
+- **[connections-auth](connections-auth/index.md)** — credential storage and user auth. Connections filter on `projectIds[]`, never a scalar
+- **[platform-editions-ee](platform-editions-ee/index.md)** — Platform → Project tenancy, and the CE/EE seam CE must never import across
+- **[ai-intelligence](ai-intelligence/index.md)** — model backends, AI credit metering, and the Agent, MCP and copilot surfaces
+- **[eventing-webhooks](eventing-webhooks/index.md)** — HTTP in and out, plus the internal bus carrying domain events
+- **[data-storage-observability](data-storage-observability/index.md)** — tables, secrets, files, and how platform activity surfaces
+- **[engineering](engineering/index.md)** — the engineering brain: how the system works and why it was built that way
+- **[decisions](decisions/)** — every hard-to-reverse call, one file per decision
 
 ## How a page is shaped
 


### PR DESCRIPTION
## What

Four changes to `brain/` and the config around it.

**`brain/knowledge/context.md` — new.** The brain has 118 files and no entry page. This is the two-minute read a new person (or agent) gets first: 19 terms this repo uses in its own particular way, the key directories with their entry-point symbols, and six gotchas. Every path was `ls`/`grep`-verified, and every gotcha traces to an Area page, a code comment or a decision record — nothing inferred.

**`brain/knowledge/index.md` — the spine was never filled in.** It still carried the scaffold's `**Example Area**` placeholder while nine real Areas sat in the folder beside it. Now one line per Area, pointing at the page that holds it.

**`.gitignore` — a real trap, worth reading even if you skip the rest.** Line 17 is an unanchored `CONTEXT.md`, so it matches at any depth. On a case-insensitive filesystem (macOS default) that also matches `brain/knowledge/context.md`, and the new page was silently invisible to git — `git add -A` reported nothing, no warning. Negated it the same way `.agents/contexts/**/CONTEXT.md` already is.

**`.claude/settings.json` — `craftspace@craftspace` → `brain@brain`.** Both plugins ship a SessionStart hook, a Stop nudge and a grill-me skill, so running both means two sets of injected rules and two nudges for the same job. The brain plugin is local files only: no server, no account, no network call.

## One thing to decide before merging

The brain plugin currently tells agents to record decisions in `brain/knowledge/ADR.md` (single file, newest first). This repo keeps `brain/knowledge/decisions/` — 118 files, one per decision. Nothing breaks on merge, but a future session following the plugin's rules would start a second, parallel decision store beside the existing one.

Two ways to close it, both cheap, and it's a preference call rather than a correctness one:
- Teach the plugin the `decisions/` folder shape, which is what this repo already proved out at scale; or
- keep the plugin as-is and let `ADR.md` be an index that points at `decisions/`.

Happy to do either as a follow-up.

## Test plan

- [x] `git check-ignore` confirms `brain/knowledge/context.md` is no longer ignored, and it appears in the diff
- [x] Every path named in `## Key files` verified to exist
- [x] No names, emails, handles, customer identifiers, credentials or absolute paths in any added file
- [ ] Confirm the plugin swap is what you want (see above)

Docs and config only — no code, no runtime change.

https://claude.ai/code/session_01WLPX4bsbivkZZBpJhwSLoF