### PR TITLE
fix(smtp): pass replyTo to mailOptions instead of inReplyTo

### DIFF
--- a/packages/pieces/core/smtp/package.json
+++ b/packages/pieces/core/smtp/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "build": "tsc -p tsconfig.lib.json && cp package.json dist/",
     "bundle": "node ../../../../dist/packages/cli/src/index.js pieces bundle",
-    "lint": "eslint 'src/**/*.ts'"
+    "lint": "eslint 'src/**/*.ts'",
+    "test": "vitest run"
   },
   "dependencies": {
     "@activepieces/pieces-common": "workspace:*",
@@ -19,6 +20,7 @@
   "devDependencies": {
     "@types/mime-types": "2.1.1",
     "@types/nodemailer": "7.0.11",
-    "tslib": "2.6.2"
+    "tslib": "2.6.2",
+    "vitest": "3.2.6"
   }
 }

--- a/packages/pieces/core/smtp/src/index.ts
+++ b/packages/pieces/core/smtp/src/index.ts
@@ -1,86 +1,11 @@
 import {
-  PieceAuth,
-  Property,
   createPiece,
+  PieceCategory,
 } from '@activepieces/pieces-framework';
-import { PieceCategory } from '@activepieces/pieces-framework';
 import { sendEmail } from './lib/actions/send-email';
-import { smtpCommon } from './lib/common';
+import { smtpAuth } from './lib/auth';
 
-const SMTPPorts = [25, 465, 587, 2525];
-
-export const smtpAuth = PieceAuth.CustomAuth({
-  required: true,
-  props: {
-    host: Property.ShortText({
-      displayName: 'Host',
-      required: true,
-    }),
-    email: Property.ShortText({
-      displayName: 'Email',
-      description: 'Leave blank if your mail relay does not require authentication.',
-      required: false,
-    }),
-    password: PieceAuth.SecretText({
-      displayName: 'Password',
-      description: 'Leave blank if your mail relay does not require authentication.',
-      required: false,
-    }),
-    port: Property.StaticDropdown({
-      displayName: 'Port',
-      required: true,
-      options: {
-        disabled: false,
-        options: SMTPPorts.map((port) => {
-          return {
-            label: port.toString(),
-            value: port,
-          };
-        }),
-      },
-    }),
-    TLS: Property.Checkbox({
-      displayName: 'Require TLS?',
-      defaultValue: false,
-      required: true,
-    }),
-  },
-  validate: async ({ auth }) => {
-        try {
-      const transporter = smtpCommon.createSMTPTransport(auth);
-      return new Promise((resolve, reject) => {
-        transporter.verify(function (error, success) {
-          if (error) {
-            resolve({ valid: false, error: JSON.stringify(error) });
-          } else {
-            resolve({ valid: true });
-          }
-        });
-      });
-    } catch (e) {
-      const castedError = (e as Record<string, unknown>)
-      const code = castedError?.['code'];
-      switch (code) {
-        case 'EDNS':
-          return {
-            valid: false,
-            error: 'SMTP server not found or unreachable with error code: EDNS',
-          };
-        case 'CONN':
-          return {
-            valid: false,
-            error: 'SMTP server connection failed with error code: CONN',
-          };
-        default:
-          break;
-      }
-      return {
-        valid: false,
-        error: JSON.stringify(e),
-      };
-    }
-  },
-});
+export { smtpAuth } from './lib/auth';
 
 export const smtp = createPiece({
   displayName: 'SMTP',

--- a/packages/pieces/core/smtp/src/lib/actions/send-email.ts
+++ b/packages/pieces/core/smtp/src/lib/actions/send-email.ts
@@ -1,5 +1,5 @@
 import { ApFile, Property, createAction } from '@activepieces/pieces-framework';
-import { smtpAuth } from '../..';
+import { smtpAuth } from '../auth';
 import { smtpCommon } from '../common';
 import { Attachment, Headers } from 'nodemailer/lib/mailer';
 import mime from 'mime-types';
@@ -107,7 +107,7 @@ export const sendEmail = createAction({
       from: getFrom(propsValue.senderName, propsValue.from),
       to: propsValue.to.join(','),
       cc: propsValue.cc?.join(','),
-      inReplyTo: propsValue.replyTo,
+      replyTo: propsValue.replyTo,
       bcc: propsValue.bcc?.join(','),
       subject: propsValue.subject,
       text: propsValue.body_type === 'plain_text' ? propsValue.body : undefined,

--- a/packages/pieces/core/smtp/src/lib/auth.ts
+++ b/packages/pieces/core/smtp/src/lib/auth.ts
@@ -1,0 +1,80 @@
+import {
+  PieceAuth,
+  Property,
+} from '@activepieces/pieces-framework';
+import { smtpCommon } from './common';
+
+const SMTPPorts = [25, 465, 587, 2525];
+
+export const smtpAuth = PieceAuth.CustomAuth({
+  required: true,
+  props: {
+    host: Property.ShortText({
+      displayName: 'Host',
+      required: true,
+    }),
+    email: Property.ShortText({
+      displayName: 'Email',
+      description: 'Leave blank if your mail relay does not require authentication.',
+      required: false,
+    }),
+    password: PieceAuth.SecretText({
+      displayName: 'Password',
+      description: 'Leave blank if your mail relay does not require authentication.',
+      required: false,
+    }),
+    port: Property.StaticDropdown({
+      displayName: 'Port',
+      required: true,
+      options: {
+        disabled: false,
+        options: SMTPPorts.map((port) => {
+          return {
+            label: port.toString(),
+            value: port,
+          };
+        }),
+      },
+    }),
+    TLS: Property.Checkbox({
+      displayName: 'Require TLS?',
+      defaultValue: false,
+      required: true,
+    }),
+  },
+  validate: async ({ auth }) => {
+    try {
+      const transporter = smtpCommon.createSMTPTransport(auth);
+      return new Promise((resolve) => {
+        transporter.verify(function (error) {
+          if (error) {
+            resolve({ valid: false, error: JSON.stringify(error) });
+          } else {
+            resolve({ valid: true });
+          }
+        });
+      });
+    } catch (e) {
+      const castedError = (e as Record<string, unknown>);
+      const code = castedError?.['code'];
+      switch (code) {
+        case 'EDNS':
+          return {
+            valid: false,
+            error: 'SMTP server not found or unreachable with error code: EDNS',
+          };
+        case 'CONN':
+          return {
+            valid: false,
+            error: 'SMTP server connection failed with error code: CONN',
+          };
+        default:
+          break;
+      }
+      return {
+        valid: false,
+        error: JSON.stringify(e),
+      };
+    }
+  },
+});

--- a/packages/pieces/core/smtp/test/send-email.test.ts
+++ b/packages/pieces/core/smtp/test/send-email.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi } from 'vitest';
+import { sendEmail } from '../src/lib/actions/send-email';
+import { smtpCommon } from '../src/lib/common';
+
+describe('sendEmail action', () => {
+  it('should pass replyTo to mailOptions when provided', async () => {
+    const sendMailMock = vi.fn().mockResolvedValue({ messageId: '123' });
+    vi.spyOn(smtpCommon, 'createSMTPTransport').mockReturnValue({
+      sendMail: sendMailMock,
+    } as any);
+
+    const context = {
+      auth: {
+        props: {
+          host: 'smtp.example.com',
+          port: 587,
+          TLS: true,
+        },
+      },
+      propsValue: {
+        from: 'sender@example.com',
+        to: ['recipient@example.com'],
+        replyTo: 'reply-here@example.com',
+        subject: 'Test Subject',
+        body_type: 'plain_text',
+        body: 'Hello World',
+        attachments: [],
+      },
+    };
+
+    await (sendEmail.run as any)(context);
+
+    expect(sendMailMock).toHaveBeenCalledTimes(1);
+    const mailOptions = sendMailMock.mock.calls[0][0];
+    expect(mailOptions.replyTo).toBe('reply-here@example.com');
+    expect(mailOptions.inReplyTo).toBeUndefined();
+    expect(mailOptions.from).toBe('sender@example.com');
+    expect(mailOptions.to).toBe('recipient@example.com');
+    expect(mailOptions.subject).toBe('Test Subject');
+    expect(mailOptions.text).toBe('Hello World');
+  });
+
+  it('should handle optional senderName and multiple recipients', async () => {
+    const sendMailMock = vi.fn().mockResolvedValue({ messageId: '456' });
+    vi.spyOn(smtpCommon, 'createSMTPTransport').mockReturnValue({
+      sendMail: sendMailMock,
+    } as any);
+
+    const context = {
+      auth: {
+        props: {
+          host: 'smtp.example.com',
+          port: 465,
+          TLS: false,
+        },
+      },
+      propsValue: {
+        from: 'sender@example.com',
+        senderName: 'Support Team',
+        to: ['a@example.com', 'b@example.com'],
+        cc: ['c@example.com'],
+        bcc: ['d@example.com'],
+        replyTo: 'support@example.com',
+        subject: 'Welcome',
+        body_type: 'html',
+        body: '<p>Welcome</p>',
+        attachments: [],
+      },
+    };
+
+    await (sendEmail.run as any)(context);
+
+    expect(sendMailMock).toHaveBeenCalledTimes(1);
+    const mailOptions = sendMailMock.mock.calls[0][0];
+    expect(mailOptions.from).toBe('"Support Team" <sender@example.com>');
+    expect(mailOptions.to).toBe('a@example.com,b@example.com');
+    expect(mailOptions.cc).toBe('c@example.com');
+    expect(mailOptions.bcc).toBe('d@example.com');
+    expect(mailOptions.replyTo).toBe('support@example.com');
+    expect(mailOptions.html).toBe('<p>Welcome</p>');
+    expect(mailOptions.text).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Description
Resolves #15415
/claim #15415

In the SMTP piece (`packages/pieces/core/smtp`), the `Reply-To` field configured by users in the flow action was being mapped to Nodemailer's `inReplyTo` option (`In-Reply-To:` header for Message-ID email threading) instead of `replyTo` (`Reply-To:` email address header).

Consequently, when recipients clicked "Reply" on emails sent via the SMTP piece, their email clients defaulted to replying to the `From:` sender address rather than the designated reply-to address.

### Changes:
1. **`packages/pieces/core/smtp/src/lib/actions/send-email.ts`**:
   - Mapped `replyTo: propsValue.replyTo` in Nodemailer's `mailOptions`.
   - Imported `smtpAuth` from `../auth` to prevent cyclic module evaluation.
2. **`packages/pieces/core/smtp/src/lib/auth.ts`**:
   - Extracted `smtpAuth` to a dedicated file conforming to standard piece architectural pattern (identical to `sftp` and other core pieces) and re-exported from `src/index.ts`.
3. **`packages/pieces/core/smtp/package.json` & `test/send-email.test.ts`**:
   - Added unit test suite validating `replyTo` header transmission, optional sender name formatting, and multiple recipients.

### Verification:
- Unit tests executed and verified:
  ```bash
  bun run --filter=@activepieces/piece-smtp test
  # ✓ test/send-email.test.ts (2 tests) 2ms
  ```
- Piece build verified cleanly:
  ```bash
  npx turbo run build --filter=@activepieces/piece-smtp
  # Tasks: 5 successful, 5 total
  ```

---
**Sovereign Settlement (Base L2)**: `0x46D5318E4397cFcBED06a235c1604E473682Ea1F`