### PR TITLE
fix(bubble): Get Thing returns the single item instead of the whole list

### DIFF
--- a/packages/pieces/community/bubble/package.json
+++ b/packages/pieces/community/bubble/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-bubble",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {

--- a/packages/pieces/community/bubble/src/lib/actions/get-thing.ts
+++ b/packages/pieces/community/bubble/src/lib/actions/get-thing.ts
@@ -24,7 +24,7 @@ export const bubbleGetThingAction = createAction({
     const { appname, token } = context.auth.props;
     const { typename, thing_id } = context.propsValue;
 
-    const server_url = `https://${appname}.bubbleapps.io/api/1.1/obj/${typename}`;
+    const server_url = `https://${appname}.bubbleapps.io/api/1.1/obj/${typename}/${thing_id}`;
 
     const response = await httpClient.sendRequest({
       method: HttpMethod.GET,
@@ -36,9 +36,6 @@ export const bubbleGetThingAction = createAction({
       authentication: {
         type: AuthenticationType.BEARER_TOKEN,
         token,
-      },
-      body: {
-        constraint: `id = ${thing_id}`,
       },
     });
 


### PR DESCRIPTION
## Description

`Get Thing` (`lib/actions/get-thing.ts`) sent `constraint: "id = X"` in the body of a `GET /obj/{type}` request. Bubble's Data API never read that — it wants the id in the URL path, `GET /obj/{type}/{id}`. So the action has always returned the unfiltered list of things instead of a single item, even before the pieces HTTP client switched to fetch (which can't send a GET body at all — it just made the existing bug more visible by silently dropping the body instead of Bubble ignoring it server-side).

Fixed by building the URL as `/obj/{typename}/{thing_id}`, matching the existing convention already used by `delete-thing.ts` in this same piece, and dropping the unused body.

## How was this tested?

- `npx turbo run build --filter=@activepieces/piece-bubble` and `npx turbo run lint --filter=@activepieces/piece-bubble` — both pass (0 errors; existing warnings are pre-existing unused imports unrelated to this change).
- No Bubble test account available in this session, so not verified against a live Bubble app; the fix mirrors the already-working `delete-thing.ts` action's URL pattern in the same piece.

Fixes # PIE-504

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)