### PR TITLE
fix(pieces): keep the deprecated flag when a published piece is registered on cloud

### DIFF
--- a/packages/server/api/src/app/ee/platform/admin/admin-platform.controller.ts
+++ b/packages/server/api/src/app/ee/platform/admin/admin-platform.controller.ts
@@ -202,6 +202,7 @@ const CreatePieceRequest = {
             categories: z.array(z.nativeEnum(PieceCategory)).optional(),
             minimumSupportedRelease: ExactVersionType,
             maximumSupportedRelease: ExactVersionType,
+            deprecated: z.boolean().optional(),
             actions: z.record(z.string(), Action),
             triggers: z.record(z.string(), Trigger),
             i18n: z.record(z.string(), z.record(z.string(), z.string())).optional(),

--- a/packages/server/api/test/integration/cloud/piece-metadata/piece-metadata.test.ts
+++ b/packages/server/api/test/integration/cloud/piece-metadata/piece-metadata.test.ts
@@ -441,3 +441,52 @@ async function createProjectAndPlan({
     await db.save('project_plan', [projectPlan])
     return project
 }
+describe('Publishing a piece through the admin endpoint', () => {
+    const publish = async (piece: Record<string, unknown>) => app!.inject({
+        method: 'POST',
+        url: '/api/v1/admin/pieces',
+        headers: { 'api-key': process.env['AP_API_KEY'] ?? '' },
+        body: {
+            displayName: 'Gone Vendor',
+            logoUrl: 'https://cdn.activepieces.com/pieces/gone-vendor.png',
+            description: 'A vendor that shut down',
+            version: '0.1.7',
+            authors: [],
+            categories: [],
+            minimumSupportedRelease: '0.0.0',
+            maximumSupportedRelease: '9999.9999.9999',
+            actions: {},
+            triggers: {},
+            ...piece,
+        },
+    })
+
+    it('keeps the deprecated flag the release pipeline sends', async () => {
+        const response = await publish({ name: '@activepieces/piece-gone-vendor', deprecated: true })
+
+        expect(response.statusCode).toBe(StatusCodes.OK)
+        expect(response.json().deprecated).toBe(true)
+
+        const saved = await databaseConnection().getRepository('piece_metadata').findOneByOrFail({ name: '@activepieces/piece-gone-vendor' })
+        expect(saved.deprecated).toBe(true)
+    })
+
+    it('hides a deprecated piece from the selector, keeps a live one listed, and still resolves the deprecated one by name', async () => {
+        await publish({ name: '@activepieces/piece-gone-vendor', deprecated: true })
+        await publish({ name: '@activepieces/piece-live-vendor', displayName: 'Live Vendor' })
+        const ctx = await createTestContext(app!, {})
+        const namesIn = (response: Awaited<ReturnType<typeof ctx.get>>): string[] => response.json().map((piece: { name: string }) => piece.name)
+
+        const listed = await ctx.get(`/v1/pieces?projectId=${ctx.project.id}`)
+        expect(listed.statusCode).toBe(StatusCodes.OK)
+        expect(namesIn(listed)).toContain('@activepieces/piece-live-vendor')
+        expect(namesIn(listed)).not.toContain('@activepieces/piece-gone-vendor')
+
+        const includingHidden = await ctx.get(`/v1/pieces?projectId=${ctx.project.id}&includeHidden=true`)
+        expect(namesIn(includingHidden)).toContain('@activepieces/piece-gone-vendor')
+
+        const byName = await ctx.get(`/v1/pieces/@activepieces/piece-gone-vendor?projectId=${ctx.project.id}`)
+        expect(byName.statusCode).toBe(StatusCodes.OK)
+        expect(byName.json().deprecated).toBe(true)
+    })
+})


### PR DESCRIPTION
## Description

The piece selector's `deprecated` filter from #14248 never fires on cloud, because the flag is dropped on the way into the registry.

The release pipeline (`tools/scripts/pieces/update-pieces-metadata.ts`) posts each published piece's metadata to `POST /v1/admin/pieces`. That route validates the body with an inline zod object that has no `deprecated` key. The zod validator replaces the request body with the parsed result, so `pieceMetadataService.create()` never sees the flag and the row is saved with `deprecated = null`. `list()` then has nothing to filter on.

Live effect today: cloud serves 765 pieces and not one has `deprecated: true`. `@activepieces/piece-aws-bedrock@0.3.0`, the precedent that #14248 shipped, carries `deprecated: true` in its published bundle and is still returned by the selector search. #14248 threaded the flag through the framework, the entity, the service and the migration, but not through this controller.

### The fix

One optional boolean in the admin request schema. Pieces that do not send the flag are unaffected.

### Why now

#15452 marks the Zagomail piece deprecated because the vendor shut down. If it merges before this change reaches cloud, its `0.1.7` is ingested with the flag stripped and the piece stays in the selector. It should merge after this ships.

### Not in this PR

Rows already ingested with `deprecated = null` (today: `aws-bedrock@0.3.0`) stay unflagged until the piece is republished with a version bump, or a data migration backfills them. Either is a small follow-up.

## How was this tested?

New integration tests in `test/integration/cloud/piece-metadata/piece-metadata.test.ts`. Cloud edition, since that is the only edition that registers the admin module:

- publishing through `/v1/admin/pieces` with `deprecated: true` returns and persists the flag;
- the deprecated piece is absent from `GET /v1/pieces`, present with `includeHidden=true`, and still resolves by exact name so existing flows keep loading, while a live piece published the same way stays listed.

Red/green: with the schema line stashed, both tests fail the way production does (`expected null to be true`; the deprecated piece is still listed). With it, all 9 tests in the file pass. `eslint` on both changed files: 0 errors.

Related: #14248, #14141, #15452, PIE-497.

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

The new field is optional. Existing publishes without it behave exactly as before.

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)

The admin route keeps its API-key pre-handler. The only change is that an optional boolean is no longer discarded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
