### PR TITLE
fix(agents): stop sending built-in web tools to a flow step that configures none

### DIFF
--- a/packages/server/worker/src/lib/execute/jobs/ee/agent/agent-tool-policy.ts
+++ b/packages/server/worker/src/lib/execute/jobs/ee/agent/agent-tool-policy.ts
@@ -69,9 +69,10 @@ function selectToolsForSource({ source, groups }: { source: AgentRunSource, grou
         }
     }
     // Nobody is reading, and an agent that asks an empty room reads the silence as a refusal.
+    const configuredNothing = Object.keys(configured).length === 0
     return {
         ...configured,
-        ...pick({ tools: groups.web, names: UNATTENDED_WEB_TOOLS }),
+        ...(configuredNothing ? {} : pick({ tools: groups.web, names: UNATTENDED_WEB_TOOLS })),
         ...groups.completion,
     }
 }

--- a/packages/server/worker/test/lib/execute/jobs/ee/agent/agent-tool-policy.test.ts
+++ b/packages/server/worker/test/lib/execute/jobs/ee/agent/agent-tool-policy.test.ts
@@ -168,6 +168,21 @@ describe('what an unattended flow step may reach', () => {
         expect(names).not.toContain('ap_execute_action')
         expect(names).not.toContain('ap_create_flow')
     })
+
+    it('keeps the web reads out when the step configured no tools of its own', () => {
+        const withoutConfiguredTools: AgentToolGroups = {
+            ...GROUPS,
+            configuredPiece: {},
+            configuredFlow: {},
+            knowledgeBase: {},
+        }
+        const names = Object.keys(agentToolPolicy.selectToolsForSource({ source: AgentRunSource.FLOW_STEP, groups: withoutConfiguredTools }))
+
+        expect(names).not.toContain('ap_fetch_url')
+        expect(names).not.toContain('ap_web_search')
+        expect(names).not.toContain('ap_scrape_url')
+        expect(names).toContain('ap_return_output')
+    })
 })
 
 describe('the shape of the policy itself', () => {


### PR DESCRIPTION
## Description

A Run Agent flow step with zero configured tools was still sending the built-in web tools (`ap_fetch_url`, `ap_web_search`, `ap_scrape_url`) to the model. The unattended (`FLOW_STEP`) branch of `selectToolsForSource` in `agent-tool-policy.ts` picked those tools unconditionally, so "no tools" did not actually mean no tools.

That is a problem for two reasons:

- It does not match what someone expects from a step they left empty on purpose.
- Some providers reject a request carrying tools the step never asked for. A self-hoster hit this on Bedrock Claude and is running a private `AP_DISABLE_FLOW_WEB_TOOLS` worker patch to work around it.

This is the cheapest fix the issue endorses: skip the built-in web tools when the step configures no tools of its own. When the step does configure at least one tool, the built-in web tools still ride along exactly as before, and the completion tool is returned in both cases.

Behavior note: this changes runtime behavior only in the zero-configured-tools case (that step now gets no built-in web tools). No configuration, migration, or env var is needed, and the private worker patch above is no longer needed for that case.

## How was this tested?

- Added a regression test in `agent-tool-policy.test.ts` ("keeps the web reads out when the step configured no tools of its own"). It fails on `main` and passes with this change.
- `agent-tool-policy` suite: 25/25 pass. Sibling agent unit tests (`execute-agent-run`, `run-agent-turn-guards`, config-failure): 59/59 pass.
- `turbo run lint --filter=worker`: no errors (the warnings present are all pre-existing in other files).
- This lives in the worker's EE agent execution path; CE is unaffected.

Fixes #15265

### Breaking change?  (required, CI fails if this is left unedited)

- [x] no, reviewed, not breaking
- [ ] yes, technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes, functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required, CI fails if this is left unedited)

- [x] no, reviewed, no security impact
- [ ] yes, security-sensitive (call out the risk and mitigation in the description above)

Incidental: a step configured with no tools no longer receives the fetch/scrape web tools it was never granted, so this narrows rather than widens the agent's outbound surface.
