### PR TITLE
fix(flows): renaming a step no longer marks it as needing a re-test

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -118,7 +118,7 @@
     },
     "packages/core/execution": {
       "name": "@activepieces/core-execution",
-      "version": "0.20.0",
+      "version": "0.21.0",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -163,7 +163,7 @@
     },
     "packages/core/shared": {
       "name": "@activepieces/shared",
-      "version": "0.162.0",
+      "version": "0.165.0",
       "dependencies": {
         "@activepieces/core-execution": "workspace:*",
         "@activepieces/core-formula": "workspace:*",
@@ -214,7 +214,7 @@
     },
     "packages/pieces/common": {
       "name": "@activepieces/pieces-common",
-      "version": "0.13.2",
+      "version": "0.13.3",
       "dependencies": {
         "@activepieces/core-utils": "workspace:*",
         "@activepieces/pieces-framework": "workspace:*",
@@ -7857,6 +7857,16 @@
         "tslib": "2.6.2",
       },
     },
+    "packages/pieces/community/sage-accounting": {
+      "name": "@activepieces/piece-sage-accounting",
+      "version": "0.0.1",
+      "dependencies": {
+        "@activepieces/pieces-common": "workspace:*",
+        "@activepieces/pieces-framework": "workspace:*",
+        "@activepieces/shared": "workspace:*",
+        "tslib": "2.6.2",
+      },
+    },
     "packages/pieces/community/saleor": {
       "name": "@activepieces/piece-saleor",
       "version": "0.1.6",
@@ -10418,7 +10428,7 @@
     },
     "packages/pieces/core/http": {
       "name": "@activepieces/piece-http",
-      "version": "0.11.21",
+      "version": "0.11.22",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -12286,6 +12296,8 @@
     "@activepieces/piece-runway": ["@activepieces/piece-runway@workspace:packages/pieces/community/runway"],
 
     "@activepieces/piece-saastic": ["@activepieces/piece-saastic@workspace:packages/pieces/community/saastic"],
+
+    "@activepieces/piece-sage-accounting": ["@activepieces/piece-sage-accounting@workspace:packages/pieces/community/sage-accounting"],
 
     "@activepieces/piece-saleor": ["@activepieces/piece-saleor@workspace:packages/pieces/community/saleor"],
 

--- a/packages/core/execution/package.json
+++ b/packages/core/execution/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/core-execution",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "scripts": {

--- a/packages/core/execution/src/lib/flows/operations/update-action.ts
+++ b/packages/core/execution/src/lib/flows/operations/update-action.ts
@@ -4,6 +4,7 @@ import { FlowAction, FlowActionType, SingleActionSchema } from '../actions/actio
 import { FlowVersion } from '../flow-version'
 import { flowStructureUtil } from '../util/flow-structure-util'
 import { UpdateActionRequest } from './index'
+import { updateStepUtil } from './update-step-util'
 
 function _updateAction(flowVersion: FlowVersion, request: UpdateActionRequest): FlowVersion {
     const next = flowStructureUtil.transferFlow(flowVersion, (stepToUpdate) => {
@@ -79,7 +80,7 @@ function _updateAction(flowVersion: FlowVersion, request: UpdateActionRequest): 
         const parseResult = SingleActionSchema.safeParse(updatedAction)
         const valid = (isNil(request.valid) ? true : request.valid) && parseResult.success
         return {
-            ...updatedAction,
+            ...updateStepUtil.preserveLastUpdatedDate({ existingStep: stepToUpdate, updatedStep: updatedAction }),
             valid,
         }
     })

--- a/packages/core/execution/src/lib/flows/operations/update-step-util.ts
+++ b/packages/core/execution/src/lib/flows/operations/update-step-util.ts
@@ -1,0 +1,70 @@
+import { FlowAction } from '../actions/action'
+import { FlowTrigger } from '../triggers/trigger'
+
+function prune(value: unknown): unknown {
+    if (Array.isArray(value)) {
+        return value.map(prune)
+    }
+    if (typeof value === 'object' && value !== null) {
+        const prunedEntries = Object.entries(value)
+            .map(([key, entryValue]) => [key, prune(entryValue)] as const)
+            .filter(([, entryValue]) => entryValue !== undefined)
+        if (prunedEntries.length === 0) {
+            return undefined
+        }
+        return Object.fromEntries(prunedEntries)
+    }
+    return value
+}
+
+function deepEquals({ a, b }: DeepEqualsParams): boolean {
+    if (a === b) {
+        return true
+    }
+    if (typeof a !== 'object' || typeof b !== 'object' || a === null || b === null) {
+        return false
+    }
+    if (Array.isArray(a) || Array.isArray(b)) {
+        return Array.isArray(a) && Array.isArray(b) && a.length === b.length && a.every((item, index) => deepEquals({ a: item, b: b[index] }))
+    }
+    const aRecord: Record<string, unknown> = { ...a }
+    const bRecord: Record<string, unknown> = { ...b }
+    const aKeys = Object.keys(aRecord)
+    const bKeys = Object.keys(bRecord)
+    return aKeys.length === bKeys.length && aKeys.every((key) => deepEquals({ a: aRecord[key], b: bRecord[key] }))
+}
+
+function contentOf(step: FlowAction | FlowTrigger): unknown {
+    const settings: Record<string, unknown> = { ...(step.settings ?? {}) }
+    delete settings['sampleData']
+    delete settings['customLogoUrl']
+    return prune({
+        type: step.type,
+        settings,
+    })
+}
+
+function preserveLastUpdatedDate<T extends FlowAction | FlowTrigger>({ existingStep, updatedStep }: PreserveLastUpdatedDateParams<T>): T {
+    const contentChanged = !deepEquals({ a: contentOf(existingStep), b: contentOf(updatedStep) })
+    if (contentChanged) {
+        return updatedStep
+    }
+    return {
+        ...updatedStep,
+        lastUpdatedDate: existingStep.lastUpdatedDate,
+    }
+}
+
+export const updateStepUtil = {
+    preserveLastUpdatedDate,
+}
+
+type DeepEqualsParams = {
+    a: unknown
+    b: unknown
+}
+
+type PreserveLastUpdatedDateParams<T extends FlowAction | FlowTrigger> = {
+    existingStep: FlowAction | FlowTrigger
+    updatedStep: T
+}

--- a/packages/core/execution/src/lib/flows/operations/update-step-util.ts
+++ b/packages/core/execution/src/lib/flows/operations/update-step-util.ts
@@ -34,14 +34,17 @@ function deepEquals({ a, b }: DeepEqualsParams): boolean {
     return aKeys.length === bKeys.length && aKeys.every((key) => deepEquals({ a: aRecord[key], b: bRecord[key] }))
 }
 
-function contentOf(step: FlowAction | FlowTrigger): unknown {
+function contentOf(step: FlowAction | FlowTrigger): Record<string, unknown> {
     const settings: Record<string, unknown> = { ...(step.settings ?? {}) }
+    const input = settings['input']
+    delete settings['input']
     delete settings['sampleData']
     delete settings['customLogoUrl']
-    return prune({
+    return {
         type: step.type,
-        settings,
-    })
+        input: input ?? {},
+        optionSettings: prune(settings),
+    }
 }
 
 function preserveLastUpdatedDate<T extends FlowAction | FlowTrigger>({ existingStep, updatedStep }: PreserveLastUpdatedDateParams<T>): T {

--- a/packages/core/execution/src/lib/flows/operations/update-trigger.ts
+++ b/packages/core/execution/src/lib/flows/operations/update-trigger.ts
@@ -6,6 +6,7 @@ import { SampleDataSettings } from '../sample-data'
 import { FlowTrigger, FlowTriggerType } from '../triggers/trigger'
 import { flowStructureUtil } from '../util/flow-structure-util'
 import { UpdateTriggerRequest } from '.'
+import { updateStepUtil } from './update-step-util'
 
 
 function createTrigger(name: string, request: UpdateTriggerRequest, nextAction: FlowAction | undefined, existingSampleData: SampleDataSettings | undefined): FlowTrigger {
@@ -45,9 +46,10 @@ function _updateTrigger(flowVersion: FlowVersion, request: UpdateTriggerRequest)
     const trigger = flowStructureUtil.getStepOrThrow(request.name, flowVersion.trigger)
     const existingSampleData = trigger.type === FlowTriggerType.PIECE ? trigger.settings.sampleData : undefined
     const updatedTrigger = createTrigger(request.name, request, trigger.nextAction, existingSampleData)
+    const finalTrigger = updateStepUtil.preserveLastUpdatedDate({ existingStep: trigger, updatedStep: updatedTrigger })
     const next = flowStructureUtil.transferFlow(flowVersion, (parentStep) => {
         if (parentStep.name === request.name) {
-            return updatedTrigger
+            return finalTrigger
         }
         return parentStep
     })

--- a/packages/core/execution/test/flow/update-step-rename.test.ts
+++ b/packages/core/execution/test/flow/update-step-rename.test.ts
@@ -9,6 +9,8 @@ import {
     PieceAction,
     PieceTrigger,
     PropertyExecutionType,
+    UpdateActionRequest,
+    UpdateTriggerRequest,
 } from '../../src'
 
 const TRIGGER_LAST_UPDATED = '2026-01-01T00:00:00.000Z'
@@ -39,18 +41,9 @@ function createFlowVersion(): FlowVersion {
                 pieceName: 'schedule',
                 pieceVersion: '0.0.2',
                 triggerName: 'cron_expression',
-                input: {
-                    cronExpression: '25 10 * * 0,1,2,3,4',
-                },
-                propertySettings: {
-                    cronExpression: {
-                        type: PropertyExecutionType.MANUAL,
-                    },
-                },
-                sampleData: {
-                    sampleDataFileId: TRIGGER_SAMPLE_FILE_ID,
-                    lastTestDate: '2026-01-03T00:00:00.000Z',
-                },
+                input: { cronExpression: '25 10 * * 0,1,2,3,4' },
+                propertySettings: { cronExpression: { type: PropertyExecutionType.MANUAL } },
+                sampleData: { sampleDataFileId: TRIGGER_SAMPLE_FILE_ID, lastTestDate: '2026-01-03T00:00:00.000Z' },
             },
             nextAction: {
                 name: 'step_1',
@@ -62,18 +55,9 @@ function createFlowVersion(): FlowVersion {
                     pieceName: 'store',
                     pieceVersion: '0.2.6',
                     actionName: 'get',
-                    input: {
-                        key: '1',
-                    },
-                    propertySettings: {
-                        key: {
-                            type: PropertyExecutionType.MANUAL,
-                        },
-                    },
-                    sampleData: {
-                        sampleDataFileId: ACTION_SAMPLE_FILE_ID,
-                        lastTestDate: '2026-01-03T00:00:00.000Z',
-                    },
+                    input: { key: '1' },
+                    propertySettings: { key: { type: PropertyExecutionType.MANUAL } },
+                    sampleData: { sampleDataFileId: ACTION_SAMPLE_FILE_ID, lastTestDate: '2026-01-03T00:00:00.000Z' },
                 },
             },
         },
@@ -95,21 +79,41 @@ function getTrigger(flowVersion: FlowVersion): PieceTrigger {
     return flowVersion.trigger
 }
 
+function applyActionUpdate(flowVersion: FlowVersion, overrides: Partial<UpdateActionRequest>): PieceAction {
+    const action = getAction(flowVersion)
+    const result = flowOperations.apply(flowVersion, {
+        type: FlowOperationType.UPDATE_ACTION,
+        request: {
+            type: FlowActionType.PIECE,
+            name: action.name,
+            displayName: action.displayName,
+            valid: action.valid,
+            settings: action.settings,
+            ...overrides,
+        },
+    })
+    return getAction(result)
+}
+
+function applyTriggerUpdate(flowVersion: FlowVersion, overrides: Partial<UpdateTriggerRequest>): PieceTrigger {
+    const trigger = getTrigger(flowVersion)
+    const result = flowOperations.apply(flowVersion, {
+        type: FlowOperationType.UPDATE_TRIGGER,
+        request: {
+            type: FlowTriggerType.PIECE,
+            name: trigger.name,
+            displayName: trigger.displayName,
+            valid: trigger.valid,
+            settings: trigger.settings,
+            ...overrides,
+        },
+    })
+    return getTrigger(result)
+}
+
 describe('rename-only updates keep the tested status (GIT-1873)', () => {
     it('CLAIM 1: UPDATE_ACTION changing only displayName keeps lastUpdatedDate and sample data', () => {
-        const flowVersion = createFlowVersion()
-        const action = getAction(flowVersion)
-        const result = flowOperations.apply(flowVersion, {
-            type: FlowOperationType.UPDATE_ACTION,
-            request: {
-                type: FlowActionType.PIECE,
-                name: action.name,
-                displayName: 'Get Renamed',
-                valid: action.valid,
-                settings: action.settings,
-            },
-        })
-        const updated = getAction(result)
+        const updated = applyActionUpdate(createFlowVersion(), { displayName: 'Get Renamed' })
         expect(updated.displayName).toBe('Get Renamed')
         expect(updated.lastUpdatedDate).toBe(ACTION_LAST_UPDATED)
         expect(updated.settings.sampleData?.sampleDataFileId).toBe(ACTION_SAMPLE_FILE_ID)
@@ -117,83 +121,34 @@ describe('rename-only updates keep the tested status (GIT-1873)', () => {
 
     it('CLAIM 2: UPDATE_ACTION changing input still bumps lastUpdatedDate', () => {
         const flowVersion = createFlowVersion()
-        const action = getAction(flowVersion)
-        const result = flowOperations.apply(flowVersion, {
-            type: FlowOperationType.UPDATE_ACTION,
-            request: {
-                type: FlowActionType.PIECE,
-                name: action.name,
-                displayName: action.displayName,
-                valid: action.valid,
-                settings: {
-                    ...action.settings,
-                    input: {
-                        key: '2',
-                    },
-                },
-            },
+        const updated = applyActionUpdate(flowVersion, {
+            settings: { ...getAction(flowVersion).settings, input: { key: '2' } },
         })
-        const updated = getAction(result)
         expect(updated.lastUpdatedDate).not.toBe(ACTION_LAST_UPDATED)
         expect(updated.settings.sampleData?.sampleDataFileId).toBe(ACTION_SAMPLE_FILE_ID)
     })
 
     it('CLAIM 3: UPDATE_ACTION renaming and changing input together bumps lastUpdatedDate', () => {
         const flowVersion = createFlowVersion()
-        const action = getAction(flowVersion)
-        const result = flowOperations.apply(flowVersion, {
-            type: FlowOperationType.UPDATE_ACTION,
-            request: {
-                type: FlowActionType.PIECE,
-                name: action.name,
-                displayName: 'Get Renamed',
-                valid: action.valid,
-                settings: {
-                    ...action.settings,
-                    input: {
-                        key: '2',
-                    },
-                },
-            },
+        const updated = applyActionUpdate(flowVersion, {
+            displayName: 'Get Renamed',
+            settings: { ...getAction(flowVersion).settings, input: { key: '2' } },
         })
-        expect(getAction(result).lastUpdatedDate).not.toBe(ACTION_LAST_UPDATED)
+        expect(updated.lastUpdatedDate).not.toBe(ACTION_LAST_UPDATED)
     })
 
     it('CLAIM 4: UPDATE_ACTION rename with stale sampleData in the request is still rename-only', () => {
         const flowVersion = createFlowVersion()
-        const action = getAction(flowVersion)
-        const result = flowOperations.apply(flowVersion, {
-            type: FlowOperationType.UPDATE_ACTION,
-            request: {
-                type: FlowActionType.PIECE,
-                name: action.name,
-                displayName: 'Get Renamed',
-                valid: action.valid,
-                settings: {
-                    ...action.settings,
-                    sampleData: undefined,
-                },
-            },
+        const updated = applyActionUpdate(flowVersion, {
+            displayName: 'Get Renamed',
+            settings: { ...getAction(flowVersion).settings, sampleData: undefined },
         })
-        const updated = getAction(result)
         expect(updated.lastUpdatedDate).toBe(ACTION_LAST_UPDATED)
         expect(updated.settings.sampleData?.sampleDataFileId).toBe(ACTION_SAMPLE_FILE_ID)
     })
 
     it('CLAIM 5: UPDATE_TRIGGER changing only displayName keeps lastUpdatedDate and sample data', () => {
-        const flowVersion = createFlowVersion()
-        const trigger = getTrigger(flowVersion)
-        const result = flowOperations.apply(flowVersion, {
-            type: FlowOperationType.UPDATE_TRIGGER,
-            request: {
-                type: FlowTriggerType.PIECE,
-                name: trigger.name,
-                displayName: 'Every Hour Renamed',
-                valid: trigger.valid,
-                settings: trigger.settings,
-            },
-        })
-        const updated = getTrigger(result)
+        const updated = applyTriggerUpdate(createFlowVersion(), { displayName: 'Every Hour Renamed' })
         expect(updated.displayName).toBe('Every Hour Renamed')
         expect(updated.lastUpdatedDate).toBe(TRIGGER_LAST_UPDATED)
         expect(updated.settings.sampleData?.sampleDataFileId).toBe(TRIGGER_SAMPLE_FILE_ID)
@@ -202,67 +157,39 @@ describe('rename-only updates keep the tested status (GIT-1873)', () => {
 
     it('CLAIM 6: UPDATE_TRIGGER changing input still bumps lastUpdatedDate', () => {
         const flowVersion = createFlowVersion()
-        const trigger = getTrigger(flowVersion)
-        const result = flowOperations.apply(flowVersion, {
-            type: FlowOperationType.UPDATE_TRIGGER,
-            request: {
-                type: FlowTriggerType.PIECE,
-                name: trigger.name,
-                displayName: trigger.displayName,
-                valid: trigger.valid,
-                settings: {
-                    ...trigger.settings,
-                    input: {
-                        cronExpression: '0 * * * *',
-                    },
-                },
-            },
+        const updated = applyTriggerUpdate(flowVersion, {
+            settings: { ...getTrigger(flowVersion).settings, input: { cronExpression: '0 * * * *' } },
         })
-        const updated = getTrigger(result)
         expect(updated.lastUpdatedDate).not.toBe(TRIGGER_LAST_UPDATED)
     })
 
     it('CLAIM 7: UPDATE_TRIGGER replacing the piece bumps lastUpdatedDate', () => {
         const flowVersion = createFlowVersion()
-        const trigger = getTrigger(flowVersion)
-        const result = flowOperations.apply(flowVersion, {
-            type: FlowOperationType.UPDATE_TRIGGER,
-            request: {
-                type: FlowTriggerType.PIECE,
-                name: trigger.name,
-                displayName: trigger.displayName,
-                valid: trigger.valid,
-                settings: {
-                    ...trigger.settings,
-                    pieceName: 'webhook',
-                    triggerName: 'catch_webhook',
-                },
-            },
+        const updated = applyTriggerUpdate(flowVersion, {
+            settings: { ...getTrigger(flowVersion).settings, pieceName: 'webhook', triggerName: 'catch_webhook' },
         })
-        const updated = getTrigger(result)
         expect(updated.lastUpdatedDate).not.toBe(TRIGGER_LAST_UPDATED)
     })
+
     it('CLAIM 8: UPDATE_ACTION rename with form-normalized empty option objects is still rename-only', () => {
         const flowVersion = createFlowVersion()
-        const action = getAction(flowVersion)
-        const result = flowOperations.apply(flowVersion, {
-            type: FlowOperationType.UPDATE_ACTION,
-            request: {
-                type: FlowActionType.PIECE,
-                name: action.name,
-                displayName: 'Get Renamed',
-                valid: action.valid,
-                settings: {
-                    ...action.settings,
-                    errorHandlingOptions: {
-                        continueOnFailure: {},
-                        retryOnFailure: {},
-                    },
-                },
+        const updated = applyActionUpdate(flowVersion, {
+            displayName: 'Get Renamed',
+            settings: {
+                ...getAction(flowVersion).settings,
+                errorHandlingOptions: { continueOnFailure: {}, retryOnFailure: {} },
             },
         })
-        const updated = getAction(result)
         expect(updated.lastUpdatedDate).toBe(ACTION_LAST_UPDATED)
         expect(updated.settings.sampleData?.sampleDataFileId).toBe(ACTION_SAMPLE_FILE_ID)
+    })
+
+    it('CLAIM 9: UPDATE_ACTION adding an empty-object input value bumps lastUpdatedDate', () => {
+        const flowVersion = createFlowVersion()
+        const action = getAction(flowVersion)
+        const updated = applyActionUpdate(flowVersion, {
+            settings: { ...action.settings, input: { ...action.settings.input, filters: {} } },
+        })
+        expect(updated.lastUpdatedDate).not.toBe(ACTION_LAST_UPDATED)
     })
 })

--- a/packages/core/execution/test/flow/update-step-rename.test.ts
+++ b/packages/core/execution/test/flow/update-step-rename.test.ts
@@ -1,0 +1,268 @@
+import {
+    FlowActionType,
+    flowOperations,
+    FlowOperationType,
+    flowStructureUtil,
+    FlowTriggerType,
+    FlowVersion,
+    FlowVersionState,
+    PieceAction,
+    PieceTrigger,
+    PropertyExecutionType,
+} from '../../src'
+
+const TRIGGER_LAST_UPDATED = '2026-01-01T00:00:00.000Z'
+const ACTION_LAST_UPDATED = '2026-01-02T00:00:00.000Z'
+const TRIGGER_SAMPLE_FILE_ID = 'trigger_sample_file'
+const ACTION_SAMPLE_FILE_ID = 'action_sample_file'
+
+function createFlowVersion(): FlowVersion {
+    return {
+        id: 'pj0KQ7Aypoa9OQGHzmKDl',
+        created: '2023-05-24T00:16:41.353Z',
+        updated: '2023-05-24T00:16:41.353Z',
+        flowId: 'lod6JEdKyPlvrnErdnrGa',
+        updatedBy: '',
+        displayName: 'Rename test',
+        agentIds: [],
+        notes: [],
+        connectionIds: [],
+        valid: true,
+        state: FlowVersionState.DRAFT,
+        trigger: {
+            name: 'trigger',
+            type: FlowTriggerType.PIECE,
+            valid: true,
+            displayName: 'Every Hour',
+            lastUpdatedDate: TRIGGER_LAST_UPDATED,
+            settings: {
+                pieceName: 'schedule',
+                pieceVersion: '0.0.2',
+                triggerName: 'cron_expression',
+                input: {
+                    cronExpression: '25 10 * * 0,1,2,3,4',
+                },
+                propertySettings: {
+                    cronExpression: {
+                        type: PropertyExecutionType.MANUAL,
+                    },
+                },
+                sampleData: {
+                    sampleDataFileId: TRIGGER_SAMPLE_FILE_ID,
+                    lastTestDate: '2026-01-03T00:00:00.000Z',
+                },
+            },
+            nextAction: {
+                name: 'step_1',
+                type: FlowActionType.PIECE,
+                valid: true,
+                displayName: 'Get',
+                lastUpdatedDate: ACTION_LAST_UPDATED,
+                settings: {
+                    pieceName: 'store',
+                    pieceVersion: '0.2.6',
+                    actionName: 'get',
+                    input: {
+                        key: '1',
+                    },
+                    propertySettings: {
+                        key: {
+                            type: PropertyExecutionType.MANUAL,
+                        },
+                    },
+                    sampleData: {
+                        sampleDataFileId: ACTION_SAMPLE_FILE_ID,
+                        lastTestDate: '2026-01-03T00:00:00.000Z',
+                    },
+                },
+            },
+        },
+    }
+}
+
+function getAction(flowVersion: FlowVersion): PieceAction {
+    const step = flowStructureUtil.getStepOrThrow('step_1', flowVersion.trigger)
+    if (step.type !== FlowActionType.PIECE) {
+        throw new Error('expected a piece action')
+    }
+    return step
+}
+
+function getTrigger(flowVersion: FlowVersion): PieceTrigger {
+    if (flowVersion.trigger.type !== FlowTriggerType.PIECE) {
+        throw new Error('expected a piece trigger')
+    }
+    return flowVersion.trigger
+}
+
+describe('rename-only updates keep the tested status (GIT-1873)', () => {
+    it('CLAIM 1: UPDATE_ACTION changing only displayName keeps lastUpdatedDate and sample data', () => {
+        const flowVersion = createFlowVersion()
+        const action = getAction(flowVersion)
+        const result = flowOperations.apply(flowVersion, {
+            type: FlowOperationType.UPDATE_ACTION,
+            request: {
+                type: FlowActionType.PIECE,
+                name: action.name,
+                displayName: 'Get Renamed',
+                valid: action.valid,
+                settings: action.settings,
+            },
+        })
+        const updated = getAction(result)
+        expect(updated.displayName).toBe('Get Renamed')
+        expect(updated.lastUpdatedDate).toBe(ACTION_LAST_UPDATED)
+        expect(updated.settings.sampleData?.sampleDataFileId).toBe(ACTION_SAMPLE_FILE_ID)
+    })
+
+    it('CLAIM 2: UPDATE_ACTION changing input still bumps lastUpdatedDate', () => {
+        const flowVersion = createFlowVersion()
+        const action = getAction(flowVersion)
+        const result = flowOperations.apply(flowVersion, {
+            type: FlowOperationType.UPDATE_ACTION,
+            request: {
+                type: FlowActionType.PIECE,
+                name: action.name,
+                displayName: action.displayName,
+                valid: action.valid,
+                settings: {
+                    ...action.settings,
+                    input: {
+                        key: '2',
+                    },
+                },
+            },
+        })
+        const updated = getAction(result)
+        expect(updated.lastUpdatedDate).not.toBe(ACTION_LAST_UPDATED)
+        expect(updated.settings.sampleData?.sampleDataFileId).toBe(ACTION_SAMPLE_FILE_ID)
+    })
+
+    it('CLAIM 3: UPDATE_ACTION renaming and changing input together bumps lastUpdatedDate', () => {
+        const flowVersion = createFlowVersion()
+        const action = getAction(flowVersion)
+        const result = flowOperations.apply(flowVersion, {
+            type: FlowOperationType.UPDATE_ACTION,
+            request: {
+                type: FlowActionType.PIECE,
+                name: action.name,
+                displayName: 'Get Renamed',
+                valid: action.valid,
+                settings: {
+                    ...action.settings,
+                    input: {
+                        key: '2',
+                    },
+                },
+            },
+        })
+        expect(getAction(result).lastUpdatedDate).not.toBe(ACTION_LAST_UPDATED)
+    })
+
+    it('CLAIM 4: UPDATE_ACTION rename with stale sampleData in the request is still rename-only', () => {
+        const flowVersion = createFlowVersion()
+        const action = getAction(flowVersion)
+        const result = flowOperations.apply(flowVersion, {
+            type: FlowOperationType.UPDATE_ACTION,
+            request: {
+                type: FlowActionType.PIECE,
+                name: action.name,
+                displayName: 'Get Renamed',
+                valid: action.valid,
+                settings: {
+                    ...action.settings,
+                    sampleData: undefined,
+                },
+            },
+        })
+        const updated = getAction(result)
+        expect(updated.lastUpdatedDate).toBe(ACTION_LAST_UPDATED)
+        expect(updated.settings.sampleData?.sampleDataFileId).toBe(ACTION_SAMPLE_FILE_ID)
+    })
+
+    it('CLAIM 5: UPDATE_TRIGGER changing only displayName keeps lastUpdatedDate and sample data', () => {
+        const flowVersion = createFlowVersion()
+        const trigger = getTrigger(flowVersion)
+        const result = flowOperations.apply(flowVersion, {
+            type: FlowOperationType.UPDATE_TRIGGER,
+            request: {
+                type: FlowTriggerType.PIECE,
+                name: trigger.name,
+                displayName: 'Every Hour Renamed',
+                valid: trigger.valid,
+                settings: trigger.settings,
+            },
+        })
+        const updated = getTrigger(result)
+        expect(updated.displayName).toBe('Every Hour Renamed')
+        expect(updated.lastUpdatedDate).toBe(TRIGGER_LAST_UPDATED)
+        expect(updated.settings.sampleData?.sampleDataFileId).toBe(TRIGGER_SAMPLE_FILE_ID)
+        expect(updated.nextAction?.name).toBe('step_1')
+    })
+
+    it('CLAIM 6: UPDATE_TRIGGER changing input still bumps lastUpdatedDate', () => {
+        const flowVersion = createFlowVersion()
+        const trigger = getTrigger(flowVersion)
+        const result = flowOperations.apply(flowVersion, {
+            type: FlowOperationType.UPDATE_TRIGGER,
+            request: {
+                type: FlowTriggerType.PIECE,
+                name: trigger.name,
+                displayName: trigger.displayName,
+                valid: trigger.valid,
+                settings: {
+                    ...trigger.settings,
+                    input: {
+                        cronExpression: '0 * * * *',
+                    },
+                },
+            },
+        })
+        const updated = getTrigger(result)
+        expect(updated.lastUpdatedDate).not.toBe(TRIGGER_LAST_UPDATED)
+    })
+
+    it('CLAIM 7: UPDATE_TRIGGER replacing the piece bumps lastUpdatedDate', () => {
+        const flowVersion = createFlowVersion()
+        const trigger = getTrigger(flowVersion)
+        const result = flowOperations.apply(flowVersion, {
+            type: FlowOperationType.UPDATE_TRIGGER,
+            request: {
+                type: FlowTriggerType.PIECE,
+                name: trigger.name,
+                displayName: trigger.displayName,
+                valid: trigger.valid,
+                settings: {
+                    ...trigger.settings,
+                    pieceName: 'webhook',
+                    triggerName: 'catch_webhook',
+                },
+            },
+        })
+        const updated = getTrigger(result)
+        expect(updated.lastUpdatedDate).not.toBe(TRIGGER_LAST_UPDATED)
+    })
+    it('CLAIM 8: UPDATE_ACTION rename with form-normalized empty option objects is still rename-only', () => {
+        const flowVersion = createFlowVersion()
+        const action = getAction(flowVersion)
+        const result = flowOperations.apply(flowVersion, {
+            type: FlowOperationType.UPDATE_ACTION,
+            request: {
+                type: FlowActionType.PIECE,
+                name: action.name,
+                displayName: 'Get Renamed',
+                valid: action.valid,
+                settings: {
+                    ...action.settings,
+                    errorHandlingOptions: {
+                        continueOnFailure: {},
+                        retryOnFailure: {},
+                    },
+                },
+            },
+        })
+        const updated = getAction(result)
+        expect(updated.lastUpdatedDate).toBe(ACTION_LAST_UPDATED)
+        expect(updated.settings.sampleData?.sampleDataFileId).toBe(ACTION_SAMPLE_FILE_ID)
+    })
+})


### PR DESCRIPTION
Fixes [GIT-1873](https://linear.app/activepieces/issue/GIT-1873)
Closes #15440

## Problem

1. Renaming a step (a displayName-only edit) flips its badge from "Tested" to "Test me", and the state persists after reopening the flow. Users read it as lost sample data and re-test every renamed step. Reported via [Pylon 5479](https://app.usepylon.com/issues?issueNumber=5479), reproduced live on 0.88.0; behavior present since 0.80.0 (`5a198942a2`).
2. Sample data itself was never lost; only the tested status was falsely invalidated (`lastUpdatedDate` stamped on every `UPDATE_ACTION`/`UPDATE_TRIGGER`, badge shows "Test me" when `lastUpdatedDate > lastTestDate`).

## Fix

- `packages/core/execution/src/lib/flows/operations/update-step-util.ts` (new): `preserveLastUpdatedDate` keeps the existing `lastUpdatedDate` when the update's content (type + settings minus `sampleData`/`customLogoUrl`, deeply-empty objects pruned) deep-equals the current step
- `update-action.ts` / `update-trigger.ts`: route the final step through it — one choke point shared by the server and the builder's optimistic local apply
- Pruning deeply-empty objects is required because the builder form normalizes `errorHandlingOptions: {}` into `{ continueOnFailure: {}, retryOnFailure: {} }` on panel open
- `@activepieces/core-execution` 0.20.0 → 0.21.0

## How was this tested?

- Red-first regression test (`packages/core/execution/test/flow/update-step-rename.test.ts`, 8 claims): the 3 rename-only claims fail on base main, all 8 pass with the fix; full core-execution suite 147/147
- `npm run lint-dev` clean
- Live dev stack (CE): rename via API and via the builder panel keeps "Tested" through close + reopen; a real settings edit still flips to "Test me"; renaming back verified; sample data file ids preserved throughout
- Repro: rename-only updates falsely flipped the badge on a stock 0.88.0 image, verified over API and real UI — full steps in the Reproduction block
- Visual: baseline both-Tested, rename via panel, after reopen, and the inverse (real edit flips to "Test me") — see the Visual verification comment
- Other affected paths: checked — `skip-action` and `update-sample-data-info` never stamped `lastUpdatedDate`; add/duplicate/paste stamp on new steps (correct); release diff zeroes the field before comparing; MCP flow-builder tools construct steps with their own stamps (unaffected)
- Product decision embedded: renaming (or a logo-only change) no longer invalidates a step's tested status; alternative considered: special-casing the badge in the web app only (rejected — the builder applies the same shared operation locally, a web-only fix desyncs client and server state)

Known boundary: a request that drops a stored settings block (e.g. omits `errorHandlingOptions: { continueOnFailure: { value: false } }`) while renaming still bumps `lastUpdatedDate` — intended, since the persisted settings genuinely change.

<details>
<summary>Plan & reasoning</summary>

## Plan
- Fix at the shared flow-operations layer (`packages/core/execution`), not the badge: both the server and the web builder apply the same ops, so one guard keeps them in sync
- Comparison = prune deeply-empty objects, then order-insensitive deep-equal on `{ type, settings }` with `sampleData`/`customLogoUrl` excluded (`sampleData` is replaced server-side by the op anyway; `customLogoUrl` is presentation-only)
- Footprint estimate: 3 product files, ~45 lines; actual: 3 product files, ~60 lines (prune pass added after live UI testing surfaced the form's empty-object normalization)

## Non-happy scenarios considered
- Builder form normalization (`errorHandlingOptions` skeleton on panel open) → covered by prune + CLAIM 8
- Flows built via API/MCP/import with raw `{}` option blocks → same prune path
- EMPTY trigger with nullish settings → `?? {}` guard
- Key-order differences between stored settings and client-echoed settings → recursive order-insensitive compare, not stringify
- Steps missing `lastUpdatedDate` (pre-v17 data) → preserved as-is, no regression

## Alternatives rejected
- Web-only badge heuristic → client cannot know what changed from timestamps alone; desyncs shared-op state
- Dedicated RENAME operation type → schema churn and client migration for a bug fix
- npm `deep-equal` dependency → core-execution is a thin bundleable package; 30 lines beat a new dependency edge
</details>

<details>
<summary>Reproduction</summary>

## Environment
- Bug repro: official `activepieces/activepieces:0.88.0` image (WORKER_AND_APP), fresh Postgres database, Redis db 2, local Docker
- Fix verification: source dev stack (api + engine + worker + web) from this branch against local Postgres/Redis, CE

## Harness
Public gist: https://gist.github.com/majewskibartosz/5e8100cac1142e7b09317855351ed2c8
- `repro5479.mjs` — drives the 0.88.0 stack over REST: setup (forms trigger + code action), baseline (SAVE_SAMPLE_DATA both steps + reads), rename (displayName-only UPDATE_TRIGGER/UPDATE_ACTION), reopen (fresh GET + per-step sample-data reads); run `node repro5479.mjs setup|baseline|rename|reopen` against `http://localhost:8080/api`
- `verify1873.mjs` — same drive against the dev stack (`http://localhost:3000/api`, dev seed login): `setup|rename|edit|renameback`, printing per-step `lastUpdatedDate` vs `lastTestDate` and the derived badge

## Trigger
A displayName-only `UPDATE_ACTION`/`UPDATE_TRIGGER` (exactly what the builder's rename control sends): every such update stamped a fresh `lastUpdatedDate`, crossing the badge's `lastUpdatedDate > lastTestDate` staleness condition without any content change.

## Results
- 0.88.0 (pre-fix): rename-only → both steps flip to "Test me"; sample data file ids and payloads remain readable (the "reset" is the status, not the data)
- This branch: rename-only → `lastUpdatedDate` unchanged, badge stays "Tested" (API + UI, immediate and after reopen); settings edit → stamps and flips to "Test me"; rename back → unchanged
</details>

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)
