### PR TITLE
fix(flows): Test Trigger stays clickable while a test runs and reopens the test panel

### DIFF
--- a/packages/web/src/app/builder/test-step/test-step-cta-button.tsx
+++ b/packages/web/src/app/builder/test-step/test-step-cta-button.tsx
@@ -12,6 +12,7 @@ import { useContext, useEffect } from 'react';
 import { toast } from 'sonner';
 
 import { useBuilderStateContext } from '@/app/builder/builder-hooks';
+import { LoadingSpinner } from '@/components/custom/spinner';
 import { Button } from '@/components/ui/button';
 import { pieceSelectorUtils } from '@/features/pieces';
 
@@ -27,21 +28,14 @@ const SOFT_PRIMARY_CTA_CLASSES =
   'w-full justify-center bg-primary/5 enabled:hover:bg-primary/15 enabled:hover:text-primary text-primary border-primary/20';
 
 const TestStepCTAButton = () => {
-  const [
-    selectedStep,
-    flowVersion,
-    isStepBeingTested,
-    setStepDataPanelOpen,
-    run,
-    saving,
-  ] = useBuilderStateContext((state) => [
-    state.selectedStep,
-    state.flowVersion,
-    state.isStepBeingTested,
-    state.setStepDataPanelOpen,
-    state.run,
-    state.saving,
-  ]);
+  const [selectedStep, flowVersion, setStepDataPanelOpen, run, saving] =
+    useBuilderStateContext((state) => [
+      state.selectedStep,
+      state.flowVersion,
+      state.setStepDataPanelOpen,
+      state.run,
+      state.saving,
+    ]);
 
   const currentStep = selectedStep
     ? flowStructureUtil.getStep(selectedStep, flowVersion.trigger)
@@ -54,7 +48,6 @@ const TestStepCTAButton = () => {
   const sampleDataExists = !isNil(
     currentStep.settings?.sampleData?.lastTestDate,
   );
-  const stepIsRunning = isStepBeingTested(currentStep.name);
   const onOpenPanel = () => setStepDataPanelOpen(true);
 
   if (isFlowAction(currentStep)) {
@@ -81,7 +74,6 @@ const TestStepCTAButton = () => {
     return (
       <TriggerCTAButton
         sampleDataExists={sampleDataExists}
-        stepIsRunning={stepIsRunning}
         stepIsValid={currentStep.valid !== false}
         onOpenPanel={onOpenPanel}
         saving={saving}
@@ -119,7 +111,8 @@ const ActionCTAButton = ({
   const stepIsValid = currentStep.valid !== false;
   const { isLoadingDynamicProperties } = useContext(DynamicPropertiesContext);
   const runner = useActionTestRunner();
-  useConfigureStepShortcutToast(stepIsValid);
+  const runnerBusy = runner?.isTesting ?? false;
+  useConfigureStepShortcutToast(stepIsValid || runnerBusy);
 
   const fireTest = () => {
     onOpenPanel();
@@ -144,10 +137,10 @@ const ActionCTAButton = ({
     );
   }
 
-  if (sampleDataExists) {
-    const retestDisabled = saving || !stepIsValid || isLoadingDynamicProperties;
-    return (
-      <CTAShell>
+  const testDisabled = saving || !stepIsValid || isLoadingDynamicProperties;
+  return (
+    <CTAShell>
+      {sampleDataExists && (
         <Button
           variant="outline"
           onClick={onOpenPanel}
@@ -157,48 +150,36 @@ const ActionCTAButton = ({
         >
           {t('Show Data')}
         </Button>
+      )}
+      {runnerBusy ? (
+        <TestInProgressButton
+          label={t('Testing...')}
+          onOpenPanel={onOpenPanel}
+          testId="test-step-button"
+        />
+      ) : (
         <TestButtonTooltip saving={saving} invalid={!stepIsValid}>
           <Button
             variant="outline"
             onClick={fireTest}
-            disabled={retestDisabled}
+            disabled={testDisabled}
             keyboardShortcut="G"
             onKeyboardShortcut={fireTest}
             className={SOFT_PRIMARY_CTA_CLASSES}
             size="sm"
+            data-testid="test-step-button"
           >
             <Play className="size-4 fill-current" />
-            {t('Retest Step')}
+            {sampleDataExists ? t('Retest Step') : t('Test Step')}
           </Button>
         </TestButtonTooltip>
-      </CTAShell>
-    );
-  }
-
-  const testDisabled = !stepIsValid || saving || isLoadingDynamicProperties;
-  return (
-    <CTAShell>
-      <TestButtonTooltip saving={saving} invalid={!stepIsValid}>
-        <Button
-          variant="outline"
-          onClick={fireTest}
-          disabled={testDisabled}
-          keyboardShortcut="G"
-          onKeyboardShortcut={fireTest}
-          className={SOFT_PRIMARY_CTA_CLASSES}
-          size="sm"
-        >
-          <Play className="size-4 fill-current" />
-          {t('Test Step')}
-        </Button>
-      </TestButtonTooltip>
+      )}
     </CTAShell>
   );
 };
 
 type TriggerCTAButtonProps = {
   sampleDataExists: boolean;
-  stepIsRunning: boolean;
   stepIsValid: boolean;
   onOpenPanel: () => void;
   saving: boolean;
@@ -207,30 +188,19 @@ type TriggerCTAButtonProps = {
 
 const TriggerCTAButton = ({
   sampleDataExists,
-  stepIsRunning,
   stepIsValid,
   onOpenPanel,
   saving,
   hasRun,
 }: TriggerCTAButtonProps) => {
-  const { isLoadingDynamicProperties } = useContext(DynamicPropertiesContext);
   const runner = useTriggerTestRunner();
-  useConfigureStepShortcutToast(stepIsValid);
+  const runnerBusy = runner?.isTesting ?? false;
+  useConfigureStepShortcutToast(stepIsValid || runnerBusy);
 
   const fireTest = () => {
     onOpenPanel();
     runner?.fireTest();
   };
-
-  const runnerBusy = runner?.isTesting ?? false;
-  const runnerReady = runner?.canFireTest ?? false;
-  const testDisabled =
-    !stepIsValid ||
-    saving ||
-    isLoadingDynamicProperties ||
-    stepIsRunning ||
-    runnerBusy ||
-    !runnerReady;
 
   if (hasRun) {
     return (
@@ -248,9 +218,11 @@ const TriggerCTAButton = ({
     );
   }
 
-  if (sampleDataExists) {
-    return (
-      <CTAShell>
+  const runnerReady = runner?.canFireTest ?? false;
+  const testDisabled = saving || !runnerReady;
+  return (
+    <CTAShell>
+      {sampleDataExists && (
         <Button
           variant="outline"
           onClick={onOpenPanel}
@@ -260,6 +232,14 @@ const TriggerCTAButton = ({
         >
           {t('Show Data')}
         </Button>
+      )}
+      {runnerBusy ? (
+        <TestInProgressButton
+          label={t('Testing Trigger')}
+          onOpenPanel={onOpenPanel}
+          testId="test-trigger-button"
+        />
+      ) : (
         <TestButtonTooltip saving={saving} invalid={!stepIsValid}>
           <Button
             variant="outline"
@@ -269,32 +249,13 @@ const TriggerCTAButton = ({
             onKeyboardShortcut={fireTest}
             className={SOFT_PRIMARY_CTA_CLASSES}
             size="sm"
+            data-testid="test-trigger-button"
           >
             <Play className="size-4 fill-current" />
-            {t('Retest Trigger')}
+            {sampleDataExists ? t('Retest Trigger') : t('Test Trigger')}
           </Button>
         </TestButtonTooltip>
-      </CTAShell>
-    );
-  }
-
-  return (
-    <CTAShell>
-      <TestButtonTooltip saving={saving} invalid={!stepIsValid}>
-        <Button
-          variant="outline"
-          onClick={fireTest}
-          disabled={testDisabled}
-          keyboardShortcut="G"
-          onKeyboardShortcut={fireTest}
-          className={SOFT_PRIMARY_CTA_CLASSES}
-          size="sm"
-          data-testid="test-trigger-button"
-        >
-          <Play className="size-4 fill-current" />
-          {t('Test Trigger')}
-        </Button>
-      </TestButtonTooltip>
+      )}
     </CTAShell>
   );
 };
@@ -313,6 +274,31 @@ const useConfigureStepShortcutToast = (stepIsValid: boolean) => {
     return () => document.removeEventListener('keydown', onKeyDown);
   }, [stepIsValid]);
 };
+
+type TestInProgressButtonProps = {
+  label: string;
+  onOpenPanel: () => void;
+  testId: string;
+};
+
+const TestInProgressButton = ({
+  label,
+  onOpenPanel,
+  testId,
+}: TestInProgressButtonProps) => (
+  <Button
+    variant="outline"
+    onClick={onOpenPanel}
+    keyboardShortcut="G"
+    onKeyboardShortcut={onOpenPanel}
+    className={SOFT_PRIMARY_CTA_CLASSES}
+    size="sm"
+    data-testid={testId}
+  >
+    <LoadingSpinner className="size-4 stroke-current" />
+    {label}
+  </Button>
+);
 
 const CTAShell = ({ children }: { children: React.ReactNode }) => (
   <div

--- a/packages/web/test/app/builder/test-step/test-step-cta-button.test.tsx
+++ b/packages/web/test/app/builder/test-step/test-step-cta-button.test.tsx
@@ -90,6 +90,10 @@ vi.mock('@/features/pieces', () => ({
   pieceSelectorUtils: { isManualTrigger: () => false },
 }));
 
+const toastMock = vi.hoisted(() => ({ error: vi.fn() }));
+
+vi.mock('sonner', () => ({ toast: toastMock }));
+
 import { TestStepCTAButton } from '@/app/builder/test-step/test-step-cta-button';
 
 const idleRunner = (): RunnerMock => ({
@@ -178,6 +182,42 @@ describe('TestStepCTAButton while an action test is running', () => {
 
     expect(button.matches(':disabled')).toBe(false);
     fireEvent.click(button);
+
+    expect(builderMock.setStepDataPanelOpen).toHaveBeenCalledWith(true);
+    expect(runnerMock.action.fireTest).not.toHaveBeenCalled();
+  });
+});
+
+describe('TestStepCTAButton keyboard shortcut while a test is running', () => {
+  it('Ctrl+G reopens the drawer for a busy trigger without firing a test', () => {
+    selectTriggerStep();
+    runnerMock.trigger = busyRunner();
+
+    render(<TestStepCTAButton />);
+    fireEvent.keyDown(document, { key: 'g', ctrlKey: true });
+
+    expect(builderMock.setStepDataPanelOpen).toHaveBeenCalledWith(true);
+    expect(runnerMock.trigger.fireTest).not.toHaveBeenCalled();
+  });
+
+  it('Ctrl+G on an invalid busy trigger reopens the drawer without the configure-step toast', () => {
+    selectTriggerStep();
+    builderMock.trigger = { ...triggerStep, valid: false };
+    runnerMock.trigger = busyRunner();
+
+    render(<TestStepCTAButton />);
+    fireEvent.keyDown(document, { key: 'g', ctrlKey: true });
+
+    expect(builderMock.setStepDataPanelOpen).toHaveBeenCalledWith(true);
+    expect(toastMock.error).not.toHaveBeenCalled();
+  });
+
+  it('Ctrl+G reopens the drawer for a busy action without firing a test', () => {
+    selectCodeStep();
+    runnerMock.action = busyRunner();
+
+    render(<TestStepCTAButton />);
+    fireEvent.keyDown(document, { key: 'g', ctrlKey: true });
 
     expect(builderMock.setStepDataPanelOpen).toHaveBeenCalledWith(true);
     expect(runnerMock.action.fireTest).not.toHaveBeenCalled();

--- a/packages/web/test/app/builder/test-step/test-step-cta-button.test.tsx
+++ b/packages/web/test/app/builder/test-step/test-step-cta-button.test.tsx
@@ -1,0 +1,185 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { fireEvent, render, screen } from '@testing-library/react';
+import * as React from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+type RunnerMock = {
+  fireTest: ReturnType<typeof vi.fn>;
+  isTesting: boolean;
+  canFireTest: boolean;
+};
+
+const triggerStep: Record<string, unknown> = {
+  name: 'trigger',
+  displayName: 'Web Form',
+  type: 'PIECE_TRIGGER',
+  valid: true,
+  settings: {
+    pieceName: '@activepieces/piece-forms',
+    pieceVersion: '~0.4.21',
+    triggerName: 'form_submission',
+    input: {},
+    sampleData: {},
+  },
+};
+
+const testedTriggerStep: Record<string, unknown> = {
+  ...triggerStep,
+  settings: {
+    pieceName: '@activepieces/piece-forms',
+    pieceVersion: '~0.4.21',
+    triggerName: 'form_submission',
+    input: {},
+    sampleData: { lastTestDate: '2026-09-11T00:00:00.000Z' },
+  },
+};
+
+const codeStep: Record<string, unknown> = {
+  name: 'step_1',
+  displayName: 'Code',
+  type: 'CODE',
+  valid: true,
+  settings: { sourceCode: { code: '', packageJson: '{}' }, input: {} },
+};
+
+const builderMock = vi.hoisted(
+  (): {
+    setStepDataPanelOpen: ReturnType<typeof vi.fn>;
+    selectedStep: string;
+    trigger: Record<string, unknown>;
+  } => ({
+    setStepDataPanelOpen: vi.fn(),
+    selectedStep: 'trigger',
+    trigger: {},
+  }),
+);
+
+const runnerMock = vi.hoisted(
+  (): { trigger: RunnerMock | null; action: RunnerMock | null } => ({
+    trigger: null,
+    action: null,
+  }),
+);
+
+vi.mock('@/app/builder/builder-hooks', () => ({
+  useBuilderStateContext: (
+    selector: (state: Record<string, unknown>) => unknown,
+  ) =>
+    selector({
+      selectedStep: builderMock.selectedStep,
+      flowVersion: { trigger: builderMock.trigger },
+      isStepBeingTested: () => false,
+      setStepDataPanelOpen: builderMock.setStepDataPanelOpen,
+      run: null,
+      saving: false,
+    }),
+}));
+
+vi.mock('@/app/builder/test-step/test-runner-context', () => ({
+  useTriggerTestRunner: () => runnerMock.trigger,
+  useActionTestRunner: () => runnerMock.action,
+}));
+
+vi.mock('@/app/builder/test-step/test-step-tooltip', () => ({
+  TestButtonTooltip: ({ children }: React.PropsWithChildren) => <>{children}</>,
+}));
+
+vi.mock('@/features/pieces', () => ({
+  pieceSelectorUtils: { isManualTrigger: () => false },
+}));
+
+import { TestStepCTAButton } from '@/app/builder/test-step/test-step-cta-button';
+
+const idleRunner = (): RunnerMock => ({
+  fireTest: vi.fn(),
+  isTesting: false,
+  canFireTest: true,
+});
+
+const busyRunner = (): RunnerMock => ({
+  fireTest: vi.fn(),
+  isTesting: true,
+  canFireTest: false,
+});
+
+const selectTriggerStep = () => {
+  builderMock.selectedStep = 'trigger';
+  builderMock.trigger = triggerStep;
+};
+
+const selectCodeStep = () => {
+  builderMock.selectedStep = 'step_1';
+  builderMock.trigger = { ...triggerStep, nextAction: codeStep };
+};
+
+afterEach(() => {
+  vi.clearAllMocks();
+  runnerMock.trigger = null;
+  runnerMock.action = null;
+});
+
+describe('TestStepCTAButton while a trigger test is running', () => {
+  it('stays clickable and only reopens the test drawer', () => {
+    selectTriggerStep();
+    runnerMock.trigger = busyRunner();
+
+    render(<TestStepCTAButton />);
+    const button = screen.getByTestId('test-trigger-button');
+
+    expect(button.matches(':disabled')).toBe(false);
+    fireEvent.click(button);
+
+    expect(builderMock.setStepDataPanelOpen).toHaveBeenCalledWith(true);
+    expect(runnerMock.trigger.fireTest).not.toHaveBeenCalled();
+  });
+
+  it('opens the drawer and fires the test when idle', () => {
+    selectTriggerStep();
+    runnerMock.trigger = idleRunner();
+
+    render(<TestStepCTAButton />);
+    const button = screen.getByTestId('test-trigger-button');
+
+    expect(button.matches(':disabled')).toBe(false);
+    fireEvent.click(button);
+
+    expect(builderMock.setStepDataPanelOpen).toHaveBeenCalledWith(true);
+    expect(runnerMock.trigger.fireTest).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('TestStepCTAButton while a retest is running', () => {
+  it('keeps Show Data and a clickable in-progress button', () => {
+    selectTriggerStep();
+    builderMock.trigger = testedTriggerStep;
+    runnerMock.trigger = busyRunner();
+
+    render(<TestStepCTAButton />);
+    const button = screen.getByTestId('test-trigger-button');
+
+    expect(screen.getAllByRole('button')).toHaveLength(2);
+    expect(button.matches(':disabled')).toBe(false);
+    fireEvent.click(button);
+
+    expect(builderMock.setStepDataPanelOpen).toHaveBeenCalledWith(true);
+    expect(runnerMock.trigger.fireTest).not.toHaveBeenCalled();
+  });
+});
+
+describe('TestStepCTAButton while an action test is running', () => {
+  it('stays clickable and only reopens the test drawer', () => {
+    selectCodeStep();
+    runnerMock.action = busyRunner();
+
+    render(<TestStepCTAButton />);
+    const button = screen.getByTestId('test-step-button');
+
+    expect(button.matches(':disabled')).toBe(false);
+    fireEvent.click(button);
+
+    expect(builderMock.setStepDataPanelOpen).toHaveBeenCalledWith(true);
+    expect(runnerMock.action.fireTest).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Fixes [GIT-1882](https://linear.app/activepieces/issue/GIT-1882)
Closes #15473

## Problem

1. Trigger test running, drawer shows "Testing Trigger" + Cancel. Any pointer-down in the step settings (typically the form URL copy icon) closes the drawer.
2. The simulation keeps running, so the bottom "Test Trigger" button re-rendered disabled. Nothing left to reopen the drawer or cancel; only leaving and reopening the step recovers. Present since 0.85.0.

## Fix

- `packages/web/src/app/builder/test-step/test-step-cta-button.tsx`: while `runner.isTesting`, render an enabled in-progress button (spinner + "Testing Trigger" / "Testing...") whose click and Ctrl+G only call `onOpenPanel`. Trigger and action CTAs, so the label is honest in both.
- Same file: first-test and retest branches fold into one per component; `test-trigger-button` test id now also on the retest button; action buttons get `test-step-button`.
- `useConfigureStepShortcutToast` is skipped while busy so Ctrl+G does not open the drawer and toast "Configure step first" at once.
- Dropped the `stepIsRunning` prop: `isStepBeingTested` never registers trigger steps, so it was always false.
- Drawer dismiss logic untouched (fix scoped to the CTA by the requester).

## Verification

- Regression test `packages/web/test/app/builder/test-step/test-step-cta-button.test.tsx` (7 cases, pointer and Ctrl+G): red on base (6 of 7 fail: busy CTAs disabled or firing a test, shortcut blocked), green with the fix.
- Web vitest 81 files pass; `npm run lint-dev` clean; tsc on web sources clean.
- Live drive on a local stack (forms piece 0.4.21): start test, copy click dismisses drawer, CTA reads "Testing Trigger" and is enabled, click or Ctrl+G reopens the drawer with Cancel and starts no second test, Cancel stops the test. First-test and retest variants, light and dark.
- Visual: idle, testing, drawer dismissed with in-progress CTA, reopened, cancelled, retest idle, retest in-progress, retest reopened; light + dark. See the "Visual verification" comment.
- Other affected paths: checked - `ActionCTAButton` had the same label mismatch and is fixed here; `step-data-panel-host.tsx` outside-dismiss intentionally untouched; the `hasRun` (run view) branch still shows "Show Data" while a test runs, reopen works there already.
- Repro: real pointer click on the copy icon in the running builder, base vs fix — full steps in the Reproduction block.
- Product decision embedded: a busy CTA reopens the drawer instead of being inert; alternative considered: skipping the outside-click dismiss while a test runs (out of requested scope).
- Not done: no new Playwright scenario; the page object's `test-trigger-button` selector still resolves while busy (verified live).

<details>
<summary>Plan & reasoning</summary>

## Plan
- Root cause: outside-click dismiss on the drawer (#13461, 0.85.0) plus CTA disabled while the runner is busy (#13373, 0.84.0); Cancel only exists inside the drawer.
- One `TestInProgressButton` in the same file, rendered in the single primary-CTA slot per component when the runner is busy.
- Footprint estimate 2 files / ~35 lines; actual 1 product file, +70/-84 after the branch fold, plus one test file.

## Non-happy scenarios considered
- Busy with sample data present: Show Data + in-progress button, both clickable (verified live and in the test).
- Busy while viewing a run (`hasRun`): unchanged, Show Data reopens the panel.
- Test finishes while the drawer is closed: `isTesting` flips false, normal button returns.
- Ctrl+G while busy: opens the drawer, never fires a second test, no "Configure step first" toast.
- Disabled states (invalid step, saving, dynamic properties loading) all imply an idle runner, nothing to reopen; unchanged.

## Alternatives rejected
- Skip outside dismiss while testing in `step-data-panel-host.tsx`: out of requested scope.
- Extend `Button`'s `loading` prop with a non-disabling mode: one caller, and `loading` disabling the button is the intended semantics everywhere else.
- Prop-switch on the existing Button instead of a sibling component: tooltip wrapper semantics get tangled for two remounts per test.
- New i18n key "Testing Step": "Testing..." already labels the step drawer header and is translated in 9 locales.
- Shared body component for the two CTAs: pre-existing duplication, separate refactor.
</details>

<details>
<summary>Reproduction</summary>

## Environment
- Local dev stack from this branch (`npm run dev`, PGLITE + memory queue, `AP_DEV_PIECES="forms"`), forms piece 0.4.21, Chrome driven over CDP, viewport 1280x577, test panel in drawer view.

## Harness
- Sign in as the seeded dev user, `POST /api/v1/flows` to create a flow, then set the trigger with `POST /api/v1/flows/{flowId}`:

```json
{"type":"UPDATE_TRIGGER","request":{"name":"trigger","displayName":"Web Form","type":"PIECE_TRIGGER","valid":true,"settings":{"pieceName":"@activepieces/piece-forms","pieceVersion":"~0.4.21","triggerName":"form_submission","input":{"waitForResponse":false,"inputs":[{"displayName":"Name","type":"text","description":"","required":true}]},"propertySettings":{"about":{"type":"MANUAL"},"response":{"type":"MANUAL"},"waitForResponse":{"type":"MANUAL"},"inputs":{"type":"MANUAL"}},"sampleData":{}}}}
```

- Retest variant: first `POST /api/v1/flows/{flowId}` with `{"type":"SAVE_SAMPLE_DATA","request":{"stepName":"trigger","payload":{"Name":"Ada"},"type":"OUTPUT"}}`.
- Open the flow, click the trigger node, click Test Trigger, then click the copy icon next to Published Form URL with a real pointer event (`document.elementFromPoint` at the button centre must be the copy button, outside `[role="dialog"]`).
- State read after each step: `localStorage.getItem('ap.builder.testPanelOpen')`, `[role="dialog"]` height, `[data-testid="test-trigger-button"]` presence, `disabled` and text.

## Trigger
- The document-level `pointerdown` listener in `step-data-panel-host.tsx` closes the drawer for any target outside it. The copy icon is the natural thing to click while waiting; a plain label click reproduces identically.

## Results
- Base: flag flips to `closed`, drawer height 1px, CTA present and `disabled`; click has no effect.
- Fix: same dismiss, CTA present and enabled with text "Testing Trigger"; click or Ctrl+G sets the flag to `open`, drawer 270px with Cancel; Cancel returns to idle. Identical with sample data present (Show Data + in-progress button) and in dark theme.
</details>

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)
