### PR TITLE
fix(tests): shrink flaky large-result-utils fixture that times out on loaded CI runners

### DIFF
--- a/packages/server/utils/test/large-result-utils.test.ts
+++ b/packages/server/utils/test/large-result-utils.test.ts
@@ -53,7 +53,7 @@ describe('largeResultUtils.fitToBudget', () => {
     })
 
     it('returns null when no rung fits, rather than a mangled prefix', () => {
-        const wide = Object.fromEntries(Array.from({ length: 200_000 }, (_, index) => [`key-${index}`, index]))
+        const wide = Object.fromEntries(Array.from({ length: 50_000 }, (_, index) => [`key-${index}`, index]))
         expect(largeResultUtils.fitToBudget({ value: wide, maxBytes: MAX_TOOL_RESULT_BYTES, wrap: wrapAsToolResult })).toBeNull()
     })
 


### PR DESCRIPTION
## Description

Fixes the flaky `main` CI failure tracked in #15404: `large-result-utils.test.ts` › "returns null when no rung fits" times out at vitest's default 5s on loaded runners and blocks unrelated PRs.

The test built a 200,000-key object. `fitToBudget` rebuilds and `JSON.stringify`s the whole ~3MB object once per `SHRINK_LADDER` rung (4 full passes — object keys are never truncated, so no rung ever fits). On an idle machine that's fine, but the `main` job runs several turbo test groups in parallel on one runner, so under load it exceeds 5s.

Shrinking the fixture to 50,000 keys cuts the wall-clock cost ~4x while the serialized object stays ~7x over `MAX_TOOL_RESULT_BYTES` (128KB), so the assertion (returns `null` when nothing fits) is unchanged.

## How was this tested?

`npx vitest run test/large-result-utils.test.ts` in `packages/server/utils` — 7/7 pass, the suite now runs in ~180ms. Test-only change, no edition-specific behavior.

Fixes #15404

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)