### PR TITLE
fix(stripe): Search Customer returns matching customers again

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -8682,7 +8682,7 @@
     },
     "packages/pieces/community/stripe": {
       "name": "@activepieces/piece-stripe",
-      "version": "0.6.14",
+      "version": "0.6.15",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -8692,6 +8692,7 @@
       },
       "devDependencies": {
         "tslib": "2.6.2",
+        "vitest": "3.2.6",
       },
     },
     "packages/pieces/community/supabase": {

--- a/packages/pieces/community/stripe/package.json
+++ b/packages/pieces/community/stripe/package.json
@@ -1,12 +1,13 @@
 {
   "name": "@activepieces/piece-stripe",
-  "version": "0.6.14",
+  "version": "0.6.15",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",
     "bundle": "node ../../../../dist/packages/cli/src/index.js pieces bundle",
-    "lint": "eslint 'src/**/*.ts'"
+    "lint": "eslint 'src/**/*.ts'",
+    "test": "vitest run"
   },
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
@@ -16,6 +17,7 @@
     "@activepieces/core-utils": "workspace:*"
   },
   "devDependencies": {
-    "tslib": "2.6.2"
+    "tslib": "2.6.2",
+    "vitest": "3.2.6"
   }
 }

--- a/packages/pieces/community/stripe/src/lib/actions/search-customer.ts
+++ b/packages/pieces/community/stripe/src/lib/actions/search-customer.ts
@@ -33,10 +33,9 @@ export const stripeSearchCustomer = createAction({
       url: `${stripeCommon.baseUrl}/customers/search`,
       headers: {
         Authorization: 'Bearer ' + context.auth.secret_text,
-        'Content-Type': 'application/x-www-form-urlencoded',
         'Stripe-Version': '2026-02-25.clover',
       },
-      body: {
+      queryParams: {
         query: `email:'${customer.email}'`,
       },
     });

--- a/packages/pieces/community/stripe/test/search-customer.test.ts
+++ b/packages/pieces/community/stripe/test/search-customer.test.ts
@@ -1,0 +1,77 @@
+/// <reference types="vitest/globals" />
+
+const { sendRequest } = vi.hoisted(() => ({ sendRequest: vi.fn() }));
+
+vi.mock('@activepieces/pieces-common', async (importOriginal) => {
+  const actual = await importOriginal<
+    typeof import('@activepieces/pieces-common')
+  >();
+  return {
+    ...actual,
+    httpClient: {
+      sendRequest: (...args: unknown[]) => sendRequest(...args),
+    },
+  };
+});
+
+vi.mock('../src/index', () => ({ stripeAuth: { type: 'SECRET_TEXT' } }));
+
+import { HttpMethod } from '@activepieces/pieces-common';
+import { stripeSearchCustomer } from '../src/lib/actions/search-customer';
+
+const auth = { secret_text: 'sk_test_dummy' };
+
+const lastRequest = () => sendRequest.mock.calls.at(-1)?.[0];
+
+function reply(body: unknown) {
+  sendRequest.mockResolvedValueOnce({ body });
+}
+
+function runAction(propsValue: unknown) {
+  return (stripeSearchCustomer as unknown as {
+    run: (ctx: unknown) => Promise<unknown>;
+  }).run({ auth, propsValue });
+}
+
+beforeEach(() => sendRequest.mockReset());
+
+describe('search customer', () => {
+  test('the search expression travels in the query string, since a GET cannot carry a body', async () => {
+    reply({ object: 'search_result', data: [] });
+    await runAction({ email: 'sally@rocketrides.io' });
+    expect(lastRequest().queryParams).toEqual({
+      query: "email:'sally@rocketrides.io'",
+    });
+  });
+
+  test('no body is sent at all, the shape that made Stripe reject the search', async () => {
+    reply({ object: 'search_result', data: [] });
+    await runAction({ email: 'sally@rocketrides.io' });
+    expect(lastRequest().body).toBeUndefined();
+  });
+
+  test('the form-urlencoded content type is gone with the body it described', async () => {
+    reply({ object: 'search_result', data: [] });
+    await runAction({ email: 'sally@rocketrides.io' });
+    expect(lastRequest().headers['Content-Type']).toBeUndefined();
+  });
+
+  test('it reads with a GET against the customer search endpoint', async () => {
+    reply({ object: 'search_result', data: [] });
+    await runAction({ email: 'sally@rocketrides.io' });
+    expect(lastRequest().method).toBe(HttpMethod.GET);
+    expect(lastRequest().url).toBe('https://api.stripe.com/v1/customers/search');
+  });
+
+  test('the pinned Stripe-Version is kept, search needs 2020-08-27 or later', async () => {
+    reply({ object: 'search_result', data: [] });
+    await runAction({ email: 'sally@rocketrides.io' });
+    expect(lastRequest().headers['Stripe-Version']).toBe('2026-02-25.clover');
+  });
+
+  test('it returns the search result untouched', async () => {
+    const result = { object: 'search_result', data: [{ id: 'cus_1' }] };
+    reply(result);
+    expect(await runAction({ email: 'sally@rocketrides.io' })).toEqual(result);
+  });
+});

--- a/packages/pieces/community/stripe/vitest.config.ts
+++ b/packages/pieces/community/stripe/vitest.config.ts
@@ -1,0 +1,17 @@
+import path from 'path'
+import { defineConfig } from 'vitest/config'
+
+const repoRoot = path.resolve(__dirname, '../../../..')
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+  },
+  resolve: {
+    alias: {
+      '@activepieces/pieces-framework': path.resolve(repoRoot, 'packages/pieces/framework/src/index.ts'),
+      '@activepieces/pieces-common': path.resolve(repoRoot, 'packages/pieces/common/src/index.ts'),
+    },
+  },
+})


### PR DESCRIPTION
## Description

`Search Customer` put its `query` in the **body** of `GET /v1/customers/search`. Since #13822 swapped axios for native fetch a GET cannot carry a body, and since #14557 the client drops it silently — so Stripe received a search with no `query` and rejected every call. Stripe was republished on 4 Sep, so this broken build is what cloud runs today.

Stripe's search endpoints take `query` as a URL parameter (their own example is `curl -G .../customers/search --data-urlencode "query=email:'sally@rocketrides.io'"`), and the sibling `Search Payment Intents` / `Search Invoices` actions in this piece already send it that way.

### The fix

`body: { query }` → `queryParams: { query }`, and the `Content-Type: application/x-www-form-urlencoded` header is dropped since there is no body left to describe. `Stripe-Version` and the bearer header are unchanged. No other call site in the piece sends a GET body.

Version `0.6.14` → `0.6.15`, synced in `bun.lock`.

### Regression test

This class of bug is a *silent* request-shape change, and nothing in the piece asserted the shape — so the fix ships with `test/search-customer.test.ts` covering where `query` travels, that no body is sent, and that the form-urlencoded content type is gone. Three of the six assertions fail on the old code and pass on the new.

The test mocks the piece barrel (`src/index.ts`). Every Stripe action imports `stripeAuth` from `'../..'`, so importing one action standalone pulls `createPiece` into a cycle and the piece fails to construct. Mocking the barrel is the smallest way around that; extracting the auth into its own module would touch ~60 action files and belongs in its own PR.

## How was this tested?

- **Unit** — `vitest run` in the piece: 6 passed. Verified red/green by reverting `search-customer.ts` to the 0.6.14 shape: the three request-shape tests fail (`expected undefined to deeply equal { Object (query) }`, `expected { Object (query) } to be undefined`, `expected 'application/x-www-form-urlencoded' to be undefined`) and pass again once restored.
- **Wire-level** — the real `FetchHttpClient` from `pieces-common`, bundled and run under Node against a local echo server with the exact request shape from before and after:

  | | path on the wire | body bytes |
  |---|---|---|
  | 0.6.14 (`body`) | `/v1/customers/search` | 0 |
  | 0.6.15 (`queryParams`) | `/v1/customers/search?query=email%3A%27sally%40rocketrides.io%27` | 0 |

  Stripe sees no `query` at all in the first case, which is why it rejects the request. The encoded value decodes back to `email:'sally@rocketrides.io'`, identical to what `curl --data-urlencode` produces.
- `eslint 'src/**/*.ts'`: 0 errors. `tsc -p tsconfig.lib.json --noEmit`: passes. The new `test/` directory is outside the lib build's `include`, matching `slack` and `ninety`.
- **Live, against a real Stripe test-mode account** — ran `Search Customer` through the local engine with a real connection (piece loaded from source at `0.6.15`). Searching a known customer's email returns that customer: `object: "search_result"`, one record, matching `id` / `email` / `name`, `has_more: false`. Step status `SUCCEEDED`.

  The same action on `0.6.14` cannot reach this point at all: Stripe requires `query` on the search endpoints and the old build never sent it. Picking the target customer also exercised the `Update Customer` dropdown against the same connection, which still populates correctly.

Linear: PIE-500

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

No prop, action or trigger `name` changes. The action goes from always failing to working; its output shape is unchanged.

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)

The customer email now travels in the URL rather than a body that was never sent. That is Stripe's documented request shape and what the official Stripe SDKs do; no credential moves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

