### PR TITLE
fix(web): prevent crash screen unmount when clicking show technical details (#15366)

### DIFF
--- a/packages/web/src/app/components/global-error-boundary.tsx
+++ b/packages/web/src/app/components/global-error-boundary.tsx
@@ -1,10 +1,9 @@
 import { t } from 'i18next';
-import { AlertTriangle, RefreshCcw } from 'lucide-react';
+import { AlertTriangle, Check, Copy, RefreshCcw } from 'lucide-react';
 import React, { useEffect, useState } from 'react';
 import { ErrorBoundary } from 'react-error-boundary';
 import { useRouteError } from 'react-router-dom';
 
-import { CopyButton } from '@/components/custom/clipboard/copy-button';
 import { Button } from '@/components/ui/button';
 import { errorReporting } from '@/lib/error-reporting';
 
@@ -38,7 +37,16 @@ const ErrorFallbackContent = ({
   componentStack?: string | null;
 }) => {
   const [showDetails, setShowDetails] = useState(false);
+  const [copied, setCopied] = useState(false);
   const isChunkError = errorReporting.isChunkLoadError(error);
+
+  const handleCopy = () => {
+    if (navigator?.clipboard?.writeText) {
+      navigator.clipboard.writeText(buildDiagnosticsText(error, componentStack));
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    }
+  };
 
   return (
     <div className="min-h-screen w-full bg-background flex items-center justify-center p-6">
@@ -86,12 +94,19 @@ const ErrorFallbackContent = ({
           </button>
           {showDetails && (
             <div className="relative w-full text-left">
-              <CopyButton
-                textToCopy={buildDiagnosticsText(error, componentStack)}
+              <Button
                 variant="ghost"
-                withoutTooltip
-                className="absolute right-2 top-2 size-7 text-muted-foreground"
-              />
+                size="icon"
+                onClick={handleCopy}
+                className="absolute right-2 top-2 size-7 text-muted-foreground hover:text-foreground"
+                aria-label={copied ? t('Copied') : t('Copy technical details')}
+              >
+                {copied ? (
+                  <Check className="size-4 text-emerald-500" />
+                ) : (
+                  <Copy className="size-4" />
+                )}
+              </Button>
               <pre className="max-h-56 overflow-auto rounded-lg border bg-muted/40 p-4 pr-12 font-mono text-xs leading-relaxed text-muted-foreground whitespace-pre-wrap break-words">
                 {buildDiagnosticsText(error, componentStack)}
               </pre>


### PR DESCRIPTION
### Description
Fixes #15366.

### Problem
Clicking **"Show technical details"** on the global crash screen failed to reveal diagnostic information and instead unmounted the entire React tree. 

As noted in #15366, `GlobalErrorBoundary` in `packages/web/src/app/app.tsx` wraps above `QueryClientProvider`. When `showDetails` flipped to `true`, it rendered `CopyButton` (`packages/web/src/components/custom/clipboard/copy-button.tsx`), which unconditionally invokes `useMutation()` from `@tanstack/react-query`. Because there is no `QueryClient` context available outside the provider, it threw an unhandled error:
```text
No QueryClient set, use QueryClientProvider to set one
```
Since `react-error-boundary` does not catch errors thrown within its own fallback render, the exception escaped and React unmounted the application tree.

### Solution
1. Remove `CopyButton` dependency from `global-error-boundary.tsx` to keep the global fallback boundary completely independent of application context and providers.
2. Provide an isolated, lightweight clipboard copy handler using `navigator.clipboard.writeText` with inline copy/check status feedback.
3. The diagnostics block now renders reliably and safely copies diagnostic stack traces without requiring any provider contexts.