### PR TITLE
feat(figranium): automate browser tasks and manage schedules

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -3125,6 +3125,19 @@
         "tslib": "2.6.2",
       },
     },
+    "packages/pieces/community/figranium": {
+      "name": "@activepieces/piece-figranium",
+      "version": "0.0.1",
+      "dependencies": {
+        "@activepieces/core-piece-types": "workspace:*",
+        "@activepieces/core-utils": "workspace:*",
+        "@activepieces/pieces-common": "workspace:*",
+        "@activepieces/pieces-framework": "workspace:*",
+      },
+      "devDependencies": {
+        "tslib": "2.6.2",
+      },
+    },
     "packages/pieces/community/filetopdf": {
       "name": "@activepieces/piece-filetopdf",
       "version": "0.0.6",
@@ -11459,6 +11472,8 @@
     "@activepieces/piece-fellow": ["@activepieces/piece-fellow@workspace:packages/pieces/community/fellow"],
 
     "@activepieces/piece-figma": ["@activepieces/piece-figma@workspace:packages/pieces/community/figma"],
+
+    "@activepieces/piece-figranium": ["@activepieces/piece-figranium@workspace:packages/pieces/community/figranium"],
 
     "@activepieces/piece-file-helper": ["@activepieces/piece-file-helper@workspace:packages/pieces/core/file-helper"],
 

--- a/packages/pieces/community/figranium/.eslintrc.json
+++ b/packages/pieces/community/figranium/.eslintrc.json
@@ -1,0 +1,47 @@
+{
+  "extends": [
+    "../../../../.eslintrc.json"
+  ],
+  "ignorePatterns": [
+    "!**/*"
+  ],
+  "overrides": [
+    {
+      "files": [
+        "*.ts",
+        "*.tsx",
+        "*.js",
+        "*.jsx"
+      ],
+      "rules": {}
+    },
+    {
+      "files": [
+        "*.ts",
+        "*.tsx"
+      ],
+      "rules": {
+        "no-restricted-imports": [
+          "error",
+          {
+            "patterns": [
+              "lodash",
+              "lodash/*",
+              "@activepieces/core-*",
+              "@activepieces/server*",
+              "@activepieces/engine",
+              "@activepieces/shared"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "files": [
+        "*.js",
+        "*.jsx"
+      ],
+      "rules": {}
+    }
+  ]
+}

--- a/packages/pieces/community/figranium/package.json
+++ b/packages/pieces/community/figranium/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@activepieces/piece-figranium",
+  "version": "0.0.1",
+  "type": "commonjs",
+  "main": "./dist/src/index.js",
+  "types": "./dist/src/index.d.ts",
+  "dependencies": {
+    "@activepieces/pieces-common": "workspace:*",
+    "@activepieces/pieces-framework": "workspace:*",
+    "@activepieces/core-piece-types": "workspace:*",
+    "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.lib.json && cp package.json dist/",
+    "bundle": "node ../../../../dist/packages/cli/src/index.js pieces bundle",
+    "lint": "eslint 'src/**/*.ts'"
+  }
+}

--- a/packages/pieces/community/figranium/src/index.ts
+++ b/packages/pieces/community/figranium/src/index.ts
@@ -1,0 +1,42 @@
+import { createPiece, PieceCategory } from '@activepieces/pieces-framework';
+import { createCustomApiCallAction } from '@activepieces/pieces-common';
+import { figraniumAuth } from './lib/auth';
+import { executeTaskAction } from './lib/actions/execute-task';
+import { listTasksAction } from './lib/actions/list-tasks';
+import { listExecutionsAction } from './lib/actions/list-executions';
+import { listSchedulesAction } from './lib/actions/list-schedules';
+import { getScheduleStatusAction } from './lib/actions/get-schedule-status';
+import { getSchedulerStatusAction } from './lib/actions/get-scheduler-status';
+import { setScheduleAction } from './lib/actions/set-schedule';
+import { deleteScheduleAction } from './lib/actions/delete-schedule';
+import { describeScheduleAction } from './lib/actions/describe-schedule';
+
+export const figranium = createPiece({
+  displayName: 'Figranium',
+  description: 'Interact with Figranium — trigger browser-automation tasks, inspect executions, and manage schedules.',
+  auth: figraniumAuth,
+  minimumSupportedRelease: '0.36.1',
+  logoUrl:
+    'https://raw.githubusercontent.com/figranium/figranium/0bde46ef4c05ff97a1304313145bdab4138b6a88/public/figranium_icon.svg',
+  categories: [PieceCategory.PRODUCTIVITY],
+  authors: ['activepieces'],
+  actions: [
+    executeTaskAction,
+    listTasksAction,
+    listExecutionsAction,
+    listSchedulesAction,
+    getScheduleStatusAction,
+    getSchedulerStatusAction,
+    setScheduleAction,
+    deleteScheduleAction,
+    describeScheduleAction,
+    createCustomApiCallAction({
+      auth: figraniumAuth,
+      baseUrl: (auth) => (auth ? auth.props.baseUrl : ''),
+      authMapping: async (auth) => ({
+        'x-api-key': auth.props.apiKey,
+      }),
+    }),
+  ],
+  triggers: [],
+});

--- a/packages/pieces/community/figranium/src/lib/actions/delete-schedule.ts
+++ b/packages/pieces/community/figranium/src/lib/actions/delete-schedule.ts
@@ -1,0 +1,33 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { figraniumAuth } from '../auth';
+import { figraniumClient } from '../common/client';
+
+export const deleteScheduleAction = createAction({
+  auth: figraniumAuth,
+  name: 'delete_schedule',
+  displayName: 'Delete Schedule',
+  description: 'Disable and remove the schedule from a task',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Disables and removes the schedule from a Figranium task, stopping it from running automatically. The task itself is not deleted. Retrying after success typically errors since the schedule no longer exists.',
+    idempotent: false,
+  },
+  props: {
+    taskId: Property.ShortText({
+      displayName: 'Task ID',
+      description: 'The ID of the task',
+      required: true,
+    }),
+  },
+  async run(context) {
+    const { taskId } = context.propsValue;
+    return figraniumClient({
+      baseUrl: context.auth.props.baseUrl,
+      apiKey: context.auth.props.apiKey,
+      method: HttpMethod.DELETE,
+      resourceUri: `/api/schedules/${encodeURIComponent(taskId)}`,
+    });
+  },
+});

--- a/packages/pieces/community/figranium/src/lib/actions/describe-schedule.ts
+++ b/packages/pieces/community/figranium/src/lib/actions/describe-schedule.ts
@@ -1,0 +1,38 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { figraniumAuth } from '../auth';
+import { figraniumClient } from '../common/client';
+import { buildScheduleBody, scheduleConfigProps, scheduleModeDropdown } from '../common/schedule-props';
+
+export const describeScheduleAction = createAction({
+  auth: figraniumAuth,
+  name: 'describe_schedule',
+  displayName: 'Describe Schedule',
+  description: 'Validate and preview a schedule config without saving it',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Validates a schedule configuration and previews its next run times without saving it to the task. Use this to check a schedule before committing to it with Set Schedule. Safe to retry, no state is changed.',
+    idempotent: true,
+  },
+  props: {
+    taskId: Property.ShortText({
+      displayName: 'Task ID',
+      description: 'The ID of the task',
+      required: true,
+    }),
+    scheduleMode: scheduleModeDropdown,
+    scheduleConfig: scheduleConfigProps,
+  },
+  async run(context) {
+    const { taskId, scheduleMode, scheduleConfig } = context.propsValue;
+    const body = buildScheduleBody({ scheduleMode, scheduleConfig });
+    return figraniumClient({
+      baseUrl: context.auth.props.baseUrl,
+      apiKey: context.auth.props.apiKey,
+      method: HttpMethod.POST,
+      resourceUri: `/api/schedules/${encodeURIComponent(taskId)}/describe`,
+      body,
+    });
+  },
+});

--- a/packages/pieces/community/figranium/src/lib/actions/execute-task.ts
+++ b/packages/pieces/community/figranium/src/lib/actions/execute-task.ts
@@ -1,0 +1,36 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { figraniumAuth } from '../auth';
+import { figraniumClient } from '../common/client';
+import { taskIdDropdown } from '../common/props';
+
+export const executeTaskAction = createAction({
+  auth: figraniumAuth,
+  name: 'execute_task',
+  displayName: 'Execute Task',
+  description: 'Run a saved Figranium task and return its result',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Runs a saved Figranium browser-automation task and returns its result. Use this to trigger an automation on demand with optional runtime variables. Each call starts a new execution, so retries run the task again.',
+    idempotent: false,
+  },
+  props: {
+    taskId: taskIdDropdown,
+    variables: Property.Object({
+      displayName: 'Variables',
+      description: 'Key-value pairs passed into the task at runtime',
+      required: false,
+    }),
+  },
+  async run(context) {
+    const { taskId, variables } = context.propsValue;
+    return figraniumClient({
+      baseUrl: context.auth.props.baseUrl,
+      apiKey: context.auth.props.apiKey,
+      method: HttpMethod.POST,
+      resourceUri: `/api/tasks/${encodeURIComponent(taskId)}/api`,
+      body: { variables: variables ?? {} },
+    });
+  },
+});

--- a/packages/pieces/community/figranium/src/lib/actions/get-schedule-status.ts
+++ b/packages/pieces/community/figranium/src/lib/actions/get-schedule-status.ts
@@ -1,0 +1,33 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { figraniumAuth } from '../auth';
+import { figraniumClient } from '../common/client';
+
+export const getScheduleStatusAction = createAction({
+  auth: figraniumAuth,
+  name: 'get_schedule_status',
+  displayName: 'Get Schedule Status',
+  description: 'Get the schedule status and next run time for a specific task',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Gets the schedule status and next run time for a single Figranium task by ID. Use this to check whether a specific task is scheduled and when it will next run. Safe to retry.',
+    idempotent: true,
+  },
+  props: {
+    taskId: Property.ShortText({
+      displayName: 'Task ID',
+      description: 'The ID of the task',
+      required: true,
+    }),
+  },
+  async run(context) {
+    const { taskId } = context.propsValue;
+    return figraniumClient({
+      baseUrl: context.auth.props.baseUrl,
+      apiKey: context.auth.props.apiKey,
+      method: HttpMethod.GET,
+      resourceUri: `/api/schedules/${encodeURIComponent(taskId)}/status`,
+    });
+  },
+});

--- a/packages/pieces/community/figranium/src/lib/actions/get-scheduler-status.ts
+++ b/packages/pieces/community/figranium/src/lib/actions/get-scheduler-status.ts
@@ -1,0 +1,26 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { figraniumAuth } from '../auth';
+import { figraniumClient } from '../common/client';
+
+export const getSchedulerStatusAction = createAction({
+  auth: figraniumAuth,
+  name: 'get_scheduler_status',
+  displayName: 'Get Scheduler Status',
+  description: 'Return the overall status of the task scheduler',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Returns the overall status of the Figranium scheduler engine, covering every scheduled task at once. Use this instead of Get Schedule Status when you need a system-wide view rather than a single task. Safe to retry.',
+    idempotent: true,
+  },
+  props: {},
+  async run(context) {
+    return figraniumClient({
+      baseUrl: context.auth.props.baseUrl,
+      apiKey: context.auth.props.apiKey,
+      method: HttpMethod.GET,
+      resourceUri: '/api/schedules/status/all',
+    });
+  },
+});

--- a/packages/pieces/community/figranium/src/lib/actions/list-executions.ts
+++ b/packages/pieces/community/figranium/src/lib/actions/list-executions.ts
@@ -1,0 +1,26 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { figraniumAuth } from '../auth';
+import { figraniumClient } from '../common/client';
+
+export const listExecutionsAction = createAction({
+  auth: figraniumAuth,
+  name: 'list_executions',
+  displayName: 'List Executions',
+  description: 'Return a summary of all past task executions',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Lists a summary of all past Figranium task executions. Use this to check recent run history or find an execution to inspect further. Safe to retry.',
+    idempotent: true,
+  },
+  props: {},
+  async run(context) {
+    return figraniumClient({
+      baseUrl: context.auth.props.baseUrl,
+      apiKey: context.auth.props.apiKey,
+      method: HttpMethod.GET,
+      resourceUri: '/api/executions/list',
+    });
+  },
+});

--- a/packages/pieces/community/figranium/src/lib/actions/list-schedules.ts
+++ b/packages/pieces/community/figranium/src/lib/actions/list-schedules.ts
@@ -1,0 +1,26 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { figraniumAuth } from '../auth';
+import { figraniumClient } from '../common/client';
+
+export const listSchedulesAction = createAction({
+  auth: figraniumAuth,
+  name: 'list_schedules',
+  displayName: 'List Schedules',
+  description: 'Return all tasks that have schedules configured',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Lists every Figranium task that has a schedule configured. Use this to audit which tasks run automatically. Safe to retry.',
+    idempotent: true,
+  },
+  props: {},
+  async run(context) {
+    return figraniumClient({
+      baseUrl: context.auth.props.baseUrl,
+      apiKey: context.auth.props.apiKey,
+      method: HttpMethod.GET,
+      resourceUri: '/api/schedules',
+    });
+  },
+});

--- a/packages/pieces/community/figranium/src/lib/actions/list-tasks.ts
+++ b/packages/pieces/community/figranium/src/lib/actions/list-tasks.ts
@@ -1,0 +1,27 @@
+import { createAction } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { figraniumAuth } from '../auth';
+import { figraniumClient, FigraniumTaskListResponse } from '../common/client';
+
+export const listTasksAction = createAction({
+  auth: figraniumAuth,
+  name: 'list_tasks',
+  displayName: 'List Tasks',
+  description: 'Return all task IDs, names, and descriptions',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Lists all saved tasks on the Figranium server with their IDs, names, and descriptions. Use this to discover which tasks exist before executing one. Safe to retry.',
+    idempotent: true,
+  },
+  props: {},
+  async run(context) {
+    const response = await figraniumClient<FigraniumTaskListResponse>({
+      baseUrl: context.auth.props.baseUrl,
+      apiKey: context.auth.props.apiKey,
+      method: HttpMethod.GET,
+      resourceUri: '/api/tasks/list',
+    });
+    return response.tasks;
+  },
+});

--- a/packages/pieces/community/figranium/src/lib/actions/set-schedule.ts
+++ b/packages/pieces/community/figranium/src/lib/actions/set-schedule.ts
@@ -1,0 +1,47 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { figraniumAuth } from '../auth';
+import { figraniumClient } from '../common/client';
+import { buildScheduleBody, scheduleConfigProps, scheduleModeDropdown } from '../common/schedule-props';
+
+export const setScheduleAction = createAction({
+  auth: figraniumAuth,
+  name: 'set_schedule',
+  displayName: 'Set Schedule',
+  description: 'Create or update a schedule on a task',
+  audience: 'both',
+  aiMetadata: {
+    description:
+      'Creates or updates the schedule on a Figranium task, either as a recurring frequency or a cron expression. Use this to make a task run automatically. Safe to retry since it upserts the schedule for the given task ID.',
+    idempotent: true,
+  },
+  props: {
+    taskId: Property.ShortText({
+      displayName: 'Task ID',
+      description: 'The ID of the task',
+      required: true,
+    }),
+    scheduleEnabled: Property.Checkbox({
+      displayName: 'Enabled',
+      description: 'Whether the schedule should be active',
+      required: false,
+      defaultValue: true,
+    }),
+    scheduleMode: scheduleModeDropdown,
+    scheduleConfig: scheduleConfigProps,
+  },
+  async run(context) {
+    const { taskId, scheduleEnabled, scheduleMode, scheduleConfig } = context.propsValue;
+    const body = {
+      enabled: scheduleEnabled ?? true,
+      ...buildScheduleBody({ scheduleMode, scheduleConfig }),
+    };
+    return figraniumClient({
+      baseUrl: context.auth.props.baseUrl,
+      apiKey: context.auth.props.apiKey,
+      method: HttpMethod.POST,
+      resourceUri: `/api/schedules/${encodeURIComponent(taskId)}`,
+      body,
+    });
+  },
+});

--- a/packages/pieces/community/figranium/src/lib/auth.ts
+++ b/packages/pieces/community/figranium/src/lib/auth.ts
@@ -1,0 +1,37 @@
+import { PieceAuth, Property } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { figraniumClient } from './common/client';
+
+export const figraniumAuth = PieceAuth.CustomAuth({
+  displayName: 'Connection',
+  required: true,
+  props: {
+    baseUrl: Property.ShortText({
+      displayName: 'Base URL',
+      description: 'Your Figranium server URL, e.g. http://localhost:11345',
+      required: true,
+      defaultValue: 'http://localhost:11345',
+    }),
+    apiKey: PieceAuth.SecretText({
+      displayName: 'API Key',
+      description: 'Generate this from Figranium Settings > API Key.',
+      required: true,
+    }),
+  },
+  validate: async ({ auth }) => {
+    try {
+      await figraniumClient({
+        baseUrl: auth.baseUrl,
+        apiKey: auth.apiKey,
+        method: HttpMethod.GET,
+        resourceUri: '/api/tasks/list',
+      });
+      return { valid: true };
+    } catch (e) {
+      return {
+        valid: false,
+        error: 'Could not connect to Figranium. Check the base URL and API key.',
+      };
+    }
+  },
+});

--- a/packages/pieces/community/figranium/src/lib/common/client.ts
+++ b/packages/pieces/community/figranium/src/lib/common/client.ts
@@ -1,0 +1,40 @@
+import { httpClient, HttpMethod, QueryParams } from '@activepieces/pieces-common';
+
+type FigraniumRequest = {
+  baseUrl: string;
+  apiKey: string;
+  method: HttpMethod;
+  resourceUri: string;
+  body?: Record<string, unknown>;
+  queryParams?: QueryParams;
+};
+
+export async function figraniumClient<T>({
+  baseUrl,
+  apiKey,
+  method,
+  resourceUri,
+  body,
+  queryParams,
+}: FigraniumRequest): Promise<T> {
+  const response = await httpClient.sendRequest<T>({
+    method,
+    url: `${baseUrl.replace(/\/+$/, '')}${resourceUri}`,
+    headers: {
+      'x-api-key': apiKey,
+    },
+    body,
+    queryParams,
+  });
+  return response.body;
+}
+
+export type FigraniumTask = {
+  id: string;
+  name?: string;
+  description?: string;
+};
+
+export type FigraniumTaskListResponse = {
+  tasks: FigraniumTask[];
+};

--- a/packages/pieces/community/figranium/src/lib/common/props.ts
+++ b/packages/pieces/community/figranium/src/lib/common/props.ts
@@ -1,0 +1,34 @@
+import { Property } from '@activepieces/pieces-framework';
+import { HttpMethod } from '@activepieces/pieces-common';
+import { figraniumAuth } from '../auth';
+import { figraniumClient, FigraniumTaskListResponse } from './client';
+
+export const taskIdDropdown = Property.Dropdown({
+  displayName: 'Task',
+  description: 'The task to execute',
+  required: true,
+  refreshers: ['auth'],
+  auth: figraniumAuth,
+  options: async ({ auth }) => {
+    if (!auth) {
+      return {
+        disabled: true,
+        placeholder: 'Please connect your Figranium account first',
+        options: [],
+      };
+    }
+    const response = await figraniumClient<FigraniumTaskListResponse>({
+      baseUrl: auth.props.baseUrl,
+      apiKey: auth.props.apiKey,
+      method: HttpMethod.GET,
+      resourceUri: '/api/tasks/list',
+    });
+    return {
+      disabled: false,
+      options: response.tasks.map((task) => ({
+        label: task.name || task.id,
+        value: task.id,
+      })),
+    };
+  },
+});

--- a/packages/pieces/community/figranium/src/lib/common/schedule-props.ts
+++ b/packages/pieces/community/figranium/src/lib/common/schedule-props.ts
@@ -1,0 +1,122 @@
+import { DynamicPropsValue, Property } from '@activepieces/pieces-framework';
+import { figraniumAuth } from '../auth';
+
+export const scheduleModeDropdown = Property.StaticDropdown({
+  displayName: 'Schedule Mode',
+  description: 'How to express the schedule timing',
+  required: true,
+  defaultValue: 'frequency',
+  options: {
+    options: [
+      { label: 'Frequency (Interval)', value: 'frequency' },
+      { label: 'Cron Expression', value: 'cron' },
+    ],
+  },
+});
+
+export const scheduleConfigProps = Property.DynamicProperties({
+  displayName: 'Schedule',
+  description: 'The timing details for the schedule',
+  required: true,
+  auth: figraniumAuth,
+  refreshers: ['scheduleMode'],
+  props: async ({ scheduleMode }): Promise<DynamicPropsValue> => {
+    if (scheduleMode === 'cron') {
+      return {
+        cronExpression: Property.ShortText({
+          displayName: 'Cron Expression',
+          description: 'A standard 5-field cron expression (minute hour day month weekday), e.g. 0 9 * * 1',
+          required: true,
+          defaultValue: '0 9 * * 1',
+        }),
+      };
+    }
+    return {
+      frequency: Property.StaticDropdown({
+        displayName: 'Frequency',
+        required: true,
+        defaultValue: 'daily',
+        options: {
+          options: [
+            { label: 'Every N Minutes', value: 'interval' },
+            { label: 'Daily', value: 'daily' },
+            { label: 'Weekly', value: 'weekly' },
+            { label: 'Monthly', value: 'monthly' },
+          ],
+        },
+      }),
+      intervalMinutes: Property.Number({
+        displayName: 'Interval (Minutes)',
+        description: 'How often to run, in minutes. Only used when Frequency is "Every N Minutes".',
+        required: false,
+        defaultValue: 60,
+      }),
+      hour: Property.Number({
+        displayName: 'Hour',
+        description: 'Hour of day to run (0-23). Used for Daily, Weekly, and Monthly.',
+        required: false,
+        defaultValue: 9,
+      }),
+      minute: Property.Number({
+        displayName: 'Minute',
+        description: 'Minute of hour to run (0-59). Used for Daily, Weekly, and Monthly.',
+        required: false,
+        defaultValue: 0,
+      }),
+      daysOfWeek: Property.StaticMultiSelectDropdown({
+        displayName: 'Days of Week',
+        description: 'Only used when Frequency is "Weekly".',
+        required: false,
+        options: {
+          options: [
+            { label: 'Sunday', value: 0 },
+            { label: 'Monday', value: 1 },
+            { label: 'Tuesday', value: 2 },
+            { label: 'Wednesday', value: 3 },
+            { label: 'Thursday', value: 4 },
+            { label: 'Friday', value: 5 },
+            { label: 'Saturday', value: 6 },
+          ],
+        },
+      }),
+      dayOfMonth: Property.Number({
+        displayName: 'Day of Month',
+        description: 'Day of month to run (1-31). Only used when Frequency is "Monthly".',
+        required: false,
+        defaultValue: 1,
+      }),
+    };
+  },
+});
+
+export function buildScheduleBody({
+  scheduleMode,
+  scheduleConfig,
+}: {
+  scheduleMode: string;
+  scheduleConfig: Record<string, unknown>;
+}): Record<string, unknown> {
+  if (scheduleMode === 'cron') {
+    return { cron: scheduleConfig['cronExpression'] };
+  }
+
+  const frequency = scheduleConfig['frequency'] as string;
+  const body: Record<string, unknown> = { frequency };
+
+  if (frequency === 'interval') {
+    body['intervalMinutes'] = scheduleConfig['intervalMinutes'];
+  } else if (frequency === 'weekly') {
+    body['hour'] = scheduleConfig['hour'];
+    body['minute'] = scheduleConfig['minute'];
+    body['daysOfWeek'] = scheduleConfig['daysOfWeek'];
+  } else if (frequency === 'monthly') {
+    body['hour'] = scheduleConfig['hour'];
+    body['minute'] = scheduleConfig['minute'];
+    body['dayOfMonth'] = scheduleConfig['dayOfMonth'];
+  } else {
+    body['hour'] = scheduleConfig['hour'];
+    body['minute'] = scheduleConfig['minute'];
+  }
+
+  return body;
+}

--- a/packages/pieces/community/figranium/tsconfig.json
+++ b/packages/pieces/community/figranium/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/packages/pieces/community/figranium/tsconfig.lib.json
+++ b/packages/pieces/community/figranium/tsconfig.lib.json
@@ -1,0 +1,22 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "baseUrl": ".",
+    "paths": {},
+    "outDir": "./dist",
+    "declaration": true,
+    "declarationMap": true,
+    "types": [
+      "node"
+    ]
+  },
+  "include": [
+    "src/**/*.ts"
+  ],
+  "exclude": [
+    "jest.config.ts",
+    "src/**/*.spec.ts",
+    "src/**/*.test.ts"
+  ]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -467,6 +467,9 @@
       "@activepieces/piece-figma": [
         "packages/pieces/community/figma/src/index.ts"
       ],
+      "@activepieces/piece-figranium": [
+        "packages/pieces/community/figranium/src/index.ts"
+      ],
       "@activepieces/piece-file-helper": [
         "packages/pieces/core/file-helper/src/index.ts"
       ],


### PR DESCRIPTION
## Description

Adds a new **Figranium** piece to Activepieces, providing native actions for integrating Figranium browser automation workflows into Activepieces flows.

This is a new submission of the Figranium piece following the previously closed PR #14756.

The piece includes support for:

- Executing Figranium tasks
- Listing available tasks
- Listing task executions
- Managing Figranium schedules
- Selecting tasks through dynamic dropdowns populated from the connected Figranium instance
- Passing task variables through native dictionary/object inputs
- Authenticating with a configurable Figranium Base URL and API key

The Execute Task action sends variables to Figranium and exposes the resulting execution data for use by subsequent Activepieces steps.

This submission incorporates the improvements made since the previous PR and brings the integration in line with the current Figranium API and Activepieces piece conventions.

## How was this tested?

- Verified authentication against a Figranium instance using the Base URL and API key.
- Verified tasks can be retrieved from `/api/tasks/list`.
- Verified task dropdowns display task names while using task IDs as their underlying values.
- Verified Execute Task sends variables using the expected `{ "variables": { ... } }` request structure.
- Verified variables can be configured through the native object/dictionary input.
- Verified task execution responses are exposed to subsequent Activepieces steps.
- Verified task listing, execution listing, and schedule actions against the Figranium API.

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)