### PR TITLE
fix(zagomail): mark the piece deprecated, the vendor has shut down

### DIFF
--- a/packages/pieces/community/zagomail/package.json
+++ b/packages/pieces/community/zagomail/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-zagomail",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {

--- a/packages/pieces/community/zagomail/src/index.ts
+++ b/packages/pieces/community/zagomail/src/index.ts
@@ -16,6 +16,7 @@ export const zagomail = createPiece({
 	displayName: 'Zagomail',
 	description: 'All-in-one email marketing and automation platform',
 	logoUrl: 'https://cdn.activepieces.com/pieces/zagomail.png',
+	deprecated: true,
 	authors: ['gs03dev'],
 	auth: zagomailAuth,
 	actions: [


### PR DESCRIPTION
## Description

Marks the Zagomail piece `deprecated: true` and bumps `0.1.6 → 0.1.7`, so it disappears from the piece selector and search while existing flows that already use it keep loading.

### Why

**The vendor has shut down.** `api.zagomail.com` and `app.zagomail.com` have no DNS records on any public resolver; `zagomail.com` is a parked Namecheap host serving a `*.web-hosting.com` certificate. AppSumo's notice of 27 Oct 2025 reads: *"Zagomail has shut down without notice. Despite our repeated attempts to reach them, they've been unresponsive and their platform is now inaccessible."* The Wayback Machine's last capture of the API host is 20 Nov 2025 (a 404).

Every action and trigger in the piece therefore fails today, and the connection test can never pass. Offering the piece in the selector only produces flows that cannot run.

### Why not fix the GET-body regression instead

This piece was on the list of nine broken by #13822 / #14557 (the pieces HTTP client no longer sends a body on GET), because it passed `publicKey` in the body of six GET calls. Two things make that fix moot here:

1. There is nothing to send the request to.
2. The vendor's own API reference (archived from `developers.zagomail.com`) documents `publicKey` as a **JSON body parameter on all seven GET endpoints**, with no query-string form. The piece was faithful to the API. Rewriting the call sites would be an untestable guess.

### Mechanism

`deprecated` on `createPiece` was added in #14248 and is what `aws-bedrock` uses. `pieceMetadataService.list()` drops a piece whose latest version is deprecated (unless `includeHidden`); `get(name, version)` is untouched, so existing flows still resolve and open. The flag rides a version bump so the normal piece sync propagates it to cloud and self-hosted instances.

## How was this tested?

- `eslint 'src/**/*.ts'` on the piece: 0 errors (9 pre-existing warnings, none on changed lines).
- `tsc -p tsconfig.lib.json --noEmit` on the piece: passes (`deprecated?: boolean` is declared on `CreatePieceParams`).
- Runtime behaviour of the flag is the one merged and live from #14248; no new code path.

Linear: PIE-497

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

No prop, action or trigger `name` changes. Existing flows keep resolving the piece; they just cannot be created from the selector any more. They were already failing at runtime because the vendor host does not resolve.

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)

