### PR TITLE
fix(pieces-common): preserve arrays in form-urlencoded bodies

### DIFF
--- a/packages/pieces/common/src/lib/http/core/fetch-http-client.ts
+++ b/packages/pieces/common/src/lib/http/core/fetch-http-client.ts
@@ -22,7 +22,7 @@ export class FetchHttpClient extends BaseHttpClient {
     super(baseUrl, authenticationConverter);
   }
 
-  async sendRequest<ResponseBody extends HttpMessageBody = any>(
+  async sendRequest<ResponseBody extends HttpMessageBody = HttpMessageBody>(
     request: HttpRequest<HttpRequestBody>,
     options?: SendRequestOptions
   ): Promise<HttpResponse<ResponseBody>> {
@@ -125,9 +125,43 @@ function serializeBody(
   }
   const contentType = headers['Content-Type'] ?? headers['content-type'] ?? '';
   if (contentType.includes('application/x-www-form-urlencoded')) {
-    return { body: new URLSearchParams(body as Record<string, string>).toString(), extraHeaders: {}, isStream: false };
+    if (!isPlainObject(body)) {
+      return { body: String(body), extraHeaders: {}, isStream: false };
+    }
+    return { body: serializeFormUrlEncodedBody(body), extraHeaders: {}, isStream: false };
   }
   return { body: JSON.stringify(body), extraHeaders: {}, isStream: false };
+}
+
+function serializeFormUrlEncodedBody(body: Record<string, unknown>): string {
+  const params = new URLSearchParams();
+  appendFormUrlEncoded(params, body);
+  return params.toString();
+}
+
+function appendFormUrlEncoded(params: URLSearchParams, value: unknown, prefix?: string): void {
+  if (isNil(value)) {
+    return;
+  }
+  if (Array.isArray(value)) {
+    if (prefix === undefined) {
+      return;
+    }
+    for (const item of value) {
+      appendFormUrlEncoded(params, item, `${prefix}[]`);
+    }
+    return;
+  }
+  if (isPlainObject(value)) {
+    for (const [key, nestedValue] of Object.entries(value)) {
+      appendFormUrlEncoded(params, nestedValue, prefix === undefined ? key : `${prefix}[${key}]`);
+    }
+    return;
+  }
+  if (prefix === undefined) {
+    return;
+  }
+  params.append(prefix, String(value));
 }
 
 async function parseResponseBody(response: Response, responseType: ResponseType): Promise<unknown> {
@@ -214,6 +248,10 @@ function isNodeFormData(body: unknown): body is NodeFormData {
 
 function isNil(value: unknown): value is null | undefined {
   return value === null || value === undefined;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return Object.prototype.toString.call(value) === '[object Object]';
 }
 
 type NodeFormData = {

--- a/packages/pieces/common/test/fetch-http-client.test.ts
+++ b/packages/pieces/common/test/fetch-http-client.test.ts
@@ -1,0 +1,45 @@
+/// <reference types="vitest/globals" />
+
+import { afterEach, expect, test, vi } from 'vitest';
+import { FetchHttpClient } from '../src/lib/http/core/fetch-http-client';
+import { HttpMethod } from '../src/lib/http/core/http-method';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+test('serializes form-urlencoded arrays as repeated bracketed keys', async () => {
+  const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response('{}', { status: 200 }));
+  const client = new FetchHttpClient();
+
+  await client.sendRequest({
+    method: HttpMethod.POST,
+    url: 'https://api.stripe.com/v1/webhook_endpoints',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+    },
+    body: {
+      enabled_events: ['refund.created', 'charge.refunded'],
+      url: 'https://example.com/webhook',
+    },
+  });
+
+  expect(fetchSpy).toHaveBeenCalledTimes(1);
+  const call = fetchSpy.mock.calls[0];
+
+  if (!call) {
+    throw new Error('expected fetch to be called');
+  }
+
+  const init = call[1];
+  const body = init?.body;
+
+  if (typeof body !== 'string') {
+    throw new Error('expected a serialized string body');
+  }
+
+  const params = new URLSearchParams(body);
+
+  expect(params.getAll('enabled_events[]')).toEqual(['refund.created', 'charge.refunded']);
+  expect(params.get('url')).toBe('https://example.com/webhook');
+});


### PR DESCRIPTION
## Description

Preserve array values when serializing `application/x-www-form-urlencoded` request bodies in `@activepieces/pieces-common`. The fetch HTTP client now emits repeated bracketed keys for arrays instead of collapsing them into a single scalar value, which keeps Stripe webhook registration requests valid.

## Related issue(s)

Closes #14972

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

Supercedes #15193（原PR分支已删，按原提交重建）
