### PR TITLE
feat(google-drive): Optimize google drive list files

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -3840,6 +3840,7 @@
       "devDependencies": {
         "@types/mime-types": "2.1.1",
         "tslib": "2.6.2",
+        "vitest": "3.2.6",
       },
     },
     "packages/pieces/community/google-forms": {

--- a/bun.lock
+++ b/bun.lock
@@ -163,7 +163,7 @@
     },
     "packages/core/shared": {
       "name": "@activepieces/shared",
-      "version": "0.162.0",
+      "version": "0.165.0",
       "dependencies": {
         "@activepieces/core-execution": "workspace:*",
         "@activepieces/core-formula": "workspace:*",
@@ -214,7 +214,7 @@
     },
     "packages/pieces/common": {
       "name": "@activepieces/pieces-common",
-      "version": "0.13.2",
+      "version": "0.13.3",
       "dependencies": {
         "@activepieces/core-utils": "workspace:*",
         "@activepieces/pieces-framework": "workspace:*",
@@ -3824,7 +3824,7 @@
     },
     "packages/pieces/community/google-drive": {
       "name": "@activepieces/piece-google-drive",
-      "version": "0.9.1",
+      "version": "0.9.2",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -7857,6 +7857,16 @@
         "tslib": "2.6.2",
       },
     },
+    "packages/pieces/community/sage-accounting": {
+      "name": "@activepieces/piece-sage-accounting",
+      "version": "0.0.1",
+      "dependencies": {
+        "@activepieces/pieces-common": "workspace:*",
+        "@activepieces/pieces-framework": "workspace:*",
+        "@activepieces/shared": "workspace:*",
+        "tslib": "2.6.2",
+      },
+    },
     "packages/pieces/community/saleor": {
       "name": "@activepieces/piece-saleor",
       "version": "0.1.6",
@@ -10418,7 +10428,7 @@
     },
     "packages/pieces/core/http": {
       "name": "@activepieces/piece-http",
-      "version": "0.11.21",
+      "version": "0.11.22",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -12286,6 +12296,8 @@
     "@activepieces/piece-runway": ["@activepieces/piece-runway@workspace:packages/pieces/community/runway"],
 
     "@activepieces/piece-saastic": ["@activepieces/piece-saastic@workspace:packages/pieces/community/saastic"],
+
+    "@activepieces/piece-sage-accounting": ["@activepieces/piece-sage-accounting@workspace:packages/pieces/community/sage-accounting"],
 
     "@activepieces/piece-saleor": ["@activepieces/piece-saleor@workspace:packages/pieces/community/saleor"],
 

--- a/packages/pieces/community/google-drive/package.json
+++ b/packages/pieces/community/google-drive/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-google-drive",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "dependencies": {

--- a/packages/pieces/community/google-drive/package.json
+++ b/packages/pieces/community/google-drive/package.json
@@ -18,10 +18,12 @@
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",
     "bundle": "node ../../../../dist/packages/cli/src/index.js pieces bundle",
-    "lint": "eslint 'src/**/*.ts'"
+    "lint": "eslint 'src/**/*.ts'",
+    "test": "vitest run"
   },
   "devDependencies": {
     "@types/mime-types": "2.1.1",
-    "tslib": "2.6.2"
+    "tslib": "2.6.2",
+    "vitest": "3.2.6"
   }
 }

--- a/packages/pieces/community/google-drive/src/lib/action/drive-export-folder-as-zip.ts
+++ b/packages/pieces/community/google-drive/src/lib/action/drive-export-folder-as-zip.ts
@@ -4,13 +4,12 @@ import {
   PieceAuth,
   MarkdownVariant,
 } from '@activepieces/pieces-framework';
-import { httpClient, HttpMethod } from '@activepieces/pieces-common';
 import { Readable } from 'node:stream';
 import { ZipWriter, ZipWriterAddDataOptions } from '@zip.js/zip.js';
 import { extension } from 'mime-types';
-import querystring from 'querystring';
 import { googleDriveAuth, GoogleDriveAuthValue, getAccessToken } from '../auth';
 import { common } from '../common';
+import { listDriveFiles } from '../common/list-drive-files';
 
 // A zip is a sequential format. Only the entry holding the writer lock streams straight into the
 // archive -- that one is paced by backpressure and costs almost nothing. Every *other* in-flight
@@ -103,40 +102,17 @@ async function listFolderChildren({
   folderId: string;
   includeTeamDrives: boolean;
 }): Promise<DriveListItem[]> {
-  const accessToken = await getAccessToken(auth);
-  const items: DriveListItem[] = [];
-
-  const params: Record<string, string> = {
-    q: `'${folderId}' in parents and trashed=false`,
-    fields: 'nextPageToken,files(id,name,mimeType,size)',
-    supportsAllDrives: 'true',
-    includeItemsFromAllDrives: includeTeamDrives ? 'true' : 'false',
-    corpora: includeTeamDrives ? 'allDrives' : 'user',
-    pageSize: '1000',
-  };
-
-  let nextPageToken: string | undefined;
-  do {
-    if (nextPageToken) {
-      params.pageToken = nextPageToken;
-    }
-    const response = await httpClient.sendRequest<{
-      files: DriveListItem[];
-      nextPageToken?: string;
-    }>({
-      method: HttpMethod.GET,
-      url: `https://www.googleapis.com/drive/v3/files?${querystring.stringify(
-        params
-      )}`,
-      headers: {
-        Authorization: `Bearer ${accessToken}`,
-      },
-    });
-    items.push(...(response.body.files ?? []));
-    nextPageToken = response.body.nextPageToken;
-  } while (nextPageToken);
-
-  return items;
+  return listDriveFiles<DriveListItem>({
+    auth,
+    params: {
+      q: `'${folderId}' in parents and trashed=false`,
+      fields: 'nextPageToken,files(id,name,mimeType,size)',
+      supportsAllDrives: 'true',
+      includeItemsFromAllDrives: includeTeamDrives ? 'true' : 'false',
+      corpora: includeTeamDrives ? 'allDrives' : 'user',
+      pageSize: '1000',
+    },
+  });
 }
 
 interface ExportError {

--- a/packages/pieces/community/google-drive/src/lib/action/drive-list-files.ts
+++ b/packages/pieces/community/google-drive/src/lib/action/drive-list-files.ts
@@ -69,7 +69,7 @@ export const driveListFiles = createAction({
     const depthLevel = context.propsValue.depth_level || 1;
 
     // Get files level-by-level, batching all folders at a level into as few queries as possible
-    const filesWithLevel = await listDriveFilesRecursive({
+    const files = await listDriveFilesRecursive({
       auth: context.auth,
       rootFolderId: context.propsValue.folder_id,
       maxLevel: depthLevel,
@@ -81,8 +81,7 @@ export const driveListFiles = createAction({
     if (context.propsValue.download_files) {
       const processedFiles: any[] = [];
 
-      for (const fileWithLevel of filesWithLevel) {
-        const file = fileWithLevel.file;
+      for (const file of files) {
         // Skip folders when downloading
         if (file.mimeType === 'application/vnd.google-apps.folder') {
           processedFiles.push(file);
@@ -130,7 +129,7 @@ export const driveListFiles = createAction({
         .map((f) => f.downloadedFile)
         .filter((url): url is string => url !== undefined);
     } else {
-      result.files = filesWithLevel.map((f) => f.file);
+      result.files = files;
     }
 
     return result;

--- a/packages/pieces/community/google-drive/src/lib/action/drive-list-files.ts
+++ b/packages/pieces/community/google-drive/src/lib/action/drive-list-files.ts
@@ -1,6 +1,6 @@
 import { googleDriveAuth } from '../auth';
 import { Property, createAction } from '@activepieces/pieces-framework';
-import { getFilesByLevel } from '../common/list-files-recursive';
+import { getFilesByLevel } from '../common/list-drive-files';
 import { downloadFileFromDrive } from '../common/get-file-content';
 import { driveListFilesOutputSchema } from '../output-schemas';
 

--- a/packages/pieces/community/google-drive/src/lib/action/drive-list-files.ts
+++ b/packages/pieces/community/google-drive/src/lib/action/drive-list-files.ts
@@ -1,6 +1,6 @@
 import { googleDriveAuth } from '../auth';
 import { Property, createAction } from '@activepieces/pieces-framework';
-import { getFilesByLevel } from '../common/list-drive-files';
+import { listDriveFilesRecursive } from '../common/list-drive-files';
 import { downloadFileFromDrive } from '../common/get-file-content';
 import { driveListFilesOutputSchema } from '../output-schemas';
 
@@ -68,7 +68,7 @@ export const driveListFiles = createAction({
     const depthLevel = context.propsValue.depth_level || 1;
 
     // Get files level-by-level, batching all folders at a level into as few queries as possible
-    const filesWithLevel = await getFilesByLevel({
+    const filesWithLevel = await listDriveFilesRecursive({
       auth: context.auth,
       rootFolderId: context.propsValue.folder_id,
       maxLevel: depthLevel,

--- a/packages/pieces/community/google-drive/src/lib/action/drive-list-files.ts
+++ b/packages/pieces/community/google-drive/src/lib/action/drive-list-files.ts
@@ -79,9 +79,8 @@ export const driveListFiles = createAction({
     // Extract just the file objects for backward compatibility
     result.files = filesWithLevel.map((f) => f.file);
 
-    // If downloadFiles is enabled, download each file and add URLs to array
+    // If downloadFiles is enabled, download each file and attach the URL onto the file itself
     if (context.propsValue.download_files) {
-      const downloadedFiles: string[] = [];
       const extensionMap: Record<string, string> = {
         'application/pdf': '.pdf',
         'image/jpeg': '.jpg',
@@ -120,13 +119,12 @@ export const driveListFiles = createAction({
         }
 
         try {
-          const fileUrl = await downloadFileFromDrive(
+          file.downloadedFile = await downloadFileFromDrive(
             context.auth,
             context.files,
             file.id,
             safeName
           );
-          downloadedFiles.push(fileUrl);
         } catch (error) {
           console.warn(
             `Failed to download file ${file.name}: ${
@@ -135,7 +133,11 @@ export const driveListFiles = createAction({
           );
         }
       }
-      result.downloadedFiles = downloadedFiles;
+
+      // Kept for backward compatibility; each URL now also lives on its file's `downloadedFile`
+      result.downloadedFiles = filesWithLevel
+        .map((f) => f.file.downloadedFile)
+        .filter((url): url is string => url !== undefined);
     }
 
     return result;

--- a/packages/pieces/community/google-drive/src/lib/action/drive-list-files.ts
+++ b/packages/pieces/community/google-drive/src/lib/action/drive-list-files.ts
@@ -1,3 +1,4 @@
+import { extension } from 'mime-types';
 import { googleDriveAuth } from '../auth';
 import { Property, createAction } from '@activepieces/pieces-framework';
 import { listDriveFilesRecursive } from '../common/list-drive-files';
@@ -76,36 +77,23 @@ export const driveListFiles = createAction({
       includeTeamDrives: context.propsValue.include_team_drives ?? false,
     });
 
-    // Extract just the file objects for backward compatibility
-    result.files = filesWithLevel.map((f) => f.file);
-
-    // If downloadFiles is enabled, download each file and attach the URL onto the file itself
+    // If downloadFiles is enabled, download each file and return a new file object carrying the URL
     if (context.propsValue.download_files) {
-      const extensionMap: Record<string, string> = {
-        'application/pdf': '.pdf',
-        'image/jpeg': '.jpg',
-        'image/png': '.png',
-        'image/tiff': '.tiff',
-        'text/plain': '.txt',
-        'text/csv': '.csv',
-        'application/vnd.openxmlformats-officedocument.wordprocessingml.document':
-          '.docx',
-        'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet':
-          '.xlsx',
-      };
+      const processedFiles: any[] = [];
 
       for (const fileWithLevel of filesWithLevel) {
         const file = fileWithLevel.file;
         // Skip folders when downloading
         if (file.mimeType === 'application/vnd.google-apps.folder') {
+          processedFiles.push(file);
           continue;
         }
 
         let safeName = file.name;
-        const correctExtension = extensionMap[file.mimeType];
+        const correctExtension = extension(file.mimeType);
         if (
           correctExtension &&
-          !safeName.toLowerCase().endsWith(correctExtension)
+          !safeName.toLowerCase().endsWith(`.${correctExtension}`)
         ) {
           // Check for the .jpeg edge case before appending .jpg
           if (
@@ -114,30 +102,35 @@ export const driveListFiles = createAction({
               safeName.toLowerCase().endsWith('.jpeg')
             )
           ) {
-            safeName = safeName + correctExtension;
+            safeName = `${safeName}.${correctExtension}`;
           }
         }
 
         try {
-          file.downloadedFile = await downloadFileFromDrive(
+          const downloadedFile = await downloadFileFromDrive(
             context.auth,
             context.files,
             file.id,
             safeName
           );
+          processedFiles.push({ ...file, downloadedFile });
         } catch (error) {
           console.warn(
             `Failed to download file ${file.name}: ${
               error instanceof Error ? error.message : 'Download failed'
             }`
           );
+          processedFiles.push(file);
         }
       }
 
+      result.files = processedFiles;
       // Kept for backward compatibility; each URL now also lives on its file's `downloadedFile`
-      result.downloadedFiles = filesWithLevel
-        .map((f) => f.file.downloadedFile)
+      result.downloadedFiles = processedFiles
+        .map((f) => f.downloadedFile)
         .filter((url): url is string => url !== undefined);
+    } else {
+      result.files = filesWithLevel.map((f) => f.file);
     }
 
     return result;

--- a/packages/pieces/community/google-drive/src/lib/action/drive-list-files.ts
+++ b/packages/pieces/community/google-drive/src/lib/action/drive-list-files.ts
@@ -1,7 +1,6 @@
-import { HttpMethod, httpClient } from '@activepieces/pieces-common';
-import { googleDriveAuth, getAccessToken } from '../auth';
+import { googleDriveAuth } from '../auth';
 import { Property, createAction } from '@activepieces/pieces-framework';
-import querystring from 'querystring';
+import { getFilesByLevel } from '../common/list-files-recursive';
 import { downloadFileFromDrive } from '../common/get-file-content';
 import { driveListFilesOutputSchema } from '../output-schemas';
 
@@ -10,101 +9,6 @@ interface ListFilesResult {
   incompleteSearch: boolean;
   files: unknown[];
   downloadedFiles?: string[];
-}
-
-interface FileWithLevel {
-  file: any;
-  level: number;
-  parentFolder?: string;
-}
-
-async function getFilesRecursively(
-  auth: any,
-  folderId: string,
-  maxLevel: number,
-  includeTrashed: boolean,
-  includeTeamDrives: boolean,
-  currentLevel = 0
-): Promise<FileWithLevel[]> {
-  const files: FileWithLevel[] = [];
-
-  if (currentLevel > maxLevel) {
-    return files;
-  }
-
-  const accessToken = await getAccessToken(auth);
-
-  let q = `'${folderId}' in parents`;
-  if (!includeTrashed) {
-    q += ' and trashed=false';
-  }
-
-  const params: Record<string, string> = {
-    q: q,
-    fields: 'nextPageToken,files(id,kind,mimeType,name,trashed,parents)',
-    supportsAllDrives: 'true',
-    includeItemsFromAllDrives: includeTeamDrives ? 'true' : 'false',
-    corpora: includeTeamDrives ? 'allDrives' : 'user',
-    pageSize: '1000',
-  };
-
-  let response = await httpClient.sendRequest({
-    method: HttpMethod.GET,
-    url: `https://www.googleapis.com/drive/v3/files?${querystring.stringify(params)}`,
-    headers: {
-      Authorization: `Bearer ${accessToken}`,
-    },
-  });
-
-  // Add files from current level
-  for (const file of response.body.files) {
-    files.push({
-      file,
-      level: currentLevel,
-      parentFolder: folderId,
-    });
-  }
-
-  // Handle pagination for current level
-  while (response.body.nextPageToken) {
-    params.pageToken = response.body.nextPageToken;
-    response = await httpClient.sendRequest({
-      method: HttpMethod.GET,
-      url: `https://www.googleapis.com/drive/v3/files?${querystring.stringify(params)}`,
-      headers: {
-        Authorization: `Bearer ${accessToken}`,
-      },
-    });
-
-    for (const file of response.body.files) {
-      files.push({
-        file,
-        level: currentLevel,
-        parentFolder: folderId,
-      });
-    }
-  }
-
-  // If we haven't reached max level, recursively get files from subfolders
-  if (currentLevel + 1 < maxLevel) {
-    const subfolders = files.filter(
-      (f) => f.file.mimeType === 'application/vnd.google-apps.folder'
-    );
-
-    for (const subfolder of subfolders) {
-      const subfolderFiles = await getFilesRecursively(
-        auth,
-        subfolder.file.id,
-        maxLevel,
-        includeTrashed,
-        includeTeamDrives,
-        currentLevel + 1
-      );
-      files.push(...subfolderFiles);
-    }
-  }
-
-  return files;
 }
 
 export const driveListFiles = createAction({
@@ -163,14 +67,14 @@ export const driveListFiles = createAction({
 
     const depthLevel = context.propsValue.depth_level || 1;
 
-    // Get files recursively based on depth level
-    const filesWithLevel = await getFilesRecursively(
-      context.auth,
-      context.propsValue.folder_id,
-      depthLevel,
-      context.propsValue.include_trashed ?? false,
-      context.propsValue.include_team_drives ?? false
-    );
+    // Get files level-by-level, batching all folders at a level into as few queries as possible
+    const filesWithLevel = await getFilesByLevel({
+      auth: context.auth,
+      rootFolderId: context.propsValue.folder_id,
+      maxLevel: depthLevel,
+      includeTrashed: context.propsValue.include_trashed ?? false,
+      includeTeamDrives: context.propsValue.include_team_drives ?? false,
+    });
 
     // Extract just the file objects for backward compatibility
     result.files = filesWithLevel.map((f) => f.file);

--- a/packages/pieces/community/google-drive/src/lib/action/list-files.action.ts
+++ b/packages/pieces/community/google-drive/src/lib/action/list-files.action.ts
@@ -1,8 +1,7 @@
-import { HttpMethod, httpClient } from '@activepieces/pieces-common';
-import { googleDriveAuth, getAccessToken } from '../auth';
+import { googleDriveAuth } from '../auth';
 import { Property, createAction } from "@activepieces/pieces-framework";
-import querystring from 'querystring';
 import { common } from '../common';
+import { getFilesByLevel } from '../common/list-files-recursive';
 import { downloadFileFromDrive } from '../common/get-file-content';
 import { listFilesActionOutputSchema } from '../output-schemas';
 
@@ -11,99 +10,6 @@ interface ListFilesResult {
   incompleteSearch: boolean;
   files: unknown[];
   downloadedFiles?: string[];
-}
-
-interface FileWithLevel {
-  file: any;
-  level: number;
-  parentFolder?: string;
-}
-
-async function getFilesRecursively(
-  auth: any,
-  folderId: string,
-  maxLevel: number,
-  includeTrashed: boolean,
-  includeTeamDrives: boolean,
-  currentLevel = 0
-): Promise<FileWithLevel[]> {
-  const files: FileWithLevel[] = [];
-
-  if (currentLevel > maxLevel) {
-    return files;
-  }
-
-  const accessToken = await getAccessToken(auth);
-
-  let q = `'${folderId}' in parents`;
-  if (!includeTrashed) {
-    q += ' and trashed=false';
-  }
-
-  const params: Record<string, string> = {
-    q: q,
-    fields: 'nextPageToken,files(id,kind,mimeType,name,trashed,parents)',
-    supportsAllDrives: 'true',
-    includeItemsFromAllDrives: includeTeamDrives ? 'true' : 'false',
-    corpora: includeTeamDrives ? 'allDrives' : 'user',
-    pageSize: '1000',
-  };
-
-  let response = await httpClient.sendRequest({
-    method: HttpMethod.GET,
-    url: `https://www.googleapis.com/drive/v3/files?${querystring.stringify(params)}`,
-    headers: {
-      Authorization: `Bearer ${accessToken}`,
-    },
-  });
-
-  // Add files from current level
-  for (const file of response.body.files) {
-    files.push({
-      file,
-      level: currentLevel,
-      parentFolder: folderId
-    });
-  }
-
-  // Handle pagination for current level
-  while (response.body.nextPageToken) {
-    params.pageToken = response.body.nextPageToken;
-    response = await httpClient.sendRequest({
-      method: HttpMethod.GET,
-      url: `https://www.googleapis.com/drive/v3/files?${querystring.stringify(params)}`,
-      headers: {
-        Authorization: `Bearer ${accessToken}`,
-      },
-    });
-
-    for (const file of response.body.files) {
-      files.push({
-        file,
-        level: currentLevel,
-        parentFolder: folderId
-      });
-    }
-  }
-
-  // If we haven't reached max level, recursively get files from subfolders
-  if (currentLevel + 1 < maxLevel) {
-    const subfolders = files.filter(f => f.file.mimeType === 'application/vnd.google-apps.folder');
-
-    for (const subfolder of subfolders) {
-      const subfolderFiles = await getFilesRecursively(
-        auth,
-        subfolder.file.id,
-        maxLevel,
-        includeTrashed,
-        includeTeamDrives,
-        currentLevel + 1
-      );
-      files.push(...subfolderFiles);
-    }
-  }
-
-  return files;
 }
 
 export const googleDriveListFiles = createAction({
@@ -153,14 +59,14 @@ export const googleDriveListFiles = createAction({
 
     const depthLevel = context.propsValue.depthLevel || 1;
     
-    // Get files recursively based on depth level
-    const filesWithLevel = await getFilesRecursively(
-      context.auth,
-      context.propsValue.folderId,
-      depthLevel,
-      context.propsValue.includeTrashed ?? false,
-      context.propsValue.include_team_drives ?? false
-    );
+    // Get files level-by-level, batching all folders at a level into as few queries as possible
+    const filesWithLevel = await getFilesByLevel({
+      auth: context.auth,
+      rootFolderId: context.propsValue.folderId,
+      maxLevel: depthLevel,
+      includeTrashed: context.propsValue.includeTrashed ?? false,
+      includeTeamDrives: context.propsValue.include_team_drives ?? false,
+    });
 
     // Extract just the file objects for backward compatibility
     result.files = filesWithLevel.map(f => f.file);

--- a/packages/pieces/community/google-drive/src/lib/action/list-files.action.ts
+++ b/packages/pieces/community/google-drive/src/lib/action/list-files.action.ts
@@ -1,3 +1,4 @@
+import { extension } from 'mime-types';
 import { googleDriveAuth } from '../auth';
 import { Property, createAction } from "@activepieces/pieces-framework";
 import { common } from '../common';
@@ -68,54 +69,48 @@ export const googleDriveListFiles = createAction({
       includeTeamDrives: context.propsValue.include_team_drives ?? false,
     });
 
-    // Extract just the file objects for backward compatibility
-    result.files = filesWithLevel.map(f => f.file);
-
-    // If downloadFiles is enabled, download each file and attach the URL onto the file itself
+    // If downloadFiles is enabled, download each file and return a new file object carrying the URL
     if (context.propsValue.downloadFiles) {
-      const extensionMap: Record<string, string> = {
-        'application/pdf': '.pdf',
-        'image/jpeg': '.jpg',
-        'image/png': '.png',
-        'image/tiff': '.tiff',
-        'text/plain': '.txt',
-        'text/csv': '.csv',
-        'application/vnd.openxmlformats-officedocument.wordprocessingml.document': '.docx',
-        'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet': '.xlsx'
-      };
+      const processedFiles: any[] = [];
 
       for (const fileWithLevel of filesWithLevel) {
         const file = fileWithLevel.file;
         // Skip folders when downloading
         if (file.mimeType === 'application/vnd.google-apps.folder') {
+          processedFiles.push(file);
           continue;
         }
 
         let safeName = file.name;
-        const correctExtension = extensionMap[file.mimeType];
-        if (correctExtension && !safeName.toLowerCase().endsWith(correctExtension)) {
+        const correctExtension = extension(file.mimeType);
+        if (correctExtension && !safeName.toLowerCase().endsWith(`.${correctExtension}`)) {
             // Check for the .jpeg edge case before appending .jpg
             if (!(file.mimeType === 'image/jpeg' && safeName.toLowerCase().endsWith('.jpeg'))) {
-                safeName = safeName + correctExtension;
+                safeName = `${safeName}.${correctExtension}`;
             }
         }
 
         try {
-          file.downloadedFile = await downloadFileFromDrive(
+          const downloadedFile = await downloadFileFromDrive(
             context.auth,
             context.files,
             file.id,
             safeName
           );
+          processedFiles.push({ ...file, downloadedFile });
         } catch (error) {
           console.warn(`Failed to download file ${file.name}: ${error instanceof Error ? error.message : 'Download failed'}`);
+          processedFiles.push(file);
         }
       }
 
+      result.files = processedFiles;
       // Kept for backward compatibility; each URL now also lives on its file's `downloadedFile`
-      result.downloadedFiles = filesWithLevel
-        .map(f => f.file.downloadedFile)
+      result.downloadedFiles = processedFiles
+        .map(f => f.downloadedFile)
         .filter((url): url is string => url !== undefined);
+    } else {
+      result.files = filesWithLevel.map(f => f.file);
     }
 
     return result;

--- a/packages/pieces/community/google-drive/src/lib/action/list-files.action.ts
+++ b/packages/pieces/community/google-drive/src/lib/action/list-files.action.ts
@@ -71,9 +71,8 @@ export const googleDriveListFiles = createAction({
     // Extract just the file objects for backward compatibility
     result.files = filesWithLevel.map(f => f.file);
 
-    // If downloadFiles is enabled, download each file and add URLs to array
+    // If downloadFiles is enabled, download each file and attach the URL onto the file itself
     if (context.propsValue.downloadFiles) {
-      const downloadedFiles: string[] = [];
       const extensionMap: Record<string, string> = {
         'application/pdf': '.pdf',
         'image/jpeg': '.jpg',
@@ -100,20 +99,23 @@ export const googleDriveListFiles = createAction({
                 safeName = safeName + correctExtension;
             }
         }
-        
+
         try {
-          const fileUrl = await downloadFileFromDrive(
+          file.downloadedFile = await downloadFileFromDrive(
             context.auth,
             context.files,
             file.id,
             safeName
           );
-          downloadedFiles.push(fileUrl);
         } catch (error) {
           console.warn(`Failed to download file ${file.name}: ${error instanceof Error ? error.message : 'Download failed'}`);
         }
       }
-      result.downloadedFiles = downloadedFiles;
+
+      // Kept for backward compatibility; each URL now also lives on its file's `downloadedFile`
+      result.downloadedFiles = filesWithLevel
+        .map(f => f.file.downloadedFile)
+        .filter((url): url is string => url !== undefined);
     }
 
     return result;

--- a/packages/pieces/community/google-drive/src/lib/action/list-files.action.ts
+++ b/packages/pieces/community/google-drive/src/lib/action/list-files.action.ts
@@ -1,7 +1,7 @@
 import { googleDriveAuth } from '../auth';
 import { Property, createAction } from "@activepieces/pieces-framework";
 import { common } from '../common';
-import { getFilesByLevel } from '../common/list-files-recursive';
+import { getFilesByLevel } from '../common/list-drive-files';
 import { downloadFileFromDrive } from '../common/get-file-content';
 import { listFilesActionOutputSchema } from '../output-schemas';
 

--- a/packages/pieces/community/google-drive/src/lib/action/list-files.action.ts
+++ b/packages/pieces/community/google-drive/src/lib/action/list-files.action.ts
@@ -61,7 +61,7 @@ export const googleDriveListFiles = createAction({
     const depthLevel = context.propsValue.depthLevel || 1;
     
     // Get files level-by-level, batching all folders at a level into as few queries as possible
-    const filesWithLevel = await listDriveFilesRecursive({
+    const files = await listDriveFilesRecursive({
       auth: context.auth,
       rootFolderId: context.propsValue.folderId,
       maxLevel: depthLevel,
@@ -73,8 +73,7 @@ export const googleDriveListFiles = createAction({
     if (context.propsValue.downloadFiles) {
       const processedFiles: any[] = [];
 
-      for (const fileWithLevel of filesWithLevel) {
-        const file = fileWithLevel.file;
+      for (const file of files) {
         // Skip folders when downloading
         if (file.mimeType === 'application/vnd.google-apps.folder') {
           processedFiles.push(file);
@@ -110,7 +109,7 @@ export const googleDriveListFiles = createAction({
         .map(f => f.downloadedFile)
         .filter((url): url is string => url !== undefined);
     } else {
-      result.files = filesWithLevel.map(f => f.file);
+      result.files = files;
     }
 
     return result;

--- a/packages/pieces/community/google-drive/src/lib/action/list-files.action.ts
+++ b/packages/pieces/community/google-drive/src/lib/action/list-files.action.ts
@@ -1,7 +1,7 @@
 import { googleDriveAuth } from '../auth';
 import { Property, createAction } from "@activepieces/pieces-framework";
 import { common } from '../common';
-import { getFilesByLevel } from '../common/list-drive-files';
+import { listDriveFilesRecursive } from '../common/list-drive-files';
 import { downloadFileFromDrive } from '../common/get-file-content';
 import { listFilesActionOutputSchema } from '../output-schemas';
 
@@ -60,7 +60,7 @@ export const googleDriveListFiles = createAction({
     const depthLevel = context.propsValue.depthLevel || 1;
     
     // Get files level-by-level, batching all folders at a level into as few queries as possible
-    const filesWithLevel = await getFilesByLevel({
+    const filesWithLevel = await listDriveFilesRecursive({
       auth: context.auth,
       rootFolderId: context.propsValue.folderId,
       maxLevel: depthLevel,

--- a/packages/pieces/community/google-drive/src/lib/common/list-drive-files.ts
+++ b/packages/pieces/community/google-drive/src/lib/common/list-drive-files.ts
@@ -35,7 +35,7 @@ export async function listDriveFiles<T = any>({
 
 const PARENT_IDS_PER_QUERY = 50;
 
-export async function getFilesByLevel({
+export async function listDriveFilesRecursive({
   auth,
   rootFolderId,
   maxLevel,
@@ -52,62 +52,41 @@ export async function getFilesByLevel({
   let currentLevelParentIds = [rootFolderId];
 
   for (let level = 0; level < maxLevel && currentLevelParentIds.length > 0; level++) {
-    const files = await fetchFilesForParents({
-      auth,
-      parentIds: currentLevelParentIds,
-      includeTrashed,
-      includeTeamDrives,
-    });
+    const nextLevelParentIds: string[] = [];
 
-    for (const file of files) {
-      filesWithLevel.push({
-        file,
-        level,
-        parentFolder: file.parents?.find((id: string) => currentLevelParentIds.includes(id)) ?? currentLevelParentIds[0],
+    for (const parentIdsChunk of chunk(currentLevelParentIds, PARENT_IDS_PER_QUERY)) {
+      const parentsClause = parentIdsChunk.map(id => `'${id}' in parents`).join(' or ');
+      const q = parentIdsChunk.length > 1 ? `(${parentsClause})` : parentsClause;
+
+      const pageFiles = await listDriveFiles({
+        auth,
+        params: {
+          q: includeTrashed ? q : `${q} and trashed=false`,
+          fields: 'nextPageToken,files(id,kind,mimeType,name,trashed,parents)',
+          supportsAllDrives: 'true',
+          includeItemsFromAllDrives: includeTeamDrives ? 'true' : 'false',
+          corpora: includeTeamDrives ? 'allDrives' : 'user',
+          pageSize: '1000',
+        },
       });
+
+      for (const file of pageFiles) {
+        filesWithLevel.push({
+          file,
+          level,
+          parentFolder: file.parents?.find((id: string) => currentLevelParentIds.includes(id)) ?? currentLevelParentIds[0],
+        });
+
+        if (file.mimeType === 'application/vnd.google-apps.folder') {
+          nextLevelParentIds.push(file.id);
+        }
+      }
     }
 
-    currentLevelParentIds = files
-      .filter(file => file.mimeType === 'application/vnd.google-apps.folder')
-      .map(file => file.id);
+    currentLevelParentIds = nextLevelParentIds;
   }
 
   return filesWithLevel;
-}
-
-async function fetchFilesForParents({
-  auth,
-  parentIds,
-  includeTrashed,
-  includeTeamDrives,
-}: {
-  auth: GoogleDriveAuthValue;
-  parentIds: string[];
-  includeTrashed: boolean;
-  includeTeamDrives: boolean;
-}): Promise<any[]> {
-  const files: any[] = [];
-
-  for (const parentIdsChunk of chunk(parentIds, PARENT_IDS_PER_QUERY)) {
-    const parentsClause = parentIdsChunk.map(id => `'${id}' in parents`).join(' or ');
-    const q = parentIdsChunk.length > 1 ? `(${parentsClause})` : parentsClause;
-
-    const pageFiles = await listDriveFiles({
-      auth,
-      params: {
-        q: includeTrashed ? q : `${q} and trashed=false`,
-        fields: 'nextPageToken,files(id,kind,mimeType,name,trashed,parents)',
-        supportsAllDrives: 'true',
-        includeItemsFromAllDrives: includeTeamDrives ? 'true' : 'false',
-        corpora: includeTeamDrives ? 'allDrives' : 'user',
-        pageSize: '1000',
-      },
-    });
-
-    files.push(...pageFiles);
-  }
-
-  return files;
 }
 
 export interface FileWithLevel {

--- a/packages/pieces/community/google-drive/src/lib/common/list-drive-files.ts
+++ b/packages/pieces/community/google-drive/src/lib/common/list-drive-files.ts
@@ -3,6 +3,36 @@ import { HttpMethod, httpClient } from '@activepieces/pieces-common';
 import { chunk } from '@activepieces/pieces-framework';
 import { GoogleDriveAuthValue, getAccessToken } from '../auth';
 
+export async function listDriveFiles<T = any>({
+  auth,
+  params,
+}: {
+  auth: GoogleDriveAuthValue;
+  params: Record<string, string>;
+}): Promise<T[]> {
+  const accessToken = await getAccessToken(auth);
+  const files: T[] = [];
+
+  let pageToken: string | undefined;
+  do {
+    const pageParams = pageToken ? { ...params, pageToken } : params;
+    const response = await httpClient.sendRequest<{
+      files: T[];
+      nextPageToken?: string;
+    }>({
+      method: HttpMethod.GET,
+      url: `https://www.googleapis.com/drive/v3/files?${querystring.stringify(pageParams)}`,
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+      },
+    });
+    files.push(...(response.body.files ?? []));
+    pageToken = response.body.nextPageToken;
+  } while (pageToken);
+
+  return files;
+}
+
 const PARENT_IDS_PER_QUERY = 50;
 
 export async function getFilesByLevel({
@@ -56,44 +86,25 @@ async function fetchFilesForParents({
   includeTrashed: boolean;
   includeTeamDrives: boolean;
 }): Promise<any[]> {
-  const accessToken = await getAccessToken(auth);
   const files: any[] = [];
 
   for (const parentIdsChunk of chunk(parentIds, PARENT_IDS_PER_QUERY)) {
     const parentsClause = parentIdsChunk.map(id => `'${id}' in parents`).join(' or ');
     const q = parentIdsChunk.length > 1 ? `(${parentsClause})` : parentsClause;
 
-    const params: Record<string, string> = {
-      q: includeTrashed ? q : `${q} and trashed=false`,
-      fields: 'nextPageToken,files(id,kind,mimeType,name,trashed,parents)',
-      supportsAllDrives: 'true',
-      includeItemsFromAllDrives: includeTeamDrives ? 'true' : 'false',
-      corpora: includeTeamDrives ? 'allDrives' : 'user',
-      pageSize: '1000',
-    };
-
-    let response = await httpClient.sendRequest({
-      method: HttpMethod.GET,
-      url: `https://www.googleapis.com/drive/v3/files?${querystring.stringify(params)}`,
-      headers: {
-        Authorization: `Bearer ${accessToken}`,
+    const pageFiles = await listDriveFiles({
+      auth,
+      params: {
+        q: includeTrashed ? q : `${q} and trashed=false`,
+        fields: 'nextPageToken,files(id,kind,mimeType,name,trashed,parents)',
+        supportsAllDrives: 'true',
+        includeItemsFromAllDrives: includeTeamDrives ? 'true' : 'false',
+        corpora: includeTeamDrives ? 'allDrives' : 'user',
+        pageSize: '1000',
       },
     });
 
-    files.push(...response.body.files);
-
-    while (response.body.nextPageToken) {
-      params.pageToken = response.body.nextPageToken;
-      response = await httpClient.sendRequest({
-        method: HttpMethod.GET,
-        url: `https://www.googleapis.com/drive/v3/files?${querystring.stringify(params)}`,
-        headers: {
-          Authorization: `Bearer ${accessToken}`,
-        },
-      });
-
-      files.push(...response.body.files);
-    }
+    files.push(...pageFiles);
   }
 
   return files;

--- a/packages/pieces/community/google-drive/src/lib/common/list-drive-files.ts
+++ b/packages/pieces/community/google-drive/src/lib/common/list-drive-files.ts
@@ -47,8 +47,8 @@ export async function listDriveFilesRecursive({
   maxLevel: number;
   includeTrashed: boolean;
   includeTeamDrives: boolean;
-}): Promise<FileWithLevel[]> {
-  const filesWithLevel: FileWithLevel[] = [];
+}): Promise<any[]> {
+  const files: any[] = [];
   let currentLevelParentIds = [rootFolderId];
 
   for (let level = 0; level < maxLevel && currentLevelParentIds.length > 0; level++) {
@@ -71,11 +71,7 @@ export async function listDriveFilesRecursive({
       });
 
       for (const file of pageFiles) {
-        filesWithLevel.push({
-          file,
-          level,
-          parentFolder: file.parents?.find((id: string) => currentLevelParentIds.includes(id)) ?? currentLevelParentIds[0],
-        });
+        files.push(file);
 
         if (file.mimeType === 'application/vnd.google-apps.folder') {
           nextLevelParentIds.push(file.id);
@@ -86,11 +82,5 @@ export async function listDriveFilesRecursive({
     currentLevelParentIds = nextLevelParentIds;
   }
 
-  return filesWithLevel;
-}
-
-export interface FileWithLevel {
-  file: any;
-  level: number;
-  parentFolder?: string;
+  return files;
 }

--- a/packages/pieces/community/google-drive/src/lib/common/list-files-recursive.ts
+++ b/packages/pieces/community/google-drive/src/lib/common/list-files-recursive.ts
@@ -1,0 +1,106 @@
+import querystring from 'querystring';
+import { HttpMethod, httpClient } from '@activepieces/pieces-common';
+import { chunk } from '@activepieces/pieces-framework';
+import { GoogleDriveAuthValue, getAccessToken } from '../auth';
+
+const PARENT_IDS_PER_QUERY = 50;
+
+export async function getFilesByLevel({
+  auth,
+  rootFolderId,
+  maxLevel,
+  includeTrashed,
+  includeTeamDrives,
+}: {
+  auth: GoogleDriveAuthValue;
+  rootFolderId: string;
+  maxLevel: number;
+  includeTrashed: boolean;
+  includeTeamDrives: boolean;
+}): Promise<FileWithLevel[]> {
+  const filesWithLevel: FileWithLevel[] = [];
+  let currentLevelParentIds = [rootFolderId];
+
+  for (let level = 0; level < maxLevel && currentLevelParentIds.length > 0; level++) {
+    const files = await fetchFilesForParents({
+      auth,
+      parentIds: currentLevelParentIds,
+      includeTrashed,
+      includeTeamDrives,
+    });
+
+    for (const file of files) {
+      filesWithLevel.push({
+        file,
+        level,
+        parentFolder: file.parents?.find((id: string) => currentLevelParentIds.includes(id)) ?? currentLevelParentIds[0],
+      });
+    }
+
+    currentLevelParentIds = files
+      .filter(file => file.mimeType === 'application/vnd.google-apps.folder')
+      .map(file => file.id);
+  }
+
+  return filesWithLevel;
+}
+
+async function fetchFilesForParents({
+  auth,
+  parentIds,
+  includeTrashed,
+  includeTeamDrives,
+}: {
+  auth: GoogleDriveAuthValue;
+  parentIds: string[];
+  includeTrashed: boolean;
+  includeTeamDrives: boolean;
+}): Promise<any[]> {
+  const accessToken = await getAccessToken(auth);
+  const files: any[] = [];
+
+  for (const parentIdsChunk of chunk(parentIds, PARENT_IDS_PER_QUERY)) {
+    const parentsClause = parentIdsChunk.map(id => `'${id}' in parents`).join(' or ');
+    const q = parentIdsChunk.length > 1 ? `(${parentsClause})` : parentsClause;
+
+    const params: Record<string, string> = {
+      q: includeTrashed ? q : `${q} and trashed=false`,
+      fields: 'nextPageToken,files(id,kind,mimeType,name,trashed,parents)',
+      supportsAllDrives: 'true',
+      includeItemsFromAllDrives: includeTeamDrives ? 'true' : 'false',
+      corpora: includeTeamDrives ? 'allDrives' : 'user',
+      pageSize: '1000',
+    };
+
+    let response = await httpClient.sendRequest({
+      method: HttpMethod.GET,
+      url: `https://www.googleapis.com/drive/v3/files?${querystring.stringify(params)}`,
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+      },
+    });
+
+    files.push(...response.body.files);
+
+    while (response.body.nextPageToken) {
+      params.pageToken = response.body.nextPageToken;
+      response = await httpClient.sendRequest({
+        method: HttpMethod.GET,
+        url: `https://www.googleapis.com/drive/v3/files?${querystring.stringify(params)}`,
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+        },
+      });
+
+      files.push(...response.body.files);
+    }
+  }
+
+  return files;
+}
+
+export interface FileWithLevel {
+  file: any;
+  level: number;
+  parentFolder?: string;
+}

--- a/packages/pieces/community/google-drive/src/lib/output-schemas.ts
+++ b/packages/pieces/community/google-drive/src/lib/output-schemas.ts
@@ -128,6 +128,12 @@ export const listFilesActionOutputSchema: OutputSchema = {
           label: 'Parent Folder ID',
           value: 'parents[0]',
         },
+        {
+          key: 'downloadedFile',
+          label: 'Downloaded File URL',
+          value: 'downloadedFile',
+          format: 'url',
+        },
       ],
     },
     {
@@ -724,6 +730,11 @@ export const driveListFilesOutputSchema: OutputSchema = {
           key: 'shared',
           label: 'Shared',
           format: 'boolean',
+        },
+        {
+          key: 'downloadedFile',
+          label: 'Downloaded File URL',
+          format: 'url',
         },
       ],
     },

--- a/packages/pieces/community/google-drive/test/list-drive-files.test.ts
+++ b/packages/pieces/community/google-drive/test/list-drive-files.test.ts
@@ -1,0 +1,215 @@
+/// <reference types="vitest/globals" />
+
+import { AppConnectionType } from '@activepieces/pieces-framework';
+
+const { sendRequest } = vi.hoisted(() => ({
+  sendRequest: vi.fn(),
+}));
+
+vi.mock('@activepieces/pieces-common', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@activepieces/pieces-common')>();
+  return {
+    ...actual,
+    httpClient: { sendRequest },
+  };
+});
+
+const { listDriveFiles, listDriveFilesRecursive } = await import('../src/lib/common/list-drive-files');
+
+const auth = { type: AppConnectionType.OAUTH2, access_token: 'test-token' } as any;
+
+function lastRequest() {
+  return sendRequest.mock.calls[sendRequest.mock.calls.length - 1][0];
+}
+
+function decodedQuery(request: { url: string }) {
+  return decodeURIComponent(request.url.split('q=')[1].split('&')[0]);
+}
+
+function driveFile(overrides: Record<string, any>) {
+  return {
+    id: 'id',
+    kind: 'drive#file',
+    mimeType: 'text/plain',
+    name: 'file',
+    trashed: false,
+    parents: [],
+    ...overrides,
+  };
+}
+
+function page(files: unknown[], nextPageToken?: string) {
+  return { status: 200, headers: {}, body: { files, nextPageToken } };
+}
+
+beforeEach(() => {
+  sendRequest.mockReset();
+});
+
+describe('listDriveFiles pagination', () => {
+  test('follows nextPageToken across multiple pages and concatenates results', async () => {
+    sendRequest
+      .mockResolvedValueOnce(page([driveFile({ id: 'a' })], 'page2'))
+      .mockResolvedValueOnce(page([driveFile({ id: 'b' })]));
+
+    const result = await listDriveFiles({ auth, params: { q: "'root' in parents" } });
+
+    expect(result.map((f: any) => f.id)).toEqual(['a', 'b']);
+    expect(sendRequest).toHaveBeenCalledTimes(2);
+    expect(sendRequest.mock.calls[1][0].url).toContain('pageToken=page2');
+  });
+
+  test('the first request carries no pageToken param', async () => {
+    sendRequest.mockResolvedValueOnce(page([]));
+
+    await listDriveFiles({ auth, params: { q: "'root' in parents" } });
+
+    expect(lastRequest().url).not.toContain('pageToken');
+  });
+
+  test('a page with no files does not throw', async () => {
+    sendRequest.mockResolvedValueOnce({ status: 200, headers: {}, body: {} });
+
+    await expect(listDriveFiles({ auth, params: { q: "'root' in parents" } })).resolves.toEqual([]);
+  });
+});
+
+describe('listDriveFilesRecursive query construction', () => {
+  test('a single parent folder produces an un-parenthesized clause, matching the old per-folder query', async () => {
+    sendRequest.mockResolvedValueOnce(page([]));
+
+    await listDriveFilesRecursive({
+      auth,
+      rootFolderId: 'root',
+      maxLevel: 1,
+      includeTrashed: false,
+      includeTeamDrives: false,
+    });
+
+    expect(decodedQuery(lastRequest())).toBe("'root' in parents and trashed=false");
+  });
+
+  test('includeTrashed omits the trashed=false clause', async () => {
+    sendRequest.mockResolvedValueOnce(page([]));
+
+    await listDriveFilesRecursive({
+      auth,
+      rootFolderId: 'root',
+      maxLevel: 1,
+      includeTrashed: true,
+      includeTeamDrives: false,
+    });
+
+    expect(decodedQuery(lastRequest())).toBe("'root' in parents");
+  });
+});
+
+describe('listDriveFilesRecursive batching across >50 sibling folders', () => {
+  test('chunks parent ids at 50 per query and returns files from every chunk', async () => {
+    const folderIds = Array.from({ length: 60 }, (_, i) => `folder-${i}`);
+
+    sendRequest
+      // level 0: single query for the root folder returns 60 subfolders
+      .mockResolvedValueOnce(
+        page(folderIds.map((id) => driveFile({ id, mimeType: 'application/vnd.google-apps.folder' })))
+      )
+      // level 1, chunk 1 (ids 0-49)
+      .mockResolvedValueOnce(page([driveFile({ id: 'chunk1-file' })]))
+      // level 1, chunk 2 (ids 50-59)
+      .mockResolvedValueOnce(page([driveFile({ id: 'chunk2-file' })]));
+
+    const result = await listDriveFilesRecursive({
+      auth,
+      rootFolderId: 'root',
+      maxLevel: 2,
+      includeTrashed: false,
+      includeTeamDrives: false,
+    });
+
+    expect(sendRequest).toHaveBeenCalledTimes(3);
+
+    const chunk1Query = decodedQuery(sendRequest.mock.calls[1][0]);
+    const chunk2Query = decodedQuery(sendRequest.mock.calls[2][0]);
+
+    expect(chunk1Query).toContain(folderIds[0]);
+    expect(chunk1Query).toContain(folderIds[49]);
+    expect(chunk1Query).not.toContain(`'${folderIds[50]}'`);
+    expect(chunk2Query).toContain(folderIds[50]);
+    expect(chunk2Query).toContain(folderIds[59]);
+    expect(chunk2Query).not.toContain(`'${folderIds[49]}'`);
+
+    // 60 folders from level 0 + 1 file from each of the 2 level-1 chunks
+    expect(result).toHaveLength(62);
+    const ids = result.map((f: any) => f.id);
+    expect(ids).toEqual(expect.arrayContaining(['chunk1-file', 'chunk2-file']));
+  });
+
+  test('pagination within one chunk is followed before moving to the next level', async () => {
+    sendRequest
+      .mockResolvedValueOnce(page([driveFile({ id: 'p1' })], 'tok'))
+      .mockResolvedValueOnce(page([driveFile({ id: 'p2' })]));
+
+    const result = await listDriveFilesRecursive({
+      auth,
+      rootFolderId: 'root',
+      maxLevel: 1,
+      includeTrashed: false,
+      includeTeamDrives: false,
+    });
+
+    expect(sendRequest).toHaveBeenCalledTimes(2);
+    expect(sendRequest.mock.calls[1][0].url).toContain('pageToken=tok');
+    expect(result.map((f: any) => f.id)).toEqual(['p1', 'p2']);
+  });
+});
+
+describe('listDriveFilesRecursive depth limits', () => {
+  test('depth 1 only fetches the root level', async () => {
+    sendRequest.mockResolvedValueOnce(
+      page([driveFile({ id: 'child-folder', mimeType: 'application/vnd.google-apps.folder' })])
+    );
+
+    const result = await listDriveFilesRecursive({
+      auth,
+      rootFolderId: 'root',
+      maxLevel: 1,
+      includeTrashed: false,
+      includeTeamDrives: false,
+    });
+
+    expect(sendRequest).toHaveBeenCalledTimes(1);
+    expect(result.map((f: any) => f.id)).toEqual(['child-folder']);
+  });
+
+  test('depth 2 also fetches the next level down', async () => {
+    sendRequest
+      .mockResolvedValueOnce(page([driveFile({ id: 'child-folder', mimeType: 'application/vnd.google-apps.folder' })]))
+      .mockResolvedValueOnce(page([driveFile({ id: 'grandchild-file' })]));
+
+    const result = await listDriveFilesRecursive({
+      auth,
+      rootFolderId: 'root',
+      maxLevel: 2,
+      includeTrashed: false,
+      includeTeamDrives: false,
+    });
+
+    expect(sendRequest).toHaveBeenCalledTimes(2);
+    expect(result.map((f: any) => f.id)).toEqual(['child-folder', 'grandchild-file']);
+  });
+
+  test('traversal stops early once a level has no subfolders left, even before maxLevel is reached', async () => {
+    sendRequest.mockResolvedValueOnce(page([driveFile({ id: 'leaf-file' })]));
+
+    const result = await listDriveFilesRecursive({
+      auth,
+      rootFolderId: 'root',
+      maxLevel: 5,
+      includeTrashed: false,
+      includeTeamDrives: false,
+    });
+
+    expect(sendRequest).toHaveBeenCalledTimes(1);
+    expect(result.map((f: any) => f.id)).toEqual(['leaf-file']);
+  });
+});

--- a/packages/pieces/community/google-drive/vitest.config.ts
+++ b/packages/pieces/community/google-drive/vitest.config.ts
@@ -1,0 +1,17 @@
+import path from 'path'
+import { defineConfig } from 'vitest/config'
+
+const repoRoot = path.resolve(__dirname, '../../../..')
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+  },
+  resolve: {
+    alias: {
+      '@activepieces/pieces-framework': path.resolve(repoRoot, 'packages/pieces/framework/src/index.ts'),
+      '@activepieces/pieces-common': path.resolve(repoRoot, 'packages/pieces/common/src/index.ts'),
+    },
+  },
+})


### PR DESCRIPTION
## Description

Optimizes the Google Drive **List files** actions (`list-files.action.ts`, `drive-list-files.ts`) to reduce API calls and cleans up how `downloadFiles` results are returned.

### What changed

- **Batch multiple parent folders into one query.** Both actions previously made one API call per folder per depth level. Drive's `q` param supports OR-ing `in parents` clauses (`('id1' in parents or 'id2' in parents) and trashed=false`), so siblings at each depth are now queried together (chunked at 50 IDs/request). A folder with 200 subfolders drops from ~201 calls to ~5.
- **Deduplicated the listing logic** into `common/list-drive-files.ts` (`listDriveFiles` for the HTTP/pagination, `listDriveFilesRecursive` for the BFS traversal) — both actions and `drive-export-folder-as-zip.ts` now share it instead of three copies of near-identical code.
- **Fixed `downloadFiles` output correlation.** Each downloaded file's URL is now attached to its own file object (`{ ...file, downloadedFile: url }`) instead of only appearing in a separate, uncorrelated `downloadedFiles` array. That flat array is kept for backward compatibility, derived from the same results.
- **Replaced the hardcoded extension map** with `mime-types`' `extension()` for broader mimetype coverage.

### Caveat

If a file/folder has multiple parents that are siblings in the same traversal frontier (rare — mostly disabled on Drive since ~2020), the old code returned it once per matching parent (a duplicate); the batched query now returns it once. Correctness fix, not expected to need any action.

## How was this tested?

Tested locally against a real google drive folder. There was a significant speedup for very large nested folder 3 levels deep. 

Closes https://linear.app/activepieces/issue/GIT-1880/google-drive-batch-list-files-folder-queries-instead-of-one-api-call

### Breaking change?  (required — CI fails if this is left unedited)

<!-- Tick exactly one box. If either "yes", apply the "⛓️‍💥 breaking-change" label AND add an entry to docs/install/reference/breaking-changes.mdx (what changed + the action self-hosters must take). -->

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

<!-- Tick exactly one box. "Security-sensitive" = touches authentication, secrets, permissions/roles, cryptography, SSRF / outbound HTTP, or file handling. -->

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)


