### PR TITLE
fix(okta): actions no longer fail with "Okta domain is required"

### DIFF
--- a/packages/pieces/community/okta/package.json
+++ b/packages/pieces/community/okta/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-okta",
-  "version": "0.1.7",
+  "version": "0.2.0",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {

--- a/packages/pieces/community/okta/src/lib/actions/find-user-by-email.ts
+++ b/packages/pieces/community/okta/src/lib/actions/find-user-by-email.ts
@@ -11,11 +11,6 @@ export const findUserByEmailAction = createAction({
   audience: 'both',
   aiMetadata: { description: 'Searches Okta for a user by exact email address and returns the first match. Use as a read-only lookup to resolve an email to an Okta user (e.g. to obtain a user ID before a lifecycle or group action). Idempotent — returns a not-found indicator when no user matches.', idempotent: true },
   props: {
-    domain: Property.ShortText({
-      displayName: 'Okta Domain',
-      description: 'Your Okta organization domain',
-      required: true,
-    }),
     email: Property.ShortText({
       displayName: 'Email',
       description: 'The user email address',
@@ -28,8 +23,7 @@ export const findUserByEmailAction = createAction({
     const response = await makeOktaRequest(
       context.auth,
       `/users?search=profile.email eq "${email}"`,
-      HttpMethod.GET,
-      context.propsValue.domain
+      HttpMethod.GET
     );
 
     if (response.body && response.body.length > 0) {

--- a/packages/pieces/community/okta/src/lib/common/common.ts
+++ b/packages/pieces/community/okta/src/lib/common/common.ts
@@ -25,8 +25,8 @@ export async function makeOktaRequest(
   method: HttpMethod = HttpMethod.GET,
   body?: any
 ) {
-  const apiToken = auth.apiToken;
-  let domain = auth.domain;
+  const apiToken = auth.props.apiToken;
+  let domain = auth.props.domain;
   
   if (!domain) {
     throw new Error('Okta domain is required');


### PR DESCRIPTION
## Description

The Okta piece could not call Okta at all. Every action and the trigger go through
`makeOktaRequest`, which read the connection as `auth.domain` / `auth.apiToken` — the flat shape.
Pieces default to context version **V2**, and under V2 the engine hands the action the whole
connection value (`{ type, props }`) instead of flattening it to `props`. So both reads were
`undefined`, and the helper threw `Okta domain is required` before sending any request. The only
action that worked was **Custom API Call**, which already read `auth.props`.

The piece contradicted itself: `index.ts` used `auth.props.domain` for Custom API Call while
`common.ts` used `auth.domain` for everything else.

```diff
-  const apiToken = auth.apiToken;
-  let domain = auth.domain;
+  const apiToken = auth.props.apiToken;
+  let domain = auth.props.domain;
```

That restores all 9 actions and the trigger.

### Also: a dead property on Find User by Email

The action declared its own **required** "Okta Domain" property that nothing consumed. The domain
has always come from the connection, and this property was passed as the *body* argument of a GET
request, which the HTTP client discards for GET and HEAD. It forced users to enter their domain a
second time, in one action, for a value that was thrown away — the only one of the nine actions
that did this. Removed, so the domain is entered once, on the connection.

## How was this tested?

Against a live Okta org (trial org, API token, now revoked):

| | Result |
|---|---|
| Before the fix | `FAILED` — `Okta domain is required` |
| After the fix | `SUCCEEDED` — returned the matching user |

Same connection, same input (`email`), only `common.ts` differed between the two runs. Also checked
directly against the Okta API that the action's query is correct:
`GET /api/v1/users?search=profile.email eq "<email>"` returns the user.

- `turbo run lint build --filter=@activepieces/piece-okta` — builds clean, 0 lint errors. The 13
  remaining `no-explicit-any` warnings are pre-existing in `common.ts` / `new-event.ts`.
- Served metadata for `find_user_by_email` now lists `props = ["email"]`, previously
  `["domain","email"]`.
- Existing flows are unaffected by the property removal: `props-processor.ts` skips stored input
  keys with no matching prop (both loops `continue` on `isNil(property)`), so a flow that already
  saved a `domain` value keeps working. Dropping a *required* prop can only widen the set of valid
  flows.
- Edition paths: piece-only change, no edition-gated code, no branding, no new env var or setup
  step — identical on CE, EE and Cloud.

Fixes # (issue)

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

No self-hoster or API consumer has to act. The piece is bumped 0.1.7 → 0.2.0 (minor) because the
action's property schema changed. The auth change is a repair, not a behaviour change: nothing
worked before it.

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)

It touches an outbound call only by removing a value from it. The removed value is the org domain,
not a credential — the API token travels in the `Authorization` header and is unchanged.
