### PR TITLE
feat(OpenRouter): step form

### DIFF
--- a/packages/pieces/community/open-router/package.json
+++ b/packages/pieces/community/open-router/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-open-router",
-  "version": "0.1.9",
+  "version": "0.2.0",
   "main": "./dist/src/index.js",
   "types": "./dist/src/index.d.ts",
   "scripts": {

--- a/packages/pieces/community/open-router/src/index.ts
+++ b/packages/pieces/community/open-router/src/index.ts
@@ -1,22 +1,9 @@
-import {
-  AuthenticationType,
-  createCustomApiCallAction,
-  httpClient,
-  HttpMethod,
-  HttpRequest,
-} from '@activepieces/pieces-common';
-import { createPiece, PieceAuth } from '@activepieces/pieces-framework';
+import { createCustomApiCallAction } from '@activepieces/pieces-common';
+import { createPiece } from '@activepieces/pieces-framework';
 import { PieceCategory } from '@activepieces/pieces-framework';
 import { askOpenRouterAction } from './lib/actions/ask-open-router';
 import { openRouterAuth } from './lib/auth';
 
-const markdownDescription = `
-Follow these instructions to get your OpenAI API Key:
-
-1. Visit the following website: https://openrouter.ai/keys.
-2. Once on the website, click on create a key.
-3. Once you have created a key, copy it and use it for the Api key field on the site.
-`;
 export const openRouter = createPiece({
   displayName: 'OpenRouter',
   description: 'Use any AI model to generate code, text, or images via OpenRouter.ai.',

--- a/packages/pieces/community/open-router/src/index.ts
+++ b/packages/pieces/community/open-router/src/index.ts
@@ -8,7 +8,7 @@ export const openRouter = createPiece({
   displayName: 'OpenRouter',
   description: 'Use any AI model to generate code, text, or images via OpenRouter.ai.',
   auth: openRouterAuth,
-  minimumSupportedRelease: '0.30.0',
+  minimumSupportedRelease: '0.88.2',
   logoUrl: 'https://cdn.activepieces.com/pieces/open-router.png',
   categories: [PieceCategory.ARTIFICIAL_INTELLIGENCE],
   authors: ["Salem-Alaa","kishanprmr","MoShizzle","abuaboud"],

--- a/packages/pieces/community/open-router/src/lib/actions/ask-open-router.ts
+++ b/packages/pieces/community/open-router/src/lib/actions/ask-open-router.ts
@@ -100,7 +100,7 @@ export const askOpenRouterAction = createAction({
   outputSchema: askLmmActionOutputSchema,
   async run(context) {
     await propsValidation.validateZod(context.propsValue, {
-      temperature: z.optional(z.number().check(z.minimum(0), z.maximum(1.0))),
+      temperature: z.optional(z.number().check(z.minimum(0), z.maximum(2))),
       topP: z.optional(z.number().check(z.minimum(0), z.maximum(1.0))),
     });
 

--- a/packages/pieces/community/open-router/src/lib/actions/ask-open-router.ts
+++ b/packages/pieces/community/open-router/src/lib/actions/ask-open-router.ts
@@ -19,15 +19,14 @@ export const askOpenRouterAction = createAction({
   name: 'ask-lmm',
   classification: 'READ',
   displayName: 'Ask LLM',
-  description: 'Ask any model supported by Open Router.',
+  description: 'Send a prompt to any model on OpenRouter and get the reply.',
   aiMetadata: { description: 'Sends a single prompt to any model in the OpenRouter catalog through one unified completions endpoint and returns the generated text, with optional temperature, top-p, and max-token controls. It is the only first-class action in the piece and is single-turn - no conversation memory, no system-role array, and no image or audio input - so use the sibling Custom API Call for any other OpenRouter endpoint, and prefer a vendor-specific piece such as OpenAI, Anthropic, or Groq when the model must come from one provider. Requires a model id from the OpenRouter model list and a prompt; not idempotent: each call bills a fresh generation and may return different text for the same input.', idempotent: false },
   auth: openRouterAuth,
   props: {
     model: Property.Dropdown({
       auth: openRouterAuth,
       displayName: 'Model',
-      description:
-        'The model which will generate the completion. Some models are suitable for natural language tasks, others specialize in code.',
+      description: 'The model that writes the reply. Type to search by name.',
       required: true,
       refreshers: [],
       defaultValue: 'pygmalionai/mythalion-13b',
@@ -54,7 +53,7 @@ export const askOpenRouterAction = createAction({
 
           const options = response.body.data.map((model) => {
             return {
-              label: model.id,
+              label: model.name || model.id,
               value: model.id,
             };
           });
@@ -62,11 +61,11 @@ export const askOpenRouterAction = createAction({
             options: options,
             disabled: false,
           };
-        } catch (error) {
+        } catch {
           return {
             options: [],
             disabled: true,
-            placeholder: `Couldn't Load Models:\n${error}`,
+            placeholder: 'Could not load models. Check your API key and try again.',
           };
         }
       },
@@ -74,25 +73,28 @@ export const askOpenRouterAction = createAction({
     prompt: Property.LongText({
       displayName: 'Prompt',
       required: true,
-      description: 'The prompt to send to the model.',
+      placeholder: 'e.g. Summarize the text below in three bullet points',
     }),
     temperature: Property.Number({
       displayName: 'Temperature',
       required: false,
+      advanced: true,
       description:
-        'Controls randomness: Lowering results in less random completions. As the temperature approaches zero, the model will become deterministic and repetitive.',
+        'Randomness from 0 to 2. Lower is focused, higher is creative.',
     }),
     maxTokens: Property.Number({
       displayName: 'Maximum Tokens',
       required: false,
+      advanced: true,
       description:
-        "The maximum number of tokens to generate. Requests can use up to 2,048 or 4,096 tokens shared between prompt and completion, don't set the value to maximum and leave some tokens for the input. The exact limit varies by model. (One token is roughly 4 characters for normal English text)",
+        'Longest reply allowed, in tokens. Empty lets the model decide.',
     }),
     topP: Property.Number({
       displayName: 'Top P',
       required: false,
+      advanced: true,
       description:
-        'An alternative to sampling with temperature, called nucleus sampling, where the model considers the results of the tokens with top_p probability mass. So 0.1 means only the tokens comprising the top 10% probability mass are considered.',
+        'Nucleus sampling from 0 to 1. Lower keeps only the likeliest words.',
     }),
   },
   outputSchema: askLmmActionOutputSchema,

--- a/packages/pieces/community/open-router/src/lib/auth.ts
+++ b/packages/pieces/community/open-router/src/lib/auth.ts
@@ -2,21 +2,16 @@ import { PieceAuth } from '@activepieces/pieces-framework';
 import { AuthenticationType, httpClient, HttpMethod, HttpRequest } from '@activepieces/pieces-common';
 
 const markdownDescription = `
-Follow these instructions to get your OpenAI API Key:
-
-1. Visit the following website: https://openrouter.ai/keys.
-2. Once on the website, click on create a key.
-3. Once you have created a key, copy it and use it for the Api key field on the site.
+1. Open [openrouter.ai/keys](https://openrouter.ai/keys) and sign in.
+2. Click **Create Key**, name it and copy the key.
+3. Paste it here. It starts with \`sk-or-\`.
 `;
 
 export const openRouterAuth = PieceAuth.SecretText({
   description: markdownDescription,
-  displayName: 'Api Key',
+  displayName: 'API Key',
   required: true,
   validate: async ({ auth }) => {
-    // we send a get request to https://openrouter.ai/api/v1/auth/key with the key as a header
-    // if the response is 200, then the key is valid
-    // if the response is 401, then the key is invalid
     try {
       const request: HttpRequest = {
         url: 'https://openrouter.ai/api/v1/auth/key',

--- a/packages/pieces/community/open-router/src/lib/common/index.ts
+++ b/packages/pieces/community/open-router/src/lib/common/index.ts
@@ -9,5 +9,6 @@ export interface promptResponse {
 export interface openRouterModels {
   data: {
     id: string;
+    name: string;
   }[];
 }


### PR DESCRIPTION
Before / after gallery: https://claude.ai/code/artifact/0ebf2951-e49f-4df6-a6c0-24e3fea4d0a8

## Description

Step-form pass on the OpenRouter piece (0.1.9 → 0.2.0): the Ask LLM form now fits the default panel without a single folded description, its three tuning options live in Advanced, and the connection dialog gets a correct API-key guide.

**Labels**
- Connection field `Api Key` → `API Key`. Prop labels unchanged (`Model`, `Prompt`, `Temperature`, `Maximum Tokens`, `Top P` match the OpenAI piece).

**Descriptions** (all ≤ 70 characters, one plain sentence)
- Action: "Send a prompt to any model on OpenRouter and get the reply."
- Model: "The model that writes the reply. Type to search by name."
- Prompt: description removed (it restated the label); placeholder added: "e.g. Summarize the text below in three bullet points".
- Temperature: "Randomness from 0 to 2. Lower is focused, higher is creative."
- Maximum Tokens: "Longest reply allowed, in tokens. Empty lets the model decide."
- Top P: "Nucleus sampling from 0 to 1. Lower keeps only the likeliest words."
- Model dropdown options now show the model's display name (e.g. "OpenAI: GPT-4o") instead of the raw id; the saved value is still the id. The load-failure placeholder no longer dumps the error object.

**One wording per concept**
- Single action, so no cross-action drift. Labels kept identical to the OpenAI piece's Send Prompt form.

**Advanced sections**
- `temperature`, `maxTokens`, `topP` → Advanced (optional, no default, do not change the result unless set). Ask LLM: 1017 px → 843 px at the default panel width.

**Banners**
- None added or present.

**Runtime fixes**
- `ask-open-router.ts`: the zod check capped `temperature` at 1 while OpenRouter documents the range [0, 2]; values above 1 were rejected before the request. Now accepts up to 2. `topP` stays [0, 1].
- `auth.ts`: the guide said "OpenAI API Key" and pointed at the wrong field name; rewritten as a three-step OpenRouter guide with a link.

**Metadata**
- `package.json` 0.1.9 → 0.2.0; `minimumSupportedRelease` 0.30.0 → 0.88.2 because `advanced` is used. As a side effect the shared Custom API Call form also renders its Advanced section on this piece (1103 px → 967 px).
- `index.ts`: dropped four unused imports and an unused duplicate of the auth guide (11 lint warnings → 0).

**Deliberately left out**
- `model.defaultValue` is `pygmalionai/mythalion-13b`, which is no longer in OpenRouter's catalog (checked against the live `/api/v1/models`, 445 models). Changing a default is out of scope for a form pass; a new step opens with a value the dropdown cannot show. Follow-up.
- `run()` returns a bare string while `outputSchema` declares a `response` field. Changing the return shape would break existing flows. Follow-up.
- The request still sends a top-level `prompt` to `/chat/completions` and reads `choices[0].text`; OpenRouter documents both ("Either 'messages' or 'prompt' is required"), so this is correct and untouched.
- `src/i18n/*` untouched; renamed strings orphan their Crowdin entries until the next sync.

## How was this tested

- `check-step-form.mjs`: 5 errors / 1 warning → 0 errors / 1 warning (the remaining warning is `followRedirects` casing in `pieces-common`'s Custom API Call, not this piece). Run with `--before` on the 0.1.9 metadata: no type changed, no prop removed.
- eslint on the package: 0 errors, 11 warnings → 0 errors, 0 warnings. The piece has no unit tests.
- Served through `AP_DEV_PIECES` by the dev watcher; every human-visible form captured before and after on a fresh step at the default 400 px panel (gallery link above).

## Breaking change?

- [x] No
- [ ] Yes

## Security impact?

- [x] No
- [ ] Yes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
