### PR TITLE
fix(web): make CopyButton provider-independent to prevent crash on error page

### DIFF
--- a/packages/web/src/components/custom/clipboard/copy-button.tsx
+++ b/packages/web/src/components/custom/clipboard/copy-button.tsx
@@ -1,4 +1,3 @@
-import { useMutation } from '@tanstack/react-query';
 import { t } from 'i18next';
 import { Check, Copy } from 'lucide-react';
 import React, { forwardRef, useState } from 'react';
@@ -33,18 +32,29 @@ export const CopyButton = forwardRef<HTMLButtonElement, CopyButtonProps>(
   ) => {
     const [isCopied, setIsCopied] = useState(false);
 
-    const { mutate: copyToClipboard } = useMutation({
-      mutationFn: async () => {
-        await navigator.clipboard.writeText(textToCopy);
+    const copyToClipboard = async () => {
+      try {
+        if (navigator?.clipboard?.writeText) {
+          await navigator.clipboard.writeText(textToCopy);
+        } else {
+          const textArea = document.createElement('textarea');
+          textArea.value = textToCopy;
+          textArea.style.position = 'fixed';
+          textArea.style.opacity = '0';
+          document.body.appendChild(textArea);
+          textArea.focus();
+          textArea.select();
+          document.execCommand('copy');
+          document.body.removeChild(textArea);
+        }
         setIsCopied(true);
         setTimeout(() => setIsCopied(false), 3000);
-      },
-      onError: () => {
+      } catch {
         toast.error(t('Failed to copy to clipboard'), {
           duration: 3000,
         });
-      },
-    });
+      }
+    };
 
     const content = (
       <>

--- a/packages/web/test/app/components/global-error-boundary.test.tsx
+++ b/packages/web/test/app/components/global-error-boundary.test.tsx
@@ -1,0 +1,86 @@
+/**
+ * @vitest-environment jsdom
+ */
+import * as React from 'react';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('i18next', () => ({ t: (key: string) => key }));
+
+vi.mock('@/lib/error-reporting', () => ({
+  errorReporting: {
+    isChunkLoadError: () => false,
+    report: vi.fn(),
+  },
+}));
+
+vi.mock('sonner', () => ({
+  toast: {
+    error: vi.fn(),
+  },
+}));
+
+vi.mock('react-router-dom', () => ({
+  useRouteError: vi.fn(),
+}));
+
+// eslint-disable-next-line import/first
+import { GlobalErrorBoundary } from '@/app/components/global-error-boundary';
+
+declare global {
+  // eslint-disable-next-line no-var
+  var IS_REACT_ACT_ENVIRONMENT: boolean;
+}
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+const ProblemChild = () => {
+  throw new Error('Test global crash error');
+};
+
+describe('GlobalErrorBoundary', () => {
+  let root: Root | undefined;
+  let container: HTMLDivElement;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    container = document.createElement('div');
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    act(() => root?.unmount());
+    container.remove();
+    document.body.innerHTML = '';
+  });
+
+  it('renders fallback and reveals technical details without unmounting outside QueryClientProvider', () => {
+    act(() => {
+      root = createRoot(container);
+      root.render(
+        <GlobalErrorBoundary>
+          <ProblemChild />
+        </GlobalErrorBoundary>,
+      );
+    });
+
+    expect(container.textContent).toContain('Something went wrong');
+
+    const showDetailsButton = Array.from(
+      container.querySelectorAll('button'),
+    ).find((b) => b.textContent?.includes('Show technical details'));
+    expect(showDetailsButton).toBeDefined();
+
+    act(() => {
+      showDetailsButton?.click();
+    });
+
+    expect(container.textContent).toContain('Hide technical details');
+    const pre = container.querySelector('pre');
+    expect(pre).not.toBeNull();
+    expect(pre?.textContent).toContain('Test global crash error');
+    expect(container.textContent).toContain('Something went wrong');
+  });
+});

--- a/packages/web/test/components/custom/copy-button.test.tsx
+++ b/packages/web/test/components/custom/copy-button.test.tsx
@@ -1,0 +1,100 @@
+/**
+ * @vitest-environment jsdom
+ */
+import * as React from 'react';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('i18next', () => ({ t: (key: string) => key }));
+
+vi.mock('sonner', () => ({
+  toast: {
+    error: vi.fn(),
+  },
+}));
+
+// eslint-disable-next-line import/first
+import { CopyButton } from '@/components/custom/clipboard/copy-button';
+
+declare global {
+  // eslint-disable-next-line no-var
+  var IS_REACT_ACT_ENVIRONMENT: boolean;
+}
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+describe('CopyButton', () => {
+  let root: Root | undefined;
+  let container: HTMLDivElement;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    container = document.createElement('div');
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    act(() => root?.unmount());
+    container.remove();
+    document.body.innerHTML = '';
+  });
+
+  it('renders and copies text to clipboard without QueryClientProvider', async () => {
+    const writeTextMock = vi.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, {
+      clipboard: {
+        writeText: writeTextMock,
+      },
+    });
+
+    act(() => {
+      root = createRoot(container);
+      root.render(
+        <CopyButton
+          textToCopy="test diagnostics text"
+          withoutTooltip
+          data-testid="copy-btn"
+        />,
+      );
+    });
+
+    const btn = container.querySelector('button');
+    expect(btn).not.toBeNull();
+
+    await act(async () => {
+      btn?.click();
+    });
+
+    expect(writeTextMock).toHaveBeenCalledWith('test diagnostics text');
+  });
+
+  it('falls back gracefully on clipboard error without crashing', async () => {
+    const writeTextMock = vi.fn().mockRejectedValue(new Error('Clipboard denied'));
+    Object.assign(navigator, {
+      clipboard: {
+        writeText: writeTextMock,
+      },
+    });
+
+    act(() => {
+      root = createRoot(container);
+      root.render(
+        <CopyButton
+          textToCopy="failure text"
+          withoutTooltip
+          data-testid="copy-btn-fail"
+        />,
+      );
+    });
+
+    const btn = container.querySelector('button');
+    expect(btn).not.toBeNull();
+
+    await act(async () => {
+      btn?.click();
+    });
+
+    expect(writeTextMock).toHaveBeenCalledWith('failure text');
+  });
+});


### PR DESCRIPTION
## Description

### Problem
When the application hits an unhandled exception, `GlobalErrorBoundary` catches the error and displays the global crash page (`"Something went wrong"`).
However, clicking **"Show technical details"** caused the entire error page to immediately unmount / crash with an unhandled React runtime error:
```
No QueryClient set, use QueryClientProvider to set one
```

### Root Cause
`GlobalErrorBoundary` sits above `QueryClientProvider` in the component tree to catch fatal bootstrap or query configuration failures.
When the user clicks "Show technical details", `GlobalErrorBoundary` expands a collapsible container that mounts `CopyButton` to allow copying the stack trace.
Previously, `CopyButton` used `@tanstack/react-query`'s `useMutation` hook solely for copying text. Because `useMutation` unconditionally expects a React context from `QueryClientProvider`, mounting `CopyButton` outside of `QueryClientProvider` threw a fatal error, unmounting the error boundary UI entirely and leaving a blank or broken page.

### Solution
1. **Provider Independence**: Refactored `CopyButton` to remove the unnecessary `@tanstack/react-query` dependency. Copying to clipboard is a standard browser DOM interaction that does not query or mutate server state; managing it via local React state makes `CopyButton` 100% provider-independent across all 26 usages in the app.
2. **Robust Fallback & Error Handling**:
   - Uses `navigator.clipboard.writeText` when supported.
   - Falls back to `document.execCommand('copy')` in restricted or legacy environments.
   - Preserves toast notifications (`toast.error(t('Failed to copy to clipboard'))`) on copy failures rather than swallowing errors silently.
3. **Automated Tests**:
   - Added `test/components/custom/copy-button.test.tsx` verifying standalone rendering and clipboard execution without `QueryClientProvider`.
   - Added `test/app/components/global-error-boundary.test.tsx` verifying that expanding technical details in `GlobalErrorBoundary` no longer unmounts the component.

Fixes #15366

## How was this tested?

- **Automated Tests**:
  - `packages/web/test/components/custom/copy-button.test.tsx` passes, verifying `CopyButton` renders, executes clipboard write, and handles failures without `QueryClientProvider`.
  - `packages/web/test/app/components/global-error-boundary.test.tsx` passes, verifying expanding technical details reveals the error trace without unmounting.
- **Manual Verification**: Verified rendering error boundaries without `QueryClientProvider` and clicking "Show technical details".

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)
