### PR TITLE
fix(talkable): move site_slug out of the GET body

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -8815,7 +8815,7 @@
     },
     "packages/pieces/community/talkable": {
       "name": "@activepieces/piece-talkable",
-      "version": "0.2.8",
+      "version": "0.2.9",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",

--- a/packages/pieces/community/talkable/package.json
+++ b/packages/pieces/community/talkable/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-talkable",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {

--- a/packages/pieces/community/talkable/src/index.ts
+++ b/packages/pieces/community/talkable/src/index.ts
@@ -20,6 +20,7 @@ import {
   updateReferralStatus,
   claimOffer,
 } from './lib/actions';
+import { TALKABLE_API_URL } from './lib/common/constants';
 
 const markdownDescription = `
 Follow these steps:
@@ -70,7 +71,7 @@ export const talkable = createPiece({
     updateReferralStatus,
     claimOffer,
     createCustomApiCallAction({
-      baseUrl: () => 'https://www.talkable.com/api/v2',
+      baseUrl: () => TALKABLE_API_URL,
       auth: talkableAuth,
       authMapping: async (auth) => ({
         Authorization: `Bearer ${auth.props.api_key}`,

--- a/packages/pieces/community/talkable/src/lib/actions/coupons/find-coupon.ts
+++ b/packages/pieces/community/talkable/src/lib/actions/coupons/find-coupon.ts
@@ -1,6 +1,7 @@
 import { createAction, Property } from '@activepieces/pieces-framework';
 import { httpClient, HttpMethod } from '@activepieces/pieces-common';
 import { talkableAuth } from '../../..';
+import { TALKABLE_API_URL } from '../../common/constants';
 
 export const findCoupon = createAction({
   name: 'find_coupon', // Must be a unique across the piece, this shouldn't be changed.
@@ -17,7 +18,6 @@ export const findCoupon = createAction({
     }),
   },
   async run(context) {
-    const TALKABLE_API_URL = 'https://www.talkable.com/api/v2';
     const { site, api_key } = context.auth.props;
     const couponInfoResponse = await httpClient
       .sendRequest<string[]>({
@@ -27,7 +27,7 @@ export const findCoupon = createAction({
           Authorization: `Bearer ${api_key}`,
           'Content-Type': 'application/json',
         },
-        body: {
+        queryParams: {
           site_slug: site,
         },
       });

--- a/packages/pieces/community/talkable/src/lib/actions/loyalty/get-loyalty-redeem-actions.ts
+++ b/packages/pieces/community/talkable/src/lib/actions/loyalty/get-loyalty-redeem-actions.ts
@@ -1,6 +1,7 @@
 import { createAction, Property } from '@activepieces/pieces-framework';
 import { httpClient, HttpMethod } from '@activepieces/pieces-common';
 import { talkableAuth } from '../../..';
+import { TALKABLE_API_URL } from '../../common/constants';
 
 export const getLoyaltyRedeemActions = createAction({
   name: 'get_loyalty_redeem_actions', // Must be a unique across the piece, this shouldn't be changed.
@@ -17,7 +18,6 @@ export const getLoyaltyRedeemActions = createAction({
     }),
   },
   async run(context) {
-    const TALKABLE_API_URL = 'https://www.talkable.com/api/v2';
     const { site, api_key } = context.auth.props;
     const getLoyaltyRedeemActionsResponse = await httpClient
       .sendRequest<string[]>({
@@ -27,7 +27,7 @@ export const getLoyaltyRedeemActions = createAction({
           Authorization: `Bearer ${api_key}`,
           'Content-Type': 'application/json',
         },
-        body: {
+        queryParams: {
           site_slug: site,
         },
       });

--- a/packages/pieces/community/talkable/src/lib/actions/origins/create-event.ts
+++ b/packages/pieces/community/talkable/src/lib/actions/origins/create-event.ts
@@ -4,6 +4,7 @@ import {
 } from '@activepieces/pieces-framework';
 import { httpClient, HttpMethod } from '@activepieces/pieces-common';
 import { talkableAuth } from '../../..';
+import { TALKABLE_API_URL } from '../../common/constants';
 
 export const createEvent = createAction({
   name: 'create_event', // Must be a unique across the piece, this shouldn't be changed.
@@ -129,7 +130,6 @@ export const createEvent = createAction({
     }),
   },
   async run(context) {
-    const TALKABLE_API_URL = 'https://www.talkable.com/api/v2';
     const { site, api_key } = context.auth.props;
     const createEventResponse = await httpClient
       .sendRequest<string[]>({

--- a/packages/pieces/community/talkable/src/lib/actions/origins/create-events-batch.ts
+++ b/packages/pieces/community/talkable/src/lib/actions/origins/create-events-batch.ts
@@ -1,6 +1,7 @@
 import { createAction, Property } from '@activepieces/pieces-framework';
 import { httpClient, HttpMethod } from '@activepieces/pieces-common';
 import { talkableAuth } from '../../..';
+import { TALKABLE_API_URL } from '../../common/constants';
 
 export const createEventsBatch = createAction({
   name: 'create_events_batch', // Must be a unique across the piece, this shouldn't be changed.
@@ -60,7 +61,6 @@ export const createEventsBatch = createAction({
     }),
   },
   async run(context) {
-    const TALKABLE_API_URL = 'https://www.talkable.com/api/v2';
     const { site, api_key } = context.auth.props;
     const createEventsBatch = await httpClient
       .sendRequest<string[]>({

--- a/packages/pieces/community/talkable/src/lib/actions/origins/create-purchase.ts
+++ b/packages/pieces/community/talkable/src/lib/actions/origins/create-purchase.ts
@@ -4,6 +4,7 @@ import {
 } from '@activepieces/pieces-framework';
 import { httpClient, HttpMethod } from '@activepieces/pieces-common';
 import { talkableAuth } from '../../..';
+import { TALKABLE_API_URL } from '../../common/constants';
 
 export const createPurchase = createAction({
   name: 'create_purchase', // Must be a unique across the piece, this shouldn't be changed.
@@ -124,7 +125,6 @@ export const createPurchase = createAction({
     }),
   },
   async run(context) {
-    const TALKABLE_API_URL = 'https://www.talkable.com/api/v2';
     const { site, api_key } = context.auth.props;
     const createPurchaseResponse = await httpClient
       .sendRequest<string[]>({

--- a/packages/pieces/community/talkable/src/lib/actions/origins/create-purchases-batch.ts
+++ b/packages/pieces/community/talkable/src/lib/actions/origins/create-purchases-batch.ts
@@ -1,6 +1,7 @@
 import { createAction, Property } from '@activepieces/pieces-framework';
 import { httpClient, HttpMethod } from '@activepieces/pieces-common';
 import { talkableAuth } from '../../..';
+import { TALKABLE_API_URL } from '../../common/constants';
 
 export const createPurchasesBatch = createAction({
   name: 'create_purchases_batch', // Must be a unique across the piece, this shouldn't be changed.
@@ -59,7 +60,6 @@ export const createPurchasesBatch = createAction({
     }),
   },
   async run(context) {
-    const TALKABLE_API_URL = 'https://www.talkable.com/api/v2';
     const { site, api_key } = context.auth.props;
     const createPurchasesBatch = await httpClient
       .sendRequest<string[]>({

--- a/packages/pieces/community/talkable/src/lib/actions/origins/refund.ts
+++ b/packages/pieces/community/talkable/src/lib/actions/origins/refund.ts
@@ -1,6 +1,7 @@
 import { createAction, Property } from '@activepieces/pieces-framework';
 import { httpClient, HttpMethod } from '@activepieces/pieces-common';
 import { talkableAuth } from '../../..';
+import { TALKABLE_API_URL } from '../../common/constants';
 
 export const refund = createAction({
   name: 'refund', // Must be a unique across the piece, this shouldn't be changed.
@@ -27,7 +28,6 @@ export const refund = createAction({
     }),
   },
   async run(context) {
-    const TALKABLE_API_URL = 'https://www.talkable.com/api/v2';
     const { site, api_key } = context.auth.props;
     const { origin_slug, refund_subtotal, refunded_at } = context.propsValue;
     const refundResponse = await httpClient

--- a/packages/pieces/community/talkable/src/lib/actions/people/anonymize-person.ts
+++ b/packages/pieces/community/talkable/src/lib/actions/people/anonymize-person.ts
@@ -1,6 +1,7 @@
 import { createAction, Property } from '@activepieces/pieces-framework';
 import { httpClient, HttpMethod } from '@activepieces/pieces-common';
 import { talkableAuth } from '../../..';
+import { TALKABLE_API_URL } from '../../common/constants';
 
 export const anonymizePerson = createAction({
   name: 'anonymize_person', // Must be a unique across the piece, this shouldn't be changed.
@@ -17,7 +18,6 @@ export const anonymizePerson = createAction({
     }),
   },
   async run(context) {
-    const TALKABLE_API_URL = 'https://www.talkable.com/api/v2';
     const { site, api_key } = context.auth.props;
     const personAnonymizeResponse = await httpClient
       .sendRequest<string[]>({

--- a/packages/pieces/community/talkable/src/lib/actions/people/find-person.ts
+++ b/packages/pieces/community/talkable/src/lib/actions/people/find-person.ts
@@ -1,9 +1,10 @@
 import { createAction, Property } from '@activepieces/pieces-framework';
 import { httpClient, HttpMethod } from '@activepieces/pieces-common';
 import { talkableAuth } from '../../..';
+import { TALKABLE_API_URL } from '../../common/constants';
 
 export const findPerson = createAction({
-  name: 'find_person', // Must be a unique across the piece, this shouldn't be changed.
+  name: 'find_person',
   auth: talkableAuth,
   displayName: 'Find person',
   description: 'Find person by email',
@@ -50,7 +51,6 @@ export const findPerson = createAction({
     }),
   },
   async run(context) {
-    const TALKABLE_API_URL = 'https://www.talkable.com/api/v2';
     const { site, api_key } = context.auth.props;
     const personInfoResponse = await httpClient
       .sendRequest<string[]>({
@@ -60,7 +60,7 @@ export const findPerson = createAction({
           Authorization: `Bearer ${api_key}`,
           'Content-Type': 'application/json',
         },
-        body: {
+        queryParams: {
           site_slug: site,
         },
       });

--- a/packages/pieces/community/talkable/src/lib/actions/people/unsubscribe-person.ts
+++ b/packages/pieces/community/talkable/src/lib/actions/people/unsubscribe-person.ts
@@ -1,6 +1,7 @@
 import { createAction, Property } from '@activepieces/pieces-framework';
 import { httpClient, HttpMethod } from '@activepieces/pieces-common';
 import { talkableAuth } from '../../..';
+import { TALKABLE_API_URL } from '../../common/constants';
 
 export const unsubscribePerson = createAction({
   name: 'unsubscribe_person', // Must be a unique across the piece, this shouldn't be changed.
@@ -17,7 +18,6 @@ export const unsubscribePerson = createAction({
     }),
   },
   async run(context) {
-    const TALKABLE_API_URL = 'https://www.talkable.com/api/v2';
     const { site, api_key } = context.auth.props;
     const personUnsubscribeResponse = await httpClient
       .sendRequest<string[]>({

--- a/packages/pieces/community/talkable/src/lib/actions/people/update-person.ts
+++ b/packages/pieces/community/talkable/src/lib/actions/people/update-person.ts
@@ -1,6 +1,7 @@
 import { createAction, Property } from '@activepieces/pieces-framework';
 import { httpClient, HttpMethod } from '@activepieces/pieces-common';
 import { talkableAuth } from '../../..';
+import { TALKABLE_API_URL } from '../../common/constants';
 
 export const updatePerson = createAction({
   name: 'update_person', // Must be a unique across the piece, this shouldn't be changed.
@@ -86,7 +87,6 @@ export const updatePerson = createAction({
     }),
   },
   async run(context) {
-    const TALKABLE_API_URL = 'https://www.talkable.com/api/v2';
     const { site, api_key } = context.auth.props;
     const {
       email,

--- a/packages/pieces/community/talkable/src/lib/actions/referrals/update-referral-status.ts
+++ b/packages/pieces/community/talkable/src/lib/actions/referrals/update-referral-status.ts
@@ -1,6 +1,7 @@
 import { createAction, Property } from '@activepieces/pieces-framework';
 import { httpClient, HttpMethod } from '@activepieces/pieces-common';
 import { talkableAuth } from '../../..';
+import { TALKABLE_API_URL } from '../../common/constants';
 
 export const updateReferralStatus = createAction({
   name: 'update-referral-status', // Must be a unique across the piece, this shouldn't be changed.
@@ -29,7 +30,6 @@ export const updateReferralStatus = createAction({
     }),
   },
   async run(context) {
-    const TALKABLE_API_URL = 'https://www.talkable.com/api/v2';
     const { site, api_key } = context.auth.props;
     const updateReferralStatusResponse = await httpClient
       .sendRequest<string[]>({

--- a/packages/pieces/community/talkable/src/lib/actions/rewards/claim-offer.ts
+++ b/packages/pieces/community/talkable/src/lib/actions/rewards/claim-offer.ts
@@ -1,6 +1,7 @@
 import { createAction, Property } from '@activepieces/pieces-framework';
 import { httpClient, HttpMethod } from '@activepieces/pieces-common';
 import { talkableAuth } from '../../..';
+import { TALKABLE_API_URL } from '../../common/constants';
 
 export const claimOffer = createAction({
   name: 'claim-offer', // Must be a unique across the piece, this shouldn't be changed.
@@ -27,7 +28,6 @@ export const claimOffer = createAction({
     }),
   },
   async run(context) {
-    const TALKABLE_API_URL = 'https://www.talkable.com/api/v2';
     const { site, api_key } = context.auth.props;
     const claimOffer = await httpClient
       .sendRequest<string[]>({

--- a/packages/pieces/community/talkable/src/lib/common/constants.ts
+++ b/packages/pieces/community/talkable/src/lib/common/constants.ts
@@ -1,0 +1,1 @@
+export const TALKABLE_API_URL = 'https://www.talkable.com/api/v2';


### PR DESCRIPTION
## Description

Since the pieces HTTP client moved to `fetch` (#13822), GET requests silently drop their body — `fetch` cannot send one. Talkable's **Find coupon**, **Get loyalty actions**, and **Find person** actions sent the required `site_slug` in the GET body, so calls fail or resolve against the wrong site since the piece was republished after #14557 (4 Aug).

Moves `site_slug` to `queryParams` on the three affected requests, and dedupes the `https://www.talkable.com/api/v2` literal (previously redefined in every action file) into a single `TALKABLE_API_URL` constant in `src/lib/common/constants.ts`.

Patch-bumps `@activepieces/piece-talkable` 0.2.8 → 0.2.9.

## How was this tested?

- `npx turbo run lint --filter=@activepieces/piece-talkable` passes.
- Not verified against a live Talkable account (needs Talkable credentials); the query-string form matches vendor docs.

Fixes PIE-499

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact