### PR TITLE
fix(convertkit): send api_secret in the query string instead of the GET body

### DIFF
--- a/packages/pieces/community/convertkit/package.json
+++ b/packages/pieces/community/convertkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-convertkit",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {

--- a/packages/pieces/community/convertkit/src/lib/actions/broadcasts.ts
+++ b/packages/pieces/community/convertkit/src/lib/actions/broadcasts.ts
@@ -21,7 +21,7 @@ import {
 } from '../common/broadcasts';
 import { Broadcast } from '../common/types';
 import { BROADCASTS_API_ENDPOINT } from '../common/constants';
-import { fetchBroadcasts } from '../common/service';
+import { buildQueryParams, fetchBroadcasts } from '../common/service';
 
 export const listBroadcasts = createAction({
   auth: convertkitAuth,
@@ -131,13 +131,9 @@ export const getBroadcastById = createAction({
     const { broadcastId } = context.propsValue;
     const url = `${BROADCASTS_API_ENDPOINT}/${broadcastId}`;
 
-    const body = {
-      api_secret: context.auth.secret_text,
-    };
-
     const request: HttpRequest = {
       url,
-      body,
+      queryParams: buildQueryParams(context.auth.secret_text),
       method: HttpMethod.GET,
     };
     const response = await httpClient.sendRequest<{ broadcast: Broadcast }>(
@@ -242,13 +238,9 @@ export const broadcastStats = createAction({
     const { broadcastId } = context.propsValue;
     const url = `${BROADCASTS_API_ENDPOINT}/${broadcastId}/stats`;
 
-    const body = {
-      api_secret: context.auth.secret_text,
-    };
-
     const request: HttpRequest = {
       url,
-      body,
+      queryParams: buildQueryParams(context.auth.secret_text),
       method: HttpMethod.GET,
     };
     const response = await httpClient.sendRequest<{ broadcast: Broadcast }>(

--- a/packages/pieces/community/convertkit/src/lib/actions/forms.ts
+++ b/packages/pieces/community/convertkit/src/lib/actions/forms.ts
@@ -10,7 +10,7 @@ import { formId } from '../common/forms';
 import { subscriberEmail, subscriberFirstName } from '../common/subscribers';
 import { allFields } from '../common/custom-fields';
 import { FORMS_API_ENDPOINT } from '../common/constants';
-import { fetchForms } from '../common/service';
+import { buildQueryParams, fetchForms } from '../common/service';
 import { tags } from '../common/tags';
 
 export const listForms = createAction({
@@ -102,13 +102,9 @@ export const listFormSubscriptions = createAction({
   async run(context) {
     const url = `${FORMS_API_ENDPOINT}/${context.propsValue.formId}/subscriptions`;
 
-    const body = {
-      api_secret: context.auth.secret_text,
-    };
-
     const request: HttpRequest = {
       url,
-      body,
+      queryParams: buildQueryParams(context.auth.secret_text),
       method: HttpMethod.GET,
     };
 

--- a/packages/pieces/community/convertkit/src/lib/actions/purchases.ts
+++ b/packages/pieces/community/convertkit/src/lib/actions/purchases.ts
@@ -28,7 +28,7 @@ import { subscriberId } from '../common/subscribers';
 import { formId } from '../common/forms';
 import { sequenceId } from '../common/sequences';
 import { PURCHASES_API_ENDPOINT } from '../common/constants';
-import { fetchPurchases } from '../common/service';
+import { buildQueryParams, fetchPurchases } from '../common/service';
 
 export const listPurchases = createAction({
   auth: convertkitAuth,
@@ -68,14 +68,10 @@ export const getPurchaseById = createAction({
     const { purchaseId } = context.propsValue;
     const url = `${PURCHASES_API_ENDPOINT}/${purchaseId}`;
 
-    const body = {
-      api_secret: context.auth.secret_text,
-    };
-
     const request: HttpRequest = {
       url,
       method: HttpMethod.GET,
-      body,
+      queryParams: buildQueryParams(context.auth.secret_text),
     };
 
     const response = await httpClient.sendRequest<{
@@ -274,15 +270,12 @@ export const listPurchasesForSubscriber = createAction({
     const { subscriberId } = context.propsValue;
     const url = PURCHASES_API_ENDPOINT;
 
-    const body = {
-      api_secret: context.auth.secret_text,
-      subscriber_id: subscriberId,
-    };
-
     const request: HttpRequest = {
       url,
       method: HttpMethod.GET,
-      body,
+      queryParams: buildQueryParams(context.auth.secret_text, {
+        subscriber_id: subscriberId,
+      }),
     };
 
     const response = await httpClient.sendRequest<{

--- a/packages/pieces/community/convertkit/src/lib/actions/sequences.ts
+++ b/packages/pieces/community/convertkit/src/lib/actions/sequences.ts
@@ -11,7 +11,7 @@ import { subscriberEmail, subscriberFirstName } from '../common/subscribers';
 import { allFields } from '../common/custom-fields';
 import { tags } from '../common/tags';
 import { SEQUENCES_API_ENDPOINT } from '../common/constants';
-import { fetchSequences } from '../common/service';
+import { buildQueryParams, fetchSequences } from '../common/service';
 
 export const listSequences = createAction({
   auth: convertkitAuth,
@@ -96,14 +96,10 @@ export const listSubscriptionsToSequence = createAction({
   async run(context) {
     const url = `${SEQUENCES_API_ENDPOINT}/${context.propsValue.sequenceId}/subscriptions`;
 
-    const body = {
-      api_secret: context.auth.secret_text,
-    };
-
     const request: HttpRequest = {
       url,
       method: HttpMethod.GET,
-      body,
+      queryParams: buildQueryParams(context.auth.secret_text),
     };
 
     const response = await httpClient.sendRequest<{

--- a/packages/pieces/community/convertkit/src/lib/actions/subscribers.ts
+++ b/packages/pieces/community/convertkit/src/lib/actions/subscribers.ts
@@ -25,6 +25,7 @@ import {
   CONVERTKIT_API_URL,
 } from '../common/constants';
 import {
+  buildQueryParams,
   fetchSubscriperById,
   fetchSubscriberByEmail,
   fetchSubscribedTags,
@@ -105,22 +106,19 @@ export const listSubscribers = createAction({
 
     const url = SUBSCRIBERS_API_ENDPOINT;
 
-    const body = {
-      api_secret: context.auth.secret_text,
-      page,
-      from,
-      to,
-      updated_from: updatedFrom,
-      updated_to: updatedTo,
-      email_address: emailAddress,
-      sort_order: sortOrder,
-      sort_field: sortField,
-    };
-
     const request: HttpRequest = {
       url,
       method: HttpMethod.GET,
-      body,
+      queryParams: buildQueryParams(context.auth.secret_text, {
+        page,
+        from,
+        to,
+        updated_from: updatedFrom,
+        updated_to: updatedTo,
+        email_address: emailAddress,
+        sort_order: sortOrder,
+        sort_field: sortField,
+      }),
     };
 
     const response = await httpClient.sendRequest<{

--- a/packages/pieces/community/convertkit/src/lib/actions/tags.ts
+++ b/packages/pieces/community/convertkit/src/lib/actions/tags.ts
@@ -23,7 +23,7 @@ import {
 import { Tag } from '../common/types';
 import { allFields } from '../common/custom-fields';
 import { TAGS_API_ENDPOINT } from '../common/constants';
-import { fetchTags } from '../common/service';
+import { buildQueryParams, fetchTags } from '../common/service';
 
 export const listTags = createAction({
   auth: convertkitAuth,
@@ -235,19 +235,16 @@ export const listSubscriptionsToATag = createAction({
   },
   async run(context) {
     const { tagId, page, sortOrder, subscriberState } = context.propsValue;
-    const url = `${TAGS_API_ENDPOINT}/${tagId}/subscriptions?`;
-
-    const body = {
-      api_secret: context.auth.secret_text,
-      page,
-      sort_order: sortOrder,
-      subscriber_state: subscriberState,
-    };
+    const url = `${TAGS_API_ENDPOINT}/${tagId}/subscriptions`;
 
     const request: HttpRequest = {
       url,
       method: HttpMethod.GET,
-      body,
+      queryParams: buildQueryParams(context.auth.secret_text, {
+        page,
+        sort_order: sortOrder,
+        subscriber_state: subscriberState,
+      }),
     };
 
     const response = await httpClient.sendRequest<{

--- a/packages/pieces/community/convertkit/src/lib/common/service.ts
+++ b/packages/pieces/community/convertkit/src/lib/common/service.ts
@@ -22,18 +22,28 @@ import {
   httpClient,
   HttpMethod,
   HttpRequest,
+  QueryParams,
 } from '@activepieces/pieces-common';
+
+export const buildQueryParams = (
+  auth: string,
+  params: Record<string, string | number | undefined | null> = {}
+): QueryParams => {
+  const queryParams: QueryParams = { api_secret: auth };
+  for (const [key, value] of Object.entries(params)) {
+    if (value !== undefined && value !== null && value !== '') {
+      queryParams[key] = String(value);
+    }
+  }
+  return queryParams;
+};
 
 export const fetchBroadcasts = async (auth: string, page: number) => {
   const url = BROADCASTS_API_ENDPOINT;
   const request: HttpRequest = {
     url,
     method: HttpMethod.GET,
-    queryParams: {
-      api_secret: auth,
-      page: page.toString(),
-      sort_order: 'desc',
-    },
+    queryParams: buildQueryParams(auth, { page, sort_order: 'desc' }),
   };
   const response = await httpClient.sendRequest<{ broadcasts: Broadcast[] }>(
     request
@@ -59,13 +69,9 @@ export const fetchCustomFields = async (
 ): Promise<CustomField[]> => {
   const url = CUSTOM_FIELDS_API_ENDPOINT;
 
-  const body = {
-    api_secret: auth,
-  };
-
   const request: HttpRequest = {
     url,
-    body,
+    queryParams: buildQueryParams(auth),
     method: HttpMethod.GET,
   };
   const response = await httpClient.sendRequest<{
@@ -90,13 +96,9 @@ export const fetchCustomFields = async (
 export const fetchForms = async (auth: string) => {
   const url = FORMS_API_ENDPOINT;
 
-  const body = {
-    api_secret: auth,
-  };
-
   const request: HttpRequest = {
     url,
-    body,
+    queryParams: buildQueryParams(auth),
     method: HttpMethod.GET,
   };
   const response = await httpClient.sendRequest<{ forms: Form[] }>(request);
@@ -119,14 +121,9 @@ export const fetchForms = async (auth: string) => {
 export const fetchPurchases = async (auth: string, page: number) => {
   const url = PURCHASES_API_ENDPOINT;
 
-  const body = {
-    api_secret: auth,
-    page,
-  };
-
   const request: HttpRequest = {
     url,
-    body,
+    queryParams: buildQueryParams(auth, { page }),
     method: HttpMethod.GET,
   };
   const response = await httpClient.sendRequest<{ purchases: Purchase[] }>(
@@ -150,12 +147,9 @@ export const fetchPurchases = async (auth: string, page: number) => {
 
 export const fetchSequences = async (auth: string) => {
   const url = SEQUENCES_API_ENDPOINT;
-  const body = {
-    api_secret: auth,
-  };
   const request: HttpRequest = {
     url,
-    body,
+    queryParams: buildQueryParams(auth),
     method: HttpMethod.GET,
   };
   const response = await httpClient.sendRequest<{ courses: Sequence[] }>(
@@ -182,13 +176,9 @@ export const fetchSubscriperById = async (
 ) => {
   const url = `${SUBSCRIBERS_API_ENDPOINT}/${subscriberId}`;
 
-  const body = {
-    api_secret: auth,
-  };
-
   const request: HttpRequest = {
     url,
-    body,
+    queryParams: buildQueryParams(auth),
     method: HttpMethod.GET,
   };
 
@@ -216,14 +206,9 @@ export const fetchSubscriberByEmail = async (
 ) => {
   const url = SUBSCRIBERS_API_ENDPOINT;
 
-  const body = {
-    api_secret: auth,
-    email_address,
-  };
-
   const request: HttpRequest = {
     url,
-    body,
+    queryParams: buildQueryParams(auth, { email_address }),
     method: HttpMethod.GET,
   };
 
@@ -253,13 +238,9 @@ export const fetchSubscribedTags = async (
 ) => {
   const url = `${SUBSCRIBERS_API_ENDPOINT}/${subscriberId}/tags`;
 
-  const body = {
-    api_secret: auth,
-  };
-
   const request: HttpRequest = {
     url,
-    body,
+    queryParams: buildQueryParams(auth),
     method: HttpMethod.GET,
   };
 
@@ -281,12 +262,9 @@ export const fetchSubscribedTags = async (
 
 export const fetchTags = async (auth: string) => {
   const url = TAGS_API_ENDPOINT;
-  const body = {
-    api_secret: auth,
-  };
   const request: HttpRequest = {
     url,
-    body,
+    queryParams: buildQueryParams(auth),
     method: HttpMethod.GET,
   };
 


### PR DESCRIPTION
## Description

Fixes the largest instance of the GET-body regression in the catalog.

`api_secret` is the only credential ConvertKit v3 accepts, and the piece sent it in the **body of every GET**. Since #13822 swapped axios for native fetch a GET cannot carry a body, and since #14557 it is dropped silently — so all **16 read call sites were calling the API unauthenticated**. Write actions were unaffected; they use POST.

### What was broken

**Actions, directly:** Get Broadcast · Broadcast Stats · List Form Subscriptions · Get Purchase By Id · List Purchases For Subscriber · List Subscriptions To Sequence · List Subscribers · List Subscriptions To Tag

**Actions, via `lib/common/service.ts`:** List Custom Fields · List Forms · List Sequences · List Tags · List Purchases · Get Subscriber By Id · Get Subscriber By Email · List Tags By Subscriber Id · List Tags By Email

**Triggers:** the Form, Sequence and Tag dropdowns are backed by the same fetches, so Tag added/removed to subscriber, Form subscribed, Sequence subscribed and Sequence completed had empty pickers — as did every write action showing one, even though the write itself succeeded.

### The fix

All 16 sites moved from `body` to `queryParams` behind one `buildQueryParams(auth, params)` helper in `common/service.ts`.

The helper drops nil and empty values, which is the part worth reviewing: `QueryParams` is `Record<string, string>` and the client appends without a nil check, so unset optional filters would serialise as the literal string `"undefined"` — a JSON body simply omitted them. `List Subscribers` has six such filters and `List Subscriptions To Tag` three, so a plain `body:` → `queryParams:` rename would have regressed both.

Two incidental cleanups: `fetchBroadcasts` already used `queryParams` and is folded onto the same helper so the file has one idiom (output unchanged), and a stray trailing `?` is dropped from the `List Subscriptions To Tag` URL now that real params are appended. `removeWebhook` keeps its body — `acceptsRequestBody` only excludes GET and HEAD.

Version `0.3.7` → `0.3.8`.

### Security note — credential moves into the query string

Called out because it is a real trade-off, not a formality. `api_secret` now travels in the URL, where it can land in access logs, proxy logs and `Referer` headers, rather than in a request body.

This is unavoidable and is the vendor's own design: **ConvertKit v3 has no header-based authentication.** `api_secret` as a query parameter is the documented mechanism and what other integrations use. The status quo is strictly worse — today the credential is not transmitted at all, so every read runs unauthenticated. No new secret is exposed to the user, the UI, or step output; the value stays inside the engine's outbound request.

## How was this tested?

Every call site was run through the local engine (CE, dev server, real ConvertKit connection).

ConvertKit returns a different 401 depending on whether the credential arrived at all — `"API Key not present"` vs `"API Key not valid"` — which makes the failure directly observable:

| all 16 read sites | 0.3.7 | 0.3.8, invalid key | 0.3.8, real secret |
|---|---|---|---|
| `API Key not present` (secret dropped) | 15 | 0 | 0 |
| `API Key not valid` (secret arrived) | 1 | 16 | 0 |
| authenticated | 0 | 0 | **16** |

The single site already passing on 0.3.7 is `broadcasts_list_broadcasts` — `fetchBroadcasts` was the one function already using `queryParams`. Same piece, same connection, same key: the only variable is query string vs body.

With a real API secret all 16 authenticate — seven 200s with data, one 200 with an empty result set, eight 404s from probe IDs that don't exist on the test account, and no auth failures. The Form/Sequence/Tag dropdowns go from `disabled: true, "Throws an error, reconnect or refresh the page"` to enabled.

`turbo run lint` passes with 0 errors (2 warnings pre-exist in an untouched file) and `turbo run build` passes.

Linear: PIE-498

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

No prop added, removed or renamed; no action or trigger `name` changed. Existing flows keep working and start returning data instead of failing.

### Security impact?  (required — CI fails if this is left unedited)

- [ ] no — reviewed, no security impact
- [x] yes — security-sensitive (call out the risk and mitigation in the description above)

Touches authentication and secret handling — see "Security note" above.

### Out of scope, noticed while here

- Every call site's `if (response.status !== 200) throw new Error(...)` is unreachable — the fetch client already throws `HttpError` on non-2xx, so users see the raw error rather than the piece's message. Catalog-wide, same origin.
- `listSubscribers` can't list all subscribers: its `emailAddress` prop is `subscriberEmail` (`required: true`), while an unused `subscriberEmailOptional` sits beside it.
- Kit labels v3 **Legacy**; v4 is current. This piece is entirely v3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
