### PR TITLE
fix(mooninvoice): dropdown props send filters as GET body, which is dropped

### DIFF
--- a/packages/pieces/community/mooninvoice/package.json
+++ b/packages/pieces/community/mooninvoice/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-mooninvoice",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "type": "commonjs",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",

--- a/packages/pieces/community/mooninvoice/src/lib/actions/add-new-contact.ts
+++ b/packages/pieces/community/mooninvoice/src/lib/actions/add-new-contact.ts
@@ -269,12 +269,12 @@ export const addNewContact = createAction({
       context.auth.props.email,
       context.auth.props.secret_text
     );
-    const response = await makeRequest(
+    const response = await makeRequest({
       accessToken,
-      HttpMethod.POST,
-      '/add_contact',
-      body
-    );
+      method: HttpMethod.POST,
+      path: '/add_contact',
+      body,
+    });
 
     return response;
   },

--- a/packages/pieces/community/mooninvoice/src/lib/actions/create-credit-note.ts
+++ b/packages/pieces/community/mooninvoice/src/lib/actions/create-credit-note.ts
@@ -257,12 +257,12 @@ export const createCreditNote = createAction({
       context.auth.props.secret_text
     );
 
-    const response = await makeRequest(
+    const response = await makeRequest({
       accessToken,
-      HttpMethod.POST,
-      '/create_credit_notes',
-      body
-    );
+      method: HttpMethod.POST,
+      path: '/create_credit_notes',
+      body,
+    });
 
     return response;
   },

--- a/packages/pieces/community/mooninvoice/src/lib/actions/create-estimate.ts
+++ b/packages/pieces/community/mooninvoice/src/lib/actions/create-estimate.ts
@@ -280,12 +280,12 @@ export const createEstimate = createAction({
       context.auth.props.secret_text
     );
 
-    const response = await makeRequest(
+    const response = await makeRequest({
       accessToken,
-      HttpMethod.POST,
-      '/create_estimate',
-      body
-    );
+      method: HttpMethod.POST,
+      path: '/create_estimate',
+      body,
+    });
 
     return response;
   },

--- a/packages/pieces/community/mooninvoice/src/lib/actions/create-expense.ts
+++ b/packages/pieces/community/mooninvoice/src/lib/actions/create-expense.ts
@@ -175,12 +175,12 @@ export const createExpense = createAction({
       context.auth.props.secret_text
     );
 
-    const response = await makeRequest(
+    const response = await makeRequest({
       accessToken,
-      HttpMethod.POST,
-      '/create_expense',
-      body
-    );
+      method: HttpMethod.POST,
+      path: '/create_expense',
+      body,
+    });
 
     return response;
   },

--- a/packages/pieces/community/mooninvoice/src/lib/actions/create-invoice.ts
+++ b/packages/pieces/community/mooninvoice/src/lib/actions/create-invoice.ts
@@ -355,12 +355,12 @@ export const createInvoice = createAction({
       context.auth.props.secret_text
     );
 
-    const response = await makeRequest(
+    const response = await makeRequest({
       accessToken,
-      HttpMethod.POST,
-      '/create_invoice',
-      body
-    );
+      method: HttpMethod.POST,
+      path: '/create_invoice',
+      body,
+    });
 
     return response;
   },

--- a/packages/pieces/community/mooninvoice/src/lib/actions/create-product.ts
+++ b/packages/pieces/community/mooninvoice/src/lib/actions/create-product.ts
@@ -185,12 +185,12 @@ export const createProduct = createAction({
       context.auth.props.secret_text
     );
 
-    const response = await makeRequest(
+    const response = await makeRequest({
       accessToken,
-      HttpMethod.POST,
-      '/add_product',
-      body
-    );
+      method: HttpMethod.POST,
+      path: '/add_product',
+      body,
+    });
 
     return response;
   },

--- a/packages/pieces/community/mooninvoice/src/lib/actions/create-task.ts
+++ b/packages/pieces/community/mooninvoice/src/lib/actions/create-task.ts
@@ -94,12 +94,12 @@ export const createTask = createAction({
       context.auth.props.secret_text
     );
 
-    const response = await makeRequest(
+    const response = await makeRequest({
       accessToken,
-      HttpMethod.POST,
-      '/add_task',
-      body
-    );
+      method: HttpMethod.POST,
+      path: '/add_task',
+      body,
+    });
 
     return response;
   },

--- a/packages/pieces/community/mooninvoice/src/lib/common/client.ts
+++ b/packages/pieces/community/mooninvoice/src/lib/common/client.ts
@@ -1,4 +1,4 @@
-import { HttpMethod, httpClient } from '@activepieces/pieces-common';
+import { HttpMethod, httpClient, QueryParams } from '@activepieces/pieces-common';
 
 export const BASE_URL = `https://www.mooninvoice.com/api_mi/public`;
 
@@ -29,12 +29,19 @@ export async function getAccessToken(
   }
 }
 
-export async function makeRequest(
-  accessToken: string,
-  method: HttpMethod,
-  path: string,
-  body?: unknown
-) {
+export async function makeRequest({
+  accessToken,
+  method,
+  path,
+  body,
+  queryParams,
+}: {
+  accessToken: string;
+  method: HttpMethod;
+  path: string;
+  body?: unknown;
+  queryParams?: QueryParams;
+}) {
   try {
     const response = await httpClient.sendRequest({
       method,
@@ -44,6 +51,7 @@ export async function makeRequest(
         'Content-Type': 'application/json',
       },
       body,
+      queryParams,
     });
     return response.body;
   } catch (error: any) {

--- a/packages/pieces/community/mooninvoice/src/lib/common/props.ts
+++ b/packages/pieces/community/mooninvoice/src/lib/common/props.ts
@@ -21,12 +21,12 @@ export const companyIdProp = Property.Dropdown({
         auth?.props.email as string,
         auth?.props.secret_text as string
       );
-      const response = await makeRequest(
+      const response = await makeRequest({
         accessToken,
-        HttpMethod.GET,
-        '/company_list',
-        { CompanySort: 'asc' }
-      );
+        method: HttpMethod.GET,
+        path: '/company_list',
+        queryParams: { CompanySort: 'asc' },
+      });
       return {
         disabled: false,
         options: response.data.map((company: any) => ({
@@ -61,12 +61,17 @@ export const contactIdProp = Property.Dropdown({
         auth?.props.email as string,
         auth?.props.secret_text as string
       );
-      const response = await makeRequest(
+      const response = await makeRequest({
         accessToken,
-        HttpMethod.GET,
-        '/contact_list',
-        { CompanyId: companyId, PageSize: 25, page: 1, ContactSort: 'asc' }
-      );
+        method: HttpMethod.GET,
+        path: '/contact_list',
+        queryParams: {
+          CompanyID: companyId as string,
+          PageSize: '25',
+          page: '1',
+          ContactSort: 'asc',
+        },
+      });
       return {
         disabled: false,
         options: response.data.contacts.map((contact: any) => ({
@@ -101,12 +106,17 @@ export const projectIdProp = Property.Dropdown({
         auth?.props.email as string,
         auth?.props.secret_text as string
       );
-      const response = await makeRequest(
+      const response = await makeRequest({
         accessToken,
-        HttpMethod.GET,
-        '/project_list',
-        { CompanyID: companyId, PageSize: 25, page: 1, ProjectSort: 'asc' }
-      );
+        method: HttpMethod.GET,
+        path: '/project_list',
+        queryParams: {
+          CompanyID: companyId as string,
+          PageSize: '25',
+          page: '1',
+          ProjectSort: 'asc',
+        },
+      });
       return {
         disabled: false,
         options: response.data.projects.map((project: any) => ({


### PR DESCRIPTION
## Description

Company/Contact/Project dropdown props (`packages/pieces/community/mooninvoice/src/lib/common/props.ts`) sent their list filters as a GET request `body`. The piece's fetch-based `httpClient` silently drops the body on GET/HEAD requests, so all three dropdowns never actually applied their filters and effectively broke.

`makeRequest` (`common/client.ts`) now accepts a `queryParams` option and forwards it to `httpClient.sendRequest`, which appends query params to the URL regardless of method — confirmed this is what Moon Invoice's `company_list` / `contact_list` / `project_list` endpoints accept (POST to those endpoints returns an encrypted, unusable payload instead).

Also fixes `contactIdProp` sending `CompanyId`, when the API only accepts `CompanyID` — found while testing against a live account.

Bumped piece version 0.0.8 → 0.0.9.

## How was this tested?

- Verified all three dropdown calls (`company_list`, `contact_list`, `project_list`) against a live Moon Invoice account — each now returns real data with the new query-param request shape.
- `npx turbo run lint --filter=@activepieces/piece-mooninvoice` — 0 errors (pre-existing `any`/unused-import warnings only, none new).
- `npx turbo run build --filter=@activepieces/piece-mooninvoice` — builds clean.
- Piece has no UI surface beyond the flow builder's dropdown/action forms; not edition-specific (CE/EE/Cloud all use the same piece code).

Fixes PIE-503

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)