### PR TITLE
feat(pieces): add Scrupp piece

### DIFF
--- a/packages/pieces/community/scrupp/.eslintrc.json
+++ b/packages/pieces/community/scrupp/.eslintrc.json
@@ -1,0 +1,47 @@
+{
+  "extends": [
+    "../../../../.eslintrc.json"
+  ],
+  "ignorePatterns": [
+    "!**/*"
+  ],
+  "overrides": [
+    {
+      "files": [
+        "*.ts",
+        "*.tsx",
+        "*.js",
+        "*.jsx"
+      ],
+      "rules": {}
+    },
+    {
+      "files": [
+        "*.ts",
+        "*.tsx"
+      ],
+      "rules": {
+        "no-restricted-imports": [
+          "error",
+          {
+            "patterns": [
+              "lodash",
+              "lodash/*",
+              "@activepieces/core-*",
+              "@activepieces/server*",
+              "@activepieces/engine",
+              "@activepieces/shared"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "files": [
+        "*.js",
+        "*.jsx"
+      ],
+      "rules": {}
+    }
+  ]
+}

--- a/packages/pieces/community/scrupp/README.md
+++ b/packages/pieces/community/scrupp/README.md
@@ -1,0 +1,5 @@
+# pieces-scrupp
+
+## Building
+
+Run `turbo run build --filter=@activepieces/piece-scrupp` to build the library.

--- a/packages/pieces/community/scrupp/package.json
+++ b/packages/pieces/community/scrupp/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@activepieces/piece-scrupp",
+  "version": "0.0.1",
+  "main": "./dist/src/index.js",
+  "types": "./dist/src/index.d.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.lib.json && cp package.json dist/",
+    "bundle": "node ../../../../dist/packages/cli/src/index.js pieces bundle",
+    "lint": "eslint 'src/**/*.ts'"
+  },
+  "dependencies": {
+    "@activepieces/pieces-common": "workspace:*",
+    "@activepieces/pieces-framework": "workspace:*",
+    "@activepieces/core-piece-types": "workspace:*",
+    "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
+  }
+}

--- a/packages/pieces/community/scrupp/src/index.ts
+++ b/packages/pieces/community/scrupp/src/index.ts
@@ -1,0 +1,44 @@
+import { createPiece, PieceCategory } from '@activepieces/pieces-framework';
+import { createCustomApiCallAction } from '@activepieces/pieces-common';
+import { scruppAuth } from './lib/auth';
+import {
+	exportLinkedinSearch,
+	exportSalesNavigatorSearch,
+	runApolloSearch,
+} from './lib/actions/search';
+import {
+	enrichLinkedinProfiles,
+	findDecisionMakers,
+	findEmails,
+	lookupCompany,
+} from './lib/actions/enrich';
+
+export { scruppAuth };
+
+export const scrupp = createPiece({
+	displayName: 'Scrupp',
+	description:
+		'Export LinkedIn, Sales Navigator and Apollo searches, find decision makers, and find and verify work emails',
+	auth: scruppAuth,
+	minimumSupportedRelease: '0.36.1',
+	logoUrl: 'https://cdn.activepieces.com/pieces/scrupp.png',
+	categories: [PieceCategory.SALES_AND_CRM],
+	authors: ['wismhero'],
+	actions: [
+		exportSalesNavigatorSearch,
+		exportLinkedinSearch,
+		runApolloSearch,
+		enrichLinkedinProfiles,
+		lookupCompany,
+		findDecisionMakers,
+		findEmails,
+		createCustomApiCallAction({
+			auth: scruppAuth,
+			baseUrl: () => 'https://api.scrupp.com/api/v1',
+			authMapping: async (auth) => ({
+				Authorization: `Bearer ${(auth as { secret_text: string }).secret_text}`,
+			}),
+		}),
+	],
+	triggers: [],
+});

--- a/packages/pieces/community/scrupp/src/lib/actions/enrich.ts
+++ b/packages/pieces/community/scrupp/src/lib/actions/enrich.ts
@@ -1,0 +1,148 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { scruppAuth } from '../auth';
+import { commaSeparated, idempotencyKey, JobType, runJob, waitProps } from '../common';
+
+export const enrichLinkedinProfiles = createAction({
+	auth: scruppAuth,
+	name: 'enrich_linkedin_profiles',
+	displayName: 'Enrich LinkedIn Profiles',
+	description: 'Full profile data for a list of LinkedIn profile URLs',
+	props: {
+		items: Property.LongText({
+			displayName: 'Profile URLs',
+			description: 'One per line, or comma separated.',
+			required: true,
+		}),
+		...waitProps,
+	},
+	async run(context) {
+		const { items, waitForResult, timeoutMinutes } = context.propsValue;
+
+		return runJob({
+			auth: context.auth,
+			type: 'linkedin.profile',
+			input: { items: commaSeparated(items.replace(/\n/g, ',')) },
+			idempotencyKey: idempotencyKey(context.run.id, 'enrich_linkedin_profiles'),
+			waitForResult: waitForResult ?? true,
+			timeoutMinutes: timeoutMinutes ?? 30,
+		});
+	},
+});
+
+export const lookupCompany = createAction({
+	auth: scruppAuth,
+	name: 'lookup_company',
+	displayName: 'Look Up Company',
+	description: 'Company data by domain, LinkedIn URL or name',
+	props: {
+		lookupBy: Property.StaticDropdown({
+			displayName: 'Look Up By',
+			required: true,
+			defaultValue: 'company.domain',
+			options: {
+				options: [
+					{ label: 'Domain', value: 'company.domain' },
+					{ label: 'LinkedIn URL', value: 'company.linkedin' },
+					{ label: 'Name', value: 'company.name' },
+				],
+			},
+		}),
+		items: Property.LongText({
+			displayName: 'Companies',
+			description: 'One per line, or comma separated. For example: openai.com, anthropic.com',
+			required: true,
+		}),
+		...waitProps,
+	},
+	async run(context) {
+		const { lookupBy, items, waitForResult, timeoutMinutes } = context.propsValue;
+
+		return runJob({
+			auth: context.auth,
+			type: lookupBy as JobType,
+			input: { items: commaSeparated(items.replace(/\n/g, ',')) },
+			idempotencyKey: idempotencyKey(context.run.id, 'lookup_company'),
+			waitForResult: waitForResult ?? true,
+			timeoutMinutes: timeoutMinutes ?? 30,
+		});
+	},
+});
+
+export const findDecisionMakers = createAction({
+	auth: scruppAuth,
+	name: 'find_decision_makers',
+	displayName: 'Find Decision Makers',
+	description: 'The people worth writing to at a company you only know the domain of',
+	props: {
+		findBy: Property.StaticDropdown({
+			displayName: 'Find By',
+			required: true,
+			defaultValue: 'contact.decision_maker.domain',
+			options: {
+				options: [
+					{ label: 'Domain', value: 'contact.decision_maker.domain' },
+					{ label: 'Company LinkedIn URL', value: 'contact.decision_maker.linkedin' },
+					{ label: 'Company Name', value: 'contact.decision_maker.name' },
+				],
+			},
+		}),
+		items: Property.LongText({
+			displayName: 'Companies',
+			description: 'One per line, or comma separated.',
+			required: true,
+		}),
+		max: Property.Number({
+			displayName: 'Decision Makers per Company',
+			required: false,
+			defaultValue: 10,
+		}),
+		...waitProps,
+	},
+	async run(context) {
+		const { findBy, items, max, waitForResult, timeoutMinutes } = context.propsValue;
+
+		return runJob({
+			auth: context.auth,
+			type: findBy as JobType,
+			input: { items: commaSeparated(items.replace(/\n/g, ',')), max: max ?? 10 },
+			idempotencyKey: idempotencyKey(context.run.id, 'find_decision_makers'),
+			waitForResult: waitForResult ?? true,
+			timeoutMinutes: timeoutMinutes ?? 30,
+		});
+	},
+});
+
+export const findEmails = createAction({
+	auth: scruppAuth,
+	name: 'find_emails',
+	displayName: 'Find Emails',
+	description: 'Work email addresses from first name, last name and company domain',
+	props: {
+		people: Property.Array({
+			displayName: 'People',
+			required: true,
+			properties: {
+				first_name: Property.ShortText({ displayName: 'First Name', required: true }),
+				last_name: Property.ShortText({ displayName: 'Last Name', required: true }),
+				domain: Property.ShortText({ displayName: 'Domain', required: true }),
+			},
+		}),
+		...waitProps,
+	},
+	async run(context) {
+		const { people, waitForResult, timeoutMinutes } = context.propsValue;
+
+		if (!Array.isArray(people) || people.length === 0) {
+			throw new Error('Add at least one person to look up.');
+		}
+
+		return runJob({
+			auth: context.auth,
+			type: 'email.initials',
+			input: { items: people },
+			idempotencyKey: idempotencyKey(context.run.id, 'find_emails'),
+			waitForResult: waitForResult ?? true,
+			timeoutMinutes: timeoutMinutes ?? 30,
+		});
+	},
+});

--- a/packages/pieces/community/scrupp/src/lib/actions/search.ts
+++ b/packages/pieces/community/scrupp/src/lib/actions/search.ts
@@ -1,0 +1,134 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { scruppAuth } from '../auth';
+import { idempotencyKey, JobType, runJob, waitProps } from '../common';
+
+/**
+ * The three search exports differ only in which platform's URL they take, so
+ * they share one builder. Keeping them as three actions rather than one action
+ * with a dropdown matches how people think: they have a Sales Navigator URL,
+ * not "a search".
+ */
+function searchAction(config: {
+	name: string;
+	displayName: string;
+	description: string;
+	type: JobType;
+	urlPlaceholder: string;
+	accountRequired: boolean;
+	accountDescription: string;
+}) {
+	return createAction({
+		auth: scruppAuth,
+		name: config.name,
+		displayName: config.displayName,
+		description: config.description,
+		props: {
+			url: Property.ShortText({
+				displayName: 'Search URL',
+				description: 'Build the filters on the platform, then paste the URL here.',
+				required: true,
+				defaultValue: config.urlPlaceholder,
+			}),
+			withEmails: Property.Checkbox({
+				displayName: 'Find Emails',
+				description: 'Also find work email addresses for the people extracted.',
+				required: false,
+				defaultValue: true,
+			}),
+			max: Property.Number({
+				displayName: 'Max Records',
+				description:
+					'Upper bound on records to extract. Drives the upfront credit hold; unused credits are refunded.',
+				required: false,
+				defaultValue: 100,
+			}),
+			account: Property.ShortText({
+				displayName: 'Account Email',
+				description: config.accountDescription,
+				required: config.accountRequired,
+			}),
+			...waitProps,
+		},
+		async run(context) {
+			const { url, withEmails, max, account, waitForResult, timeoutMinutes } = context.propsValue;
+
+			return runJob({
+				auth: context.auth,
+				type: config.type,
+				input: {
+					url,
+					with_emails: withEmails ?? true,
+					max: max ?? 100,
+					...(account ? { account } : {}),
+				},
+				idempotencyKey: idempotencyKey(context.run.id, config.name),
+				waitForResult: waitForResult ?? true,
+				timeoutMinutes: timeoutMinutes ?? 30,
+			});
+		},
+	});
+}
+
+export const exportSalesNavigatorSearch = searchAction({
+	name: 'export_sales_navigator_search',
+	displayName: 'Export Sales Navigator Search',
+	description: 'Extract the people from a Sales Navigator search URL',
+	type: 'sales_navigator.search',
+	urlPlaceholder: '',
+	accountRequired: false,
+	accountDescription:
+		'Connected Sales Navigator account to run with. Needed only for searches that use personal filters such as saved lists or relationships.',
+});
+
+export const exportLinkedinSearch = searchAction({
+	name: 'export_linkedin_search',
+	displayName: 'Export LinkedIn Search',
+	description: 'Extract the people from a LinkedIn people-search URL',
+	type: 'linkedin.search',
+	urlPlaceholder: '',
+	accountRequired: false,
+	accountDescription: 'Connected LinkedIn account to run with. Optional.',
+});
+
+export const runApolloSearch = createAction({
+	auth: scruppAuth,
+	name: 'run_apollo_search',
+	displayName: 'Run Apollo Search',
+	description: 'Extract the people from an Apollo search URL',
+	props: {
+		url: Property.ShortText({
+			displayName: 'Search URL',
+			description: 'Build the filters in Apollo, then paste the URL here.',
+			required: true,
+		}),
+		withEmails: Property.Checkbox({
+			displayName: 'Find Emails',
+			required: false,
+			defaultValue: true,
+		}),
+		max: Property.Number({
+			displayName: 'Max Records',
+			description: 'Upper bound on records. Unused credits are refunded.',
+			required: false,
+			defaultValue: 100,
+		}),
+		account: Property.ShortText({
+			displayName: 'Account Email',
+			description: 'Connected Apollo account to run with. Apollo searches always need one.',
+			required: true,
+		}),
+		...waitProps,
+	},
+	async run(context) {
+		const { url, withEmails, max, account, waitForResult, timeoutMinutes } = context.propsValue;
+
+		return runJob({
+			auth: context.auth,
+			type: 'apollo.search',
+			input: { url, with_emails: withEmails ?? true, max: max ?? 100, account },
+			idempotencyKey: idempotencyKey(context.run.id, 'run_apollo_search'),
+			waitForResult: waitForResult ?? true,
+			timeoutMinutes: timeoutMinutes ?? 30,
+		});
+	},
+});

--- a/packages/pieces/community/scrupp/src/lib/auth.ts
+++ b/packages/pieces/community/scrupp/src/lib/auth.ts
@@ -1,0 +1,10 @@
+import { PieceAuth } from '@activepieces/pieces-framework';
+import { validateApiKey } from './common';
+
+export const scruppAuth = PieceAuth.SecretText({
+	displayName: 'API Key',
+	required: true,
+	description:
+		'Sign in at [app.scrupp.com](https://app.scrupp.com), open **Settings → API Keys**, create a key and paste it here.',
+	validate: async ({ auth }) => validateApiKey(auth),
+});

--- a/packages/pieces/community/scrupp/src/lib/common/index.ts
+++ b/packages/pieces/community/scrupp/src/lib/common/index.ts
@@ -1,0 +1,169 @@
+import {
+	AuthenticationType,
+	httpClient,
+	HttpError,
+	HttpMethod,
+} from '@activepieces/pieces-common';
+import { AppConnectionValueForAuthProperty, Property } from '@activepieces/pieces-framework';
+import { scruppAuth } from '../auth';
+
+export const BASE_URL = 'https://api.scrupp.com/api/v1';
+
+export type ScruppAuth = AppConnectionValueForAuthProperty<typeof scruppAuth>;
+
+export type JobType =
+	| 'sales_navigator.search'
+	| 'linkedin.search'
+	| 'apollo.search'
+	| 'linkedin.profile'
+	| 'company.linkedin'
+	| 'company.domain'
+	| 'company.name'
+	| 'contact.decision_maker.linkedin'
+	| 'contact.decision_maker.name'
+	| 'contact.decision_maker.domain'
+	| 'email.initials'
+	| 'email.linkedin';
+
+const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+async function call<T>(
+	apiKey: string,
+	method: HttpMethod,
+	path: string,
+	body?: unknown,
+	headers?: Record<string, string>,
+): Promise<T> {
+	const response = await httpClient.sendRequest<T>({
+		method,
+		url: `${BASE_URL}${path}`,
+		authentication: { type: AuthenticationType.BEARER_TOKEN, token: apiKey },
+		headers,
+		body,
+	});
+
+	return response.body;
+}
+
+/**
+ * Shared by every action: create the job, wait for it, hand back the records.
+ *
+ * The wait honours the `retry_after` the API returns rather than a fixed
+ * interval — a 2,500-record search and a three-address email lookup have very
+ * different rhythms, and guessing costs either minutes or rate limit.
+ */
+export async function runJob(params: {
+	auth: ScruppAuth;
+	type: JobType;
+	input: Record<string, unknown>;
+	/** Stable across retries so a re-run returns the original job instead of paying twice. */
+	idempotencyKey: string;
+	waitForResult: boolean;
+	timeoutMinutes: number;
+}): Promise<unknown[]> {
+	const apiKey = params.auth.secret_text;
+
+	const created = await call<{ job_id: number }>(
+		apiKey,
+		HttpMethod.POST,
+		'/jobs',
+		{ type: params.type, input: params.input },
+		{ 'Idempotency-Key': params.idempotencyKey },
+	);
+
+	if (!params.waitForResult) {
+		return [created];
+	}
+
+	const deadline = Date.now() + params.timeoutMinutes * 60_000;
+	let status = 'queued';
+
+	while (Date.now() < deadline) {
+		const state = await call<{ status: string; retry_after?: number; error?: string }>(
+			apiKey,
+			HttpMethod.GET,
+			`/jobs/${created.job_id}`,
+		);
+		status = state.status;
+
+		if (status === 'failed') {
+			throw new Error(`Scrupp job ${created.job_id} failed: ${state.error ?? 'unknown error'}`);
+		}
+		if (status === 'succeeded') {
+			break;
+		}
+
+		await delay(Math.max(1, state.retry_after ?? 5) * 1000);
+	}
+
+	if (status !== 'succeeded') {
+		throw new Error(
+			`Scrupp job ${created.job_id} did not finish within ${params.timeoutMinutes} minutes. ` +
+				'It is still running — fetch it later with its job ID.',
+		);
+	}
+
+	const result = await call<{ data?: { items?: unknown[] } }>(
+		apiKey,
+		HttpMethod.GET,
+		`/jobs/${created.job_id}/result`,
+	);
+
+	return result.data?.items ?? [];
+}
+
+export async function validateApiKey(apiKey: string) {
+	try {
+		// /ping is free and instant, so connecting never costs a credit.
+		await call(apiKey, HttpMethod.GET, '/ping');
+		return { valid: true as const };
+	} catch (error) {
+		const status = error instanceof HttpError ? error.response.status : undefined;
+		return {
+			valid: false as const,
+			error:
+				status === 403
+					? 'That key was rejected. Check it in Scrupp under Settings → API Keys, and that your plan includes API access.'
+					: 'Could not reach the Scrupp API. Try again in a moment.',
+		};
+	}
+}
+
+/** Every action carries these two, and they mean the same thing everywhere. */
+export const waitProps = {
+	waitForResult: Property.Checkbox({
+		displayName: 'Wait for Results',
+		description:
+			'Wait for the job to finish and return the records. Turn off to get the job ID back immediately.',
+		required: false,
+		defaultValue: true,
+	}),
+	timeoutMinutes: Property.Number({
+		displayName: 'Timeout (Minutes)',
+		description:
+			'Give up waiting after this long. The job keeps running on Scrupp and can still be fetched by its ID.',
+		required: false,
+		defaultValue: 30,
+	}),
+};
+
+export function commaSeparated(raw: string): string[] {
+	const items = raw
+		.split(',')
+		.map((value) => value.trim())
+		.filter((value) => value !== '');
+
+	if (items.length === 0) {
+		throw new Error('Provide at least one value to look up.');
+	}
+
+	return items;
+}
+
+/**
+ * Activepieces gives every run an id; combining it with the action name keeps
+ * the key stable across a retry of the same step and distinct between steps.
+ */
+export function idempotencyKey(runId: string, action: string): string {
+	return `activepieces-${runId}-${action}`;
+}

--- a/packages/pieces/community/scrupp/tsconfig.json
+++ b/packages/pieces/community/scrupp/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "importHelpers": true,
+    "noImplicitOverride": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "noPropertyAccessFromIndexSignature": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/packages/pieces/community/scrupp/tsconfig.lib.json
+++ b/packages/pieces/community/scrupp/tsconfig.lib.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "baseUrl": ".",
+    "paths": {},
+    "outDir": "./dist",
+    "declaration": true,
+    "declarationMap": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
Adds a piece for [Scrupp](https://scrupp.com), a B2B lead-extraction and enrichment API.

### What it does

| Action | |
| --- | --- |
| Export Sales Navigator Search | people out of a Sales Navigator search URL |
| Export LinkedIn Search | the same for a regular LinkedIn people search |
| Run Apollo Search | an Apollo search through a connected Apollo account |
| Enrich LinkedIn Profiles | full profile data for a list of profile URLs |
| Look Up Company | company data by domain, LinkedIn URL or name |
| Find Decision Makers | who to contact at a company you only know the domain of |
| Find Emails | work email addresses from first name, last name and domain |

Plus the custom API call action, so anything not covered above is still reachable.

### Notes for review

**Async by design.** Every Scrupp operation is a job: create it, poll it, fetch the
result. The actions poll on the `retry_after` the API returns rather than a fixed
interval — a 2,500-record export and a three-address email lookup need very different
rhythms. There is a user-set timeout (default 30 minutes) after which the action fails
with the job id rather than holding a worker open, and a **Wait for Results** toggle that
returns the `job_id` immediately for flows that would rather poll themselves.

**Retries do not double-bill.** Each create call sends an `Idempotency-Key` derived from
the run id, so a retried step returns the original job instead of starting and paying
for a second one.

**Connecting is free.** The auth `validate` hook calls `/ping`, which costs no credits,
so a wrong key is rejected in the connection dialog rather than on first use.

**No triggers in v1.** A "new records" trigger belongs on top of Scrupp's callback URL
and needs a public endpoint per flow — a follow-up PR rather than something to hold the
listing for.

### Logo

`logoUrl` points at `https://cdn.activepieces.com/pieces/scrupp.png`, following the
other community pieces. A 512×512 PNG is attached to this PR for a maintainer to host.

Docs: https://scrupp.com/docs/api/integrations-jobs
OpenAPI: https://scrupp.com/api-docs/openapi-v1.yaml
