### PR TITLE
fix(kimai): activity dropdown ignores project, migrate auth to Bearer token

### DIFF
--- a/docs/install/reference/breaking-changes.mdx
+++ b/docs/install/reference/breaking-changes.mdx
@@ -207,6 +207,16 @@ The region on these connections is also validated against the AWS region format 
 
 Only if you use the IAM Role / OIDC method on an AWS piece. Allow outbound HTTPS to `sts.<region>.amazonaws.com` from the machine running the worker, and make sure `AP_FRONTEND_URL` matches the Provider URL of your IAM OIDC identity provider, since the issuer in the signed token is derived from it. Existing saved connections keep working and are not revalidated automatically — pressing **Recheck** on a connection whose trust policy is wrong will now move it to an error state, which reflects what already happens when a flow runs.
 
+#### Kimai connections now authenticate with an API token instead of a username and API password
+
+Kimai is deprecating its legacy `X-AUTH-USER` / `X-AUTH-TOKEN` authentication (API passwords), with removal planned no later than July 2026 — see [Kimai's announcement](https://www.kimai.org/en/blog/2026/removing-api-passwords). The Kimai piece's connection now sends `Authorization: Bearer <token>` instead, matching Kimai's current API. This also fixes the Activity dropdown on the Create Timesheet action, which ignored the selected project because it tried to filter on a GET request body that the piece's HTTP client cannot send.
+
+The connection's `Username` and `API Password` fields are removed and replaced with a single `API Token` field.
+
+#### What you need to do
+
+Only if you have an existing Kimai connection. Reconnect it: in your Kimai instance, generate an API token from your user profile's "API Access" page, then re-enter your Kimai connection in Activepieces with the Server URL and that token. Existing connections using the old username/API-password fields will fail to authenticate until reconnected.
+
 ## 0.91.0
 
 ### What has changed?

--- a/packages/pieces/community/kimai/package.json
+++ b/packages/pieces/community/kimai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-kimai",
-  "version": "0.2.7",
+  "version": "0.3.0",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {

--- a/packages/pieces/community/kimai/src/index.ts
+++ b/packages/pieces/community/kimai/src/index.ts
@@ -19,7 +19,7 @@ export const kimaiAuth = PieceAuth.CustomAuth({
 
   1. Go to Kimai Web UI;
   2. Click on your user profile and then go to "API Access";
-  3. Configure an API password (different from user password).
+  3. Generate an API token.
   `,
   props: {
     base_url: Property.ShortText({
@@ -27,14 +27,9 @@ export const kimaiAuth = PieceAuth.CustomAuth({
       description: 'Kimai Instance URL (e.g. https://demo.kimai.org)',
       required: true,
     }),
-    user: Property.ShortText({
-      displayName: 'Username',
-      description: 'Kimai Username/Email',
-      required: true,
-    }),
-    api_password: PieceAuth.SecretText({
-      displayName: 'API Password',
-      description: 'Kimai API Password',
+    api_token: PieceAuth.SecretText({
+      displayName: 'API Token',
+      description: 'Kimai API Token',
       required: true,
     }),
   },
@@ -103,8 +98,7 @@ export const kimai = createPiece({
      baseUrl: (auth) => (auth?.props.base_url ?? ''),
       auth: kimaiAuth,
       authMapping: async (auth) => ({
-        'X-AUTH-USER': auth.props.user,
-        'X-AUTH-TOKEN': auth.props.api_password,
+        Authorization: `Bearer ${auth.props.api_token}`,
       }),
     }),
   ],

--- a/packages/pieces/community/kimai/src/lib/common/client.ts
+++ b/packages/pieces/community/kimai/src/lib/common/client.ts
@@ -3,7 +3,9 @@ import {
   HttpMessageBody,
   httpClient,
   HttpResponse,
+  QueryParams,
 } from '@activepieces/pieces-common';
+import { spreadIfDefined } from '@activepieces/pieces-framework';
 
 type PingResponse = {
   message: string;
@@ -40,21 +42,27 @@ type TimesheetResponse = {
 export class KimaiClient {
   constructor(
     private baseUrl: string,
-    private user: string,
-    private apiPassword: string
+    private apiToken: string
   ) {
     // Remove trailing slash from base URL
     this.baseUrl = baseUrl.replace(/\/$/, '');
   }
 
   async ping(): Promise<PingResponse> {
-    return (await this.makeRequest<PingResponse>(HttpMethod.GET, '/api/ping'))
-      .body;
+    return (
+      await this.makeRequest<PingResponse>({
+        method: HttpMethod.GET,
+        resourceUri: '/api/ping',
+      })
+    ).body;
   }
 
   async getProjects(): Promise<ProjectResponse[]> {
     return (
-      await this.makeRequest<ProjectResponse[]>(HttpMethod.GET, '/api/projects')
+      await this.makeRequest<ProjectResponse[]>({
+        method: HttpMethod.GET,
+        resourceUri: '/api/projects',
+      })
     ).body;
   }
 
@@ -62,13 +70,11 @@ export class KimaiClient {
     project: number | undefined = undefined
   ): Promise<ActivityResponse[]> {
     return (
-      await this.makeRequest<ActivityResponse[]>(
-        HttpMethod.GET,
-        '/api/activities',
-        {
-          project: project,
-        }
-      )
+      await this.makeRequest<ActivityResponse[]>({
+        method: HttpMethod.GET,
+        resourceUri: '/api/activities',
+        queryParams: spreadIfDefined('project', project?.toString()),
+      })
     ).body;
   }
 
@@ -76,27 +82,33 @@ export class KimaiClient {
     createData: TimesheetCreateRequest
   ): Promise<TimesheetResponse> {
     return (
-      await this.makeRequest<TimesheetResponse>(
-        HttpMethod.POST,
-        '/api/timesheets',
-        createData
-      )
+      await this.makeRequest<TimesheetResponse>({
+        method: HttpMethod.POST,
+        resourceUri: '/api/timesheets',
+        body: createData,
+      })
     ).body;
   }
 
-  async makeRequest<T extends HttpMessageBody>(
-    method: HttpMethod,
-    resourceUri: string,
-    body: any | undefined = undefined
-  ): Promise<HttpResponse<T>> {
+  async makeRequest<T extends HttpMessageBody>({
+    method,
+    resourceUri,
+    body = undefined,
+    queryParams = undefined,
+  }: {
+    method: HttpMethod;
+    resourceUri: string;
+    body?: HttpMessageBody;
+    queryParams?: QueryParams;
+  }): Promise<HttpResponse<T>> {
     return await httpClient.sendRequest<T>({
       method: method,
       url: `${this.baseUrl}${resourceUri}`,
       headers: {
-        'X-AUTH-USER': this.user,
-        'X-AUTH-TOKEN': this.apiPassword,
+        Authorization: `Bearer ${this.apiToken}`,
       },
       body: body,
+      queryParams: queryParams,
     });
   }
 }

--- a/packages/pieces/community/kimai/src/lib/common/index.ts
+++ b/packages/pieces/community/kimai/src/lib/common/index.ts
@@ -82,6 +82,6 @@ export const kimaiCommon = {
 export async function makeClient(
   auth: AppConnectionValueForAuthProperty<typeof kimaiAuth>
 ): Promise<KimaiClient> {
-  const client = new KimaiClient(auth.props.base_url, auth.props.user, auth.props.api_password);
+  const client = new KimaiClient(auth.props.base_url, auth.props.api_token);
   return client;
 }


### PR DESCRIPTION
## Description

Two related fixes to the Kimai piece:

1. **PIE-502** — `KimaiClient.getActivities()` passed `{ project }` as the body of a `GET /api/activities` request. Since the pieces HTTP client is fetch-based, a GET/HEAD body is silently dropped, so the Activity dropdown on **Create Timesheet** listed every activity in the instance instead of the ones belonging to the selected project. Fixed by sending `project` as a query parameter instead.

2. **Auth migration to Bearer token** — Kimai is deprecating its legacy `X-AUTH-USER` / `X-AUTH-TOKEN` (username + API password) authentication, with removal planned no later than July 2026 ([Kimai's announcement](https://www.kimai.org/en/blog/2026/removing-api-passwords)). Verified live against a Kimai Cloud instance that the old headers now return `403 Invalid credentials` while `Authorization: Bearer <token>` succeeds. The piece's connection is updated to a single `API Token` field, dropping `Username`/`API Password`.

Both fixes are in the same file (`client.ts`) and were verified together against a live Kimai Cloud instance.

## How was this tested?

- `npx turbo run build --filter=@activepieces/piece-kimai` and `npx turbo run lint --filter=@activepieces/piece-kimai` — both pass (0 errors).
- Verified live against a real Kimai Cloud instance via `curl`:
  - Legacy `X-AUTH-USER`/`X-AUTH-TOKEN` headers → `403 Invalid credentials` (confirms deprecation).
  - `Authorization: Bearer <token>` → `200 OK` on `/api/ping`, `/api/projects`.
  - `GET /api/activities?project=1` (query param, matching the new client code) → `200 OK`, correctly filtered to the given project.
- Not tested against a self-hosted CE/EE Kimai instance; this is a third-party piece connection change, not gated by Activepieces edition.

Fixes # PIE-502

### Breaking change?  (required — CI fails if this is left unedited)

- [ ] no — reviewed, not breaking
- [x] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)