### PR TITLE
fix(platform): hide the health page version check on cloud

### DIFF
--- a/packages/web/src/app/routes/platform/infra/health/components/system-health-tab.tsx
+++ b/packages/web/src/app/routes/platform/infra/health/components/system-health-tab.tsx
@@ -1,4 +1,4 @@
-import { isNil } from '@activepieces/shared';
+import { ApEdition, ApFlagId, isNil } from '@activepieces/shared';
 import { t } from 'i18next';
 import {
   Boxes,
@@ -18,6 +18,7 @@ import { LoadingSpinner } from '@/components/custom/spinner';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Card, CardContent } from '@/components/ui/card';
 import { healthQueries } from '@/features/platform-admin';
+import { flagsHooks } from '@/hooks/flags-hooks';
 import { cn } from '@/lib/utils';
 
 import { DailyHealthStrip } from './daily-health-strip';
@@ -37,6 +38,8 @@ type SystemHealthTabProps = {
 };
 
 export function SystemHealthTab({ onSeeRuns }: SystemHealthTabProps) {
+  const { data: edition } = flagsHooks.useFlag<ApEdition>(ApFlagId.EDITION);
+  const isCloud = edition === ApEdition.CLOUD;
   const { data: systemHealth, isPending } = healthQueries.useSystemHealth();
   const latestVersion = systemHealth?.latestVersion;
   const release = systemHealth?.release;
@@ -76,7 +79,7 @@ export function SystemHealthTab({ onSeeRuns }: SystemHealthTabProps) {
     );
   })();
 
-  const appRows: HealthRow[] = [
+  const allAppRows: HealthRow[] = [
     {
       id: 'version',
       title: t('Version'),
@@ -128,6 +131,9 @@ export function SystemHealthTab({ onSeeRuns }: SystemHealthTabProps) {
       message: t('At least 1 CPU core is required.'),
     },
   ];
+  const appRows = isCloud
+    ? allAppRows.filter((row) => row.id !== 'version')
+    : allAppRows;
 
   const workersConnected = !isNil(systemHealth?.workerRam);
 

--- a/packages/web/src/app/routes/platform/infra/health/components/system-health-tab.tsx
+++ b/packages/web/src/app/routes/platform/infra/health/components/system-health-tab.tsx
@@ -33,6 +33,8 @@ const PRODUCTION_SETUP_LINK =
 // it could not read its release from package.json. Not importable here (server-only package).
 const UNREADABLE_RELEASE_VERSION = '0.0.0';
 
+const CLOUD_HIDDEN_ROW_IDS = ['version', 'release-integrity'];
+
 type SystemHealthTabProps = {
   onSeeRuns: () => void;
 };
@@ -132,7 +134,7 @@ export function SystemHealthTab({ onSeeRuns }: SystemHealthTabProps) {
     },
   ];
   const appRows = isCloud
-    ? allAppRows.filter((row) => row.id !== 'version')
+    ? allAppRows.filter((row) => !CLOUD_HIDDEN_ROW_IDS.includes(row.id))
     : allAppRows;
 
   const workersConnected = !isNil(systemHealth?.workerRam);

--- a/packages/web/test/app/routes/platform/infra/health/components/system-health-tab.test.tsx
+++ b/packages/web/test/app/routes/platform/infra/health/components/system-health-tab.test.tsx
@@ -2,11 +2,11 @@
  * @vitest-environment jsdom
  */
 /* eslint-disable testing-library/no-unnecessary-act */
-import { GetSystemHealthChecksResponse } from '@activepieces/shared';
+import { ApEdition, GetSystemHealthChecksResponse } from '@activepieces/shared';
 import * as React from 'react';
 import { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const versions = vi.hoisted(() => ({
   running: '0.88.1',
@@ -42,9 +42,13 @@ vi.mock('@/features/platform-admin', () => ({
   },
 }));
 
+const editionMock = vi.hoisted(() => ({ value: '' }));
+
 vi.mock('@/hooks/flags-hooks', () => ({
   flagsHooks: {
-    useFlag: () => ({ data: versions.staleFlag }),
+    useFlag: (flagId: string) => ({
+      data: flagId === 'EDITION' ? editionMock.value : versions.staleFlag,
+    }),
   },
 }));
 
@@ -73,6 +77,10 @@ describe('SystemHealthTab version row', () => {
     return container.textContent ?? '';
   };
 
+  beforeEach(() => {
+    editionMock.value = ApEdition.COMMUNITY;
+  });
+
   afterEach(() => {
     act(() => root?.unmount());
     container?.remove();
@@ -94,6 +102,25 @@ describe('SystemHealthTab version row', () => {
   });
 
   it('needs attention when the payload release is behind the latest release', () => {
+    const text = readTabText(versions.staleFlag);
+
+    expect(text).toContain(`Current ${versions.staleFlag}`);
+    expect(text).toContain('Needs attention');
+  });
+
+  it('hides the version row on cloud edition even when behind the latest release', () => {
+    editionMock.value = ApEdition.CLOUD;
+
+    const text = readTabText(versions.staleFlag);
+
+    expect(text).not.toContain('Current');
+    expect(text).not.toContain('Needs attention');
+    expect(text).toContain('Release Integrity');
+  });
+
+  it('keeps the version row on enterprise edition', () => {
+    editionMock.value = ApEdition.ENTERPRISE;
+
     const text = readTabText(versions.staleFlag);
 
     expect(text).toContain(`Current ${versions.staleFlag}`);

--- a/packages/web/test/app/routes/platform/infra/health/components/system-health-tab.test.tsx
+++ b/packages/web/test/app/routes/platform/infra/health/components/system-health-tab.test.tsx
@@ -108,14 +108,15 @@ describe('SystemHealthTab version row', () => {
     expect(text).toContain('Needs attention');
   });
 
-  it('hides the version row on cloud edition even when behind the latest release', () => {
+  it('hides the version and release integrity rows on cloud edition', () => {
     editionMock.value = ApEdition.CLOUD;
 
     const text = readTabText(versions.staleFlag);
 
     expect(text).not.toContain('Current');
     expect(text).not.toContain('Needs attention');
-    expect(text).toContain('Release Integrity');
+    expect(text).not.toContain('Release Integrity');
+    expect(text).toContain('Disk');
   });
 
   it('keeps the version row on enterprise edition', () => {


### PR DESCRIPTION
Fixes [GIT-1875](https://linear.app/activepieces/issue/GIT-1875)
Closes #15444

## Description

1. On cloud, Platform → Infra → Health renders the Version row (`Current 0.90.2 • Latest 0.90.4`) with a red "Needs attention" badge. Cloud users cannot upgrade, and cloud routinely trails the latest GitHub tag, so the row sits red most of a release cycle. The Release Integrity row likewise reports on infrastructure only we operate.
2. Fix: `system-health-tab.tsx` reads the edition via `flagsHooks.useFlag<ApEdition>(ApFlagId.EDITION)` (same idiom as `workers/index.tsx`) and filters the `version` and `release-integrity` rows out of the App card when the edition is CLOUD. CE and EE keep both rows.

## How was this tested?

- New vitest cases: cloud hides both rows, EE keeps them; the cloud test was proven red-first (fails on the pre-fix component, passes now). Full web suite 739/739.
- Live drive on a real local stack in all three editions: CE and EE show the Version and Release Integrity rows, cloud hides both — screenshots in the Visual verification comment.
- `npm run lint-dev` clean (0 errors).
- Pre-existing, unrelated: `packages/server/engine/test/handler/flow-with-delay.test.ts` (5 tests) fails on upstream/main; engine is untouched by this diff.
- Visual: CE light (row present), EE light (row present), cloud light (version + release integrity rows hidden). Dark mode is not reachable on the platform admin surface (app forces light there).
- Other affected paths: checked - none. `systemHealth.latestVersion` has exactly one consumer (this component). The backend `getLatestRelease()` GitHub fetch still runs on cloud (one call per health-tab mount) — left as-is; removing it spans 3 packages for no user-visible gain.

<details>
<summary>Plan & reasoning</summary>

## Plan
- Gate the rows inside the component that builds them: read the edition flag, filter the `version` and `release-integrity` rows when CLOUD.
- Extend the existing test file (already mocks flags-hooks) with a per-flag mock so the original stale-flag guard keeps guarding.
- Footprint: estimated 1 product file ~7 lines; actual 13 changed lines (scope grew mid-review: hide Release Integrity on cloud too, per team ask).

## Non-happy scenarios considered
- Edition flag not loaded yet → `useFlag` is a suspense query warmed by the route guard; no flash of the row on cloud.
- Version behind latest on CE/EE → row still shows "Needs attention" (pinned by test).
- Release Integrity / Disk / RAM / CPU rows → untouched on every edition (pinned by live drive).

## Alternatives rejected
- Backend omission of `latestVersion` on cloud → still needs the frontend change, plus schema loosening in `@activepieces/shared` and a CLI consumer update; 3 packages vs 1 file.
- Route-level gate → hides a whole page; only one row goes away.
- `editions` field on `HealthRow` → config mechanism with a single consumer.
</details>

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)
